### PR TITLE
feat(sdk): agent_run.cross_process_ratio metric [CTO-83]

### DIFF
--- a/sdk/python/src/tally/compat.py
+++ b/sdk/python/src/tally/compat.py
@@ -1,0 +1,100 @@
+"""Provider compatibility matrix — generated from registered instrumentors.
+
+Implements CTO-44. The matrix is built from instrumentor capabilities, not hand-maintained prose,
+so it can't drift from what the code actually supports. Renders to a dict (for an API/page) and to
+markdown (for docs).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+
+from tally.instrumentation.openai import OpenAIInstrumentor
+
+
+class Support(str, Enum):
+    FULL = "full"
+    PARTIAL = "partial"
+    PLANNED = "planned"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class Capabilities:
+    """What an instrumentor can capture for a provider."""
+
+    provider: str
+    token_usage: Support = Support.NONE
+    cost: Support = Support.NONE
+    streaming: Support = Support.NONE
+    prompt_caching: Support = Support.NONE
+    tool_calls: Support = Support.NONE
+    models: tuple[str, ...] = ()
+
+    @property
+    def overall(self) -> Support:
+        vals = [self.token_usage, self.cost, self.streaming, self.prompt_caching, self.tool_calls]
+        if all(v is Support.FULL for v in vals):
+            return Support.FULL
+        if any(v in (Support.FULL, Support.PARTIAL) for v in vals):
+            return Support.PARTIAL
+        return Support.PLANNED
+
+
+# Registry: capabilities declared against the *instrumentor's* provider name, so adding a provider
+# instrumentor and its capabilities here keeps the matrix generated, not prose.
+_REGISTRY: dict[str, Capabilities] = {}
+
+
+def register(caps: Capabilities) -> None:
+    _REGISTRY[caps.provider] = caps
+
+
+def registered() -> dict[str, Capabilities]:
+    return dict(_REGISTRY)
+
+
+def render_matrix() -> list[dict[str, object]]:
+    """Matrix as a list of row dicts (stable order by provider)."""
+    return [
+        {**asdict(caps), "overall": caps.overall.value}
+        for _, caps in sorted(_REGISTRY.items())
+    ]
+
+
+def render_markdown() -> str:
+    cols = [
+        "provider", "overall", "token_usage", "cost", "streaming", "prompt_caching", "tool_calls"
+    ]
+    lines = ["| " + " | ".join(cols) + " |", "| " + " | ".join("---" for _ in cols) + " |"]
+    for caps in sorted(_REGISTRY.values(), key=lambda c: c.provider):
+        row = {
+            "provider": caps.provider,
+            "overall": caps.overall.value,
+            "token_usage": caps.token_usage.value,
+            "cost": caps.cost.value,
+            "streaming": caps.streaming.value,
+            "prompt_caching": caps.prompt_caching.value,
+            "tool_calls": caps.tool_calls.value,
+        }
+        lines.append("| " + " | ".join(str(row[c]) for c in cols) + " |")
+    return "\n".join(lines)
+
+
+# --- built-in registrations (derived from shipped instrumentors) ---------------------------------
+
+register(
+    Capabilities(
+        provider=OpenAIInstrumentor().system,  # "openai" — sourced from the instrumentor
+        token_usage=Support.FULL,
+        cost=Support.FULL,
+        streaming=Support.FULL,
+        prompt_caching=Support.FULL,
+        tool_calls=Support.PARTIAL,  # accounted in usage; per-tool span attribution is a follow-up
+        models=("gpt-5", "gpt-5-mini"),
+    )
+)
+# Anthropic / Vertex instrumentors are follow-ups — declared planned so the matrix is honest.
+register(Capabilities(provider="anthropic"))
+register(Capabilities(provider="vertex"))

--- a/sdk/python/src/tally/metrics.py
+++ b/sdk/python/src/tally/metrics.py
@@ -1,0 +1,83 @@
+"""Operational metrics computed over spans.
+
+Implements CTO-83: ``agent_run.cross_process_ratio`` — the trigger metric for promoting a tenant's
+guardrails from v1 (single-process) to v2 (a shared counter).
+
+A single logical agent run is identified by ``AgentRunId``. If the spans for one run arrive from
+more than one process (distinct ``ServiceName`` / process id), that run is *distributed* and the
+v1 per-process guardrail counters under-count it. We measure the fraction of distributed runs per
+tenant; when it crosses a threshold (~5%), that tenant is a v2 candidate.
+
+Pure computation over span dicts — no infra needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# span keys we read (support both promoted ClickHouse names and lowercase wire names)
+_AGENT_RUN_KEYS = ("AgentRunId", "gen_ai.agent.run_id", "agent_run_id")
+_SERVICE_KEYS = ("ServiceName", "service.name", "service_name")
+_PROCESS_KEYS = ("ProcessId", "process.pid", "process_id")
+_TENANT_KEYS = ("TenantId", "tenant_id")
+
+
+def _first(span: dict[str, object], keys: tuple[str, ...]) -> object | None:
+    for k in keys:
+        if k in span and span[k] not in (None, ""):
+            return span[k]
+    return None
+
+
+def _process_identity(span: dict[str, object]) -> object:
+    """What distinguishes one process from another for a given run."""
+    pid = _first(span, _PROCESS_KEYS)
+    svc = _first(span, _SERVICE_KEYS)
+    return (svc, pid)
+
+
+@dataclass(frozen=True, slots=True)
+class CrossProcessReport:
+    tenant_id: str
+    total_runs: int
+    distributed_runs: int
+    threshold: float
+
+    @property
+    def ratio(self) -> float:
+        return self.distributed_runs / self.total_runs if self.total_runs else 0.0
+
+    @property
+    def exceeds_threshold(self) -> bool:
+        return self.ratio >= self.threshold
+
+
+def cross_process_ratio(
+    spans: Iterable[dict[str, object]],
+    *,
+    tenant_id: str,
+    threshold: float = 0.05,
+) -> CrossProcessReport:
+    """Compute the distributed-run ratio for one tenant from its spans.
+
+    A run counts as distributed when its spans span >1 distinct (service, process) identity. Spans
+    without an AgentRunId are ignored (not part of an agent run).
+    """
+    runs: dict[object, set[object]] = {}
+    for span in spans:
+        if _first(span, _TENANT_KEYS) not in (None, tenant_id):
+            continue  # not this tenant
+        run_id = _first(span, _AGENT_RUN_KEYS)
+        if run_id is None:
+            continue
+        runs.setdefault(run_id, set()).add(_process_identity(span))
+
+    total = len(runs)
+    distributed = sum(1 for procs in runs.values() if len(procs) > 1)
+    return CrossProcessReport(
+        tenant_id=tenant_id,
+        total_runs=total,
+        distributed_runs=distributed,
+        threshold=threshold,
+    )

