### PR TITLE
feat(web): Cost workflow screen [CTO-65/66]

### DIFF
--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -1,4 +1,112 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Cost" ticket="CTO-65 / CTO-66" />;
+import { Card } from "@/components/Card";
+import { Legend, StackedBarChart } from "@/components/StackedBarChart";
+import {
+  LAYER_LABEL,
+  LAYERS,
+  costSeries,
+  estimatedTotal,
+  featureRows,
+  hiddenCostAlerts,
+  reconciledTotal,
+  totalRange,
+  type Layer,
+} from "@/lib/cost";
+import { formatUSD, type SpendByLayer } from "@/lib/types";
+
+function sumLayer(rows: typeof featureRows, layer: Layer) {
+  return rows.reduce((s, r) => s + r.byLayer[layer], 0);
+}
+
+export default function CostPage() {
+  const total = totalRange(costSeries);
+  const reconciled = reconciledTotal(costSeries);
+  const estimated = estimatedTotal(costSeries);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Cost</h1>
+
+      <Card title="Cost by layer — last 14 days">
+        <div className="mb-2 flex items-baseline gap-3 text-sm">
+          <span className="text-2xl font-semibold">{formatUSD(total)}</span>
+          <span className="text-muted">
+            reconciled {formatUSD(reconciled)} (through {costSeries.reconciledThrough}) · estimated {formatUSD(estimated)}
+          </span>
+        </div>
+        <StackedBarChart series={costSeries} />
+        <Legend />
+      </Card>
+
+      {hiddenCostAlerts.map((a) => (
+        <div
+          key={a.message}
+          className={`rounded-xl border p-4 text-sm ${
+            a.severity === "warn"
+              ? "border-warn/40 bg-warn/10 text-warn"
+              : "border-edge bg-panel text-muted"
+          }`}
+        >
+          <span className="font-medium">Hidden cost: </span>
+          {a.message}
+        </div>
+      ))}
+
+      <Card title="By feature">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-muted">
+              <tr>
+                <th className="py-1 text-left font-medium">Feature</th>
+                {LAYERS.map((l) => (
+                  <th key={l} className="py-1 text-right font-medium">
+                    {LAYER_LABEL[l]}
+                  </th>
+                ))}
+                <th className="py-1 text-right font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {featureRows.map((r) => {
+                const t = LAYERS.reduce((s, l) => s + r.byLayer[l], 0);
+                return (
+                  <tr key={r.feature} className="border-t border-edge">
+                    <td className="py-2 font-medium">{r.feature}</td>
+                    {LAYERS.map((l) => (
+                      <td key={l} className="py-2 text-right tabular-nums">
+                        {formatUSD(r.byLayer[l])}
+                      </td>
+                    ))}
+                    <td className="py-2 text-right tabular-nums">{formatUSD(t)}</td>
+                  </tr>
+                );
+              })}
+              <FooterRow rows={featureRows} />
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function FooterRow({ rows }: { rows: typeof featureRows }) {
+  const totals = LAYERS.reduce<SpendByLayer>(
+    (acc, l) => {
+      acc[l] = sumLayer(rows, l);
+      return acc;
+    },
+    { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 },
+  );
+  const grand = LAYERS.reduce((s, l) => s + totals[l], 0);
+  return (
+    <tr className="border-t border-edge bg-ink/40 font-medium">
+      <td className="py-2">all features</td>
+      {LAYERS.map((l) => (
+        <td key={l} className="py-2 text-right tabular-nums">
+          {formatUSD(totals[l])}
+        </td>
+      ))}
+      <td className="py-2 text-right tabular-nums">{formatUSD(grand)}</td>
+    </tr>
+  );
 }

