### PR TITLE
web: wire Features, Data Quality & Agents to live ClickHouse

### DIFF
--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from "next/server";
-import { agents, runs } from "@/lib/agents";
 
-export function GET() {
-  return NextResponse.json({ agents, runs });
+import { agents, runs } from "@/lib/agents";
+import { queryAgents } from "@/lib/clickhouse";
+
+// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const live = await queryAgents();
+  return NextResponse.json({
+    agents: live && live.agents.length > 0 ? live.agents : agents,
+    runs: live && live.runs.length > 0 ? live.runs : runs,
+  });
 }

--- a/web/app/api/agents/runs/[runId]/route.ts
+++ b/web/app/api/agents/runs/[runId]/route.ts
@@ -1,9 +1,15 @@
 import { NextResponse } from "next/server";
+
 import { getRun } from "@/lib/agents";
+import { queryAgentRun } from "@/lib/clickhouse";
+
+// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 export async function GET(_req: Request, ctx: { params: Promise<{ runId: string }> }) {
   const { runId } = await ctx.params;
-  const run = getRun(runId);
+  const run = (await queryAgentRun(runId)) ?? getRun(runId);
   if (!run) return new NextResponse("Not found", { status: 404 });
   return NextResponse.json(run);
 }

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -25,7 +25,7 @@ describe("api routes", () => {
   });
 
   it("GET /api/agents returns agents + runs", async () => {
-    const body = await json<{ agents: unknown[]; runs: unknown[] }>(AgentsGET());
+    const body = await json<{ agents: unknown[]; runs: unknown[] }>(await AgentsGET());
     expect(body.agents.length).toBeGreaterThan(0);
     expect(body.runs.length).toBeGreaterThan(0);
   });
@@ -50,13 +50,13 @@ describe("api routes", () => {
   });
 
   it("GET /api/features returns features + diagnostics", async () => {
-    const body = await json<{ features: unknown[]; diagnostics: unknown }>(FeaturesGET());
+    const body = await json<{ features: unknown[]; diagnostics: unknown }>(await FeaturesGET());
     expect(body.features.length).toBeGreaterThan(0);
     expect(body.diagnostics).toBeDefined();
   });
 
   it("GET /api/data-quality returns a report", async () => {
-    const body = await json<{ overall: { attributionRate: number } }>(DataQualityGET());
+    const body = await json<{ overall: { attributionRate: number } }>(await DataQualityGET());
     expect(body.overall.attributionRate).toBeGreaterThan(0);
   });
 

--- a/web/app/api/data-quality/route.ts
+++ b/web/app/api/data-quality/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
-import { dq } from "@/lib/dq";
 
-export function GET() {
-  return NextResponse.json(dq);
+import { dq } from "@/lib/dq";
+import { queryDataQualityReport } from "@/lib/clickhouse";
+
+// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const live = await queryDataQualityReport();
+  return NextResponse.json(live ?? dq);
 }

--- a/web/app/api/features/route.ts
+++ b/web/app/api/features/route.ts
@@ -1,6 +1,19 @@
 import { NextResponse } from "next/server";
-import { diagnostics, features } from "@/lib/features";
 
-export function GET() {
-  return NextResponse.json({ features, diagnostics });
+import { diagnostics, features } from "@/lib/features";
+import { queryAttributionDiagnostics, queryFeatureEconomics } from "@/lib/clickhouse";
+
+// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const [liveFeatures, liveDiagnostics] = await Promise.all([
+    queryFeatureEconomics(),
+    queryAttributionDiagnostics(),
+  ]);
+  return NextResponse.json({
+    features: liveFeatures && liveFeatures.length > 0 ? liveFeatures : features,
+    diagnostics: liveDiagnostics ?? diagnostics,
+  });
 }

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -23,6 +23,15 @@ import type {
 } from "./types";
 import type { CostDayPoint, CostSeries, FeatureCostRow } from "./cost";
 import { LAYERS, type Layer } from "./cost";
+import type { AttributionDiagnostics, FeatureEconomics } from "./features";
+import type {
+  AttributionByFeature,
+  CalibrationDay,
+  ContextDropsByService,
+  DataQualityReport,
+  SampleByStratum,
+} from "./dq";
+import type { AgentRun, AgentSummary, RunSpan } from "./agents";
 
 const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
@@ -72,6 +81,30 @@ async function rows<T>(db: ClickHouseClient, query: string, tenant: string): Pro
     format: "JSONEachRow",
   });
   return rs.json<T>();
