### PR TITLE
chore: land Phase-1 SDK stack onto main (PRs #2–#15 consolidation)

### DIFF
--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -1,0 +1,80 @@
+-- otel_spans — primary span table (ai-tally telemetry store)
+-- Implements CTO-22. Spec §5.1.
+--
+-- Shared multi-tenant cluster (CTO-18): TenantId is FIRST in ORDER BY and is load-bearing —
+-- every read must be tenant-scoped or it scans the whole cluster.
+--
+-- Cost is Decimal64(8) (money, never Float64). Dual-track: EstimatedCost + ReconciledCost +
+-- CostSource. UserIdHashKeyVersion supports HMAC versioned-key rotation (CTO-74).
+-- High-value attributes are promoted to typed columns; the long tail stays in SpanAttributes.
+
+CREATE TABLE IF NOT EXISTS otel_spans
+(
+    TenantId               LowCardinality(String),
+    Timestamp              DateTime64(9)            CODEC(Delta, ZSTD(1)),
+    TraceId                String                   CODEC(ZSTD(1)),
+    SpanId                 String                   CODEC(ZSTD(1)),
+    ParentSpanId           String                   CODEC(ZSTD(1)),
+
+    ServiceName            LowCardinality(String),
+    SpanName               LowCardinality(String),
+    StatusCode             UInt8,
+    DurationNs             UInt64                   CODEC(T64, ZSTD(1)),
+
+    -- Business / attribution
+    FeatureTag             LowCardinality(String),
+    SessionId              String                   CODEC(ZSTD(1)),
+    UserIdHash             FixedString(64)          CODEC(ZSTD(1)),  -- HMAC-SHA256 hex
+    UserIdHashKeyVersion   LowCardinality(String),                  -- HMAC rotation (CTO-74)
+    IdempotencyKey         String                   CODEC(ZSTD(1)),
+
+    -- GenAI core (gen_ai.* semconv)
+    GenAiSystem            LowCardinality(String),
+    GenAiRequestModel      LowCardinality(String),
+    GenAiResponseModel     LowCardinality(String),
+    GenAiOperation         LowCardinality(String),
+    GenAiToolName          LowCardinality(String),
+    InputTokens            UInt32                   CODEC(T64, ZSTD(1)),
+    OutputTokens           UInt32                   CODEC(T64, ZSTD(1)),
+    CachedInputTokens      UInt32                   CODEC(T64, ZSTD(1)),
+
+    -- Cost (dual-track; Decimal64(8), NOT Float64)
+    EstimatedCost          Decimal64(8)             CODEC(ZSTD(1)),
+    ReconciledCost         Nullable(Decimal64(8))   CODEC(ZSTD(1)),
+    CostCurrency           LowCardinality(String),
+    CostSource             Enum8('estimated' = 1, 'reconciled' = 2),
+    PriceCatalogVersion    LowCardinality(String),
+
+    -- Agent context
+    AgentRunId             String                   CODEC(ZSTD(1)),
+    AgentStepIndex         UInt16,
+
+    -- Replay (Workflow 1)
+    ResolvedPromptHash     FixedString(64),
+    ResolvedContextRef     String,
+
+    -- Long tail
+    SpanAttributes         Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    SpanEvents             Array(Tuple(name String, ts DateTime64(9), attrs Map(String, String))),
+
+    -- Sampling
+    SampleRate             Float32 DEFAULT 1.0,
+
+    INDEX idx_trace_id     TraceId                  TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_session_id   SessionId                TYPE bloom_filter(0.01)  GRANULARITY 4,
+    INDEX idx_user_id      UserIdHash               TYPE bloom_filter(0.01)  GRANULARITY 4,
+    INDEX idx_agent_run    AgentRunId               TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_attr_keys    mapKeys(SpanAttributes)  TYPE bloom_filter(0.01)  GRANULARITY 4
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (TenantId, FeatureTag, ServiceName, SpanName, Timestamp)
+-- Tiering: hot SSD -> warm volume at 7d, drop raw spans at 90d.
+-- NOTE: ClickHouse `TTL ... GROUP BY` requires its keys to be a prefix of the primary key, so we
+-- deliberately do NOT aggregate-on-expire here (toDate(Timestamp)/GenAiResponseModel are not a PK
+-- prefix). Long-horizon aggregates live in the rollup materialized views (CTO-24), which persist
+-- independently of this raw table's retention. Storage volumes ('warm') are configured in the
+-- ClickHouse storage policy (infra, CTO-94).
+TTL
+    toDateTime(Timestamp) + INTERVAL 7 DAY  TO VOLUME 'warm',
+    toDateTime(Timestamp) + INTERVAL 90 DAY DELETE;

--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -1,0 +1,77 @@
+"""TallyClient — the SDK entrypoint skeleton.
+
+Minimal, safe-by-construction surface (CTO-45). Every public method runs inside the safety
+boundary so a bug in the SDK — or in a pluggable exporter — never escapes into the customer's
+code path. Real export/batching lands in CTO-49; for now spans accumulate in an in-memory sink so
+the boundary behavior is observable and testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from tally.safety import SelfObservability, safe
+from tally.schema import SpanFields, build_span_attributes
+
+
+class Exporter(Protocol):
+    """Pluggable span sink. Implementations may raise — the client must absorb it."""
+
+    def export(self, attributes: dict[str, object]) -> None: ...
+
+
+class MemoryExporter:
+    """Default no-network exporter: keeps spans in a list. Useful for tests and local dev."""
+
+    def __init__(self) -> None:
+        self.spans: list[dict[str, object]] = []
+
+    def export(self, attributes: dict[str, object]) -> None:
+        self.spans.append(attributes)
+
+
+class TallyClient:
+    """Customer-facing entrypoint.
+
+    Args:
+        api_key: tenant-scoped key (unused until egress lands; stored for later).
+        endpoint: ingest endpoint (unused until egress lands).
+        exporter: pluggable sink; defaults to an in-memory exporter.
+        observability: optional shared :class:`SelfObservability`.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        endpoint: str | None = None,
+        *,
+        exporter: Exporter | None = None,
+        observability: SelfObservability | None = None,
+    ) -> None:
+        self.obs = observability or SelfObservability()
+        self._api_key = api_key
+        self._endpoint = endpoint
+        self._exporter: Exporter = exporter or MemoryExporter()
+
+    @property
+    def observability(self) -> SelfObservability:
+        return self.obs
+
+    def record_span(self, fields: SpanFields) -> None:
+        """Record one span. Never raises — a faulty exporter or builder is absorbed."""
+        self._record_span_impl(fields)
+
+    # Wrapped so any failure (build or export) is recorded and swallowed.
+    def _record_span_impl(self, fields: SpanFields) -> None:
+        @safe(self.obs, where="TallyClient.record_span")
+        def _do() -> None:
+            attrs = build_span_attributes(fields)
+            self._exporter.export(attrs)
+
+        _do()
+
+
+def make_client(record_fn_factory: Callable[[], Exporter] | None = None) -> TallyClient:
+    """Convenience constructor used in tests/examples."""
+    return TallyClient(exporter=record_fn_factory() if record_fn_factory else None)

--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -1,23 +1,30 @@
-"""TallyClient — the SDK entrypoint skeleton.
+"""TallyClient — the SDK entrypoint.
 
-Minimal, safe-by-construction surface (CTO-45). Every public method runs inside the safety
-boundary so a bug in the SDK — or in a pluggable exporter — never escapes into the customer's
-code path. Real export/batching lands in CTO-49; for now spans accumulate in an in-memory sink so
-the boundary behavior is observable and testable.
+Ties the spine together: schema (CTO-47) + safety (CTO-45) + context (CTO-46) + sampling (CTO-50)
++ pricing (CTO-52) + egress (CTO-49), with a cohesive high-level ``record_llm_call()`` API.
+
+Every public method runs inside the safety boundary so a bug in the SDK — or a pluggable
+exporter/transport — never escapes into the customer's code path. Guardrail *enforcement* is the
+one intentional exception and lives behind :meth:`guard` (it may raise, by design, for the agent
+framework to catch); ``record_llm_call`` itself never raises.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
 from typing import Protocol
 
+from tally.context import current_context, note_context_drop
+from tally.egress import BatchProcessor
+from tally.guardrails import GuardrailConfig, GuardrailEngine, GuardrailState, Verdict
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
 from tally.safety import SelfObservability, safe
+from tally.sampling import BillingMeter, Sampler, TraceSignals
 from tally.schema import SpanFields, build_span_attributes
 
 
 class Exporter(Protocol):
-    """Pluggable span sink. Implementations may raise — the client must absorb it."""
-
     def export(self, attributes: dict[str, object]) -> None: ...
 
 
@@ -31,14 +38,26 @@ class MemoryExporter:
         self.spans.append(attributes)
 
 
+@dataclass(frozen=True, slots=True)
+class LlmCallResult:
+    trace_id: str | None
+    cost_micro_usd: int | None
+    kept: bool
+    sample_rate: float
+    attributes: dict[str, object]
+
+
 class TallyClient:
     """Customer-facing entrypoint.
 
     Args:
-        api_key: tenant-scoped key (unused until egress lands; stored for later).
-        endpoint: ingest endpoint (unused until egress lands).
-        exporter: pluggable sink; defaults to an in-memory exporter.
-        observability: optional shared :class:`SelfObservability`.
+        api_key / endpoint: stored for egress wiring.
+        exporter: simple span sink (used when no ``processor`` is given).
+        processor: :class:`BatchProcessor` for real egress (buffer/batch/backoff). Takes
+            precedence over ``exporter`` when both are set.
+        catalog: price catalog for server-agnostic cost estimation.
+        sampler / billing_meter / guardrails: spine components (sensible defaults).
+        tenant_id: for per-tenant price overrides.
     """
 
     def __init__(
@@ -47,31 +66,133 @@ class TallyClient:
         endpoint: str | None = None,
         *,
         exporter: Exporter | None = None,
+        processor: BatchProcessor | None = None,
+        catalog: PriceCatalog | None = None,
+        sampler: Sampler | None = None,
+        billing_meter: BillingMeter | None = None,
+        guardrails: GuardrailEngine | None = None,
         observability: SelfObservability | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         self.obs = observability or SelfObservability()
         self._api_key = api_key
         self._endpoint = endpoint
+        self._processor = processor
         self._exporter: Exporter = exporter or MemoryExporter()
+        self.catalog = catalog
+        self.sampler = sampler or Sampler()
+        self.billing = billing_meter or BillingMeter()
+        self.guardrails = guardrails or GuardrailEngine()
+        self.tenant_id = tenant_id
 
     @property
     def observability(self) -> SelfObservability:
         return self.obs
 
+    # --- low-level: record a pre-built span ---
     def record_span(self, fields: SpanFields) -> None:
-        """Record one span. Never raises — a faulty exporter or builder is absorbed."""
-        self._record_span_impl(fields)
+        """Record one span from explicit fields. Never raises."""
 
-    # Wrapped so any failure (build or export) is recorded and swallowed.
-    def _record_span_impl(self, fields: SpanFields) -> None:
         @safe(self.obs, where="TallyClient.record_span")
         def _do() -> None:
-            attrs = build_span_attributes(fields)
-            self._exporter.export(attrs)
+            self._emit(build_span_attributes(fields))
 
         _do()
 
+    def ingest_span(self, attributes: dict[str, object]) -> None:
+        """Sink for instrumentation (CTO-48 ``on_span``). Never raises."""
 
-def make_client(record_fn_factory: Callable[[], Exporter] | None = None) -> TallyClient:
-    """Convenience constructor used in tests/examples."""
-    return TallyClient(exporter=record_fn_factory() if record_fn_factory else None)
+        @safe(self.obs, where="TallyClient.ingest_span")
+        def _do() -> None:
+            self._emit(attributes)
+
+        _do()
+
+    # --- high-level: record an LLM call (cost + sampling + billing + egress) ---
+    def record_llm_call(
+        self,
+        *,
+        provider: str,
+        model: str,
+        usage: Usage,
+        signals: TraceSignals | None = None,
+        at: date | None = None,
+    ) -> LlmCallResult:
+        """Record an LLM call end-to-end. Never raises.
+
+        Steps (all inside the safety boundary):
+          1. read trace context (note a drop if no active trace),
+          2. count the trace for billing at HEAD (before sampling),
+          3. estimate cost from the catalog,
+          4. build a conformant span,
+          5. make the sampling decision; emit the span only if kept,
+          6. return a :class:`LlmCallResult` for the caller.
+        """
+
+        @safe(self.obs, where="TallyClient.record_llm_call", fallback=None)
+        def _do() -> LlmCallResult:
+            ctx = current_context()
+            trace_id = ctx.trace_id
+            if trace_id is None:
+                note_context_drop(self.obs, where="record_llm_call")
+
+            # Billing counts at HEAD, before sampling (CTO-50/CTO-84).
+            if trace_id is not None:
+                self.billing.count_trace(trace_id)
+
+            cost_micro: int | None = None
+            catalog_version: str | None = None
+            if self.catalog is not None:
+                cost_micro, version = compute_cost_micro_usd(
+                    self.catalog, provider, model, usage, at=at, tenant_id=self.tenant_id
+                )
+                catalog_version = version or None
+
+            decision = self.sampler.decide(
+                trace_id or "no-trace", signals, feature_tag=ctx.feature_tag
+            )
+
+            fields = SpanFields(
+                system=provider,
+                request_model=model,
+                response_model=model,
+                operation="chat",
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cached_input_tokens=usage.cached_input_tokens or None,
+                cost_estimated_micro_usd=cost_micro,
+                price_catalog_version=catalog_version,
+                feature_tag=ctx.feature_tag,
+                session_id=ctx.session_id,
+            )
+            attrs = build_span_attributes(fields)
+            # NB: sample_rate travels at the batch level (wire Sampling, §12.2), not as a span
+            # attribute — so the span stays schema-conformant. It's returned in the result.
+            if decision.keep:
+                self._emit(attrs)
+
+            return LlmCallResult(
+                trace_id=trace_id,
+                cost_micro_usd=cost_micro,
+                kept=decision.keep,
+                sample_rate=decision.sample_rate,
+                attributes=attrs,
+            )
+
+        result = _do()
+        if result is None:  # boundary swallowed an error; return a benign result
+            return LlmCallResult(None, None, False, 1.0, {})
+        return result
+
+    # --- guardrails (may raise, by design — pre-call check) ---
+    def guard(self, state: GuardrailState, config: GuardrailConfig) -> Verdict:
+        """Consult guardrails before the next call. May raise CostLimitExceededException in
+        GRACEFUL/HARD_STOP modes — that propagation is intentional (the agent framework catches it
+        and degrades). Not wrapped in the safety boundary."""
+        return self.guardrails.evaluate(state, config)
+
+    def _emit(self, attributes: dict[str, object]) -> None:
+        if self._processor is not None:
+            self._processor.enqueue(attributes)
+        else:
+            self._exporter.export(attributes)

--- a/sdk/python/src/tally/compat.py
+++ b/sdk/python/src/tally/compat.py
@@ -1,0 +1,100 @@
+"""Provider compatibility matrix — generated from registered instrumentors.
+
+Implements CTO-44. The matrix is built from instrumentor capabilities, not hand-maintained prose,
+so it can't drift from what the code actually supports. Renders to a dict (for an API/page) and to
+markdown (for docs).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+
+from tally.instrumentation.openai import OpenAIInstrumentor
+
+
+class Support(str, Enum):
+    FULL = "full"
+    PARTIAL = "partial"
+    PLANNED = "planned"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class Capabilities:
+    """What an instrumentor can capture for a provider."""
+
+    provider: str
+    token_usage: Support = Support.NONE
+    cost: Support = Support.NONE
+    streaming: Support = Support.NONE
+    prompt_caching: Support = Support.NONE
+    tool_calls: Support = Support.NONE
+    models: tuple[str, ...] = ()
+
+    @property
+    def overall(self) -> Support:
+        vals = [self.token_usage, self.cost, self.streaming, self.prompt_caching, self.tool_calls]
+        if all(v is Support.FULL for v in vals):
+            return Support.FULL
+        if any(v in (Support.FULL, Support.PARTIAL) for v in vals):
+            return Support.PARTIAL
+        return Support.PLANNED
+
+
+# Registry: capabilities declared against the *instrumentor's* provider name, so adding a provider
+# instrumentor and its capabilities here keeps the matrix generated, not prose.
+_REGISTRY: dict[str, Capabilities] = {}
+
+
+def register(caps: Capabilities) -> None:
+    _REGISTRY[caps.provider] = caps
+
+
+def registered() -> dict[str, Capabilities]:
+    return dict(_REGISTRY)
+
+
+def render_matrix() -> list[dict[str, object]]:
+    """Matrix as a list of row dicts (stable order by provider)."""
+    return [
+        {**asdict(caps), "overall": caps.overall.value}
+        for _, caps in sorted(_REGISTRY.items())
+    ]
+
+
+def render_markdown() -> str:
+    cols = [
+        "provider", "overall", "token_usage", "cost", "streaming", "prompt_caching", "tool_calls"
+    ]
+    lines = ["| " + " | ".join(cols) + " |", "| " + " | ".join("---" for _ in cols) + " |"]
+    for caps in sorted(_REGISTRY.values(), key=lambda c: c.provider):
+        row = {
+            "provider": caps.provider,
+            "overall": caps.overall.value,
+            "token_usage": caps.token_usage.value,
+            "cost": caps.cost.value,
+            "streaming": caps.streaming.value,
+            "prompt_caching": caps.prompt_caching.value,
+            "tool_calls": caps.tool_calls.value,
+        }
+        lines.append("| " + " | ".join(str(row[c]) for c in cols) + " |")
+    return "\n".join(lines)
+
+
+# --- built-in registrations (derived from shipped instrumentors) ---------------------------------
+
+register(
+    Capabilities(
+        provider=OpenAIInstrumentor().system,  # "openai" — sourced from the instrumentor
+        token_usage=Support.FULL,
+        cost=Support.FULL,
+        streaming=Support.FULL,
+        prompt_caching=Support.FULL,
+        tool_calls=Support.PARTIAL,  # accounted in usage; per-tool span attribution is a follow-up
+        models=("gpt-5", "gpt-5-mini"),
+    )
+)
+# Anthropic / Vertex instrumentors are follow-ups — declared planned so the matrix is honest.
+register(Capabilities(provider="anthropic"))
+register(Capabilities(provider="vertex"))

--- a/sdk/python/src/tally/context.py
+++ b/sdk/python/src/tally/context.py
@@ -1,0 +1,103 @@
+"""Context propagation — trace_id + feature_tag that survive async boundaries.
+
+The make-or-break piece (CTO-46): if context is lost across an ``await`` / thread / background
+task, attribution and agent trees break. We use :mod:`contextvars`, which propagate correctly
+across ``asyncio`` tasks (each task copies the current context) and stay isolated across threads.
+
+Public surface:
+
+- :func:`start_trace` — begin a new trace context (generates a trace_id).
+- :func:`with_trace_context` — context manager to set/restore explicitly (the escape hatch for
+  places where automatic propagation fails: Celery, Temporal, Lambda cold starts, etc.).
+- :func:`current_context` — read the active context.
+- :func:`note_context_drop` — record that an expected context was missing (feeds
+  ``SelfObservability.context_drop_count``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from tally.safety import SelfObservability
+
+_trace_id: ContextVar[str | None] = ContextVar("tally_trace_id", default=None)
+_feature_tag: ContextVar[str | None] = ContextVar("tally_feature_tag", default=None)
+_session_id: ContextVar[str | None] = ContextVar("tally_session_id", default=None)
+
+
+@dataclass(frozen=True, slots=True)
+class TraceContext:
+    trace_id: str | None
+    feature_tag: str | None
+    session_id: str | None
+
+    @property
+    def is_active(self) -> bool:
+        return self.trace_id is not None
+
+
+def new_trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def current_context() -> TraceContext:
+    """Snapshot the active context (may be inactive)."""
+    return TraceContext(_trace_id.get(), _feature_tag.get(), _session_id.get())
+
+
+@contextmanager
+def with_trace_context(
+    *,
+    trace_id: str | None = None,
+    feature_tag: str | None = None,
+    session_id: str | None = None,
+    inherit: bool = True,
+) -> Iterator[TraceContext]:
+    """Set the trace context for the duration of the block, then restore prior values.
+
+    This is both the normal entrypoint and the manual escape hatch when automatic propagation
+    can't carry context (e.g. across a process/queue boundary — re-establish it on the far side).
+
+    Args:
+        trace_id: explicit id; if ``None`` and no active trace, a new one is generated.
+        feature_tag / session_id: optional tags.
+        inherit: when True, unset fields fall back to the currently-active context.
+    """
+    cur = current_context()
+    resolved_trace = trace_id or (cur.trace_id if inherit else None) or new_trace_id()
+    resolved_feature = feature_tag or (cur.feature_tag if inherit else None)
+    resolved_session = session_id or (cur.session_id if inherit else None)
+
+    t_tok = _trace_id.set(resolved_trace)
+    f_tok = _feature_tag.set(resolved_feature)
+    s_tok = _session_id.set(resolved_session)
+    try:
+        yield TraceContext(resolved_trace, resolved_feature, resolved_session)
+    finally:
+        _trace_id.reset(t_tok)
+        _feature_tag.reset(f_tok)
+        _session_id.reset(s_tok)
+
+
+def start_trace(
+    *, feature_tag: str | None = None, session_id: str | None = None
+) -> AbstractContextManager[TraceContext]:
+    """Begin a fresh trace (always a new trace_id). Returns the context manager."""
+    return with_trace_context(
+        trace_id=new_trace_id(),
+        feature_tag=feature_tag,
+        session_id=session_id,
+        inherit=False,
+    )
+
+
+def note_context_drop(obs: SelfObservability, *, where: str = "context") -> None:
+    """Record that a span was produced with no active trace context where one was expected."""
+    obs.context_drop_count += 1
+    obs.last_errors.append(f"{where}: context drop (no active trace_id)")
+    if len(obs.last_errors) > obs._max_errors:
+        del obs.last_errors[0]

--- a/sdk/python/src/tally/egress.py
+++ b/sdk/python/src/tally/egress.py
@@ -1,0 +1,209 @@
+"""Egress — bounded buffer, batch processor, pluggable transport, backoff.
+
+Implements CTO-49.
+
+Telemetry export must never block or crash the host. Spans are appended to a bounded in-memory
+buffer (drop-oldest on overflow, counted) and flushed in the background. Transport is pluggable
+(a real gRPC OTLP transport sits behind this interface later); failures trigger exponential
+backoff with jitter, and the server can push back via :class:`ServerHints`.
+
+Design for testability: the background thread is optional. :meth:`BatchProcessor.flush_once`
+performs exactly one flush cycle so tests are deterministic without sleeping.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from tally.safety import SelfObservability, safe_block
+
+
+@dataclass(frozen=True, slots=True)
+class ServerHints:
+    """Server-driven backpressure. Any field may be None (no change)."""
+
+    suggested_flush_interval_ms: int | None = None
+    suggested_max_batch_size: int | None = None
+    current_sample_rate_override: float | None = None
+    retry_after_ms: int | None = None
+
+
+class TransportError(Exception):
+    """Raised by a transport when a batch cannot be delivered."""
+
+
+class Transport(Protocol):
+    """Pluggable span sink. ``send`` may raise :class:`TransportError`; the processor absorbs it."""
+
+    def send(self, batch: list[dict[str, object]]) -> ServerHints | None: ...
+
+
+class MemoryTransport:
+    """Default no-network transport: records delivered batches. For tests/local dev."""
+
+    def __init__(self) -> None:
+        self.batches: list[list[dict[str, object]]] = []
+
+    def send(self, batch: list[dict[str, object]]) -> ServerHints | None:
+        self.batches.append(list(batch))
+        return None
+
+    @property
+    def delivered(self) -> list[dict[str, object]]:
+        return [span for b in self.batches for span in b]
+
+
+class FlakyTransport:
+    """Test transport that fails the first ``fail_times`` sends, then succeeds."""
+
+    def __init__(self, fail_times: int) -> None:
+        self._remaining_failures = fail_times
+        self.delivered: list[dict[str, object]] = []
+        self.attempts = 0
+
+    def send(self, batch: list[dict[str, object]]) -> ServerHints | None:
+        self.attempts += 1
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise TransportError("simulated outage")
+        self.delivered.extend(batch)
+        return None
+
+
+@dataclass(slots=True)
+class BackoffPolicy:
+    base_ms: int = 100
+    max_ms: int = 30_000
+    factor: float = 2.0
+    jitter: float = 0.25  # +/- fraction
+    rng: random.Random = field(default_factory=random.Random)
+
+    def delay_ms(self, consecutive_failures: int) -> float:
+        if consecutive_failures <= 0:
+            return 0.0
+        raw = min(self.base_ms * (self.factor ** (consecutive_failures - 1)), self.max_ms)
+        spread = raw * self.jitter
+        return max(0.0, raw + self.rng.uniform(-spread, spread))
+
+
+class BatchProcessor:
+    """Bounded buffer + batched, backoff-aware flushing. Enqueue never blocks or raises."""
+
+    def __init__(
+        self,
+        transport: Transport | None = None,
+        *,
+        observability: SelfObservability | None = None,
+        max_buffer: int = 10_000,
+        max_batch_size: int = 512,
+        flush_interval_ms: int = 1_000,
+        backoff: BackoffPolicy | None = None,
+    ) -> None:
+        self.obs = observability or SelfObservability()
+        self.transport: Transport = transport or MemoryTransport()
+        self.max_buffer = max_buffer
+        self.max_batch_size = max_batch_size
+        self.flush_interval_ms = flush_interval_ms
+        self.backoff = backoff or BackoffPolicy()
+
+        self._buf: deque[dict[str, object]] = deque()
+        self._lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._last_hints: ServerHints | None = None
+
+    # --- enqueue (hot path) ---
+    def enqueue(self, span: dict[str, object]) -> None:
+        """Add a span. Never blocks, never raises. Drops oldest on overflow (counted)."""
+        with safe_block(self.obs, where="BatchProcessor.enqueue"):
+            with self._lock:
+                if len(self._buf) >= self.max_buffer:
+                    # drop oldest to make room
+                    self._buf.popleft()
+                    self.obs.dropped_span_count += 1
+                self._buf.append(span)
+
+    def pending(self) -> int:
+        with self._lock:
+            return len(self._buf)
+
+    def _take_batch(self) -> list[dict[str, object]]:
+        with self._lock:
+            n = min(self.max_batch_size, len(self._buf))
+            return [self._buf.popleft() for _ in range(n)]
+
+    def _requeue_front(self, batch: list[dict[str, object]]) -> None:
+        with self._lock:
+            self._buf.extendleft(reversed(batch))
+            # enforce cap after requeue (drop oldest)
+            while len(self._buf) > self.max_buffer:
+                self._buf.popleft()
+                self.obs.dropped_span_count += 1
+
+    def _apply_hints(self, hints: ServerHints | None) -> None:
+        if hints is None:
+            return
+        self._last_hints = hints
+        if hints.suggested_max_batch_size:
+            self.max_batch_size = max(1, hints.suggested_max_batch_size)
+        if hints.suggested_flush_interval_ms:
+            self.flush_interval_ms = max(0, hints.suggested_flush_interval_ms)
+
+    @property
+    def last_hints(self) -> ServerHints | None:
+        return self._last_hints
+
+    def flush_once(self) -> bool:
+        """Flush a single batch. Returns True on delivery, False on failure/empty.
+
+        On failure the batch is requeued and the failure counter advances (for backoff). Never
+        raises into the caller.
+        """
+        batch = self._take_batch()
+        if not batch:
+            return False
+        try:
+            hints = self.transport.send(batch)
+        except Exception as exc:  # noqa: BLE001 - boundary; transport errors must never escape
+            self._consecutive_failures += 1
+            self.obs.record_error(exc, "BatchProcessor.flush")
+            self._requeue_front(batch)
+            return False
+        self._consecutive_failures = 0
+        self._apply_hints(hints)
+        return True
+
+    def current_backoff_ms(self) -> float:
+        return self.backoff.delay_ms(self._consecutive_failures)
+
+    # --- optional background loop ---
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+
+        def _run() -> None:
+            while not self._stop.is_set():
+                delivered = self.flush_once()
+                if delivered:
+                    wait = self.flush_interval_ms
+                else:
+                    backoff = self.current_backoff_ms()
+                    wait = backoff if backoff > 0 else self.flush_interval_ms
+                self._stop.wait(timeout=max(wait, 1) / 1000.0)
+            # drain remaining on stop (best-effort)
+            while self.pending() and self.flush_once():
+                pass
+
+        self._thread = threading.Thread(target=_run, name="tally-egress", daemon=True)
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None

--- a/sdk/python/src/tally/guardrails.py
+++ b/sdk/python/src/tally/guardrails.py
@@ -1,0 +1,147 @@
+"""Local guardrail engine — protect budget without ever corrupting customer state.
+
+Implements CTO-51.
+
+A per-trace counter state machine ``{cumulative_cost, step_count, tool_call_count}``. Before each
+outbound LLM/tool call the engine is consulted. Enforcement is tiered and **never hard-kills by
+default**:
+
+- ``OBSERVE`` (default): record what *would* have fired; always proceed. Powers the "fires/wk"
+  graduation metric in the UI (CTO-58).
+- ``WARN``: proceed, but return a warning the agent can act on (e.g. inject "you have used 80% of
+  budget; converge").
+- ``GRACEFUL``: raise a localized :class:`CostLimitExceededException` that the agent framework
+  catches, runs cleanup, and returns a degraded response. The process is **not** killed.
+- ``HARD_STOP``: opt-in only, for idempotent/read-only agents.
+
+v1 is single-process (counters are per-process). The metric that triggers v2 (a shared counter)
+is ``agent_run.cross_process_ratio`` — see CTO-83.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Mode(str, Enum):
+    OBSERVE = "observe"
+    WARN = "warn"
+    GRACEFUL = "graceful"
+    HARD_STOP = "hard_stop"
+
+
+class Limit(str, Enum):
+    COST = "cost"
+    STEPS = "steps"
+    TOOL_CALLS = "tool_calls"
+
+
+class CostLimitExceededException(Exception):
+    """Raised in GRACEFUL/HARD_STOP modes. Localized — meant to be caught by the agent framework
+    so it can clean up and return a degraded response. Never a process kill."""
+
+    def __init__(self, limit: Limit, value: float, cap: float, trace_id: str | None = None):
+        self.limit = limit
+        self.value = value
+        self.cap = cap
+        self.trace_id = trace_id
+        super().__init__(
+            f"guardrail '{limit.value}' exceeded: {value} > {cap}"
+            + (f" (trace {trace_id})" if trace_id else "")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GuardrailConfig:
+    mode: Mode = Mode.OBSERVE
+    max_cost_micro_usd: int | None = None
+    max_steps: int | None = None
+    max_tool_calls: int | None = None
+    #: fraction of a cap at which WARN mode starts warning (0.8 == 80%)
+    warn_at: float = 0.8
+
+
+@dataclass(slots=True)
+class GuardrailState:
+    trace_id: str
+    cumulative_cost_micro_usd: int = 0
+    step_count: int = 0
+    tool_call_count: int = 0
+
+    def add_cost(self, micro_usd: int) -> None:
+        self.cumulative_cost_micro_usd += micro_usd
+
+    def incr_step(self) -> None:
+        self.step_count += 1
+
+    def incr_tool_call(self) -> None:
+        self.tool_call_count += 1
+
+
+@dataclass(frozen=True, slots=True)
+class Verdict:
+    proceed: bool
+    breached: Limit | None = None
+    warning: str | None = None
+    #: True when a breach occurred but mode was OBSERVE (would-have-fired)
+    would_fire: bool = False
+
+
+def _first_breach(state: GuardrailState, config: GuardrailConfig) -> tuple[Limit, int, int] | None:
+    if config.max_cost_micro_usd is not None and (
+        state.cumulative_cost_micro_usd > config.max_cost_micro_usd
+    ):
+        return Limit.COST, state.cumulative_cost_micro_usd, config.max_cost_micro_usd
+    if config.max_steps is not None and state.step_count > config.max_steps:
+        return Limit.STEPS, state.step_count, config.max_steps
+    if config.max_tool_calls is not None and state.tool_call_count > config.max_tool_calls:
+        return Limit.TOOL_CALLS, state.tool_call_count, config.max_tool_calls
+    return None
+
+
+def _near_breach(state: GuardrailState, config: GuardrailConfig) -> str | None:
+    checks = [
+        (config.max_cost_micro_usd, state.cumulative_cost_micro_usd, "cost"),
+        (config.max_steps, state.step_count, "steps"),
+        (config.max_tool_calls, state.tool_call_count, "tool_calls"),
+    ]
+    for cap, value, name in checks:
+        if cap is not None and cap > 0 and value >= config.warn_at * cap:
+            pct = round(100 * value / cap)
+            return f"{name} at {pct}% of budget ({value}/{cap}); converge"
+    return None
+
+
+@dataclass(slots=True)
+class GuardrailEngine:
+    """Evaluates guardrails against per-trace state. Holds the OBSERVE-mode would-fire tally."""
+
+    would_fire_counts: dict[Limit, int] = field(default_factory=dict)
+
+    def evaluate(self, state: GuardrailState, config: GuardrailConfig) -> Verdict:
+        """Consult the guardrail. Call BEFORE the next LLM/tool call.
+
+        Raises :class:`CostLimitExceededException` only in GRACEFUL / HARD_STOP modes.
+        """
+        breach = _first_breach(state, config)
+
+        if breach is None:
+            warning = _near_breach(state, config) if config.mode == Mode.WARN else None
+            return Verdict(proceed=True, warning=warning)
+
+        limit, value, cap = breach
+
+        if config.mode == Mode.OBSERVE:
+            self.would_fire_counts[limit] = self.would_fire_counts.get(limit, 0) + 1
+            return Verdict(proceed=True, breached=limit, would_fire=True)
+
+        if config.mode == Mode.WARN:
+            return Verdict(
+                proceed=True,
+                breached=limit,
+                warning=f"guardrail '{limit.value}' exceeded ({value}/{cap})",
+            )
+
+        # GRACEFUL or HARD_STOP — localized exception, never a process kill.
+        raise CostLimitExceededException(limit, value, cap, state.trace_id)

--- a/sdk/python/src/tally/instrumentation/__init__.py
+++ b/sdk/python/src/tally/instrumentation/__init__.py
@@ -1,0 +1,29 @@
+"""Auto-instrumentation — provider call wrappers that emit conformant spans.
+
+Implements CTO-48 (OpenAI first).
+
+The design is pluggable: a :class:`ProviderInstrumentor` knows how to (a) extract token usage from a
+provider response and (b) name the model/system. Everything else — building the conformant span via
+:mod:`tally.schema`, pricing via :mod:`tally.pricing`, and the never-crash boundary — is shared, so
+adding a new provider is just another extractor (no core change).
+
+Instrumentation must NEVER swallow the provider's own exceptions (the customer needs their real
+API errors). Only *our* span-building runs inside the safety boundary.
+"""
+
+from tally.instrumentation.base import (
+    ProviderInstrumentor,
+    Usage,
+    build_span,
+    wrap_create,
+)
+from tally.instrumentation.openai import OpenAIInstrumentor, instrument_openai_create
+
+__all__ = [
+    "ProviderInstrumentor",
+    "Usage",
+    "build_span",
+    "wrap_create",
+    "OpenAIInstrumentor",
+    "instrument_openai_create",
+]

--- a/sdk/python/src/tally/instrumentation/base.py
+++ b/sdk/python/src/tally/instrumentation/base.py
@@ -1,0 +1,102 @@
+"""Shared instrumentation machinery: provider interface, span builder, call wrapper."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from datetime import date
+from typing import Protocol
+
+from tally.context import current_context
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
+from tally.safety import SelfObservability, safe_block
+from tally.schema import SpanFields, build_span_attributes
+
+
+class ProviderInstrumentor(Protocol):
+    """Per-provider knowledge. Pure functions over a provider response object."""
+
+    system: str
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None: ...
+    def response_model(self, response: object) -> str | None: ...
+    def extract_usage(self, response: object) -> Usage: ...
+
+
+def build_span(
+    instrumentor: ProviderInstrumentor,
+    *,
+    args: tuple,
+    kwargs: dict,
+    response: object,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    at: date | None = None,
+) -> dict[str, object]:
+    """Build a conformant span attribute dict from a provider response.
+
+    Pulls feature_tag/session from the active trace context, computes cost from the catalog (if
+    given), and returns attributes guaranteed to pass ``validate_span_attributes``.
+    """
+    usage = instrumentor.extract_usage(response)
+    req_model = instrumentor.request_model(args, kwargs)
+    resp_model = instrumentor.response_model(response) or req_model
+    ctx = current_context()
+
+    cost_micro: int | None = None
+    catalog_version: str | None = None
+    if catalog is not None and resp_model:
+        cost_micro, version = compute_cost_micro_usd(
+            catalog, instrumentor.system, resp_model, usage, at=at, tenant_id=tenant_id
+        )
+        catalog_version = version or None
+
+    fields = SpanFields(
+        system=instrumentor.system,
+        request_model=req_model,
+        response_model=resp_model,
+        operation="chat",
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cached_input_tokens=usage.cached_input_tokens or None,
+        cost_estimated_micro_usd=cost_micro,
+        price_catalog_version=catalog_version,
+        feature_tag=ctx.feature_tag,
+        session_id=ctx.session_id,
+    )
+    return build_span_attributes(fields)
+
+
+def wrap_create(
+    create_fn: Callable[..., object],
+    instrumentor: ProviderInstrumentor,
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+) -> Callable[..., object]:
+    """Wrap a provider ``create``-style callable so each successful call emits a span.
+
+    The provider call itself is NOT guarded — its exceptions propagate to the caller unchanged.
+    Only span building + ``on_span`` run inside the safety boundary, so instrumentation can never
+    break the customer's call.
+    """
+    observ = obs or SelfObservability()
+
+    @functools.wraps(create_fn)
+    def wrapper(*args, **kwargs):
+        response = create_fn(*args, **kwargs)  # provider errors propagate — by design
+        with safe_block(observ, where=f"instrument.{instrumentor.system}"):
+            attrs = build_span(
+                instrumentor,
+                args=args,
+                kwargs=kwargs,
+                response=response,
+                catalog=catalog,
+                tenant_id=tenant_id,
+            )
+            on_span(attrs)
+        return response
+
+    return wrapper

--- a/sdk/python/src/tally/instrumentation/openai.py
+++ b/sdk/python/src/tally/instrumentation/openai.py
@@ -1,0 +1,74 @@
+"""OpenAI instrumentor — extracts usage from a Chat Completions response.
+
+Works with both the SDK's object responses and plain dicts, so it can be tested with a fake client
+and no network. Reads ``usage.prompt_tokens`` / ``usage.completion_tokens`` and
+``usage.prompt_tokens_details.cached_tokens`` when present.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tally.instrumentation.base import ProviderInstrumentor, wrap_create
+from tally.pricing import PriceCatalog, Usage
+from tally.safety import SelfObservability
+
+
+def _get(obj: object, key: str, default: object = None) -> object:
+    """Attribute-or-key accessor (supports SDK objects and dicts)."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+class OpenAIInstrumentor:
+    system = "openai"
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None:
+        return kwargs.get("model")
+
+    def response_model(self, response: object) -> str | None:
+        model = _get(response, "model")
+        return model if isinstance(model, str) else None
+
+    def extract_usage(self, response: object) -> Usage:
+        usage = _get(response, "usage")
+        prompt = int(_get(usage, "prompt_tokens", 0) or 0)
+        completion = int(_get(usage, "completion_tokens", 0) or 0)
+        details = _get(usage, "prompt_tokens_details")
+        cached = int(_get(details, "cached_tokens", 0) or 0)
+        return Usage(
+            input_tokens=prompt, output_tokens=completion, cached_input_tokens=cached
+        )
+
+
+# satisfy the Protocol at import time (structural; this is a no-op assertion for readers)
+_INSTRUMENTOR: ProviderInstrumentor = OpenAIInstrumentor()
+
+
+def instrument_openai_create(
+    create_fn: Callable[..., object],
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+) -> Callable[..., object]:
+    """Wrap ``client.chat.completions.create`` so each call emits a conformant span.
+
+    Example::
+
+        client.chat.completions.create = instrument_openai_create(
+            client.chat.completions.create, on_span=tally_client.ingest_span, catalog=catalog
+        )
+    """
+    return wrap_create(
+        create_fn,
+        OpenAIInstrumentor(),
+        on_span=on_span,
+        obs=obs,
+        catalog=catalog,
+        tenant_id=tenant_id,
+    )

--- a/sdk/python/src/tally/metrics.py
+++ b/sdk/python/src/tally/metrics.py
@@ -1,0 +1,83 @@
+"""Operational metrics computed over spans.
+
+Implements CTO-83: ``agent_run.cross_process_ratio`` — the trigger metric for promoting a tenant's
+guardrails from v1 (single-process) to v2 (a shared counter).
+
+A single logical agent run is identified by ``AgentRunId``. If the spans for one run arrive from
+more than one process (distinct ``ServiceName`` / process id), that run is *distributed* and the
+v1 per-process guardrail counters under-count it. We measure the fraction of distributed runs per
+tenant; when it crosses a threshold (~5%), that tenant is a v2 candidate.
+
+Pure computation over span dicts — no infra needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# span keys we read (support both promoted ClickHouse names and lowercase wire names)
+_AGENT_RUN_KEYS = ("AgentRunId", "gen_ai.agent.run_id", "agent_run_id")
+_SERVICE_KEYS = ("ServiceName", "service.name", "service_name")
+_PROCESS_KEYS = ("ProcessId", "process.pid", "process_id")
+_TENANT_KEYS = ("TenantId", "tenant_id")
+
+
+def _first(span: dict[str, object], keys: tuple[str, ...]) -> object | None:
+    for k in keys:
+        if k in span and span[k] not in (None, ""):
+            return span[k]
+    return None
+
+
+def _process_identity(span: dict[str, object]) -> object:
+    """What distinguishes one process from another for a given run."""
+    pid = _first(span, _PROCESS_KEYS)
+    svc = _first(span, _SERVICE_KEYS)
+    return (svc, pid)
+
+
+@dataclass(frozen=True, slots=True)
+class CrossProcessReport:
+    tenant_id: str
+    total_runs: int
+    distributed_runs: int
+    threshold: float
+
+    @property
+    def ratio(self) -> float:
+        return self.distributed_runs / self.total_runs if self.total_runs else 0.0
+
+    @property
+    def exceeds_threshold(self) -> bool:
+        return self.ratio >= self.threshold
+
+
+def cross_process_ratio(
+    spans: Iterable[dict[str, object]],
+    *,
+    tenant_id: str,
+    threshold: float = 0.05,
+) -> CrossProcessReport:
+    """Compute the distributed-run ratio for one tenant from its spans.
+
+    A run counts as distributed when its spans span >1 distinct (service, process) identity. Spans
+    without an AgentRunId are ignored (not part of an agent run).
+    """
+    runs: dict[object, set[object]] = {}
+    for span in spans:
+        if _first(span, _TENANT_KEYS) not in (None, tenant_id):
+            continue  # not this tenant
+        run_id = _first(span, _AGENT_RUN_KEYS)
+        if run_id is None:
+            continue
+        runs.setdefault(run_id, set()).add(_process_identity(span))
+
+    total = len(runs)
+    distributed = sum(1 for procs in runs.values() if len(procs) > 1)
+    return CrossProcessReport(
+        tenant_id=tenant_id,
+        total_runs=total,
+        distributed_runs=distributed,
+        threshold=threshold,
+    )

--- a/sdk/python/src/tally/pricing.py
+++ b/sdk/python/src/tally/pricing.py
@@ -1,0 +1,206 @@
+"""Price catalog — versioned, multi-provider rate table + cost computation.
+
+Implements CTO-52.
+
+All ``EstimatedCost`` derives from this table. It is *versioned* and *time-windowed* so historical
+cost can be recomputed if a rate is corrected, and so a price change doesn't retroactively rewrite
+past cost. Per-tenant overrides take precedence over the public catalog (enterprise contracts).
+
+Rates are :class:`~decimal.Decimal` (never float — this is money). Cost is returned as integer
+micro-USD via :func:`tally.schema.usd_to_micro`.
+
+The seed data here is illustrative and meant to be replaced by the daily scraper (CTO-53); treat
+the *shape* as authoritative, the *numbers* as placeholders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+
+from tally.schema import DEFAULT_CURRENCY, usd_to_micro
+
+
+class PriceType(str, Enum):
+    INPUT = "input"
+    OUTPUT = "output"
+    CACHED_INPUT = "cached_input"
+    TOOL_CALL = "tool_call"
+    EMBEDDING = "embedding"
+
+
+class Unit(str, Enum):
+    PER_MILLION_TOKENS = "per_million_tokens"
+    PER_CALL = "per_call"
+    PER_GB = "per_gb"
+
+
+@dataclass(frozen=True, slots=True)
+class PriceEntry:
+    version: str
+    valid_from: date
+    provider: str
+    model: str
+    price_type: PriceType
+    unit: Unit
+    price_per_unit: Decimal
+    currency: str = DEFAULT_CURRENCY
+    valid_to: date | None = None
+
+    def is_valid_at(self, at: date) -> bool:
+        return self.valid_from <= at and (self.valid_to is None or at < self.valid_to)
+
+
+class PriceCatalogMiss(Exception):
+    """No applicable price entry was found for the lookup."""
+
+
+class PriceCatalog:
+    """In-memory price catalog with time-windowed lookup and per-tenant overrides."""
+
+    def __init__(self, entries: list[PriceEntry] | None = None) -> None:
+        self._entries: list[PriceEntry] = list(entries or [])
+        # per-tenant override entries, keyed by tenant id
+        self._overrides: dict[str, list[PriceEntry]] = {}
+
+    def add(self, entry: PriceEntry) -> None:
+        self._entries.append(entry)
+
+    def add_override(self, tenant_id: str, entry: PriceEntry) -> None:
+        self._overrides.setdefault(tenant_id, []).append(entry)
+
+    def _best(
+        self, pool: list[PriceEntry], provider: str, model: str, price_type: PriceType, at: date
+    ) -> PriceEntry | None:
+        candidates = [
+            e
+            for e in pool
+            if e.provider == provider
+            and e.model == model
+            and e.price_type == price_type
+            and e.is_valid_at(at)
+        ]
+        if not candidates:
+            return None
+        # most recent applicable valid_from wins
+        return max(candidates, key=lambda e: e.valid_from)
+
+    def lookup(
+        self,
+        provider: str,
+        model: str,
+        price_type: PriceType,
+        *,
+        at: date | None = None,
+        tenant_id: str | None = None,
+    ) -> PriceEntry | None:
+        at = at or date.today()
+        if tenant_id and tenant_id in self._overrides:
+            hit = self._best(self._overrides[tenant_id], provider, model, price_type, at)
+            if hit is not None:
+                return hit
+        return self._best(self._entries, provider, model, price_type, at)
+
+
+@dataclass(frozen=True, slots=True)
+class Usage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input_tokens: int = 0
+
+
+def compute_cost_micro_usd(
+    catalog: PriceCatalog,
+    provider: str,
+    model: str,
+    usage: Usage,
+    *,
+    at: date | None = None,
+    tenant_id: str | None = None,
+    strict: bool = False,
+) -> tuple[int, str]:
+    """Compute estimated cost in micro-USD for a chat/completion call.
+
+    Cached input tokens are billed at the cached rate when available, and the remaining
+    (input - cached) at the standard input rate.
+
+    Returns ``(micro_usd, catalog_version)``.
+
+    Raises :class:`PriceCatalogMiss` when ``strict`` and a required rate is missing; otherwise
+    missing components contribute 0 (and an empty version string signals a partial price).
+    """
+    at = at or date.today()
+    total_usd = Decimal(0)
+    version = ""
+
+    def rate(pt: PriceType) -> PriceEntry | None:
+        return catalog.lookup(provider, model, pt, at=at, tenant_id=tenant_id)
+
+    input_entry = rate(PriceType.INPUT)
+    output_entry = rate(PriceType.OUTPUT)
+    cached_entry = rate(PriceType.CACHED_INPUT)
+
+    if strict and (input_entry is None or output_entry is None):
+        raise PriceCatalogMiss(f"missing input/output price for {provider}/{model} at {at}")
+
+    cached_tokens = min(usage.cached_input_tokens, usage.input_tokens)
+    uncached_input = usage.input_tokens - cached_tokens
+
+    if input_entry is not None:
+        total_usd += _line(input_entry, uncached_input)
+        version = input_entry.version
+    if cached_entry is not None and cached_tokens:
+        total_usd += _line(cached_entry, cached_tokens)
+    elif input_entry is not None and cached_tokens:
+        # no cached rate → fall back to standard input rate for cached tokens
+        total_usd += _line(input_entry, cached_tokens)
+    if output_entry is not None:
+        total_usd += _line(output_entry, usage.output_tokens)
+        version = output_entry.version or version
+
+    return usd_to_micro(total_usd), version
+
+
+def _line(entry: PriceEntry, tokens: int) -> Decimal:
+    if entry.unit is Unit.PER_MILLION_TOKENS:
+        return entry.price_per_unit * Decimal(tokens) / Decimal(1_000_000)
+    if entry.unit is Unit.PER_CALL:
+        return entry.price_per_unit
+    return Decimal(0)
+
+
+# --- Seed data (illustrative; replaced by the scraper, CTO-53) ----------------------------------
+
+_SEED_VERSION = "seed-2026-05-01"
+_SEED_FROM = date(2026, 5, 1)
+
+
+def _mtok(provider: str, model: str, pt: PriceType, usd_per_mtok: str) -> PriceEntry:
+    return PriceEntry(
+        version=_SEED_VERSION,
+        valid_from=_SEED_FROM,
+        provider=provider,
+        model=model,
+        price_type=pt,
+        unit=Unit.PER_MILLION_TOKENS,
+        price_per_unit=Decimal(usd_per_mtok),
+    )
+
+
+def seed_catalog() -> PriceCatalog:
+    """A small OpenAI-first seed catalog. Numbers are placeholders for the scraper."""
+    cat = PriceCatalog()
+    seeds = [
+        ("openai", "gpt-5-mini", PriceType.INPUT, "0.25"),
+        ("openai", "gpt-5-mini", PriceType.CACHED_INPUT, "0.025"),
+        ("openai", "gpt-5-mini", PriceType.OUTPUT, "2.00"),
+        ("openai", "gpt-5", PriceType.INPUT, "2.50"),
+        ("openai", "gpt-5", PriceType.CACHED_INPUT, "0.25"),
+        ("openai", "gpt-5", PriceType.OUTPUT, "10.00"),
+        ("openai", "text-embedding-3-small", PriceType.EMBEDDING, "0.02"),
+    ]
+    for provider, model, pt, rate in seeds:
+        cat.add(_mtok(provider, model, pt, rate))
+    return cat

--- a/sdk/python/src/tally/pricing_scraper.py
+++ b/sdk/python/src/tally/pricing_scraper.py
@@ -1,0 +1,125 @@
+"""Price scraper scaffold — pluggable fetchers, diff, and a human-review gate.
+
+Implements CTO-53.
+
+A stale catalog silently corrupts every cost number, so price updates are:
+1. fetched from pluggable per-provider :class:`PriceFetcher` sources into a *candidate* version,
+2. diffed against the current catalog,
+3. published only behind an explicit human :class:`Approval` (the review gate). New versions are
+   additive — old versions are retained so historical cost stays recomputable (CTO-52).
+
+This is the scaffold (the actual scraping of provider pages lives in concrete fetchers); tested
+here with a fake fetcher.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Protocol
+
+from tally.pricing import PriceCatalog, PriceEntry
+
+
+class PriceFetcher(Protocol):
+    """A source of candidate prices for one provider. Implementations do the actual scraping."""
+
+    provider: str
+
+    def fetch(self, *, version: str, valid_from: date) -> list[PriceEntry]: ...
+
+
+def _key(e: PriceEntry) -> tuple[str, str, str]:
+    return (e.provider, e.model, e.price_type.value)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogDiff:
+    added: list[PriceEntry] = field(default_factory=list)
+    changed: list[tuple[PriceEntry, PriceEntry]] = field(default_factory=list)  # (old, new)
+    removed: list[PriceEntry] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.added or self.changed or self.removed)
+
+    @property
+    def magnitude(self) -> int:
+        return len(self.added) + len(self.changed) + len(self.removed)
+
+
+def diff_entries(current: list[PriceEntry], candidate: list[PriceEntry]) -> CatalogDiff:
+    """Diff candidate vs. current by (provider, model, price_type)."""
+    cur = {_key(e): e for e in current}
+    cand = {_key(e): e for e in candidate}
+    added = [cand[k] for k in cand.keys() - cur.keys()]
+    removed = [cur[k] for k in cur.keys() - cand.keys()]
+    changed = [
+        (cur[k], cand[k])
+        for k in cur.keys() & cand.keys()
+        if cur[k].price_per_unit != cand[k].price_per_unit
+    ]
+    return CatalogDiff(added=added, changed=changed, removed=removed)
+
+
+@dataclass(frozen=True, slots=True)
+class Approval:
+    approved: bool
+    reviewer: str = ""
+    #: explicit acknowledgement required when a diff exceeds ``large_diff_threshold``
+    ack_large_diff: bool = False
+
+
+class PriceReviewError(Exception):
+    """Raised when a candidate cannot be published under the review gate."""
+
+
+@dataclass(slots=True)
+class PriceScraper:
+    """Runs fetchers, proposes a diff, and publishes behind a review gate."""
+
+    fetchers: list[PriceFetcher]
+    large_diff_threshold: int = 10
+
+    def build_candidate(self, *, version: str, valid_from: date) -> list[PriceEntry]:
+        """Fetch all sources into a candidate set tagged with ``version``.
+
+        A fetcher that raises does not abort the run — its failure is skipped (and the missing
+        provider simply isn't updated). Callers should monitor for missing providers.
+        """
+        out: list[PriceEntry] = []
+        for f in self.fetchers:
+            try:
+                out.extend(f.fetch(version=version, valid_from=valid_from))
+            except Exception:  # noqa: BLE001 - one bad source shouldn't sink the run
+                continue
+        return out
+
+    def propose(self, current: PriceCatalog, candidate: list[PriceEntry]) -> CatalogDiff:
+        # diff against the catalog's public entries (latest of each key, regardless of version)
+        current_entries = list(current._entries)  # noqa: SLF001 - same package
+        return diff_entries(current_entries, candidate)
+
+    def publish(
+        self,
+        current: PriceCatalog,
+        candidate: list[PriceEntry],
+        approval: Approval,
+    ) -> CatalogDiff:
+        """Publish the candidate into ``current`` (additive) iff approved.
+
+        Raises :class:`PriceReviewError` when not approved, or when the diff is large and the
+        reviewer didn't explicitly acknowledge it.
+        """
+        diff = self.propose(current, candidate)
+        if diff.is_empty:
+            return diff
+        if not approval.approved:
+            raise PriceReviewError("candidate not approved by a reviewer")
+        if diff.magnitude > self.large_diff_threshold and not approval.ack_large_diff:
+            raise PriceReviewError(
+                f"large diff ({diff.magnitude} changes) requires ack_large_diff=True"
+            )
+        for entry in candidate:
+            current.add(entry)  # additive: old versions retained
+        return diff

--- a/sdk/python/src/tally/safety.py
+++ b/sdk/python/src/tally/safety.py
@@ -1,0 +1,105 @@
+"""SDK safety boundary — the never-crash-host invariant.
+
+THE INVARIANT (CTO-45): the SDK must never raise into the customer's code path. Every internal
+operation runs inside a boundary that catches *all* exceptions (including ``BaseException``
+subclasses we can safely swallow — but never ``KeyboardInterrupt`` / ``SystemExit``), records them
+to a self-observability channel, and returns a fallback so the customer's call proceeds unmodified.
+
+Usage:
+
+    from tally.safety import SelfObservability, safe, safe_block
+
+    obs = SelfObservability()
+
+    @safe(obs, fallback=None)
+    def _internal(...): ...
+
+    with safe_block(obs):
+        ... # best-effort internal work; exceptions recorded, never raised
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+_log = logging.getLogger("tally")
+
+T = TypeVar("T")
+
+# We swallow Exception, never these (let the program exit/interrupt as the user intends).
+_NEVER_SWALLOW = (KeyboardInterrupt, SystemExit)
+
+
+@dataclass(slots=True)
+class SelfObservability:
+    """Counters the SDK reports about *itself* (surfaced to the customer's dashboard).
+
+    See CTO-46 for ``context_drop_count`` and CTO-49 for ``dropped_span_count``; this module owns
+    ``internal_error_count`` and the optional error hook.
+    """
+
+    internal_error_count: int = 0
+    context_drop_count: int = 0
+    dropped_span_count: int = 0
+    #: optional sink for the last few error reprs (bounded), for debugging
+    last_errors: list[str] = field(default_factory=list)
+    _max_errors: int = 20
+
+    def record_error(self, exc: BaseException, where: str) -> None:
+        self.internal_error_count += 1
+        msg = f"{where}: {type(exc).__name__}: {exc}"
+        self.last_errors.append(msg)
+        if len(self.last_errors) > self._max_errors:
+            del self.last_errors[0]
+        # Never propagate; log at debug so we don't spam the customer's logs by default.
+        _log.debug("tally internal error suppressed (%s)", msg)
+
+    def snapshot(self) -> dict[str, int]:
+        return {
+            "internal_error_count": self.internal_error_count,
+            "context_drop_count": self.context_drop_count,
+            "dropped_span_count": self.dropped_span_count,
+        }
+
+
+def safe(obs: SelfObservability, *, fallback: T = None, where: str | None = None):
+    """Decorator: run the wrapped callable inside the safety boundary.
+
+    On any swallowable exception, record it and return ``fallback`` instead of raising.
+    """
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+        label = where or fn.__qualname__
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs) -> T:
+            try:
+                return fn(*args, **kwargs)
+            except _NEVER_SWALLOW:
+                raise
+            except BaseException as exc:  # noqa: BLE001 - intentional catch-all boundary
+                obs.record_error(exc, label)
+                return fallback
+
+        return wrapper
+
+    return decorator
+
+
+@contextmanager
+def safe_block(obs: SelfObservability, *, where: str = "safe_block") -> Iterator[None]:
+    """Context manager form of :func:`safe`.
+
+    Exceptions inside the block are recorded, not raised.
+    """
+    try:
+        yield
+    except _NEVER_SWALLOW:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - intentional catch-all boundary
+        obs.record_error(exc, where)

--- a/sdk/python/src/tally/sampling.py
+++ b/sdk/python/src/tally/sampling.py
@@ -1,0 +1,151 @@
+"""Deterministic, stratified, whole-trace sampling — with billing decoupled from sampling.
+
+Implements CTO-50.
+
+Why stratified: agent cost is a power law. Uniform sampling would lose the expensive tail (the
+part that matters) and add huge variance to extrapolated cost. So we sample the cheap, high-volume
+body down and keep the expensive tail at ~100%. Extrapolated analytics cost is then computed
+per-stratum as ``sum(cost_i / sample_rate_i)`` — the tail is exact, error is confined to the cheap
+body where it is harmless.
+
+Why deterministic + whole-trace: the keep/drop decision is a pure function of ``trace_id`` (+ the
+configured rate), so every span in a trace shares one decision and the same trace always decides
+the same way. Never partial.
+
+Billing is **decoupled**: :class:`BillingMeter` counts every trace at HEAD, *before* the sampling
+decision, so invoices are exact regardless of the analytics sample rate (per CTO-21 / CTO-84).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Stratum(str, Enum):
+    """Cost/complexity stratum chosen at head time, cheapest → most expensive."""
+
+    BODY = "body"  # cheap, high-volume single-shot calls
+    MID = "mid"
+    TAIL = "tail"  # expensive: agents, long context, top-tier models
+
+
+@dataclass(frozen=True, slots=True)
+class TraceSignals:
+    """Head-time signals available before the call completes."""
+
+    is_agent: bool = False
+    prompt_tokens_estimate: int = 0
+    model_tier: str = "standard"  # "standard" | "premium"
+
+
+@dataclass(frozen=True, slots=True)
+class SamplingConfig:
+    """Per-stratum keep rates in [0, 1]. Tail defaults to 1.0 (always keep)."""
+
+    body_rate: float = 0.1
+    mid_rate: float = 0.5
+    tail_rate: float = 1.0
+    #: per-feature-tag overrides of the *whole* config's effective rate (applied to all strata)
+    feature_overrides: dict[str, float] = field(default_factory=dict)
+    #: thresholds for stratum assignment
+    mid_prompt_tokens: int = 2_000
+    tail_prompt_tokens: int = 8_000
+
+    def __post_init__(self) -> None:
+        for name in ("body_rate", "mid_rate", "tail_rate"):
+            v = getattr(self, name)
+            if not (0.0 <= v <= 1.0):
+                raise ValueError(f"{name} must be in [0, 1], got {v}")
+
+
+@dataclass(frozen=True, slots=True)
+class SampleDecision:
+    keep: bool
+    sample_rate: float
+    stratum: Stratum
+
+
+def assign_stratum(signals: TraceSignals, config: SamplingConfig) -> Stratum:
+    """Deterministically map head-time signals to a stratum (tail = expensive)."""
+    if (
+        signals.is_agent
+        or signals.model_tier == "premium"
+        or signals.prompt_tokens_estimate >= config.tail_prompt_tokens
+    ):
+        return Stratum.TAIL
+    if signals.prompt_tokens_estimate >= config.mid_prompt_tokens:
+        return Stratum.MID
+    return Stratum.BODY
+
+
+def _unit_hash(trace_id: str) -> float:
+    """Map a trace_id deterministically to a float in [0, 1)."""
+    digest = hashlib.sha256(trace_id.encode("utf-8")).digest()
+    # 8 bytes → 64-bit int → [0,1)
+    n = int.from_bytes(digest[:8], "big")
+    return n / 2**64
+
+
+class Sampler:
+    """Deterministic stratified sampler. Pure: same (trace_id, signals) → same decision."""
+
+    def __init__(self, config: SamplingConfig | None = None) -> None:
+        self.config = config or SamplingConfig()
+
+    def _rate_for(self, stratum: Stratum, feature_tag: str | None) -> float:
+        if feature_tag and feature_tag in self.config.feature_overrides:
+            return self.config.feature_overrides[feature_tag]
+        return {
+            Stratum.BODY: self.config.body_rate,
+            Stratum.MID: self.config.mid_rate,
+            Stratum.TAIL: self.config.tail_rate,
+        }[stratum]
+
+    def decide(
+        self,
+        trace_id: str,
+        signals: TraceSignals | None = None,
+        *,
+        feature_tag: str | None = None,
+    ) -> SampleDecision:
+        stratum = assign_stratum(signals or TraceSignals(), self.config)
+        rate = self._rate_for(stratum, feature_tag)
+        keep = rate >= 1.0 or _unit_hash(trace_id) < rate
+        return SampleDecision(keep=keep, sample_rate=rate, stratum=stratum)
+
+
+@dataclass(slots=True)
+class BillingMeter:
+    """Head-count meter — counts every trace BEFORE the sampling decision.
+
+    Tamper-evidence and reconciliation against ingest live server-side (CTO-84); this is the SDK
+    hook that guarantees a billable trace is counted exactly once regardless of sampling.
+    """
+
+    trace_count: int = 0
+    _seen: set[str] = field(default_factory=set)
+
+    def count_trace(self, trace_id: str) -> None:
+        if trace_id not in self._seen:
+            self._seen.add(trace_id)
+            self.trace_count += 1
+
+
+def extrapolate_cost(samples: list[tuple[int, float]]) -> int:
+    """Extrapolate total cost (micro-USD) from kept samples.
+
+    Args:
+        samples: list of ``(cost_micro_usd, sample_rate)`` for kept traces.
+
+    Returns:
+        Estimated total cost = ``sum(cost_i / rate_i)``. Per-stratum rates mean the tail (rate 1.0)
+        contributes exactly and only the cheap body is scaled up.
+    """
+    total = 0.0
+    for cost, rate in samples:
+        if rate <= 0:
+            continue
+        total += cost / rate
+    return round(total)

--- a/sdk/python/src/tally/schema.py
+++ b/sdk/python/src/tally/schema.py
@@ -1,0 +1,217 @@
+"""Span schema — OpenTelemetry ``gen_ai.*`` semantic conventions plus ai-tally extensions.
+
+A single namespace (``gen_ai.*``). We do not fork the convention; our additions are namespaced
+under ``gen_ai.*`` and proposed upstream where missing (notably cost).
+
+Cost on the wire is an **integer number of micro-USD** (1e-6 USD). This avoids floating-point on
+the network and matches the Decimal64(8) storage choice. Use :func:`usd_to_micro` /
+:func:`micro_to_usd` at the boundary.
+
+The authoritative list of keys lives in :class:`GenAI`. :func:`build_span_attributes` produces a
+conformant attribute dict; :func:`validate_span_attributes` checks an arbitrary dict against the
+schema and returns a list of human-readable violations (empty == conformant).
+
+Implements CTO-47.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+
+class GenAI:
+    """Attribute keys. Standard OTel semconv + ai-tally extensions (all ``gen_ai.*``)."""
+
+    # --- Standard OTel GenAI semantic conventions ---
+    SYSTEM = "gen_ai.system"  # e.g. "openai", "anthropic"
+    REQUEST_MODEL = "gen_ai.request.model"
+    RESPONSE_MODEL = "gen_ai.response.model"
+    OPERATION_NAME = "gen_ai.operation.name"  # e.g. "chat", "embeddings", "tool"
+    USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+    USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+    USAGE_CACHED_INPUT_TOKENS = "gen_ai.usage.cached_input_tokens"
+
+    # --- ai-tally extensions (proposed upstream) ---
+    COST_ESTIMATED_MICRO_USD = "gen_ai.cost.estimated_micro_usd"  # int, micro-USD
+    COST_CURRENCY = "gen_ai.cost.currency"  # ISO-4217, default "USD"
+    COST_PRICE_CATALOG_VERSION = "gen_ai.cost.price_catalog_version"
+
+    FEATURE_TAG = "gen_ai.feature_tag"
+    SESSION_ID = "gen_ai.session_id"
+    USER_ID_HASH = "gen_ai.user_id_hash"  # HMAC-SHA256 hex
+    USER_ID_HASH_KEY_VERSION = "gen_ai.user_id_hash_key_version"
+    IDEMPOTENCY_KEY = "gen_ai.idempotency_key"
+
+    AGENT_RUN_ID = "gen_ai.agent.run_id"
+    AGENT_STEP_INDEX = "gen_ai.agent.step.index"
+    AGENT_STEP_MAX = "gen_ai.agent.step.max_steps"
+
+    TOOL_NAME = "gen_ai.tool.name"
+    TOOL_CALL_ID = "gen_ai.tool.call_id"
+    TOOL_COST_MICRO_USD = "gen_ai.tool.cost_micro_usd"
+
+    RESOLVED_CONTEXT_REF = "gen_ai.resolved_context_ref"
+
+
+# Known operation names (open set — unknown values are allowed but should be lowercase tokens).
+OPERATIONS = frozenset({"chat", "completion", "embeddings", "tool", "agent", "rerank"})
+
+#: Default currency when none supplied.
+DEFAULT_CURRENCY = "USD"
+
+# Expected python types per key. ``int`` keys must not be ``bool``.
+_INT_KEYS = frozenset(
+    {
+        GenAI.USAGE_INPUT_TOKENS,
+        GenAI.USAGE_OUTPUT_TOKENS,
+        GenAI.USAGE_CACHED_INPUT_TOKENS,
+        GenAI.COST_ESTIMATED_MICRO_USD,
+        GenAI.TOOL_COST_MICRO_USD,
+        GenAI.AGENT_STEP_INDEX,
+        GenAI.AGENT_STEP_MAX,
+    }
+)
+_STR_KEYS = frozenset(
+    {
+        GenAI.SYSTEM,
+        GenAI.REQUEST_MODEL,
+        GenAI.RESPONSE_MODEL,
+        GenAI.OPERATION_NAME,
+        GenAI.COST_CURRENCY,
+        GenAI.COST_PRICE_CATALOG_VERSION,
+        GenAI.FEATURE_TAG,
+        GenAI.SESSION_ID,
+        GenAI.USER_ID_HASH,
+        GenAI.USER_ID_HASH_KEY_VERSION,
+        GenAI.IDEMPOTENCY_KEY,
+        GenAI.AGENT_RUN_ID,
+        GenAI.TOOL_NAME,
+        GenAI.TOOL_CALL_ID,
+        GenAI.RESOLVED_CONTEXT_REF,
+    }
+)
+_ALL_KEYS = _INT_KEYS | _STR_KEYS
+
+_MICRO = Decimal(1_000_000)
+
+
+def usd_to_micro(amount_usd: Decimal | str | int) -> int:
+    """Convert a USD amount to integer micro-USD (round half-up at the 6th decimal)."""
+    d = amount_usd if isinstance(amount_usd, Decimal) else Decimal(str(amount_usd))
+    return int((d * _MICRO).quantize(Decimal(1), rounding=ROUND_HALF_UP))
+
+
+def micro_to_usd(micro: int) -> Decimal:
+    """Convert integer micro-USD back to a USD :class:`~decimal.Decimal`."""
+    return (Decimal(micro) / _MICRO).quantize(Decimal("0.00000001"))
+
+
+@dataclass(slots=True)
+class SpanFields:
+    """Typed convenience holder for the common fields. All optional; ``build_span_attributes``
+    emits only the keys that are set (non-None)."""
+
+    system: str | None = None
+    request_model: str | None = None
+    response_model: str | None = None
+    operation: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    cost_estimated_micro_usd: int | None = None
+    cost_currency: str | None = None
+    price_catalog_version: str | None = None
+    feature_tag: str | None = None
+    session_id: str | None = None
+    user_id_hash: str | None = None
+    user_id_hash_key_version: str | None = None
+    idempotency_key: str | None = None
+    agent_run_id: str | None = None
+    agent_step_index: int | None = None
+    agent_step_max: int | None = None
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    tool_cost_micro_usd: int | None = None
+    resolved_context_ref: str | None = None
+
+
+_FIELD_TO_KEY = {
+    "system": GenAI.SYSTEM,
+    "request_model": GenAI.REQUEST_MODEL,
+    "response_model": GenAI.RESPONSE_MODEL,
+    "operation": GenAI.OPERATION_NAME,
+    "input_tokens": GenAI.USAGE_INPUT_TOKENS,
+    "output_tokens": GenAI.USAGE_OUTPUT_TOKENS,
+    "cached_input_tokens": GenAI.USAGE_CACHED_INPUT_TOKENS,
+    "cost_estimated_micro_usd": GenAI.COST_ESTIMATED_MICRO_USD,
+    "cost_currency": GenAI.COST_CURRENCY,
+    "price_catalog_version": GenAI.COST_PRICE_CATALOG_VERSION,
+    "feature_tag": GenAI.FEATURE_TAG,
+    "session_id": GenAI.SESSION_ID,
+    "user_id_hash": GenAI.USER_ID_HASH,
+    "user_id_hash_key_version": GenAI.USER_ID_HASH_KEY_VERSION,
+    "idempotency_key": GenAI.IDEMPOTENCY_KEY,
+    "agent_run_id": GenAI.AGENT_RUN_ID,
+    "agent_step_index": GenAI.AGENT_STEP_INDEX,
+    "agent_step_max": GenAI.AGENT_STEP_MAX,
+    "tool_name": GenAI.TOOL_NAME,
+    "tool_call_id": GenAI.TOOL_CALL_ID,
+    "tool_cost_micro_usd": GenAI.TOOL_COST_MICRO_USD,
+    "resolved_context_ref": GenAI.RESOLVED_CONTEXT_REF,
+}
+
+
+def build_span_attributes(fields: SpanFields) -> dict[str, object]:
+    """Build a conformant attribute dict from :class:`SpanFields`.
+
+    Only set (non-None) fields are emitted. ``cost_currency`` defaults to ``USD`` whenever any cost
+    is present. The result is guaranteed to pass :func:`validate_span_attributes`.
+    """
+    attrs: dict[str, object] = {}
+    for field_name, key in _FIELD_TO_KEY.items():
+        value = getattr(fields, field_name)
+        if value is not None:
+            attrs[key] = value
+    if GenAI.COST_ESTIMATED_MICRO_USD in attrs and GenAI.COST_CURRENCY not in attrs:
+        attrs[GenAI.COST_CURRENCY] = DEFAULT_CURRENCY
+    return attrs
+
+
+def validate_span_attributes(attrs: dict[str, object]) -> list[str]:
+    """Return a list of conformance violations (empty list == conformant).
+
+    Checks: known keys only, correct value types (int keys reject ``bool`` and floats),
+    non-negative token/cost integers, known-ish operation name, ISO-4217-shaped currency.
+    """
+    violations: list[str] = []
+
+    for key, value in attrs.items():
+        if key not in _ALL_KEYS:
+            violations.append(f"unknown attribute key: {key!r}")
+            continue
+        if key in _INT_KEYS:
+            if isinstance(value, bool) or not isinstance(value, int):
+                violations.append(f"{key} must be int, got {type(value).__name__}")
+            elif value < 0:
+                violations.append(f"{key} must be >= 0, got {value}")
+        elif key in _STR_KEYS:
+            if not isinstance(value, str):
+                violations.append(f"{key} must be str, got {type(value).__name__}")
+            elif value == "":
+                violations.append(f"{key} must be non-empty")
+
+    op = attrs.get(GenAI.OPERATION_NAME)
+    if isinstance(op, str) and op and op != op.lower():
+        violations.append(f"{GenAI.OPERATION_NAME} should be lowercase, got {op!r}")
+
+    currency = attrs.get(GenAI.COST_CURRENCY)
+    if isinstance(currency, str) and not (len(currency) == 3 and currency.isalpha()):
+        violations.append(
+            f"{GenAI.COST_CURRENCY} must be a 3-letter ISO-4217 code, got {currency!r}"
+        )
+
+    if GenAI.COST_ESTIMATED_MICRO_USD in attrs and GenAI.COST_CURRENCY not in attrs:
+        violations.append("cost present without gen_ai.cost.currency")
+
+    return violations

--- a/sdk/python/src/tally/wire.py
+++ b/sdk/python/src/tally/wire.py
@@ -1,0 +1,220 @@
+"""Wire envelope + idempotency — the SDK↔ingest batch contract (transport-agnostic).
+
+Implements CTO-32.
+
+Defines the :class:`BatchRequest` / :class:`BatchResponse` shapes and a JSON codec. The protobuf
+wire format is a later infra ticket; this pure-Python layer lets us build and test the envelope,
+idempotency, and dedup semantics now.
+
+Idempotency: a batch carries a client-generated ``batch_id`` (UUIDv7, time-ordered). The gateway
+dedupes on ``(tenant_id, batch_id)`` for 24h — a replayed batch returns the original response
+without re-processing. Within a batch, spans dedupe on ``(trace_id, span_id)``, business events on
+``business_event_id``, identity links on ``(identity_a, identity_b, source)``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+
+# --- UUIDv7 (time-ordered) -----------------------------------------------------------------------
+
+
+def uuid7() -> str:
+    """Generate a UUIDv7 (48-bit big-endian ms timestamp + random). Time-ordered hex string.
+
+    Python's stdlib lacks uuid7 before 3.14, so we build one per RFC 9562.
+    """
+    ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    rand = os.urandom(10)
+    b = bytearray(ms.to_bytes(6, "big") + rand)
+    b[6] = (b[6] & 0x0F) | 0x70  # version 7
+    b[8] = (b[8] & 0x3F) | 0x80  # variant
+    return str(uuid.UUID(bytes=bytes(b)))
+
+
+# --- messages ------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Sampling:
+    head_sample_rate: float = 1.0
+    sampling_strategy: str = "deterministic_trace"
+
+
+@dataclass(frozen=True, slots=True)
+class BusinessEvent:
+    business_event_id: str
+    event_name: str
+    user_id_hash: str
+    occurred_at_ns: int
+    value_amount_micro: int | None = None
+    value_currency: str = "USD"
+    value_type: str = "monetary"
+    source: str = "sdk"
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityLink:
+    identity_a: str
+    identity_a_type: str
+    identity_b: str
+    identity_b_type: str
+    observed_at_ns: int
+    source: str = "sdk"
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class ClientHealth:
+    dropped_span_count: int = 0
+    context_drop_count: int = 0
+    internal_error_count: int = 0
+    buffer_high_water: int = 0
+
+
+@dataclass(slots=True)
+class BatchRequest:
+    tenant_id: str
+    sdk_version: str
+    resource_spans: list[dict[str, object]] = field(default_factory=list)
+    business_events: list[BusinessEvent] = field(default_factory=list)
+    identity_links: list[IdentityLink] = field(default_factory=list)
+    sampling: Sampling = field(default_factory=Sampling)
+    client_health: ClientHealth = field(default_factory=ClientHealth)
+    batch_id: str = field(default_factory=uuid7)
+    client_send_ts_ns: int = field(default_factory=lambda: time.time_ns())
+
+    def deduplicated(self) -> BatchRequest:
+        """Return a copy with intra-batch duplicates removed (spans, events, identity links)."""
+        seen_spans: set[tuple[object, object]] = set()
+        spans: list[dict[str, object]] = []
+        for s in self.resource_spans:
+            key = (s.get("TraceId") or s.get("trace_id"), s.get("SpanId") or s.get("span_id"))
+            if key in seen_spans:
+                continue
+            seen_spans.add(key)
+            spans.append(s)
+
+        seen_ev: set[str] = set()
+        events: list[BusinessEvent] = []
+        for e in self.business_events:
+            if e.business_event_id in seen_ev:
+                continue
+            seen_ev.add(e.business_event_id)
+            events.append(e)
+
+        seen_links: set[tuple[str, str, str]] = set()
+        links: list[IdentityLink] = []
+        for ln in self.identity_links:
+            key2 = (ln.identity_a, ln.identity_b, ln.source)
+            if key2 in seen_links:
+                continue
+            seen_links.add(key2)
+            links.append(ln)
+
+        return BatchRequest(
+            tenant_id=self.tenant_id,
+            sdk_version=self.sdk_version,
+            resource_spans=spans,
+            business_events=events,
+            identity_links=links,
+            sampling=self.sampling,
+            client_health=self.client_health,
+            batch_id=self.batch_id,
+            client_send_ts_ns=self.client_send_ts_ns,
+        )
+
+
+class Status(str, Enum):
+    ACCEPTED = "accepted"
+    PARTIAL = "partial"
+    REJECTED = "rejected"
+    RETRY = "retry"
+
+
+@dataclass(frozen=True, slots=True)
+class PartialError:
+    item_id: str
+    code: str
+    message: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class BatchResponse:
+    batch_id: str
+    status: Status = Status.ACCEPTED
+    partial_errors: list[PartialError] = field(default_factory=list)
+    accepted_spans: int = 0
+
+
+# --- JSON codec ----------------------------------------------------------------------------------
+
+
+def encode_request(req: BatchRequest) -> str:
+    payload = {
+        "tenant_id": req.tenant_id,
+        "sdk_version": req.sdk_version,
+        "batch_id": req.batch_id,
+        "client_send_ts_ns": req.client_send_ts_ns,
+        "sampling": asdict(req.sampling),
+        "client_health": asdict(req.client_health),
+        "resource_spans": req.resource_spans,
+        "business_events": [asdict(e) for e in req.business_events],
+        "identity_links": [asdict(x) for x in req.identity_links],
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def decode_request(blob: str) -> BatchRequest:
+    d = json.loads(blob)
+    return BatchRequest(
+        tenant_id=d["tenant_id"],
+        sdk_version=d["sdk_version"],
+        batch_id=d["batch_id"],
+        client_send_ts_ns=d["client_send_ts_ns"],
+        sampling=Sampling(**d.get("sampling", {})),
+        client_health=ClientHealth(**d.get("client_health", {})),
+        resource_spans=d.get("resource_spans", []),
+        business_events=[BusinessEvent(**e) for e in d.get("business_events", [])],
+        identity_links=[IdentityLink(**x) for x in d.get("identity_links", [])],
+    )
+
+
+# --- idempotency ---------------------------------------------------------------------------------
+
+
+class IdempotencyCache:
+    """Server-side dedup keyed on (tenant_id, batch_id) with a TTL (default 24h).
+
+    ``check_or_store`` returns the cached response for a replayed batch, else stores + returns None
+    (caller then processes and records the response via :meth:`record`).
+    """
+
+    def __init__(self, ttl_seconds: float = 24 * 3600, now: object = None) -> None:
+        self.ttl = ttl_seconds
+        self._now = now or time.time
+        self._store: dict[tuple[str, str], tuple[float, BatchResponse]] = {}
+
+    def _purge(self, t: float) -> None:
+        expired = [k for k, (ts, _) in self._store.items() if t - ts > self.ttl]
+        for k in expired:
+            del self._store[k]
+
+    def check_or_store(self, req: BatchRequest) -> BatchResponse | None:
+        t = self._now()
+        self._purge(t)
+        key = (req.tenant_id, req.batch_id)
+        hit = self._store.get(key)
+        if hit is not None:
+            return hit[1]
+        # reserve the slot with a provisional ACCEPTED; updated by record()
+        self._store[key] = (t, BatchResponse(batch_id=req.batch_id))
+        return None
+
+    def record(self, req: BatchRequest, response: BatchResponse) -> None:
+        self._store[(req.tenant_id, req.batch_id)] = (self._now(), response)

--- a/sdk/python/tests/test_compat.py
+++ b/sdk/python/tests/test_compat.py
@@ -1,0 +1,64 @@
+from tally.compat import (
+    Capabilities,
+    Support,
+    register,
+    registered,
+    render_markdown,
+    render_matrix,
+)
+
+
+def test_openai_is_registered_from_instrumentor():
+    caps = registered()["openai"]
+    assert caps.provider == "openai"
+    assert caps.token_usage is Support.FULL
+    assert caps.cost is Support.FULL
+    assert "gpt-5-mini" in caps.models
+
+
+def test_overall_full_when_all_full():
+    c = Capabilities(
+        provider="x",
+        token_usage=Support.FULL,
+        cost=Support.FULL,
+        streaming=Support.FULL,
+        prompt_caching=Support.FULL,
+        tool_calls=Support.FULL,
+    )
+    assert c.overall is Support.FULL
+
+
+def test_overall_partial_when_mixed():
+    c = Capabilities(provider="x", token_usage=Support.FULL)
+    assert c.overall is Support.PARTIAL
+
+
+def test_overall_planned_when_none():
+    assert Capabilities(provider="x").overall is Support.PLANNED
+
+
+def test_matrix_rows_sorted_and_have_overall():
+    rows = render_matrix()
+    providers = [r["provider"] for r in rows]
+    assert providers == sorted(providers)
+    assert all("overall" in r for r in rows)
+
+
+def test_markdown_renders_header_and_openai():
+    md = render_markdown()
+    assert md.startswith("| provider |")
+    assert "openai" in md
+    assert "anthropic" in md  # planned, but listed honestly
+
+
+def test_register_is_idempotent_by_provider():
+    before = len(registered())
+    register(Capabilities(provider="openai", token_usage=Support.FULL))  # overwrite
+    after = len(registered())
+    assert after == before  # same provider key, not a new row
+
+
+def test_planned_providers_present():
+    reg = registered()
+    assert reg["anthropic"].overall is Support.PLANNED
+    assert reg["vertex"].overall is Support.PLANNED

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -1,0 +1,88 @@
+import asyncio
+import threading
+
+from tally.context import (
+    current_context,
+    note_context_drop,
+    start_trace,
+    with_trace_context,
+)
+from tally.safety import SelfObservability
+
+
+def test_inactive_by_default():
+    assert current_context().is_active is False
+
+
+def test_set_and_restore():
+    assert current_context().trace_id is None
+    with with_trace_context(trace_id="t1", feature_tag="research") as ctx:
+        assert ctx.trace_id == "t1"
+        assert current_context().feature_tag == "research"
+    # restored
+    assert current_context().trace_id is None
+
+
+def test_inherit_nested():
+    with with_trace_context(trace_id="t1", feature_tag="f1"):
+        with with_trace_context(session_id="s1"):
+            c = current_context()
+            assert c.trace_id == "t1"  # inherited
+            assert c.feature_tag == "f1"  # inherited
+            assert c.session_id == "s1"
+
+
+def test_start_trace_generates_id():
+    with start_trace(feature_tag="f") as ctx:
+        assert ctx.trace_id and len(ctx.trace_id) == 32
+        assert current_context().trace_id == ctx.trace_id
+
+
+def test_propagates_across_asyncio_tasks():
+    seen: dict[str, str | None] = {}
+
+    async def child():
+        seen["trace"] = current_context().trace_id
+
+    async def main():
+        with with_trace_context(trace_id="async-1"):
+            # a child task copies the current context at creation time
+            await asyncio.create_task(child())
+
+    asyncio.run(main())
+    assert seen["trace"] == "async-1"
+
+
+def test_isolated_across_threads():
+    results: dict[str, str | None] = {}
+    barrier = threading.Barrier(2)
+
+    def worker(name: str, tid: str):
+        with with_trace_context(trace_id=tid):
+            barrier.wait()  # ensure both are inside their context simultaneously
+            results[name] = current_context().trace_id
+
+    t1 = threading.Thread(target=worker, args=("a", "thread-a"))
+    t2 = threading.Thread(target=worker, args=("b", "thread-b"))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    assert results == {"a": "thread-a", "b": "thread-b"}
+
+
+def test_generator_keeps_context():
+    def gen():
+        for _ in range(3):
+            yield current_context().trace_id
+
+    with with_trace_context(trace_id="gen-1"):
+        values = list(gen())
+    assert values == ["gen-1", "gen-1", "gen-1"]
+
+
+def test_context_drop_counter():
+    obs = SelfObservability()
+    note_context_drop(obs, where="record_span")
+    assert obs.context_drop_count == 1
+    assert "context drop" in obs.last_errors[-1]

--- a/sdk/python/tests/test_egress.py
+++ b/sdk/python/tests/test_egress.py
@@ -1,0 +1,128 @@
+import random
+import threading
+import time
+
+from tally.egress import (
+    BackoffPolicy,
+    BatchProcessor,
+    FlakyTransport,
+    MemoryTransport,
+    ServerHints,
+    TransportError,
+)
+
+
+def test_enqueue_and_flush_delivers():
+    t = MemoryTransport()
+    bp = BatchProcessor(t, max_batch_size=10)
+    for i in range(5):
+        bp.enqueue({"i": i})
+    assert bp.flush_once() is True
+    assert len(t.delivered) == 5
+    assert bp.pending() == 0
+
+
+def test_flush_empty_is_false():
+    bp = BatchProcessor(MemoryTransport())
+    assert bp.flush_once() is False
+
+
+def test_batch_size_limit():
+    t = MemoryTransport()
+    bp = BatchProcessor(t, max_batch_size=3)
+    for i in range(7):
+        bp.enqueue({"i": i})
+    assert bp.flush_once() is True
+    assert len(t.batches[0]) == 3
+    assert bp.pending() == 4
+
+
+def test_drop_oldest_on_overflow_counts():
+    bp = BatchProcessor(MemoryTransport(), max_buffer=3)
+    for i in range(5):
+        bp.enqueue({"i": i})
+    assert bp.pending() == 3
+    assert bp.obs.dropped_span_count == 2
+    # oldest dropped → buffer holds 2,3,4
+    bp.flush_once()
+    delivered = bp.transport.delivered
+    assert [s["i"] for s in delivered] == [2, 3, 4]
+
+
+def test_failure_requeues_and_counts():
+    t = FlakyTransport(fail_times=1)
+    bp = BatchProcessor(t)
+    bp.enqueue({"i": 1})
+    assert bp.flush_once() is False  # first send fails
+    assert bp.pending() == 1  # requeued
+    assert bp.obs.internal_error_count == 1
+    assert bp.flush_once() is True  # retry succeeds
+    assert [s["i"] for s in t.delivered] == [1]
+
+
+def test_backoff_grows_then_resets():
+    rng = random.Random(0)
+    bp = BatchProcessor(
+        FlakyTransport(fail_times=3),
+        backoff=BackoffPolicy(base_ms=100, jitter=0.0, rng=rng),
+    )
+    bp.enqueue({"i": 1})
+    assert bp.flush_once() is False
+    d1 = bp.current_backoff_ms()
+    assert bp.flush_once() is False
+    d2 = bp.current_backoff_ms()
+    assert d2 > d1  # exponential growth
+    bp.flush_once()  # 3rd failure
+    bp.flush_once()  # success
+    assert bp.current_backoff_ms() == 0.0  # reset after success
+
+
+def test_backoff_capped():
+    pol = BackoffPolicy(base_ms=100, max_ms=500, factor=2.0, jitter=0.0)
+    assert pol.delay_ms(100) == 500  # capped
+
+
+def test_honors_server_hints():
+    class HintingTransport:
+        def send(self, batch):
+            return ServerHints(suggested_max_batch_size=2, suggested_flush_interval_ms=5000)
+
+    bp = BatchProcessor(HintingTransport(), max_batch_size=512, flush_interval_ms=1000)
+    bp.enqueue({"i": 1})
+    bp.flush_once()
+    assert bp.max_batch_size == 2
+    assert bp.flush_interval_ms == 5000
+    assert bp.last_hints is not None
+
+
+def test_enqueue_never_raises_on_bad_state():
+    bp = BatchProcessor(MemoryTransport())
+    # enqueue is wrapped in the safety boundary; even a weird payload won't raise
+    bp.enqueue({"ok": object()})
+    assert bp.pending() == 1
+
+
+def test_background_loop_drains(monkeypatch):
+    t = MemoryTransport()
+    bp = BatchProcessor(t, max_batch_size=100, flush_interval_ms=5)
+    for i in range(50):
+        bp.enqueue({"i": i})
+    bp.start()
+    # wait briefly for the daemon to flush
+    deadline = time.time() + 2.0
+    while time.time() < deadline and len(t.delivered) < 50:
+        time.sleep(0.01)
+    bp.stop()
+    assert len(t.delivered) == 50
+
+
+def test_transport_error_is_swallowed():
+    class Boom:
+        def send(self, batch):
+            raise TransportError("down")
+
+    bp = BatchProcessor(Boom())
+    bp.enqueue({"i": 1})
+    # must not raise
+    assert bp.flush_once() is False
+    assert threading.active_count() >= 1  # sanity: no crash

--- a/sdk/python/tests/test_guardrails.py
+++ b/sdk/python/tests/test_guardrails.py
@@ -1,0 +1,99 @@
+import pytest
+
+from tally.guardrails import (
+    CostLimitExceededException,
+    GuardrailConfig,
+    GuardrailEngine,
+    GuardrailState,
+    Limit,
+    Mode,
+)
+
+
+def test_under_limit_proceeds():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=100)
+    cfg = GuardrailConfig(mode=Mode.GRACEFUL, max_cost_micro_usd=1000)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed and v.breached is None
+
+
+def test_observe_never_raises_but_counts():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", step_count=20)
+    cfg = GuardrailConfig(mode=Mode.OBSERVE, max_steps=15)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed is True
+    assert v.would_fire is True
+    assert v.breached is Limit.STEPS
+    assert eng.would_fire_counts[Limit.STEPS] == 1
+
+
+def test_graceful_raises_localized_exception():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="run-1", cumulative_cost_micro_usd=2000)
+    cfg = GuardrailConfig(mode=Mode.GRACEFUL, max_cost_micro_usd=1000)
+    with pytest.raises(CostLimitExceededException) as ei:
+        eng.evaluate(state, cfg)
+    assert ei.value.limit is Limit.COST
+    assert ei.value.trace_id == "run-1"
+
+
+def test_hard_stop_raises():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", tool_call_count=99)
+    cfg = GuardrailConfig(mode=Mode.HARD_STOP, max_tool_calls=10)
+    with pytest.raises(CostLimitExceededException):
+        eng.evaluate(state, cfg)
+
+
+def test_warn_proceeds_with_message():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=1500)
+    cfg = GuardrailConfig(mode=Mode.WARN, max_cost_micro_usd=1000)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed is True
+    assert v.breached is Limit.COST
+    assert "exceeded" in v.warning
+
+
+def test_warn_near_threshold():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", step_count=8)
+    cfg = GuardrailConfig(mode=Mode.WARN, max_steps=10, warn_at=0.8)
+    v = eng.evaluate(state, cfg)
+    assert v.proceed is True
+    assert v.breached is None
+    assert "converge" in v.warning
+
+
+def test_cost_checked_first():
+    eng = GuardrailEngine()
+    state = GuardrailState(
+        trace_id="t", cumulative_cost_micro_usd=5000, step_count=99, tool_call_count=99
+    )
+    cfg = GuardrailConfig(
+        mode=Mode.GRACEFUL, max_cost_micro_usd=1000, max_steps=10, max_tool_calls=10
+    )
+    with pytest.raises(CostLimitExceededException) as ei:
+        eng.evaluate(state, cfg)
+    assert ei.value.limit is Limit.COST
+
+
+def test_state_counters_accumulate():
+    state = GuardrailState(trace_id="t")
+    state.add_cost(100)
+    state.add_cost(50)
+    state.incr_step()
+    state.incr_tool_call()
+    state.incr_tool_call()
+    assert state.cumulative_cost_micro_usd == 150
+    assert state.step_count == 1
+    assert state.tool_call_count == 2
+
+
+def test_no_caps_always_proceeds():
+    eng = GuardrailEngine()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=10**9)
+    v = eng.evaluate(state, GuardrailConfig(mode=Mode.GRACEFUL))
+    assert v.proceed is True

--- a/sdk/python/tests/test_instrumentation.py
+++ b/sdk/python/tests/test_instrumentation.py
@@ -1,0 +1,106 @@
+"""CTO-48 — OpenAI auto-instrumentation, tested with a fake client (no network)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tally.context import with_trace_context
+from tally.instrumentation import instrument_openai_create
+from tally.instrumentation.openai import OpenAIInstrumentor
+from tally.pricing import seed_catalog
+from tally.schema import GenAI, validate_span_attributes
+
+
+# --- fake OpenAI response objects ---
+@dataclass
+class _Details:
+    cached_tokens: int = 0
+
+
+@dataclass
+class _Usage:
+    prompt_tokens: int
+    completion_tokens: int
+    prompt_tokens_details: _Details | None = None
+
+
+@dataclass
+class _Resp:
+    model: str
+    usage: _Usage
+
+
+def _fake_create(*, model, cached=0, prompt=1000, completion=500, **_):
+    return _Resp(model=model, usage=_Usage(prompt, completion, _Details(cached)))
+
+
+def test_extract_usage_object_and_dict():
+    inst = OpenAIInstrumentor()
+    obj = _Resp("gpt-5-mini", _Usage(10, 20, _Details(4)))
+    u = inst.extract_usage(obj)
+    assert (u.input_tokens, u.output_tokens, u.cached_input_tokens) == (10, 20, 4)
+
+    as_dict = {"model": "gpt-5-mini", "usage": {"prompt_tokens": 7, "completion_tokens": 3}}
+    u2 = inst.extract_usage(as_dict)
+    assert (u2.input_tokens, u2.output_tokens) == (7, 3)
+
+
+def test_wrap_emits_conformant_span_with_cost():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(
+        _fake_create, on_span=spans.append, catalog=seed_catalog()
+    )
+    resp = wrapped(model="gpt-5-mini", prompt=1_000_000, completion=1_000_000)
+    assert isinstance(resp, _Resp)  # original response returned unchanged
+    assert len(spans) == 1
+    attrs = spans[0]
+    assert validate_span_attributes(attrs) == []
+    assert attrs[GenAI.SYSTEM] == "openai"
+    assert attrs[GenAI.USAGE_INPUT_TOKENS] == 1_000_000
+    # 0.25 + 2.00 USD = 2_250_000 micro
+    assert attrs[GenAI.COST_ESTIMATED_MICRO_USD] == 2_250_000
+
+
+def test_feature_tag_from_context():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(_fake_create, on_span=spans.append, catalog=seed_catalog())
+    with with_trace_context(trace_id="t1", feature_tag="research", session_id="s1"):
+        wrapped(model="gpt-5-mini")
+    assert spans[0][GenAI.FEATURE_TAG] == "research"
+    assert spans[0][GenAI.SESSION_ID] == "s1"
+
+
+def test_provider_errors_propagate():
+    def boom(**_):
+        raise RuntimeError("openai 500")
+
+    wrapped = instrument_openai_create(boom, on_span=lambda a: None)
+    with pytest.raises(RuntimeError, match="openai 500"):
+        wrapped(model="gpt-5-mini")
+
+
+def test_faulty_on_span_never_breaks_call():
+    def bad_sink(_attrs):
+        raise ValueError("sink boom")
+
+    wrapped = instrument_openai_create(_fake_create, on_span=bad_sink, catalog=seed_catalog())
+    # instrumentation must not break the provider call
+    resp = wrapped(model="gpt-5-mini")
+    assert isinstance(resp, _Resp)
+
+
+def test_no_catalog_means_no_cost():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(_fake_create, on_span=spans.append)  # no catalog
+    wrapped(model="gpt-5-mini")
+    assert GenAI.COST_ESTIMATED_MICRO_USD not in spans[0]
+
+
+def test_cached_tokens_priced_cheaper():
+    spans: list[dict] = []
+    wrapped = instrument_openai_create(_fake_create, on_span=spans.append, catalog=seed_catalog())
+    wrapped(model="gpt-5-mini", prompt=1_000_000, completion=0, cached=1_000_000)
+    # all input cached → 0.025 USD = 25_000 micro
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] == 25_000

--- a/sdk/python/tests/test_integration.py
+++ b/sdk/python/tests/test_integration.py
@@ -1,0 +1,106 @@
+"""End-to-end integration: start_trace -> record_llm_call -> conformant span with cost."""
+
+from __future__ import annotations
+
+from tally.client import MemoryExporter, TallyClient
+from tally.context import start_trace, with_trace_context
+from tally.egress import BatchProcessor, MemoryTransport
+from tally.guardrails import CostLimitExceededException, GuardrailConfig, GuardrailState, Mode
+from tally.pricing import Usage, seed_catalog
+from tally.sampling import Sampler, SamplingConfig, TraceSignals
+from tally.schema import GenAI, validate_span_attributes
+
+
+def _client(**kw):
+    return TallyClient(catalog=seed_catalog(), **kw)
+
+
+def test_end_to_end_emits_conformant_span_with_cost():
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t1", feature_tag="research", session_id="s1"):
+        result = client.record_llm_call(
+            provider="openai",
+            model="gpt-5-mini",
+            usage=Usage(input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+    assert result.kept is True
+    assert result.cost_micro_usd == 2_250_000
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    assert span[GenAI.FEATURE_TAG] == "research"
+    assert span[GenAI.COST_ESTIMATED_MICRO_USD] == 2_250_000
+
+
+def test_billing_counts_at_head_even_when_dropped():
+    # body_rate 0 → analytics drops everything, billing still counts
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=0.0)))
+    with start_trace(feature_tag="f"):
+        r = client.record_llm_call(
+            provider="openai", model="gpt-5-mini", usage=Usage(100, 50)
+        )
+    assert r.kept is False
+    assert client.billing.trace_count == 1
+
+
+def test_tail_kept_body_dropped():
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=0.0)))
+    with with_trace_context(trace_id="agent-1"):
+        r = client.record_llm_call(
+            provider="openai", model="gpt-5", usage=Usage(10, 10),
+            signals=TraceSignals(is_agent=True),  # tail → kept
+        )
+    assert r.kept is True
+    assert len(exporter.spans) == 1
+
+
+def test_records_via_processor_egress():
+    transport = MemoryTransport()
+    proc = BatchProcessor(transport, max_batch_size=10)
+    client = _client(processor=proc, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with start_trace():
+        client.record_llm_call(provider="openai", model="gpt-5-mini", usage=Usage(10, 5))
+    assert proc.pending() == 1
+    proc.flush_once()
+    assert len(transport.delivered) == 1
+
+
+def test_no_active_trace_notes_drop_but_does_not_raise():
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    r = client.record_llm_call(provider="openai", model="gpt-5-mini", usage=Usage(10, 5))
+    assert r.trace_id is None
+    assert client.observability.context_drop_count == 1
+
+
+def test_record_never_raises_on_bad_catalog():
+    # a catalog whose lookup explodes must not break record_llm_call
+    class BoomCatalog:
+        def lookup(self, *a, **k):
+            raise RuntimeError("catalog down")
+
+    client = TallyClient(catalog=BoomCatalog(), sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with start_trace():
+        r = client.record_llm_call(provider="openai", model="gpt-5-mini", usage=Usage(10, 5))
+    # boundary returns a benign result; error counted
+    assert client.observability.internal_error_count == 1
+    assert r.kept is False
+
+
+def test_guard_raises_in_graceful_mode():
+    client = _client()
+    state = GuardrailState(trace_id="t", cumulative_cost_micro_usd=5000)
+    cfg = GuardrailConfig(mode=Mode.GRACEFUL, max_cost_micro_usd=1000)
+    try:
+        client.guard(state, cfg)
+        raise AssertionError("expected CostLimitExceededException")
+    except CostLimitExceededException:
+        pass
+
+
+def test_guard_observe_mode_proceeds():
+    client = _client()
+    state = GuardrailState(trace_id="t", step_count=99)
+    v = client.guard(state, GuardrailConfig(mode=Mode.OBSERVE, max_steps=10))
+    assert v.proceed is True and v.would_fire is True

--- a/sdk/python/tests/test_metrics.py
+++ b/sdk/python/tests/test_metrics.py
@@ -1,0 +1,80 @@
+from tally.metrics import cross_process_ratio
+
+
+def _span(run, service, pid, tenant="t1"):
+    return {"TenantId": tenant, "AgentRunId": run, "ServiceName": service, "ProcessId": pid}
+
+
+def test_all_single_process_ratio_zero():
+    spans = [
+        _span("r1", "api", 1),
+        _span("r1", "api", 1),
+        _span("r2", "api", 1),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 2
+    assert rep.distributed_runs == 0
+    assert rep.ratio == 0.0
+    assert rep.exceeds_threshold is False
+
+
+def test_distributed_run_detected():
+    spans = [
+        _span("r1", "api", 1),
+        _span("r1", "worker", 2),  # same run, different service/process → distributed
+        _span("r2", "api", 1),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.distributed_runs == 1
+    assert rep.ratio == 0.5
+    assert rep.exceeds_threshold is True
+
+
+def test_threshold_boundary():
+    # 1 distributed of 20 = 5% → exactly meets default 0.05
+    spans = []
+    spans += [_span("d", "api", 1), _span("d", "worker", 2)]
+    for i in range(19):
+        spans.append(_span(f"s{i}", "api", 1))
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 20
+    assert rep.distributed_runs == 1
+    assert abs(rep.ratio - 0.05) < 1e-9
+    assert rep.exceeds_threshold is True
+
+
+def test_spans_without_run_ignored():
+    spans = [
+        {"TenantId": "t1", "ServiceName": "api"},  # no AgentRunId
+        _span("r1", "api", 1),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 1
+
+
+def test_other_tenant_excluded():
+    spans = [
+        _span("r1", "api", 1, tenant="t1"),
+        _span("r1", "worker", 2, tenant="t1"),
+        _span("r2", "api", 1, tenant="other"),
+        _span("r2", "worker", 9, tenant="other"),
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.total_runs == 1
+    assert rep.distributed_runs == 1
+
+
+def test_lowercase_wire_keys_supported():
+    spans = [
+        {"tenant_id": "t1", "gen_ai.agent.run_id": "r1", "service.name": "api", "process.pid": 1},
+        {"tenant_id": "t1", "gen_ai.agent.run_id": "r1", "service.name": "api", "process.pid": 2},
+    ]
+    rep = cross_process_ratio(spans, tenant_id="t1")
+    assert rep.distributed_runs == 1
+
+
+def test_empty_is_zero_not_crash():
+    rep = cross_process_ratio([], tenant_id="t1")
+    assert rep.total_runs == 0
+    assert rep.ratio == 0.0
+    assert rep.exceeds_threshold is False

--- a/sdk/python/tests/test_otel_spans_ddl.py
+++ b/sdk/python/tests/test_otel_spans_ddl.py
@@ -1,0 +1,81 @@
+"""Structural validation of the otel_spans DDL (CTO-22).
+
+We can't stand up ClickHouse in CI here, so this asserts the invariants the spec makes
+load-bearing: TenantId-first ORDER BY, Decimal64 (not Float) cost, dual-track + key-version
+columns, required codecs, and the bloom-filter indexes. A guard against silent schema drift.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DDL_PATH = Path(__file__).resolve().parents[3] / "db" / "clickhouse" / "otel_spans.sql"
+
+
+@pytest.fixture(scope="module")
+def ddl() -> str:
+    assert DDL_PATH.exists(), f"DDL not found at {DDL_PATH}"
+    return DDL_PATH.read_text()
+
+
+@pytest.fixture(scope="module")
+def ddl_code(ddl: str) -> str:
+    """DDL with ``--`` comment lines stripped, so assertions test executable SQL only."""
+    return "\n".join(line for line in ddl.splitlines() if not line.lstrip().startswith("--"))
+
+
+def test_table_created(ddl):
+    assert "CREATE TABLE IF NOT EXISTS otel_spans" in ddl
+
+
+def test_tenant_id_first_in_order_by(ddl):
+    m = re.search(r"ORDER BY \(([^)]*)\)", ddl)
+    assert m, "ORDER BY clause not found"
+    first_key = m.group(1).split(",")[0].strip()
+    assert first_key == "TenantId", f"TenantId must be first in ORDER BY, got {first_key!r}"
+
+
+def test_cost_is_decimal_not_float(ddl):
+    assert "EstimatedCost          Decimal64(8)" in ddl
+    assert "ReconciledCost         Nullable(Decimal64(8))" in ddl
+    assert "EstimatedCost          Float" not in ddl
+
+
+def test_dual_track_and_key_version_columns(ddl):
+    for col in ("CostSource", "PriceCatalogVersion", "UserIdHashKeyVersion"):
+        assert col in ddl, f"missing required column {col}"
+
+
+def test_required_codecs(ddl):
+    assert "CODEC(Delta, ZSTD(1))" in ddl  # timestamp
+    assert "CODEC(T64, ZSTD(1))" in ddl    # token counts
+
+
+def test_bloom_filter_indexes(ddl):
+    for idx in ("idx_trace_id", "idx_session_id", "idx_user_id", "idx_agent_run", "idx_attr_keys"):
+        assert idx in ddl, f"missing index {idx}"
+    assert "bloom_filter(0.001)" in ddl  # tight for trace/agent lookups
+
+
+def test_daily_partition(ddl):
+    assert "PARTITION BY toDate(Timestamp)" in ddl
+
+
+def test_ttl_tiering(ddl):
+    assert "TO VOLUME 'warm'" in ddl   # hot -> warm at 7d
+    assert "INTERVAL 90 DAY DELETE" in ddl  # drop raw at 90d (aggregates live in MVs, CTO-24)
+
+
+def test_no_invalid_ttl_group_by(ddl_code):
+    # Guard against re-introducing a TTL GROUP BY whose keys are not a PK prefix (would fail on a
+    # real cluster). Long-horizon aggregates belong in the rollup MVs (CTO-24), not here.
+    # Checked against comment-stripped SQL so explanatory prose doesn't trip the guard.
+    assert "GROUP BY" not in ddl_code.split("TTL", 1)[-1]
+
+
+def test_balanced_parens(ddl):
+    # cheap sanity check that the statement isn't truncated
+    assert ddl.count("(") == ddl.count(")")

--- a/sdk/python/tests/test_pricing.py
+++ b/sdk/python/tests/test_pricing.py
@@ -1,0 +1,109 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tally.pricing import (
+    PriceCatalog,
+    PriceCatalogMiss,
+    PriceEntry,
+    PriceType,
+    Unit,
+    Usage,
+    compute_cost_micro_usd,
+    seed_catalog,
+)
+
+
+def _entry(model, pt, rate, version="v1", valid_from=date(2026, 5, 1), valid_to=None):
+    return PriceEntry(
+        version=version,
+        valid_from=valid_from,
+        provider="openai",
+        model=model,
+        price_type=pt,
+        unit=Unit.PER_MILLION_TOKENS,
+        price_per_unit=Decimal(rate),
+        valid_to=valid_to,
+    )
+
+
+def test_lookup_basic():
+    cat = PriceCatalog([_entry("gpt-5-mini", PriceType.INPUT, "0.25")])
+    hit = cat.lookup("openai", "gpt-5-mini", PriceType.INPUT, at=date(2026, 6, 1))
+    assert hit and hit.price_per_unit == Decimal("0.25")
+
+
+def test_lookup_time_window():
+    cat = PriceCatalog(
+        [
+            _entry("m", PriceType.INPUT, "1.00", version="v1",
+                   valid_from=date(2026, 1, 1), valid_to=date(2026, 5, 1)),
+            _entry("m", PriceType.INPUT, "2.00", version="v2", valid_from=date(2026, 5, 1)),
+        ]
+    )
+    old = cat.lookup("openai", "m", PriceType.INPUT, at=date(2026, 3, 1))
+    new = cat.lookup("openai", "m", PriceType.INPUT, at=date(2026, 6, 1))
+    assert old.version == "v1" and new.version == "v2"
+
+
+def test_lookup_miss_returns_none():
+    cat = PriceCatalog()
+    assert cat.lookup("openai", "ghost", PriceType.INPUT, at=date(2026, 6, 1)) is None
+
+
+def test_tenant_override_precedence():
+    cat = PriceCatalog([_entry("gpt-5", PriceType.INPUT, "2.50")])
+    cat.add_override("tenant-x", _entry("gpt-5", PriceType.INPUT, "1.00", version="contract"))
+    public = cat.lookup("openai", "gpt-5", PriceType.INPUT, at=date(2026, 6, 1))
+    contract = cat.lookup(
+        "openai", "gpt-5", PriceType.INPUT, at=date(2026, 6, 1), tenant_id="tenant-x"
+    )
+    assert public.price_per_unit == Decimal("2.50")
+    assert contract.price_per_unit == Decimal("1.00")
+
+
+def test_compute_cost_chat():
+    cat = seed_catalog()
+    # 1M input + 1M output on gpt-5-mini = 0.25 + 2.00 = 2.25 USD = 2_250_000 micro
+    micro, version = compute_cost_micro_usd(
+        cat, "openai", "gpt-5-mini",
+        Usage(input_tokens=1_000_000, output_tokens=1_000_000),
+        at=date(2026, 6, 1),
+    )
+    assert micro == 2_250_000
+    assert version == "seed-2026-05-01"
+
+
+def test_compute_cost_cached_input_cheaper():
+    cat = seed_catalog()
+    # 1M input of which 1M cached, 0 output. cached rate 0.025 → 25_000 micro
+    micro, _ = compute_cost_micro_usd(
+        cat, "openai", "gpt-5-mini",
+        Usage(input_tokens=1_000_000, cached_input_tokens=1_000_000),
+        at=date(2026, 6, 1),
+    )
+    assert micro == 25_000
+
+
+def test_strict_raises_on_miss():
+    cat = PriceCatalog()
+    with pytest.raises(PriceCatalogMiss):
+        compute_cost_micro_usd(
+            cat, "openai", "ghost", Usage(input_tokens=10), at=date(2026, 6, 1), strict=True
+        )
+
+
+def test_non_strict_partial_price():
+    # only input priced; output missing → cost from input only, no crash
+    cat = PriceCatalog([_entry("m", PriceType.INPUT, "1.00")])
+    micro, _ = compute_cost_micro_usd(
+        cat, "openai", "m", Usage(input_tokens=1_000_000, output_tokens=500),
+        at=date(2026, 6, 1),
+    )
+    assert micro == 1_000_000
+
+
+def test_seed_catalog_has_openai():
+    cat = seed_catalog()
+    assert cat.lookup("openai", "gpt-5", PriceType.OUTPUT, at=date(2026, 6, 1)) is not None

--- a/sdk/python/tests/test_pricing_scraper.py
+++ b/sdk/python/tests/test_pricing_scraper.py
@@ -1,0 +1,116 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tally.pricing import PriceCatalog, PriceEntry, PriceType, Unit
+from tally.pricing_scraper import (
+    Approval,
+    PriceReviewError,
+    PriceScraper,
+    diff_entries,
+)
+
+
+def _e(model, pt, rate, version="v2", valid_from=date(2026, 6, 1)):
+    return PriceEntry(
+        version=version,
+        valid_from=valid_from,
+        provider="openai",
+        model=model,
+        price_type=pt,
+        unit=Unit.PER_MILLION_TOKENS,
+        price_per_unit=Decimal(rate),
+    )
+
+
+class FakeFetcher:
+    provider = "openai"
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def fetch(self, *, version, valid_from):
+        # re-tag with the requested version
+        return [
+            PriceEntry(
+                version=version,
+                valid_from=valid_from,
+                provider=e.provider,
+                model=e.model,
+                price_type=e.price_type,
+                unit=e.unit,
+                price_per_unit=e.price_per_unit,
+            )
+            for e in self._entries
+        ]
+
+
+class BoomFetcher:
+    provider = "broken"
+
+    def fetch(self, *, version, valid_from):
+        raise RuntimeError("scrape failed")
+
+
+def test_diff_detects_added_changed_removed():
+    current = [_e("a", PriceType.INPUT, "1.0"), _e("gone", PriceType.INPUT, "9.0")]
+    candidate = [_e("a", PriceType.INPUT, "2.0"), _e("new", PriceType.OUTPUT, "5.0")]
+    d = diff_entries(current, candidate)
+    assert [x.model for x in d.added] == ["new"]
+    assert [x.model for x in d.removed] == ["gone"]
+    assert len(d.changed) == 1 and d.changed[0][0].model == "a"
+    assert d.magnitude == 3
+
+
+def test_build_candidate_skips_failing_fetcher():
+    scraper = PriceScraper([FakeFetcher([_e("a", PriceType.INPUT, "1.0")]), BoomFetcher()])
+    cand = scraper.build_candidate(version="v2", valid_from=date(2026, 6, 1))
+    assert len(cand) == 1
+    assert cand[0].version == "v2"
+
+
+def test_publish_requires_approval():
+    cat = PriceCatalog([_e("a", PriceType.INPUT, "1.0", version="v1")])
+    scraper = PriceScraper([])
+    candidate = [_e("a", PriceType.INPUT, "2.0", version="v2")]
+    with pytest.raises(PriceReviewError, match="not approved"):
+        scraper.publish(cat, candidate, Approval(approved=False))
+
+
+def test_publish_additive_when_approved():
+    # current is an older version; candidate has a later valid_from (newest wins on lookup)
+    cat = PriceCatalog(
+        [_e("a", PriceType.INPUT, "1.0", version="v1", valid_from=date(2026, 5, 1))]
+    )
+    scraper = PriceScraper([])
+    candidate = [_e("a", PriceType.INPUT, "2.0", version="v2", valid_from=date(2026, 6, 1))]
+    diff = scraper.publish(cat, candidate, Approval(approved=True, reviewer="me"))
+    assert len(diff.changed) == 1
+    # additive: newest valid_from wins on lookup, old version retained
+    hit = cat.lookup("openai", "a", PriceType.INPUT, at=date(2026, 7, 1))
+    assert hit.price_per_unit == Decimal("2.0")
+
+
+def test_large_diff_requires_ack():
+    cat = PriceCatalog()
+    scraper = PriceScraper([], large_diff_threshold=2)
+    candidate = [
+        _e("m1", PriceType.INPUT, "1"),
+        _e("m2", PriceType.INPUT, "1"),
+        _e("m3", PriceType.INPUT, "1"),
+    ]
+    with pytest.raises(PriceReviewError, match="large diff"):
+        scraper.publish(cat, candidate, Approval(approved=True))
+    # with ack it goes through
+    diff = scraper.publish(cat, candidate, Approval(approved=True, ack_large_diff=True))
+    assert diff.magnitude == 3
+
+
+def test_empty_diff_is_noop():
+    cat = PriceCatalog([_e("a", PriceType.INPUT, "1.0", version="v1")])
+    scraper = PriceScraper([])
+    # identical price → empty diff → publish is a no-op even without approval
+    candidate = [_e("a", PriceType.INPUT, "1.0", version="v2")]
+    diff = scraper.publish(cat, candidate, Approval(approved=False))
+    assert diff.is_empty

--- a/sdk/python/tests/test_safety.py
+++ b/sdk/python/tests/test_safety.py
@@ -1,0 +1,73 @@
+import pytest
+
+from tally.client import MemoryExporter, TallyClient
+from tally.safety import SelfObservability, safe, safe_block
+from tally.schema import GenAI, SpanFields
+
+
+def test_safe_swallows_and_returns_fallback():
+    obs = SelfObservability()
+
+    @safe(obs, fallback=-1)
+    def boom():
+        raise ValueError("kaboom")
+
+    assert boom() == -1
+    assert obs.internal_error_count == 1
+    assert "kaboom" in obs.last_errors[-1]
+
+
+def test_safe_passes_through_success():
+    obs = SelfObservability()
+
+    @safe(obs, fallback=None)
+    def ok(x):
+        return x * 2
+
+    assert ok(21) == 42
+    assert obs.internal_error_count == 0
+
+
+def test_safe_block_records_not_raises():
+    obs = SelfObservability()
+    with safe_block(obs, where="unit"):
+        raise RuntimeError("inside block")
+    assert obs.internal_error_count == 1
+
+
+@pytest.mark.parametrize("exc", [KeyboardInterrupt, SystemExit])
+def test_never_swallow_interrupts(exc):
+    obs = SelfObservability()
+
+    @safe(obs)
+    def interrupt():
+        raise exc()
+
+    with pytest.raises(exc):
+        interrupt()
+
+
+def test_client_absorbs_faulty_exporter():
+    class FaultyExporter:
+        def export(self, attributes):
+            raise OSError("network down")
+
+    client = TallyClient(exporter=FaultyExporter())
+    # Must not raise into caller.
+    client.record_span(SpanFields(system="openai", input_tokens=5))
+    assert client.observability.internal_error_count == 1
+
+
+def test_client_happy_path_exports():
+    exporter = MemoryExporter()
+    client = TallyClient(exporter=exporter)
+    client.record_span(SpanFields(system="openai", request_model="gpt-5-mini", input_tokens=10))
+    assert len(exporter.spans) == 1
+    assert exporter.spans[0][GenAI.SYSTEM] == "openai"
+    assert client.observability.internal_error_count == 0
+
+
+def test_snapshot_shape():
+    obs = SelfObservability()
+    snap = obs.snapshot()
+    assert set(snap) == {"internal_error_count", "context_drop_count", "dropped_span_count"}

--- a/sdk/python/tests/test_sampling.py
+++ b/sdk/python/tests/test_sampling.py
@@ -1,0 +1,81 @@
+from tally.sampling import (
+    BillingMeter,
+    Sampler,
+    SamplingConfig,
+    Stratum,
+    TraceSignals,
+    assign_stratum,
+    extrapolate_cost,
+)
+
+
+def test_stratum_assignment():
+    cfg = SamplingConfig()
+    assert assign_stratum(TraceSignals(is_agent=True), cfg) is Stratum.TAIL
+    assert assign_stratum(TraceSignals(model_tier="premium"), cfg) is Stratum.TAIL
+    assert assign_stratum(TraceSignals(prompt_tokens_estimate=9000), cfg) is Stratum.TAIL
+    assert assign_stratum(TraceSignals(prompt_tokens_estimate=3000), cfg) is Stratum.MID
+    assert assign_stratum(TraceSignals(prompt_tokens_estimate=10), cfg) is Stratum.BODY
+
+
+def test_decision_is_deterministic():
+    s = Sampler(SamplingConfig(body_rate=0.5))
+    d1 = s.decide("trace-xyz", TraceSignals())
+    d2 = s.decide("trace-xyz", TraceSignals())
+    assert d1 == d2
+
+
+def test_tail_always_kept():
+    s = Sampler(SamplingConfig(tail_rate=1.0))
+    for i in range(200):
+        d = s.decide(f"t{i}", TraceSignals(is_agent=True))
+        assert d.keep is True
+        assert d.stratum is Stratum.TAIL
+        assert d.sample_rate == 1.0
+
+
+def test_body_sampled_down_statistically():
+    s = Sampler(SamplingConfig(body_rate=0.1))
+    kept = sum(
+        1 for i in range(10_000) if s.decide(f"id-{i}", TraceSignals()).keep
+    )
+    # ~10% with tolerance
+    assert 800 <= kept <= 1200
+
+
+def test_whole_trace_one_decision():
+    # The decision depends only on trace_id, so every span in a trace agrees.
+    s = Sampler(SamplingConfig(body_rate=0.3))
+    d = s.decide("same-trace", TraceSignals())
+    for _ in range(50):
+        assert s.decide("same-trace", TraceSignals()).keep == d.keep
+
+
+def test_feature_override():
+    s = Sampler(SamplingConfig(body_rate=0.0, feature_overrides={"vip": 1.0}))
+    assert s.decide("anything", TraceSignals(), feature_tag="vip").keep is True
+    assert s.decide("anything", TraceSignals(), feature_tag="other").keep is False
+
+
+def test_billing_counts_regardless_of_sampling():
+    s = Sampler(SamplingConfig(body_rate=0.0))  # drop everything from analytics
+    meter = BillingMeter()
+    for i in range(100):
+        tid = f"trace-{i}"
+        meter.count_trace(tid)  # at HEAD, before sampling
+        s.decide(tid, TraceSignals())  # would drop
+    assert meter.trace_count == 100  # billing unaffected by sampling
+
+
+def test_billing_dedup_per_trace():
+    meter = BillingMeter()
+    meter.count_trace("t1")
+    meter.count_trace("t1")
+    meter.count_trace("t2")
+    assert meter.trace_count == 2
+
+
+def test_extrapolation_tail_exact_body_scaled():
+    # tail kept at 1.0 contributes exactly; body kept at 0.1 scales up ~10x
+    samples = [(1000, 1.0), (50, 0.1)]
+    assert extrapolate_cost(samples) == 1000 + 500

--- a/sdk/python/tests/test_schema.py
+++ b/sdk/python/tests/test_schema.py
@@ -1,0 +1,85 @@
+from decimal import Decimal
+
+import pytest
+
+from tally.schema import (
+    DEFAULT_CURRENCY,
+    GenAI,
+    SpanFields,
+    build_span_attributes,
+    micro_to_usd,
+    usd_to_micro,
+    validate_span_attributes,
+)
+
+
+def test_build_emits_only_set_fields():
+    attrs = build_span_attributes(SpanFields(system="openai", input_tokens=10))
+    assert attrs[GenAI.SYSTEM] == "openai"
+    assert attrs[GenAI.USAGE_INPUT_TOKENS] == 10
+    assert GenAI.RESPONSE_MODEL not in attrs
+
+
+def test_build_is_conformant():
+    fields = SpanFields(
+        system="openai",
+        request_model="gpt-5-mini",
+        response_model="gpt-5-mini",
+        operation="chat",
+        input_tokens=1200,
+        output_tokens=300,
+        cached_input_tokens=512,
+        cost_estimated_micro_usd=1234,
+        feature_tag="research_agent",
+        session_id="sess_1",
+        user_id_hash="a" * 64,
+        user_id_hash_key_version="v1",
+        agent_run_id="run_1",
+        agent_step_index=3,
+        tool_name="web_fetch",
+        tool_cost_micro_usd=10,
+    )
+    attrs = build_span_attributes(fields)
+    assert validate_span_attributes(attrs) == []
+    # currency defaulted because a cost is present
+    assert attrs[GenAI.COST_CURRENCY] == DEFAULT_CURRENCY
+
+
+def test_unknown_key_is_violation():
+    assert any("unknown" in v for v in validate_span_attributes({"llm.tokens": 5}))
+
+
+def test_int_keys_reject_bool_and_float():
+    assert validate_span_attributes({GenAI.USAGE_INPUT_TOKENS: True})
+    assert validate_span_attributes({GenAI.USAGE_INPUT_TOKENS: 1.5})
+
+
+def test_negative_tokens_rejected():
+    assert validate_span_attributes({GenAI.USAGE_OUTPUT_TOKENS: -1})
+
+
+def test_cost_requires_currency():
+    violations = validate_span_attributes({GenAI.COST_ESTIMATED_MICRO_USD: 100})
+    assert any("currency" in v for v in violations)
+
+
+def test_operation_must_be_lowercase():
+    assert validate_span_attributes({GenAI.OPERATION_NAME: "Chat"})
+
+
+def test_bad_currency_rejected():
+    assert validate_span_attributes(
+        {GenAI.COST_ESTIMATED_MICRO_USD: 1, GenAI.COST_CURRENCY: "dollars"}
+    )
+
+
+@pytest.mark.parametrize(
+    "usd,micro",
+    [("0.0012", 1200), ("1", 1_000_000), ("0.0000005", 1), ("0.00000049", 0)],
+)
+def test_usd_micro_roundtrip(usd, micro):
+    assert usd_to_micro(usd) == micro
+
+
+def test_micro_to_usd():
+    assert micro_to_usd(1200) == Decimal("0.00120000")

--- a/sdk/python/tests/test_wire.py
+++ b/sdk/python/tests/test_wire.py
@@ -1,0 +1,120 @@
+from tally.wire import (
+    BatchRequest,
+    BatchResponse,
+    BusinessEvent,
+    IdempotencyCache,
+    IdentityLink,
+    Status,
+    decode_request,
+    encode_request,
+    uuid7,
+)
+
+
+def test_uuid7_is_version_7_and_ordered():
+    import time
+
+    a = uuid7()
+    assert a[14] == "7"  # version nibble
+    time.sleep(0.002)
+    b = uuid7()
+    # time-ordered: later id sorts after earlier (first 48 bits are ms timestamp)
+    assert b > a
+
+
+def test_codec_roundtrip():
+    req = BatchRequest(
+        tenant_id="t1",
+        sdk_version="py-0.0.1",
+        resource_spans=[{"TraceId": "tr", "SpanId": "sp", "x": 1}],
+        business_events=[
+            BusinessEvent("ev1", "signup", "u" * 64, occurred_at_ns=123)
+        ],
+        identity_links=[
+            IdentityLink("a", "anonymous_id", "b", "user_id", observed_at_ns=1)
+        ],
+    )
+    back = decode_request(encode_request(req))
+    assert back.tenant_id == "t1"
+    assert back.batch_id == req.batch_id
+    assert back.resource_spans == req.resource_spans
+    assert back.business_events[0].event_name == "signup"
+    assert back.identity_links[0].identity_a_type == "anonymous_id"
+
+
+def test_intra_batch_span_dedup():
+    req = BatchRequest(
+        tenant_id="t",
+        sdk_version="v",
+        resource_spans=[
+            {"TraceId": "tr", "SpanId": "s1"},
+            {"TraceId": "tr", "SpanId": "s1"},  # dup
+            {"TraceId": "tr", "SpanId": "s2"},
+        ],
+    )
+    dd = req.deduplicated()
+    assert len(dd.resource_spans) == 2
+
+
+def test_intra_batch_event_and_link_dedup():
+    req = BatchRequest(
+        tenant_id="t",
+        sdk_version="v",
+        business_events=[
+            BusinessEvent("e1", "x", "u", 1),
+            BusinessEvent("e1", "x", "u", 1),  # dup id
+        ],
+        identity_links=[
+            IdentityLink("a", "t1", "b", "t2", 1, source="sdk"),
+            IdentityLink("a", "t1", "b", "t2", 1, source="sdk"),  # dup
+            IdentityLink("a", "t1", "b", "t2", 1, source="cdp"),  # different source
+        ],
+    )
+    dd = req.deduplicated()
+    assert len(dd.business_events) == 1
+    assert len(dd.identity_links) == 2
+
+
+def test_idempotency_returns_cached_on_replay():
+    cache = IdempotencyCache()
+    req = BatchRequest(tenant_id="t", sdk_version="v")
+
+    first = cache.check_or_store(req)
+    assert first is None  # not seen before
+    cache.record(
+        req, BatchResponse(batch_id=req.batch_id, status=Status.ACCEPTED, accepted_spans=3)
+    )
+
+    replay = cache.check_or_store(req)
+    assert replay is not None
+    assert replay.accepted_spans == 3  # original response returned, not reprocessed
+
+
+def test_idempotency_distinct_batches_not_deduped():
+    cache = IdempotencyCache()
+    r1 = BatchRequest(tenant_id="t", sdk_version="v")
+    r2 = BatchRequest(tenant_id="t", sdk_version="v")
+    assert cache.check_or_store(r1) is None
+    assert cache.check_or_store(r2) is None  # different batch_id
+
+
+def test_idempotency_ttl_expiry():
+    clock = {"t": 1000.0}
+    cache = IdempotencyCache(ttl_seconds=10, now=lambda: clock["t"])
+    req = BatchRequest(tenant_id="t", sdk_version="v")
+    cache.check_or_store(req)
+    cache.record(req, BatchResponse(batch_id=req.batch_id))
+    clock["t"] += 11  # past TTL
+    # entry purged → treated as new
+    assert cache.check_or_store(req) is None
+
+
+def test_same_batch_id_different_tenant_isolated():
+    cache = IdempotencyCache()
+    bid = uuid7()
+    a = BatchRequest(tenant_id="A", sdk_version="v", batch_id=bid)
+    b = BatchRequest(tenant_id="B", sdk_version="v", batch_id=bid)
+    assert cache.check_or_store(a) is None
+    cache.record(a, BatchResponse(batch_id=bid, accepted_spans=1))
+    # same batch_id but different tenant must NOT collide
+    assert cache.check_or_store(b) is None


### PR DESCRIPTION
## Why this PR exists
PRs #2–#15 were stacked (each based on the previous feature branch). When merged, their code landed in the **intermediate branches, not `main`** — so although all 15 show "merged", `main` still only contains the scaffold (#1). This PR lands the full, already-reviewed Phase-1 SDK stack onto `main` in one merge.

## What's included (all previously reviewed + CI-green)
- Span schema (CTO-47), SDK safety (CTO-45), context propagation (CTO-46)
- Sampling (CTO-50), guardrails (CTO-51), price catalog (CTO-52)
- `otel_spans` DDL (CTO-22), egress (CTO-49), OpenAI instrumentation (CTO-48)
- `record_llm_call()` integration (CTO-9), price scraper (CTO-53)
- Wire envelope + idempotency (CTO-32), cross_process_ratio (CTO-83), compat matrix (CTO-44)

16 modules, ~3.5k lines, 122 tests. CI green on the tip branch.

## After merging
`main` becomes the true source of truth and future work branches off it normally (no more stacking). 

## Process note for next time
To avoid this, either base each PR on `main` (independent PRs) or use a merge-queue/“rebase onto main” so stacked merges propagate to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)