### PR TITLE
feat(sdk): server-side cost enrichment + drift detection [CTO-35]

### DIFF
--- a/sdk/python/src/tally/enrichment.py
+++ b/sdk/python/src/tally/enrichment.py
@@ -1,0 +1,97 @@
+"""Server-side cost enrichment.
+
+Implements CTO-35. Spec §12.3.
+
+Cost must be trustworthy and consistent, so the gateway recomputes it from the price catalog
+rather than trusting the client. The client-emitted cost is kept only as a *hint*: if it diverges
+from the server value by more than a threshold (default 5%), that's logged as catalog drift (the
+client's price table is stale, or ours is). The authoritative server value is written onto the
+span along with the catalog version (so it can be recomputed later).
+
+Pure function over a span attribute dict — no infra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
+from tally.schema import GenAI
+
+DEFAULT_DRIFT_THRESHOLD = 0.05  # 5%
+
+
+@dataclass(frozen=True, slots=True)
+class EnrichmentResult:
+    attributes: dict[str, object]
+    server_cost_micro_usd: int | None
+    client_cost_micro_usd: int | None
+    drift: float | None
+    drift_exceeded: bool
+    catalog_miss: bool
+
+
+def _int_or_none(v: object) -> int | None:
+    return v if isinstance(v, int) and not isinstance(v, bool) else None
+
+
+def enrich_cost(
+    attributes: dict[str, object],
+    catalog: PriceCatalog,
+    *,
+    at: date | None = None,
+    tenant_id: str | None = None,
+    drift_threshold: float = DEFAULT_DRIFT_THRESHOLD,
+) -> EnrichmentResult:
+    """Recompute cost server-side and write the authoritative value onto a copy of ``attributes``.
+
+    - server value (from the catalog) overwrites ``gen_ai.cost.estimated_micro_usd``;
+    - ``gen_ai.cost.price_catalog_version`` is set;
+    - the client-emitted value is treated as a hint and compared for drift;
+    - on a catalog miss the cost key is removed and ``catalog_miss`` is True (span still returned).
+    """
+    out = dict(attributes)
+    client_cost = _int_or_none(out.get(GenAI.COST_ESTIMATED_MICRO_USD))
+
+    provider = out.get(GenAI.SYSTEM)
+    model = out.get(GenAI.RESPONSE_MODEL) or out.get(GenAI.REQUEST_MODEL)
+    if not isinstance(provider, str) or not isinstance(model, str):
+        # nothing to price against
+        return EnrichmentResult(out, None, client_cost, None, False, catalog_miss=True)
+
+    usage = Usage(
+        input_tokens=_int_or_none(out.get(GenAI.USAGE_INPUT_TOKENS)) or 0,
+        output_tokens=_int_or_none(out.get(GenAI.USAGE_OUTPUT_TOKENS)) or 0,
+        cached_input_tokens=_int_or_none(out.get(GenAI.USAGE_CACHED_INPUT_TOKENS)) or 0,
+    )
+    server_cost, version = compute_cost_micro_usd(
+        catalog, provider, model, usage, at=at, tenant_id=tenant_id
+    )
+
+    catalog_miss = not version
+    if catalog_miss:
+        # no authoritative price → don't assert a cost
+        out.pop(GenAI.COST_ESTIMATED_MICRO_USD, None)
+        out.pop(GenAI.COST_PRICE_CATALOG_VERSION, None)
+        return EnrichmentResult(out, None, client_cost, None, False, catalog_miss=True)
+
+    # authoritative server value wins
+    out[GenAI.COST_ESTIMATED_MICRO_USD] = server_cost
+    out[GenAI.COST_CURRENCY] = out.get(GenAI.COST_CURRENCY, "USD")
+    out[GenAI.COST_PRICE_CATALOG_VERSION] = version
+
+    drift: float | None = None
+    drift_exceeded = False
+    if client_cost is not None and server_cost > 0:
+        drift = abs(client_cost - server_cost) / server_cost
+        drift_exceeded = drift > drift_threshold
+
+    return EnrichmentResult(
+        attributes=out,
+        server_cost_micro_usd=server_cost,
+        client_cost_micro_usd=client_cost,
+        drift=drift,
+        drift_exceeded=drift_exceeded,
+        catalog_miss=False,
+    )

--- a/sdk/python/tests/test_enrichment.py
+++ b/sdk/python/tests/test_enrichment.py
@@ -1,0 +1,84 @@
+from datetime import date
+
+from tally.enrichment import enrich_cost
+from tally.pricing import PriceCatalog, seed_catalog
+from tally.schema import GenAI, SpanFields, build_span_attributes
+
+
+def _span(client_cost=None, model="gpt-5-mini", inp=1_000_000, out=1_000_000):
+    fields = SpanFields(
+        system="openai",
+        request_model=model,
+        response_model=model,
+        operation="chat",
+        input_tokens=inp,
+        output_tokens=out,
+        cost_estimated_micro_usd=client_cost,
+    )
+    return build_span_attributes(fields)
+
+
+AT = date(2026, 6, 1)
+
+
+def test_server_value_overwrites_and_sets_version():
+    res = enrich_cost(_span(client_cost=999), seed_catalog(), at=AT)
+    assert res.server_cost_micro_usd == 2_250_000  # 0.25 + 2.00 USD
+    assert res.attributes[GenAI.COST_ESTIMATED_MICRO_USD] == 2_250_000
+    assert res.attributes[GenAI.COST_PRICE_CATALOG_VERSION] == "seed-2026-05-01"
+    assert res.catalog_miss is False
+
+
+def test_client_cost_is_hint_only():
+    # client claimed a wildly different cost; server value still wins
+    res = enrich_cost(_span(client_cost=10), seed_catalog(), at=AT)
+    assert res.attributes[GenAI.COST_ESTIMATED_MICRO_USD] == res.server_cost_micro_usd
+    assert res.client_cost_micro_usd == 10
+
+
+def test_drift_flagged_over_threshold():
+    res = enrich_cost(_span(client_cost=10), seed_catalog(), at=AT)  # ~100% off
+    assert res.drift is not None and res.drift > 0.05
+    assert res.drift_exceeded is True
+
+
+def test_drift_within_threshold_not_flagged():
+    # client within 5% of the 2_250_000 server value
+    res = enrich_cost(_span(client_cost=2_200_000), seed_catalog(), at=AT)
+    assert res.drift_exceeded is False
+
+
+def test_no_client_cost_no_drift():
+    res = enrich_cost(_span(client_cost=None), seed_catalog(), at=AT)
+    assert res.client_cost_micro_usd is None
+    assert res.drift is None
+    assert res.drift_exceeded is False
+
+
+def test_catalog_miss_removes_cost():
+    res = enrich_cost(_span(client_cost=500, model="ghost-model"), seed_catalog(), at=AT)
+    assert res.catalog_miss is True
+    assert GenAI.COST_ESTIMATED_MICRO_USD not in res.attributes
+
+
+def test_empty_catalog_is_miss():
+    res = enrich_cost(_span(client_cost=500), PriceCatalog(), at=AT)
+    assert res.catalog_miss is True
+    assert res.server_cost_micro_usd is None
+
+
+def test_cached_input_priced_via_catalog():
+    fields = SpanFields(
+        system="openai", request_model="gpt-5-mini", response_model="gpt-5-mini",
+        operation="chat", input_tokens=1_000_000, output_tokens=0,
+        cached_input_tokens=1_000_000,
+    )
+    res = enrich_cost(build_span_attributes(fields), seed_catalog(), at=AT)
+    assert res.server_cost_micro_usd == 25_000  # all cached at 0.025 USD
+
+
+def test_original_not_mutated():
+    span = _span(client_cost=10)
+    before = dict(span)
+    enrich_cost(span, seed_catalog(), at=AT)
+    assert span == before  # enrich returns a copy


### PR DESCRIPTION
Branched off `main`.

## Summary
`enrichment.py` — `enrich_cost(span, catalog)`: recompute cost server-side (authoritative), write value + `price_catalog_version`; client cost is a hint; drift > 5% flagged; catalog miss removes cost; input never mutated.

## Acceptance criteria
- [x] EstimatedCost recomputed server-side from (provider, model, tokens, catalog)
- [x] Client-emitted cost treated as hint; >5% discrepancy flagged as drift
- [x] PriceCatalogVersion recorded; catalog miss → cost null + flag, span retained
- [x] Cached-input priced via catalog; original dict not mutated

## Out of scope
Gateway wiring + drift metric emission (CTO-31/33 infra); catalog table/scraper (CTO-52/53, merged).

## Test plan
- [x] `ruff` + `pytest` green (131 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)