### PR TITLE
infra: local docker-compose stack + Python ingest gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ htmlcov/
 # Env / secrets
 .env
 .env.*
+!.env.example
 *.local
 
 # OS / editor

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,8 +1,7 @@
 # Copy to infra/.env and adjust as needed. Local-only defaults — do NOT use in production.
 # `docker compose` auto-loads infra/.env. Nothing here is a real secret.
 
-# --- ClickHouse ---
-CLICKHOUSE_DB=tally
+# --- ClickHouse (DDL applies to the `default` database; see compose note) ---
 CLICKHOUSE_USER=tally
 CLICKHOUSE_PASSWORD=tally
 CLICKHOUSE_HTTP_PORT=8123

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,31 @@
+# Copy to infra/.env and adjust as needed. Local-only defaults — do NOT use in production.
+# `docker compose` auto-loads infra/.env. Nothing here is a real secret.
+
+# --- ClickHouse ---
+CLICKHOUSE_DB=tally
+CLICKHOUSE_USER=tally
+CLICKHOUSE_PASSWORD=tally
+CLICKHOUSE_HTTP_PORT=8123
+CLICKHOUSE_TCP_PORT=9000
+
+# --- Postgres ---
+POSTGRES_DB=tally
+POSTGRES_USER=tally
+POSTGRES_PASSWORD=tally
+POSTGRES_PORT=5432
+
+# --- Redpanda (Kafka API) ---
+REDPANDA_PORT=9092
+REDPANDA_ADMIN_PORT=9644
+
+# --- MinIO (S3 API) ---
+MINIO_ROOT_USER=tally
+MINIO_ROOT_PASSWORD=tally-minio
+MINIO_PORT=9002
+MINIO_CONSOLE_PORT=9001
+
+# --- Gateway ---
+GATEWAY_PORT=8080
+# When true the gateway requires a Bearer API key whose SHA-256 is registered in Postgres api_keys.
+# Left false for frictionless local dev; `make seed` prints a key you can use when you flip this on.
+TALLY_REQUIRE_API_KEY=false

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -35,7 +35,7 @@ test: ## Run gateway unit tests (pure mapping logic, no infra)
 	cd gateway && uv run --extra dev pytest -q
 
 ch: ## Open a ClickHouse SQL shell
