### PR TITLE
feat(db): rollup MVs + last_touch + attribution DDL [CTO-24/25/26]

### DIFF
--- a/db/clickhouse/attribution.sql
+++ b/db/clickhouse/attribution.sql
@@ -1,0 +1,76 @@
+-- Attribution tables (Workflow 2). Implements CTO-26. Spec §5.1, §7.
+-- TenantId-first throughout (shared multi-tenant). Carries UserIdHashKeyVersion for cross-version
+-- identity bridging (CTO-74). Defined pre-data — adding columns later is a backfill incident.
+
+-- identity_graph: transitive identity edges (anonymous <-> user <-> session, across key versions).
+CREATE TABLE IF NOT EXISTS identity_graph
+(
+    TenantId              LowCardinality(String),
+    IdentityA             FixedString(64),
+    IdentityAType         Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5),
+    IdentityB             FixedString(64),
+    IdentityBType         Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5),
+    UserIdHashKeyVersion  LowCardinality(String),
+    Confidence            Float32,
+    ObservedAt            DateTime64(9),
+    Source                LowCardinality(String),
+    INDEX idx_a IdentityA TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_b IdentityB TYPE bloom_filter(0.01) GRANULARITY 4
+)
+ENGINE = ReplacingMergeTree(ObservedAt)
+ORDER BY (TenantId, IdentityA, IdentityB, Source);
+
+-- business_events: inbound value events from CDPs/webhooks.
+CREATE TABLE IF NOT EXISTS business_events
+(
+    TenantId          LowCardinality(String),
+    BusinessEventId   String,
+    EventName         LowCardinality(String),
+    UserIdHash        FixedString(64),
+    OccurredAt        DateTime64(9),
+    IngestedAt        DateTime64(9),
+    ValueAmountMicro  Nullable(Int64),
+    ValueCurrency     LowCardinality(String),
+    ValueType         Enum8('monetary'=1,'count'=2,'mrr'=3,'refund'=4),
+    Source            LowCardinality(String),
+    RawPayload        String CODEC(ZSTD(3))
+)
+ENGINE = ReplacingMergeTree(IngestedAt)
+PARTITION BY toYYYYMM(OccurredAt)
+ORDER BY (TenantId, BusinessEventId);
+
+-- attribution_records: idempotent on (TenantId, BusinessEventId, FeatureTag).
+CREATE TABLE IF NOT EXISTS attribution_records
+(
+    TenantId              LowCardinality(String),
+    BusinessEventId       String,
+    FeatureTag            LowCardinality(String),
+    AttributedTraceId     String,
+    AttributedTraceTs     DateTime64(9),
+    AttributedTraceCost   Decimal64(8),
+    ValueAmountMicro      Nullable(Int64),
+    ValueCurrency         LowCardinality(String),
+    AttributionModel      LowCardinality(String),
+    AttributionConfidence Enum8('direct'=1,'session_stitched'=2,'identity_graph_stitched'=3),
+    UserIdHashKeyVersion  LowCardinality(String),
+    LookbackWindowDays    UInt16,
+    StitchedAt            DateTime64(9),
+    StitcherVersion       LowCardinality(String)
+)
+ENGINE = ReplacingMergeTree(StitchedAt)
+PARTITION BY toYYYYMM(AttributedTraceTs)
+ORDER BY (TenantId, BusinessEventId, FeatureTag);
+
+-- unattributed_events: queryable, NOT a silent drop. Re-checked by the reconciler.
+CREATE TABLE IF NOT EXISTS unattributed_events
+(
+    TenantId         LowCardinality(String),
+    BusinessEventId  String,
+    EventName        LowCardinality(String),
+    UserIdHash       FixedString(64),
+    OccurredAt       DateTime64(9),
+    Reason           Enum8('no_trace_in_window'=1,'unknown_user'=2,'identity_unresolved'=3,'feature_tag_missing'=4),
+    LastCheckedAt    DateTime64(9)
+)
+ENGINE = ReplacingMergeTree(LastCheckedAt)
+ORDER BY (TenantId, BusinessEventId);

