### PR TITLE
feat(sdk): attribution stitcher (pure Python) [CTO-69]

### DIFF
--- a/sdk/python/src/tally/stitcher.py
+++ b/sdk/python/src/tally/stitcher.py
@@ -1,0 +1,395 @@
+"""Attribution stitcher — bridge async business events to traces.
+
+Implements CTO-69 / spec §7.
+
+The stitcher is intentionally a pure library here: it operates on in-memory inputs (touches,
+identity edges, events) so it's testable without ClickHouse. In production the lookups are
+backed by ``last_touch_index`` / ``identity_graph`` tables (CTO-25/26); a backend implementing
+:class:`TouchStore` is the only thing that changes.
+
+Algorithm (per spec §7.1):
+
+1. Resolve the event's user-hash to its identity set via transitive lookup in
+   :class:`IdentityGraph` (bounded depth, default 2). This bridges anonymous→authenticated,
+   cross-device, and HMAC key versions (CTO-74).
+2. For each configured ``AttributionRule`` (one per `(event_name, feature_tag)`):
+   look up the most recent touch within the lookback window from any hash in the identity set.
+3. Decide the attribution confidence (direct / session_stitched / identity_graph_stitched).
+4. Upsert an idempotent :class:`AttributionRecord` keyed on
+   ``(tenant_id, business_event_id, feature_tag)``.
+5. If no candidate touch is found, emit an :class:`UnattributedRecord` (queryable, never silent).
+6. On a late identity edge, re-run for previously unattributed events involving the edge's
+   endpoints (:func:`restitch_on_new_edge`).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Protocol
+
+# --- types ---------------------------------------------------------------------------------------
+
+
+class IdentityType(str, Enum):
+    USER_ID = "user_id"
+    ANONYMOUS_ID = "anonymous_id"
+    SESSION_ID = "session_id"
+    EMAIL = "email"
+    EXTERNAL_ID = "external_id"
+
+
+class AttributionConfidence(str, Enum):
+    DIRECT = "direct"
+    SESSION_STITCHED = "session_stitched"
+    IDENTITY_GRAPH_STITCHED = "identity_graph_stitched"
+
+
+class ValueType(str, Enum):
+    MONETARY = "monetary"
+    COUNT = "count"
+    MRR = "mrr"
+    REFUND = "refund"
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityEdge:
+    """An edge in the identity graph (hashed identities only)."""
+
+    a: str
+    a_type: IdentityType
+    b: str
+    b_type: IdentityType
+    observed_at: datetime
+    source: str = "sdk"
+    confidence: float = 1.0
+    key_version: str = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class Touch:
+    """A trace's most recent attributable touch (matches ``last_touch_index`` rows)."""
+
+    trace_id: str
+    user_hash: str
+    feature_tag: str
+    ts: datetime
+    cost_micro_usd: int
+    key_version: str = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class BusinessEvent:
+    business_event_id: str
+    tenant_id: str
+    user_hash: str
+    event_name: str
+    occurred_at: datetime
+    value_amount_micro: int | None = None
+    value_currency: str = "USD"
+    value_type: ValueType = ValueType.MONETARY
+    source: str = "sdk"
+
+
+@dataclass(frozen=True, slots=True)
+class AttributionRule:
+    """Per-tenant config: which value events to attribute to which features, with what window."""
+
+    event_name: str
+    feature_tag: str
+    lookback_days: int = 30
+    attribution_model: str = "last_touch_v1"
+
+
+@dataclass(frozen=True, slots=True)
+class AttributionRecord:
+    tenant_id: str
+    business_event_id: str
+    feature_tag: str
+    attributed_trace_id: str
+    attributed_trace_ts: datetime
+    attributed_trace_cost_micro_usd: int
+    value_amount_micro: int | None
+    value_currency: str
+    value_type: ValueType
+    attribution_model: str
+    confidence: AttributionConfidence
+    user_id_hash_key_version: str
+    lookback_window_days: int
+    stitched_at: datetime
+    stitcher_version: str = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class UnattributedRecord:
+    tenant_id: str
+    business_event_id: str
+    event_name: str
+    user_hash: str
+    occurred_at: datetime
+    reason: str  # 'no_trace_in_window' | 'feature_tag_no_rule' | etc.
+    last_checked_at: datetime
+
+
+# --- identity graph ------------------------------------------------------------------------------
+
+
+class IdentityGraph:
+    """Undirected (symmetric) transitive identity graph over hashed IDs.
+
+    Edges keyed by ``(tenant_id, identity)`` so traversal is tenant-scoped (no cross-tenant leak).
+    """
+
+    def __init__(self) -> None:
+        self._adj: dict[tuple[str, str], set[tuple[str, IdentityEdge]]] = defaultdict(set)
+
+    def add_edge(self, tenant_id: str, edge: IdentityEdge) -> None:
+        # store both directions so the graph is undirected at traversal time
+        self._adj[(tenant_id, edge.a)].add((edge.b, edge))
+        self._adj[(tenant_id, edge.b)].add((edge.a, edge))
+
+    def resolve(
+        self,
+        tenant_id: str,
+        start: str,
+        *,
+        max_depth: int = 2,
+        as_of: datetime | None = None,
+    ) -> set[str]:
+        """Return all identities reachable from ``start`` within ``max_depth`` hops.
+
+        Edges with ``observed_at > as_of`` are ignored (avoids "leaking" later edges into a
+        historical attribution).
+        """
+        seen: set[str] = {start}
+        frontier: list[tuple[str, int]] = [(start, 0)]
+        while frontier:
+            node, depth = frontier.pop()
+            if depth >= max_depth:
+                continue
+            for neighbour, edge in self._adj.get((tenant_id, node), set()):
+                if as_of is not None and edge.observed_at > as_of:
+                    continue
+                if neighbour in seen:
+                    continue
+                seen.add(neighbour)
+                frontier.append((neighbour, depth + 1))
+        return seen
+
+    def edge_type_between(
+        self, tenant_id: str, a: str, b: str
+    ) -> IdentityType | None:
+        """If a single edge links ``a`` and ``b`` directly, return the *other side*'s type."""
+        for neighbour, edge in self._adj.get((tenant_id, a), set()):
+            if neighbour == b:
+                return edge.b_type if edge.a == a else edge.a_type
+        return None
+
+
+# --- touch store ---------------------------------------------------------------------------------
+
+
+class TouchStore(Protocol):
+    """Backend interface for "most recent touch per (user, feature) within a window".
+
+    The :class:`MemoryTouchStore` below is the test/dev implementation; ClickHouse-backed
+    implementations live in the gateway and read from ``last_touch_index`` (CTO-25).
+    """
+
+    def query_last_touch(
+        self,
+        *,
+        tenant_id: str,
+        user_hashes: set[str],
+        feature_tag: str,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> Touch | None: ...
+
+
+@dataclass(slots=True)
+class MemoryTouchStore:
+    """In-memory store: each ``add_touch`` keeps the newest touch per (tenant, user, feature)."""
+
+    _by_key: dict[tuple[str, str, str], Touch] = field(default_factory=dict)
+
+    def add_touch(self, tenant_id: str, touch: Touch) -> None:
+        key = (tenant_id, touch.user_hash, touch.feature_tag)
+        cur = self._by_key.get(key)
+        if cur is None or touch.ts > cur.ts:
+            self._by_key[key] = touch
+
+    def query_last_touch(
+        self,
+        *,
+        tenant_id: str,
+        user_hashes: set[str],
+        feature_tag: str,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> Touch | None:
+        best: Touch | None = None
+        for u in user_hashes:
+            t = self._by_key.get((tenant_id, u, feature_tag))
+            if t is None:
+                continue
+            if t.ts < window_start or t.ts > window_end:
+                continue
+            if best is None or t.ts > best.ts:
+                best = t
+        return best
+
+
+# --- stitcher ------------------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Stitcher:
+    """Per-tenant stitcher. Holds rules + identity graph + touches.
+
+    Idempotent on ``(tenant_id, business_event_id, feature_tag)`` — re-stitching produces an
+    upsert in :attr:`records`, not a duplicate.
+    """
+
+    identity_graph: IdentityGraph = field(default_factory=IdentityGraph)
+    touches: TouchStore = field(default_factory=MemoryTouchStore)
+    rules: list[AttributionRule] = field(default_factory=list)
+    records: dict[tuple[str, str, str], AttributionRecord] = field(default_factory=dict)
+    unattributed: dict[tuple[str, str], UnattributedRecord] = field(default_factory=dict)
+    identity_resolve_max_depth: int = 2
+
+    def stitch(
+        self,
+        event: BusinessEvent,
+        *,
+        now: datetime | None = None,
+        identity_as_of: datetime | None = None,
+    ) -> list[AttributionRecord]:
+        """Stitch one event against all configured rules. Returns the records produced/updated.
+
+        Per-feature: a single event can attribute to multiple features (one record each). The UI
+        is explicit that summing across features double-counts at the conversion level (spec §7.2).
+
+        ``identity_as_of`` bounds which identity edges are eligible. Defaults to
+        ``event.occurred_at`` (initial stitch — don't leak edges observed after the event). Pass
+        ``now`` from :func:`restitch_on_new_edge` so a late edge retroactively reveals identity.
+        """
+        now = now or event.occurred_at
+        as_of = identity_as_of if identity_as_of is not None else event.occurred_at
+        applicable = [r for r in self.rules if r.event_name == event.event_name]
+
+        if not applicable:
+            # Not a value event for this tenant — ignore (not an unattributed-with-reason).
+            return []
+
+        identity_set = self.identity_graph.resolve(
+            event.tenant_id,
+            event.user_hash,
+            max_depth=self.identity_resolve_max_depth,
+            as_of=as_of,
+        )
+
+        out: list[AttributionRecord] = []
+        for rule in applicable:
+            window_start = event.occurred_at - timedelta(days=rule.lookback_days)
+            candidate = self.touches.query_last_touch(
+                tenant_id=event.tenant_id,
+                user_hashes=identity_set,
+                feature_tag=rule.feature_tag,
+                window_start=window_start,
+                window_end=event.occurred_at,  # use occurred_at, not ingested_at
+            )
+
+            if candidate is None:
+                self.unattributed[(event.tenant_id, event.business_event_id)] = UnattributedRecord(
+                    tenant_id=event.tenant_id,
+                    business_event_id=event.business_event_id,
+                    event_name=event.event_name,
+                    user_hash=event.user_hash,
+                    occurred_at=event.occurred_at,
+                    reason="no_trace_in_window",
+                    last_checked_at=now,
+                )
+                continue
+
+            confidence = self._confidence(event, candidate)
+
+            record = AttributionRecord(
+                tenant_id=event.tenant_id,
+                business_event_id=event.business_event_id,
+                feature_tag=rule.feature_tag,
+                attributed_trace_id=candidate.trace_id,
+                attributed_trace_ts=candidate.ts,
+                attributed_trace_cost_micro_usd=candidate.cost_micro_usd,
+                value_amount_micro=event.value_amount_micro,
+                value_currency=event.value_currency,
+                value_type=event.value_type,
+                attribution_model=rule.attribution_model,
+                confidence=confidence,
+                user_id_hash_key_version=candidate.key_version,
+                lookback_window_days=rule.lookback_days,
+                stitched_at=now,
+            )
+            self.records[(event.tenant_id, event.business_event_id, rule.feature_tag)] = record
+            self.unattributed.pop((event.tenant_id, event.business_event_id), None)
+            out.append(record)
+
+        return out
+
+    def _confidence(self, event: BusinessEvent, candidate: Touch) -> AttributionConfidence:
+        if candidate.user_hash == event.user_hash:
+            return AttributionConfidence.DIRECT
+        direct_neighbour_type = self.identity_graph.edge_type_between(
+            event.tenant_id, event.user_hash, candidate.user_hash
+        )
+        if direct_neighbour_type is IdentityType.SESSION_ID:
+            return AttributionConfidence.SESSION_STITCHED
+        # one-hop via session also stitched as session_stitched? Spec keeps it bucketed by source:
+        # if the direct edge between the two was session, call it session-stitched; otherwise it's
+        # via the identity graph (anonymous->user, cross-device, key-version bridge, ...).
+        return AttributionConfidence.IDENTITY_GRAPH_STITCHED
+
+
+# --- re-stitch on late identity edge -------------------------------------------------------------
+
+
+def restitch_on_new_edge(
+    stitcher: Stitcher,
+    edge: IdentityEdge,
+    pending_events: Iterable[BusinessEvent],
+    *,
+    tenant_id: str,
+    now: datetime | None = None,
+) -> list[AttributionRecord]:
+    """When a new identity edge lands, re-run stitch for unattributed events whose user_hash
+    is now connected to ``edge.a`` or ``edge.b``.
+
+    ``pending_events`` is the set of stored business events for the tenant — typically the rows in
+    ``business_events`` whose ids appear in :attr:`Stitcher.unattributed`.
+    """
+    stitcher.identity_graph.add_edge(tenant_id, edge)
+    # If caller didn't supply a clock, anchor on the edge's observed_at (the moment we learned
+    # these identities are the same). Any edge with observed_at <= this is eligible.
+    effective_now = now or edge.observed_at
+
+    seeds = {edge.a, edge.b}
+    out: list[AttributionRecord] = []
+    for event in pending_events:
+        if event.tenant_id != tenant_id:
+            continue
+        if (event.tenant_id, event.business_event_id) not in stitcher.unattributed:
+            continue
+        identity_set = stitcher.identity_graph.resolve(
+            tenant_id,
+            event.user_hash,
+            max_depth=stitcher.identity_resolve_max_depth,
+            as_of=effective_now,
+        )
+        if identity_set.isdisjoint(seeds):
+            continue
+        # Re-stitch eligibility extends to effective_now so the new edge applies retroactively.
+        out.extend(stitcher.stitch(event, now=effective_now, identity_as_of=effective_now))
+    return out

--- a/sdk/python/tests/test_stitcher.py
+++ b/sdk/python/tests/test_stitcher.py
@@ -1,0 +1,263 @@
+"""Tests for the attribution stitcher (CTO-69, spec §7)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from tally.stitcher import (
+    AttributionConfidence,
+    AttributionRule,
+    BusinessEvent,
+    IdentityEdge,
+    IdentityType,
+    MemoryTouchStore,
+    Stitcher,
+    Touch,
+    ValueType,
+    restitch_on_new_edge,
+)
+
+T = "tenant_x"
+NOW = datetime(2026, 5, 28, 12, 0, 0)
+
+
+def _event(*, id_="ev1", user="u_alice", name="subscription_created", at=NOW, value=10_000_000):
+    return BusinessEvent(
+        business_event_id=id_,
+        tenant_id=T,
+        user_hash=user,
+        event_name=name,
+        occurred_at=at,
+        value_amount_micro=value,
+    )
+
+
+def _touch(
+    *,
+    trace="tr1",
+    user="u_alice",
+    feature="research_agent",
+    at=NOW - timedelta(hours=1),
+    cost=200_000,
+):
+    return Touch(trace_id=trace, user_hash=user, feature_tag=feature, ts=at, cost_micro_usd=cost)
+
+
+def _rule(*, name="subscription_created", feature="research_agent", days=30):
+    return AttributionRule(event_name=name, feature_tag=feature, lookback_days=days)
+
+
+# --- happy path ---------------------------------------------------------------------------------
+
+
+def test_direct_attribution_when_user_matches():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch())  # type: ignore[union-attr]
+    out = s.stitch(_event())
+    assert len(out) == 1
+    r = out[0]
+    assert r.confidence is AttributionConfidence.DIRECT
+    assert r.attributed_trace_id == "tr1"
+    assert r.feature_tag == "research_agent"
+    assert r.value_amount_micro == 10_000_000
+
+
+def test_idempotent_upsert_not_duplicate():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch())  # type: ignore[union-attr]
+    s.stitch(_event())
+    s.stitch(_event())  # replay same event
+    assert len(s.records) == 1
+
+
+def test_per_feature_attribution_credits_each():
+    s = Stitcher(
+        rules=[_rule(feature="research_agent"), _rule(feature="inline_writer")],
+        touches=MemoryTouchStore(),
+    )
+    s.touches.add_touch(T, _touch(feature="research_agent", trace="tr_r"))  # type: ignore[union-attr]
+    s.touches.add_touch(T, _touch(feature="inline_writer", trace="tr_w"))  # type: ignore[union-attr]
+    out = s.stitch(_event())
+    assert {r.feature_tag for r in out} == {"research_agent", "inline_writer"}
+
+
+# --- identity graph stitching --------------------------------------------------------------------
+
+
+def test_anonymous_to_authenticated_stitch():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    # touch was made under anonymous id; conversion fires under authenticated user_hash
+    s.touches.add_touch(T, _touch(user="u_anon"))  # type: ignore[union-attr]
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge(
+            a="u_anon",
+            a_type=IdentityType.ANONYMOUS_ID,
+            b="u_alice",
+            b_type=IdentityType.USER_ID,
+            observed_at=NOW - timedelta(minutes=30),
+            source="cdp_alias",
+        ),
+    )
+    out = s.stitch(_event(user="u_alice"))
+    assert len(out) == 1
+    assert out[0].confidence is AttributionConfidence.IDENTITY_GRAPH_STITCHED
+
+
+def test_session_stitched_when_edge_is_session():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch(user="u_alice_session"))  # type: ignore[union-attr]
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge(
+            a="u_alice",
+            a_type=IdentityType.USER_ID,
+            b="u_alice_session",
+            b_type=IdentityType.SESSION_ID,
+            observed_at=NOW - timedelta(minutes=30),
+        ),
+    )
+    out = s.stitch(_event(user="u_alice"))
+    assert out[0].confidence is AttributionConfidence.SESSION_STITCHED
+
+
+def test_2_hop_identity_graph_resolves():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    # anonymous → user → cross-device user
+    s.touches.add_touch(T, _touch(user="u_device_a"))  # type: ignore[union-attr]
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge(
+            "u_alice", IdentityType.USER_ID, "u_device_a", IdentityType.EXTERNAL_ID,
+            NOW - timedelta(days=1),
+        ),
+    )
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge(
+            "u_anon", IdentityType.ANONYMOUS_ID, "u_alice", IdentityType.USER_ID,
+            NOW - timedelta(hours=2),
+        ),
+    )
+    out = s.stitch(_event(user="u_anon"))
+    assert len(out) == 1
+
+
+def test_resolve_depth_is_bounded():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore(), identity_resolve_max_depth=1)
+    s.touches.add_touch(T, _touch(user="u_far"))  # type: ignore[union-attr]
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge("u_alice", IdentityType.USER_ID, "u_mid", IdentityType.USER_ID, NOW),
+    )
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge("u_mid", IdentityType.USER_ID, "u_far", IdentityType.USER_ID, NOW),
+    )
+    out = s.stitch(_event(user="u_alice"))
+    assert out == []  # u_far is 2 hops away, blocked by depth=1
+
+
+def test_resolve_does_not_use_edges_observed_after_event():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch(user="u_other"))  # type: ignore[union-attr]
+    # edge observed AFTER the event must not leak into the historical attribution
+    s.identity_graph.add_edge(
+        T,
+        IdentityEdge(
+            "u_alice", IdentityType.USER_ID, "u_other", IdentityType.USER_ID,
+            NOW + timedelta(hours=1),
+        ),
+    )
+    assert s.stitch(_event(user="u_alice")) == []
+
+
+# --- window + unattributed -----------------------------------------------------------------------
+
+
+def test_touch_outside_window_unattributed():
+    s = Stitcher(rules=[_rule(days=30)], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch(at=NOW - timedelta(days=45)))  # type: ignore[union-attr]
+    out = s.stitch(_event())
+    assert out == []
+    assert (T, "ev1") in s.unattributed
+    assert s.unattributed[(T, "ev1")].reason == "no_trace_in_window"
+
+
+def test_uses_occurred_at_not_now():
+    # touch is 25 days before the EVENT (which itself occurred a year ago) — still inside window
+    occurred = NOW - timedelta(days=365)
+    s = Stitcher(rules=[_rule(days=30)], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch(at=occurred - timedelta(days=25)))  # type: ignore[union-attr]
+    # stitched today, but window anchored at occurred_at
+    out = s.stitch(_event(at=occurred), now=NOW)
+    assert len(out) == 1
+
+
+# --- tenant isolation ---------------------------------------------------------------------------
+
+
+def test_identity_graph_does_not_leak_across_tenants():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch(user="u_anon"))  # type: ignore[union-attr]
+    # edge added under a *different* tenant must not connect u_anon→u_alice for T
+    s.identity_graph.add_edge(
+        "other_tenant",
+        IdentityEdge(
+            "u_anon", IdentityType.ANONYMOUS_ID, "u_alice", IdentityType.USER_ID,
+            NOW - timedelta(hours=1),
+        ),
+    )
+    out = s.stitch(_event(user="u_alice"))
+    assert out == []
+
+
+# --- re-stitch on late edge ----------------------------------------------------------------------
+
+
+def test_restitch_on_late_identity_edge():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch(user="u_anon"))  # type: ignore[union-attr]
+    pending = [_event(user="u_alice")]
+    # initial stitch fails (no edge)
+    assert s.stitch(pending[0]) == []
+    assert (T, "ev1") in s.unattributed
+    # later, an alias edge arrives — re-stitch should attribute
+    new_edge = IdentityEdge(
+        "u_anon", IdentityType.ANONYMOUS_ID, "u_alice", IdentityType.USER_ID,
+        observed_at=NOW + timedelta(hours=6),
+    )
+    out = restitch_on_new_edge(s, new_edge, pending, tenant_id=T)
+    assert len(out) == 1
+    assert (T, "ev1") not in s.unattributed
+    assert (T, "ev1", "research_agent") in s.records
+
+
+# --- refunds (negative value) flow through unchanged ---------------------------------------------
+
+
+def test_refund_event_attributes_with_value_type_refund():
+    s = Stitcher(rules=[_rule(name="refund")], touches=MemoryTouchStore())
+    s.touches.add_touch(T, _touch())  # type: ignore[union-attr]
+    refund = BusinessEvent(
+        business_event_id="rf1",
+        tenant_id=T,
+        user_hash="u_alice",
+        event_name="refund",
+        occurred_at=NOW,
+        value_amount_micro=-10_000_000,
+        value_type=ValueType.REFUND,
+    )
+    out = s.stitch(refund)
+    assert len(out) == 1 and out[0].value_type is ValueType.REFUND
+    assert out[0].value_amount_micro == -10_000_000
+
+
+# --- unknown event names are silently ignored ----------------------------------------------------
+
+
+def test_unknown_event_name_is_ignored_not_unattributed():
+    s = Stitcher(rules=[_rule()], touches=MemoryTouchStore())
+    out = s.stitch(_event(name="random_event"))
+    assert out == []
+    assert s.unattributed == {}  # not "unattributed" — just not a value event


### PR DESCRIPTION
Branched off \`main\`. Pure library; no infra needed.

## Summary
- Implements **§7 stitching algorithm**: identity resolve → per-rule last-touch within window → confidence (direct / session / identity_graph) → idempotent upsert keyed (tenant, business_event_id, feature_tag) → unattributed-with-reason otherwise.
- \`IdentityGraph\`: tenant-scoped, transitive, bounded depth, \`as_of\` filter so historical attribution can't leak later edges — except on \`restitch_on_new_edge\` which anchors on the edge's \`observed_at\` so late edges apply **retroactively** (the spec's late-arrival case).
- \`TouchStore\` protocol — \`MemoryTouchStore\` for tests; ClickHouse-backed impl drops in at the gateway.
- Refunds (\`value_type=REFUND\`) flow through with negative value.

## Acceptance criteria
- [x] Stitcher consumes \`(business_events, identity_graph, last_touch_index)\` via abstractions
- [x] Resolves transitive identity (bounded depth, tenant-scoped — no cross-tenant leak)
- [x] Per-feature attribution (one record per (event, feature) rule); idempotent on replay
- [x] Confidence labeled direct / session / identity_graph
- [x] Unattributed events emitted with reason (never silent)
- [x] Late edge → re-stitch (retroactive)

## Out of scope
ClickHouse-backed \`TouchStore\` (wiring at the gateway, CTO-31); CDP/Stripe connectors that feed events (CTO-68); ROI UI (CTO-70, already merged — reads these records).

## Test plan
- [x] \`ruff\` + \`pytest\` green (**177 tests**, +14 stitcher)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)