--- a/sdk/python/tests/test_compat.py
+++ b/sdk/python/tests/test_compat.py
@@ -1,0 +1,64 @@
+from tally.compat import (
+    Capabilities,
+    Support,
+    register,
+    registered,
+    render_markdown,
+    render_matrix,
+)
+
+
+def test_openai_is_registered_from_instrumentor():
+    caps = registered()["openai"]
+    assert caps.provider == "openai"
+    assert caps.token_usage is Support.FULL
+    assert caps.cost is Support.FULL
+    assert "gpt-5-mini" in caps.models
+
+
+def test_overall_full_when_all_full():
+    c = Capabilities(
+        provider="x",
+        token_usage=Support.FULL,
+        cost=Support.FULL,
+        streaming=Support.FULL,
+        prompt_caching=Support.FULL,
+        tool_calls=Support.FULL,
+    )
+    assert c.overall is Support.FULL
+
+
+def test_overall_partial_when_mixed():
+    c = Capabilities(provider="x", token_usage=Support.FULL)
+    assert c.overall is Support.PARTIAL
+
+
+def test_overall_planned_when_none():
+    assert Capabilities(provider="x").overall is Support.PLANNED
+
+
+def test_matrix_rows_sorted_and_have_overall():
+    rows = render_matrix()
+    providers = [r["provider"] for r in rows]
+    assert providers == sorted(providers)
+    assert all("overall" in r for r in rows)
+
+
+def test_markdown_renders_header_and_openai():
+    md = render_markdown()
+    assert md.startswith("| provider |")
+    assert "openai" in md
+    assert "anthropic" in md  # planned, but listed honestly
+
+
+def test_register_is_idempotent_by_provider():
+    before = len(registered())
+    register(Capabilities(provider="openai", token_usage=Support.FULL))  # overwrite
+    after = len(registered())
+    assert after == before  # same provider key, not a new row
+
+
+def test_planned_providers_present():
+    reg = registered()
+    assert reg["anthropic"].overall is Support.PLANNED
+    assert reg["vertex"].overall is Support.PLANNED

