### PR TITLE
feat(sdk): auto-instrumentation — OpenAI [CTO-48]

### DIFF
--- a/sdk/python/src/tally/instrumentation/__init__.py
+++ b/sdk/python/src/tally/instrumentation/__init__.py
@@ -1,0 +1,29 @@
+"""Auto-instrumentation — provider call wrappers that emit conformant spans.
+
+Implements CTO-48 (OpenAI first).
+
+The design is pluggable: a :class:`ProviderInstrumentor` knows how to (a) extract token usage from a
+provider response and (b) name the model/system. Everything else — building the conformant span via
+:mod:`tally.schema`, pricing via :mod:`tally.pricing`, and the never-crash boundary — is shared, so
+adding a new provider is just another extractor (no core change).
+
+Instrumentation must NEVER swallow the provider's own exceptions (the customer needs their real
+API errors). Only *our* span-building runs inside the safety boundary.
+"""
+
+from tally.instrumentation.base import (
+    ProviderInstrumentor,
+    Usage,
+    build_span,
+    wrap_create,
+)
+from tally.instrumentation.openai import OpenAIInstrumentor, instrument_openai_create
+
+__all__ = [
+    "ProviderInstrumentor",
+    "Usage",
+    "build_span",
+    "wrap_create",
+    "OpenAIInstrumentor",
+    "instrument_openai_create",
+]

