### PR TITLE
feat(sdk): local guardrail engine — tiered, graceful degradation [CTO-51]

### DIFF
--- a/sdk/python/src/tally/guardrails.py
+++ b/sdk/python/src/tally/guardrails.py
@@ -1,0 +1,147 @@
+"""Local guardrail engine — protect budget without ever corrupting customer state.
+
+Implements CTO-51.
+
+A per-trace counter state machine ``{cumulative_cost, step_count, tool_call_count}``. Before each
+outbound LLM/tool call the engine is consulted. Enforcement is tiered and **never hard-kills by
+default**:
+
+- ``OBSERVE`` (default): record what *would* have fired; always proceed. Powers the "fires/wk"
+  graduation metric in the UI (CTO-58).
+- ``WARN``: proceed, but return a warning the agent can act on (e.g. inject "you have used 80% of
+  budget; converge").
+- ``GRACEFUL``: raise a localized :class:`CostLimitExceededException` that the agent framework
+  catches, runs cleanup, and returns a degraded response. The process is **not** killed.
+- ``HARD_STOP``: opt-in only, for idempotent/read-only agents.
+
+v1 is single-process (counters are per-process). The metric that triggers v2 (a shared counter)
+is ``agent_run.cross_process_ratio`` — see CTO-83.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Mode(str, Enum):
+    OBSERVE = "observe"
+    WARN = "warn"
+    GRACEFUL = "graceful"
+    HARD_STOP = "hard_stop"
+
+
+class Limit(str, Enum):
+    COST = "cost"
+    STEPS = "steps"
+    TOOL_CALLS = "tool_calls"
+
+
+class CostLimitExceededException(Exception):
+    """Raised in GRACEFUL/HARD_STOP modes. Localized — meant to be caught by the agent framework
+    so it can clean up and return a degraded response. Never a process kill."""
+
+    def __init__(self, limit: Limit, value: float, cap: float, trace_id: str | None = None):
+        self.limit = limit
+        self.value = value
+        self.cap = cap
+        self.trace_id = trace_id
+        super().__init__(
+            f"guardrail '{limit.value}' exceeded: {value} > {cap}"
+            + (f" (trace {trace_id})" if trace_id else "")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GuardrailConfig:
+    mode: Mode = Mode.OBSERVE
+    max_cost_micro_usd: int | None = None
+    max_steps: int | None = None
+    max_tool_calls: int | None = None
+    #: fraction of a cap at which WARN mode starts warning (0.8 == 80%)
+    warn_at: float = 0.8
+
+
+@dataclass(slots=True)
+class GuardrailState:
+    trace_id: str
+    cumulative_cost_micro_usd: int = 0
+    step_count: int = 0
+    tool_call_count: int = 0
+
+    def add_cost(self, micro_usd: int) -> None:
+        self.cumulative_cost_micro_usd += micro_usd
+
+    def incr_step(self) -> None:
+        self.step_count += 1
+
+    def incr_tool_call(self) -> None:
+        self.tool_call_count += 1
+
+
+@dataclass(frozen=True, slots=True)
+class Verdict:
+    proceed: bool
+    breached: Limit | None = None
+    warning: str | None = None
+    #: True when a breach occurred but mode was OBSERVE (would-have-fired)
+    would_fire: bool = False
+
+
+def _first_breach(state: GuardrailState, config: GuardrailConfig) -> tuple[Limit, int, int] | None:
+    if config.max_cost_micro_usd is not None and (
+        state.cumulative_cost_micro_usd > config.max_cost_micro_usd
+    ):
+        return Limit.COST, state.cumulative_cost_micro_usd, config.max_cost_micro_usd
+    if config.max_steps is not None and state.step_count > config.max_steps:
+        return Limit.STEPS, state.step_count, config.max_steps
+    if config.max_tool_calls is not None and state.tool_call_count > config.max_tool_calls:
+        return Limit.TOOL_CALLS, state.tool_call_count, config.max_tool_calls
+    return None
+
+
+def _near_breach(state: GuardrailState, config: GuardrailConfig) -> str | None:
+    checks = [
+        (config.max_cost_micro_usd, state.cumulative_cost_micro_usd, "cost"),
+        (config.max_steps, state.step_count, "steps"),
+        (config.max_tool_calls, state.tool_call_count, "tool_calls"),
+    ]
+    for cap, value, name in checks:
+        if cap is not None and cap > 0 and value >= config.warn_at * cap:
+            pct = round(100 * value / cap)
+            return f"{name} at {pct}% of budget ({value}/{cap}); converge"
+    return None
+
+
+@dataclass(slots=True)
+class GuardrailEngine:
+    """Evaluates guardrails against per-trace state. Holds the OBSERVE-mode would-fire tally."""
+
+    would_fire_counts: dict[Limit, int] = field(default_factory=dict)
+
+    def evaluate(self, state: GuardrailState, config: GuardrailConfig) -> Verdict:
+        """Consult the guardrail. Call BEFORE the next LLM/tool call.
+
+        Raises :class:`CostLimitExceededException` only in GRACEFUL / HARD_STOP modes.
+        """
+        breach = _first_breach(state, config)
+
+        if breach is None:
+            warning = _near_breach(state, config) if config.mode == Mode.WARN else None
+            return Verdict(proceed=True, warning=warning)
+
+        limit, value, cap = breach
+
+        if config.mode == Mode.OBSERVE:
+            self.would_fire_counts[limit] = self.would_fire_counts.get(limit, 0) + 1
+            return Verdict(proceed=True, breached=limit, would_fire=True)
+
+        if config.mode == Mode.WARN:
+            return Verdict(
+                proceed=True,
+                breached=limit,
+                warning=f"guardrail '{limit.value}' exceeded ({value}/{cap})",
+            )
+
+        # GRACEFUL or HARD_STOP — localized exception, never a process kill.
+        raise CostLimitExceededException(limit, value, cap, state.trace_id)

--- a/sdk/python/tests/test_guardrails.py
+++ b/sdk/python/tests/test_guardrails.py
@@ -1,0 +1,99 @@
+import pytest
+
+from tally.guardrails import (
+    CostLimitExceededException,
+    GuardrailConfig,
+    GuardrailEngine,
+    GuardrailState,
+    Limit,
+    Mode,
+)
+
+
+def test_under_limit_proceeds():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=100)
+    cfg = GuardrailConfig(mode=Mode.GRACEFUL, max_cost_micro_usd=1000)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed and v.breached is None
+
+
+def test_observe_never_raises_but_counts():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", step_count=20)
+    cfg = GuardrailConfig(mode=Mode.OBSERVE, max_steps=15)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed is True
+    assert v.would_fire is True
+    assert v.breached is Limit.STEPS
+    assert eng.would_fire_counts[Limit.STEPS] == 1
+
+
+def test_graceful_raises_localized_exception():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="run-1", cumulative_cost_micro_usd=2000)
+    cfg = GuardrailConfig(mode=Mode.GRACEFUL, max_cost_micro_usd=1000)
+    with pytest.raises(CostLimitExceededException) as ei:
+        eng.evaluate(state, cfg)
+    assert ei.value.limit is Limit.COST
+    assert ei.value.trace_id == "run-1"
+
+
+def test_hard_stop_raises():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", tool_call_count=99)
+    cfg = GuardrailConfig(mode=Mode.HARD_STOP, max_tool_calls=10)
+    with pytest.raises(CostLimitExceededException):
+        eng.evaluate(state, cfg)
+
+
+def test_warn_proceeds_with_message():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=1500)
+    cfg = GuardrailConfig(mode=Mode.WARN, max_cost_micro_usd=1000)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed is True
+    assert v.breached is Limit.COST
+    assert "exceeded" in v.warning
+
+
+def test_warn_near_threshold():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", step_count=8)
+    cfg = GuardrailConfig(mode=Mode.WARN, max_steps=10, warn_at=0.8)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed is True
+    assert v.breached is None
+    assert "converge" in v.warning
+
+
+def test_cost_checked_first():
+    eng = GuardrailEngine()
+    state = GuardrailState(
+        trace_id="t", cumulative_cost_micro_usd=5000, step_count=99, tool_call_count=99
+    )
+    cfg = GuardrailConfig(
+        mode=Mode.GRACEFUL, max_cost_micro_usd=1000, max_steps=10, max_tool_calls=10
+    )
+    with pytest.raises(CostLimitExceededException) as ei:
+        eng.evaluate(state, cfg)
+    assert ei.value.limit is Limit.COST
+
+
+def test_state_counters_accumulate():
+    state = GuardrailState(trace_id="t")
+    state.add_cost(100)
+    state.add_cost(50)
+    state.incr_step()
+    state.incr_tool_call()
+    state.incr_tool_call()
+    assert state.cumulative_cost_micro_usd == 150
+    assert state.step_count == 1
+    assert state.tool_call_count == 2
+
+
+def test_no_caps_always_proceeds():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=10**9)
+    v = eng.evaluate(state, GuardrailConfig(mode=Mode.GRACEFUL))
+    assert v.proceed is True


### PR DESCRIPTION
Implements **CTO-51**. Stacked on #5 (base `feat/cto-50-sampling`).

## Summary
- Per-trace `GuardrailState` counters; `GuardrailEngine.evaluate()` consulted before each call.
- Tiers: **OBSERVE** (record would-fire, proceed) → **WARN** (proceed + message, incl. near-threshold nudge) → **GRACEFUL** (raise localized `CostLimitExceededException` for the framework to catch + degrade) → **HARD_STOP** (opt-in).
- Never hard-kills by default; cost checked first; OBSERVE-mode `would_fire_counts` power the "fires/wk" UI.

## Acceptance criteria
- [x] Per-trace counter state machine
- [x] Tiers implemented; localized exception (not a process kill) in GRACEFUL/HARD_STOP
- [x] OBSERVE never raises; would-fire counted
- [x] Single-process documented; v2 trigger is CTO-83

## Out of scope
v2 multi-process shared counter (CTO-83); guardrail config UI (CTO-58); config-cache/local-override (lands with egress/config wiring).

## Test plan
- [x] `ruff` + `pytest` green (48 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)