### PR TITLE
web: wire Home + Cost dashboards to live ClickHouse

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -17,7 +17,7 @@ async function json<T = unknown>(res: Response): Promise<T> {
 
 describe("api routes", () => {
   it("GET /api/home returns the four cards", async () => {
-    const body = await json<{ spend: unknown; outliers: unknown[]; roi: unknown[]; dq: unknown }>(HomeGET());
+    const body = await json<{ spend: unknown; outliers: unknown[]; roi: unknown[]; dq: unknown }>(await HomeGET());
     expect(body.spend).toBeDefined();
     expect(Array.isArray(body.outliers)).toBe(true);
     expect(Array.isArray(body.roi)).toBe(true);
@@ -44,7 +44,7 @@ describe("api routes", () => {
   });
 
   it("GET /api/cost returns series + featureRows + alerts", async () => {
-    const body = await json<{ series: unknown; featureRows: unknown[]; alerts: unknown[] }>(CostGET());
+    const body = await json<{ series: unknown; featureRows: unknown[]; alerts: unknown[] }>(await CostGET());
     expect(body.series).toBeDefined();
     expect(body.featureRows.length).toBeGreaterThan(0);
   });

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -1,6 +1,18 @@
 import { NextResponse } from "next/server";
-import { costSeries, featureRows, hiddenCostAlerts } from "@/lib/cost";
 
-export function GET() {
-  return NextResponse.json({ series: costSeries, featureRows, alerts: hiddenCostAlerts });
+import { costSeries, featureRows, hiddenCostAlerts } from "@/lib/cost";
+import { queryCostSeries, queryFeatureCostRows } from "@/lib/clickhouse";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const [series, rows] = await Promise.all([queryCostSeries(), queryFeatureCostRows()]);
+  return NextResponse.json({
+    series: series ?? costSeries,
+    featureRows: rows && rows.length > 0 ? rows : featureRows,
+    // Hidden-cost alerts are derived from cross-source comparison (not wired live yet); only show
+    // the canned alert when we're serving mock data.
+    alerts: rows && rows.length > 0 ? [] : hiddenCostAlerts,
+  });
 }

--- a/web/app/api/home/route.ts
+++ b/web/app/api/home/route.ts
@@ -1,11 +1,23 @@
 import { NextResponse } from "next/server";
-import { mockDataQuality, mockOutliers, mockRoi, mockSpend } from "@/lib/mock";
 
-export function GET() {
+import { mockDataQuality, mockOutliers, mockRoi, mockSpend } from "@/lib/mock";
+import { queryDataQuality, queryOutliers, queryRoi, querySpendSummary } from "@/lib/clickhouse";
+
+// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const [spend, outliers, roi, dq] = await Promise.all([
+    querySpendSummary(),
+    queryOutliers(),
+    queryRoi(),
+    queryDataQuality(),
+  ]);
   return NextResponse.json({
-    spend: mockSpend,
-    outliers: mockOutliers,
-    roi: mockRoi,
-    dq: mockDataQuality,
+    spend: spend ?? mockSpend,
+    outliers: outliers && outliers.length > 0 ? outliers : mockOutliers,
+    roi: roi && roi.length > 0 ? roi : mockRoi,
+    dq: dq ?? mockDataQuality,
   });
 }

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1,0 +1,245 @@
+// Live ClickHouse reads for the dashboard (server-only).
+//
+// The Route Handlers call these and fall back to mock data when ClickHouse is unreachable (no
+// stack running, CI, fresh clone) — so `npm run dev/build/test` never depend on infra. Money comes
+// back from ClickHouse as Decimal strings; we convert to integer micro-USD at the boundary to match
+// the wire/UI contract.
+//
+// Today only LLM spans exist in `otel_spans`, so cost lands in the `llm`/`tools`/`embeddings`
+// layers; vector/compute/egress are zero until those sources are instrumented. That's honest: the
+// dashboard shows exactly the telemetry that exists.
+//
+// Server-only: imported solely by Route Handlers pinned to the nodejs runtime (never a client
+// component), so it never reaches the browser bundle.
+
+import { createClient, type ClickHouseClient } from "@clickhouse/client";
+
+import type {
+  CostOutlier,
+  DataQuality,
+  FeatureRoi,
+  SpendByLayer,
+  SpendSummary,
+} from "./types";
+import type { CostDayPoint, CostSeries, FeatureCostRow } from "./cost";
+import { LAYERS, type Layer } from "./cost";
+
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+
+let _client: ClickHouseClient | null = null;
+
+function client(): ClickHouseClient {
+  if (_client === null) {
+    _client = createClient({
+      url: process.env.TALLY_CLICKHOUSE_URL ?? "http://localhost:8123",
+      username: process.env.TALLY_CLICKHOUSE_USER ?? "tally",
+      password: process.env.TALLY_CLICKHOUSE_PASSWORD ?? "tally",
+      database: process.env.TALLY_CLICKHOUSE_DB ?? "default",
+      request_timeout: 4000,
+    });
+  }
+  return _client;
+}
+
+/** Run `fn` against ClickHouse; return null on any failure so callers can fall back to mock. */
+export async function tryLive<T>(fn: (db: ClickHouseClient, tenant: string) => Promise<T>): Promise<T | null> {
+  try {
+    return await fn(client(), TENANT);
+  } catch (err) {
+    console.warn("[clickhouse] live query failed, falling back to mock:", (err as Error).message);
+    return null;
+  }
+}
+
+// Decimal string (USD) -> integer micro-USD.
+function micro(decimalUsd: string | number | null | undefined): number {
+  const n = typeof decimalUsd === "number" ? decimalUsd : parseFloat(decimalUsd ?? "0");
+  return Math.round((Number.isFinite(n) ? n : 0) * 1_000_000);
+}
+
+function zeroLayers(): SpendByLayer {
+  return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 };
+}
+
+// Map a gen_ai operation to a cost layer. Only LLM-family spans exist today.
+const LAYER_CASE =
+  "multiIf(GenAiOperation = 'tool', 'tools', GenAiOperation = 'embeddings', 'embeddings', 'llm')";
+
+async function rows<T>(db: ClickHouseClient, query: string, tenant: string): Promise<T[]> {
+  const rs = await db.query({
+    query,
+    query_params: { tenant },
+    format: "JSONEachRow",
+  });
+  return rs.json<T>();
+}
+
+// --- Home / spend -------------------------------------------------------------------------------
+
+export async function querySpendSummary(): Promise<SpendSummary | null> {
+  return tryLive(async (db, tenant) => {
+    const totals = await rows<{ total: string; estimated: string; reconciled: string; recThrough: string | null }>(
+      db,
+      `SELECT
+         sum(EstimatedCost) AS total,
+         sumIf(EstimatedCost, CostSource = 'estimated') AS estimated,
+         sumIf(EstimatedCost, CostSource = 'reconciled') AS reconciled,
+         toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY`,
+      tenant,
+    );
+    const byLayerRows = await rows<{ layer: Layer; cost: string }>(
+      db,
+      `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
+       GROUP BY layer`,
+      tenant,
+    );
+    const byLayer = zeroLayers();
+    for (const r of byLayerRows) {
+      if ((LAYERS as readonly string[]).includes(r.layer)) byLayer[r.layer] = micro(r.cost);
+    }
+    const t = totals[0] ?? { total: "0", estimated: "0", reconciled: "0", recThrough: null };
+    return {
+      totalMicroUsd: micro(t.total),
+      estimatedMicroUsd: micro(t.estimated),
+      reconciledMicroUsd: micro(t.reconciled),
+      // No reconciled data yet → boundary in the far past so everything reads as estimated.
+      reconciledThrough: t.recThrough && t.recThrough !== "\\N" ? t.recThrough : "1970-01-01",
+      byLayer,
+    };
+  });
+}
+
+export async function queryOutliers(): Promise<CostOutlier[] | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ runId: string; agent: string; cost: string; mult: string | null }>(
+      db,
+      `WITH runs AS (
+         SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost
+         FROM otel_spans
+         WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 24 HOUR
+         GROUP BY TraceId
+       )
+       SELECT runId, agent, cost,
+              cost / nullIf((SELECT quantileExact(0.5)(cost) FROM runs), 0) AS mult
+       FROM runs
+       ORDER BY cost DESC
+       LIMIT 5`,
+      tenant,
+    );
+    return out.map((r) => ({
+      runId: r.runId,
+      agent: r.agent || "untagged",
+      costMicroUsd: micro(r.cost),
+      multipleOfMedian: r.mult ? Math.round(parseFloat(r.mult) * 10) / 10 : 1,
+    }));
+  });
+}
+
+export async function queryRoi(): Promise<FeatureRoi[] | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ feature: string; cost: string; users: string }>(
+      db,
+      `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       GROUP BY FeatureTag
+       ORDER BY cost DESC`,
+      tenant,
+    );
+    return out.map((r) => {
+      const users = Math.max(1, parseInt(r.users, 10) || 1);
+      return {
+        feature: r.feature,
+        costPerUserMicroUsd: Math.round(micro(r.cost) / users),
+        // value/payback/attribution require business-event attribution (not wired yet) → null.
+        valuePerUserMicroUsd: null,
+        paybackDays: null,
+        attributionRate: null,
+      };
+    });
+  });
+}
+
+export async function queryDataQuality(): Promise<DataQuality | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ attributed: string; total: string }>(
+      db,
+      `SELECT
+         (SELECT count() FROM attribution_records WHERE TenantId = {tenant:String}) AS attributed,
+         (SELECT count() FROM business_events WHERE TenantId = {tenant:String}) AS total`,
+      tenant,
+    );
+    const attributed = parseInt(out[0]?.attributed ?? "0", 10);
+    const total = parseInt(out[0]?.total ?? "0", 10);
+    return {
+      // No value events yet → nothing to miss, rate is vacuously 1.0.
+      attributionRate: total > 0 ? attributed / total : 1,
+      contextDropCount: 0,
+      estimateCalibration: 0,
+    };
+  });
+}
+
+// --- Cost workflow ------------------------------------------------------------------------------
+
+export async function queryCostSeries(): Promise<CostSeries | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ day: string; layer: Layer; cost: string }>(
+      db,
+      `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY
+       GROUP BY day, layer
+       ORDER BY day`,
+      tenant,
+    );
+    // Pivot into one CostDayPoint per calendar day (fill gaps with zero layers).
+    const byDay = new Map<string, CostDayPoint>();
+    for (let i = 13; i >= 0; i--) {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() - i);
+      const iso = d.toISOString().slice(0, 10);
+      byDay.set(iso, { date: iso, byLayer: zeroLayers() });
+    }
+    for (const r of out) {
+      const point = byDay.get(r.day);
+      if (point && (LAYERS as readonly string[]).includes(r.layer)) {
+        point.byLayer[r.layer] = micro(r.cost);
+      }
+    }
+    return {
+      reconciledThrough: "1970-01-01", // nothing reconciled yet
+      days: [...byDay.values()],
+    };
+  });
+}
+
+export async function queryFeatureCostRows(): Promise<FeatureCostRow[] | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ feature: string; layer: Layer; cost: string }>(
+      db,
+      `SELECT FeatureTag AS feature, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       GROUP BY feature, layer`,
+      tenant,
+    );
+    const byFeature = new Map<string, FeatureCostRow>();
+    for (const r of out) {
+      let row = byFeature.get(r.feature);
+      if (!row) {
+        row = { feature: r.feature, byLayer: zeroLayers() };
+        byFeature.set(r.feature, row);
+      }
+      if ((LAYERS as readonly string[]).includes(r.layer)) row.byLayer[r.layer] = micro(r.cost);
+    }
+    return [...byFeature.values()].sort(
+      (a, b) =>
+        LAYERS.reduce((s, l) => s + b.byLayer[l], 0) - LAYERS.reduce((s, l) => s + a.byLayer[l], 0),
+    );
+  });
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ai-tally-web",
       "version": "0.0.1",
       "dependencies": {
+        "@clickhouse/client": "^1.19.0",
         "next": "^15.5.18",
         "react": "19.0.0",
         "react-dom": "19.0.0"
@@ -354,6 +355,24 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@clickhouse/client": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.19.0.tgz",
+      "integrity": "sha512-R/35tIFZjwRyqtTN0cnlvd45zU+YREuQ/cnfi6c+KGGkVSCF+1cl8mZ9kkxshqHx2U4YjcmPVElJaRn2bEqJ4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/client-common": "1.19.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@clickhouse/client-common": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.19.0.tgz",
+      "integrity": "sha512-HHQw7MUt1aFquSlnoQhlRO8e7zhRw7rJZFNSYiHP2wxzEVeoI0cX8kKoTp+xlVySvFi8s0mAC3bi8D031xmIQg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@clickhouse/client": "^1.19.0",
     "next": "^15.5.18",
     "react": "19.0.0",
     "react-dom": "19.0.0"


### PR DESCRIPTION
## Summary
- Restores the live-ClickHouse wiring for the Home and Cost dashboards onto `main`.
- The original PR #32 was stacked on `infra/compose-and-gateway` and merged into that branch instead of `main`, so commit `7923fd8` never landed on `main`. This re-applies it cleanly off `main`.
- Adds `web/lib/clickhouse.ts` server-only query layer with graceful mock fallback (`tryLive`), and switches `/api/home` and `/api/cost` route handlers to read live data when ClickHouse is reachable.

## Test plan
- [x] `npm run lint` — no warnings/errors
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 38 passed
- [x] `npm run build` — succeeds