--- a/sdk/python/src/tally/instrumentation/base.py
+++ b/sdk/python/src/tally/instrumentation/base.py
@@ -1,0 +1,102 @@
+"""Shared instrumentation machinery: provider interface, span builder, call wrapper."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from datetime import date
+from typing import Protocol
+
+from tally.context import current_context
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
+from tally.safety import SelfObservability, safe_block
+from tally.schema import SpanFields, build_span_attributes
+
+
+class ProviderInstrumentor(Protocol):
+    """Per-provider knowledge. Pure functions over a provider response object."""
+
+    system: str
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None: ...
+    def response_model(self, response: object) -> str | None: ...
+    def extract_usage(self, response: object) -> Usage: ...
+
+
+def build_span(
+    instrumentor: ProviderInstrumentor,
+    *,
+    args: tuple,
+    kwargs: dict,
+    response: object,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    at: date | None = None,
+) -> dict[str, object]:
+    """Build a conformant span attribute dict from a provider response.
+
+    Pulls feature_tag/session from the active trace context, computes cost from the catalog (if
+    given), and returns attributes guaranteed to pass ``validate_span_attributes``.
+    """
+    usage = instrumentor.extract_usage(response)
+    req_model = instrumentor.request_model(args, kwargs)
+    resp_model = instrumentor.response_model(response) or req_model
+    ctx = current_context()
+
+    cost_micro: int | None = None
+    catalog_version: str | None = None
+    if catalog is not None and resp_model:
+        cost_micro, version = compute_cost_micro_usd(
+            catalog, instrumentor.system, resp_model, usage, at=at, tenant_id=tenant_id
+        )
+        catalog_version = version or None
+
+    fields = SpanFields(
+        system=instrumentor.system,
+        request_model=req_model,
+        response_model=resp_model,
+        operation="chat",
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cached_input_tokens=usage.cached_input_tokens or None,
+        cost_estimated_micro_usd=cost_micro,
+        price_catalog_version=catalog_version,
+        feature_tag=ctx.feature_tag,
+        session_id=ctx.session_id,
+    )
+    return build_span_attributes(fields)
+
+
+def wrap_create(
+    create_fn: Callable[..., object],
+    instrumentor: ProviderInstrumentor,
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+) -> Callable[..., object]:
+    """Wrap a provider ``create``-style callable so each successful call emits a span.
+
+    The provider call itself is NOT guarded — its exceptions propagate to the caller unchanged.
+    Only span building + ``on_span`` run inside the safety boundary, so instrumentation can never
+    break the customer's call.
+    """
+    observ = obs or SelfObservability()
+
+    @functools.wraps(create_fn)
+    def wrapper(*args, **kwargs):
+        response = create_fn(*args, **kwargs)  # provider errors propagate — by design
+        with safe_block(observ, where=f"instrument.{instrumentor.system}"):
+            attrs = build_span(
+                instrumentor,
+                args=args,
+                kwargs=kwargs,
+                response=response,
+                catalog=catalog,
+                tenant_id=tenant_id,
+            )
+            on_span(attrs)
+        return response
+
+    return wrapper

--- a/sdk/python/src/tally/instrumentation/openai.py
+++ b/sdk/python/src/tally/instrumentation/openai.py
@@ -1,0 +1,74 @@
+"""OpenAI instrumentor — extracts usage from a Chat Completions response.
+
+Works with both the SDK's object responses and plain dicts, so it can be tested with a fake client
+and no network. Reads ``usage.prompt_tokens`` / ``usage.completion_tokens`` and
+``usage.prompt_tokens_details.cached_tokens`` when present.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tally.instrumentation.base import ProviderInstrumentor, wrap_create
+from tally.pricing import PriceCatalog, Usage
+from tally.safety import SelfObservability
+
+
+def _get(obj: object, key: str, default: object = None) -> object:
+    """Attribute-or-key accessor (supports SDK objects and dicts)."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+class OpenAIInstrumentor:
+    system = "openai"
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None:
+        return kwargs.get("model")
+
+    def response_model(self, response: object) -> str | None:
+        model = _get(response, "model")
+        return model if isinstance(model, str) else None
+
+    def extract_usage(self, response: object) -> Usage:
+        usage = _get(response, "usage")
+        prompt = int(_get(usage, "prompt_tokens", 0) or 0)
+        completion = int(_get(usage, "completion_tokens", 0) or 0)
+        details = _get(usage, "prompt_tokens_details")
+        cached = int(_get(details, "cached_tokens", 0) or 0)
+        return Usage(
+            input_tokens=prompt, output_tokens=completion, cached_input_tokens=cached
+        )
+
+
+# satisfy the Protocol at import time (structural; this is a no-op assertion for readers)
+_INSTRUMENTOR: ProviderInstrumentor = OpenAIInstrumentor()
+
+
+def instrument_openai_create(
+    create_fn: Callable[..., object],
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+) -> Callable[..., object]:
+    """Wrap ``client.chat.completions.create`` so each call emits a conformant span.
+
+    Example::
+
+        client.chat.completions.create = instrument_openai_create(
+            client.chat.completions.create, on_span=tally_client.ingest_span, catalog=catalog
+        )
+    """
+    return wrap_create(
+        create_fn,
+        OpenAIInstrumentor(),
+        on_span=on_span,
+        obs=obs,
+        catalog=catalog,
+        tenant_id=tenant_id,
+    )

--- a/sdk/python/tests/test_instrumentation.py
+++ b/sdk/python/tests/test_instrumentation.py
@@ -1,0 +1,106 @@
+"""CTO-48 — OpenAI auto-instrumentation, tested with a fake client (no network)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tally.context import with_trace_context
+from tally.instrumentation import instrument_openai_create
+from tally.instrumentation.openai import OpenAIInstrumentor
+from tally.pricing import seed_catalog
+from tally.schema import GenAI, validate_span_attributes
+
+
+# --- fake OpenAI response objects ---
+@dataclass
+class _Details:
+    cached_tokens: int = 0
+
+
+@dataclass
+class _Usage:
+    prompt_tokens: int
+    completion_tokens: int
+    prompt_tokens_details: _Details | None = None
+
+
+@dataclass
+class _Resp:
+    model: str
+    usage: _Usage
+
+
+def _fake_create(*, model, cached=0, prompt=1000, completion=500, **_):
+    return _Resp(model=model, usage=_Usage(prompt, completion, _Details(cached)))
+
+
+def test_extract_usage_object_and_dict():
+    inst = OpenAIInstrumentor()
+    obj = _Resp("gpt-5-mini", _Usage(10, 20, _Details(4)))
+    u = inst.extract_usage(obj)
+    assert (u.input_tokens, u.output_tokens, u.cached_input_tokens) == (10, 20, 4)
+
+    as_dict = {"model": "gpt-5-mini", "usage": {"prompt_tokens": 7, "completion_tokens": 3}}
+    u2 = inst.extract_usage(as_dict)
+    assert (u2.input_tokens, u2.output_tokens) == (7, 3)
+
+
+def test_wrap_emits_conformant_span_with_cost():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(
+        _fake_create, on_span=spans.append, catalog=seed_catalog()
+    )
+    resp = wrapped(model="gpt-5-mini", prompt=1_000_000, completion=1_000_000)
+    assert isinstance(resp, _Resp)  # original response returned unchanged
+    assert len(spans) == 1
+    attrs = spans[0]
+    assert validate_span_attributes(attrs) == []
+    assert attrs[GenAI.SYSTEM] == "openai"
+    assert attrs[GenAI.USAGE_INPUT_TOKENS] == 1_000_000
+    # 0.25 + 2.00 USD = 2_250_000 micro
+    assert attrs[GenAI.COST_ESTIMATED_MICRO_USD] == 2_250_000
+
+
+def test_feature_tag_from_context():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(_fake_create, on_span=spans.append, catalog=seed_catalog())
+    with with_trace_context(trace_id="t1", feature_tag="research", session_id="s1"):
+        wrapped(model="gpt-5-mini")
+    assert spans[0][GenAI.FEATURE_TAG] == "research"
+    assert spans[0][GenAI.SESSION_ID] == "s1"
+
+
+def test_provider_errors_propagate():
+    def boom(**_):
+        raise RuntimeError("openai 500")
+
+    wrapped = instrument_openai_create(boom, on_span=lambda a: None)
+    with pytest.raises(RuntimeError, match="openai 500"):
+        wrapped(model="gpt-5-mini")
+
+
+def test_faulty_on_span_never_breaks_call():
+    def bad_sink(_attrs):
+        raise ValueError("sink boom")
+
+    wrapped = instrument_openai_create(_fake_create, on_span=bad_sink, catalog=seed_catalog())
+    # instrumentation must not break the provider call
+    resp = wrapped(model="gpt-5-mini")
+    assert isinstance(resp, _Resp)
+
+
+def test_no_catalog_means_no_cost():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(_fake_create, on_span=spans.append)  # no catalog
+    wrapped(model="gpt-5-mini")
+    assert GenAI.COST_ESTIMATED_MICRO_USD not in spans[0]
+
+
+def test_cached_tokens_priced_cheaper():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(_fake_create, on_span=spans.append, catalog=seed_catalog())
+    wrapped(model="gpt-5-mini", prompt=1_000_000, completion=0, cached=1_000_000)
+    # all input cached → 0.025 USD = 25_000 micro
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] == 25_000


### PR DESCRIPTION
Implements **CTO-48** (OpenAI first). Stacked on #9 (base `feat/cto-49-egress`).

## Summary
- `instrumentation/base.py`: `ProviderInstrumentor` protocol + shared `build_span()` (feature_tag/session from context, cost via catalog) + `wrap_create()`.
- `instrumentation/openai.py`: `OpenAIInstrumentor` (usage incl. cached_tokens; object or dict) + `instrument_openai_create()`.
- Pluggable — a new provider is just another extractor, no core change.

## Acceptance criteria
- [x] OpenAI wrapper emits a conformant span (validates clean) using schema + pricing
- [x] Pluggable provider interface
- [x] Provider exceptions propagate; faulty `on_span` never breaks the call (never-crash invariant)
- [x] Tested with a fake client, no network

## Out of scope
Anthropic/Vertex/framework instrumentors (follow-ups); real `openai` dependency (works against duck-typed responses).

## Test plan
- [x] `ruff` + `pytest` green (85 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)