### PR TITLE
feat(web): Features (ROI + attribution diagnostics) [CTO-70]

### DIFF
--- a/web/app/features/page.tsx
+++ b/web/app/features/page.tsx
@@ -1,4 +1,144 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Features" ticket="CTO-70" />;
+import { Card } from "@/components/Card";
+import { diagnostics, features, margin } from "@/lib/features";
+import { formatUSD } from "@/lib/types";
+
+export default function FeaturesPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Features</h1>
+
+      <Card title="Unit economics — per feature">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-muted">
+              <tr>
+                <th className="py-1 text-left font-medium">Feature</th>
+                <th className="py-1 text-right font-medium">Cost/user</th>
+                <th className="py-1 text-right font-medium">Value/user</th>
+                <th className="py-1 text-right font-medium">Margin</th>
+                <th className="py-1 text-right font-medium">Payback</th>
+                <th className="py-1 text-right font-medium">Attribution rate</th>
+                <th className="py-1 pl-3 text-left font-medium">Value event</th>
+              </tr>
+            </thead>
+            <tbody>
+              {features.map((f) => {
+                const m = margin(f);
+                return (
+                  <tr key={f.feature} className="border-t border-edge">
+                    <td className="py-2 font-medium">{f.feature}</td>
+                    <td className="py-2 text-right tabular-nums">{formatUSD(f.costPerUserMicroUsd)}</td>
+                    <td className="py-2 text-right tabular-nums">
+                      {f.valuePerUserMicroUsd === null ? <Dash /> : formatUSD(f.valuePerUserMicroUsd)}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">
+                      {m === null ? <Dash /> : <MarginCell m={m} />}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">
+                      {f.paybackDays === null ? <Dash /> : `${f.paybackDays}d`}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">
+                      {f.attributionRate === null ? <Dash /> : `${Math.round(f.attributionRate * 100)}%`}
+                    </td>
+                    <td className="py-2 pl-3">
+                      {f.valueEvent === null ? (
+                        <span className="text-warn text-xs">configure value event →</span>
+                      ) : (
+                        <span className="font-mono text-xs text-gray-300">{f.valueEvent}</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <Card title="Attribution diagnostics">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div>
+            <h3 className="mb-2 text-xs uppercase text-muted">Per-feature confidence breakdown</h3>
+            <ul className="space-y-3 text-sm">
+              {features
+                .filter((f) => f.attributionRate !== null)
+                .map((f) => (
+                  <li key={f.feature}>
+                    <div className="mb-1 flex items-baseline justify-between">
+                      <span className="font-medium">{f.feature}</span>
+                      <span className="tabular-nums text-muted">
+                        {Math.round((f.attributionRate ?? 0) * 100)}% attributed
+                      </span>
+                    </div>
+                    <ConfidenceBar b={f.attributionBreakdown} />
+                  </li>
+                ))}
+            </ul>
+            <Legend />
+          </div>
+
+          <div>
+            <h3 className="mb-2 text-xs uppercase text-muted">Tenant-wide</h3>
+            <dl className="space-y-1.5 text-sm">
+              <Diag k="late-arriving events (7d)" v={diagnostics.lateArrivalEvents7d.toLocaleString()} />
+              <Diag k="median lag" v={`${diagnostics.lateArrivalMedianHours.toFixed(1)}h`} />
+              <Diag k="reconciler last ran" v={`${diagnostics.reconcilerLastRunMinutesAgo} min ago`} good />
+            </dl>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function Dash() {
+  return <span className="text-muted">—</span>;
+}
+
+function MarginCell({ m }: { m: number }) {
+  const pct = Math.round(m * 100);
+  return <span className={m > 0.5 ? "text-good" : m > 0 ? "" : "text-bad"}>{pct}%</span>;
+}
+
+function ConfidenceBar({
+  b,
+}: {
+  b: { direct: number; sessionStitched: number; identityGraphStitched: number; unmatched: number };
+}) {
+  const total = b.direct + b.sessionStitched + b.identityGraphStitched + b.unmatched;
+  if (total === 0) return null;
+  const seg = (n: number) => `${(n / total) * 100}%`;
+  return (
+    <div className="flex h-2 w-full overflow-hidden rounded bg-edge">
+      <div style={{ width: seg(b.direct) }} className="bg-good" title={`direct: ${b.direct}`} />
+      <div style={{ width: seg(b.sessionStitched) }} className="bg-accent" title={`session: ${b.sessionStitched}`} />
+      <div
+        style={{ width: seg(b.identityGraphStitched) }}
+        className="bg-warn"
+        title={`identity graph: ${b.identityGraphStitched}`}
+      />
+      <div style={{ width: seg(b.unmatched) }} className="bg-bad/70" title={`unmatched: ${b.unmatched}`} />
+    </div>
+  );
+}
+
+function Legend() {
+  const dot = (cls: string) => <span aria-hidden className={`inline-block h-2 w-2 rounded-sm ${cls}`} />;
+  return (
+    <ul className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
+      <li className="flex items-center gap-1.5">{dot("bg-good")} direct</li>
+      <li className="flex items-center gap-1.5">{dot("bg-accent")} session</li>
+      <li className="flex items-center gap-1.5">{dot("bg-warn")} identity graph</li>
+      <li className="flex items-center gap-1.5">{dot("bg-bad/70")} unmatched</li>
+    </ul>
+  );
+}
+
+function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between">
+      <dt className="text-muted">{k}</dt>
+      <dd className={good ? "text-good" : ""}>{v}</dd>
+    </div>
+  );
 }

--- a/web/lib/features.test.ts
+++ b/web/lib/features.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { features, margin } from "./features";
+
+describe("features", () => {
+  it("margin: positive when value > cost", () => {
+    const research = features.find((f) => f.feature === "research_agent")!;
+    const m = margin(research);
+    expect(m).not.toBeNull();
+    expect(m!).toBeGreaterThan(0.5); // (1.4 - 0.18) / 1.4 ≈ 0.87
+  });
+
+  it("margin: null when value is unattributed", () => {
+    const smart = features.find((f) => f.feature === "smart_search")!;
+    expect(margin(smart)).toBeNull();
+  });
+
+  it("attribution breakdown sums to per-feature event total", () => {
+    for (const f of features) {
+      if (f.attributionRate === null) continue;
+      const b = f.attributionBreakdown;
+      expect(b.direct + b.sessionStitched + b.identityGraphStitched + b.unmatched).toBeGreaterThan(0);
+    }
+  });
+
+  it("attributed >= unattributed for inline_writer (88% attributed)", () => {
+    const w = features.find((f) => f.feature === "inline_writer")!;
+    const b = w.attributionBreakdown;
+    const attributed = b.direct + b.sessionStitched + b.identityGraphStitched;
+    expect(attributed).toBeGreaterThan(b.unmatched);
+  });
+});

--- a/web/lib/features.ts
+++ b/web/lib/features.ts
@@ -1,0 +1,68 @@
+// Mock data for the Features / Business attribution workflow (CTO-70). Typed for the eventual API.
+
+import type { MicroUSD } from "./types";
+
+export interface FeatureEconomics {
+  feature: string;
+  /** value event the ROI is attributed against; null = unattributed */
+  valueEvent: string | null;
+  costPerUserMicroUsd: MicroUSD;
+  valuePerUserMicroUsd: MicroUSD | null;
+  paybackDays: number | null;
+  attributionRate: number | null; // 0..1
+  /** events attributed by stitching source */
+  attributionBreakdown: {
+    direct: number;
+    sessionStitched: number;
+    identityGraphStitched: number;
+    unmatched: number;
+  };
+}
+
+export function margin(e: FeatureEconomics): number | null {
+  if (e.valuePerUserMicroUsd === null) return null;
+  if (e.valuePerUserMicroUsd === 0) return 0;
+  return (e.valuePerUserMicroUsd - e.costPerUserMicroUsd) / e.valuePerUserMicroUsd;
+}
+
+export interface AttributionDiagnostics {
+  lateArrivalEvents7d: number;
+  lateArrivalMedianHours: number;
+  reconcilerLastRunMinutesAgo: number;
+}
+
+export const features: FeatureEconomics[] = [
+  {
+    feature: "research_agent",
+    valueEvent: "subscription_created",
+    costPerUserMicroUsd: 180_000,
+    valuePerUserMicroUsd: 1_400_000,
+    paybackDays: 13,
+    attributionRate: 0.91,
+    attributionBreakdown: { direct: 1313, sessionStitched: 255, identityGraphStitched: 90, unmatched: 162 },
+  },
+  {
+    feature: "inline_writer",
+    valueEvent: "paid_conversion",
+    costPerUserMicroUsd: 40_000,
+    valuePerUserMicroUsd: 210_000,
+    paybackDays: 7,
+    attributionRate: 0.88,
+    attributionBreakdown: { direct: 880, sessionStitched: 120, identityGraphStitched: 35, unmatched: 145 },
+  },
+  {
+    feature: "smart_search",
+    valueEvent: null,
+    costPerUserMicroUsd: 20_000,
+    valuePerUserMicroUsd: null,
+    paybackDays: null,
+    attributionRate: null,
+    attributionBreakdown: { direct: 0, sessionStitched: 0, identityGraphStitched: 0, unmatched: 0 },
+  },
+];
+
+export const diagnostics: AttributionDiagnostics = {
+  lateArrivalEvents7d: 180,
+  lateArrivalMedianHours: 4.2,
+  reconcilerLastRunMinutesAgo: 47,
+};


### PR DESCRIPTION
Branched off \`main\`. Mock data, preview-verified.

## Summary
- **\`/features\`** — unit economics table (cost/user, value/user, **margin**, payback, attribution rate). Unattributed features dash-flagged + \"configure value event →\" prompt (no silent zeros).
- **Attribution diagnostics**: per-feature confidence breakdown bars (direct / session-stitched / identity-graph / unmatched) — the trust-under-uncertainty story made literal — plus tenant-wide late-arrival lag + reconciler last-run.
- Typed \`lib/features.ts\` mock + \`margin()\` helper, unit-tested.

## Verification
tsc clean · vitest **14/14** · \`next lint\` clean · build prerenders \`/features\`. Preview-rendered, no console errors.

## Out of scope
Live data wiring (needs stitcher + CDP connectors, CTO-67/68/69); cohort retention × cost table (follow-up).

## Test plan
- [x] typecheck / test / lint / build green
- [x] preview-verified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)