### PR TITLE
feat(sdk): clock-skew handling for ingest timestamps [CTO-38]

### DIFF
--- a/sdk/python/src/tally/timekeeping.py
+++ b/sdk/python/src/tally/timekeeping.py
@@ -1,0 +1,77 @@
+"""Clock-skew handling for ingest timestamps.
+
+Implements CTO-38. Spec §12.9.
+
+Spans carry a client-emitted timestamp; the gateway also records when it received the batch.
+Client clocks drift, and a future-dated client timestamp would poison time-bucketed rollups. So:
+
+- the **effective** timestamp used for rollups is ``min(client_ts, server_recv_ts + max_future)``
+  — a slightly-fast client is tolerated up to ``max_future`` (default 1h), a wildly-future client
+  is clamped to "now-ish";
+- skew beyond a threshold (default 5 min) is flagged per tenant for monitoring.
+
+Pure functions over nanosecond epoch timestamps — no infra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+NS_PER_SECOND = 1_000_000_000
+DEFAULT_MAX_FUTURE_S = 3600  # 1 hour
+DEFAULT_SKEW_THRESHOLD_S = 300  # 5 minutes
+
+
+def effective_timestamp_ns(
+    client_ts_ns: int,
+    server_recv_ts_ns: int,
+    *,
+    max_future_s: int = DEFAULT_MAX_FUTURE_S,
+) -> int:
+    """Timestamp to use for storage/rollups: ``min(client_ts, server_recv + max_future)``.
+
+    A client behind the server clock is used as-is (past timestamps are fine). A client ahead of
+    the server by more than ``max_future`` is clamped so it can't land in a future rollup bucket.
+    """
+    ceiling = server_recv_ts_ns + max_future_s * NS_PER_SECOND
+    return min(client_ts_ns, ceiling)
+
+
+def skew_seconds(client_ts_ns: int, server_recv_ts_ns: int) -> float:
+    """Signed skew in seconds: positive = client ahead of server."""
+    return (client_ts_ns - server_recv_ts_ns) / NS_PER_SECOND
+
+
+def is_skewed(
+    client_ts_ns: int,
+    server_recv_ts_ns: int,
+    *,
+    threshold_s: int = DEFAULT_SKEW_THRESHOLD_S,
+) -> bool:
+    """True when |skew| exceeds the threshold (default 5 min)."""
+    return abs(skew_seconds(client_ts_ns, server_recv_ts_ns)) > threshold_s
+
+
+@dataclass(frozen=True, slots=True)
+class SkewAssessment:
+    effective_ts_ns: int
+    skew_s: float
+    skewed: bool
+    clamped: bool
+
+
+def assess(
+    client_ts_ns: int,
+    server_recv_ts_ns: int,
+    *,
+    max_future_s: int = DEFAULT_MAX_FUTURE_S,
+    threshold_s: int = DEFAULT_SKEW_THRESHOLD_S,
+) -> SkewAssessment:
+    """One-shot: effective timestamp + skew + flags. The gateway logs ``skewed`` per tenant."""
+    eff = effective_timestamp_ns(client_ts_ns, server_recv_ts_ns, max_future_s=max_future_s)
+    return SkewAssessment(
+        effective_ts_ns=eff,
+        skew_s=skew_seconds(client_ts_ns, server_recv_ts_ns),
+        skewed=is_skewed(client_ts_ns, server_recv_ts_ns, threshold_s=threshold_s),
+        clamped=eff < client_ts_ns,
+    )

--- a/sdk/python/tests/test_timekeeping.py
+++ b/sdk/python/tests/test_timekeeping.py
@@ -1,0 +1,61 @@
+from tally.timekeeping import (
+    NS_PER_SECOND,
+    assess,
+    effective_timestamp_ns,
+    is_skewed,
+    skew_seconds,
+)
+
+
+def _s(seconds: float) -> int:
+    return int(seconds * NS_PER_SECOND)
+
+
+def test_client_in_past_used_as_is():
+    client = _s(1000)
+    server = _s(1010)  # server later → client is in the past
+    assert effective_timestamp_ns(client, server) == client
+
+
+def test_client_slightly_ahead_within_tolerance_used_as_is():
+    server = _s(1000)
+    client = _s(1000 + 600)  # 10 min ahead, under 1h ceiling
+    assert effective_timestamp_ns(client, server) == client
+
+
+def test_runaway_future_client_clamped():
+    server = _s(1000)
+    client = _s(1000 + 10 * 3600)  # 10h ahead
+    eff = effective_timestamp_ns(client, server)
+    assert eff == server + 3600 * NS_PER_SECOND  # clamped to server + 1h
+    assert eff < client
+
+
+def test_skew_seconds_signed():
+    assert skew_seconds(_s(1100), _s(1000)) == 100.0   # client ahead
+    assert skew_seconds(_s(900), _s(1000)) == -100.0   # client behind
+
+
+def test_is_skewed_threshold():
+    assert is_skewed(_s(1000 + 400), _s(1000)) is True   # 400s > 300s
+    assert is_skewed(_s(1000 + 100), _s(1000)) is False  # within 300s
+    assert is_skewed(_s(1000 - 400), _s(1000)) is True   # behind also counts
+
+
+def test_assess_clamped_and_flagged():
+    server = _s(1000)
+    client = _s(1000 + 10 * 3600)
+    a = assess(client, server)
+    assert a.clamped is True
+    assert a.skewed is True
+    assert a.skew_s == 10 * 3600
+    assert a.effective_ts_ns == server + 3600 * NS_PER_SECOND
+
+
+def test_assess_clean_case():
+    server = _s(1000)
+    client = _s(1001)
+    a = assess(client, server)
+    assert a.clamped is False
+    assert a.skewed is False
+    assert a.effective_ts_ns == client


### PR DESCRIPTION
Branched off `main`.

## Summary
`timekeeping.py` — pure ns-epoch functions: `effective_timestamp_ns` = `min(client, server_recv + 1h)`, `skew_seconds`, `is_skewed` (5-min threshold), `assess()`.

## Acceptance criteria
- [x] Records both timestamps' relationship; effective ts clamps runaway-future clients
- [x] Skew > 5 min flagged (signed; behind counts too)
- [x] Rollup-poisoning prevented (future client → clamped to server+1h), unit-tested

## Out of scope
Gateway wiring + per-tenant skew metric emission (CTO-31/33 infra); the MV `least(...)` expression mirrors this (CTO-24, already merged).

## Test plan
- [x] `ruff` + `pytest` green (129 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)