### PR TITLE
feat(sdk): price scraper scaffold — fetchers, diff, review gate [CTO-53]

### DIFF
--- a/sdk/python/src/tally/pricing_scraper.py
+++ b/sdk/python/src/tally/pricing_scraper.py
@@ -1,0 +1,125 @@
+"""Price scraper scaffold — pluggable fetchers, diff, and a human-review gate.
+
+Implements CTO-53.
+
+A stale catalog silently corrupts every cost number, so price updates are:
+1. fetched from pluggable per-provider :class:`PriceFetcher` sources into a *candidate* version,
+2. diffed against the current catalog,
+3. published only behind an explicit human :class:`Approval` (the review gate). New versions are
+   additive — old versions are retained so historical cost stays recomputable (CTO-52).
+
+This is the scaffold (the actual scraping of provider pages lives in concrete fetchers); tested
+here with a fake fetcher.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Protocol
+
+from tally.pricing import PriceCatalog, PriceEntry
+
+
+class PriceFetcher(Protocol):
+    """A source of candidate prices for one provider. Implementations do the actual scraping."""
+
+    provider: str
+
+    def fetch(self, *, version: str, valid_from: date) -> list[PriceEntry]: ...
+
+
+def _key(e: PriceEntry) -> tuple[str, str, str]:
+    return (e.provider, e.model, e.price_type.value)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogDiff:
+    added: list[PriceEntry] = field(default_factory=list)
+    changed: list[tuple[PriceEntry, PriceEntry]] = field(default_factory=list)  # (old, new)
+    removed: list[PriceEntry] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.added or self.changed or self.removed)
+
+    @property
+    def magnitude(self) -> int:
+        return len(self.added) + len(self.changed) + len(self.removed)
+
+
+def diff_entries(current: list[PriceEntry], candidate: list[PriceEntry]) -> CatalogDiff:
+    """Diff candidate vs. current by (provider, model, price_type)."""
+    cur = {_key(e): e for e in current}
+    cand = {_key(e): e for e in candidate}
+    added = [cand[k] for k in cand.keys() - cur.keys()]
+    removed = [cur[k] for k in cur.keys() - cand.keys()]
+    changed = [
+        (cur[k], cand[k])
+        for k in cur.keys() & cand.keys()
+        if cur[k].price_per_unit != cand[k].price_per_unit
+    ]
+    return CatalogDiff(added=added, changed=changed, removed=removed)
+
+
+@dataclass(frozen=True, slots=True)
+class Approval:
+    approved: bool
+    reviewer: str = ""
+    #: explicit acknowledgement required when a diff exceeds ``large_diff_threshold``
+    ack_large_diff: bool = False
+
+
+class PriceReviewError(Exception):
+    """Raised when a candidate cannot be published under the review gate."""
+
+
+@dataclass(slots=True)
+class PriceScraper:
+    """Runs fetchers, proposes a diff, and publishes behind a review gate."""
+
+    fetchers: list[PriceFetcher]
+    large_diff_threshold: int = 10
+
+    def build_candidate(self, *, version: str, valid_from: date) -> list[PriceEntry]:
+        """Fetch all sources into a candidate set tagged with ``version``.
+
+        A fetcher that raises does not abort the run — its failure is skipped (and the missing
+        provider simply isn't updated). Callers should monitor for missing providers.
+        """
+        out: list[PriceEntry] = []
+        for f in self.fetchers:
+            try:
+                out.extend(f.fetch(version=version, valid_from=valid_from))
+            except Exception:  # noqa: BLE001 - one bad source shouldn't sink the run
+                continue
+        return out
+
+    def propose(self, current: PriceCatalog, candidate: list[PriceEntry]) -> CatalogDiff:
+        # diff against the catalog's public entries (latest of each key, regardless of version)
+        current_entries = list(current._entries)  # noqa: SLF001 - same package
+        return diff_entries(current_entries, candidate)
+
+    def publish(
+        self,
+        current: PriceCatalog,
+        candidate: list[PriceEntry],
+        approval: Approval,
+    ) -> CatalogDiff:
+        """Publish the candidate into ``current`` (additive) iff approved.
+
+        Raises :class:`PriceReviewError` when not approved, or when the diff is large and the
+        reviewer didn't explicitly acknowledge it.
+        """
+        diff = self.propose(current, candidate)
+        if diff.is_empty:
+            return diff
+        if not approval.approved:
+            raise PriceReviewError("candidate not approved by a reviewer")
+        if diff.magnitude > self.large_diff_threshold and not approval.ack_large_diff:
+            raise PriceReviewError(
+                f"large diff ({diff.magnitude} changes) requires ack_large_diff=True"
+            )
+        for entry in candidate:
+            current.add(entry)  # additive: old versions retained
+        return diff

--- a/sdk/python/tests/test_pricing_scraper.py
+++ b/sdk/python/tests/test_pricing_scraper.py
@@ -1,0 +1,116 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tally.pricing import PriceCatalog, PriceEntry, PriceType, Unit
+from tally.pricing_scraper import (
+    Approval,
+    PriceReviewError,
+    PriceScraper,
+    diff_entries,
+)
+
+
+def _e(model, pt, rate, version="v2", valid_from=date(2026, 6, 1)):
+    return PriceEntry(
+        version=version,
+        valid_from=valid_from,
+        provider="openai",
+        model=model,
+        price_type=pt,
+        unit=Unit.PER_MILLION_TOKENS,
+        price_per_unit=Decimal(rate),
+    )
+
+
+class FakeFetcher:
+    provider = "openai"
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def fetch(self, *, version, valid_from):
+        # re-tag with the requested version
+        return [
+            PriceEntry(
+                version=version,
+                valid_from=valid_from,
+                provider=e.provider,
+                model=e.model,
+                price_type=e.price_type,
+                unit=e.unit,
+                price_per_unit=e.price_per_unit,
+            )
+            for e in self._entries
+        ]
+
+
+class BoomFetcher:
+    provider = "broken"
+
+    def fetch(self, *, version, valid_from):
+        raise RuntimeError("scrape failed")
+
+
+def test_diff_detects_added_changed_removed():
+    current = [_e("a", PriceType.INPUT, "1.0"), _e("gone", PriceType.INPUT, "9.0")]
+    candidate = [_e("a", PriceType.INPUT, "2.0"), _e("new", PriceType.OUTPUT, "5.0")]
+    d = diff_entries(current, candidate)
+    assert [x.model for x in d.added] == ["new"]
+    assert [x.model for x in d.removed] == ["gone"]
+    assert len(d.changed) == 1 and d.changed[0][0].model == "a"
+    assert d.magnitude == 3
+
+
+def test_build_candidate_skips_failing_fetcher():
+    scraper = PriceScraper([FakeFetcher([_e("a", PriceType.INPUT, "1.0")]), BoomFetcher()])
+    cand = scraper.build_candidate(version="v2", valid_from=date(2026, 6, 1))
+    assert len(cand) == 1
+    assert cand[0].version == "v2"
+
+
+def test_publish_requires_approval():
+    cat = PriceCatalog([_e("a", PriceType.INPUT, "1.0", version="v1")])
+    scraper = PriceScraper([])
+    candidate = [_e("a", PriceType.INPUT, "2.0", version="v2")]
+    with pytest.raises(PriceReviewError, match="not approved"):
+        scraper.publish(cat, candidate, Approval(approved=False))
+
+
+def test_publish_additive_when_approved():
+    # current is an older version; candidate has a later valid_from (newest wins on lookup)
+    cat = PriceCatalog(
+        [_e("a", PriceType.INPUT, "1.0", version="v1", valid_from=date(2026, 5, 1))]
+    )
+    scraper = PriceScraper([])
+    candidate = [_e("a", PriceType.INPUT, "2.0", version="v2", valid_from=date(2026, 6, 1))]
+    diff = scraper.publish(cat, candidate, Approval(approved=True, reviewer="me"))
+    assert len(diff.changed) == 1
+    # additive: newest valid_from wins on lookup, old version retained
+    hit = cat.lookup("openai", "a", PriceType.INPUT, at=date(2026, 7, 1))
+    assert hit.price_per_unit == Decimal("2.0")
+
+
+def test_large_diff_requires_ack():
+    cat = PriceCatalog()
+    scraper = PriceScraper([], large_diff_threshold=2)
+    candidate = [
+        _e("m1", PriceType.INPUT, "1"),
+        _e("m2", PriceType.INPUT, "1"),
+        _e("m3", PriceType.INPUT, "1"),
+    ]
+    with pytest.raises(PriceReviewError, match="large diff"):
+        scraper.publish(cat, candidate, Approval(approved=True))
+    # with ack it goes through
+    diff = scraper.publish(cat, candidate, Approval(approved=True, ack_large_diff=True))
+    assert diff.magnitude == 3
+
+
+def test_empty_diff_is_noop():
+    cat = PriceCatalog([_e("a", PriceType.INPUT, "1.0", version="v1")])
+    scraper = PriceScraper([])
+    # identical price → empty diff → publish is a no-op even without approval
+    candidate = [_e("a", PriceType.INPUT, "1.0", version="v2")]
+    diff = scraper.publish(cat, candidate, Approval(approved=False))
+    assert diff.is_empty


### PR DESCRIPTION
Implements **CTO-53**. Stacked on #11 (base `feat/integration-record-llm-call`).

## Summary
- `PriceFetcher` protocol — pluggable per-provider scraping sources.
- `diff_entries()` / `CatalogDiff` — added/changed/removed by (provider, model, price_type).
- `PriceScraper.build_candidate()` — runs fetchers; a failing source is skipped, not fatal.
- `publish()` — additive (old versions retained for recompute) behind a human `Approval`; large diffs require explicit `ack_large_diff`.

## Acceptance criteria
- [x] Daily-scrape shape: fetch → candidate version
- [x] Diff vs. current surfaced; publish requires approval (review gate)
- [x] New version additive (old retained)
- [x] Failing/large-diff handling (skip bad source; large diff needs ack)

## Out of scope
Concrete provider scrapers + the scheduled job (infra); catalog table (CTO-52, merged below). Numbers come from real fetchers later.

## Test plan
- [x] `ruff` + `pytest` green (99 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)