### PR TITLE
feat(web): Compare workflow screen [CTO-62]

### DIFF
--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -1,4 +1,134 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Compare" ticket="CTO-62" />;
+import { Card } from "@/components/Card";
+import { comparison, deltaPct } from "@/lib/compare";
+import { formatUSD, type MicroUSD } from "@/lib/types";
+
+export default function ComparePage() {
+  const { workload, current, candidates, recommendation, diagnostics } = comparison;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Compare</h1>
+        <p className="mt-1 text-sm text-muted">
+          Workload: <span className="font-mono text-gray-300">{workload}</span>
+        </p>
+      </div>
+
+      <Card title="Candidates vs. current">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-muted">
+              <tr>
+                <th className="py-1 text-left font-medium">Model</th>
+                <th className="py-1 text-right font-medium">Cost/mo</th>
+                <th className="py-1 text-right font-medium">Quality</th>
+                <th className="py-1 text-right font-medium">Latency p95</th>
+                <th className="py-1 text-right font-medium">Error rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              <Row label={`current · ${current.model}`} m={current} highlight />
+              {candidates.map((c) => (
+                <Row key={c.model} label={c.model} m={c} current={current} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <Card title={`Recommendation — ${recommendation.verdict}`}>
+        <p className="text-sm text-gray-200">{recommendation.summary}</p>
+        <div className="mt-3 flex items-baseline gap-2 text-sm">
+          <span className="text-good text-lg font-semibold">
+            saves {formatUSD(recommendation.projectedSavingsMicroUsd)}/mo
+          </span>
+          <span className="text-muted">
+            ({Math.round(recommendation.projectedSavingsPct * 100)}% reduction)
+          </span>
+        </div>
+        <button
+          type="button"
+          className="mt-3 rounded-md border border-edge bg-ink px-3 py-1.5 text-sm text-gray-200 hover:bg-edge"
+        >
+          Export routing rule
+        </button>
+      </Card>
+
+      <Card title="Replay diagnostics">
+        <dl className="grid grid-cols-1 gap-y-1.5 text-sm sm:grid-cols-2">
+          <Diag k="samples replayed" v={`${diagnostics.samplesReplayed.toLocaleString()} of ${diagnostics.samplesAvailable.toLocaleString()} prod traces`} />
+          <Diag k="excluded (rate limits)" v={diagnostics.excludedRateLimited.toLocaleString()} />
+          <Diag k="replay cost" v={formatUSD(diagnostics.replayCostMicroUsd)} />
+          <Diag k="context fidelity" v={diagnostics.contextFidelity} good />
+        </dl>
+      </Card>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  m,
+  current,
+  highlight,
+}: {
+  label: string;
+  m: { monthlyCostMicroUsd: MicroUSD; qualityScore: number; latencyP95Ms: number; errorRate: number };
+  current?: { monthlyCostMicroUsd: MicroUSD; qualityScore: number; latencyP95Ms: number; errorRate: number };
+  highlight?: boolean;
+}) {
+  return (
+    <tr className={`border-t border-edge ${highlight ? "font-medium" : ""}`}>
+      <td className="py-2">{label}</td>
+      <td className="py-2 text-right tabular-nums">
+        {formatUSD(m.monthlyCostMicroUsd)}
+        {current && <Delta v={deltaPct(current.monthlyCostMicroUsd, m.monthlyCostMicroUsd)} betterWhenNegative />}
+      </td>
+      <td className="py-2 text-right tabular-nums">
+        {(m.qualityScore * 100).toFixed(1)}%
+        {current && <DeltaPp v={(m.qualityScore - current.qualityScore) * 100} betterWhenPositive />}
+      </td>
+      <td className="py-2 text-right tabular-nums">
+        {m.latencyP95Ms} ms
+        {current && <Delta v={deltaPct(current.latencyP95Ms, m.latencyP95Ms)} betterWhenNegative />}
+      </td>
+      <td className="py-2 text-right tabular-nums">
+        {(m.errorRate * 100).toFixed(2)}%
+        {current && <DeltaPp v={(m.errorRate - current.errorRate) * 100} betterWhenPositive={false} />}
+      </td>
+    </tr>
+  );
+}
+
+function Delta({ v, betterWhenNegative }: { v: number; betterWhenNegative: boolean }) {
+  if (v === 0) return null;
+  const good = betterWhenNegative ? v < 0 : v > 0;
+  const sign = v > 0 ? "+" : "";
+  return (
+    <span className={`ml-1 text-xs ${good ? "text-good" : "text-bad"}`}>
+      {sign}
+      {Math.round(v * 100)}%
+    </span>
+  );
+}
+
+function DeltaPp({ v, betterWhenPositive }: { v: number; betterWhenPositive: boolean }) {
+  if (Math.abs(v) < 0.05) return null;
+  const good = betterWhenPositive ? v > 0 : v < 0;
+  const sign = v > 0 ? "+" : "";
+  return (
+    <span className={`ml-1 text-xs ${good ? "text-good" : "text-bad"}`}>
+      {sign}
+      {v.toFixed(1)}pp
+    </span>
+  );
+}
+
+function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
+  return (
+    <>
+      <dt className="text-muted">{k}</dt>
+      <dd className={good ? "text-good" : ""}>{v}</dd>
+    </>
+  );
 }

--- a/web/lib/compare.test.ts
+++ b/web/lib/compare.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { comparison, deltaPct } from "./compare";
+
+describe("compare", () => {
+  it("deltaPct: negative when candidate cheaper than current", () => {
+    expect(deltaPct(100, 28)).toBeCloseTo(-0.72, 2);
+  });
+
+  it("deltaPct: positive when candidate is worse (latency)", () => {
+    expect(deltaPct(1000, 1500)).toBeCloseTo(0.5, 2);
+  });
+
+  it("deltaPct: zero baseline returns 0 (no divide-by-zero)", () => {
+    expect(deltaPct(0, 100)).toBe(0);
+  });
+
+  it("mock comparison has at least 2 candidates and a recommendation", () => {
+    expect(comparison.candidates.length).toBeGreaterThanOrEqual(2);
+    expect(comparison.recommendation.verdict).toBeDefined();
+    expect(comparison.recommendation.projectedSavingsMicroUsd).toBeGreaterThan(0);
+  });
+
+  it("diagnostics excludes throttled samples from headline metrics (modeled)", () => {
+    expect(comparison.diagnostics.excludedRateLimited).toBeGreaterThan(0);
+    expect(comparison.diagnostics.contextFidelity).toMatch(/resolved-context/);
+  });
+});

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -1,0 +1,93 @@
+// Mock data + helpers for the Cross-provider Compare workflow (CTO-62). Typed for the eventual API.
+
+import type { MicroUSD } from "./types";
+
+export interface CandidateMetrics {
+  /** display label, e.g. "claude-haiku-4.5" */
+  model: string;
+  provider: string;
+  /** projected monthly cost at current traffic */
+  monthlyCostMicroUsd: MicroUSD;
+  /** pass rate from default LLM-judge eval (0..1) */
+  qualityScore: number;
+  /** p95 latency in milliseconds */
+  latencyP95Ms: number;
+  errorRate: number; // 0..1
+}
+
+export interface Comparison {
+  workload: string;        // e.g. "research_agent / production / last 7 days"
+  current: CandidateMetrics;
+  candidates: CandidateMetrics[];
+  /** human-written-ish recommendation (the routing rule export hooks off this) */
+  recommendation: {
+    verdict: "switch" | "keep" | "mixed";
+    summary: string;
+    projectedSavingsMicroUsd: MicroUSD;
+    projectedSavingsPct: number; // 0..1
+  };
+  diagnostics: {
+    samplesReplayed: number;
+    samplesAvailable: number;
+    excludedRateLimited: number;
+    replayCostMicroUsd: MicroUSD;
+    contextFidelity: "resolved-context replay (no live retrieval)" | "live retrieval";
+  };
+}
+
+export function deltaPct(current: number, candidate: number): number {
+  if (current === 0) return 0;
+  return (candidate - current) / current;
+}
+
+export const comparison: Comparison = {
+  workload: "research_agent / production / last 7 days",
+  current: {
+    model: "claude-sonnet-4.5",
+    provider: "anthropic",
+    monthlyCostMicroUsd: 6_420_000_000,
+    qualityScore: 0.941,
+    latencyP95Ms: 2400,
+    errorRate: 0.004,
+  },
+  candidates: [
+    {
+      model: "claude-haiku-4.5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 1_780_000_000,
+      qualityScore: 0.908,
+      latencyP95Ms: 1800,
+      errorRate: 0.006,
+    },
+    {
+      model: "gpt-5-mini",
+      provider: "openai",
+      monthlyCostMicroUsd: 2_100_000_000,
+      qualityScore: 0.894,
+      latencyP95Ms: 1600,
+      errorRate: 0.009,
+    },
+    {
+      model: "gemini-3-flash",
+      provider: "google",
+      monthlyCostMicroUsd: 1_510_000_000,
+      qualityScore: 0.871,
+      latencyP95Ms: 1400,
+      errorRate: 0.012,
+    },
+  ],
+  recommendation: {
+    verdict: "mixed",
+    summary:
+      "Route short prompts (<1k tokens) to haiku-4.5; keep current for long-context. Quality delta -1.1pp at projected mix.",
+    projectedSavingsMicroUsd: 4_100_000_000,
+    projectedSavingsPct: 0.64,
+  },
+  diagnostics: {
+    samplesReplayed: 4200,
+    samplesAvailable: 87_400,
+    excludedRateLimited: 312,
+    replayCostMicroUsd: 14_200_000,
+    contextFidelity: "resolved-context replay (no live retrieval)",
+  },
+};


### PR DESCRIPTION
Branched off \`main\`. Mock data, preview-verified.

## Summary
- **\`/compare\`** — side-by-side current vs. N candidates with deltas (cost %, quality pp, latency %, error pp).
- **Recommendation** block: verdict (switch / keep / **mixed**) + summary + projected savings + **Export routing rule** button.
- **Replay diagnostics** block — samples replayed / excluded for rate limits / replay cost / context fidelity ✓. Lead with honesty (the trust feature).
- Typed \`lib/compare.ts\` mock layer shaped for the eventual API.

## Verification
tsc clean · vitest **13/13** · \`next lint\` clean · build prerenders \`/compare\`. Preview-rendered, no console errors.

## Out of scope
Live data / actual replay engine (needs gateway + W1 replay infra); real routing-rule generation. Mock for now.

## Test plan
- [x] typecheck / test / lint / build green
- [x] preview-verified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)