### PR TITLE
feat(web): Agents workflow screens [CTO-55/56/57]

### DIFF
--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -1,4 +1,85 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Agents" ticket="CTO-55 / CTO-56 / CTO-57" />;
+import Link from "next/link";
+import { Card } from "@/components/Card";
+import { Histogram } from "@/components/Histogram";
+import { agents, p99Ratio, runs } from "@/lib/agents";
+import { formatUSD } from "@/lib/types";
+
+export default function AgentsPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Agents</h1>
+
+      <Card title="Agent cost — distribution is the story">
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              <th className="py-1 text-left font-medium">Agent</th>
+              <th className="py-1 text-right font-medium">Runs/day</th>
+              <th className="py-1 text-right font-medium">Cost/day</th>
+              <th className="py-1 text-right font-medium">p50</th>
+              <th className="py-1 text-right font-medium">p99</th>
+              <th className="py-1 text-right font-medium">p99/p50</th>
+              <th className="py-1 pl-4 text-left font-medium">Distribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((a) => {
+              const ratio = p99Ratio(a);
+              const hot = ratio > 20;
+              return (
+                <tr key={a.name} className="border-t border-edge">
+                  <td className="py-2 font-medium">{a.name}</td>
+                  <td className="py-2 text-right tabular-nums">{a.runsPerDay.toLocaleString()}</td>
+                  <td className="py-2 text-right tabular-nums">{formatUSD(a.costPerDayMicroUsd)}</td>
+                  <td className="py-2 text-right tabular-nums">{formatUSD(a.p50MicroUsd)}</td>
+                  <td className="py-2 text-right tabular-nums">{formatUSD(a.p99MicroUsd)}</td>
+                  <td className="py-2 text-right tabular-nums">
+                    <span className={hot ? "rounded bg-bad/20 px-1.5 py-0.5 text-bad" : ""}>
+                      {ratio.toFixed(0)}×{hot ? " ⚠" : ""}
+                    </span>
+                  </td>
+                  <td className="py-2 pl-4">
+                    <Histogram buckets={a.distribution} />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Card>
+
+      <Card title="Pathological runs (top cost outliers)">
+        <ul className="divide-y divide-edge text-sm">
+          {runs
+            .slice()
+            .sort((a, b) => b.totalCostMicroUsd - a.totalCostMicroUsd)
+            .map((r) => (
+              <li key={r.runId} className="flex items-center justify-between gap-3 py-2">
+                <Link
+                  href={`/agents/runs/${r.runId}`}
+                  className="font-mono text-accent hover:underline"
+                >
+                  {r.runId}
+                </Link>
+                <span className="flex items-center gap-3">
+                  <OutcomeBadge outcome={r.outcome} />
+                  <span className="tabular-nums">{formatUSD(r.totalCostMicroUsd)}</span>
+                  <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+                </span>
+              </li>
+            ))}
+        </ul>
+      </Card>
+    </div>
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome: "success" | "failed" | "abandoned" }) {
+  const cls =
+    outcome === "success"
+      ? "bg-good/20 text-good"
+      : outcome === "failed"
+        ? "bg-bad/20 text-bad"
+        : "bg-edge text-muted";
+  return <span className={`rounded px-1.5 py-0.5 text-xs ${cls}`}>{outcome}</span>;
 }

--- a/web/app/agents/runs/[runId]/page.tsx
+++ b/web/app/agents/runs/[runId]/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Card } from "@/components/Card";
+import { getRun, runs } from "@/lib/agents";
+import { formatUSD } from "@/lib/types";
+
+export function generateStaticParams() {
+  return runs.map((r) => ({ runId: r.runId }));
+}
+
+export default async function RunPage({ params }: { params: Promise<{ runId: string }> }) {
+  const { runId } = await params;
+  const run = getRun(runId);
+  if (!run) notFound();
+
+  const max = Math.max(...run.spans.map((s) => s.costMicroUsd));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2 text-sm text-muted">
+        <Link href="/agents" className="text-accent hover:underline">
+          Agents
+        </Link>
+        <span>/</span>
+        <span className="font-mono">{run.runId}</span>
+      </div>
+
+      <div className="flex items-baseline gap-4">
+        <h1 className="text-xl font-semibold">{run.agent}</h1>
+        <span className="text-2xl font-semibold tabular-nums">{formatUSD(run.totalCostMicroUsd)}</span>
+        <span className="text-bad">{run.multipleOfMedian}× median</span>
+        <span className="text-muted">· {run.steps} steps · {run.outcome}</span>
+      </div>
+
+      <Card title="Why expensive">
+        <p className="text-sm leading-relaxed text-gray-200">{run.whyExpensive}</p>
+      </Card>
+
+      <Card title="Run waterfall">
+        <div className="space-y-1.5">
+          {run.spans.map((s) => {
+            const depth = s.parentSpanId ? 1 : 0;
+            const pct = max === 0 ? 0 : (s.costMicroUsd / max) * 100;
+            return (
+              <div key={s.spanId} className="flex items-center gap-3 text-sm">
+                <div className="w-64 shrink-0 truncate" style={{ paddingLeft: depth * 16 }}>
+                  <span className={s.status === "retry" ? "text-warn" : s.status === "error" ? "text-bad" : ""}>
+                    {s.name}
+                  </span>
+                </div>
+                <div className="relative h-4 flex-1 rounded bg-ink">
+                  <div
+                    className="absolute inset-y-0 left-0 rounded bg-accent/70"
+                    style={{ width: `${Math.max(1, pct)}%` }}
+                  />
+                </div>
+                <div className="w-20 shrink-0 text-right tabular-nums">{formatUSD(s.costMicroUsd)}</div>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/web/components/Histogram.tsx
+++ b/web/components/Histogram.tsx
@@ -1,0 +1,16 @@
+// Tiny inline log-scale distribution histogram (no chart lib).
+export function Histogram({ buckets }: { buckets: number[] }) {
+  const max = Math.max(1, ...buckets);
+  return (
+    <div className="flex h-8 items-end gap-0.5" aria-label="cost distribution">
+      {buckets.map((b, i) => (
+        <div
+          key={i}
+          className="w-1.5 rounded-sm bg-accent/70"
+          style={{ height: `${Math.max(2, (b / max) * 100)}%` }}
+          title={`${b} runs`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/web/lib/agents.test.ts
+++ b/web/lib/agents.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { agents, getRun, p99Ratio, runsForAgent } from "./agents";
+
+describe("agents data + helpers", () => {
+  it("computes p99/p50 ratio", () => {
+    const research = agents.find((a) => a.name === "research_agent")!;
+    expect(Math.round(p99Ratio(research))).toBe(28); // 3.4M / 120k
+  });
+
+  it("flags research_agent as a tail outlier (ratio > 20)", () => {
+    const research = agents.find((a) => a.name === "research_agent")!;
+    expect(p99Ratio(research)).toBeGreaterThan(20);
+  });
+
+  it("inline_writer is not a tail outlier", () => {
+    const writer = agents.find((a) => a.name === "inline_writer")!;
+    expect(p99Ratio(writer)).toBeLessThan(20);
+  });
+
+  it("runsForAgent filters by agent", () => {
+    expect(runsForAgent("research_agent").length).toBe(2);
+    expect(runsForAgent("nope").length).toBe(0);
+  });
+
+  it("getRun returns a run with a why-expensive narrative + spans", () => {
+    const r = getRun("research_run_8af2")!;
+    expect(r).toBeDefined();
+    expect(r.whyExpensive).toMatch(/retry loop/i);
+    expect(r.spans.length).toBeGreaterThan(0);
+    // root span has no parent
+    expect(r.spans[0].parentSpanId).toBeNull();
+  });
+});

--- a/web/lib/agents.ts
+++ b/web/lib/agents.ts
@@ -1,0 +1,122 @@
+// Mock data + helpers for the Agents workflow (CTO-55/56/57). Typed like the eventual API.
+
+import type { MicroUSD } from "./types";
+
+export interface AgentSummary {
+  name: string;
+  runsPerDay: number;
+  costPerDayMicroUsd: MicroUSD;
+  p50MicroUsd: MicroUSD;
+  p99MicroUsd: MicroUSD;
+  /** log-scale distribution buckets (counts), cheap → expensive */
+  distribution: number[];
+}
+
+export function p99Ratio(a: AgentSummary): number {
+  return a.p50MicroUsd === 0 ? 0 : a.p99MicroUsd / a.p50MicroUsd;
+}
+
+export interface RunSpan {
+  spanId: string;
+  parentSpanId: string | null;
+  name: string;
+  costMicroUsd: MicroUSD;
+  durationMs: number;
+  status: "ok" | "retry" | "error";
+}
+
+export interface AgentRun {
+  runId: string;
+  agent: string;
+  totalCostMicroUsd: MicroUSD;
+  multipleOfMedian: number;
+  steps: number;
+  outcome: "success" | "failed" | "abandoned";
+  /** one-sentence auto-generated root cause (CTO-57) */
+  whyExpensive: string;
+  spans: RunSpan[];
+}
+
+export const agents: AgentSummary[] = [
+  {
+    name: "research_agent",
+    runsPerDay: 1240,
+    costPerDayMicroUsd: 214_000_000,
+    p50MicroUsd: 120_000,
+    p99MicroUsd: 3_400_000,
+    distribution: [40, 120, 260, 180, 90, 40, 18, 8, 4, 2],
+  },
+  {
+    name: "support_triage",
+    runsPerDay: 8300,
+    costPerDayMicroUsd: 180_000_000,
+    p50MicroUsd: 20_000,
+    p99MicroUsd: 140_000,
+    distribution: [200, 620, 410, 160, 60, 20, 8, 3, 1, 0],
+  },
+  {
+    name: "inline_writer",
+    runsPerDay: 42_100,
+    costPerDayMicroUsd: 85_000_000,
+    p50MicroUsd: 2_000,
+    p99MicroUsd: 10_000,
+    distribution: [900, 1400, 700, 220, 70, 20, 6, 2, 0, 0],
+  },
+];
+
+export const runs: AgentRun[] = [
+  {
+    runId: "research_run_8af2",
+    agent: "research_agent",
+    totalCostMicroUsd: 3_400_000,
+    multipleOfMedian: 78,
+    steps: 21,
+    outcome: "success",
+    whyExpensive:
+      "47× median due to a 14-step retry loop on tool web_fetch after a 429, then a 24k-token synthesize/refine pair (87% of cost).",
+    spans: [
+      { spanId: "s0", parentSpanId: null, name: "agent.run", costMicroUsd: 3_400_000, durationMs: 10040, status: "ok" },
+      { spanId: "s1", parentSpanId: "s0", name: "llm.plan", costMicroUsd: 12_000, durationMs: 740, status: "ok" },
+      { spanId: "s2", parentSpanId: "s0", name: "tool.web_fetch (×14, 429 backoff)", costMicroUsd: 14_000, durationMs: 6200, status: "retry" },
+      { spanId: "s3", parentSpanId: "s0", name: "llm.synthesize (16k ctx)", costMicroUsd: 1_840_000, durationMs: 1300, status: "ok" },
+      { spanId: "s4", parentSpanId: "s0", name: "llm.refine (24k ctx)", costMicroUsd: 1_420_000, durationMs: 980, status: "ok" },
+    ],
+  },
+  {
+    runId: "research_run_3c01",
+    agent: "research_agent",
+    totalCostMicroUsd: 1_920_000,
+    multipleOfMedian: 44,
+    steps: 12,
+    outcome: "failed",
+    whyExpensive:
+      "44× median: tool fan-out called search_docs 9× before the model gave up; failed run still incurred full retrieval cost.",
+    spans: [
+      { spanId: "s0", parentSpanId: null, name: "agent.run", costMicroUsd: 1_920_000, durationMs: 7100, status: "error" },
+      { spanId: "s1", parentSpanId: "s0", name: "llm.plan", costMicroUsd: 11_000, durationMs: 600, status: "ok" },
+      { spanId: "s2", parentSpanId: "s0", name: "tool.search_docs (×9)", costMicroUsd: 9_000, durationMs: 3400, status: "ok" },
+      { spanId: "s3", parentSpanId: "s0", name: "llm.synthesize", costMicroUsd: 1_900_000, durationMs: 1900, status: "error" },
+    ],
+  },
+  {
+    runId: "support_run_5d77",
+    agent: "support_triage",
+    totalCostMicroUsd: 140_000,
+    multipleOfMedian: 7,
+    steps: 4,
+    outcome: "success",
+    whyExpensive: "7× median: a single long-context classification; within normal range for this agent.",
+    spans: [
+      { spanId: "s0", parentSpanId: null, name: "agent.run", costMicroUsd: 140_000, durationMs: 1200, status: "ok" },
+      { spanId: "s1", parentSpanId: "s0", name: "llm.classify (8k ctx)", costMicroUsd: 140_000, durationMs: 1100, status: "ok" },
+    ],
+  },
+];
+
+export function runsForAgent(agent: string): AgentRun[] {
+  return runs.filter((r) => r.agent === agent);
+}
+
+export function getRun(runId: string): AgentRun | undefined {
+  return runs.find((r) => r.runId === runId);
+}


### PR DESCRIPTION
Branched off `main`. Mock data, preview-verified. The flagship workflow.

## Summary
- **`/agents`** (CTO-55/56): distribution-first table — runs/day, cost/day, p50, p99, headline **p99/p50 ratio** with a red warning chip >20×, inline log-scale histogram; pathological-runs list (outcome badge + ×median).
- **`/agents/runs/[runId]`** (CTO-57): single-run **waterfall** (indented spans, retry/error coloring, cost bars) + auto-generated **"why expensive"** one-sentence narrative.
- Typed `lib/agents.ts` mock layer shaped for the eventual API; helpers unit-tested.

## Verification
- `tsc --noEmit` clean · vitest **10/10** · `next lint` clean · `next build` prerenders `/agents` + all 3 run pages.
- Preview-rendered both screens (screenshots in session); no console errors.

## Out of scope
Live data wiring (needs gateway + ClickHouse); guardrail config UI (CTO-58); cost-per-outcome aggregation chart (follow-up). All mock for now.

## Test plan
- [x] typecheck / test / lint / build green locally
- [x] preview-verified, no console errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)