+}
+
+// Like `rows` but allows extra named query params (e.g. an Array(String) of trace ids).
+async function rowsP<T>(
+  db: ClickHouseClient,
+  query: string,
+  params: Record<string, unknown>,
+): Promise<T[]> {
+  const rs = await db.query({ query, query_params: params, format: "JSONEachRow" });
+  return rs.json<T>();
+}
+
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function quantile(xs: number[], q: number): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const idx = Math.min(s.length - 1, Math.max(0, Math.round(q * (s.length - 1))));
+  return s[idx];
 }
 
 // --- Home / spend -------------------------------------------------------------------------------
@@ -241,5 +274,295 @@ export async function queryFeatureCostRows(): Promise<FeatureCostRow[] | null> {
       (a, b) =>
         LAYERS.reduce((s, l) => s + b.byLayer[l], 0) - LAYERS.reduce((s, l) => s + a.byLayer[l], 0),
     );
+  });
+}
+
+// --- Features (ROI + attribution diagnostics) ---------------------------------------------------
+
+export async function queryFeatureEconomics(): Promise<FeatureEconomics[] | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ feature: string; cost: string; users: string }>(
+      db,
+      `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       GROUP BY FeatureTag
+       ORDER BY cost DESC`,
+      tenant,
+    );
+    return out.map((r) => {
+      const users = Math.max(1, parseInt(r.users, 10) || 1);
+      return {
+        feature: r.feature,
+        // Value events / payback / attribution all require business-event attribution, which is not
+        // wired yet — surface honest nulls rather than fabricated ROI.
+        valueEvent: null,
+        costPerUserMicroUsd: Math.round(micro(r.cost) / users),
+        valuePerUserMicroUsd: null,
+        paybackDays: null,
+        attributionRate: null,
+        attributionBreakdown: { direct: 0, sessionStitched: 0, identityGraphStitched: 0, unmatched: 0 },
+      };
+    });
+  });
+}
+
+export async function queryAttributionDiagnostics(): Promise<AttributionDiagnostics | null> {
+  // No reconciler / late-arrival pipeline runs yet, so every counter is honestly zero. We still
+  // gate on ClickHouse being reachable (tryLive) so a live deployment shows live zeros, not mock.
+  return tryLive(async (db, tenant) => {
+    await rows(db, `SELECT 1 FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1`, tenant);
+    return { lateArrivalEvents7d: 0, lateArrivalMedianHours: 0, reconcilerLastRunMinutesAgo: 0 };
+  });
+}
+
+// --- Data Quality (dedicated report) ------------------------------------------------------------
+
+export async function queryDataQualityReport(): Promise<DataQualityReport | null> {
+  return tryLive(async (db, tenant) => {
+    const attr = await rows<{ attributed: string; total: string }>(
+      db,
+      `SELECT
+         (SELECT count() FROM attribution_records WHERE TenantId = {tenant:String}) AS attributed,
+         (SELECT count() FROM business_events WHERE TenantId = {tenant:String}) AS total`,
+      tenant,
+    );
+    const attributed = parseInt(attr[0]?.attributed ?? "0", 10);
+    const totalEvents = parseInt(attr[0]?.total ?? "0", 10);
+
+    const sample = await rows<{ rate: string }>(
+      db,
+      `SELECT avg(SampleRate) AS rate FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY`,
+      tenant,
+    );
+    const effectiveSampleRate = parseFloat(sample[0]?.rate ?? "1") || 1;
+
+    const perFeature = await rows<{ feature: string; events: string }>(
+      db,
+      `SELECT FeatureTag AS feature, count() AS events FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 7 DAY AND FeatureTag != ''
+       GROUP BY feature ORDER BY events DESC`,
+      tenant,
+    );
+    // No value attribution yet → per-feature rate is 0 (nothing matched), but event counts are real.
+    const attribution: AttributionByFeature[] = perFeature.map((r) => ({
+      feature: r.feature,
+      rate: 0,
+      events7d: parseInt(r.events, 10) || 0,
+    }));
+
+    const svc = await rows<{ service: string; sdk: string }>(
+      db,
+      `SELECT ServiceName AS service, any(SpanAttributes['telemetry.sdk.version']) AS sdk
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 24 HOUR
+       GROUP BY service`,
+      tenant,
+    );
+    // Context-drop detection isn't instrumented yet → 0 drops, but the service inventory is real.
+    const contextDrops: ContextDropsByService[] = svc.map((r) => ({
+      service: r.service || "unknown",
+      sdkVersion: r.sdk || "unknown",
+      drops24h: 0,
+    }));
+
+    const cal = await rows<{ date: string; est: string; recon: string }>(
+      db,
+      `SELECT toString(toDate(Timestamp)) AS date,
+              sum(EstimatedCost) AS est,
+              sumIf(EstimatedCost, CostSource = 'reconciled') AS recon
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY
+       GROUP BY date ORDER BY date`,
+      tenant,
+    );
+    const calibration: CalibrationDay[] = cal.map((r) => ({
+      date: r.date,
+      estimatedMicroUsd: micro(r.est),
+      reconciledMicroUsd: micro(r.recon),
+    }));
+
+    // No stratified-sampling metadata in otel_spans yet → leave empty (the page renders no rows).
+    const sampling: SampleByStratum[] = [];
+
+    return {
+      overall: {
+        attributionRate: totalEvents > 0 ? attributed / totalEvents : 1,
+        contextDropCount24h: 0,
+        estimateCalibration: 0,
+        effectiveSampleRate,
+      },
+      attribution,
+      contextDrops,
+      calibration,
+      sampling,
+    };
+  });
+}
+
+// --- Agents (summaries + expensive runs) --------------------------------------------------------
+
+interface RunAgg {
+  runId: string;
+  agent: string;
+  cost: string;
+  steps: string;
+  maxStatus: string;
+  tsEpoch: string;
+}
+
+// Order-of-magnitude histogram bucket (micro-USD) → 10 buckets, cheap → expensive.
+function costBucket(costMicro: number): number {
+  if (costMicro <= 0) return 0;
+  return Math.min(9, Math.max(0, Math.floor(Math.log10(costMicro))));
+}
+
+interface SpanRowRaw {
+  runId: string;
+  spanId: string;
+  parentSpanId: string;
+  name: string;
+  cost: string;
+  durNs: string;
+  status: string;
+}
+
+function toRunSpan(s: SpanRowRaw): RunSpan {
+  return {
+    spanId: s.spanId,
+    parentSpanId: s.parentSpanId || null,
+    name: s.name,
+    costMicroUsd: micro(s.cost),
+    durationMs: Math.round((parseInt(s.durNs, 10) || 0) / 1e6),
+    status: parseInt(s.status, 10) === 2 ? "error" : "ok",
+  };
+}
+
+// Fetch ordered spans for the given trace ids, grouped by trace id (a plain Record — avoids Map +
+// for-of, which behaved unreliably under Next's bundling for this query path).
+async function fetchSpansFor(
+  db: ClickHouseClient,
+  tenant: string,
+  runIds: string[],
+): Promise<Record<string, RunSpan[]>> {
+  const grouped: Record<string, RunSpan[]> = {};
+  // Trace ids are hex strings from ClickHouse itself; whitelist-sanitize defensively and inline the
+  // IN list (parameterised array/list binding mis-serializes under Next's bundled @clickhouse/client).
+  const safeIds = runIds.map((id) => id.replace(/[^0-9a-zA-Z]/g, "")).filter((id) => id.length > 0);
+  if (safeIds.length === 0) return grouped;
+  const inList = safeIds.map((id) => `'${id}'`).join(",");
+  const sql = `SELECT TraceId AS runId, SpanId AS spanId, ParentSpanId AS parentSpanId,
+            SpanName AS name, EstimatedCost AS cost, DurationNs AS durNs, StatusCode AS status
+     FROM otel_spans
+     WHERE TenantId = {tenant:String} AND TraceId IN (${inList})
+     ORDER BY AgentStepIndex, Timestamp`;
+  const spanRows = await rows<SpanRowRaw>(db, sql, tenant);
+  spanRows.forEach((s) => {
+    (grouped[s.runId] ??= []).push(toRunSpan(s));
+  });
+  return grouped;
+}
+
+function whyExpensive(spans: RunSpan[], total: number): string {
+  if (spans.length === 0 || total <= 0) return "No cost breakdown available for this run.";
+  const top = [...spans].sort((a, b) => b.costMicroUsd - a.costMicroUsd)[0];
+  const pct = Math.round((top.costMicroUsd / total) * 100);
+  return `${pct}% of run cost concentrated in ${top.name} across ${spans.length} steps.`;
+}
+
+function buildRun(agg: RunAgg, spans: RunSpan[], agentMedian: number): AgentRun {
+  const total = micro(agg.cost);
+  return {
+    runId: agg.runId,
+    agent: agg.agent || "untagged",
+    totalCostMicroUsd: total,
+    multipleOfMedian: agentMedian > 0 ? Math.round((total / agentMedian) * 10) / 10 : 1,
+    steps: parseInt(agg.steps, 10) || spans.length,
+    // Only success/failed are inferable from OTel StatusCode (2 = error); abandoned isn't tracked.
+    outcome: parseInt(agg.maxStatus, 10) === 2 ? "failed" : "success",
+    whyExpensive: whyExpensive(spans, total),
+    spans,
+  };
+}
+
+/** Per-agent summaries + the top expensive runs (with span trees), built from otel_spans. */
+export async function queryAgents(): Promise<{ agents: AgentSummary[]; runs: AgentRun[] } | null> {
+  return tryLive(async (db, tenant) => {
+    const aggs = await rows<RunAgg>(
+      db,
+      `SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost,
+              count() AS steps, max(StatusCode) AS maxStatus, toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       GROUP BY TraceId`,
+      tenant,
+    );
+    if (aggs.length === 0) return { agents: [], runs: [] };
+
+    // Group runs by agent to derive summaries and per-agent medians.
+    const byAgent = new Map<string, RunAgg[]>();
+    for (const a of aggs) {
+      const list = byAgent.get(a.agent) ?? [];
+      list.push(a);
+      byAgent.set(a.agent, list);
+    }
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    const dayAgo = nowEpoch - 24 * 3600;
+    const agentMedian = new Map<string, number>();
+
+    const agents: AgentSummary[] = [...byAgent.entries()].map(([name, list]) => {
+      const costs = list.map((r) => micro(r.cost));
+      agentMedian.set(name, median(costs));
+      const last24 = list.filter((r) => (parseInt(r.tsEpoch, 10) || 0) >= dayAgo);
+      const distribution = new Array(10).fill(0);
+      for (const c of costs) distribution[costBucket(c)]++;
+      return {
+        name,
+        runsPerDay: last24.length,
+        costPerDayMicroUsd: last24.reduce((s, r) => s + micro(r.cost), 0),
+        p50MicroUsd: quantile(costs, 0.5),
+        p99MicroUsd: quantile(costs, 0.99),
+        distribution,
+      };
+    });
+    agents.sort((a, b) => b.costPerDayMicroUsd - a.costPerDayMicroUsd);
+
+    // Top expensive runs across all agents (with span trees) for the run list / drill-down.
+    const topAggs = [...aggs].sort((a, b) => micro(b.cost) - micro(a.cost)).slice(0, 12);
+    const spansByRun = await fetchSpansFor(db, tenant, topAggs.map((a) => a.runId));
+    const runs = topAggs.map((a) =>
+      buildRun(a, spansByRun[a.runId] ?? [], agentMedian.get(a.agent) ?? 0),
+    );
+    return { agents, runs };
+  });
+}
+
+/** A single run with its span tree, for the drill-down page. Null when the run isn't in ClickHouse. */
+export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
+  return tryLive(async (db, tenant) => {
+    const aggs = await rowsP<RunAgg>(
+      db,
+      `SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost,
+              count() AS steps, max(StatusCode) AS maxStatus, toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND TraceId = {runId:String}
+       GROUP BY TraceId`,
+      { tenant, runId },
+    );
+    const agg = aggs[0];
+    if (!agg) return null;
+
+    const peers = await rowsP<{ cost: string }>(
+      db,
+      `SELECT sum(EstimatedCost) AS cost FROM otel_spans
+       WHERE TenantId = {tenant:String} AND FeatureTag = {agent:String}
+         AND Timestamp >= now() - INTERVAL 30 DAY
+       GROUP BY TraceId`,
+      { tenant, agent: agg.agent },
+    );
+    const agentMedian = median(peers.map((p) => micro(p.cost)));
+    const spans = (await fetchSpansFor(db, tenant, [runId]))[runId] ?? [];
+    return buildRun(agg, spans, agentMedian);
   });
 }


