### PR TITLE
feat(db): otel_spans ClickHouse DDL [CTO-22]

### DIFF
--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -1,0 +1,80 @@
+-- otel_spans — primary span table (ai-tally telemetry store)
+-- Implements CTO-22. Spec §5.1.
+--
+-- Shared multi-tenant cluster (CTO-18): TenantId is FIRST in ORDER BY and is load-bearing —
+-- every read must be tenant-scoped or it scans the whole cluster.
+--
+-- Cost is Decimal64(8) (money, never Float64). Dual-track: EstimatedCost + ReconciledCost +
+-- CostSource. UserIdHashKeyVersion supports HMAC versioned-key rotation (CTO-74).
+-- High-value attributes are promoted to typed columns; the long tail stays in SpanAttributes.
+
+CREATE TABLE IF NOT EXISTS otel_spans
+(
+    TenantId               LowCardinality(String),
+    Timestamp              DateTime64(9)            CODEC(Delta, ZSTD(1)),
+    TraceId                String                   CODEC(ZSTD(1)),
+    SpanId                 String                   CODEC(ZSTD(1)),
+    ParentSpanId           String                   CODEC(ZSTD(1)),
+
+    ServiceName            LowCardinality(String),
+    SpanName               LowCardinality(String),
+    StatusCode             UInt8,
+    DurationNs             UInt64                   CODEC(T64, ZSTD(1)),
+
+    -- Business / attribution
+    FeatureTag             LowCardinality(String),
+    SessionId              String                   CODEC(ZSTD(1)),
+    UserIdHash             FixedString(64)          CODEC(ZSTD(1)),  -- HMAC-SHA256 hex
+    UserIdHashKeyVersion   LowCardinality(String),                  -- HMAC rotation (CTO-74)
+    IdempotencyKey         String                   CODEC(ZSTD(1)),
+
+    -- GenAI core (gen_ai.* semconv)
+    GenAiSystem            LowCardinality(String),
+    GenAiRequestModel      LowCardinality(String),
+    GenAiResponseModel     LowCardinality(String),
+    GenAiOperation         LowCardinality(String),
+    GenAiToolName          LowCardinality(String),
+    InputTokens            UInt32                   CODEC(T64, ZSTD(1)),
+    OutputTokens           UInt32                   CODEC(T64, ZSTD(1)),
+    CachedInputTokens      UInt32                   CODEC(T64, ZSTD(1)),
+
+    -- Cost (dual-track; Decimal64(8), NOT Float64)
+    EstimatedCost          Decimal64(8)             CODEC(ZSTD(1)),
+    ReconciledCost         Nullable(Decimal64(8))   CODEC(ZSTD(1)),
+    CostCurrency           LowCardinality(String),
+    CostSource             Enum8('estimated' = 1, 'reconciled' = 2),
+    PriceCatalogVersion    LowCardinality(String),
+
+    -- Agent context
+    AgentRunId             String                   CODEC(ZSTD(1)),
+    AgentStepIndex         UInt16,
+
+    -- Replay (Workflow 1)
+    ResolvedPromptHash     FixedString(64),
+    ResolvedContextRef     String,
+
+    -- Long tail
+    SpanAttributes         Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    SpanEvents             Array(Tuple(name String, ts DateTime64(9), attrs Map(String, String))),
+
+    -- Sampling
+    SampleRate             Float32 DEFAULT 1.0,
+
+    INDEX idx_trace_id     TraceId                  TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_session_id   SessionId                TYPE bloom_filter(0.01)  GRANULARITY 4,
+    INDEX idx_user_id      UserIdHash               TYPE bloom_filter(0.01)  GRANULARITY 4,
+    INDEX idx_agent_run    AgentRunId               TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_attr_keys    mapKeys(SpanAttributes)  TYPE bloom_filter(0.01)  GRANULARITY 4
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (TenantId, FeatureTag, ServiceName, SpanName, Timestamp)
+-- Tiering: hot SSD -> warm volume at 7d, drop raw spans at 90d.
+-- NOTE: ClickHouse `TTL ... GROUP BY` requires its keys to be a prefix of the primary key, so we
+-- deliberately do NOT aggregate-on-expire here (toDate(Timestamp)/GenAiResponseModel are not a PK
+-- prefix). Long-horizon aggregates live in the rollup materialized views (CTO-24), which persist
+-- independently of this raw table's retention. Storage volumes ('warm') are configured in the
+-- ClickHouse storage policy (infra, CTO-94).
+TTL
+    toDateTime(Timestamp) + INTERVAL 7 DAY  TO VOLUME 'warm',
+    toDateTime(Timestamp) + INTERVAL 90 DAY DELETE;

--- a/sdk/python/tests/test_otel_spans_ddl.py
+++ b/sdk/python/tests/test_otel_spans_ddl.py
@@ -1,0 +1,81 @@
+"""Structural validation of the otel_spans DDL (CTO-22).
+
+We can't stand up ClickHouse in CI here, so this asserts the invariants the spec makes
+load-bearing: TenantId-first ORDER BY, Decimal64 (not Float) cost, dual-track + key-version
+columns, required codecs, and the bloom-filter indexes. A guard against silent schema drift.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DDL_PATH = Path(__file__).resolve().parents[3] / "db" / "clickhouse" / "otel_spans.sql"
+
+
+@pytest.fixture(scope="module")
+def ddl() -> str:
+    assert DDL_PATH.exists(), f"DDL not found at {DDL_PATH}"
+    return DDL_PATH.read_text()
+
+
+@pytest.fixture(scope="module")
+def ddl_code(ddl: str) -> str:
+    """DDL with ``--`` comment lines stripped, so assertions test executable SQL only."""
+    return "\n".join(line for line in ddl.splitlines() if not line.lstrip().startswith("--"))
+
+
+def test_table_created(ddl):
+    assert "CREATE TABLE IF NOT EXISTS otel_spans" in ddl
+
+
+def test_tenant_id_first_in_order_by(ddl):
+    m = re.search(r"ORDER BY \(([^)]*)\)", ddl)
+    assert m, "ORDER BY clause not found"
+    first_key = m.group(1).split(",")[0].strip()
+    assert first_key == "TenantId", f"TenantId must be first in ORDER BY, got {first_key!r}"
+
+
+def test_cost_is_decimal_not_float(ddl):
+    assert "EstimatedCost          Decimal64(8)" in ddl
+    assert "ReconciledCost         Nullable(Decimal64(8))" in ddl
+    assert "EstimatedCost          Float" not in ddl
+
+
+def test_dual_track_and_key_version_columns(ddl):
+    for col in ("CostSource", "PriceCatalogVersion", "UserIdHashKeyVersion"):
+        assert col in ddl, f"missing required column {col}"
+
+
+def test_required_codecs(ddl):
+    assert "CODEC(Delta, ZSTD(1))" in ddl  # timestamp
+    assert "CODEC(T64, ZSTD(1))" in ddl    # token counts
+
+
+def test_bloom_filter_indexes(ddl):
+    for idx in ("idx_trace_id", "idx_session_id", "idx_user_id", "idx_agent_run", "idx_attr_keys"):
+        assert idx in ddl, f"missing index {idx}"
+    assert "bloom_filter(0.001)" in ddl  # tight for trace/agent lookups
+
+
+def test_daily_partition(ddl):
+    assert "PARTITION BY toDate(Timestamp)" in ddl
+
+
+def test_ttl_tiering(ddl):
+    assert "TO VOLUME 'warm'" in ddl   # hot -> warm at 7d
+    assert "INTERVAL 90 DAY DELETE" in ddl  # drop raw at 90d (aggregates live in MVs, CTO-24)
+
+
+def test_no_invalid_ttl_group_by(ddl_code):
+    # Guard against re-introducing a TTL GROUP BY whose keys are not a PK prefix (would fail on a
+    # real cluster). Long-horizon aggregates belong in the rollup MVs (CTO-24), not here.
+    # Checked against comment-stripped SQL so explanatory prose doesn't trip the guard.
+    assert "GROUP BY" not in ddl_code.split("TTL", 1)[-1]
+
+
+def test_balanced_parens(ddl):
+    # cheap sanity check that the statement isn't truncated
+    assert ddl.count("(") == ddl.count(")")


### PR DESCRIPTION
Implements **CTO-22**. Stacked on #7 (base `feat/cto-52-price-catalog`).

## Summary
- `db/clickhouse/otel_spans.sql`: primary span table. TenantId-first ORDER BY, `Decimal64(8)` cost (not Float), dual-track cost + `UserIdHashKeyVersion`, promoted `gen_ai.*` columns + long-tail `SpanAttributes`, required codecs, bloom-filter indexes, daily partition, 7d→warm / 90d→delete TTL.
- Structural validation test (ClickHouse not available in CI).

## Note for reviewer
The spec's `TTL ... GROUP BY` aggregate-on-expire is **not** used: ClickHouse requires its GROUP BY keys to be a primary-key prefix, which `toDate(Timestamp)/GenAiResponseModel` is not — it would fail on a real cluster. Long-horizon aggregates already live in the rollup MVs (CTO-24), so raw spans just delete at 90d. Flagging since it diverges from the spec wording (spec should be updated to match).

## Acceptance criteria
- [x] All promoted columns incl. UserIdHashKeyVersion, dual-track cost
- [x] Decimal64 not Float; codecs; bloom indexes; TenantId-first ORDER BY; daily partition
- [ ] Insert/query smoke test on a real ClickHouse (needs infra, CTO-94) — structural test stands in for CI

## Out of scope
Materialized views (CTO-24/25), resource-group isolation (CTO-30), storage-policy/volume setup (CTO-94).

## Test plan
- [x] `ruff` + `pytest` green (67 tests incl. 10 DDL assertions)
- [ ] CI green; real-ClickHouse apply deferred to infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)