### PR TITLE
feat(sdk): SDK skeleton + never-crash-host invariant [CTO-45]

### DIFF
--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -1,0 +1,77 @@
+"""TallyClient — the SDK entrypoint skeleton.
+
+Minimal, safe-by-construction surface (CTO-45). Every public method runs inside the safety
+boundary so a bug in the SDK — or in a pluggable exporter — never escapes into the customer's
+code path. Real export/batching lands in CTO-49; for now spans accumulate in an in-memory sink so
+the boundary behavior is observable and testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from tally.safety import SelfObservability, safe
+from tally.schema import SpanFields, build_span_attributes
+
+
+class Exporter(Protocol):
+    """Pluggable span sink. Implementations may raise — the client must absorb it."""
+
+    def export(self, attributes: dict[str, object]) -> None: ...
+
+
+class MemoryExporter:
+    """Default no-network exporter: keeps spans in a list. Useful for tests and local dev."""
+
+    def __init__(self) -> None:
+        self.spans: list[dict[str, object]] = []
+
+    def export(self, attributes: dict[str, object]) -> None:
+        self.spans.append(attributes)
+
+
+class TallyClient:
+    """Customer-facing entrypoint.
+
+    Args:
+        api_key: tenant-scoped key (unused until egress lands; stored for later).
+        endpoint: ingest endpoint (unused until egress lands).
+        exporter: pluggable sink; defaults to an in-memory exporter.
+        observability: optional shared :class:`SelfObservability`.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        endpoint: str | None = None,
+        *,
+        exporter: Exporter | None = None,
+        observability: SelfObservability | None = None,
+    ) -> None:
+        self.obs = observability or SelfObservability()
+        self._api_key = api_key
+        self._endpoint = endpoint
+        self._exporter: Exporter = exporter or MemoryExporter()
+
+    @property
+    def observability(self) -> SelfObservability:
+        return self.obs
+
+    def record_span(self, fields: SpanFields) -> None:
+        """Record one span. Never raises — a faulty exporter or builder is absorbed."""
+        self._record_span_impl(fields)
+
+    # Wrapped so any failure (build or export) is recorded and swallowed.
+    def _record_span_impl(self, fields: SpanFields) -> None:
+        @safe(self.obs, where="TallyClient.record_span")
+        def _do() -> None:
+            attrs = build_span_attributes(fields)
+            self._exporter.export(attrs)
+
+        _do()
+
+
+def make_client(record_fn_factory: Callable[[], Exporter] | None = None) -> TallyClient:
+    """Convenience constructor used in tests/examples."""
+    return TallyClient(exporter=record_fn_factory() if record_fn_factory else None)