--- a/sdk/python/tests/test_metrics.py
+++ b/sdk/python/tests/test_metrics.py
@@ -1,0 +1,80 @@
+from tally.metrics import cross_process_ratio
+
+
+def _span(run, service, pid, tenant="t1"):
+    return {"TenantId": tenant, "AgentRunId": run, "ServiceName": service, "ProcessId": pid}
+
+
+def test_all_single_process_ratio_zero():
+    spans = [
+        _span("r1", "api", 1),
+        _span("r1", "api", 1),
+        _span("r2", "api", 1),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 2
+    assert rep.distributed_runs == 0
+    assert rep.ratio == 0.0
+    assert rep.exceeds_threshold is False
+
+
+def test_distributed_run_detected():
+    spans = [
+        _span("r1", "api", 1),
+        _span("r1", "worker", 2),  # same run, different service/process → distributed
+        _span("r2", "api", 1),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.distributed_runs == 1
+    assert rep.ratio == 0.5
+    assert rep.exceeds_threshold is True
+
+
+def test_threshold_boundary():
+    # 1 distributed of 20 = 5% → exactly meets default 0.05
+    spans = []
+    spans += [_span("d", "api", 1), _span("d", "worker", 2)]
+    for i in range(19):
+        spans.append(_span(f"s{i}", "api", 1))
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 20
+    assert rep.distributed_runs == 1
+    assert abs(rep.ratio - 0.05) < 1e-9
+    assert rep.exceeds_threshold is True
+
+
+def test_spans_without_run_ignored():
+    spans = [
+        {"TenantId": "t1", "ServiceName": "api"},  # no AgentRunId
+        _span("r1", "api", 1),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 1
+
+
+def test_other_tenant_excluded():
+    spans = [
+        _span("r1", "api", 1, tenant="t1"),
+        _span("r1", "worker", 2, tenant="t1"),
+        _span("r2", "api", 1, tenant="other"),
+        _span("r2", "worker", 9, tenant="other"),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 1
+    assert rep.distributed_runs == 1
+
+
+def test_lowercase_wire_keys_supported():
+    spans = [
+        {"tenant_id": "t1", "gen_ai.agent.run_id": "r1", "service.name": "api", "process.pid": 1},
+        {"tenant_id": "t1", "gen_ai.agent.run_id": "r1", "service.name": "api", "process.pid": 2},
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.distributed_runs == 1
+
+
+def test_empty_is_zero_not_crash():
+    rep = cross_process_ratio([], tenant_id="t1")
+    assert rep.total_runs == 0
+    assert rep.ratio == 0.0
+    assert rep.exceeds_threshold is False


### PR DESCRIPTION
Implements **CTO-83**. Stacked on #13 (base `feat/cto-32-batch-envelope`).

## Summary
- `cross_process_ratio()`: groups spans by `AgentRunId`; a run is distributed when its spans span >1 distinct `(service, process)`; returns per-tenant ratio + `exceeds_threshold` (default 5%).
- Supports promoted + lowercase wire key names; ignores non-agent spans; excludes other tenants.

## Acceptance criteria
- [x] Detects spans sharing AgentRunId from different ServiceName/process
- [x] Emits per-tenant ratio; flags at ~5% (boundary tested)
- [x] Pure span aggregation, no new infra
- [x] Synthetic-span tests (single/distributed/threshold/other-tenant/empty)

## Out of scope
The v2 Redis shared-counter + server-side backstop (future, triggered by this metric).

## Test plan
- [x] `ruff` + `pytest` green (114 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)