### PR TITLE
Ingest spine: auth, validation, backpressure, OTLP/ingest-v1 (Epic CTO-7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,24 @@ jobs:
       - name: Test
         run: uv run pytest
 
+  gateway:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/gateway
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Sync (dev)
+        run: uv sync --extra dev
+      - name: Lint
+        run: uv run ruff check .
+      - name: Test
+        run: uv run pytest
+
   web:
     runs-on: ubuntu-latest
     defaults:

--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "clickhouse-connect>=0.7.16",
     "psycopg[binary]>=3.2",
     "pydantic-settings>=2.4",
-    "tally",
+    "tally-sdk",
 ]
 
 [project.optional-dependencies]
@@ -21,7 +21,8 @@ dev = [
 
 [tool.uv.sources]
 # The gateway reuses the SDK's wire/enrichment/timekeeping/pricing logic directly.
-tally = { path = "../../sdk/python", editable = true }
+# Distribution name is `tally-sdk`; the import package is `tally`.
+tally-sdk = { path = "../../sdk/python", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -29,11 +29,13 @@ from tally.wire import (
     IdentityLink,
     PartialError,
     Sampling,
+    ServerHints,
     Status,
     uuid7,
 )
 
 from gateway.auth import ApiKeyAuth
+from gateway.backpressure import Backpressure
 from gateway.config import get_settings
 from gateway.errors import ErrorCode
 from gateway.mapping import span_to_row
@@ -60,12 +62,27 @@ async def lifespan(app: FastAPI):
     # Known feature tags aren't loaded yet (per-tenant Postgres lookup is a follow-up), so the
     # unknown-tag flag is disabled for now — schema + PII checks are always on.
     app.state.validator = SpanValidator(max_span_bytes=settings.max_span_bytes)
+    app.state.backpressure = Backpressure(soft_limit=settings.backpressure_soft_limit)
+    app.state.in_flight = 0
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
     app.state.store.close()
 
 
 app = FastAPI(title="ai-tally ingest gateway", version="0.1.0", lifespan=lifespan)
+
+
+@app.middleware("http")
+async def _in_flight_gauge(request: Request, call_next: Any) -> Any:
+    """Track concurrent ingest requests so backpressure can read live load (CTO-36)."""
+    is_ingest = request.url.path == "/v1/batches"
+    if is_ingest:
+        app.state.in_flight = getattr(app.state, "in_flight", 0) + 1
+    try:
+        return await call_next(request)
+    finally:
+        if is_ingest:
+            app.state.in_flight = max(0, getattr(app.state, "in_flight", 1) - 1)
 
 
 def _parse_batch(payload: dict[str, Any]) -> BatchRequest:
@@ -172,10 +189,23 @@ async def ingest_batch(
     batch = batch.deduplicated()
     server_recv_ns = time.time_ns()
 
+    # --- backpressure: under load, shed the batch's overflow (retryable) + tighten client hints ---
+    backpressure: Backpressure = app.state.backpressure
+    shed = backpressure.evaluate(getattr(app.state, "in_flight", 1), len(batch.resource_spans))
+    hints = shed.hints
+    partial_errors: list[PartialError] = []
+    if shed.overloaded and shed.keep < len(batch.resource_spans):
+        overflow = batch.resource_spans[shed.keep :]
+        batch.resource_spans = batch.resource_spans[: shed.keep]
+        for index, span in enumerate(overflow, start=shed.keep):
+            item_id = span_item_id(span, index) if isinstance(span, dict) else f"#{index}"
+            partial_errors.append(
+                PartialError(item_id=item_id, code=ErrorCode.RATE_LIMITED.value, message="shed under load")
+            )
+
     # --- validate (per item) + enrich + map spans ---
     validator: SpanValidator = app.state.validator
     rows: list[tuple[object, ...]] = []
-    partial_errors: list[PartialError] = []
     drift_count = 0
     for index, span in enumerate(batch.resource_spans):
         item_id = span_item_id(span, index) if isinstance(span, dict) else f"#{index}"
@@ -207,7 +237,10 @@ async def ingest_batch(
     rejected_only = bool(batch.resource_spans) and not rows
     if rejected_only:
         resp = BatchResponse(
-            batch_id=batch.batch_id, status=Status.REJECTED, partial_errors=partial_errors
+            batch_id=batch.batch_id,
+            status=Status.REJECTED,
+            partial_errors=partial_errors,
+            server_hints=hints,
         )
         idempotency.record(batch, resp)
         return JSONResponse(_response_dict(resp), status_code=422)
@@ -219,7 +252,7 @@ async def ingest_batch(
         store.insert_identity_links(batch.tenant_id, batch.identity_links)
     except Exception:  # noqa: BLE001 - surface as retryable, keep the gateway alive
         logger.exception("clickhouse insert failed")
-        resp = BatchResponse(batch_id=batch.batch_id, status=Status.RETRY)
+        resp = BatchResponse(batch_id=batch.batch_id, status=Status.RETRY, server_hints=hints)
         idempotency.record(batch, resp)
         return JSONResponse(_response_dict(resp), status_code=503)
 
@@ -234,12 +267,14 @@ async def ingest_batch(
         status=status,
         accepted_spans=accepted,
         partial_errors=partial_errors,
+        server_hints=hints,
     )
     idempotency.record(batch, resp)
     return JSONResponse(_response_dict(resp), status_code=200)
 
 
 def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, Any]:
+    hints = resp.server_hints or ServerHints()
     return {
         "batch_id": resp.batch_id,
         "status": resp.status.value,
@@ -247,5 +282,11 @@ def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, 
         "partial_errors": [
             {"item_id": e.item_id, "code": e.code, "message": e.message} for e in resp.partial_errors
         ],
+        "server_hints": {
+            "flush_interval_ms": hints.flush_interval_ms,
+            "max_batch_size": hints.max_batch_size,
+            "sample_rate_override": hints.sample_rate_override,
+            "retry_after_ms": hints.retry_after_ms,
+        },
         "replayed": replayed,
     }

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -34,7 +34,9 @@ from tally.wire import (
 
 from gateway.auth import ApiKeyAuth
 from gateway.config import get_settings
+from gateway.errors import ErrorCode
 from gateway.mapping import span_to_row
+from gateway.ratelimit import RateLimiter
 from gateway.store import ClickHouseStore
 
 logger = logging.getLogger("tally.gateway")
@@ -48,6 +50,11 @@ async def lifespan(app: FastAPI):
     app.state.auth = ApiKeyAuth(settings)
     app.state.catalog = seed_catalog()
     app.state.idempotency = IdempotencyCache(ttl_seconds=settings.idempotency_ttl_s)
+    app.state.limiter = RateLimiter(
+        rps=settings.rate_limit_rps,
+        burst=settings.rate_limit_burst,
+        monthly_quota=settings.monthly_quota_spans,
+    )
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
     app.state.store.close()
@@ -70,6 +77,11 @@ def _parse_batch(payload: dict[str, Any]) -> BatchRequest:
         )
     except (KeyError, TypeError) as exc:
         raise HTTPException(status_code=422, detail=f"malformed batch: {exc}") from exc
+
+
+def _error(status_code: int, code: ErrorCode, message: str) -> HTTPException:
+    """An HTTPException whose detail carries a stable wire error code clients can branch on."""
+    return HTTPException(status_code=status_code, detail={"code": code.value, "message": message})
 
 
 @app.get("/healthz")
@@ -106,21 +118,46 @@ async def ingest_batch(
     auth: ApiKeyAuth = app.state.auth
     catalog = app.state.catalog
     idempotency: IdempotencyCache = app.state.idempotency
+    limiter: RateLimiter = app.state.limiter
 
     payload = await request.json()
     batch = _parse_batch(payload)
+    claimed_tenant = batch.tenant_id
 
-    # --- auth: resolve tenant ---
+    # --- auth: resolve tenant + scope ---
     if settings.require_api_key:
         if not authorization or not authorization.lower().startswith("bearer "):
-            raise HTTPException(status_code=401, detail="missing bearer token")
+            raise _error(401, ErrorCode.UNAUTHENTICATED, "missing bearer token")
         token = authorization.split(" ", 1)[1].strip()
-        tenant_id = auth.tenant_for_key(token)
-        if tenant_id is None:
-            raise HTTPException(status_code=403, detail="invalid api key")
-        batch.tenant_id = tenant_id  # trust the key's tenant, not the body
+        result = auth.authenticate(token)
+        if result is None:
+            raise _error(401, ErrorCode.UNAUTHENTICATED, "invalid or revoked api key")
+        if not result.can_write:
+            raise _error(403, ErrorCode.FORBIDDEN_SCOPE, f"scope '{result.scope}' cannot write spans")
+        # A key is tenant-bound: a body claiming a *different* tenant is refused, never silently
+        # re-tagged. (Empty/own tenant in the body is fine.)
+        if claimed_tenant and claimed_tenant != result.tenant_id:
+            raise _error(403, ErrorCode.TENANT_MISMATCH, "key is not bound to the requested tenant")
+        batch.tenant_id = result.tenant_id  # the key's tenant is authoritative
     elif not batch.tenant_id:
         raise HTTPException(status_code=422, detail="tenant_id required when auth is disabled")
+
+    # --- rate limit + monthly quota (one unit per span) ---
+    decision = limiter.check(batch.tenant_id, max(1, len(batch.resource_spans)))
+    if not decision.allowed:
+        # Both RATE_LIMITED and QUOTA_EXCEEDED are 429 so a conformant client backs off honoring
+        # Retry-After; the body's error.code lets it distinguish a transient cap from a spent quota.
+        retry_after_s = max(1, round(decision.retry_after_s))
+        return JSONResponse(
+            {
+                "batch_id": batch.batch_id,
+                "status": Status.REJECTED.value,
+                "error": {"code": decision.code.value if decision.code else "", "message": decision.message},
+                "retry_after_ms": decision.retry_after_ms,
+            },
+            status_code=429,
+            headers={"Retry-After": str(retry_after_s)},
+        )
 
     # --- idempotency: replayed batch returns the original response ---
     cached = idempotency.check_or_store(batch)

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -39,6 +39,12 @@ from gateway.backpressure import Backpressure
 from gateway.config import get_settings
 from gateway.errors import ErrorCode
 from gateway.mapping import span_to_row
+from gateway.protocol import (
+    SUPPORTED_PROTOCOLS,
+    capabilities,
+    negotiate,
+    otlp_traces_to_spans,
+)
 from gateway.ratelimit import RateLimiter
 from gateway.store import ClickHouseStore
 from gateway.validation import SpanValidator, span_item_id
@@ -130,11 +136,56 @@ def readyz() -> JSONResponse:
     return JSONResponse({"ready": ready, "checks": checks}, status_code=200 if ready else 503)
 
 
-@app.post("/v1/batches")
-async def ingest_batch(
+@app.get("/v1/capabilities")
+def capabilities_endpoint() -> dict[str, Any]:
+    """Advertise supported protocols, ceilings, and optional features for client negotiation."""
+    settings = app.state.settings
+    limiter: RateLimiter = app.state.limiter
+    return capabilities(
+        max_batch_size=getattr(limiter, "burst", 0) or settings.rate_limit_burst,
+        max_span_bytes=settings.max_span_bytes,
+    )
+
+
+@app.post("/v1/otlp/traces")
+async def ingest_otlp_traces(
     request: Request,
     authorization: str | None = Header(default=None),
 ) -> JSONResponse:
+    """OTLP/HTTP JSON fallback: translate ExportTraceServiceRequest → native spans, then ingest.
+
+    Lets any OpenTelemetry SDK ship gen_ai spans without the ai-tally SDK. Tenant comes from the
+    api key (auth on) or the ``X-Tenant-Id`` header (auth off, local dev).
+    """
+    otlp = await request.json()
+    spans = otlp_traces_to_spans(otlp)
+    tenant = request.headers.get("x-tenant-id", "")
+    batch = _parse_batch(
+        {"tenant_id": tenant, "sdk_version": "otlp-http", "resource_spans": spans}
+    )
+    return await _run_pipeline(batch, authorization)
+
+
+@app.post("/v1/batches")
+async def ingest_batch(
+    request: Request,
+    protocol_version: str | None = Header(default=None, alias="X-Ingest-Protocol"),
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    payload = await request.json()
+    # --- version negotiation: an unrecognized explicit protocol is a clean 400, not a guess. ---
+    negotiated = negotiate(protocol_version)
+    if negotiated is None:
+        raise _error(
+            400,
+            ErrorCode.INVALID_SCHEMA,
+            f"unsupported ingest protocol '{protocol_version}'; supported: {list(SUPPORTED_PROTOCOLS)}",
+        )
+    batch = _parse_batch(payload)
+    return await _run_pipeline(batch, authorization)
+
+
+async def _run_pipeline(batch: BatchRequest, authorization: str | None) -> JSONResponse:
     settings = app.state.settings
     store: ClickHouseStore = app.state.store
     auth: ApiKeyAuth = app.state.auth
@@ -142,8 +193,6 @@ async def ingest_batch(
     idempotency: IdempotencyCache = app.state.idempotency
     limiter: RateLimiter = app.state.limiter
 
-    payload = await request.json()
-    batch = _parse_batch(payload)
     claimed_tenant = batch.tenant_id
 
     # --- auth: resolve tenant + scope ---

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -27,6 +27,7 @@ from tally.wire import (
     BusinessEvent,
     IdempotencyCache,
     IdentityLink,
+    PartialError,
     Sampling,
     Status,
     uuid7,
@@ -38,6 +39,7 @@ from gateway.errors import ErrorCode
 from gateway.mapping import span_to_row
 from gateway.ratelimit import RateLimiter
 from gateway.store import ClickHouseStore
+from gateway.validation import SpanValidator, span_item_id
 
 logger = logging.getLogger("tally.gateway")
 
@@ -55,6 +57,9 @@ async def lifespan(app: FastAPI):
         burst=settings.rate_limit_burst,
         monthly_quota=settings.monthly_quota_spans,
     )
+    # Known feature tags aren't loaded yet (per-tenant Postgres lookup is a follow-up), so the
+    # unknown-tag flag is disabled for now — schema + PII checks are always on.
+    app.state.validator = SpanValidator(max_span_bytes=settings.max_span_bytes)
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
     app.state.store.close()
@@ -167,12 +172,22 @@ async def ingest_batch(
     batch = batch.deduplicated()
     server_recv_ns = time.time_ns()
 
-    # --- enrich + map spans ---
+    # --- validate (per item) + enrich + map spans ---
+    validator: SpanValidator = app.state.validator
     rows: list[tuple[object, ...]] = []
+    partial_errors: list[PartialError] = []
     drift_count = 0
-    for span in batch.resource_spans:
-        if not isinstance(span, dict):
+    for index, span in enumerate(batch.resource_spans):
+        item_id = span_item_id(span, index) if isinstance(span, dict) else f"#{index}"
+        verdict = validator.validate(span)
+        if not verdict.accepted:
+            partial_errors.append(
+                PartialError(item_id=item_id, code=verdict.rejection.value, message=verdict.message)
+            )
             continue
+        for flag in verdict.flags:  # accepted-but-flagged (e.g. UNKNOWN_FEATURE_TAG)
+            partial_errors.append(PartialError(item_id=item_id, code=flag.value, message=""))
+        assert isinstance(span, dict)  # narrowed by verdict.accepted
         result = enrich_cost(span, catalog, tenant_id=batch.tenant_id)
         if result.drift_exceeded:
             drift_count += 1
@@ -188,6 +203,15 @@ async def ingest_batch(
             )
         )
 
+    # If every span was rejected (and there were spans), nothing to write — REJECTED, no retry.
+    rejected_only = bool(batch.resource_spans) and not rows
+    if rejected_only:
+        resp = BatchResponse(
+            batch_id=batch.batch_id, status=Status.REJECTED, partial_errors=partial_errors
+        )
+        idempotency.record(batch, resp)
+        return JSONResponse(_response_dict(resp), status_code=422)
+
     # --- write ---
     try:
         accepted = store.insert_spans(rows)
@@ -202,7 +226,15 @@ async def ingest_batch(
     if drift_count:
         logger.info("catalog drift on %d/%d spans (batch %s)", drift_count, len(rows), batch.batch_id)
 
-    resp = BatchResponse(batch_id=batch.batch_id, status=Status.ACCEPTED, accepted_spans=accepted)
+    # Some items rejected/flagged but others written → PARTIAL; otherwise clean ACCEPTED.
+    fatal = [e for e in partial_errors if e.code != ErrorCode.UNKNOWN_FEATURE_TAG.value]
+    status = Status.PARTIAL if fatal else Status.ACCEPTED
+    resp = BatchResponse(
+        batch_id=batch.batch_id,
+        status=status,
+        accepted_spans=accepted,
+        partial_errors=partial_errors,
+    )
     idempotency.record(batch, resp)
     return JSONResponse(_response_dict(resp), status_code=200)
 
@@ -212,5 +244,8 @@ def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, 
         "batch_id": resp.batch_id,
         "status": resp.status.value,
         "accepted_spans": resp.accepted_spans,
+        "partial_errors": [
+            {"item_id": e.item_id, "code": e.code, "message": e.message} for e in resp.partial_errors
+        ],
         "replayed": replayed,
     }

--- a/infra/gateway/src/gateway/auth.py
+++ b/infra/gateway/src/gateway/auth.py
@@ -1,36 +1,59 @@
 """API-key auth against the Postgres control plane.
 
 Keys are never stored raw — ``api_keys.key_hash`` holds the SHA-256 hex of the token. We hash the
-presented bearer token and look up a non-revoked row, returning its tenant_id.
+presented bearer token and look up a non-revoked row, returning its tenant_id **and scope**
+(``read`` / ``write`` / ``admin``). Ingest (writing spans) requires ``write`` or ``admin``; a
+read-only key is rejected with ``FORBIDDEN_SCOPE`` (CTO-33).
 """
 
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 
 import psycopg
 
 from gateway.config import Settings
+
+# Scopes that may write ingest data. ``read`` keys can authenticate but not POST batches.
+WRITE_SCOPES = frozenset({"write", "admin"})
 
 
 def hash_key(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+@dataclass(frozen=True, slots=True)
+class AuthResult:
+    tenant_id: str
+    scope: str
+
+    @property
+    def can_write(self) -> bool:
+        return self.scope in WRITE_SCOPES
+
+
 class ApiKeyAuth:
     def __init__(self, settings: Settings) -> None:
         self._dsn = settings.postgres_dsn
 
-    def tenant_for_key(self, token: str) -> str | None:
-        """Return the tenant_id (UUID str) for a valid, non-revoked key, else None."""
+    def authenticate(self, token: str) -> AuthResult | None:
+        """Return the :class:`AuthResult` for a valid, non-revoked key, else None."""
         key_hash = hash_key(token)
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
             cur.execute(
-                "SELECT tenant_id FROM api_keys WHERE key_hash = %s AND revoked_at IS NULL",
+                "SELECT tenant_id, scope FROM api_keys WHERE key_hash = %s AND revoked_at IS NULL",
                 (key_hash,),
             )
             row = cur.fetchone()
-            return str(row[0]) if row else None
+            if not row:
+                return None
+            return AuthResult(tenant_id=str(row[0]), scope=str(row[1]))
+
+    def tenant_for_key(self, token: str) -> str | None:
+        """Back-compat shim: tenant_id only (kept for callers that don't need scope)."""
+        result = self.authenticate(token)
+        return result.tenant_id if result else None
 
     def ping(self) -> bool:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:

--- a/infra/gateway/src/gateway/backpressure.py
+++ b/infra/gateway/src/gateway/backpressure.py
@@ -1,0 +1,86 @@
+"""Backpressure + retry semantics — flow-control advice the gateway returns (CTO-36).
+
+The gateway can't push back via TCP alone: a well-behaved SDK self-throttles only if we *tell*
+it to. So every response carries :class:`tally.wire.ServerHints` — a flush cadence, a per-batch
+ceiling, an optional sample-rate override, and (on a retryable response) a backoff. A conformant
+client treats these as the new ceiling until the next response updates them.
+
+This module is pure and clock-free: :class:`Backpressure` maps a live in-flight count to hints and
+a shed decision; :func:`is_retryable` classifies an HTTP status. The HTTP wiring (an in-flight gauge
+middleware) lives in app.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tally.wire import ServerHints
+
+# Retryable HTTP statuses: 429 (slow down) and any 5xx (transient server fault). A 4xx other than
+# 429 is a client contract error — retrying replays the same rejection, so it is NOT retryable.
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 503})
+
+
+def is_retryable(http_status: int) -> bool:
+    """True iff a client should retry this response (429 or any 5xx); 4xx contract errors are not."""
+    return http_status in _RETRYABLE_STATUSES or 500 <= http_status <= 599
+
+
+@dataclass(frozen=True, slots=True)
+class Shed:
+    """Outcome of evaluating current load against an incoming batch.
+
+    ``hints`` is what to echo back to the client. ``keep`` is how many items to admit this batch
+    (the rest are shed → retryable PARTIAL). ``overloaded`` flags that we tightened the hints.
+    """
+
+    hints: ServerHints
+    keep: int
+    overloaded: bool
+
+
+class Backpressure:
+    """Pure controller mapping an in-flight request count to client flow-control hints.
+
+    Below ``soft_limit`` the gateway is healthy and emits steady-state hints. At/above it the
+    gateway is saturated: it lengthens the flush interval, shrinks the per-batch ceiling, asks the
+    client to sample down, and sheds the overflow of the current batch as retryable.
+    """
+
+    def __init__(
+        self,
+        *,
+        soft_limit: int = 64,
+        healthy_flush_ms: int = 5000,
+        healthy_max_batch: int = 1000,
+        overload_flush_ms: int = 15000,
+        overload_max_batch: int = 250,
+        overload_sample_rate: float = 0.25,
+        overload_retry_after_ms: int = 2000,
+    ) -> None:
+        if soft_limit < 1:
+            raise ValueError("soft_limit must be >= 1")
+        self.soft_limit = soft_limit
+        self._healthy = ServerHints(
+            flush_interval_ms=healthy_flush_ms,
+            max_batch_size=healthy_max_batch,
+            sample_rate_override=None,
+            retry_after_ms=0,
+        )
+        self._overloaded = ServerHints(
+            flush_interval_ms=overload_flush_ms,
+            max_batch_size=overload_max_batch,
+            sample_rate_override=overload_sample_rate,
+            retry_after_ms=overload_retry_after_ms,
+        )
+
+    def healthy_hints(self) -> ServerHints:
+        """Steady-state hints (used for replays and the non-overloaded path)."""
+        return self._healthy
+
+    def evaluate(self, in_flight: int, batch_items: int) -> Shed:
+        """Decide hints + admission for a batch of ``batch_items`` given ``in_flight`` concurrency."""
+        if in_flight < self.soft_limit:
+            return Shed(hints=self._healthy, keep=batch_items, overloaded=False)
+        keep = min(batch_items, self._overloaded.max_batch_size)
+        return Shed(hints=self._overloaded, keep=keep, overloaded=True)

--- a/infra/gateway/src/gateway/buffer.py
+++ b/infra/gateway/src/gateway/buffer.py
@@ -1,0 +1,142 @@
+"""Ingest burst buffer — pure logic with an in-memory mock backend (CTO-37).
+
+In production a Kafka topic absorbs ingest bursts so the gateway never returns 5xx under load and a
+slow ClickHouse can't backpressure the edge. This module is the *transport-agnostic* core: a
+:class:`BufferRecord`, a producer that assigns partitions (:mod:`gateway.partition`), a
+:class:`InMemoryBuffer` mock that preserves per-partition FIFO order, and a :class:`BufferConsumer`
+that drains to a store with **at-least-once + dedup** (pairs with CTO-32 idempotency).
+
+The real Kafka producer/consumer is a later infra ticket; this lets us build and test partition
+ordering, fairness, and at-least-once dedup now without any broker running.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from gateway.partition import DEFAULT_PARTITIONS, trace_partition
+
+
+@dataclass(frozen=True, slots=True)
+class BufferRecord:
+    """One span en route to ClickHouse, tagged with its routing identity."""
+
+    tenant_id: str
+    trace_id: str
+    span_id: str
+    partition: int
+    row: tuple[object, ...]
+
+    @property
+    def dedup_key(self) -> tuple[str, str, str]:
+        return (self.tenant_id, self.trace_id, self.span_id)
+
+
+class SpanStore(Protocol):
+    def insert_spans(self, rows: list[tuple[object, ...]]) -> int: ...
+
+
+def to_records(
+    tenant_id: str,
+    spans: Iterable[tuple[str, str, tuple[object, ...]]],
+    partitions: int = DEFAULT_PARTITIONS,
+) -> list[BufferRecord]:
+    """Build partition-tagged records from ``(trace_id, span_id, row)`` triples."""
+    out: list[BufferRecord] = []
+    for trace_id, span_id, row in spans:
+        out.append(
+            BufferRecord(
+                tenant_id=tenant_id,
+                trace_id=trace_id,
+                span_id=span_id,
+                partition=trace_partition(tenant_id, trace_id, partitions),
+                row=row,
+            )
+        )
+    return out
+
+
+@dataclass(slots=True)
+class InMemoryBuffer:
+    """A mock burst buffer: one FIFO queue per partition (stands in for a Kafka topic).
+
+    Per-partition order is preserved on drain, so spans of a trace consume in produce order. Drains
+    are *fair across tenants* — a round-robin over tenants prevents one tenant's burst from starving
+    others sharing a partition.
+    """
+
+    partitions: int = DEFAULT_PARTITIONS
+    _queues: dict[int, deque[BufferRecord]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.partitions < 1:
+            raise ValueError("partitions must be >= 1")
+        self._queues = {p: deque() for p in range(self.partitions)}
+
+    def produce(self, records: Iterable[BufferRecord]) -> int:
+        n = 0
+        for rec in records:
+            self._queues[rec.partition].append(rec)
+            n += 1
+        return n
+
+    def depth(self) -> int:
+        """Total buffered records across all partitions."""
+        return sum(len(q) for q in self._queues.values())
+
+    def drain(self, max_records: int) -> list[BufferRecord]:
+        """Pop up to ``max_records`` fairly across tenants, preserving per-partition order.
+
+        Within a partition we always take from the front (FIFO). Across the buffer we round-robin by
+        tenant so no single tenant monopolizes a drain. Returns fewer than ``max_records`` only when
+        the buffer empties.
+        """
+        if max_records <= 0:
+            return []
+        out: list[BufferRecord] = []
+        # Snapshot the per-tenant head order so the round-robin is deterministic.
+        while len(out) < max_records:
+            took_any = False
+            seen_tenants: set[str] = set()
+            for p in range(self.partitions):
+                q = self._queues[p]
+                if not q:
+                    continue
+                tenant = q[0].tenant_id
+                if tenant in seen_tenants:
+                    continue  # already served this tenant this round → fairness
+                seen_tenants.add(tenant)
+                out.append(q.popleft())
+                took_any = True
+                if len(out) >= max_records:
+                    break
+            if not took_any:
+                break
+        return out
+
+
+class BufferConsumer:
+    """Drains buffered records to a store with at-least-once delivery + dedup.
+
+    Dedup is on ``(tenant_id, trace_id, span_id)`` so a redelivered record (Kafka at-least-once, or a
+    replayed batch) is written exactly once. On a store failure nothing is marked seen and the count
+    is 0 — the records are still in the buffer, so the next drain retries them (at-least-once).
+    """
+
+    def __init__(self, store: SpanStore) -> None:
+        self._store = store
+        self._seen: set[tuple[str, str, str]] = set()
+
+    def consume(self, records: list[BufferRecord]) -> int:
+        """Write the not-yet-seen rows; return how many were newly written (0 on store failure)."""
+        fresh = [r for r in records if r.dedup_key not in self._seen]
+        if not fresh:
+            return 0
+        rows = [r.row for r in fresh]
+        written = self._store.insert_spans(rows)  # may raise → caller's records stay un-acked
+        for r in fresh:
+            self._seen.add(r.dedup_key)
+        return written

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -36,6 +36,10 @@ class Settings(BaseSettings):
     # Per-span payload cap (bytes) for boundary validation (CTO-34).
     max_span_bytes: int = 64 * 1024
 
+    # Backpressure (CTO-36): concurrent in-flight ingest requests at/above which the gateway
+    # tightens client flow-control hints and sheds the overflow of a batch as retryable.
+    backpressure_soft_limit: int = 64
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -27,6 +27,12 @@ class Settings(BaseSettings):
     # Idempotency window (seconds) for (tenant_id, batch_id) dedup.
     idempotency_ttl_s: int = 24 * 3600
 
+    # Per-tenant rate limit (token bucket) + monthly span quota (CTO-33). Process-local enforcement;
+    # cluster-wide fairness is a later concern (CTO-30). Defaults are generous for local dev.
+    rate_limit_rps: float = 500.0
+    rate_limit_burst: float = 2000.0
+    monthly_quota_spans: int = 50_000_000
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -33,6 +33,9 @@ class Settings(BaseSettings):
     rate_limit_burst: float = 2000.0
     monthly_quota_spans: int = 50_000_000
 
+    # Per-span payload cap (bytes) for boundary validation (CTO-34).
+    max_span_bytes: int = 64 * 1024
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/errors.py
+++ b/infra/gateway/src/gateway/errors.py
@@ -1,0 +1,38 @@
+"""Stable gateway error codes — the wire contract for rejections.
+
+These strings are part of the public ingest contract: clients branch on them (e.g. the SDK egress
+loop drops 4xx-class items but retries QUOTA_EXCEEDED/RATE_LIMITED honoring ``retry_after``). Keep
+them additive — never rename or repurpose an existing code.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ErrorCode(str, Enum):
+    # --- auth / tenancy (CTO-33) ---
+    UNAUTHENTICATED = "UNAUTHENTICATED"        # missing/invalid/revoked bearer key
+    FORBIDDEN_SCOPE = "FORBIDDEN_SCOPE"        # key lacks the scope for this operation
+    TENANT_MISMATCH = "TENANT_MISMATCH"        # body claims a tenant the key isn't bound to
+    QUOTA_EXCEEDED = "QUOTA_EXCEEDED"          # monthly tenant quota spent
+    RATE_LIMITED = "RATE_LIMITED"              # short-term per-tenant rate cap hit
+
+    # --- validation (CTO-34) ---
+    INVALID_SCHEMA = "INVALID_SCHEMA"          # span/event fails OTel + extension schema
+    PII_DETECTED = "PII_DETECTED"              # raw (un-hashed) user id / email present
+    PAYLOAD_TOO_LARGE = "PAYLOAD_TOO_LARGE"    # item exceeds size cap
+    UNKNOWN_FEATURE_TAG = "UNKNOWN_FEATURE_TAG"  # accepted-but-flagged (not a rejection)
+
+
+# Codes that mean "do not retry this item as-is" (4xx-class). The rest are retryable.
+NON_RETRYABLE: frozenset[ErrorCode] = frozenset(
+    {
+        ErrorCode.UNAUTHENTICATED,
+        ErrorCode.FORBIDDEN_SCOPE,
+        ErrorCode.TENANT_MISMATCH,
+        ErrorCode.INVALID_SCHEMA,
+        ErrorCode.PII_DETECTED,
+        ErrorCode.PAYLOAD_TOO_LARGE,
+    }
+)

--- a/infra/gateway/src/gateway/partition.py
+++ b/infra/gateway/src/gateway/partition.py
@@ -1,0 +1,35 @@
+"""Topic partition strategy for the ingest buffer (CTO-37).
+
+A burst buffer (Kafka in prod) sits between the gateway and ClickHouse async inserts. The topic is
+partitioned by ``(tenant_id, trace_id_hash % N)`` so that:
+
+* **Per-trace ordering** is preserved — every span of a given ``(tenant_id, trace_id)`` hashes to the
+  same partition, so a consumer sees them in produce order.
+* **Per-tenant spread** keeps one trace from hot-spotting; a tenant's traces fan out across the N
+  partitions rather than serializing on one.
+
+The hash is :func:`hashlib.blake2b` (not Python's salted ``hash()``) so partitioning is *stable across
+processes and restarts* — a replayed batch lands on the same partition as the original.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+#: Default partition count (spec: trace_id_hash % 4).
+DEFAULT_PARTITIONS = 4
+
+
+def trace_partition(tenant_id: str, trace_id: str, partitions: int = DEFAULT_PARTITIONS) -> int:
+    """Stable partition index in ``[0, partitions)`` for a ``(tenant_id, trace_id)`` pair."""
+    if partitions < 1:
+        raise ValueError("partitions must be >= 1")
+    digest = hashlib.blake2b(
+        f"{tenant_id}\x00{trace_id}".encode(), digest_size=8
+    ).digest()
+    return int.from_bytes(digest, "big") % partitions
+
+
+def partition_key(tenant_id: str, trace_id: str, partitions: int = DEFAULT_PARTITIONS) -> str:
+    """Human-readable partition key ``"<tenant>:<index>"`` (useful for logs/metrics)."""
+    return f"{tenant_id}:{trace_partition(tenant_id, trace_id, partitions)}"

--- a/infra/gateway/src/gateway/protocol.py
+++ b/infra/gateway/src/gateway/protocol.py
@@ -1,0 +1,113 @@
+"""Ingest protocol: version negotiation, capabilities, and OTLP/HTTP fallback (CTO-31).
+
+ai-tally's native wire is ``ingest-v1`` (the :mod:`tally.wire` envelope). The contract is *additive*:
+new optional fields may appear; an older gateway/client tolerates unknown fields rather than
+rejecting (see :func:`negotiate` and the unknown-field tests). For interop, the gateway also accepts
+standard **OTLP/HTTP JSON** trace exports and translates them into native span dicts, so any
+OpenTelemetry SDK can ship spans without the ai-tally SDK.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Native ingest protocol identifier (advertised + negotiated).
+INGEST_V1 = "ingest-v1"
+
+#: Protocols this gateway can accept, newest first.
+SUPPORTED_PROTOCOLS: tuple[str, ...] = (INGEST_V1,)
+
+
+def negotiate(requested: str | None) -> str | None:
+    """Resolve a client's requested protocol to one we support.
+
+    ``None``/empty means "client didn't ask" → default to the native protocol. A non-empty value we
+    don't recognize returns ``None`` (caller rejects with a clear error rather than guessing).
+    """
+    if not requested:
+        return INGEST_V1
+    return requested if requested in SUPPORTED_PROTOCOLS else None
+
+
+def capabilities(*, max_batch_size: int, max_span_bytes: int) -> dict[str, Any]:
+    """Self-describing capability document for ``GET /v1/capabilities``.
+
+    A conformant client fetches this once to learn the negotiated protocol, ceilings, and which
+    optional features (idempotency, server hints, OTLP fallback) the gateway honors.
+    """
+    return {
+        "protocols": list(SUPPORTED_PROTOCOLS),
+        "default_protocol": INGEST_V1,
+        "max_batch_size": max_batch_size,
+        "max_span_bytes": max_span_bytes,
+        "compression": ["none"],
+        "features": {
+            "idempotency": True,
+            "server_hints": True,
+            "partial_acceptance": True,
+            "otlp_http_traces": True,
+            "unknown_field_tolerance": True,
+        },
+    }
+
+
+# --- OTLP/HTTP JSON → native span dicts ----------------------------------------------------------
+
+
+def _any_value(v: dict[str, Any]) -> Any:
+    """Unwrap an OTLP ``AnyValue`` (https://opentelemetry.io/docs/specs/otlp) to a Python scalar."""
+    if "stringValue" in v:
+        return v["stringValue"]
+    if "intValue" in v:
+        # OTLP encodes int64 as a string in JSON; coerce back to int.
+        try:
+            return int(v["intValue"])
+        except (TypeError, ValueError):
+            return v["intValue"]
+    if "doubleValue" in v:
+        return v["doubleValue"]
+    if "boolValue" in v:
+        return v["boolValue"]
+    if "arrayValue" in v:
+        return [_any_value(e) for e in v["arrayValue"].get("values", [])]
+    return None
+
+
+def _attrs_to_dict(attributes: list[dict[str, Any]]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for a in attributes or []:
+        key = a.get("key")
+        if isinstance(key, str) and "value" in a:
+            out[key] = _any_value(a["value"])
+    return out
+
+
+def otlp_traces_to_spans(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Translate an OTLP/HTTP ``ExportTraceServiceRequest`` (JSON) into native span dicts.
+
+    Resource attributes are merged under each span (span attributes win on conflict). ``traceId`` /
+    ``spanId`` / ``startTimeUnixNano`` map to our structural keys; everything else (notably
+    ``gen_ai.*``) passes through unchanged so the existing validator + enricher apply as-is.
+    """
+    spans: list[dict[str, Any]] = []
+    for rs in payload.get("resourceSpans", []):
+        resource_attrs = _attrs_to_dict(rs.get("resource", {}).get("attributes", []))
+        service_name = resource_attrs.get("service.name")
+        for ss in rs.get("scopeSpans", []):
+            for sp in ss.get("spans", []):
+                span: dict[str, Any] = dict(resource_attrs)
+                span.update(_attrs_to_dict(sp.get("attributes", [])))
+                if sp.get("traceId"):
+                    span["trace_id"] = sp["traceId"]
+                if sp.get("spanId"):
+                    span["span_id"] = sp["spanId"]
+                start = sp.get("startTimeUnixNano")
+                if start is not None:
+                    try:
+                        span["timestamp_ns"] = int(start)
+                    except (TypeError, ValueError):
+                        pass
+                if service_name is not None and "ServiceName" not in span:
+                    span["ServiceName"] = service_name
+                spans.append(span)
+    return spans

--- a/infra/gateway/src/gateway/ratelimit.py
+++ b/infra/gateway/src/gateway/ratelimit.py
@@ -1,0 +1,194 @@
+"""Per-tenant rate limiting + monthly quota — pure, in-memory, clock-injectable.
+
+Two independent guards (CTO-33, spec §12.1/§4.5):
+
+* **Rate limit** — a token bucket per tenant smooths short bursts. Capacity = burst, refilled at
+  ``rps`` tokens/sec. One token per span. Empty bucket → ``RATE_LIMITED`` with a ``retry_after``.
+* **Quota** — a monthly span ceiling per tenant. Spent quota → ``QUOTA_EXCEEDED`` with a
+  ``retry_after`` pointing at the start of next month.
+
+Both are process-local: this is the single-node enforcement layer. Cluster-wide fairness (shared
+Redis counters) is a later infra concern (CTO-30); the contract returned here — a
+:class:`Decision` with a stable :class:`~gateway.errors.ErrorCode` and a ``retry_after`` — does not
+change when that lands.
+
+The clock is injectable so the whole module tests deterministically with zero sleeps.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from gateway.errors import ErrorCode
+
+# A monotonic-ish wall clock in seconds. Injectable for tests.
+Clock = Callable[[], float]
+
+
+@dataclass(frozen=True, slots=True)
+class Decision:
+    """Outcome of a limiter check. ``allowed`` true → proceed; else ``code``/``retry_after_s`` set."""
+
+    allowed: bool
+    code: ErrorCode | None = None
+    retry_after_s: float = 0.0
+    message: str = ""
+
+    @property
+    def retry_after_ms(self) -> int:
+        return int(self.retry_after_s * 1000)
+
+
+_ALLOW = Decision(allowed=True)
+
+
+class TokenBucket:
+    """Classic token bucket. ``capacity`` tokens, refilled at ``rps``/sec, lazily on read."""
+
+    __slots__ = ("capacity", "rps", "_tokens", "_last", "_clock")
+
+    def __init__(self, capacity: float, rps: float, clock: Clock, *, start_full: bool = True) -> None:
+        if capacity <= 0 or rps <= 0:
+            raise ValueError("capacity and rps must be positive")
+        self.capacity = float(capacity)
+        self.rps = float(rps)
+        self._tokens = float(capacity) if start_full else 0.0
+        self._clock = clock
+        self._last = clock()
+
+    def _refill(self) -> None:
+        now = self._clock()
+        elapsed = now - self._last
+        if elapsed > 0:
+            self._tokens = min(self.capacity, self._tokens + elapsed * self.rps)
+            self._last = now
+
+    def try_consume(self, n: float = 1.0) -> bool:
+        self._refill()
+        if self._tokens >= n:
+            self._tokens -= n
+            return True
+        return False
+
+    def retry_after_s(self, n: float = 1.0) -> float:
+        """Seconds until ``n`` tokens are available (0 if already available)."""
+        self._refill()
+        deficit = n - self._tokens
+        return max(0.0, deficit / self.rps)
+
+
+class MonthlyQuota:
+    """A per-tenant span counter that resets at the start of each UTC month.
+
+    ``month_key`` buckets usage; when the key rolls over the counter resets. Cheap and exact enough
+    for single-node enforcement; the authoritative billing meter is a separate ledger (CTO-84/85).
+    """
+
+    __slots__ = ("limit", "_clock", "_used", "_month")
+
+    def __init__(self, limit: int, clock: Clock) -> None:
+        self.limit = int(limit)
+        self._clock = clock
+        self._used: dict[str, int] = {}
+        self._month: dict[str, tuple[int, int]] = {}
+
+    @staticmethod
+    def _ym(epoch_s: float) -> tuple[int, int]:
+        import time as _time
+
+        t = _time.gmtime(epoch_s)
+        return (t.tm_year, t.tm_mon)
+
+    @staticmethod
+    def _seconds_until_next_month(epoch_s: float) -> float:
+        import calendar
+        import time as _time
+
+        t = _time.gmtime(epoch_s)
+        year, month = (t.tm_year + 1, 1) if t.tm_mon == 12 else (t.tm_year, t.tm_mon + 1)
+        next_start = calendar.timegm((year, month, 1, 0, 0, 0, 0, 0, 0))
+        return max(0.0, next_start - epoch_s)
+
+    def _roll(self, tenant: str) -> None:
+        cur = self._ym(self._clock())
+        if self._month.get(tenant) != cur:
+            self._month[tenant] = cur
+            self._used[tenant] = 0
+
+    def remaining(self, tenant: str) -> int:
+        self._roll(tenant)
+        return max(0, self.limit - self._used.get(tenant, 0))
+
+    def would_exceed(self, tenant: str, n: int) -> bool:
+        self._roll(tenant)
+        return self._used.get(tenant, 0) + n > self.limit
+
+    def consume(self, tenant: str, n: int) -> None:
+        self._roll(tenant)
+        self._used[tenant] = self._used.get(tenant, 0) + n
+
+    def retry_after_s(self) -> float:
+        return self._seconds_until_next_month(self._clock())
+
+
+class RateLimiter:
+    """Combined per-tenant rate + quota guard. Thread-safe; clock-injectable.
+
+    ``check(tenant, n)`` returns a :class:`Decision`. It is *side-effecting on success*: it consumes
+    ``n`` rate tokens and ``n`` quota units only when both guards pass, so a rejected batch never
+    burns budget. Rate is checked before quota (cheap, transient) so an over-quota tenant still gets
+    the more-actionable QUOTA_EXCEEDED only once past the burst gate.
+    """
+
+    def __init__(
+        self,
+        *,
+        rps: float,
+        burst: float,
+        monthly_quota: int,
+        clock: Clock | None = None,
+    ) -> None:
+        import time as _time
+
+        self._rps = rps
+        self._burst = burst
+        # One wall clock for both guards keeps tests deterministic (inject a fake) and keeps the
+        # quota's month-boundary math correct (token buckets only care about elapsed deltas).
+        self._clock: Clock = clock or _time.time
+        self._buckets: dict[str, TokenBucket] = {}
+        self._quota = MonthlyQuota(monthly_quota, self._clock)
+        self._lock = threading.Lock()
+
+    def _bucket(self, tenant: str) -> TokenBucket:
+        b = self._buckets.get(tenant)
+        if b is None:
+            b = TokenBucket(self._burst, self._rps, self._clock)
+            self._buckets[tenant] = b
+        return b
+
+    def check(self, tenant: str, n: int = 1) -> Decision:
+        with self._lock:
+            bucket = self._bucket(tenant)
+            # Quota first as a read-only test so we don't consume tokens for a doomed batch.
+            if self._quota.would_exceed(tenant, n):
+                return Decision(
+                    allowed=False,
+                    code=ErrorCode.QUOTA_EXCEEDED,
+                    retry_after_s=self._quota.retry_after_s(),
+                    message="monthly span quota exhausted",
+                )
+            if not bucket.try_consume(n):
+                return Decision(
+                    allowed=False,
+                    code=ErrorCode.RATE_LIMITED,
+                    retry_after_s=bucket.retry_after_s(n),
+                    message="per-tenant rate limit exceeded",
+                )
+            self._quota.consume(tenant, n)
+            return _ALLOW
+
+    def remaining_quota(self, tenant: str) -> int:
+        with self._lock:
+            return self._quota.remaining(tenant)

--- a/infra/gateway/src/gateway/validation.py
+++ b/infra/gateway/src/gateway/validation.py
@@ -1,0 +1,186 @@
+"""Per-item span validation + PII rejection at the ingest boundary (CTO-34, spec §4.5/§12.6).
+
+Garbage in poisons every downstream workflow, and raw PII must never land in storage. Validation
+happens here, per span, so one bad item never fails the whole batch.
+
+Three rejection classes (item dropped) and one non-fatal flag:
+
+* ``INVALID_SCHEMA``   — span isn't a dict, or a *known* gen_ai typed field has the wrong type /
+  negative value / malformed currency or operation. Unknown keys are tolerated (additive-only
+  contract, CTO-31) — they pass through to the ``SpanAttributes`` map.
+* ``PII_DETECTED``     — a raw e-mail appears in any string value, ``user_id_hash`` looks un-hashed,
+  or a forbidden raw-PII key (``email``, ``user.email``, ...) is present. The SDK is supposed to
+  hash before egress; this is the server-side backstop.
+* ``PAYLOAD_TOO_LARGE`` — the JSON-serialized span exceeds ``max_span_bytes``.
+* ``UNKNOWN_FEATURE_TAG`` (flag, not a rejection) — a feature tag the tenant never declared. We keep
+  the span but surface the flag so the dashboard can prompt the customer to declare it.
+
+This module is pure (no infra) and unit-tested without a stack.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from tally.schema import GenAI
+
+from gateway.errors import ErrorCode
+
+# An e-mail anywhere in a string value is treated as raw PII.
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+
+# Keys that must never carry raw identifiers — their mere presence is a PII violation.
+_FORBIDDEN_PII_KEYS = frozenset(
+    {
+        "email", "user_email", "user.email", "gen_ai.user.email",
+        "user_id", "gen_ai.user.id", "phone", "phone_number", "ssn",
+    }
+)
+
+# gen_ai typed-int keys and the value ceilings we sanity-check. (Mirrors tally.schema._INT_KEYS.)
+_INT_KEYS = frozenset(
+    {
+        GenAI.USAGE_INPUT_TOKENS, GenAI.USAGE_OUTPUT_TOKENS, GenAI.USAGE_CACHED_INPUT_TOKENS,
+        GenAI.COST_ESTIMATED_MICRO_USD, GenAI.TOOL_COST_MICRO_USD,
+        GenAI.AGENT_STEP_INDEX, GenAI.AGENT_STEP_MAX,
+    }
+)
+
+# gen_ai keys that must be non-empty strings when present.
+_STR_KEYS = frozenset(
+    {
+        GenAI.SYSTEM, GenAI.REQUEST_MODEL, GenAI.RESPONSE_MODEL, GenAI.OPERATION_NAME,
+        GenAI.COST_CURRENCY, GenAI.FEATURE_TAG, GenAI.SESSION_ID, GenAI.USER_ID_HASH,
+    }
+)
+
+DEFAULT_MAX_SPAN_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class ItemResult:
+    """Outcome for one span. ``accepted`` items are written; ``rejection`` items are dropped.
+
+    ``flags`` are non-fatal (e.g. UNKNOWN_FEATURE_TAG): the item is still accepted but the flag is
+    reported back so the client/dashboard can act.
+    """
+
+    accepted: bool
+    rejection: ErrorCode | None = None
+    message: str = ""
+    flags: list[ErrorCode] = field(default_factory=list)
+
+
+def _iter_str_values(span: dict[str, object]) -> Iterable[tuple[str, str]]:
+    for k, v in span.items():
+        if isinstance(v, str):
+            yield str(k), v
+
+
+def _looks_unhashed(user_id_hash: str) -> bool:
+    """A real HMAC-SHA256 hex is 64 lowercase hex chars. Reject obvious raw ids / e-mails.
+
+    Heuristic, deliberately conservative to avoid false positives: only flag when the value clearly
+    isn't a hash — contains '@', or contains non-hex characters (a raw username/id would).
+    """
+    if "@" in user_id_hash:
+        return True
+    s = user_id_hash.strip().lower()
+    if not s:
+        return False
+    is_hexish = all(c in "0123456789abcdef" for c in s) and len(s) >= 16
+    return not is_hexish
+
+
+class SpanValidator:
+    """Validates one span at a time. Construct once per request with the tenant's known feature tags.
+
+    ``known_feature_tags=None`` disables the unknown-tag flag (used when the tenant's declared tags
+    aren't available); pass a set to enable it.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_span_bytes: int = DEFAULT_MAX_SPAN_BYTES,
+        known_feature_tags: set[str] | None = None,
+    ) -> None:
+        self._max_bytes = max_span_bytes
+        self._known_tags = known_feature_tags
+
+    def validate(self, span: object) -> ItemResult:
+        if not isinstance(span, dict):
+            return ItemResult(False, ErrorCode.INVALID_SCHEMA, "span is not an object")
+
+        # 1) size — cheap reject before deeper inspection.
+        try:
+            size = len(json.dumps(span, default=str).encode("utf-8"))
+        except (TypeError, ValueError):
+            return ItemResult(False, ErrorCode.INVALID_SCHEMA, "span is not JSON-serializable")
+        if size > self._max_bytes:
+            return ItemResult(
+                False, ErrorCode.PAYLOAD_TOO_LARGE, f"span {size}B exceeds {self._max_bytes}B cap"
+            )
+
+        # 2) PII — forbidden keys, raw e-mails, un-hashed user id.
+        pii = self._detect_pii(span)
+        if pii is not None:
+            return ItemResult(False, ErrorCode.PII_DETECTED, pii)
+
+        # 3) schema — only *known* typed keys are checked; unknown keys pass through.
+        schema_err = self._check_schema(span)
+        if schema_err is not None:
+            return ItemResult(False, ErrorCode.INVALID_SCHEMA, schema_err)
+
+        # 4) non-fatal flags.
+        flags: list[ErrorCode] = []
+        tag = span.get(GenAI.FEATURE_TAG)
+        if self._known_tags is not None and isinstance(tag, str) and tag and tag not in self._known_tags:
+            flags.append(ErrorCode.UNKNOWN_FEATURE_TAG)
+
+        return ItemResult(True, flags=flags)
+
+    def _detect_pii(self, span: dict[str, object]) -> str | None:
+        for key in span:
+            if str(key).lower() in _FORBIDDEN_PII_KEYS:
+                return f"forbidden raw-PII key present: {key!r}"
+        for key, value in _iter_str_values(span):
+            if key == GenAI.USER_ID_HASH:
+                if _looks_unhashed(value):
+                    return "gen_ai.user_id_hash is not a hash (raw identifier?)"
+                continue
+            if _EMAIL_RE.search(value):
+                return f"raw e-mail detected in {key!r}"
+        return None
+
+    def _check_schema(self, span: dict[str, object]) -> str | None:
+        for key, value in span.items():
+            if key in _INT_KEYS:
+                if isinstance(value, bool) or not isinstance(value, int):
+                    return f"{key} must be int, got {type(value).__name__}"
+                if value < 0:
+                    return f"{key} must be >= 0, got {value}"
+            elif key in _STR_KEYS:
+                if not isinstance(value, str):
+                    return f"{key} must be str, got {type(value).__name__}"
+                if value == "":
+                    return f"{key} must be non-empty"
+        op = span.get(GenAI.OPERATION_NAME)
+        if isinstance(op, str) and op and op != op.lower():
+            return f"{GenAI.OPERATION_NAME} must be lowercase, got {op!r}"
+        currency = span.get(GenAI.COST_CURRENCY)
+        if isinstance(currency, str) and not (len(currency) == 3 and currency.isalpha()):
+            return f"{GenAI.COST_CURRENCY} must be a 3-letter ISO-4217 code, got {currency!r}"
+        return None
+
+
+def span_item_id(span: dict[str, object], index: int) -> str:
+    """A stable id for per-item error reporting: trace:span if present, else the batch index."""
+    trace = span.get("TraceId") or span.get("trace_id")
+    sp = span.get("SpanId") or span.get("span_id")
+    if trace and sp:
+        return f"{trace}:{sp}"
+    return f"#{index}"

--- a/infra/gateway/tests/test_app_auth.py
+++ b/infra/gateway/tests/test_app_auth.py
@@ -1,0 +1,104 @@
+"""Gateway auth + rate-limit wiring tests (CTO-33).
+
+These exercise the rejection paths only — every assertion here returns *before* any ClickHouse
+write, so the tests need no running infra. The happy path (which inserts) is covered by the pure
+limiter/mapping tests plus the live smoke in the PR description.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.auth import AuthResult
+from gateway.ratelimit import RateLimiter
+
+
+class FakeAuth:
+    """In-memory token → AuthResult map standing in for the Postgres control plane."""
+
+    def __init__(self, mapping: dict[str, AuthResult]) -> None:
+        self._mapping = mapping
+
+    def authenticate(self, token: str) -> AuthResult | None:
+        return self._mapping.get(token)
+
+    def ping(self) -> bool:
+        return True
+
+
+TENANT_A = "11111111-1111-1111-1111-111111111111"
+TENANT_B = "22222222-2222-2222-2222-222222222222"
+
+
+def _batch(tenant_id: str, n_spans: int = 1) -> dict:
+    return {
+        "tenant_id": tenant_id,
+        "sdk_version": "test",
+        "resource_spans": [{"trace_id": f"t{i}", "span_id": f"s{i}"} for i in range(n_spans)],
+    }
+
+
+@contextmanager
+def _client(
+    *, keys: dict[str, AuthResult] | None = None, limiter: RateLimiter | None = None
+) -> Iterator[TestClient]:
+    # `with TestClient(app)` runs the lifespan exactly once; we then override the infra-touching
+    # bits (auth → in-memory, optionally the limiter) before yielding.
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = True
+        app.state.auth = FakeAuth(keys or {})
+        if limiter is not None:
+            app.state.limiter = limiter
+        yield client
+
+
+def test_missing_bearer_is_unauthenticated() -> None:
+    with _client(keys={}) as c:
+        r = c.post("/v1/batches", json=_batch(TENANT_A))
+        assert r.status_code == 401
+        assert r.json()["detail"]["code"] == "UNAUTHENTICATED"
+
+
+def test_invalid_key_is_unauthenticated() -> None:
+    with _client(keys={}) as c:
+        r = c.post("/v1/batches", json=_batch(TENANT_A), headers={"Authorization": "Bearer nope"})
+        assert r.status_code == 401
+        assert r.json()["detail"]["code"] == "UNAUTHENTICATED"
+
+
+def test_read_scope_cannot_write() -> None:
+    keys = {"rk": AuthResult(tenant_id=TENANT_A, scope="read")}
+    with _client(keys=keys) as c:
+        r = c.post("/v1/batches", json=_batch(TENANT_A), headers={"Authorization": "Bearer rk"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "FORBIDDEN_SCOPE"
+
+
+def test_tenant_a_key_cannot_write_tenant_b() -> None:
+    keys = {"wk": AuthResult(tenant_id=TENANT_A, scope="write")}
+    with _client(keys=keys) as c:
+        r = c.post("/v1/batches", json=_batch(TENANT_B), headers={"Authorization": "Bearer wk"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "TENANT_MISMATCH"
+
+
+def test_rate_limit_exceeded_returns_429_with_retry_after() -> None:
+    keys = {"wk": AuthResult(tenant_id=TENANT_A, scope="write")}
+    # burst=2 but the batch carries 5 spans → rate-limited before any insert.
+    limiter = RateLimiter(rps=1, burst=2, monthly_quota=1_000_000)
+    with _client(keys=keys, limiter=limiter) as c:
+        r = c.post(
+            "/v1/batches",
+            json=_batch(TENANT_A, n_spans=5),
+            headers={"Authorization": "Bearer wk"},
+        )
+        assert r.status_code == 429
+        body = r.json()
+        assert body["status"] == "rejected"
+        assert body["error"]["code"] == "RATE_LIMITED"
+        assert int(r.headers["Retry-After"]) >= 1
+        assert body["retry_after_ms"] > 0

--- a/infra/gateway/tests/test_app_backpressure.py
+++ b/infra/gateway/tests/test_app_backpressure.py
@@ -1,0 +1,140 @@
+"""App-level tests: server_hints round-trip, overload shedding, retry semantics (CTO-36).
+
+Auth is off and the store is a fake, so accepted spans take the write path without infra.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+from tally.schema import GenAI
+from tally.wire import ServerHints
+
+from gateway.app import app
+from gateway.backpressure import Backpressure, is_retryable
+
+
+class FakeStore:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.spans: list[tuple] = []
+        self.fail = fail
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        if self.fail:
+            raise RuntimeError("clickhouse down")
+        self.spans.extend(rows)
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+@contextmanager
+def _client(*, store_fail: bool = False) -> Iterator[tuple[TestClient, FakeStore]]:
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = False
+        store = FakeStore(fail=store_fail)
+        app.state.store = store
+        yield client, store
+
+
+def _good(i: int) -> dict:
+    return {
+        "trace_id": f"t{i}",
+        "span_id": f"s{i}",
+        GenAI.SYSTEM: "openai",
+        GenAI.OPERATION_NAME: "chat",
+        GenAI.USAGE_INPUT_TOKENS: 10,
+    }
+
+
+def _post(c: TestClient, spans: list[dict]):
+    body = {"tenant_id": "t-local", "sdk_version": "test", "resource_spans": spans}
+    return c.post("/v1/batches", json=body)
+
+
+def test_healthy_response_carries_baseline_hints() -> None:
+    with _client() as (c, _store):
+        r = _post(c, [_good(1)])
+        assert r.status_code == 200
+        hints = r.json()["server_hints"]
+        assert hints["sample_rate_override"] is None
+        assert hints["retry_after_ms"] == 0
+        assert hints["max_batch_size"] >= 1
+
+
+def test_overload_sheds_overflow_as_retryable_partial() -> None:
+    # soft_limit=1 → the in-flight request itself trips overload; cap batch to 2 items.
+    with _client() as (c, store):
+        app.state.backpressure = Backpressure(soft_limit=1, overload_max_batch=2)
+        r = _post(c, [_good(1), _good(2), _good(3), _good(4)])
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "partial"
+        assert body["accepted_spans"] == 2  # only the admitted prefix written
+        assert len(store.spans) == 2
+        shed = [e for e in body["partial_errors"] if e["code"] == "RATE_LIMITED"]
+        assert len(shed) == 2  # the two overflow spans
+        # Tightened hints tell a conformant client to back off.
+        hints = body["server_hints"]
+        assert hints["sample_rate_override"] == 0.25
+        assert hints["retry_after_ms"] > 0
+    app.state.backpressure = Backpressure()  # restore default for other tests
+
+
+def test_store_failure_is_retryable_503() -> None:
+    with _client(store_fail=True) as (c, _store):
+        r = _post(c, [_good(1)])
+        assert r.status_code == 503
+        assert r.json()["status"] == "retry"
+        assert is_retryable(r.status_code) is True
+
+
+def test_conformant_client_honors_hints_round_trip() -> None:
+    """A minimal client that resends shed items in hint-sized batches eventually lands them all."""
+
+    class ConformantClient:
+        def __init__(self) -> None:
+            self.max_batch_size = 1000
+
+        def apply(self, hints: dict) -> None:
+            self.max_batch_size = hints["max_batch_size"]
+
+    with _client() as (c, store):
+        app.state.backpressure = Backpressure(soft_limit=1, overload_max_batch=2)
+        client = ConformantClient()
+        pending = [_good(i) for i in range(5)]
+        rounds = 0
+        while pending and rounds < 10:
+            rounds += 1
+            send = pending[: client.max_batch_size]
+            remainder = pending[client.max_batch_size :]
+            r = _post(c, send)
+            body = r.json()
+            client.apply(body["server_hints"])
+            shed_ids = {e["item_id"] for e in body["partial_errors"] if e["code"] == "RATE_LIMITED"}
+            # Resend what the server shed, plus anything that didn't fit this round's ceiling.
+            reshed = [s for s in send if f"{s['trace_id']}:{s['span_id']}" in shed_ids]
+            pending = remainder + reshed
+        assert pending == []  # everything eventually accepted
+        assert len(store.spans) == 5
+    app.state.backpressure = Backpressure()
+
+
+def test_server_hints_dataclass_defaults() -> None:
+    h = ServerHints()
+    assert h.flush_interval_ms == 5000
+    assert h.max_batch_size == 1000
+    assert h.sample_rate_override is None
+    assert h.retry_after_ms == 0

--- a/infra/gateway/tests/test_app_protocol.py
+++ b/infra/gateway/tests/test_app_protocol.py
@@ -1,0 +1,133 @@
+"""App-level tests: capabilities, version negotiation, OTLP endpoint, unknown-field tolerance (CTO-31)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+from tally.schema import GenAI
+
+from gateway.app import app
+from gateway.protocol import INGEST_V1
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.spans: list[tuple] = []
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        self.spans.extend(rows)
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+@contextmanager
+def _client() -> Iterator[tuple[TestClient, FakeStore]]:
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = False
+        store = FakeStore()
+        app.state.store = store
+        yield client, store
+
+
+def _good(i: int) -> dict:
+    return {
+        "trace_id": f"t{i}",
+        "span_id": f"s{i}",
+        GenAI.SYSTEM: "openai",
+        GenAI.OPERATION_NAME: "chat",
+        GenAI.USAGE_INPUT_TOKENS: 10,
+    }
+
+
+def test_capabilities_endpoint() -> None:
+    with _client() as (c, _store):
+        r = c.get("/v1/capabilities")
+        assert r.status_code == 200
+        body = r.json()
+        assert INGEST_V1 in body["protocols"]
+        assert body["features"]["server_hints"] is True
+
+
+def test_known_protocol_header_accepted() -> None:
+    with _client() as (c, store):
+        body = {"tenant_id": "t-local", "sdk_version": "test", "resource_spans": [_good(1)]}
+        r = c.post("/v1/batches", json=body, headers={"X-Ingest-Protocol": INGEST_V1})
+        assert r.status_code == 200
+        assert len(store.spans) == 1
+
+
+def test_unknown_protocol_header_rejected_400() -> None:
+    with _client() as (c, _store):
+        body = {"tenant_id": "t-local", "sdk_version": "test", "resource_spans": [_good(1)]}
+        r = c.post("/v1/batches", json=body, headers={"X-Ingest-Protocol": "ingest-v999"})
+        assert r.status_code == 400
+
+
+def test_unknown_top_level_fields_tolerated() -> None:
+    """Additive contract: a future client may add envelope fields; an older gateway ignores them."""
+    with _client() as (c, store):
+        body = {
+            "tenant_id": "t-local",
+            "sdk_version": "test",
+            "resource_spans": [_good(1)],
+            "future_field": {"some": "thing"},  # unknown — must not break ingest
+            "another_new_knob": 42,
+        }
+        r = c.post("/v1/batches", json=body)
+        assert r.status_code == 200
+        assert r.json()["status"] == "accepted"
+        assert len(store.spans) == 1
+
+
+def test_otlp_traces_endpoint_ingests() -> None:
+    with _client() as (c, store):
+        otlp = {
+            "resourceSpans": [
+                {
+                    "resource": {
+                        "attributes": [
+                            {"key": "service.name", "value": {"stringValue": "svc"}}
+                        ]
+                    },
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "traceId": "abc",
+                                    "spanId": "def",
+                                    "startTimeUnixNano": "1717000000000000000",
+                                    "attributes": [
+                                        {"key": GenAI.SYSTEM, "value": {"stringValue": "openai"}},
+                                        {
+                                            "key": GenAI.OPERATION_NAME,
+                                            "value": {"stringValue": "chat"},
+                                        },
+                                        {
+                                            "key": GenAI.USAGE_INPUT_TOKENS,
+                                            "value": {"intValue": "55"},
+                                        },
+                                    ],
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+        r = c.post("/v1/otlp/traces", json=otlp, headers={"X-Tenant-Id": "t-local"})
+        assert r.status_code == 200
+        assert r.json()["status"] == "accepted"
+        assert len(store.spans) == 1

--- a/infra/gateway/tests/test_app_validation.py
+++ b/infra/gateway/tests/test_app_validation.py
@@ -1,0 +1,100 @@
+"""App-level tests for validation wiring → PARTIAL / REJECTED responses (CTO-34).
+
+Auth is disabled (require_api_key=False) and the ClickHouse store is replaced with an in-memory
+fake, so accepted spans take the write path without any running infra.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+from tally.schema import GenAI
+
+from gateway.app import app
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.spans: list[tuple] = []
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        self.spans.extend(rows)
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+@contextmanager
+def _client() -> Iterator[tuple[TestClient, FakeStore]]:
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = False
+        store = FakeStore()
+        app.state.store = store
+        yield client, store
+
+
+def _good(i: int) -> dict:
+    return {
+        "trace_id": f"t{i}",
+        "span_id": f"s{i}",
+        GenAI.SYSTEM: "openai",
+        GenAI.OPERATION_NAME: "chat",
+        GenAI.USAGE_INPUT_TOKENS: 10,
+    }
+
+
+def _post(c: TestClient, spans: list[dict]) -> dict:
+    body = {"tenant_id": "t-local", "sdk_version": "test", "resource_spans": spans}
+    return c.post("/v1/batches", json=body)
+
+
+def test_all_good_spans_accepted() -> None:
+    with _client() as (c, store):
+        r = _post(c, [_good(1), _good(2)])
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "accepted"
+        assert body["accepted_spans"] == 2
+        assert body["partial_errors"] == []
+        assert len(store.spans) == 2
+
+
+def test_one_bad_span_yields_partial() -> None:
+    bad = _good(2)
+    bad["email"] = "alice@example.com"  # PII → rejected
+    with _client() as (c, store):
+        r = _post(c, [_good(1), bad])
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "partial"
+        assert body["accepted_spans"] == 1  # only the good one written
+        codes = {e["code"] for e in body["partial_errors"]}
+        assert "PII_DETECTED" in codes
+        assert len(store.spans) == 1
+
+
+def test_all_bad_spans_yields_rejected() -> None:
+    bad1 = _good(1)
+    bad1[GenAI.USAGE_INPUT_TOKENS] = -5  # invalid schema
+    bad2 = _good(2)
+    bad2["user_email"] = "bob@example.com"  # forbidden PII key
+    with _client() as (c, store):
+        r = _post(c, [bad1, bad2])
+        assert r.status_code == 422
+        body = r.json()
+        assert body["status"] == "rejected"
+        assert body["accepted_spans"] == 0
+        assert len(body["partial_errors"]) == 2
+        assert store.spans == []

--- a/infra/gateway/tests/test_backpressure.py
+++ b/infra/gateway/tests/test_backpressure.py
@@ -1,0 +1,55 @@
+"""Pure tests for the backpressure controller + retry classification (CTO-36). No infra."""
+
+from __future__ import annotations
+
+from gateway.backpressure import Backpressure, is_retryable
+
+
+def test_healthy_below_soft_limit_admits_all() -> None:
+    bp = Backpressure(soft_limit=10)
+    shed = bp.evaluate(in_flight=3, batch_items=500)
+    assert shed.overloaded is False
+    assert shed.keep == 500
+    assert shed.hints.sample_rate_override is None
+    assert shed.hints.retry_after_ms == 0
+
+
+def test_overloaded_at_soft_limit_tightens_and_sheds() -> None:
+    bp = Backpressure(soft_limit=10, overload_max_batch=100)
+    shed = bp.evaluate(in_flight=10, batch_items=500)
+    assert shed.overloaded is True
+    assert shed.keep == 100  # capped to the tightened ceiling
+    assert shed.hints.max_batch_size == 100
+    assert shed.hints.sample_rate_override == 0.25
+    assert shed.hints.retry_after_ms > 0
+    assert shed.hints.flush_interval_ms > bp.healthy_hints().flush_interval_ms
+
+
+def test_overloaded_small_batch_keeps_all_but_still_advises() -> None:
+    bp = Backpressure(soft_limit=10, overload_max_batch=100)
+    shed = bp.evaluate(in_flight=20, batch_items=40)
+    assert shed.overloaded is True
+    assert shed.keep == 40  # nothing to shed, but hints still tightened
+    assert shed.hints.sample_rate_override == 0.25
+
+
+def test_soft_limit_must_be_positive() -> None:
+    try:
+        Backpressure(soft_limit=0)
+    except ValueError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_is_retryable_classification() -> None:
+    assert is_retryable(429) is True
+    assert is_retryable(503) is True
+    assert is_retryable(500) is True
+    assert is_retryable(502) is True
+    # 4xx contract errors (other than 429) are terminal — retrying replays the rejection.
+    assert is_retryable(400) is False
+    assert is_retryable(401) is False
+    assert is_retryable(403) is False
+    assert is_retryable(422) is False
+    assert is_retryable(200) is False

--- a/infra/gateway/tests/test_buffer.py
+++ b/infra/gateway/tests/test_buffer.py
@@ -1,0 +1,95 @@
+"""Pure tests for the ingest burst buffer: ordering, fairness, at-least-once dedup (CTO-37)."""
+
+from __future__ import annotations
+
+from gateway.buffer import BufferConsumer, BufferRecord, InMemoryBuffer, to_records
+from gateway.partition import trace_partition
+
+
+class FakeStore:
+    def __init__(self, *, fail_once: bool = False) -> None:
+        self.rows: list[tuple] = []
+        self.fail_once = fail_once
+        self.calls = 0
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        self.calls += 1
+        if self.fail_once and self.calls == 1:
+            raise RuntimeError("clickhouse down")
+        self.rows.extend(rows)
+        return len(rows)
+
+
+def _rec(tenant: str, trace: str, span: str, payload: object) -> BufferRecord:
+    return BufferRecord(
+        tenant_id=tenant,
+        trace_id=trace,
+        span_id=span,
+        partition=trace_partition(tenant, trace),
+        row=(payload,),
+    )
+
+
+def test_to_records_assigns_matching_partition() -> None:
+    recs = to_records("t-acme", [("trace-1", "s1", ("row1",)), ("trace-1", "s2", ("row2",))])
+    assert len(recs) == 2
+    assert recs[0].partition == trace_partition("t-acme", "trace-1")
+    assert recs[0].partition == recs[1].partition  # same trace → same partition (ordering)
+
+
+def test_produce_and_depth() -> None:
+    buf = InMemoryBuffer()
+    n = buf.produce(_rec("t", f"trace-{i}", f"s{i}", i) for i in range(5))
+    assert n == 5
+    assert buf.depth() == 5
+
+
+def test_drain_preserves_per_partition_fifo_order() -> None:
+    buf = InMemoryBuffer()
+    # All spans of one trace land in one partition → must drain in produce order.
+    recs = [_rec("t", "trace-A", f"s{i}", i) for i in range(4)]
+    buf.produce(recs)
+    drained = buf.drain(10)
+    assert [r.span_id for r in drained] == ["s0", "s1", "s2", "s3"]
+    assert buf.depth() == 0
+
+
+def _rec_on(partition: int, tenant: str, trace: str, span: str) -> BufferRecord:
+    return BufferRecord(tenant_id=tenant, trace_id=trace, span_id=span, partition=partition, row=(span,))
+
+
+def test_drain_is_fair_across_tenants() -> None:
+    # Fairness is a cross-partition property: the partition hash includes tenant_id, so distinct
+    # tenants land on distinct partitions and a round-robin drain serves each once per round.
+    buf = InMemoryBuffer(partitions=2)
+    buf.produce(_rec_on(0, "hog", f"h-trace-{i}", f"s{i}") for i in range(5))  # floods partition 0
+    buf.produce([_rec_on(1, "small", "s-trace", "s0")])  # one record on partition 1
+    first_round = buf.drain(2)  # one drain round should serve each tenant once
+    tenants = {r.tenant_id for r in first_round}
+    assert "small" in tenants  # the small tenant is not starved behind the hog's burst
+    assert "hog" in tenants
+
+
+def test_consumer_at_least_once_dedup() -> None:
+    store = FakeStore()
+    consumer = BufferConsumer(store)
+    recs = [_rec("t", "trace-A", "s1", "x"), _rec("t", "trace-A", "s2", "y")]
+    assert consumer.consume(recs) == 2
+    # Redelivery of the same records (Kafka at-least-once) must not double-write.
+    assert consumer.consume(recs) == 0
+    assert len(store.rows) == 2
+
+
+def test_consumer_retries_after_store_failure() -> None:
+    store = FakeStore(fail_once=True)
+    consumer = BufferConsumer(store)
+    recs = [_rec("t", "trace-A", "s1", "x")]
+    # First attempt: store raises → nothing acked, records remain eligible.
+    try:
+        consumer.consume(recs)
+    except RuntimeError:
+        pass
+    assert store.rows == []
+    # Retry succeeds and writes exactly once (at-least-once delivery).
+    assert consumer.consume(recs) == 1
+    assert len(store.rows) == 1

--- a/infra/gateway/tests/test_partition.py
+++ b/infra/gateway/tests/test_partition.py
@@ -1,0 +1,47 @@
+"""Pure tests for the buffer partition strategy (CTO-37)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.partition import DEFAULT_PARTITIONS, partition_key, trace_partition
+
+
+def test_partition_is_deterministic_across_calls() -> None:
+    a = trace_partition("t-acme", "trace-123")
+    b = trace_partition("t-acme", "trace-123")
+    assert a == b  # stable hash, not Python's salted hash()
+
+
+def test_partition_in_range() -> None:
+    for i in range(200):
+        p = trace_partition("t-acme", f"trace-{i}")
+        assert 0 <= p < DEFAULT_PARTITIONS
+
+
+def test_all_spans_of_a_trace_share_a_partition() -> None:
+    # Per-trace ordering relies on every span of a trace routing to one partition.
+    p = trace_partition("t-acme", "trace-xyz")
+    for _span in range(10):
+        assert trace_partition("t-acme", "trace-xyz") == p
+
+
+def test_traces_spread_across_partitions() -> None:
+    seen = {trace_partition("t-acme", f"trace-{i}") for i in range(500)}
+    assert seen == set(range(DEFAULT_PARTITIONS))  # all 4 partitions exercised
+
+
+def test_tenant_isolation_in_key() -> None:
+    # Same trace_id under different tenants may land differently; the key namespaces by tenant.
+    assert partition_key("t-a", "trace-1").startswith("t-a:")
+    assert partition_key("t-b", "trace-1").startswith("t-b:")
+
+
+def test_custom_partition_count() -> None:
+    for i in range(100):
+        assert 0 <= trace_partition("t", f"x{i}", partitions=8) < 8
+
+
+def test_zero_partitions_rejected() -> None:
+    with pytest.raises(ValueError):
+        trace_partition("t", "x", partitions=0)

--- a/infra/gateway/tests/test_protocol.py
+++ b/infra/gateway/tests/test_protocol.py
@@ -1,0 +1,139 @@
+"""Pure tests for protocol negotiation, capabilities, and OTLP/HTTP translation (CTO-31)."""
+
+from __future__ import annotations
+
+from tally.schema import GenAI
+
+from gateway.protocol import (
+    INGEST_V1,
+    SUPPORTED_PROTOCOLS,
+    capabilities,
+    negotiate,
+    otlp_traces_to_spans,
+)
+
+
+def test_negotiate_default_when_unspecified() -> None:
+    assert negotiate(None) == INGEST_V1
+    assert negotiate("") == INGEST_V1
+
+
+def test_negotiate_known_protocol() -> None:
+    assert negotiate(INGEST_V1) == INGEST_V1
+
+
+def test_negotiate_unknown_is_none() -> None:
+    assert negotiate("ingest-v999") is None
+    assert negotiate("totally-made-up") is None
+
+
+def test_capabilities_shape() -> None:
+    caps = capabilities(max_batch_size=2000, max_span_bytes=65536)
+    assert caps["default_protocol"] == INGEST_V1
+    assert list(SUPPORTED_PROTOCOLS) == caps["protocols"]
+    assert caps["max_batch_size"] == 2000
+    assert caps["max_span_bytes"] == 65536
+    assert caps["features"]["idempotency"] is True
+    assert caps["features"]["otlp_http_traces"] is True
+
+
+# --- OTLP/HTTP translation ------------------------------------------------------------------------
+
+
+def _otlp_doc() -> dict:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "checkout-api"}},
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": "abc123",
+                                "spanId": "def456",
+                                "startTimeUnixNano": "1717000000000000000",
+                                "attributes": [
+                                    {"key": GenAI.SYSTEM, "value": {"stringValue": "openai"}},
+                                    {"key": GenAI.OPERATION_NAME, "value": {"stringValue": "chat"}},
+                                    {
+                                        "key": GenAI.USAGE_INPUT_TOKENS,
+                                        "value": {"intValue": "120"},
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_otlp_translation_maps_structural_keys() -> None:
+    spans = otlp_traces_to_spans(_otlp_doc())
+    assert len(spans) == 1
+    s = spans[0]
+    assert s["trace_id"] == "abc123"
+    assert s["span_id"] == "def456"
+    assert s["timestamp_ns"] == 1717000000000000000
+    assert s["ServiceName"] == "checkout-api"
+    assert s[GenAI.SYSTEM] == "openai"
+
+
+def test_otlp_intvalue_coerced_to_int() -> None:
+    s = otlp_traces_to_spans(_otlp_doc())[0]
+    assert s[GenAI.USAGE_INPUT_TOKENS] == 120
+    assert isinstance(s[GenAI.USAGE_INPUT_TOKENS], int)
+
+
+def test_otlp_span_attrs_win_over_resource() -> None:
+    doc = _otlp_doc()
+    doc["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"].append(
+        {"key": "service.name", "value": {"stringValue": "override"}}
+    )
+    s = otlp_traces_to_spans(doc)[0]
+    assert s["service.name"] == "override"
+
+
+def test_otlp_empty_doc_is_empty_list() -> None:
+    assert otlp_traces_to_spans({}) == []
+    assert otlp_traces_to_spans({"resourceSpans": []}) == []
+
+
+def test_otlp_value_variants() -> None:
+    doc = {
+        "resourceSpans": [
+            {
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": "t",
+                                "spanId": "s",
+                                "attributes": [
+                                    {"key": "d", "value": {"doubleValue": 1.5}},
+                                    {"key": "b", "value": {"boolValue": True}},
+                                    {
+                                        "key": "arr",
+                                        "value": {
+                                            "arrayValue": {
+                                                "values": [{"stringValue": "x"}, {"intValue": "2"}]
+                                            }
+                                        },
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    s = otlp_traces_to_spans(doc)[0]
+    assert s["d"] == 1.5
+    assert s["b"] is True
+    assert s["arr"] == ["x", 2]

--- a/infra/gateway/tests/test_ratelimit.py
+++ b/infra/gateway/tests/test_ratelimit.py
@@ -1,0 +1,149 @@
+"""Pure tests for the per-tenant rate limiter + monthly quota (CTO-33). No infra, no sleeps."""
+
+from __future__ import annotations
+
+import calendar
+
+from gateway.errors import ErrorCode
+from gateway.ratelimit import MonthlyQuota, RateLimiter, TokenBucket
+
+
+class FakeClock:
+    """A controllable wall clock in seconds."""
+
+    def __init__(self, t: float = 1_000_000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, secs: float) -> None:
+        self.t += secs
+
+
+# --- TokenBucket ---------------------------------------------------------------------------------
+
+
+def test_bucket_starts_full_and_drains() -> None:
+    clk = FakeClock()
+    b = TokenBucket(capacity=3, rps=1, clock=clk)
+    assert b.try_consume() is True
+    assert b.try_consume() is True
+    assert b.try_consume() is True
+    assert b.try_consume() is False  # empty
+
+
+def test_bucket_refills_at_rps() -> None:
+    clk = FakeClock()
+    b = TokenBucket(capacity=2, rps=2, clock=clk)
+    assert b.try_consume(2) is True
+    assert b.try_consume() is False
+    clk.advance(0.5)  # 0.5s * 2 rps = 1 token
+    assert b.try_consume() is True
+    assert b.try_consume() is False
+
+
+def test_bucket_refill_capped_at_capacity() -> None:
+    clk = FakeClock()
+    b = TokenBucket(capacity=5, rps=100, clock=clk)
+    b.try_consume(5)
+    clk.advance(10)  # would add 1000 tokens, capped at 5
+    assert b.try_consume(5) is True
+    assert b.try_consume() is False
+
+
+def test_bucket_retry_after_reflects_deficit() -> None:
+    clk = FakeClock()
+    b = TokenBucket(capacity=1, rps=2, clock=clk)
+    assert b.try_consume() is True
+    # need 1 token, have 0, at 2 rps → 0.5s
+    assert abs(b.retry_after_s(1) - 0.5) < 1e-9
+
+
+# --- MonthlyQuota --------------------------------------------------------------------------------
+
+
+def test_quota_counts_and_blocks() -> None:
+    clk = FakeClock(calendar.timegm((2026, 5, 10, 0, 0, 0, 0, 0, 0)))
+    q = MonthlyQuota(limit=10, clock=clk)
+    assert q.would_exceed("t", 10) is False
+    q.consume("t", 8)
+    assert q.remaining("t") == 2
+    assert q.would_exceed("t", 3) is True
+    assert q.would_exceed("t", 2) is False
+
+
+def test_quota_resets_next_month() -> None:
+    clk = FakeClock(calendar.timegm((2026, 5, 20, 0, 0, 0, 0, 0, 0)))
+    q = MonthlyQuota(limit=5, clock=clk)
+    q.consume("t", 5)
+    assert q.remaining("t") == 0
+    clk.t = calendar.timegm((2026, 6, 1, 0, 0, 0, 0, 0, 0))  # roll to June
+    assert q.remaining("t") == 5
+
+
+def test_quota_retry_after_points_at_next_month() -> None:
+    start = calendar.timegm((2026, 5, 31, 23, 0, 0, 0, 0, 0))
+    clk = FakeClock(start)
+    q = MonthlyQuota(limit=1, clock=clk)
+    # 1 hour until June 1 00:00 UTC
+    assert abs(q.retry_after_s() - 3600) < 1.0
+
+
+def test_quota_tenants_are_independent() -> None:
+    clk = FakeClock()
+    q = MonthlyQuota(limit=3, clock=clk)
+    q.consume("a", 3)
+    assert q.would_exceed("a", 1) is True
+    assert q.would_exceed("b", 3) is False
+
+
+# --- RateLimiter (combined) ----------------------------------------------------------------------
+
+
+def test_limiter_allows_within_limits() -> None:
+    clk = FakeClock()
+    rl = RateLimiter(rps=10, burst=10, monthly_quota=1000, clock=clk)
+    d = rl.check("t", 5)
+    assert d.allowed is True
+    assert rl.remaining_quota("t") == 995
+
+
+def test_limiter_rate_limits_then_recovers() -> None:
+    clk = FakeClock()
+    rl = RateLimiter(rps=10, burst=10, monthly_quota=1000, clock=clk)
+    assert rl.check("t", 10).allowed is True
+    d = rl.check("t", 1)
+    assert d.allowed is False
+    assert d.code == ErrorCode.RATE_LIMITED
+    assert d.retry_after_ms > 0
+    clk.advance(1.0)  # +10 tokens
+    assert rl.check("t", 1).allowed is True
+
+
+def test_limiter_quota_exceeded_does_not_burn_rate_tokens() -> None:
+    clk = FakeClock()
+    rl = RateLimiter(rps=100, burst=100, monthly_quota=5, clock=clk)
+    assert rl.check("t", 5).allowed is True
+    d = rl.check("t", 1)
+    assert d.allowed is False
+    assert d.code == ErrorCode.QUOTA_EXCEEDED
+    assert d.retry_after_s > 0
+
+
+def test_limiter_rejected_batch_consumes_no_quota() -> None:
+    clk = FakeClock()
+    # burst smaller than the request → rate-limited before quota is touched
+    rl = RateLimiter(rps=1, burst=2, monthly_quota=1000, clock=clk)
+    d = rl.check("t", 5)
+    assert d.allowed is False
+    assert d.code == ErrorCode.RATE_LIMITED
+    assert rl.remaining_quota("t") == 1000  # untouched
+
+
+def test_limiter_tenants_isolated() -> None:
+    clk = FakeClock()
+    rl = RateLimiter(rps=1, burst=2, monthly_quota=1000, clock=clk)
+    assert rl.check("a", 2).allowed is True
+    assert rl.check("a", 1).allowed is False  # a is drained
+    assert rl.check("b", 2).allowed is True  # b unaffected

--- a/infra/gateway/tests/test_validation.py
+++ b/infra/gateway/tests/test_validation.py
@@ -1,0 +1,164 @@
+"""Pure tests for per-item span validation + PII rejection (CTO-34). No infra."""
+
+from __future__ import annotations
+
+from tally.schema import GenAI
+
+from gateway.errors import ErrorCode
+from gateway.validation import SpanValidator, span_item_id
+
+
+def _v(**kw) -> SpanValidator:
+    return SpanValidator(**kw)
+
+
+def _good_span() -> dict[str, object]:
+    return {
+        "trace_id": "abc",
+        "span_id": "def",
+        GenAI.SYSTEM: "openai",
+        GenAI.OPERATION_NAME: "chat",
+        GenAI.USAGE_INPUT_TOKENS: 100,
+        GenAI.COST_ESTIMATED_MICRO_USD: 750,
+        GenAI.COST_CURRENCY: "USD",
+        GenAI.FEATURE_TAG: "assistant",
+    }
+
+
+def test_conformant_span_accepted() -> None:
+    r = _v().validate(_good_span())
+    assert r.accepted is True
+    assert r.rejection is None
+    assert r.flags == []
+
+
+def test_non_dict_is_invalid_schema() -> None:
+    r = _v().validate("not a span")
+    assert r.accepted is False
+    assert r.rejection == ErrorCode.INVALID_SCHEMA
+
+
+def test_wrong_int_type_is_invalid_schema() -> None:
+    span = _good_span()
+    span[GenAI.USAGE_INPUT_TOKENS] = "100"  # string, not int
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.INVALID_SCHEMA
+
+
+def test_negative_token_is_invalid_schema() -> None:
+    span = _good_span()
+    span[GenAI.USAGE_OUTPUT_TOKENS] = -1
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.INVALID_SCHEMA
+
+
+def test_bool_is_not_accepted_as_int() -> None:
+    span = _good_span()
+    span[GenAI.USAGE_INPUT_TOKENS] = True
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.INVALID_SCHEMA
+
+
+def test_uppercase_operation_is_invalid() -> None:
+    span = _good_span()
+    span[GenAI.OPERATION_NAME] = "Chat"
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.INVALID_SCHEMA
+
+
+def test_bad_currency_is_invalid() -> None:
+    span = _good_span()
+    span[GenAI.COST_CURRENCY] = "DOLLARS"
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.INVALID_SCHEMA
+
+
+def test_unknown_keys_are_tolerated() -> None:
+    span = _good_span()
+    span["gen_ai.custom.flag"] = "x"
+    span["some_future_field"] = 42
+    r = _v().validate(span)
+    assert r.accepted is True
+
+
+# --- PII ------------------------------------------------------------------------------------------
+
+
+def test_raw_email_in_any_value_is_pii() -> None:
+    span = _good_span()
+    span["gen_ai.prompt.snippet"] = "contact me at alice@example.com please"
+    r = _v().validate(span)
+    assert r.accepted is False
+    assert r.rejection == ErrorCode.PII_DETECTED
+
+
+def test_forbidden_pii_key_is_rejected() -> None:
+    span = _good_span()
+    span["email"] = "x"
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.PII_DETECTED
+
+
+def test_unhashed_user_id_hash_is_pii() -> None:
+    span = _good_span()
+    span[GenAI.USER_ID_HASH] = "alice@example.com"
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.PII_DETECTED
+
+
+def test_raw_username_as_hash_is_pii() -> None:
+    span = _good_span()
+    span[GenAI.USER_ID_HASH] = "alice_smith"  # not hex
+    r = _v().validate(span)
+    assert r.rejection == ErrorCode.PII_DETECTED
+
+
+def test_real_hash_accepted() -> None:
+    span = _good_span()
+    span[GenAI.USER_ID_HASH] = "a" * 64  # 64 hex chars
+    r = _v().validate(span)
+    assert r.accepted is True
+
+
+# --- size -----------------------------------------------------------------------------------------
+
+
+def test_oversized_span_is_payload_too_large() -> None:
+    span = _good_span()
+    span["blob"] = "x" * 2048
+    r = _v(max_span_bytes=1024).validate(span)
+    assert r.rejection == ErrorCode.PAYLOAD_TOO_LARGE
+
+
+# --- unknown feature tag (flag, not rejection) ----------------------------------------------------
+
+
+def test_unknown_feature_tag_is_flagged_not_rejected() -> None:
+    span = _good_span()
+    span[GenAI.FEATURE_TAG] = "brand_new_feature"
+    r = _v(known_feature_tags={"assistant", "summarize"}).validate(span)
+    assert r.accepted is True
+    assert ErrorCode.UNKNOWN_FEATURE_TAG in r.flags
+
+
+def test_known_feature_tag_not_flagged() -> None:
+    span = _good_span()
+    r = _v(known_feature_tags={"assistant"}).validate(span)
+    assert r.accepted is True
+    assert r.flags == []
+
+
+def test_no_known_tags_disables_flag() -> None:
+    span = _good_span()
+    span[GenAI.FEATURE_TAG] = "whatever"
+    r = _v(known_feature_tags=None).validate(span)
+    assert r.accepted is True
+    assert r.flags == []
+
+
+# --- item id --------------------------------------------------------------------------------------
+
+
+def test_item_id_prefers_trace_span() -> None:
+    assert span_item_id({"trace_id": "t", "span_id": "s"}, 3) == "t:s"
+    assert span_item_id({}, 3) == "#3"

--- a/sdk/python/src/tally/wire.py
+++ b/sdk/python/src/tally/wire.py
@@ -145,11 +145,28 @@ class PartialError:
 
 
 @dataclass(frozen=True, slots=True)
+class ServerHints:
+    """Flow-control advice the gateway returns so a conformant client can self-tune (CTO-36).
+
+    The client should treat these as the new ceiling until the next response updates them: flush no
+    more often than ``flush_interval_ms``, send no more than ``max_batch_size`` items per batch,
+    apply ``sample_rate_override`` when present (gateway-directed shedding), and — on a retryable
+    response — wait ``retry_after_ms`` before resending.
+    """
+
+    flush_interval_ms: int = 5000
+    max_batch_size: int = 1000
+    sample_rate_override: float | None = None
+    retry_after_ms: int = 0
+
+
+@dataclass(frozen=True, slots=True)
 class BatchResponse:
     batch_id: str
     status: Status = Status.ACCEPTED
     partial_errors: list[PartialError] = field(default_factory=list)
     accepted_spans: int = 0
+    server_hints: ServerHints | None = None
 
 
 # --- JSON codec ----------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Builds the gateway ingest spine (Epic CTO-7) as sequential commits on one branch — no stacked PRs. All gateway logic leans on the SDK's already-tested pure code; the gateway is the HTTP + storage shell. Dev/test never needs running infra (fakes + in-memory stores throughout).

- **CTO-33 — Auth scope + per-tenant rate limit & quota.** API key → tenant/scope resolution (SHA-256 hash lookup), write-scope enforcement, tenant-mismatch refusal. Pure, clock-injectable token-bucket rate limiter + monthly span quota (quota checked read-only before burning tokens).
- **CTO-34 — Schema validation + PII rejection.** Per-item validator: typed-key schema checks (tolerant of unknown keys), raw-email / forbidden-PII-key / unhashed-user-id detection, payload size cap, unknown-feature-tag flag. Rejected items become `PartialError`s → PARTIAL/REJECTED.
- **CTO-36 — Backpressure ServerHints + retry semantics.** Every response carries `tally.wire.ServerHints` (flush cadence, per-batch ceiling, optional sample-rate override, backoff). A pure `Backpressure` controller maps live in-flight concurrency to hints + a shed decision; overflow is shed as retryable PARTIAL. `is_retryable()` classifies 429/5xx as retryable, other 4xx as terminal.
- **CTO-31 — OTLP/ingest-v1 skeleton (contract layer).** Version negotiation (unknown protocol → 400), self-describing `GET /v1/capabilities`, and an OTLP/HTTP JSON traces fallback (`POST /v1/otlp/traces`). Additive contract: unknown envelope fields tolerated. _gRPC/TLS/zstd transport + load test remain infra follow-ups._
- **CTO-37 — Ingest buffer partition strategy + at-least-once dedup (pure core).** Stable blake2b `(tenant_id, trace_id)` → partition routing (per-trace ordering + tenant spread); in-memory burst buffer with per-partition FIFO + tenant-fair round-robin drain; consumer with at-least-once delivery + dedup on `(tenant, trace, span)`. _Real Kafka producer/consumer + load test remain infra follow-ups._
- **CI** — adds a gateway job (ruff + pytest); the package previously had no CI coverage.

## Test plan

- [x] `uv run --extra dev pytest -q` in infra/gateway — 82 passing
- [x] `uv run --extra dev ruff check .` in infra/gateway — clean
- [x] `uv run --extra dev pytest -q` in sdk/python — 175 passing (wire.py ServerHints addition)
- [x] `uv run --extra dev ruff check .` in sdk/python — clean
- [x] CI gateway job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)