--- a/sdk/python/src/tally/safety.py
+++ b/sdk/python/src/tally/safety.py
@@ -1,0 +1,105 @@
+"""SDK safety boundary — the never-crash-host invariant.
+
+THE INVARIANT (CTO-45): the SDK must never raise into the customer's code path. Every internal
+operation runs inside a boundary that catches *all* exceptions (including ``BaseException``
+subclasses we can safely swallow — but never ``KeyboardInterrupt`` / ``SystemExit``), records them
+to a self-observability channel, and returns a fallback so the customer's call proceeds unmodified.
+
+Usage:
+
+    from tally.safety import SelfObservability, safe, safe_block
+
+    obs = SelfObservability()
+
+    @safe(obs, fallback=None)
+    def _internal(...): ...
+
+    with safe_block(obs):
+        ... # best-effort internal work; exceptions recorded, never raised
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+_log = logging.getLogger("tally")
+
+T = TypeVar("T")
+
+# We swallow Exception, never these (let the program exit/interrupt as the user intends).
+_NEVER_SWALLOW = (KeyboardInterrupt, SystemExit)
+
+
+@dataclass(slots=True)
+class SelfObservability:
+    """Counters the SDK reports about *itself* (surfaced to the customer's dashboard).
+
+    See CTO-46 for ``context_drop_count`` and CTO-49 for ``dropped_span_count``; this module owns
+    ``internal_error_count`` and the optional error hook.
+    """
+
+    internal_error_count: int = 0
+    context_drop_count: int = 0
+    dropped_span_count: int = 0
+    #: optional sink for the last few error reprs (bounded), for debugging
+    last_errors: list[str] = field(default_factory=list)
+    _max_errors: int = 20
+
+    def record_error(self, exc: BaseException, where: str) -> None:
+        self.internal_error_count += 1
+        msg = f"{where}: {type(exc).__name__}: {exc}"
+        self.last_errors.append(msg)
+        if len(self.last_errors) > self._max_errors:
+            del self.last_errors[0]
+        # Never propagate; log at debug so we don't spam the customer's logs by default.
+        _log.debug("tally internal error suppressed (%s)", msg)
+
+    def snapshot(self) -> dict[str, int]:
+        return {
+            "internal_error_count": self.internal_error_count,
+            "context_drop_count": self.context_drop_count,
+            "dropped_span_count": self.dropped_span_count,
+        }
+
+
+def safe(obs: SelfObservability, *, fallback: T = None, where: str | None = None):
+    """Decorator: run the wrapped callable inside the safety boundary.
+
+    On any swallowable exception, record it and return ``fallback`` instead of raising.
+    """
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+        label = where or fn.__qualname__
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs) -> T:
+            try:
+                return fn(*args, **kwargs)
+            except _NEVER_SWALLOW:
+                raise
+            except BaseException as exc:  # noqa: BLE001 - intentional catch-all boundary
+                obs.record_error(exc, label)
+                return fallback
+
+        return wrapper
+
+    return decorator
+
+
+@contextmanager
+def safe_block(obs: SelfObservability, *, where: str = "safe_block") -> Iterator[None]:
+    """Context manager form of :func:`safe`.
+
+    Exceptions inside the block are recorded, not raised.
+    """
+    try:
+        yield
+    except _NEVER_SWALLOW:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - intentional catch-all boundary
+        obs.record_error(exc, where)

--- a/sdk/python/tests/test_safety.py
+++ b/sdk/python/tests/test_safety.py
@@ -1,0 +1,73 @@
+import pytest
+
+from tally.client import MemoryExporter, TallyClient
+from tally.safety import SelfObservability, safe, safe_block
+from tally.schema import GenAI, SpanFields
+
+
+def test_safe_swallows_and_returns_fallback():
+    obs = SelfObservability()
+
+    @safe(obs, fallback=-1)
+    def boom():
+        raise ValueError("kaboom")
+
+    assert boom() == -1
+    assert obs.internal_error_count == 1
+    assert "kaboom" in obs.last_errors[-1]
+
+
+def test_safe_passes_through_success():
+    obs = SelfObservability()
+
+    @safe(obs, fallback=None)
+    def ok(x):
+        return x * 2
+
+    assert ok(21) == 42
+    assert obs.internal_error_count == 0
+
+
+def test_safe_block_records_not_raises():
+    obs = SelfObservability()
+    with safe_block(obs, where="unit"):
+        raise RuntimeError("inside block")
+    assert obs.internal_error_count == 1
+
+
+@pytest.mark.parametrize("exc", [KeyboardInterrupt, SystemExit])
+def test_never_swallow_interrupts(exc):
+    obs = SelfObservability()
+
+    @safe(obs)
+    def interrupt():
+        raise exc()
+
+    with pytest.raises(exc):
+        interrupt()
+
+
+def test_client_absorbs_faulty_exporter():
+    class FaultyExporter:
+        def export(self, attributes):
+            raise OSError("network down")
+
+    client = TallyClient(exporter=FaultyExporter())
+    # Must not raise into caller.
+    client.record_span(SpanFields(system="openai", input_tokens=5))
+    assert client.observability.internal_error_count == 1
+
+
+def test_client_happy_path_exports():
+    exporter = MemoryExporter()
+    client = TallyClient(exporter=exporter)
+    client.record_span(SpanFields(system="openai", request_model="gpt-5-mini", input_tokens=10))
+    assert len(exporter.spans) == 1
+    assert exporter.spans[0][GenAI.SYSTEM] == "openai"
+    assert client.observability.internal_error_count == 0
+
+
+def test_snapshot_shape():
+    obs = SelfObservability()
+    snap = obs.snapshot()
+    assert set(snap) == {"internal_error_count", "context_drop_count", "dropped_span_count"}


### PR DESCRIPTION
Implements **CTO-45**. Stacked on #2 (base `feat/cto-47-span-schema`).

## Summary
- `safety.py`: the boundary. `SelfObservability` counters + `safe()` decorator and `safe_block()` context manager that catch every swallowable exception (never `KeyboardInterrupt`/`SystemExit`), record to self-observability, and return a fallback.
- `client.py`: `TallyClient` entrypoint; `record_span()` runs inside the boundary. Pluggable `Exporter` protocol; `MemoryExporter` default (no network until CTO-49).

## Acceptance criteria
- [x] Installable package; init with key + endpoint
- [x] **Invariant**: SDK never raises into customer code — fault-injection suite proves a raising exporter is absorbed and counted
- [x] Emits a span end-to-end (to the in-memory exporter)

## Out of scope
Context propagation (CTO-46), span schema (CTO-47, merged below), auto-instrumentation (CTO-48), egress (CTO-49).

## Test plan
- [x] `ruff` + `pytest` green (22 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)