### PR TITLE
feat(web): Data Quality dedicated page [CTO-79]

### DIFF
--- a/web/app/data-quality/page.tsx
+++ b/web/app/data-quality/page.tsx
@@ -1,4 +1,194 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Data Quality" ticket="CTO-79" />;
+import { Card } from "@/components/Card";
+import { classify, dq, type Health } from "@/lib/dq";
+import { formatUSD } from "@/lib/types";
+
+export default function DataQualityPage() {
+  const { overall, attribution, contextDrops, calibration, sampling } = dq;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Data Quality</h1>
+        <p className="mt-1 text-sm text-muted">
+          Every number we show, and how confident you can be in it. Honest under uncertainty.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <KpiCard
+          label="Attribution rate"
+          value={`${Math.round(overall.attributionRate * 100)}%`}
+          health={classify("attribution", overall.attributionRate)}
+          hint="business events successfully tied to a trace"
+        />
+        <KpiCard
+          label="Context drops (24h)"
+          value={overall.contextDropCount24h.toLocaleString()}
+          health={classify("drops", overall.contextDropCount24h)}
+          hint="spans missing an active trace context — detectable, never silent"
+        />
+        <KpiCard
+          label="Estimate calibration"
+          value={`${(overall.estimateCalibration * 100).toFixed(1)}% off`}
+          health={classify("calibration", overall.estimateCalibration)}
+          hint="|estimated − reconciled| / reconciled for the last reconciled period"
+        />
+        <KpiCard
+          label="Effective sample rate"
+          value={`${Math.round(overall.effectiveSampleRate * 100)}%`}
+          health="good"
+          hint="weighted across strata — tail kept ~100%, body sampled down"
+        />
+      </div>
+
+      <Card title="Attribution by feature">
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              <th className="py-1 text-left font-medium">Feature</th>
+              <th className="py-1 text-right font-medium">Rate</th>
+              <th className="py-1 text-right font-medium">Events (7d)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {attribution.map((a) => {
+              const h = classify("attribution", a.events7d === 0 ? 1 : a.rate);
+              return (
+                <tr key={a.feature} className="border-t border-edge">
+                  <td className="py-2 font-medium">{a.feature}</td>
+                  <td className="py-2 text-right tabular-nums">
+                    {a.events7d === 0 ? (
+                      <span className="text-muted">no value event</span>
+                    ) : (
+                      <HealthText h={h}>{Math.round(a.rate * 100)}%</HealthText>
+                    )}
+                  </td>
+                  <td className="py-2 text-right tabular-nums">{a.events7d.toLocaleString()}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Card>
+
+      <Card title="Context drops by service">
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              <th className="py-1 text-left font-medium">Service</th>
+              <th className="py-1 text-left font-medium">SDK</th>
+              <th className="py-1 text-right font-medium">Drops (24h)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contextDrops.map((d) => (
+              <tr key={`${d.service}-${d.sdkVersion}`} className="border-t border-edge">
+                <td className="py-2">{d.service}</td>
+                <td className="py-2 font-mono text-xs text-gray-300">{d.sdkVersion}</td>
+                <td className="py-2 text-right tabular-nums">
+                  <HealthText h={classify("drops", d.drops24h)}>
+                    {d.drops24h.toLocaleString()}
+                  </HealthText>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+
+      <Card title="Estimate vs. reconciled — last 7 reconciled days">
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              <th className="py-1 text-left font-medium">Date</th>
+              <th className="py-1 text-right font-medium">Estimated</th>
+              <th className="py-1 text-right font-medium">Reconciled</th>
+              <th className="py-1 text-right font-medium">Δ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {calibration.map((c) => {
+              const diff = c.estimatedMicroUsd - c.reconciledMicroUsd;
+              const pct = diff / c.reconciledMicroUsd;
+              const h = classify("calibration", Math.abs(pct));
+              return (
+                <tr key={c.date} className="border-t border-edge">
+                  <td className="py-2 font-mono text-xs text-gray-300">{c.date}</td>
+                  <td className="py-2 text-right tabular-nums">{formatUSD(c.estimatedMicroUsd)}</td>
+                  <td className="py-2 text-right tabular-nums">{formatUSD(c.reconciledMicroUsd)}</td>
+                  <td className="py-2 text-right tabular-nums">
+                    <HealthText h={h}>
+                      {pct > 0 ? "+" : ""}
+                      {(pct * 100).toFixed(1)}%
+                    </HealthText>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Card>
+
+      <Card title="Sampling by stratum">
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              <th className="py-1 text-left font-medium">Stratum</th>
+              <th className="py-1 text-right font-medium">Keep rate</th>
+              <th className="py-1 text-right font-medium">CI on extrapolated cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sampling.map((s) => (
+              <tr key={s.stratum} className="border-t border-edge">
+                <td className="py-2 capitalize">{s.stratum}</td>
+                <td className="py-2 text-right tabular-nums">{Math.round(s.rate * 100)}%</td>
+                <td className="py-2 text-right tabular-nums">
+                  {s.ciHalfWidthPct === 0 ? (
+                    <span className="text-good">exact</span>
+                  ) : (
+                    `±${Math.round(s.ciHalfWidthPct * 100)}%`
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  health,
+  hint,
+}: {
+  label: string;
+  value: string;
+  health: Health;
+  hint: string;
+}) {
+  const ring =
+    health === "good"
+      ? "border-good/40"
+      : health === "warn"
+        ? "border-warn/40"
+        : "border-bad/40";
+  return (
+    <div className={`rounded-xl border ${ring} bg-panel p-5`}>
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className={`mt-2 text-3xl font-semibold tabular-nums ${textFor(health)}`}>{value}</div>
+      <div className="mt-2 text-xs text-muted">{hint}</div>
+    </div>
+  );
+}
+
+function HealthText({ h, children }: { h: Health; children: React.ReactNode }) {
+  return <span className={textFor(h)}>{children}</span>;
+}
+
+function textFor(h: Health): string {
+  return h === "good" ? "text-good" : h === "warn" ? "text-warn" : "text-bad";
 }

--- a/web/lib/dq.test.ts
+++ b/web/lib/dq.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { classify, dq } from "./dq";
+
+describe("data-quality", () => {
+  it("classifies attribution thresholds", () => {
+    expect(classify("attribution", 0.95)).toBe("good");
+    expect(classify("attribution", 0.8)).toBe("warn");
+    expect(classify("attribution", 0.5)).toBe("bad");
+  });
+
+  it("zero context drops = good; many = bad", () => {
+    expect(classify("drops", 0)).toBe("good");
+    expect(classify("drops", 5)).toBe("warn");
+    expect(classify("drops", 100)).toBe("bad");
+  });
+
+  it("calibration: smaller is better", () => {
+    expect(classify("calibration", 0.01)).toBe("good");
+    expect(classify("calibration", 0.05)).toBe("warn");
+    expect(classify("calibration", 0.1)).toBe("bad");
+  });
+
+  it("sampling: tail kept exactly (CI half-width = 0)", () => {
+    const tail = dq.sampling.find((s) => s.stratum === "tail")!;
+    expect(tail.rate).toBe(1);
+    expect(tail.ciHalfWidthPct).toBe(0);
+  });
+
+  it("body has wider CI than mid", () => {
+    const body = dq.sampling.find((s) => s.stratum === "body")!;
+    const mid = dq.sampling.find((s) => s.stratum === "mid")!;
+    expect(body.ciHalfWidthPct).toBeGreaterThan(mid.ciHalfWidthPct);
+  });
+});

--- a/web/lib/dq.ts
+++ b/web/lib/dq.ts
@@ -1,0 +1,79 @@
+// Mock data for the Data Quality surface (CTO-79). Typed for the eventual API.
+
+export type Health = "good" | "warn" | "bad";
+
+export interface AttributionByFeature {
+  feature: string;
+  rate: number; // 0..1
+  events7d: number;
+}
+
+export interface ContextDropsByService {
+  service: string;
+  sdkVersion: string;
+  drops24h: number;
+}
+
+export interface CalibrationDay {
+  date: string;
+  estimatedMicroUsd: number;
+  reconciledMicroUsd: number;
+}
+
+export interface SampleByStratum {
+  stratum: "body" | "mid" | "tail";
+  rate: number; // 0..1
+  ciHalfWidthPct: number; // 0..1 fractional half-width of CI on extrapolated cost
+}
+
+export interface DataQualityReport {
+  overall: {
+    attributionRate: number;
+    contextDropCount24h: number;
+    estimateCalibration: number; // |est - recon| / recon, last reconciled period
+    effectiveSampleRate: number; // weighted across strata
+  };
+  attribution: AttributionByFeature[];
+  contextDrops: ContextDropsByService[];
+  calibration: CalibrationDay[];
+  sampling: SampleByStratum[];
+}
+
+export function classify(metric: "attribution" | "drops" | "calibration", v: number): Health {
+  if (metric === "attribution") return v >= 0.9 ? "good" : v >= 0.75 ? "warn" : "bad";
+  if (metric === "drops") return v === 0 ? "good" : v < 10 ? "warn" : "bad";
+  // calibration: smaller is better
+  return v < 0.03 ? "good" : v < 0.07 ? "warn" : "bad";
+}
+
+export const dq: DataQualityReport = {
+  overall: {
+    attributionRate: 0.91,
+    contextDropCount24h: 0,
+    estimateCalibration: 0.021,
+    effectiveSampleRate: 0.22,
+  },
+  attribution: [
+    { feature: "research_agent", rate: 0.91, events7d: 1820 },
+    { feature: "inline_writer", rate: 0.88, events7d: 1180 },
+    { feature: "smart_search", rate: 0.0, events7d: 0 },
+  ],
+  contextDrops: [
+    { service: "api-prod", sdkVersion: "py-0.0.1", drops24h: 0 },
+    { service: "worker-prod", sdkVersion: "py-0.0.1", drops24h: 0 },
+  ],
+  calibration: [
+    { date: "2026-05-13", estimatedMicroUsd: 950_000_000, reconciledMicroUsd: 935_000_000 },
+    { date: "2026-05-14", estimatedMicroUsd: 980_000_000, reconciledMicroUsd: 968_000_000 },
+    { date: "2026-05-15", estimatedMicroUsd: 1_020_000_000, reconciledMicroUsd: 1_004_000_000 },
+    { date: "2026-05-16", estimatedMicroUsd: 1_010_000_000, reconciledMicroUsd: 1_018_000_000 },
+    { date: "2026-05-17", estimatedMicroUsd: 1_050_000_000, reconciledMicroUsd: 1_028_000_000 },
+    { date: "2026-05-18", estimatedMicroUsd: 1_080_000_000, reconciledMicroUsd: 1_062_000_000 },
+    { date: "2026-05-19", estimatedMicroUsd: 1_120_000_000, reconciledMicroUsd: 1_101_000_000 },
+  ],
+  sampling: [
+    { stratum: "tail", rate: 1.0, ciHalfWidthPct: 0.0 },
+    { stratum: "mid", rate: 0.5, ciHalfWidthPct: 0.04 },
+    { stratum: "body", rate: 0.1, ciHalfWidthPct: 0.18 },
+  ],
+};


### PR DESCRIPTION
Branched off \`main\`. Mock data, preview-verified.

## Summary
- **\`/data-quality\`** — the POV made tangible. Four KPI cards (attribution rate, context drops, estimate calibration, effective sample rate), each color-coded by health threshold with a one-line hint explaining what the metric means.
- **Detail tables**: attribution by feature (no-value-event flagged), context drops by service+SDK, estimate vs reconciled (signed delta), sampling by stratum (tail = **exact**, body = ±CI half-width).
- \`lib/dq.ts\` + \`classify()\` helper, unit-tested across the threshold edges.

## Verification
tsc clean · vitest **15/15** · \`next lint\` clean · build prerenders \`/data-quality\`. Preview-rendered, no console errors.

## Out of scope
Live metrics wiring (needs gateway + reconciler); time-series sparklines per metric (follow-up).

## Test plan
- [x] typecheck / test / lint / build green
- [x] preview-verified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)