--- a/web/components/StackedBarChart.tsx
+++ b/web/components/StackedBarChart.tsx
@@ -1,0 +1,90 @@
+// Hand-rolled SVG stacked-bar chart by layer over time, with a vertical boundary
+// separating reconciled (past) from estimated (recent). No chart library; deterministic.
+
+import { LAYER_COLORS, LAYER_LABEL, LAYERS, type Layer, totalForDay, type CostSeries } from "@/lib/cost";
+
+export function StackedBarChart({ series }: { series: CostSeries }) {
+  const W = 720;
+  const H = 220;
+  const PAD_L = 40;
+  const PAD_R = 16;
+  const PAD_T = 12;
+  const PAD_B = 28;
+  const plotW = W - PAD_L - PAD_R;
+  const plotH = H - PAD_T - PAD_B;
+  const n = series.days.length;
+  const barW = (plotW / n) * 0.7;
+  const step = plotW / n;
+
+  const maxTotal = Math.max(...series.days.map(totalForDay));
+
+  // boundary x: just after the last reconciled day
+  const reconciledIdx = series.days.findIndex((d) => d.date > series.reconciledThrough);
+  const boundaryX = PAD_L + (reconciledIdx === -1 ? plotW : reconciledIdx * step);
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="stacked cost by layer over time" className="w-full">
+      {/* boundary band: estimated region */}
+      <rect
+        x={boundaryX}
+        y={PAD_T}
+        width={W - PAD_R - boundaryX}
+        height={plotH}
+        fill="#252b37"
+        opacity="0.35"
+      />
+      <line x1={boundaryX} x2={boundaryX} y1={PAD_T} y2={H - PAD_B} stroke="#8a93a6" strokeDasharray="4 3" />
+      <text x={boundaryX + 4} y={PAD_T + 12} fontSize="10" fill="#8a93a6">
+        ← reconciled · estimated →
+      </text>
+
+      {series.days.map((d, i) => {
+        const cx = PAD_L + i * step + step / 2;
+        let yCursor = H - PAD_B;
+        return (
+          <g key={d.date}>
+            {LAYERS.map((l) => {
+              const v = d.byLayer[l];
+              const h = (v / maxTotal) * plotH;
+              yCursor -= h;
+              return (
+                <rect
+                  key={l}
+                  x={cx - barW / 2}
+                  y={yCursor}
+                  width={barW}
+                  height={h}
+                  fill={LAYER_COLORS[l]}
+                >
+                  <title>{`${d.date} · ${LAYER_LABEL[l]}: $${(v / 1_000_000).toFixed(2)}`}</title>
+                </rect>
+              );
+            })}
+            {i % 3 === 0 && (
+              <text x={cx} y={H - 10} fontSize="9" fill="#8a93a6" textAnchor="middle">
+                {d.date.slice(5)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export function Legend() {
+  return (
+    <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+      {LAYERS.map((l) => (
+        <li key={l} className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-sm"
+            style={{ background: LAYER_COLORS[l as Layer] }}
+          />
+          {LAYER_LABEL[l]}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/lib/cost.test.ts
+++ b/web/lib/cost.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  costSeries,
+  estimatedTotal,
+  reconciledTotal,
+  totalForDay,
+  totalRange,
+} from "./cost";
+
+describe("cost series", () => {
+  it("totalForDay sums all layers", () => {
+    const t = totalForDay(costSeries.days[0]);
+    expect(t).toBeGreaterThan(0);
+  });
+
+  it("totalRange = reconciled + estimated (no overlap, no gap)", () => {
+    expect(reconciledTotal(costSeries) + estimatedTotal(costSeries)).toBe(totalRange(costSeries));
+  });
+
+  it("reconciled days are <= reconciledThrough boundary", () => {
+    const cutoff = costSeries.reconciledThrough;
+    const reconciledDays = costSeries.days.filter((d) => d.date <= cutoff);
+    const estimatedDays = costSeries.days.filter((d) => d.date > cutoff);
+    expect(reconciledDays.length).toBeGreaterThan(0);
+    expect(estimatedDays.length).toBeGreaterThan(0);
+  });
+
+  it("vector spike emerges after the boundary (the hidden-cost story)", () => {
+    const cutoff = costSeries.reconciledThrough;
+    const before = costSeries.days.filter((d) => d.date <= cutoff).at(-1)!;
+    const after = costSeries.days.at(-1)!;
+    expect(after.byLayer.vector).toBeGreaterThan(before.byLayer.vector * 2);
+  });
+});

--- a/web/lib/cost.ts
+++ b/web/lib/cost.ts
@@ -1,0 +1,124 @@
+// Mock data for the Cost workflow (CTO-65/66). Typed for the eventual API.
+
+import type { MicroUSD, SpendByLayer } from "./types";
+
+export interface CostDayPoint {
+  date: string; // ISO yyyy-mm-dd
+  byLayer: SpendByLayer;
+}
+
+export interface CostSeries {
+  /** chronological points, oldest → newest */
+  days: CostDayPoint[];
+  /** Boundary: data on or before this date is reconciled; after is estimated. */
+  reconciledThrough: string;
+}
+
+export interface FeatureCostRow {
+  feature: string;
+  byLayer: SpendByLayer;
+}
+
+export interface HiddenCostAlert {
+  message: string;
+  severity: "info" | "warn";
+}
+
+export const LAYERS = ["llm", "vector", "tools", "compute", "embeddings", "egress"] as const;
+export type Layer = (typeof LAYERS)[number];
+
+export const LAYER_COLORS: Record<Layer, string> = {
+  llm: "#5e6ad2",      // accent
+  vector: "#26b5ce",
+  tools: "#4cb782",    // good
+  compute: "#f2c94c",  // warn
+  embeddings: "#bb87fc",
+  egress: "#8a93a6",   // muted
+};
+
+export const LAYER_LABEL: Record<Layer, string> = {
+  llm: "LLM",
+  vector: "Vector DB",
+  tools: "Tool calls",
+  compute: "Compute",
+  embeddings: "Embeddings",
+  egress: "Egress",
+};
+
+export function totalForDay(p: CostDayPoint): MicroUSD {
+  return LAYERS.reduce((sum, l) => sum + p.byLayer[l], 0);
+}
+
+// 14 days, oldest → newest. Reconciled through day 8 (index), estimated after.
+function point(date: string, base: number, vectorBoost = 1): CostDayPoint {
+  return {
+    date,
+    byLayer: {
+      llm: base * 0.55,
+      vector: base * 0.14 * vectorBoost,
+      tools: base * 0.13,
+      compute: base * 0.12,
+      embeddings: base * 0.04,
+      egress: base * 0.02,
+    },
+  };
+}
+
+export const costSeries: CostSeries = {
+  reconciledThrough: "2026-05-19",
+  days: [
+    point("2026-05-13", 950_000_000),
+    point("2026-05-14", 980_000_000),
+    point("2026-05-15", 1_020_000_000),
+    point("2026-05-16", 1_010_000_000),
+    point("2026-05-17", 1_050_000_000),
+    point("2026-05-18", 1_080_000_000),
+    point("2026-05-19", 1_120_000_000),
+    point("2026-05-20", 1_160_000_000, 2.4), // hidden vector spike
+    point("2026-05-21", 1_220_000_000, 3.0),
+    point("2026-05-22", 1_260_000_000, 3.4),
+    point("2026-05-23", 1_300_000_000, 3.6),
+    point("2026-05-24", 1_340_000_000, 3.8),
+    point("2026-05-25", 1_380_000_000, 4.0),
+    point("2026-05-26", 1_400_000_000, 4.0),
+  ],
+};
+
+export const featureRows: FeatureCostRow[] = [
+  {
+    feature: "research_agent",
+    byLayer: { llm: 4_210_000_000, vector: 1_820_000_000, tools: 1_640_000_000, compute: 1_210_000_000, embeddings: 380_000_000, egress: 60_000_000 },
+  },
+  {
+    feature: "inline_writer",
+    byLayer: { llm: 2_100_000_000, vector: 80_000_000, tools: 120_000_000, compute: 310_000_000, embeddings: 30_000_000, egress: 10_000_000 },
+  },
+  {
+    feature: "smart_search",
+    byLayer: { llm: 1_900_000_000, vector: 240_000_000, tools: 310_000_000, compute: 290_000_000, embeddings: 100_000_000, egress: 10_000_000 },
+  },
+];
+
+export const hiddenCostAlerts: HiddenCostAlert[] = [
+  {
+    severity: "warn",
+    message:
+      "Your vector DB cost grew 4× this month while LLM cost was flat — index size doubled May 20.",
+  },
+];
+
+export function totalRange(series: CostSeries): MicroUSD {
+  return series.days.reduce((s, d) => s + totalForDay(d), 0);
+}
+
+export function reconciledTotal(series: CostSeries): MicroUSD {
+  return series.days
+    .filter((d) => d.date <= series.reconciledThrough)
+    .reduce((s, d) => s + totalForDay(d), 0);
+}
+
+export function estimatedTotal(series: CostSeries): MicroUSD {
+  return series.days
+    .filter((d) => d.date > series.reconciledThrough)
+    .reduce((s, d) => s + totalForDay(d), 0);
+}


### PR DESCRIPTION
Branched off \`main\`. Mock data, preview-verified.

## Summary
- **\`/cost\`** — stacked-by-layer SVG chart over 14 days (no chart lib), with a **visible boundary** separating reconciled (past) from estimated (recent). The vector-DB spike emerges after the boundary, matching the **hidden-cost alert** below.
- Per-feature breakdown table with layer totals footer.
- \`reconciledTotal\` + \`estimatedTotal\` helpers, unit-tested (they sum to total — no overlap/gap).

## Verification
tsc clean · vitest **14/14** · \`next lint\` clean · build prerenders \`/cost\`. Preview-rendered, no console errors.

## Out of scope
Live data + reconciler wiring (CTO-64); per-request waterfall view (follow-up); anomaly detection from real data (currently a labeled mock).

## Test plan
- [x] typecheck / test / lint / build green
- [x] preview-verified (boundary + alert visible together)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)