### PR TITLE
feat(web): Estimate (pre-deploy) screen [CTO-73]

### DIFF
--- a/web/app/estimate/page.tsx
+++ b/web/app/estimate/page.tsx
@@ -1,4 +1,150 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Estimate" ticket="CTO-73" />;
+import { Card } from "@/components/Card";
+import { pctDelta, projection } from "@/lib/estimate";
+import { formatUSD } from "@/lib/types";
+
+export default function EstimatePage() {
+  const { workload, pr, current, proposed, blowUpRisk, drivers, sample } = projection;
+  const costDelta = pctDelta(current.monthlyCostMicroUsd, proposed.monthlyCostMicroUsd);
+  const p99Delta = pctDelta(current.p99CostMicroUsd, proposed.p99CostMicroUsd);
+  const latDelta = pctDelta(current.meanLatencyMs, proposed.meanLatencyMs);
+  const riskSeverity =
+    blowUpRisk >= 0.3 ? "bad" : blowUpRisk >= 0.1 ? "warn" : "good";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Estimate</h1>
+        <p className="mt-1 text-sm text-muted">
+          Workload: <span className="font-mono text-gray-300">{workload}</span>
+        </p>
+      </div>
+
+      {pr && (
+        <div className="rounded-xl border border-edge bg-panel p-4 text-sm">
+          <span className="text-muted">Estimating PR </span>
+          <span className="font-mono text-accent">
+            {pr.repo}#{pr.number}
+          </span>
+          <span className="text-muted"> — </span>
+          <span>{pr.title}</span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Kpi
+          label="Cost / month"
+          current={formatUSD(current.monthlyCostMicroUsd)}
+          proposed={formatUSD(proposed.monthlyCostMicroUsd)}
+          delta={costDelta}
+          betterWhenNegative
+        />
+        <Kpi
+          label="p99 cost / run"
+          current={formatUSD(current.p99CostMicroUsd)}
+          proposed={formatUSD(proposed.p99CostMicroUsd)}
+          delta={p99Delta}
+          betterWhenNegative
+          headline
+        />
+        <Kpi
+          label="Blow-up risk"
+          current="—"
+          proposed={`${Math.round(blowUpRisk * 100)}%`}
+          severity={riskSeverity}
+          hint="P(p99 > 2× current)"
+        />
+        <Kpi
+          label="Mean latency"
+          current={`${current.meanLatencyMs} ms`}
+          proposed={`${proposed.meanLatencyMs} ms`}
+          delta={latDelta}
+          betterWhenNegative
+        />
+      </div>
+
+      <Card title="Driver breakdown">
+        <ul className="space-y-2 text-sm">
+          {drivers.map((d) => (
+            <li key={d.reason} className="flex items-baseline justify-between gap-3">
+              <span className="text-gray-300">{d.reason}</span>
+              <span
+                className={`tabular-nums font-medium ${d.delta > 0 ? "text-bad" : "text-good"}`}
+              >
+                {d.delta > 0 ? "+" : ""}
+                {formatUSD(d.delta)}/mo
+              </span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      <Card title="Sample diagnostics">
+        <dl className="grid grid-cols-1 gap-y-1.5 text-sm sm:grid-cols-2">
+          <Diag k="samples used" v={`${sample.used} (${sample.tailWeighted} tail-weighted, ${sample.used - sample.tailWeighted} random)`} />
+          <Diag k="pathological runs included" v={sample.pathologicalIncluded.toString()} good />
+          <Diag k="confidence interval (on p99)" v={`±${Math.round(sample.ciHalfWidthPct * 100)}%`} />
+          <Diag k="sampling strategy" v="tail-weighted (recommended)" good />
+        </dl>
+      </Card>
+    </div>
+  );
+}
+
+function Kpi({
+  label,
+  current,
+  proposed,
+  delta,
+  betterWhenNegative,
+  headline,
+  severity,
+  hint,
+}: {
+  label: string;
+  current: string;
+  proposed: string;
+  delta?: number;
+  betterWhenNegative?: boolean;
+  headline?: boolean;
+  severity?: "good" | "warn" | "bad";
+  hint?: string;
+}) {
+  const ring =
+    severity === "bad"
+      ? "border-bad/40"
+      : severity === "warn"
+        ? "border-warn/40"
+        : headline
+          ? "border-accent/40"
+          : "border-edge";
+  const valueClass =
+    severity === "bad" ? "text-bad" : severity === "warn" ? "text-warn" : "";
+  return (
+    <div className={`rounded-xl border ${ring} bg-panel p-5`}>
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className={`mt-2 text-2xl font-semibold tabular-nums ${valueClass}`}>{proposed}</div>
+      <div className="mt-1 text-xs text-muted">from {current}</div>
+      {delta !== undefined && delta !== 0 && (
+        <div
+          className={`mt-2 text-sm tabular-nums ${
+            (betterWhenNegative ? delta < 0 : delta > 0) ? "text-good" : "text-bad"
+          }`}
+        >
+          {delta > 0 ? "+" : ""}
+          {Math.round(delta * 100)}%
+          {Math.abs(delta) >= 0.5 && (betterWhenNegative ? delta > 0 : delta < 0) ? " ⚠" : ""}
+        </div>
+      )}
+      {hint && <div className="mt-2 text-xs text-muted">{hint}</div>}
+    </div>
+  );
+}
+
+function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
+  return (
+    <>
+      <dt className="text-muted">{k}</dt>
+      <dd className={good ? "text-good" : ""}>{v}</dd>
+    </>
+  );
 }

--- a/web/lib/estimate.test.ts
+++ b/web/lib/estimate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { pctDelta, projection } from "./estimate";
+
+describe("estimate", () => {
+  it("pctDelta returns 0 for zero baseline (no divide-by-zero)", () => {
+    expect(pctDelta(0, 100)).toBe(0);
+  });
+
+  it("driver breakdown reasons are non-empty + at least one increase", () => {
+    expect(projection.drivers.length).toBeGreaterThan(0);
+    expect(projection.drivers.some((d) => d.delta > 0)).toBe(true);
+  });
+
+  it("driver breakdown roughly explains the monthly delta (within 20%)", () => {
+    const sum = projection.drivers.reduce((s, d) => s + d.delta, 0);
+    const actual =
+      projection.proposed.monthlyCostMicroUsd - projection.current.monthlyCostMicroUsd;
+    const rel = Math.abs(sum - actual) / Math.abs(actual);
+    expect(rel).toBeLessThan(0.2);
+  });
+
+  it("blow-up risk in [0, 1]", () => {
+    expect(projection.blowUpRisk).toBeGreaterThanOrEqual(0);
+    expect(projection.blowUpRisk).toBeLessThanOrEqual(1);
+  });
+
+  it("sample includes pathological runs by design", () => {
+    expect(projection.sample.pathologicalIncluded).toBeGreaterThan(0);
+  });
+});

--- a/web/lib/estimate.ts
+++ b/web/lib/estimate.ts
@@ -1,0 +1,59 @@
+// Mock data for the pre-deploy Estimate workflow (CTO-71/72/73).
+
+import type { MicroUSD } from "./types";
+
+export interface Projection {
+  workload: string;
+  pr?: { repo: string; number: number; title: string };
+  current: {
+    monthlyCostMicroUsd: MicroUSD;
+    p99CostMicroUsd: MicroUSD;
+    meanLatencyMs: number;
+  };
+  proposed: {
+    monthlyCostMicroUsd: MicroUSD;
+    p99CostMicroUsd: MicroUSD;
+    meanLatencyMs: number;
+  };
+  /** Probability that p99 cost more than doubles under the change (0..1). The headline risk. */
+  blowUpRisk: number;
+  drivers: { delta: number; reason: string }[]; // delta in micro-USD/month
+  sample: {
+    used: number;
+    tailWeighted: number;
+    pathologicalIncluded: number;
+    ciHalfWidthPct: number; // on p99
+  };
+}
+
+export function pctDelta(cur: number, prop: number): number {
+  if (cur === 0) return 0;
+  return (prop - cur) / cur;
+}
+
+export const projection: Projection = {
+  workload: "research_agent / production / last 30 days",
+  pr: { repo: "jain-aanchal/ai-tally", number: 1284, title: "agent: add web_fetch retries + reranker step" },
+  current: {
+    monthlyCostMicroUsd: 6_420_000_000,
+    p99CostMicroUsd: 3_400_000,
+    meanLatencyMs: 1400,
+  },
+  proposed: {
+    monthlyCostMicroUsd: 11_200_000_000,
+    p99CostMicroUsd: 8_100_000,
+    meanLatencyMs: 2100,
+  },
+  blowUpRisk: 0.42,
+  drivers: [
+    { delta: 3_800_000_000, reason: "longer system prompt (4.2k → 6.8k tokens)" },
+    { delta: 1_400_000_000, reason: "new tool call in 60% of paths" },
+    { delta: -400_000_000, reason: "cached input recapture" },
+  ],
+  sample: {
+    used: 180,
+    tailWeighted: 140,
+    pathologicalIncluded: 18,
+    ciHalfWidthPct: 0.18,
+  },
+};


### PR DESCRIPTION
Branched off \`main\`. Mock data, preview-verified.

## Summary
- **\`/estimate\`** — four KPI cards: cost/month, **p99 cost/run** (headline, accent-ringed), **blow-up risk** = P(p99 > 2× current) with severity-coded ring (42% → red), mean latency. Each shows current → proposed with ⚠ when delta > 50% in the wrong direction.
- **Driver breakdown** with signed dollar deltas per cause (drivers ≈ monthly delta — unit-tested invariant).
- **Sample diagnostics** — samples used (tail-weighted vs. random), pathological runs included, CI on p99, sampling strategy.

## Verification
tsc clean · vitest **15/15** · \`next lint\` clean · build prerenders \`/estimate\`. Preview-rendered (full desktop width, all 4 KPIs in a row); no console errors.

## Out of scope
CLI + GitHub Action PR-comment integration (separate SDK/infra ticket); interactive paste-prompt → run-estimate (needs replay engine, CTO-59/72 server side).

## Test plan
- [x] typecheck / test / lint / build green
- [x] preview-verified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)