### PR TITLE
feat(sdk): integrate spine into record_llm_call() [CTO-9]

### DIFF
--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -1,23 +1,30 @@
-"""TallyClient — the SDK entrypoint skeleton.
+"""TallyClient — the SDK entrypoint.
 
-Minimal, safe-by-construction surface (CTO-45). Every public method runs inside the safety
-boundary so a bug in the SDK — or in a pluggable exporter — never escapes into the customer's
-code path. Real export/batching lands in CTO-49; for now spans accumulate in an in-memory sink so
-the boundary behavior is observable and testable.
+Ties the spine together: schema (CTO-47) + safety (CTO-45) + context (CTO-46) + sampling (CTO-50)
++ pricing (CTO-52) + egress (CTO-49), with a cohesive high-level ``record_llm_call()`` API.
+
+Every public method runs inside the safety boundary so a bug in the SDK — or a pluggable
+exporter/transport — never escapes into the customer's code path. Guardrail *enforcement* is the
+one intentional exception and lives behind :meth:`guard` (it may raise, by design, for the agent
+framework to catch); ``record_llm_call`` itself never raises.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
 from typing import Protocol
 
+from tally.context import current_context, note_context_drop
+from tally.egress import BatchProcessor
+from tally.guardrails import GuardrailConfig, GuardrailEngine, GuardrailState, Verdict
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
 from tally.safety import SelfObservability, safe
+from tally.sampling import BillingMeter, Sampler, TraceSignals
 from tally.schema import SpanFields, build_span_attributes
 
 
 class Exporter(Protocol):
-    """Pluggable span sink. Implementations may raise — the client must absorb it."""
-
     def export(self, attributes: dict[str, object]) -> None: ...
 
 
@@ -31,14 +38,26 @@ class MemoryExporter:
         self.spans.append(attributes)
 
 