--- a/db/clickhouse/last_touch_index.sql
+++ b/db/clickhouse/last_touch_index.sql
@@ -1,0 +1,34 @@
+-- last_touch_index — O(1) "most recent trace per (tenant, user, feature)" for the stitcher.
+-- Implements CTO-25. Spec §5.1, §7.
+--
+-- ReplacingMergeTree keyed (TenantId, UserIdHash, FeatureTag); newest UpdatedAt wins. Carries
+-- UserIdHashKeyVersion so cross-version identity bridging works after HMAC rotation (CTO-74).
+-- Query with FINAL (or argMax) to collapse to the latest row.
+
+CREATE TABLE IF NOT EXISTS last_touch_index
+(
+    TenantId             LowCardinality(String),
+    UserIdHash           FixedString(64),
+    FeatureTag           LowCardinality(String),
+    UserIdHashKeyVersion LowCardinality(String),
+    LastTraceId          String,
+    LastTraceTs          DateTime64(9),
+    LastTraceCost        Decimal64(8),
+    UpdatedAt            DateTime64(9) DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(UpdatedAt)
+ORDER BY (TenantId, UserIdHash, FeatureTag);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS last_touch_index_mv
+TO last_touch_index
+AS SELECT
+    TenantId,
+    UserIdHash,
+    FeatureTag,
+    UserIdHashKeyVersion,
+    TraceId        AS LastTraceId,
+    Timestamp      AS LastTraceTs,
+    EstimatedCost  AS LastTraceCost,
+    Timestamp      AS UpdatedAt
+FROM otel_spans
+WHERE UserIdHash != '';

--- a/db/clickhouse/rollups.sql
+++ b/db/clickhouse/rollups.sql
@@ -1,0 +1,83 @@
+-- Rollup materialized views (ai-tally telemetry store)
+-- Implements CTO-24. Spec §5.1, Appendix A.
+--
+-- CRITICAL PATH: dashboard queries read these rollups, never raw otel_spans. SummingMergeTree
+-- aggregates per (TenantId, FeatureTag, GenAiResponseModel, bucket). Long-horizon aggregates live
+-- here (they persist independently of otel_spans' 90d retention, CTO-22/CTO-29).
+--
+-- uniqState/sumState are AggregateFunction states; query with -Merge combinators.
+
+CREATE TABLE IF NOT EXISTS daily_feature_rollup
+(
+    TenantId            LowCardinality(String),
+    Day                 Date,
+    FeatureTag          LowCardinality(String),
+    GenAiResponseModel  LowCardinality(String),
+    InputTokens         UInt64,
+    OutputTokens        UInt64,
+    CachedInputTokens   UInt64,
+    EstimatedCost       Decimal64(8),
+    ReconciledCost      Decimal64(8),
+    SpanCount           UInt64,
+    TraceCountState     AggregateFunction(uniq, String),
+    UserCountState      AggregateFunction(uniq, FixedString(64))
+)
+ENGINE = SummingMergeTree
+PARTITION BY toYYYYMM(Day)
+ORDER BY (TenantId, FeatureTag, GenAiResponseModel, Day);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS daily_feature_rollup_mv
+TO daily_feature_rollup
+AS SELECT
+    TenantId,
+    toDate(Timestamp)                      AS Day,
+    FeatureTag,
+    GenAiResponseModel,
+    sum(InputTokens)                       AS InputTokens,
+    sum(OutputTokens)                      AS OutputTokens,
+    sum(CachedInputTokens)                 AS CachedInputTokens,
+    sum(EstimatedCost)                     AS EstimatedCost,
+    sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+    count()                                AS SpanCount,
+    uniqState(TraceId)                     AS TraceCountState,
+    uniqState(UserIdHash)                  AS UserCountState
+FROM otel_spans
+GROUP BY TenantId, Day, FeatureTag, GenAiResponseModel;
+
+-- Hourly rollup: same shape, finer bucket. Powers "last hour" views without scanning raw spans.
+CREATE TABLE IF NOT EXISTS hourly_feature_rollup
+(
+    TenantId            LowCardinality(String),
+    Hour                DateTime,
+    FeatureTag          LowCardinality(String),
+    GenAiResponseModel  LowCardinality(String),
+    InputTokens         UInt64,
+    OutputTokens        UInt64,
+    CachedInputTokens   UInt64,
+    EstimatedCost       Decimal64(8),
+    ReconciledCost      Decimal64(8),
+    SpanCount           UInt64,
+    TraceCountState     AggregateFunction(uniq, String),
+    UserCountState      AggregateFunction(uniq, FixedString(64))
+)
+ENGINE = SummingMergeTree
+PARTITION BY toYYYYMM(Hour)
+ORDER BY (TenantId, FeatureTag, GenAiResponseModel, Hour);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS hourly_feature_rollup_mv
+TO hourly_feature_rollup
+AS SELECT
+    TenantId,
+    toStartOfHour(Timestamp)               AS Hour,
+    FeatureTag,
+    GenAiResponseModel,
+    sum(InputTokens)                       AS InputTokens,
+    sum(OutputTokens)                      AS OutputTokens,
+    sum(CachedInputTokens)                 AS CachedInputTokens,
+    sum(EstimatedCost)                     AS EstimatedCost,
+    sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+    count()                                AS SpanCount,
+    uniqState(TraceId)                     AS TraceCountState,
+    uniqState(UserIdHash)                  AS UserCountState
+FROM otel_spans
+GROUP BY TenantId, Hour, FeatureTag, GenAiResponseModel;

--- a/sdk/python/tests/test_views_ddl.py
+++ b/sdk/python/tests/test_views_ddl.py
@@ -1,0 +1,82 @@
+"""Structural validation for the rollup MV, last_touch_index, and attribution DDL.
+
+CTO-24/25/26. ClickHouse isn't available in CI, so we assert the spec-load-bearing invariants:
+TenantId-first ordering, MVs read from otel_spans, UserIdHashKeyVersion present where bridging
+needs it, idempotency keys, and balanced parens (not truncated).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DB = Path(__file__).resolve().parents[3] / "db" / "clickhouse"
+
+
+def _read(name: str) -> str:
+    p = DB / name
+    assert p.exists(), f"missing DDL {p}"
+    return p.read_text()
+
+
+@pytest.fixture(scope="module")
+def rollups() -> str:
+    return _read("rollups.sql")
+
+
+@pytest.fixture(scope="module")
+def last_touch() -> str:
+    return _read("last_touch_index.sql")
+
+
+@pytest.fixture(scope="module")
+def attribution() -> str:
+    return _read("attribution.sql")
+
+
+def test_rollups_read_from_spans_and_sum(rollups):
+    assert rollups.count("FROM otel_spans") == 2  # daily + hourly
+    assert "SummingMergeTree" in rollups
+    assert "daily_feature_rollup" in rollups and "hourly_feature_rollup" in rollups
+
+
+def test_rollups_tenant_first(rollups):
+    for clause in rollups.split("ORDER BY ("):
+        first = clause.split(")")[0].split(",")[0].strip()
+        if first and not first.startswith("--"):
+            # every ORDER BY in this file starts with TenantId
+            assert first == "TenantId", f"expected TenantId-first, got {first!r}"
+
+
+def test_last_touch_replacing_and_keyed(last_touch):
+    assert "ReplacingMergeTree(UpdatedAt)" in last_touch
+    assert "ORDER BY (TenantId, UserIdHash, FeatureTag)" in last_touch
+    assert "FROM otel_spans" in last_touch
+    assert "UserIdHashKeyVersion" in last_touch  # cross-version bridging
+
+
+def test_attribution_has_four_tables(attribution):
+    for t in ("identity_graph", "business_events", "attribution_records", "unattributed_events"):
+        assert f"CREATE TABLE IF NOT EXISTS {t}" in attribution
+
+
+def test_attribution_idempotent_key(attribution):
+    # attribution_records idempotent on (TenantId, BusinessEventId, FeatureTag)
+    assert "ORDER BY (TenantId, BusinessEventId, FeatureTag)" in attribution
+
+
+def test_attribution_carries_key_version(attribution):
+    # identity_graph + attribution_records need the HMAC key version for bridging
+    assert attribution.count("UserIdHashKeyVersion") >= 2
+
+
+def test_unattributed_is_modeled(attribution):
+    assert "unattributed_events" in attribution
+    assert "no_trace_in_window" in attribution  # reasons enumerated, not silent drop
+
+
+@pytest.mark.parametrize("name", ["rollups.sql", "last_touch_index.sql", "attribution.sql"])
+def test_balanced_parens(name):
+    sql = _read(name)
+    assert sql.count("(") == sql.count(")")


### PR DESCRIPTION
Branched off `main` (consolidation #16 landed the SDK stack). No more stacking.

## Summary
- **CTO-24** `rollups.sql`: daily + hourly SummingMergeTree MVs from `otel_spans` (the critical read path — dashboards never scan raw spans).
- **CTO-25** `last_touch_index.sql`: ReplacingMergeTree for O(1) stitcher lookups; carries `UserIdHashKeyVersion`.
- **CTO-26** `attribution.sql`: `identity_graph`, `business_events`, `attribution_records` (idempotent on tenant+event+feature), `unattributed_events` (queryable, not silent).

## Acceptance criteria
- [x] Rollups aggregate per (TenantId, FeatureTag, GenAiResponseModel, bucket), read from otel_spans
- [x] last_touch keyed (TenantId, UserIdHash, FeatureTag) + key version
- [x] Four attribution tables, TenantId-first, idempotency keys, key-version for bridging
- [ ] Live apply on real ClickHouse (infra, CTO-94) — structural tests stand in for CI

## Out of scope
The stitcher/reconciler logic (CTO-69/64), CDP connectors (CTO-68), resource-group isolation (CTO-30).

## Test plan
- [x] `ruff` + `pytest` green (132 tests, +10 DDL assertions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)