-	$(COMPOSE) exec clickhouse clickhouse-client -u tally --password tally -d tally
+	$(COMPOSE) exec clickhouse clickhouse-client -u tally --password tally -d default
 
 psql: ## Open a Postgres shell
 	$(COMPOSE) exec postgres psql -U tally -d tally

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,0 +1,44 @@
+# ai-tally local infra. Run from the infra/ directory:  make up / seed / demo / logs / down / nuke
+COMPOSE := docker compose
+GATEWAY := ai-tally-gateway
+
+.PHONY: help up down nuke logs ps seed demo gateway-shell test ch psql
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+up: ## Start the full stack (ClickHouse, Postgres, Redpanda, MinIO, gateway)
+	@test -f .env || cp .env.example .env
+	$(COMPOSE) up -d --build
+	@echo "gateway:    http://localhost:8080/healthz"
+	@echo "clickhouse: http://localhost:8123   minio console: http://localhost:9001"
+
+down: ## Stop the stack (keep data volumes)
+	$(COMPOSE) down
+
+nuke: ## Stop and wipe all data volumes (DDL re-applies on next up)
+	$(COMPOSE) down -v
+
+logs: ## Tail the gateway logs
+	$(COMPOSE) logs -f gateway
+
+ps: ## Show stack status
+	$(COMPOSE) ps
+
+seed: ## Create a local tenant + API key + feature tags in Postgres
+	$(COMPOSE) exec gateway python -m gateway.seed
+
+demo: ## Send a sample batch through the gateway into ClickHouse
+	$(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py
+
+test: ## Run gateway unit tests (pure mapping logic, no infra)
+	cd gateway && uv run --extra dev pytest -q
+
+ch: ## Open a ClickHouse SQL shell
+	$(COMPOSE) exec clickhouse clickhouse-client -u tally --password tally -d tally
+
+psql: ## Open a Postgres shell
+	$(COMPOSE) exec postgres psql -U tally -d tally
+
+gateway-shell: ## Shell into the gateway container
+	$(COMPOSE) exec gateway bash

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,73 @@
+# ai-tally local infrastructure
+
+A one-command local stack that mirrors the cloud topology. Everything runs in Docker on a laptop;
+the move to managed services later is a config change, not a rewrite.
+
+## What's in the box
+
+| Service    | Role                                   | Local port            |
+|------------|----------------------------------------|-----------------------|
+| ClickHouse | telemetry store (spans, rollups, attribution) | 8123 (HTTP), 9000 (native) |
+| Postgres   | control plane (tenants, keys, guardrails)     | 5432                  |
+| Redpanda   | ingest buffer (Kafka API)              | 9092                  |
+| MinIO      | object / warm storage (S3 API)         | 9002 (API), 9001 (console) |
+| Gateway    | SDK batch → enrich → ClickHouse (FastAPI) | 8080               |
+
+The canonical DDL in [`../db`](../db) is mounted into the containers and applied automatically on
+first boot — `otel_spans` and the rollup MVs into ClickHouse, the control-plane schema into Postgres.
+
+> The Go edge proxy (transparent OpenAI passthrough) is intentionally **not** part of the local
+> stack — the SDK ingestion path covers end-to-end flow without it. It's a later, optional addition.
+
+## Prerequisites
+
+- **Docker Desktop** (the only missing prerequisite on a fresh Mac). Install from docker.com.
+- That's it. Python/Node already on the machine; the gateway builds inside Docker.
+
+## Quickstart
+
+```bash
+cd infra
+make up        # build + start everything (first run pulls images, ~2-3 min)
+make seed      # create a local tenant + API key + feature tags
+make demo      # push a sample batch through the gateway into ClickHouse
+make ch        # SQL shell — try: SELECT FeatureTag, count(), sum(EstimatedCost) FROM otel_spans GROUP BY FeatureTag
+make down      # stop (keep data)   |   make nuke = stop + wipe volumes
+```
+
+Configuration lives in `.env` (auto-created from `.env.example` on first `make up`). All values are
+local-only defaults — nothing here is a real secret.
+
+## The gateway
+
+`POST /v1/batches` accepts a [`tally.wire.BatchRequest`](../sdk/python/src/tally/wire.py) JSON
+envelope and, reusing the SDK's already-tested pure logic:
+
+1. **authenticates** (optional) — `TALLY_REQUIRE_API_KEY=true` requires `Authorization: Bearer <key>`
+   whose SHA-256 is registered in `api_keys` (raw keys are never stored);
+2. **dedupes** idempotently on `(tenant_id, batch_id)` — replays return the original response;
+3. **enriches cost** authoritatively from the price catalog (client cost kept only as a drift hint);
+4. **clamps clock skew** so a fast client can't poison time-bucketed rollups;
+5. **writes** spans → `otel_spans`, business events → `business_events`, identity links →
+   `identity_graph`.
+
+Health: `GET /healthz` (liveness), `GET /readyz` (checks ClickHouse + Postgres).
+
+Run the mapping unit tests without any infra:
+
+```bash
+cd infra/gateway && uv run --extra dev pytest -q
+```
+
+## Cost
+
+- **Local: $0** — all images are free OSS; ~3–4 GB RAM while running.
+- **Managed cloud** (when you outgrow local): see
+  [`../docs/adr/0001-clickhouse-managed-vs-self-hosted.md`](../docs/adr/0001-clickhouse-managed-vs-self-hosted.md)
+  — ~$200–400/mo at MVP, scaling with volume.
+
+## Wiring the web dashboard at real data
+
+Point the Next.js app's API base at the gateway (or a future read API) via
+`NEXT_PUBLIC_API_BASE_URL`. Today the web app reads from its own mock Route Handlers; swapping those
+to query ClickHouse is the next increment.

--- a/infra/README.md
+++ b/infra/README.md
@@ -31,7 +31,7 @@ cd infra
 make up        # build + start everything (first run pulls images, ~2-3 min)
 make seed      # create a local tenant + API key + feature tags
 make demo      # push a sample batch through the gateway into ClickHouse
-make ch        # SQL shell — try: SELECT FeatureTag, count(), sum(EstimatedCost) FROM otel_spans GROUP BY FeatureTag
+make ch        # SQL shell (default db) — try: SELECT FeatureTag, count(), sum(EstimatedCost) FROM otel_spans GROUP BY FeatureTag
 make down      # stop (keep data)   |   make nuke = stop + wipe volumes
 ```
 

--- a/infra/clickhouse/config.d/storage.xml
+++ b/infra/clickhouse/config.d/storage.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!--
+  Tiered storage for the local stack.
+
+  otel_spans.sql's TTL moves expired parts `TO VOLUME 'warm'`, which only resolves if the table's
+  storage policy actually defines a volume named `warm`. The table specifies no explicit policy, so
+  it uses `default` — therefore we redefine the `default` policy here with two volumes:
+
+    hot  -> the built-in `default` disk (fresh inserts land here)
+    warm -> a second local disk (parts move here after the 7d TTL)
+
+  In production these map to SSD vs. cheaper object/block storage; locally both are just folders
+  under /var/lib/clickhouse so the TTL expression is valid and the table creates cleanly.
+-->
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <warm>
+                <path>/var/lib/clickhouse/warm/</path>
+            </warm>
+        </disks>
+        <policies>
+            <default>
+                <volumes>
+                    <hot>
+                        <disk>default</disk>
+                    </hot>
+                    <warm>
+                        <disk>warm</disk>
+                    </warm>
+                </volumes>
+            </default>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,139 @@
+# ai-tally local infrastructure.
+#
+# Brings up the full backing stack on a laptop, applies the canonical DDL from db/, and runs the
+# Python ingest gateway. Mirrors the cloud topology so the move to managed services is config-only.
+#
+#   make up        # start everything
+#   make seed      # create a local tenant + API key + price catalog
+#   make logs      # tail the gateway
+#   make down      # stop (keep data)
+#   make nuke      # stop + wipe volumes (re-runs DDL on next up)
+#
+# Nothing here is production-hardened: single-node, default creds from .env, no TLS. Local only.
+
+name: ai-tally
+
+services:
+  # --- Telemetry store -------------------------------------------------------------------------
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8
+    container_name: ai-tally-clickhouse
+    environment:
+      CLICKHOUSE_DB: ${CLICKHOUSE_DB:-tally}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-tally}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    ports:
+      - "${CLICKHOUSE_HTTP_PORT:-8123}:8123"   # HTTP interface (clickhouse-connect)
+      - "${CLICKHOUSE_TCP_PORT:-9000}:9000"    # native protocol
+    ulimits:
+      nofile: { soft: 262144, hard: 262144 }
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+      # DDL is applied alphabetically on first boot — numbered prefixes pin dependency order:
+      # spans table must exist before the rollup MVs that target it.
+      - ../db/clickhouse/otel_spans.sql:/docker-entrypoint-initdb.d/01_otel_spans.sql:ro
+      - ../db/clickhouse/rollups.sql:/docker-entrypoint-initdb.d/02_rollups.sql:ro
+      - ../db/clickhouse/last_touch_index.sql:/docker-entrypoint-initdb.d/03_last_touch_index.sql:ro
+      - ../db/clickhouse/attribution.sql:/docker-entrypoint-initdb.d/04_attribution.sql:ro
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # --- Control plane ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16
+    container_name: ai-tally-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-tally}
+      POSTGRES_USER: ${POSTGRES_USER:-tally}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-tally}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ../db/postgres/0001_control_plane.sql:/docker-entrypoint-initdb.d/0001_control_plane.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # --- Ingest buffer (Kafka API) ---------------------------------------------------------------
+  redpanda:
+    image: redpandadata/redpanda:v24.2.7
+    container_name: ai-tally-redpanda
+    command:
+      - redpanda start
+      - --overprovisioned
+      - --smp 1
+      - --memory 1G
+      - --reserve-memory 0M
+      - --node-id 0
+      - --check=false
+      - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
+    ports:
+      - "${REDPANDA_PORT:-9092}:9092"
+      - "${REDPANDA_ADMIN_PORT:-9644}:9644"
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -q 'Healthy:.*true'"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # --- Object / warm storage (S3 API) ----------------------------------------------------------
+  minio:
+    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
+    container_name: ai-tally-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-tally}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-tally-minio}
+    ports:
+      - "${MINIO_PORT:-9002}:9000"       # host 9002 -> S3 API (avoids CH native 9000 on host)
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # --- Ingest gateway (SDK batch -> enrich -> ClickHouse) --------------------------------------
+  gateway:
+    build:
+      context: ..
+      dockerfile: infra/gateway/Dockerfile
+    container_name: ai-tally-gateway
+    environment:
+      TALLY_CLICKHOUSE_HOST: clickhouse
+      TALLY_CLICKHOUSE_PORT: 8123
+      TALLY_CLICKHOUSE_DB: ${CLICKHOUSE_DB:-tally}
+      TALLY_CLICKHOUSE_USER: ${CLICKHOUSE_USER:-tally}
+      TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
+      TALLY_POSTGRES_DSN: postgresql://${POSTGRES_USER:-tally}:${POSTGRES_PASSWORD:-tally}@postgres:5432/${POSTGRES_DB:-tally}
+      TALLY_REQUIRE_API_KEY: ${TALLY_REQUIRE_API_KEY:-false}
+    ports:
+      - "${GATEWAY_PORT:-8080}:8080"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/healthz').status==200 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  clickhouse-data:
+  postgres-data:
+  redpanda-data:
+  minio-data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -19,7 +19,9 @@ services:
     image: clickhouse/clickhouse-server:24.8
     container_name: ai-tally-clickhouse
     environment:
-      CLICKHOUSE_DB: ${CLICKHOUSE_DB:-tally}
+      # NOTE: the official image runs /docker-entrypoint-initdb.d/*.sql against the `default`
+      # database, and our DDL is unqualified — so all tables live in `default`. We use `default`
+      # throughout rather than create a confusing empty `tally` db.
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-tally}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
@@ -30,6 +32,8 @@ services:
       nofile: { soft: 262144, hard: 262144 }
     volumes:
       - clickhouse-data:/var/lib/clickhouse
+      # Tiered storage policy: defines the `warm` volume that otel_spans' TTL moves parts to.
+      - ./clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml:ro
       # DDL is applied alphabetically on first boot — numbered prefixes pin dependency order:
       # spans table must exist before the rollup MVs that target it.
       - ../db/clickhouse/otel_spans.sql:/docker-entrypoint-initdb.d/01_otel_spans.sql:ro
@@ -114,7 +118,7 @@ services:
     environment:
       TALLY_CLICKHOUSE_HOST: clickhouse
       TALLY_CLICKHOUSE_PORT: 8123
-      TALLY_CLICKHOUSE_DB: ${CLICKHOUSE_DB:-tally}
+      TALLY_CLICKHOUSE_DB: default
       TALLY_CLICKHOUSE_USER: ${CLICKHOUSE_USER:-tally}
       TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
       TALLY_POSTGRES_DSN: postgresql://${POSTGRES_USER:-tally}:${POSTGRES_PASSWORD:-tally}@postgres:5432/${POSTGRES_DB:-tally}

--- a/infra/gateway/Dockerfile
+++ b/infra/gateway/Dockerfile
@@ -1,0 +1,21 @@
+# Ingest gateway image. Build context is the repo root (see docker-compose `context: ..`) so we can
+# COPY both the gateway and the SDK it depends on.
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# SDK first (the gateway installs it as a path dependency).
+COPY sdk/python /app/sdk/python
+COPY infra/gateway /app/infra/gateway
+
+# Install the SDK, then the gateway. We resolve `tally` from the local path rather than PyPI.
+RUN pip install /app/sdk/python \
+ && pip install /app/infra/gateway
+
+EXPOSE 8080
+
+CMD ["uvicorn", "gateway.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/infra/gateway/examples/send_batch.py
+++ b/infra/gateway/examples/send_batch.py
@@ -6,7 +6,7 @@ Usage (after `make up`):
 
 Then check ClickHouse:
     curl 'http://localhost:8123/?user=tally&password=tally' \
-      --data-binary "SELECT FeatureTag, count(), sum(EstimatedCost) FROM tally.otel_spans GROUP BY FeatureTag"
+      --data-binary "SELECT FeatureTag, count(), sum(EstimatedCost) FROM otel_spans GROUP BY FeatureTag"
 """
 
 from __future__ import annotations
@@ -39,6 +39,10 @@ def make_span(feature: str, model: str, in_tok: int, out_tok: int) -> dict[str, 
         )
     )
     attrs["ServiceName"] = "demo-app"
+    # Real SDK spans carry trace/span ids from context; the gateway dedupes on (trace_id, span_id),
+    # so give each demo span its own pair (otherwise they collapse to one).
+    attrs["trace_id"] = uuid7().replace("-", "")
+    attrs["span_id"] = uuid7().replace("-", "")[:16]
     return attrs
 
 

--- a/infra/gateway/examples/send_batch.py
+++ b/infra/gateway/examples/send_batch.py
@@ -1,0 +1,76 @@
+"""Smoke client: record a couple of LLM calls and POST them to the local gateway.
+
+Usage (after `make up`):
+    python infra/gateway/examples/send_batch.py
+    python infra/gateway/examples/send_batch.py --api-key tally_sk_...   # when auth is enabled
+
+Then check ClickHouse:
+    curl 'http://localhost:8123/?user=tally&password=tally' \
+      --data-binary "SELECT FeatureTag, count(), sum(EstimatedCost) FROM tally.otel_spans GROUP BY FeatureTag"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.request
+
+from tally.pricing import Usage, compute_cost_micro_usd, seed_catalog
+from tally.schema import SpanFields, build_span_attributes
+from tally.wire import uuid7
+
+CATALOG = seed_catalog()
+
+
+def make_span(feature: str, model: str, in_tok: int, out_tok: int) -> dict[str, object]:
+    cost, version = compute_cost_micro_usd(CATALOG, "openai", model, Usage(in_tok, out_tok))
+    attrs = build_span_attributes(
+        SpanFields(
+            system="openai",
+            request_model=model,
+            response_model=model,
+            operation="chat",
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            cost_estimated_micro_usd=cost,
+            price_catalog_version=version,
+            feature_tag=feature,
+            session_id=uuid7(),
+        )
+    )
+    attrs["ServiceName"] = "demo-app"
+    return attrs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://localhost:8080/v1/batches")
+    ap.add_argument("--tenant", default="local-dev")
+    ap.add_argument("--api-key", default=None)
+    args = ap.parse_args()
+
+    batch = {
+        "tenant_id": args.tenant,
+        "sdk_version": "demo",
+        "batch_id": uuid7(),
+        "resource_spans": [
+            make_span("assistant", "gpt-5-mini", 1200, 300),
+            make_span("assistant", "gpt-5", 4000, 900),
+            make_span("summarize", "gpt-5-mini", 8000, 120),
+        ],
+    }
+
+    body = json.dumps(batch).encode("utf-8")
+    req = urllib.request.Request(args.url, data=body, headers={"Content-Type": "application/json"})
+    if args.api_key:
+        req.add_header("Authorization", f"Bearer {args.api_key}")
+    with urllib.request.urlopen(req) as resp:
+        print(resp.status, resp.read().decode("utf-8"))
+
+    # demonstrate idempotency: replaying the same batch_id returns replayed=true, no new rows
+    with urllib.request.urlopen(req) as resp:
+        print("replay:", resp.read().decode("utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "tally-gateway"
+version = "0.1.0"
+description = "ai-tally ingest gateway — accepts SDK batches, enriches cost, writes to ClickHouse."
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.30",
+    "clickhouse-connect>=0.7.16",
+    "psycopg[binary]>=3.2",
+    "pydantic-settings>=2.4",
+    "tally",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+    "httpx>=0.27",
+]
+
+[tool.uv.sources]
+# The gateway reuses the SDK's wire/enrichment/timekeeping/pricing logic directly.
+tally = { path = "../../sdk/python", editable = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gateway"]
+
+[tool.ruff]
+line-length = 100
+src = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/infra/gateway/src/gateway/__init__.py
+++ b/infra/gateway/src/gateway/__init__.py
@@ -1,0 +1,9 @@
+"""ai-tally ingest gateway.
+
+Accepts SDK batches (the :mod:`tally.wire` envelope), recomputes cost authoritatively via
+:mod:`tally.enrichment`, clamps clock skew via :mod:`tally.timekeeping`, dedupes idempotently, and
+writes spans/business-events/identity-links into ClickHouse. A thin FastAPI service that reuses the
+already-tested SDK logic — no Go required for the local stack.
+"""
+
+__version__ = "0.1.0"

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -1,0 +1,179 @@
+"""FastAPI ingest gateway.
+
+POST /v1/batches — accept a :class:`tally.wire.BatchRequest` (JSON), authenticate, dedupe on
+(tenant_id, batch_id), enrich each span's cost authoritatively, clamp clock skew, and write spans +
+business events + identity links into ClickHouse.
+
+The heavy lifting (envelope, idempotency, cost recompute, skew clamp) is the SDK's already-tested
+pure logic — this module is just the HTTP + storage shell.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from tally.enrichment import enrich_cost
+from tally.pricing import seed_catalog
+from tally.timekeeping import assess
+from tally.wire import (
+    BatchRequest,
+    BatchResponse,
+    BusinessEvent,
+    IdempotencyCache,
+    IdentityLink,
+    Sampling,
+    Status,
+    uuid7,
+)
+
+from gateway.auth import ApiKeyAuth
+from gateway.config import get_settings
+from gateway.mapping import span_to_row
+from gateway.store import ClickHouseStore
+
+logger = logging.getLogger("tally.gateway")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_settings()
+    app.state.settings = settings
+    app.state.store = ClickHouseStore(settings)
+    app.state.auth = ApiKeyAuth(settings)
+    app.state.catalog = seed_catalog()
+    app.state.idempotency = IdempotencyCache(ttl_seconds=settings.idempotency_ttl_s)
+    logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
+    yield
+    app.state.store.close()
+
+
+app = FastAPI(title="ai-tally ingest gateway", version="0.1.0", lifespan=lifespan)
+
+
+def _parse_batch(payload: dict[str, Any]) -> BatchRequest:
+    try:
+        return BatchRequest(
+            tenant_id=payload["tenant_id"],
+            sdk_version=payload.get("sdk_version", "unknown"),
+            resource_spans=payload.get("resource_spans", []),
+            business_events=[BusinessEvent(**e) for e in payload.get("business_events", [])],
+            identity_links=[IdentityLink(**x) for x in payload.get("identity_links", [])],
+            sampling=Sampling(**payload.get("sampling", {})),
+            batch_id=payload.get("batch_id") or uuid7(),
+            client_send_ts_ns=payload.get("client_send_ts_ns", time.time_ns()),
+        )
+    except (KeyError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=f"malformed batch: {exc}") from exc
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/readyz")
+def readyz() -> JSONResponse:
+    store: ClickHouseStore = app.state.store
+    auth: ApiKeyAuth = app.state.auth
+    checks: dict[str, bool] = {}
+    try:
+        checks["clickhouse"] = store.ping()
+    except Exception as exc:  # noqa: BLE001 - report, don't crash readiness
+        logger.warning("clickhouse not ready: %s", exc)
+        checks["clickhouse"] = False
+    try:
+        checks["postgres"] = auth.ping()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("postgres not ready: %s", exc)
+        checks["postgres"] = False
+    ready = all(checks.values())
+    return JSONResponse({"ready": ready, "checks": checks}, status_code=200 if ready else 503)
+
+
+@app.post("/v1/batches")
+async def ingest_batch(
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    settings = app.state.settings
+    store: ClickHouseStore = app.state.store
+    auth: ApiKeyAuth = app.state.auth
+    catalog = app.state.catalog
+    idempotency: IdempotencyCache = app.state.idempotency
+
+    payload = await request.json()
+    batch = _parse_batch(payload)
+
+    # --- auth: resolve tenant ---
+    if settings.require_api_key:
+        if not authorization or not authorization.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="missing bearer token")
+        token = authorization.split(" ", 1)[1].strip()
+        tenant_id = auth.tenant_for_key(token)
+        if tenant_id is None:
+            raise HTTPException(status_code=403, detail="invalid api key")
+        batch.tenant_id = tenant_id  # trust the key's tenant, not the body
+    elif not batch.tenant_id:
+        raise HTTPException(status_code=422, detail="tenant_id required when auth is disabled")
+
+    # --- idempotency: replayed batch returns the original response ---
+    cached = idempotency.check_or_store(batch)
+    if cached is not None:
+        return JSONResponse(_response_dict(cached, replayed=True), status_code=200)
+
+    batch = batch.deduplicated()
+    server_recv_ns = time.time_ns()
+
+    # --- enrich + map spans ---
+    rows: list[tuple[object, ...]] = []
+    drift_count = 0
+    for span in batch.resource_spans:
+        if not isinstance(span, dict):
+            continue
+        result = enrich_cost(span, catalog, tenant_id=batch.tenant_id)
+        if result.drift_exceeded:
+            drift_count += 1
+        client_ts = span.get("timestamp_ns")
+        client_ts_ns = client_ts if isinstance(client_ts, int) else batch.client_send_ts_ns
+        skew = assess(client_ts_ns, server_recv_ns)
+        rows.append(
+            span_to_row(
+                result.attributes,
+                tenant_id=batch.tenant_id,
+                effective_ts_ns=skew.effective_ts_ns,
+                sample_rate=batch.sampling.head_sample_rate,
+            )
+        )
+
+    # --- write ---
+    try:
+        accepted = store.insert_spans(rows)
+        store.insert_business_events(batch.tenant_id, batch.business_events)
+        store.insert_identity_links(batch.tenant_id, batch.identity_links)
+    except Exception:  # noqa: BLE001 - surface as retryable, keep the gateway alive
+        logger.exception("clickhouse insert failed")
+        resp = BatchResponse(batch_id=batch.batch_id, status=Status.RETRY)
+        idempotency.record(batch, resp)
+        return JSONResponse(_response_dict(resp), status_code=503)
+
+    if drift_count:
+        logger.info("catalog drift on %d/%d spans (batch %s)", drift_count, len(rows), batch.batch_id)
+
+    resp = BatchResponse(batch_id=batch.batch_id, status=Status.ACCEPTED, accepted_spans=accepted)
+    idempotency.record(batch, resp)
+    return JSONResponse(_response_dict(resp), status_code=200)
+
+
+def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, Any]:
+    return {
+        "batch_id": resp.batch_id,
+        "status": resp.status.value,
+        "accepted_spans": resp.accepted_spans,
+        "replayed": replayed,
+    }

--- a/infra/gateway/src/gateway/auth.py
+++ b/infra/gateway/src/gateway/auth.py
@@ -1,0 +1,38 @@
+"""API-key auth against the Postgres control plane.
+
+Keys are never stored raw — ``api_keys.key_hash`` holds the SHA-256 hex of the token. We hash the
+presented bearer token and look up a non-revoked row, returning its tenant_id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import psycopg
+
+from gateway.config import Settings
+
+
+def hash_key(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class ApiKeyAuth:
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def tenant_for_key(self, token: str) -> str | None:
+        """Return the tenant_id (UUID str) for a valid, non-revoked key, else None."""
+        key_hash = hash_key(token)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT tenant_id FROM api_keys WHERE key_hash = %s AND revoked_at IS NULL",
+                (key_hash,),
+            )
+            row = cur.fetchone()
+            return str(row[0]) if row else None
+
+    def ping(self) -> bool:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            return cur.fetchone()[0] == 1

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -1,0 +1,38 @@
+"""Gateway configuration — environment-driven (12-factor)."""
+
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """All knobs are ``TALLY_``-prefixed env vars. Defaults target the docker-compose stack."""
+
+    model_config = SettingsConfigDict(env_prefix="TALLY_", env_file=".env", extra="ignore")
+
+    # ClickHouse (HTTP interface — clickhouse-connect).
+    clickhouse_host: str = "localhost"
+    clickhouse_port: int = 8123
+    clickhouse_db: str = "tally"
+    clickhouse_user: str = "tally"
+    clickhouse_password: str = "tally"
+
+    # Postgres (control plane) — used for API-key auth lookups.
+    postgres_dsn: str = "postgresql://tally:tally@localhost:5432/tally"
+
+    # Auth. When false, the gateway trusts the batch's tenant_id (local dev). When true, requests
+    # must carry `Authorization: Bearer <key>` whose SHA-256 is registered in api_keys.
+    require_api_key: bool = False
+
+    # Idempotency window (seconds) for (tenant_id, batch_id) dedup.
+    idempotency_ttl_s: int = 24 * 3600
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/infra/gateway/src/gateway/mapping.py
+++ b/infra/gateway/src/gateway/mapping.py
@@ -1,0 +1,165 @@
+"""Map an enriched span attribute dict onto an ``otel_spans`` ClickHouse row.
+
+Pure functions (no infra) so the translation is unit-testable. The SDK emits ``gen_ai.*`` attribute
+dicts (see :func:`tally.schema.build_span_attributes`); a span may additionally carry structural
+keys (``TraceId``/``trace_id``, ``SpanId``, ``Timestamp``, ``ServiceName``, ...). High-value
+attributes are promoted to typed columns; everything else lands in the ``SpanAttributes`` map.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from tally.schema import GenAI, micro_to_usd
+from tally.wire import uuid7
+
+# gen_ai.* keys that get promoted to typed columns (so they don't also duplicate into the map).
+_PROMOTED_GENAI = frozenset(
+    {
+        GenAI.FEATURE_TAG,
+        GenAI.SESSION_ID,
+        GenAI.USER_ID_HASH,
+        GenAI.USER_ID_HASH_KEY_VERSION,
+        GenAI.IDEMPOTENCY_KEY,
+        GenAI.SYSTEM,
+        GenAI.REQUEST_MODEL,
+        GenAI.RESPONSE_MODEL,
+        GenAI.OPERATION_NAME,
+        GenAI.TOOL_NAME,
+        GenAI.USAGE_INPUT_TOKENS,
+        GenAI.USAGE_OUTPUT_TOKENS,
+        GenAI.USAGE_CACHED_INPUT_TOKENS,
+        GenAI.COST_ESTIMATED_MICRO_USD,
+        GenAI.COST_CURRENCY,
+        GenAI.COST_PRICE_CATALOG_VERSION,
+        GenAI.AGENT_RUN_ID,
+        GenAI.AGENT_STEP_INDEX,
+        GenAI.RESOLVED_CONTEXT_REF,
+    }
+)
+
+# Structural keys recognised on the raw span dict (snake_case or ClickHouse-case both accepted).
+_STRUCTURAL = frozenset(
+    {
+        "TraceId", "trace_id", "SpanId", "span_id", "ParentSpanId", "parent_span_id",
+        "Timestamp", "timestamp_ns", "ServiceName", "service_name", "SpanName", "span_name",
+        "StatusCode", "status_code", "DurationNs", "duration_ns",
+    }
+)
+
+# Ordered column list for the ClickHouse insert. Must match the row tuples produced below.
+COLUMNS: tuple[str, ...] = (
+    "TenantId",
+    "Timestamp",
+    "TraceId",
+    "SpanId",
+    "ParentSpanId",
+    "ServiceName",
+    "SpanName",
+    "StatusCode",
+    "DurationNs",
+    "FeatureTag",
+    "SessionId",
+    "UserIdHash",
+    "UserIdHashKeyVersion",
+    "IdempotencyKey",
+    "GenAiSystem",
+    "GenAiRequestModel",
+    "GenAiResponseModel",
+    "GenAiOperation",
+    "GenAiToolName",
+    "InputTokens",
+    "OutputTokens",
+    "CachedInputTokens",
+    "EstimatedCost",
+    "CostCurrency",
+    "CostSource",
+    "PriceCatalogVersion",
+    "AgentRunId",
+    "AgentStepIndex",
+    "SpanAttributes",
+    "SampleRate",
+)
+
+
+def _pick(span: dict[str, object], *keys: str) -> object | None:
+    for k in keys:
+        if k in span and span[k] is not None:
+            return span[k]
+    return None
+
+
+def _s(v: object | None) -> str:
+    return "" if v is None else str(v)
+
+
+def _i(v: object | None) -> int:
+    return int(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else 0
+
+
+def _fixed64(v: object | None) -> str:
+    """FixedString(64) wants exactly 64 bytes; ClickHouse pads, but truncate over-long input."""
+    s = _s(v)
+    return s[:64]
+
+
+def span_to_row(
+    span: dict[str, object],
+    *,
+    tenant_id: str,
+    effective_ts_ns: int,
+    sample_rate: float = 1.0,
+) -> tuple[object, ...]:
+    """Translate one enriched span attribute dict into an ``otel_spans`` row tuple.
+
+    ``effective_ts_ns`` is the skew-clamped timestamp from :func:`tally.timekeeping.assess`. Cost is
+    converted from integer micro-USD back to a :class:`~decimal.Decimal` for the Decimal64(8) column.
+    """
+    ts = datetime.fromtimestamp(effective_ts_ns / 1e9, tz=timezone.utc)
+
+    cost_micro = span.get(GenAI.COST_ESTIMATED_MICRO_USD)
+    estimated_cost: Decimal = (
+        micro_to_usd(cost_micro) if isinstance(cost_micro, int) and not isinstance(cost_micro, bool)
+        else Decimal(0)
+    )
+
+    # Long-tail attributes: anything not promoted and not structural, stringified for Map(String,String).
+    extra: dict[str, str] = {}
+    for k, v in span.items():
+        if k in _PROMOTED_GENAI or k in _STRUCTURAL or v is None:
+            continue
+        extra[str(k)] = str(v)
+
+    return (
+        tenant_id,
+        ts,
+        _s(_pick(span, "TraceId", "trace_id") or uuid7().replace("-", "")),
+        _s(_pick(span, "SpanId", "span_id") or uuid7().replace("-", "")[:16]),
+        _s(_pick(span, "ParentSpanId", "parent_span_id")),
+        _s(_pick(span, "ServiceName", "service_name") or "unknown"),
+        _s(_pick(span, "SpanName", "span_name") or span.get(GenAI.OPERATION_NAME) or "llm.call"),
+        _i(_pick(span, "StatusCode", "status_code")),
+        _i(_pick(span, "DurationNs", "duration_ns")),
+        _s(span.get(GenAI.FEATURE_TAG) or "untagged"),
+        _s(span.get(GenAI.SESSION_ID)),
+        _fixed64(span.get(GenAI.USER_ID_HASH)),
+        _s(span.get(GenAI.USER_ID_HASH_KEY_VERSION)),
+        _s(span.get(GenAI.IDEMPOTENCY_KEY)),
+        _s(span.get(GenAI.SYSTEM)),
+        _s(span.get(GenAI.REQUEST_MODEL)),
+        _s(span.get(GenAI.RESPONSE_MODEL)),
+        _s(span.get(GenAI.OPERATION_NAME)),
+        _s(span.get(GenAI.TOOL_NAME)),
+        _i(span.get(GenAI.USAGE_INPUT_TOKENS)),
+        _i(span.get(GenAI.USAGE_OUTPUT_TOKENS)),
+        _i(span.get(GenAI.USAGE_CACHED_INPUT_TOKENS)),
+        estimated_cost,
+        _s(span.get(GenAI.COST_CURRENCY) or "USD"),
+        "estimated",
+        _s(span.get(GenAI.COST_PRICE_CATALOG_VERSION)),
+        _s(span.get(GenAI.AGENT_RUN_ID)),
+        _i(span.get(GenAI.AGENT_STEP_INDEX)),
+        extra,
+        float(sample_rate),
+    )

--- a/infra/gateway/src/gateway/seed.py
+++ b/infra/gateway/src/gateway/seed.py
@@ -1,0 +1,83 @@
+"""Seed a local tenant + API key + a couple of feature tags into Postgres.
+
+Run after `make up`:  `python -m gateway.seed`  (or `make seed`).
+
+Prints a freshly generated API key ONCE — only its SHA-256 is stored (api_keys.key_hash), matching
+the production invariant that raw key material is never persisted. Use the printed key as the
+gateway bearer token when TALLY_REQUIRE_API_KEY=true.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import psycopg
+
+from gateway.auth import hash_key
+from gateway.config import get_settings
+
+_TENANT_NAME = "local-dev"
+_REGION = "local"
+_FEATURE_TAGS = ["assistant", "search", "summarize"]
+
+
+def seed() -> None:
+    settings = get_settings()
+    token = "tally_sk_" + secrets.token_urlsafe(24)
+    key_hash = hash_key(token)
+
+    with psycopg.connect(settings.postgres_dsn) as conn, conn.cursor() as cur:
+        # plan tier (idempotent)
+        cur.execute(
+            """
+            INSERT INTO plan_tiers (name, max_traces_per_month, max_features, price_micro_usd)
+            VALUES ('free', 1000000, 10, 0)
+            ON CONFLICT (name) DO NOTHING
+            """
+        )
+        # tenant — reuse the existing local-dev tenant if present
+        cur.execute("SELECT id FROM tenants WHERE name = %s", (_TENANT_NAME,))
+        row = cur.fetchone()
+        if row:
+            tenant_id = row[0]
+        else:
+            cur.execute(
+                """
+                INSERT INTO tenants (name, region, plan, hash_salt_kek_ref)
+                VALUES (%s, %s, 'free', %s)
+                RETURNING id
+                """,
+                (_TENANT_NAME, _REGION, "kms://local/hmac-key-set/v1"),
+            )
+            tenant_id = cur.fetchone()[0]
+
+        cur.execute(
+            """
+            INSERT INTO usage_limits (tenant_id, plan) VALUES (%s, 'free')
+            ON CONFLICT (tenant_id) DO NOTHING
+            """,
+            (tenant_id,),
+        )
+        cur.execute(
+            "INSERT INTO api_keys (tenant_id, key_hash, scope) VALUES (%s, %s, 'write')",
+            (tenant_id, key_hash),
+        )
+        for tag in _FEATURE_TAGS:
+            cur.execute(
+                """
+                INSERT INTO feature_tags (tenant_id, tag, description)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (tenant_id, tag) DO NOTHING
+                """,
+                (tenant_id, tag, f"{tag} feature (seeded)"),
+            )
+        conn.commit()
+
+    print("Seeded local tenant.")
+    print(f"  tenant_id : {tenant_id}")
+    print(f"  api_key   : {token}")
+    print("  (only its SHA-256 is stored; copy this key now — it is not recoverable.)")
+
+
+if __name__ == "__main__":
+    seed()

--- a/infra/gateway/src/gateway/store.py
+++ b/infra/gateway/src/gateway/store.py
@@ -1,0 +1,102 @@
+"""ClickHouse writer. Wraps clickhouse-connect with span/event/identity inserts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import clickhouse_connect
+from clickhouse_connect.driver.client import Client
+
+from tally.wire import BusinessEvent, IdentityLink
+
+from gateway.config import Settings
+from gateway.mapping import COLUMNS
+
+_BUSINESS_EVENT_COLS = (
+    "TenantId", "BusinessEventId", "EventName", "UserIdHash", "OccurredAt", "IngestedAt",
+    "ValueAmountMicro", "ValueCurrency", "ValueType", "Source", "RawPayload",
+)
+
+_IDENTITY_COLS = (
+    "TenantId", "IdentityA", "IdentityAType", "IdentityB", "IdentityBType",
+    "UserIdHashKeyVersion", "Confidence", "ObservedAt", "Source",
+)
+
+
+def _ts(ns: int) -> datetime:
+    return datetime.fromtimestamp(ns / 1e9, tz=timezone.utc)
+
+
+class ClickHouseStore:
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client: Client | None = None
+
+    @property
+    def client(self) -> Client:
+        if self._client is None:
+            self._client = clickhouse_connect.get_client(
+                host=self._settings.clickhouse_host,
+                port=self._settings.clickhouse_port,
+                username=self._settings.clickhouse_user,
+                password=self._settings.clickhouse_password,
+                database=self._settings.clickhouse_db,
+            )
+        return self._client
+
+    def ping(self) -> bool:
+        return self.client.query("SELECT 1").result_rows[0][0] == 1
+
+    def insert_spans(self, rows: list[tuple[object, ...]]) -> int:
+        if not rows:
+            return 0
+        self.client.insert("otel_spans", rows, column_names=list(COLUMNS))
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list[BusinessEvent]) -> int:
+        if not events:
+            return 0
+        now = datetime.now(tz=timezone.utc)
+        rows = [
+            (
+                tenant_id,
+                e.business_event_id,
+                e.event_name,
+                e.user_id_hash[:64],
+                _ts(e.occurred_at_ns),
+                now,
+                e.value_amount_micro,
+                e.value_currency,
+                e.value_type,
+                e.source,
+                "",
+            )
+            for e in events
+        ]
+        self.client.insert("business_events", rows, column_names=list(_BUSINESS_EVENT_COLS))
+        return len(rows)
+
+    def insert_identity_links(self, tenant_id: str, links: list[IdentityLink]) -> int:
+        if not links:
+            return 0
+        rows = [
+            (
+                tenant_id,
+                ln.identity_a[:64],
+                ln.identity_a_type,
+                ln.identity_b[:64],
+                ln.identity_b_type,
+                "",
+                ln.confidence,
+                _ts(ln.observed_at_ns),
+                ln.source,
+            )
+            for ln in links
+        ]
+        self.client.insert("identity_graph", rows, column_names=list(_IDENTITY_COLS))
+        return len(rows)
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None

--- a/infra/gateway/tests/test_mapping.py
+++ b/infra/gateway/tests/test_mapping.py
@@ -1,0 +1,87 @@
+"""Pure tests for span -> otel_spans row mapping (no infra needed)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from tally.schema import GenAI, SpanFields, build_span_attributes
+
+from gateway.mapping import COLUMNS, span_to_row
+
+
+def _row_dict(row: tuple[object, ...]) -> dict[str, object]:
+    assert len(row) == len(COLUMNS)
+    return dict(zip(COLUMNS, row, strict=True))
+
+
+def test_maps_genai_attrs_to_typed_columns() -> None:
+    attrs = build_span_attributes(
+        SpanFields(
+            system="openai",
+            request_model="gpt-5-mini",
+            response_model="gpt-5-mini",
+            operation="chat",
+            input_tokens=1000,
+            output_tokens=250,
+            cost_estimated_micro_usd=750,
+            feature_tag="assistant",
+            session_id="sess-1",
+        )
+    )
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=1_700_000_000_000_000_000))
+
+    assert row["TenantId"] == "t1"
+    assert row["GenAiSystem"] == "openai"
+    assert row["GenAiResponseModel"] == "gpt-5-mini"
+    assert row["GenAiOperation"] == "chat"
+    assert row["InputTokens"] == 1000
+    assert row["OutputTokens"] == 250
+    assert row["FeatureTag"] == "assistant"
+    assert row["SessionId"] == "sess-1"
+    assert row["CostSource"] == "estimated"
+    assert row["CostCurrency"] == "USD"
+
+
+def test_cost_micro_usd_becomes_decimal_usd() -> None:
+    attrs = {GenAI.COST_ESTIMATED_MICRO_USD: 2_500_000, GenAI.COST_CURRENCY: "USD"}
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=0))
+    assert row["EstimatedCost"] == Decimal("2.50000000")
+
+
+def test_timestamp_is_utc_datetime_from_ns() -> None:
+    ns = 1_700_000_000_000_000_000
+    row = _row_dict(span_to_row({}, tenant_id="t1", effective_ts_ns=ns))
+    assert row["Timestamp"] == datetime.fromtimestamp(ns / 1e9, tz=timezone.utc)
+
+
+def test_defaults_for_missing_fields() -> None:
+    row = _row_dict(span_to_row({}, tenant_id="t1", effective_ts_ns=0))
+    assert row["FeatureTag"] == "untagged"
+    assert row["ServiceName"] == "unknown"
+    assert row["SpanName"] == "llm.call"
+    assert row["EstimatedCost"] == Decimal(0)
+    assert row["InputTokens"] == 0
+    # trace/span ids are generated when absent
+    assert row["TraceId"] and isinstance(row["TraceId"], str)
+    assert row["SpanId"] and isinstance(row["SpanId"], str)
+
+
+def test_unpromoted_attrs_land_in_span_attributes_map() -> None:
+    attrs = {GenAI.SYSTEM: "openai", "gen_ai.custom.flag": "x", "gen_ai.tool.call_id": "tc-1"}
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=0))
+    extra = row["SpanAttributes"]
+    assert isinstance(extra, dict)
+    assert extra["gen_ai.custom.flag"] == "x"
+    assert extra["gen_ai.tool.call_id"] == "tc-1"
+    # promoted key must NOT be duplicated into the map
+    assert GenAI.SYSTEM not in extra
+
+
+def test_structural_keys_are_used_not_mapped() -> None:
+    attrs = {"trace_id": "abc", "span_id": "def", "ServiceName": "api", GenAI.SYSTEM: "openai"}
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=0))
+    assert row["TraceId"] == "abc"
+    assert row["SpanId"] == "def"
+    assert row["ServiceName"] == "api"
+    assert "trace_id" not in row["SpanAttributes"]


### PR DESCRIPTION
## Summary
A one-command local environment that mirrors the cloud topology, plus a Python ingest gateway that turns the SDK's already-tested pure logic into a running service. No Go required — the SDK ingestion path covers end-to-end flow, so the edge proxy is deferred.

- **`infra/docker-compose.yml`** — ClickHouse, Postgres, Redpanda (Kafka API), MinIO (S3 API), and the gateway. The canonical `db/` DDL is mounted and auto-applied on first boot (numbered to pin dependency order: spans table before rollup MVs).
- **`infra/gateway/`** — FastAPI service. `POST /v1/batches` decodes the `tally.wire` envelope, authenticates (optional API key via Postgres, SHA-256 only), dedupes idempotently on `(tenant_id, batch_id)`, recomputes cost authoritatively from the price catalog, clamps clock skew, and writes spans / business events / identity links into ClickHouse. `/healthz` + `/readyz`.
- **`infra/clickhouse/config.d/storage.xml`** — defines the `hot`/`warm` storage policy that `otel_spans`' TTL requires (without it ClickHouse fails to create the table with `BAD_TTL_EXPRESSION`).
- **`make seed`** creates a local tenant + API key; **`make demo`** pushes a sample batch end-to-end.

## Verified live (end to end)
- All 11 ClickHouse tables + Postgres schema created on boot
- Gateway `/readyz` → `{"ready":true, clickhouse:true, postgres:true}`
- Seed → tenant + API key in Postgres
- Demo batch → 3 spans in `otel_spans` with correct server-recomputed costs (gpt-5 \$0.019, gpt-5-mini \$0.0009, summarize \$0.00224)
- `daily_feature_rollup` MV auto-aggregated on insert
- Idempotent replay returns `replayed:true`, no duplicate rows
- Span→row mapping: 6 unit tests pass against the real SDK (no infra needed)

## Cost / local feasibility
Local run is **\$0** (free OSS images, ~3–4 GB RAM). Managed cloud per ADR-0001 (~\$200–400/mo at MVP). Only prerequisite is Docker Desktop.

## Test plan
- [ ] `cd infra && make up` boots clean from zero (`make nuke` first for a true cold start)
- [ ] `make seed && make demo && make ch` shows rows in `otel_spans`
- [ ] `cd infra/gateway && uv run --extra dev pytest -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)