+@dataclass(frozen=True, slots=True)
+class LlmCallResult:
+    trace_id: str | None
+    cost_micro_usd: int | None
+    kept: bool
+    sample_rate: float
+    attributes: dict[str, object]
+
+
 class TallyClient:
     """Customer-facing entrypoint.
 
     Args:
-        api_key: tenant-scoped key (unused until egress lands; stored for later).
-        endpoint: ingest endpoint (unused until egress lands).
-        exporter: pluggable sink; defaults to an in-memory exporter.
-        observability: optional shared :class:`SelfObservability`.
+        api_key / endpoint: stored for egress wiring.
+        exporter: simple span sink (used when no ``processor`` is given).
+        processor: :class:`BatchProcessor` for real egress (buffer/batch/backoff). Takes
+            precedence over ``exporter`` when both are set.
+        catalog: price catalog for server-agnostic cost estimation.
+        sampler / billing_meter / guardrails: spine components (sensible defaults).
+        tenant_id: for per-tenant price overrides.
     """
 
     def __init__(
@@ -47,31 +66,133 @@ class TallyClient:
         endpoint: str | None = None,
         *,
         exporter: Exporter | None = None,
+        processor: BatchProcessor | None = None,
+        catalog: PriceCatalog | None = None,
+        sampler: Sampler | None = None,
+        billing_meter: BillingMeter | None = None,
+        guardrails: GuardrailEngine | None = None,
         observability: SelfObservability | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         self.obs = observability or SelfObservability()
         self._api_key = api_key
         self._endpoint = endpoint
+        self._processor = processor
         self._exporter: Exporter = exporter or MemoryExporter()
+        self.catalog = catalog
+        self.sampler = sampler or Sampler()
+        self.billing = billing_meter or BillingMeter()
+        self.guardrails = guardrails or GuardrailEngine()
+        self.tenant_id = tenant_id
 
     @property
     def observability(self) -> SelfObservability:
         return self.obs
 
+    # --- low-level: record a pre-built span ---
     def record_span(self, fields: SpanFields) -> None:
-        """Record one span. Never raises — a faulty exporter or builder is absorbed."""
-        self._record_span_impl(fields)
+        """Record one span from explicit fields. Never raises."""
 
-    # Wrapped so any failure (build or export) is recorded and swallowed.
-    def _record_span_impl(self, fields: SpanFields) -> None:
         @safe(self.obs, where="TallyClient.record_span")
         def _do() -> None:
-            attrs = build_span_attributes(fields)
-            self._exporter.export(attrs)
+            self._emit(build_span_attributes(fields))
 
         _do()
 
+    def ingest_span(self, attributes: dict[str, object]) -> None:
+        """Sink for instrumentation (CTO-48 ``on_span``). Never raises."""
 
-def make_client(record_fn_factory: Callable[[], Exporter] | None = None) -> TallyClient:
-    """Convenience constructor used in tests/examples."""
-    return TallyClient(exporter=record_fn_factory() if record_fn_factory else None)
+        @safe(self.obs, where="TallyClient.ingest_span")
+        def _do() -> None:
+            self._emit(attributes)
+
+        _do()
+
+    # --- high-level: record an LLM call (cost + sampling + billing + egress) ---
+    def record_llm_call(
+        self,
+        *,
+        provider: str,
+        model: str,
+        usage: Usage,
+        signals: TraceSignals | None = None,
+        at: date | None = None,
+    ) -> LlmCallResult:
+        """Record an LLM call end-to-end. Never raises.
+
+        Steps (all inside the safety boundary):
+          1. read trace context (note a drop if no active trace),
+          2. count the trace for billing at HEAD (before sampling),
+          3. estimate cost from the catalog,
+          4. build a conformant span,
+          5. make the sampling decision; emit the span only if kept,
+          6. return a :class:`LlmCallResult` for the caller.
+        """
+
+        @safe(self.obs, where="TallyClient.record_llm_call", fallback=None)
+        def _do() -> LlmCallResult:
+            ctx = current_context()
+            trace_id = ctx.trace_id
+            if trace_id is None:
+                note_context_drop(self.obs, where="record_llm_call")
+
+            # Billing counts at HEAD, before sampling (CTO-50/CTO-84).
+            if trace_id is not None:
+                self.billing.count_trace(trace_id)
+
+            cost_micro: int | None = None
+            catalog_version: str | None = None
+            if self.catalog is not None:
+                cost_micro, version = compute_cost_micro_usd(
+                    self.catalog, provider, model, usage, at=at, tenant_id=self.tenant_id
+                )
+                catalog_version = version or None
+
+            decision = self.sampler.decide(
+                trace_id or "no-trace", signals, feature_tag=ctx.feature_tag
+            )
+
+            fields = SpanFields(
+                system=provider,
+                request_model=model,
+                response_model=model,
+                operation="chat",
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cached_input_tokens=usage.cached_input_tokens or None,
+                cost_estimated_micro_usd=cost_micro,
+                price_catalog_version=catalog_version,
+                feature_tag=ctx.feature_tag,
+                session_id=ctx.session_id,
+            )
+            attrs = build_span_attributes(fields)
+            # NB: sample_rate travels at the batch level (wire Sampling, §12.2), not as a span
+            # attribute — so the span stays schema-conformant. It's returned in the result.
+            if decision.keep:
+                self._emit(attrs)
+
+            return LlmCallResult(
+                trace_id=trace_id,
+                cost_micro_usd=cost_micro,
+                kept=decision.keep,
+                sample_rate=decision.sample_rate,
+                attributes=attrs,
+            )
+
+        result = _do()
+        if result is None:  # boundary swallowed an error; return a benign result
+            return LlmCallResult(None, None, False, 1.0, {})
+        return result
+
+    # --- guardrails (may raise, by design — pre-call check) ---
+    def guard(self, state: GuardrailState, config: GuardrailConfig) -> Verdict:
+        """Consult guardrails before the next call. May raise CostLimitExceededException in
+        GRACEFUL/HARD_STOP modes — that propagation is intentional (the agent framework catches it
+        and degrades). Not wrapped in the safety boundary."""
+        return self.guardrails.evaluate(state, config)
+
+    def _emit(self, attributes: dict[str, object]) -> None:
+        if self._processor is not None:
+            self._processor.enqueue(attributes)
+        else:
+            self._exporter.export(attributes)

--- a/sdk/python/tests/test_integration.py
+++ b/sdk/python/tests/test_integration.py
@@ -1,0 +1,106 @@
+"""End-to-end integration: start_trace -> record_llm_call -> conformant span with cost."""
+
+from __future__ import annotations
+
+from tally.client import MemoryExporter, TallyClient
+from tally.context import start_trace, with_trace_context
+from tally.egress import BatchProcessor, MemoryTransport
+from tally.guardrails import CostLimitExceededException, GuardrailConfig, GuardrailState, Mode
+from tally.pricing import Usage, seed_catalog
+from tally.sampling import Sampler, SamplingConfig, TraceSignals
+from tally.schema import GenAI, validate_span_attributes
+
+
+def _client(**kw):
+    return TallyClient(catalog=seed_catalog(), **kw)
+
+
+def test_end_to_end_emits_conformant_span_with_cost():
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t1", feature_tag="research", session_id="s1"):
+        result = client.record_llm_call(
+            provider="openai",
+            model="gpt-5-mini",
+            usage=Usage(input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+    assert result.kept is True
+    assert result.cost_micro_usd == 2_250_000
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    assert span[GenAI.FEATURE_TAG] == "research"
+    assert span[GenAI.COST_ESTIMATED_MICRO_USD] == 2_250_000
+
+
+def test_billing_counts_at_head_even_when_dropped():
+    # body_rate 0 → analytics drops everything, billing still counts
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=0.0)))
+    with start_trace(feature_tag="f"):
+        r = client.record_llm_call(
+            provider="openai", model="gpt-5-mini", usage=Usage(100, 50)
+        )
+    assert r.kept is False
+    assert client.billing.trace_count == 1
+
+
+def test_tail_kept_body_dropped():
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=0.0)))
+    with with_trace_context(trace_id="agent-1"):
+        r = client.record_llm_call(
+            provider="openai", model="gpt-5", usage=Usage(10, 10),
+            signals=TraceSignals(is_agent=True),  # tail → kept
+        )
+    assert r.kept is True
+    assert len(exporter.spans) == 1
+
+
+def test_records_via_processor_egress():
+    transport = MemoryTransport()
+    proc = BatchProcessor(transport, max_batch_size=10)
+    client = _client(processor=proc, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with start_trace():
+        client.record_llm_call(provider="openai", model="gpt-5-mini", usage=Usage(10, 5))
+    assert proc.pending() == 1
+    proc.flush_once()
+    assert len(transport.delivered) == 1
+
+
+def test_no_active_trace_notes_drop_but_does_not_raise():
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    r = client.record_llm_call(provider="openai", model="gpt-5-mini", usage=Usage(10, 5))
+    assert r.trace_id is None
+    assert client.observability.context_drop_count == 1
+
+
+def test_record_never_raises_on_bad_catalog():
+    # a catalog whose lookup explodes must not break record_llm_call
+    class BoomCatalog:
+        def lookup(self, *a, **k):
+            raise RuntimeError("catalog down")
+
+    client = TallyClient(catalog=BoomCatalog(), sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with start_trace():
+        r = client.record_llm_call(provider="openai", model="gpt-5-mini", usage=Usage(10, 5))
+    # boundary returns a benign result; error counted
+    assert client.observability.internal_error_count == 1
+    assert r.kept is False
+
+
+def test_guard_raises_in_graceful_mode():
+    client = _client()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=5000)
+    cfg = GuardrailConfig(mode=Mode.GRACEFUL, max_cost_micro_usd=1000)
+    try:
+        client.guard(state, cfg)
+        raise AssertionError("expected CostLimitExceededException")
+    except CostLimitExceededException:
+        pass
+
+
+def test_guard_observe_mode_proceeds():
+    client = _client()
+    state = GuardrailState(trace_id="t", step_count=99)
+    v = client.guard(state, GuardrailConfig(mode=Mode.OBSERVE, max_steps=10))
+    assert v.proceed is True and v.would_fire is True


### PR DESCRIPTION
Integration PR (epic **CTO-9**). Stacked on #10 (base `feat/cto-48-instrumentation`).

Ties the spine modules into one high-level API.

## Summary
- `TallyClient.record_llm_call(...)`: context → **billing count at head** → cost estimate → conformant span → sampling decision → emit-if-kept → `LlmCallResult`. Never raises.
- `ingest_span()`: sink for CTO-48 instrumentation `on_span`.
- `guard()`: pre-call guardrail check that **may raise by design** (graceful/hard-stop), deliberately outside the safety boundary.
- `_emit` routes to a `BatchProcessor` (egress) when set, else the exporter.

## Acceptance criteria
- [x] start_trace → record → exporter sees a conformant span with cost (e2e test)
- [x] Billing counts at head even when analytics drops the trace
- [x] Tail kept / body dropped honored; processor egress path works
- [x] Never-crash invariant holds (a catalog that explodes is absorbed + counted)
- [x] `guard()` raises in graceful mode; observe proceeds

## Out of scope
Real gRPC transport; wire-level batch Sampling field (carried in the protocol, CTO-32).

## Test plan
- [x] `ruff` + `pytest` green (93 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)