### PR DESCRIPTION
## Summary
Wires the remaining dashboard surfaces to live ClickHouse, reusing the `lib/clickhouse.ts` query-layer + mock-fallback pattern from the Home/Cost work:
- **/api/features** — per-feature cost-per-user from `otel_spans`; value/payback/attribution surface honest `null` (business-event attribution not wired yet).
- **/api/data-quality** — real per-feature event counts, service inventory, effective sample rate, calibration days; honest zeros/empties where reconciliation, drop-detection, and sampling strata don't exist yet.
- **/api/agents** — per-agent summaries (runs/day, cost/day, p50/p99, cost histogram) + top expensive runs with span trees.
- **/api/agents/runs/:id** — single run + span-tree drill-down, with an auto-generated "why expensive" line.

All endpoints fall back to mock when ClickHouse is unreachable, so dev/build/test never depend on infra.

> Stacked on `web/live-clickhouse-to-main` (PR #33), which restores the Home/Cost live wiring to `main`. Retarget to `main` once #33 merges.

## Notes
- Span `IN`-lists are inlined as sanitized hex rather than array params, and span grouping uses a plain `Record` — `Map` + `for...of` mis-behaved under Next's bundled `@clickhouse/client` on this path (verified: query returned rows, grouping dropped them).

## Test plan
- [x] `npm run lint` / `tsc --noEmit` / `vitest run` (38 passed) / `npm run build`
- [x] Verified live against the local stack: features (assistant/summarize cost-per-user), data-quality (real event counts + service `demo-app`), agents (live summaries + span trees) all return real telemetry; confirmed mock fallback when CH is down.