### PR TITLE
web: empty / partial / stale states across workflows (CTO-80)

### DIFF
--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -1,8 +1,13 @@
 import Link from "next/link";
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { Histogram } from "@/components/Histogram";
 import { type AgentRun, type AgentSummary, p99Ratio } from "@/lib/agents";
 import { apiGet } from "@/lib/api";
+import { deriveDataState } from "@/lib/dataState";
 import { formatUSD } from "@/lib/types";
 
 interface AgentsPayload {
@@ -12,10 +17,15 @@ interface AgentsPayload {
 
 export default async function AgentsPage() {
   const { agents, runs } = await apiGet<AgentsPayload>("/api/agents");
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Agents</h1>
 
+  // Agents has no reconciliation boundary — only empty/partial states apply.
+  const noAgents = agents.length === 0 || agents.every((a) => a.costPerDayMicroUsd === 0);
+  const someEmptyAgents =
+    agents.some((a) => a.runsPerDay === 0) && agents.some((a) => a.runsPerDay > 0);
+  const state = deriveDataState({ isEmpty: noAgents, isPartial: someEmptyAgents });
+
+  const body = (
+    <div className="space-y-6">
       <Card title="Agent cost — distribution is the story">
         <table className="w-full text-sm">
           <thead className="text-xs uppercase text-muted">
@@ -77,6 +87,20 @@ export default async function AgentsPage() {
             ))}
         </ul>
       </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Agents</h1>
+
+      {state === "partial" && <PartialDataBanner missing="telemetry for some agents" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Agents">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
     </div>
   );
 }

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -1,21 +1,24 @@
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
 import { type Comparison, deltaPct } from "@/lib/compare";
+import { deriveDataState } from "@/lib/dataState";
 import { formatUSD, type MicroUSD } from "@/lib/types";
 
 export default async function ComparePage() {
   const comparison = await apiGet<Comparison>("/api/compare");
   const { workload, current, candidates, recommendation, diagnostics } = comparison;
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold">Compare</h1>
-        <p className="mt-1 text-sm text-muted">
-          Workload: <span className="font-mono text-gray-300">{workload}</span>
-        </p>
-      </div>
+  // No reconciliation boundary on this what-if surface — only empty/partial apply.
+  const noBaseline = current.monthlyCostMicroUsd === 0 || candidates.length === 0;
+  const noReplay = diagnostics.samplesReplayed === 0 && diagnostics.samplesAvailable > 0;
+  const state = deriveDataState({ isEmpty: noBaseline, isPartial: noReplay });
 
+  const body = (
+    <div className="space-y-6">
       <Card title="Candidates vs. current">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
@@ -64,6 +67,25 @@ export default async function ComparePage() {
           <Diag k="context fidelity" v={diagnostics.contextFidelity} good />
         </dl>
       </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Compare</h1>
+        <p className="mt-1 text-sm text-muted">
+          Workload: <span className="font-mono text-gray-300">{workload}</span>
+        </p>
+      </div>
+
+      {state === "partial" && <PartialDataBanner missing="the replay sampler" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Compare">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
     </div>
   );
 }

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -1,6 +1,12 @@
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  StaleBadge,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { Legend, StackedBarChart } from "@/components/StackedBarChart";
 import { apiGet } from "@/lib/api";
+import { asOfLabel, deriveDataState, relativeAge, someZero } from "@/lib/dataState";
 import {
   LAYER_LABEL,
   LAYERS,
@@ -31,10 +37,22 @@ export default async function CostPage() {
   const reconciled = reconciledTotal(costSeries);
   const estimated = estimatedTotal(costSeries);
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Cost</h1>
+  const layerTotals = LAYERS.reduce<Record<Layer, number>>(
+    (acc, l) => {
+      acc[l] = sumLayer(featureRows, l);
+      return acc;
+    },
+    { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 },
+  );
+  const state = deriveDataState({
+    isEmpty: total === 0,
+    isPartial: someZero({ ...layerTotals }),
+    reconciledThrough: costSeries.reconciledThrough,
+  });
+  const asOf = asOfLabel(costSeries.reconciledThrough);
 
+  const body = (
+    <div className="space-y-6">
       <Card title="Cost by layer — last 14 days">
         <div className="mb-2 flex items-baseline gap-3 text-sm">
           <span className="text-2xl font-semibold">{formatUSD(total)}</span>
@@ -94,6 +112,29 @@ export default async function CostPage() {
           </table>
         </div>
       </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Cost</h1>
+        {state !== "empty" && asOf && (
+          <StaleBadge
+            asOf={asOf}
+            age={relativeAge(costSeries.reconciledThrough)}
+            stale={state === "stale"}
+          />
+        )}
+      </div>
+
+      {state === "partial" && <PartialDataBanner missing="a cost layer connector" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Cost">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
     </div>
   );
 }

--- a/web/app/data-quality/page.tsx
+++ b/web/app/data-quality/page.tsx
@@ -1,5 +1,11 @@
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  StaleBadge,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
+import { asOfLabel, deriveDataState, relativeAge } from "@/lib/dataState";
 import { classify, type DataQualityReport, type Health } from "@/lib/dq";
 import { formatUSD } from "@/lib/types";
 
@@ -7,15 +13,21 @@ export default async function DataQualityPage() {
   const dq = await apiGet<DataQualityReport>("/api/data-quality");
   const { overall, attribution, contextDrops, calibration, sampling } = dq;
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold">Data Quality</h1>
-        <p className="mt-1 text-sm text-muted">
-          Every number we show, and how confident you can be in it. Honest under uncertainty.
-        </p>
-      </div>
+  // Latest reconciled calibration day is the freshness boundary; absence ⇒ pre-data.
+  const reconciledThrough = calibration.length > 0 ? calibration[calibration.length - 1].date : "1970-01-01";
+  const noData =
+    attribution.length === 0 && calibration.length === 0 && overall.attributionRate === 0;
+  const someUnattributed =
+    attribution.some((a) => a.events7d === 0) && attribution.some((a) => a.events7d > 0);
+  const state = deriveDataState({
+    isEmpty: noData,
+    isPartial: someUnattributed,
+    reconciledThrough,
+  });
+  const asOf = asOfLabel(reconciledThrough);
 
+  const body = (
+    <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <KpiCard
           label="Attribution rate"
@@ -157,6 +169,30 @@ export default async function DataQualityPage() {
           </tbody>
         </table>
       </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">Data Quality</h1>
+          <p className="mt-1 text-sm text-muted">
+            Every number we show, and how confident you can be in it. Honest under uncertainty.
+          </p>
+        </div>
+        {state !== "empty" && asOf && (
+          <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
+        )}
+      </div>
+
+      {state === "partial" && <PartialDataBanner missing="a value-event source for every feature" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Data Quality">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
     </div>
   );
 }

--- a/web/app/estimate/page.tsx
+++ b/web/app/estimate/page.tsx
@@ -1,5 +1,10 @@
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
+import { deriveDataState } from "@/lib/dataState";
 import { pctDelta, type Projection } from "@/lib/estimate";
 import { formatUSD } from "@/lib/types";
 
@@ -12,15 +17,13 @@ export default async function EstimatePage() {
   const riskSeverity =
     blowUpRisk >= 0.3 ? "bad" : blowUpRisk >= 0.1 ? "warn" : "good";
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold">Estimate</h1>
-        <p className="mt-1 text-sm text-muted">
-          Workload: <span className="font-mono text-gray-300">{workload}</span>
-        </p>
-      </div>
+  // No reconciliation boundary on this what-if surface — only empty/partial apply.
+  const noBaseline = current.monthlyCostMicroUsd === 0;
+  const thinSample = sample.used > 0 && sample.pathologicalIncluded === 0;
+  const state = deriveDataState({ isEmpty: noBaseline, isPartial: thinSample });
 
+  const body = (
+    <div className="space-y-6">
       {pr && (
         <div className="rounded-xl border border-edge bg-panel p-4 text-sm">
           <span className="text-muted">Estimating PR </span>
@@ -88,6 +91,25 @@ export default async function EstimatePage() {
           <Diag k="sampling strategy" v="tail-weighted (recommended)" good />
         </dl>
       </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Estimate</h1>
+        <p className="mt-1 text-sm text-muted">
+          Workload: <span className="font-mono text-gray-300">{workload}</span>
+        </p>
+      </div>
+
+      {state === "partial" && <PartialDataBanner missing="tail-weighted sampling" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Estimate">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
     </div>
   );
 }

--- a/web/app/features/page.tsx
+++ b/web/app/features/page.tsx
@@ -1,5 +1,11 @@
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  StaleBadge,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
+import { deriveDataState, relativeAge, STALE_AFTER_MS } from "@/lib/dataState";
 import {
   type AttributionDiagnostics,
   type FeatureEconomics,
@@ -14,10 +20,23 @@ interface FeaturesPayload {
 
 export default async function FeaturesPage() {
   const { features, diagnostics } = await apiGet<FeaturesPayload>("/api/features");
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Features</h1>
 
+  // Features has no reconciliation date; the reconciler's last-run minutes is its freshness signal.
+  const reconciledThrough = new Date(
+    Date.now() - diagnostics.reconcilerLastRunMinutesAgo * 60_000,
+  ).toISOString();
+  const noEconomics = features.length === 0 || features.every((f) => f.costPerUserMicroUsd === 0);
+  const someUnattributed =
+    features.some((f) => f.valueEvent === null) && features.some((f) => f.valueEvent !== null);
+  const state = deriveDataState({
+    isEmpty: noEconomics,
+    isPartial: someUnattributed,
+    reconciledThrough,
+  });
+  const reconcilerStale = diagnostics.reconcilerLastRunMinutesAgo * 60_000 > STALE_AFTER_MS;
+
+  const body = (
+    <div className="space-y-6">
       <Card title="Unit economics — per feature">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
@@ -93,11 +112,38 @@ export default async function FeaturesPage() {
             <dl className="space-y-1.5 text-sm">
               <Diag k="late-arriving events (7d)" v={diagnostics.lateArrivalEvents7d.toLocaleString()} />
               <Diag k="median lag" v={`${diagnostics.lateArrivalMedianHours.toFixed(1)}h`} />
-              <Diag k="reconciler last ran" v={`${diagnostics.reconcilerLastRunMinutesAgo} min ago`} good />
+              <Diag
+                k="reconciler last ran"
+                v={`${diagnostics.reconcilerLastRunMinutesAgo} min ago`}
+                good={!reconcilerStale}
+              />
             </dl>
           </div>
         </div>
       </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Features</h1>
+        {state !== "empty" && (
+          <StaleBadge
+            asOf={relativeAge(reconciledThrough)}
+            age={relativeAge(reconciledThrough)}
+            stale={state === "stale"}
+          />
+        )}
+      </div>
+
+      {state === "partial" && <PartialDataBanner missing="value-event tracking for every feature" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Features">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
     </div>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,17 @@
 import { Card } from "@/components/Card";
+import {
+  PartialDataBanner,
+  StaleBadge,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
+import {
+  allZero,
+  asOfLabel,
+  deriveDataState,
+  relativeAge,
+  someZero,
+} from "@/lib/dataState";
 import type { CostOutlier, DataQuality, FeatureRoi, SpendSummary } from "@/lib/types";
 import { formatUSD } from "@/lib/types";
 
@@ -13,13 +25,18 @@ interface HomePayload {
 export default async function HomePage() {
   const { spend: s, outliers, roi, dq } = await apiGet<HomePayload>("/api/home");
   const hidden = s.byLayer.vector + s.byLayer.tools + s.byLayer.compute + s.byLayer.embeddings + s.byLayer.egress;
-  const hiddenPct = Math.round((hidden / s.totalMicroUsd) * 100);
+  const hiddenPct = s.totalMicroUsd === 0 ? 0 : Math.round((hidden / s.totalMicroUsd) * 100);
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Home</h1>
+  const layers: Record<string, number> = { ...s.byLayer };
+  const state = deriveDataState({
+    isEmpty: s.totalMicroUsd === 0 && allZero(layers),
+    isPartial: someZero(layers),
+    reconciledThrough: s.reconciledThrough,
+  });
+  const asOf = asOfLabel(s.reconciledThrough);
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+  const grid = (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <Card title="Spend — last 30 days">
           <div className="text-3xl font-semibold">{formatUSD(s.totalMicroUsd)}</div>
           <div className="mt-2 text-sm text-muted">
@@ -88,6 +105,24 @@ export default async function HomePage() {
           </dl>
         </Card>
       </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Home</h1>
+        {state !== "empty" && asOf && (
+          <StaleBadge asOf={asOf} age={relativeAge(s.reconciledThrough)} stale={state === "stale"} />
+        )}
+      </div>
+
+      {state === "partial" && <PartialDataBanner missing="a cost layer connector" />}
+
+      {state === "empty" ? (
+        <SyntheticPreviewBanner workflow="Home">{grid}</SyntheticPreviewBanner>
+      ) : (
+        grid
+      )}
     </div>
   );
 }

--- a/web/components/DataStateBanner.tsx
+++ b/web/components/DataStateBanner.tsx
@@ -1,0 +1,113 @@
+// Shared empty / partial / stale UI for every workflow (CTO-80, spec 13.8 "never show stale as
+// fresh"). One implementation, applied identically across all five surfaces.
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+/** Single connector call-to-action. Links to /connectors, which already exists. */
+export function ConnectorCta({ label = "Connect a data source" }: { label?: string }) {
+  return (
+    <Link
+      href="/connectors"
+      className="inline-flex items-center rounded-md border border-accent/50 bg-accent/15 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/25"
+    >
+      {label}
+    </Link>
+  );
+}
+
+/**
+ * Pre-data state. Wraps a synthetic preview of the workflow with an unmistakable "SAMPLE DATA"
+ * label and a single connector CTA, so a preview is never confused for real data.
+ */
+export function SyntheticPreviewBanner({
+  workflow,
+  children,
+}: {
+  workflow: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-dashed border-accent/40 bg-accent/5">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-dashed border-accent/30 px-4 py-3">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="rounded bg-accent/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-accent">
+            Sample data
+          </span>
+          <span className="text-muted">
+            Preview of {workflow} — no real telemetry yet. These numbers are synthetic.
+          </span>
+        </div>
+        <ConnectorCta />
+      </div>
+      <div className="relative p-4">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute right-3 top-3 select-none rounded bg-ink/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-accent/80"
+        >
+          Preview
+        </span>
+        <div className="opacity-90">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Partial-data state. A banner pointing at the missing connector, rendered above whatever real
+ * data does exist.
+ */
+export function PartialDataBanner({ missing }: { missing: string }) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-warn/40 bg-warn/10 px-4 py-3 text-sm">
+      <div className="text-warn">
+        <span className="font-medium">Partial data. </span>
+        <span>Showing what we have, but {missing} isn&apos;t connected yet — some numbers are incomplete.</span>
+      </div>
+      <ConnectorCta label="Finish setup" />
+    </div>
+  );
+}
+
+/**
+ * "Data as of" badge. Fresh: a muted timestamp. Stale (boundary &gt; 2h old): turns into a warning
+ * so stale numbers are never presented as fresh.
+ */
+export function StaleBadge({
+  asOf,
+  age,
+  stale,
+}: {
+  asOf: string;
+  age: string;
+  stale: boolean;
+}) {
+  if (stale) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-warn/50 bg-warn/10 px-2.5 py-1 text-xs font-medium text-warn">
+        <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full bg-warn" />
+        Stale — reconciled {age} (as of {asOf})
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink px-2.5 py-1 text-xs text-muted">
+      <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full bg-good" />
+      Data as of {asOf}
+    </span>
+  );
+}
+
+/**
+ * Empty state for surfaces with no reconciliation boundary (what-if tools): a labelled synthetic
+ * preview plus a single connector CTA.
+ */
+export function EmptyState({
+  workflow,
+  children,
+}: {
+  workflow: string;
+  children: ReactNode;
+}) {
+  return <SyntheticPreviewBanner workflow={workflow}>{children}</SyntheticPreviewBanner>;
+}

--- a/web/lib/dataState.test.ts
+++ b/web/lib/dataState.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  allZero,
+  asOfLabel,
+  ageMs,
+  deriveDataState,
+  isSentinelBoundary,
+  isStale,
+  relativeAge,
+  someZero,
+  STALE_AFTER_MS,
+} from "./dataState";
+
+const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+describe("isSentinelBoundary", () => {
+  it("treats the 1970 epoch sentinel as pre-data, not a real boundary", () => {
+    expect(isSentinelBoundary("1970-01-01")).toBe(true);
+  });
+  it("treats unparseable timestamps as sentinel", () => {
+    expect(isSentinelBoundary("not-a-date")).toBe(true);
+  });
+  it("treats a recent real boundary as non-sentinel", () => {
+    expect(isSentinelBoundary("2026-05-30T10:00:00Z")).toBe(false);
+  });
+});
+
+describe("isStale", () => {
+  it("a boundary older than 2h is stale", () => {
+    const boundary = new Date(NOW - STALE_AFTER_MS - 60_000).toISOString();
+    expect(isStale(boundary, NOW)).toBe(true);
+  });
+  it("a boundary within 2h is fresh", () => {
+    const boundary = new Date(NOW - 60 * 60 * 1000).toISOString();
+    expect(isStale(boundary, NOW)).toBe(false);
+  });
+  it("the 1970 sentinel is never stale (it's empty, not stale)", () => {
+    expect(isStale("1970-01-01", NOW)).toBe(false);
+  });
+});
+
+describe("deriveDataState precedence", () => {
+  it("empty wins over everything", () => {
+    expect(
+      deriveDataState({ isEmpty: true, isPartial: true, reconciledThrough: "1970-01-01", now: NOW }),
+    ).toBe("empty");
+  });
+  it("the 1970 sentinel with no data is empty, not stale", () => {
+    expect(
+      deriveDataState({ isEmpty: true, isPartial: false, reconciledThrough: "1970-01-01", now: NOW }),
+    ).toBe("empty");
+  });
+  it("stale outranks partial", () => {
+    const old = new Date(NOW - STALE_AFTER_MS - 1).toISOString();
+    expect(deriveDataState({ isEmpty: false, isPartial: true, reconciledThrough: old, now: NOW })).toBe(
+      "stale",
+    );
+  });
+  it("partial when fresh but missing a source", () => {
+    const fresh = new Date(NOW - 1000).toISOString();
+    expect(deriveDataState({ isEmpty: false, isPartial: true, reconciledThrough: fresh, now: NOW })).toBe(
+      "partial",
+    );
+  });
+  it("fresh when populated and recent", () => {
+    const fresh = new Date(NOW - 1000).toISOString();
+    expect(deriveDataState({ isEmpty: false, isPartial: false, reconciledThrough: fresh, now: NOW })).toBe(
+      "fresh",
+    );
+  });
+  it("fresh when no boundary is provided and data is full", () => {
+    expect(deriveDataState({ isEmpty: false, isPartial: false })).toBe("fresh");
+  });
+});
+
+describe("allZero / someZero", () => {
+  it("allZero true for all-zero record", () => {
+    expect(allZero({ a: 0, b: 0 })).toBe(true);
+  });
+  it("allZero true for empty record", () => {
+    expect(allZero({})).toBe(true);
+  });
+  it("allZero false when any value is non-zero", () => {
+    expect(allZero({ a: 0, b: 1 })).toBe(false);
+  });
+  it("someZero true for mixed record", () => {
+    expect(someZero({ a: 0, b: 1 })).toBe(true);
+  });
+  it("someZero false for all-zero record", () => {
+    expect(someZero({ a: 0, b: 0 })).toBe(false);
+  });
+  it("someZero false for all-non-zero record", () => {
+    expect(someZero({ a: 2, b: 1 })).toBe(false);
+  });
+});
+
+describe("labels", () => {
+  it("asOfLabel returns the boundary for a real timestamp", () => {
+    expect(asOfLabel("2026-05-30")).toBe("2026-05-30");
+  });
+  it("asOfLabel returns null for the sentinel", () => {
+    expect(asOfLabel("1970-01-01")).toBeNull();
+  });
+  it("relativeAge reads in hours", () => {
+    const boundary = new Date(NOW - 3 * 60 * 60 * 1000).toISOString();
+    expect(relativeAge(boundary, NOW)).toBe("3h ago");
+  });
+  it("ageMs is positive for past boundaries", () => {
+    expect(ageMs("2026-05-30T10:00:00Z", NOW)).toBeGreaterThan(0);
+  });
+});

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -1,0 +1,94 @@
+// Shared state-derivation for the "never show stale as fresh" requirement (CTO-80, spec 13.8).
+//
+// Every workflow surface derives one of four DataStates from the data it already receives, and
+// renders the matching banner/badge so users can never mistake synthetic, partial, or stale
+// numbers for fresh real data. These are pure functions — no I/O, no React — so they are unit
+// testable and reused identically across all five workflows.
+
+/** Two hours in milliseconds — the freshness threshold from spec 13.8. */
+export const STALE_AFTER_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Far-past sentinel boundary. The seeded data uses `reconciledThrough: "1970-01-01"` to mean
+ * "nothing has reconciled yet". Anything on or before this is treated as the empty/pre-data case,
+ * NOT a stale warning. We use the start of 2000 as a generous cutoff: no real reconciliation
+ * boundary will ever predate it, and epoch-style sentinels fall below it.
+ */
+export const SENTINEL_BEFORE_MS = Date.UTC(2000, 0, 1);
+
+export type DataState = "empty" | "partial" | "stale" | "fresh";
+
+/** How long ago, in ms, the reconciliation boundary is relative to `now`. */
+export function ageMs(reconciledThrough: string, now: number = Date.now()): number {
+  return now - Date.parse(reconciledThrough);
+}
+
+/** A far-past sentinel boundary means nothing has reconciled yet (pre-data), not stale. */
+export function isSentinelBoundary(reconciledThrough: string): boolean {
+  const t = Date.parse(reconciledThrough);
+  return Number.isNaN(t) || t <= SENTINEL_BEFORE_MS;
+}
+
+/** Stale = a real (non-sentinel) boundary older than the 2h freshness window. */
+export function isStale(reconciledThrough: string, now: number = Date.now()): boolean {
+  if (isSentinelBoundary(reconciledThrough)) return false;
+  return ageMs(reconciledThrough, now) > STALE_AFTER_MS;
+}
+
+export interface DataStateInput {
+  /** True when no real telemetry exists — render the synthetic preview + connector CTA. */
+  isEmpty: boolean;
+  /** True when some sources/layers are populated but others are missing. */
+  isPartial: boolean;
+  /** Reconciliation boundary timestamp, if the surface has one. */
+  reconciledThrough?: string;
+  /** Override "now" for testing. */
+  now?: number;
+}
+
+/**
+ * Resolve the single DataState for a surface. Precedence:
+ *   empty  > stale > partial > fresh
+ * Empty wins because there's nothing real to be stale or partial about. Stale outranks partial
+ * because presenting stale numbers as fresh is the cardinal sin this ticket guards against.
+ */
+export function deriveDataState(input: DataStateInput): DataState {
+  if (input.isEmpty) return "empty";
+  if (input.reconciledThrough && isStale(input.reconciledThrough, input.now)) return "stale";
+  if (input.isPartial) return "partial";
+  return "fresh";
+}
+
+/** Human "data as of" label. Returns null for sentinel/unparseable boundaries. */
+export function asOfLabel(reconciledThrough: string): string | null {
+  const t = Date.parse(reconciledThrough);
+  if (Number.isNaN(t) || t <= SENTINEL_BEFORE_MS) return null;
+  return reconciledThrough;
+}
+
+/** Compact relative-age string, e.g. "3h ago", "2d ago", "just now". */
+export function relativeAge(reconciledThrough: string, now: number = Date.now()): string {
+  const ms = ageMs(reconciledThrough, now);
+  if (ms < 60_000) return "just now";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** True if every numeric value in a record is zero (or the record is empty). */
+export function allZero(values: Record<string, number>): boolean {
+  const xs = Object.values(values) as number[];
+  return xs.length === 0 || xs.every((v) => v === 0);
+}
+
+/** True if some values are zero and some are non-zero — the signature of partial coverage. */
+export function someZero(values: Record<string, number>): boolean {
+  const xs = Object.values(values) as number[];
+  if (xs.length === 0) return false;
+  const hasZero = xs.some((v) => v === 0);
+  const hasNonZero = xs.some((v) => v !== 0);
+  return hasZero && hasNonZero;
+}


### PR DESCRIPTION
## Summary
Implements CTO-80 / spec 13.8 ("never show stale as fresh") entirely within `web/`. Each workflow now derives one of four data states from the data it already receives and renders a consistent treatment, so users can never mistake synthetic, partial, or stale numbers for fresh real data.

- **Empty (pre-data):** a clearly-labeled synthetic preview ("SAMPLE DATA" badge + a "Preview" watermark) wrapping the workflow, with a single connector CTA linking to `/connectors`. The seeded `reconciledThrough: "1970-01-01"` sentinel maps to *empty* ("nothing reconciled yet"), not stale.
- **Partial:** a banner points at the missing connector while still rendering whatever real data exists.
- **Stale:** a "Data as of ..." badge that turns into a warning when the reconciliation boundary is older than 2h.

State precedence: `empty > stale > partial > fresh` (stale outranks partial so stale numbers are never shown as fresh).

## New files
- `web/lib/dataState.ts` — pure, dependency-free state-derivation helper (`deriveDataState`, `isStale`, `isSentinelBoundary`, `allZero`, `someZero`, `relativeAge`, `asOfLabel`).
- `web/lib/dataState.test.ts` — unit tests for sentinel vs. stale, precedence, and zero-coverage helpers.
- `web/components/DataStateBanner.tsx` — reusable `SyntheticPreviewBanner` / `EmptyState`, `PartialDataBanner`, `StaleBadge`, `ConnectorCta`.

## Pages updated (all 7 workflow surfaces, consistently)
Home, Cost, Features, Data Quality (full empty/partial/stale); Agents, Compare, Estimate (empty/partial — these what-if surfaces have no reconciliation boundary).

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 60 passed (incl. 22 new)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)