### PR TITLE
sdk: first-class identity graph + identify/alias ingestion (CTO-67)

### DIFF
--- a/sdk/python/src/tally/identity.py
+++ b/sdk/python/src/tally/identity.py
@@ -1,0 +1,214 @@
+"""Identity graph + resolution — transitive, bounded depth (CTO-67 / spec §7 identity correction).
+
+Attribution's highest-value case — anonymous→authenticated conversion — only works with an identity
+graph. A naive ``user_id`` join silently loses the pre-login traces. This module is the canonical,
+transport-agnostic home for that graph; the stitcher (CTO-69) consumes it.
+
+The graph is **undirected, tenant-scoped, and over hashed IDs only** (no raw PII ever). It is
+populated from two event kinds that any SDK or CDP emits:
+
+* **identify** — ties an ``anonymous_id`` (and optional ``session_id``) to a ``user_id`` at login.
+* **alias** — merges two ids the product knows are the same person (e.g. a CDP ``alias`` call).
+
+:meth:`IdentityGraph.resolve_identity` does a bounded-depth (default 2) transitive walk that bridges
+``anonymous_id ↔ user_id ↔ session_id`` and across **HMAC key versions** (CTO-74 rotates the user-id
+hashing key; the same person hashes differently under v1 vs v2, so a key-rotation edge re-links
+them). Bounded depth + a visited-set keep cycles and runaway fan-out in check.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class IdentityType(str, Enum):
+    USER_ID = "user_id"
+    ANONYMOUS_ID = "anonymous_id"
+    SESSION_ID = "session_id"
+    EMAIL = "email"
+    EXTERNAL_ID = "external_id"
+
+
+# Source tag for a synthetic edge linking the same identity across HMAC key versions (CTO-74).
+KEY_ROTATION_SOURCE = "key_rotation"
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityEdge:
+    """An edge in the identity graph (hashed identities only)."""
+
+    a: str
+    a_type: IdentityType
+    b: str
+    b_type: IdentityType
+    observed_at: datetime
+    source: str = "sdk"
+    confidence: float = 1.0
+    key_version: str = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class IdentifyEvent:
+    """SDK/CDP ``identify``: an anonymous visitor logs in and becomes a known user.
+
+    Produces the ``anonymous_id ↔ user_id`` link (and ``session_id ↔ user_id`` when present) — the
+    edges that let a conversion attributed to ``user_id`` reach back to pre-login anonymous traces.
+    """
+
+    user_id: str
+    observed_at: datetime
+    anonymous_id: str | None = None
+    session_id: str | None = None
+    source: str = "sdk"
+    key_version: str = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class AliasEvent:
+    """CDP ``alias``: two ids the product asserts are the same person (e.g. cross-device merge)."""
+
+    previous_id: str
+    previous_type: IdentityType
+    new_id: str
+    new_type: IdentityType
+    observed_at: datetime
+    source: str = "cdp"
+    key_version: str = "v1"
+
+
+class IdentityGraph:
+    """Undirected (symmetric) transitive identity graph over hashed IDs.
+
+    Edges keyed by ``(tenant_id, identity)`` so traversal is tenant-scoped (no cross-tenant leak).
+    """
+
+    def __init__(self) -> None:
+        self._adj: dict[tuple[str, str], set[tuple[str, IdentityEdge]]] = defaultdict(set)
+
+    # --- population --------------------------------------------------------------------------
+
+    def add_edge(self, tenant_id: str, edge: IdentityEdge) -> None:
+        # store both directions so the graph is undirected at traversal time
+        self._adj[(tenant_id, edge.a)].add((edge.b, edge))
+        self._adj[(tenant_id, edge.b)].add((edge.a, edge))
+
+    def ingest_identify(self, tenant_id: str, event: IdentifyEvent) -> int:
+        """Populate edges from an identify event. Returns the number of edges added."""
+        added = 0
+        if event.anonymous_id:
+            self.add_edge(
+                tenant_id,
+                IdentityEdge(
+                    a=event.anonymous_id,
+                    a_type=IdentityType.ANONYMOUS_ID,
+                    b=event.user_id,
+                    b_type=IdentityType.USER_ID,
+                    observed_at=event.observed_at,
+                    source=event.source,
+                    key_version=event.key_version,
+                ),
+            )
+            added += 1
+        if event.session_id:
+            self.add_edge(
+                tenant_id,
+                IdentityEdge(
+                    a=event.session_id,
+                    a_type=IdentityType.SESSION_ID,
+                    b=event.user_id,
+                    b_type=IdentityType.USER_ID,
+                    observed_at=event.observed_at,
+                    source=event.source,
+                    key_version=event.key_version,
+                ),
+            )
+            added += 1
+        return added
+
+    def ingest_alias(self, tenant_id: str, event: AliasEvent) -> None:
+        """Populate an edge from a CDP alias event (an explicit same-person assertion)."""
+        self.add_edge(
+            tenant_id,
+            IdentityEdge(
+                a=event.previous_id,
+                a_type=event.previous_type,
+                b=event.new_id,
+                b_type=event.new_type,
+                observed_at=event.observed_at,
+                source=event.source,
+                key_version=event.key_version,
+            ),
+        )
+
+    def bridge_key_versions(
+        self,
+        tenant_id: str,
+        identity_old: str,
+        identity_new: str,
+        observed_at: datetime,
+        *,
+        identity_type: IdentityType = IdentityType.USER_ID,
+        old_key_version: str = "v1",
+        new_key_version: str = "v2",
+    ) -> None:
+        """Link the *same* logical identity hashed under two HMAC key versions (CTO-74 rotation).
+
+        Without this, rotating the user-id hashing key would silently fork every user into a
+        pre- and post-rotation identity and break attribution across the boundary.
+        """
+        self.add_edge(
+            tenant_id,
+            IdentityEdge(
+                a=identity_old,
+                a_type=identity_type,
+                b=identity_new,
+                b_type=identity_type,
+                observed_at=observed_at,
+                source=KEY_ROTATION_SOURCE,
+                key_version=f"{old_key_version}->{new_key_version}",
+            ),
+        )
+
+    # --- resolution --------------------------------------------------------------------------
+
+    def resolve_identity(
+        self,
+        tenant_id: str,
+        start: str,
+        *,
+        max_depth: int = 2,
+        as_of: datetime | None = None,
+    ) -> set[str]:
+        """Return identities reachable from ``start`` within ``max_depth`` hops (incl. ``start``).
+
+        Edges with ``observed_at > as_of`` are ignored so a historical attribution never "leaks" an
+        identity link learned after the fact. Bounded depth + the visited-set make cycles and
+        runaway fan-out safe.
+        """
+        seen: set[str] = {start}
+        frontier: list[tuple[str, int]] = [(start, 0)]
+        while frontier:
+            node, depth = frontier.pop()
+            if depth >= max_depth:
+                continue
+            for neighbour, edge in self._adj.get((tenant_id, node), set()):
+                if as_of is not None and edge.observed_at > as_of:
+                    continue
+                if neighbour in seen:
+                    continue
+                seen.add(neighbour)
+                frontier.append((neighbour, depth + 1))
+        return seen
+
+    # Back-compat alias: the stitcher (CTO-69) and its tests call ``resolve``.
+    resolve = resolve_identity
+
+    def edge_type_between(self, tenant_id: str, a: str, b: str) -> IdentityType | None:
+        """If a single edge links ``a`` and ``b`` directly, return the *other side*'s type."""
+        for neighbour, edge in self._adj.get((tenant_id, a), set()):
+            if neighbour == b:
+                return edge.b_type if edge.a == a else edge.a_type
+        return None

--- a/sdk/python/src/tally/stitcher.py
+++ b/sdk/python/src/tally/stitcher.py
@@ -24,22 +24,27 @@ Algorithm (per spec §7.1):
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Protocol
 
+# Identity graph primitives are now a first-class component (CTO-67); re-exported here so the
+# stitcher's public surface (and its tests) keep importing them from ``tally.stitcher``.
+from tally.identity import (
+    IdentityEdge,
+    IdentityGraph,
+    IdentityType,
+)
+
+__all__ = [
+    "IdentityEdge",
+    "IdentityGraph",
+    "IdentityType",
+]
+
 # --- types ---------------------------------------------------------------------------------------
-
-
-class IdentityType(str, Enum):
-    USER_ID = "user_id"
-    ANONYMOUS_ID = "anonymous_id"
-    SESSION_ID = "session_id"
-    EMAIL = "email"
-    EXTERNAL_ID = "external_id"
 
 
 class AttributionConfidence(str, Enum):
@@ -53,20 +58,6 @@ class ValueType(str, Enum):
     COUNT = "count"
     MRR = "mrr"
     REFUND = "refund"
-
-
-@dataclass(frozen=True, slots=True)
-class IdentityEdge:
-    """An edge in the identity graph (hashed identities only)."""
-
-    a: str
-    a_type: IdentityType
-    b: str
-    b_type: IdentityType
-    observed_at: datetime
-    source: str = "sdk"
-    confidence: float = 1.0
-    key_version: str = "v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,61 +123,6 @@ class UnattributedRecord:
     occurred_at: datetime
     reason: str  # 'no_trace_in_window' | 'feature_tag_no_rule' | etc.
     last_checked_at: datetime
-
-
-# --- identity graph ------------------------------------------------------------------------------
-
-
-class IdentityGraph:
-    """Undirected (symmetric) transitive identity graph over hashed IDs.
-
-    Edges keyed by ``(tenant_id, identity)`` so traversal is tenant-scoped (no cross-tenant leak).
-    """
-
-    def __init__(self) -> None:
-        self._adj: dict[tuple[str, str], set[tuple[str, IdentityEdge]]] = defaultdict(set)
-
-    def add_edge(self, tenant_id: str, edge: IdentityEdge) -> None:
-        # store both directions so the graph is undirected at traversal time
-        self._adj[(tenant_id, edge.a)].add((edge.b, edge))
-        self._adj[(tenant_id, edge.b)].add((edge.a, edge))
-
-    def resolve(
-        self,
-        tenant_id: str,
-        start: str,
-        *,
-        max_depth: int = 2,
-        as_of: datetime | None = None,
-    ) -> set[str]:
-        """Return all identities reachable from ``start`` within ``max_depth`` hops.
-
-        Edges with ``observed_at > as_of`` are ignored (avoids "leaking" later edges into a
-        historical attribution).
-        """
-        seen: set[str] = {start}
-        frontier: list[tuple[str, int]] = [(start, 0)]
-        while frontier:
-            node, depth = frontier.pop()
-            if depth >= max_depth:
-                continue
-            for neighbour, edge in self._adj.get((tenant_id, node), set()):
-                if as_of is not None and edge.observed_at > as_of:
-                    continue
-                if neighbour in seen:
-                    continue
-                seen.add(neighbour)
-                frontier.append((neighbour, depth + 1))
-        return seen
-
-    def edge_type_between(
-        self, tenant_id: str, a: str, b: str
-    ) -> IdentityType | None:
-        """If a single edge links ``a`` and ``b`` directly, return the *other side*'s type."""
-        for neighbour, edge in self._adj.get((tenant_id, a), set()):
-            if neighbour == b:
-                return edge.b_type if edge.a == a else edge.a_type
-        return None
 
 
 # --- touch store ---------------------------------------------------------------------------------

--- a/sdk/python/tests/test_identity.py
+++ b/sdk/python/tests/test_identity.py
@@ -1,0 +1,155 @@
+"""Identity graph: transitive bounded-depth resolution, ingestion, key-version bridge (CTO-67)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from tally.identity import (
+    KEY_ROTATION_SOURCE,
+    AliasEvent,
+    IdentifyEvent,
+    IdentityEdge,
+    IdentityGraph,
+    IdentityType,
+)
+
+NOW = datetime(2026, 5, 30, 12, 0, 0)
+T = "t-acme"
+
+
+def _g() -> IdentityGraph:
+    return IdentityGraph()
+
+
+# --- resolution -----------------------------------------------------------------------------------
+
+
+def test_resolve_self_only_when_no_edges() -> None:
+    g = _g()
+    assert g.resolve_identity(T, "u_alice") == {"u_alice"}
+
+
+def test_resolve_one_hop() -> None:
+    g = _g()
+    g.add_edge(
+        T, IdentityEdge("u_anon", IdentityType.ANONYMOUS_ID, "u_alice", IdentityType.USER_ID, NOW)
+    )
+    assert g.resolve_identity(T, "u_anon") == {"u_anon", "u_alice"}
+
+
+def test_resolve_respects_max_depth() -> None:
+    g = _g()
+    g.add_edge(T, IdentityEdge("a", IdentityType.ANONYMOUS_ID, "b", IdentityType.USER_ID, NOW))
+    g.add_edge(T, IdentityEdge("b", IdentityType.USER_ID, "c", IdentityType.SESSION_ID, NOW))
+    g.add_edge(T, IdentityEdge("c", IdentityType.SESSION_ID, "d", IdentityType.USER_ID, NOW))
+    # depth 2 from "a" reaches b (1) and c (2) but not d (3).
+    assert g.resolve_identity(T, "a", max_depth=2) == {"a", "b", "c"}
+    assert "d" not in g.resolve_identity(T, "a", max_depth=2)
+    assert "d" in g.resolve_identity(T, "a", max_depth=3)
+
+
+def test_resolve_handles_cycles() -> None:
+    g = _g()
+    g.add_edge(T, IdentityEdge("a", IdentityType.USER_ID, "b", IdentityType.USER_ID, NOW))
+    g.add_edge(T, IdentityEdge("b", IdentityType.USER_ID, "a", IdentityType.USER_ID, NOW))
+    # a self-referential cycle must terminate, not loop forever.
+    assert g.resolve_identity(T, "a", max_depth=5) == {"a", "b"}
+
+
+def test_resolve_is_tenant_scoped() -> None:
+    g = _g()
+    g.add_edge(
+        T, IdentityEdge("u_anon", IdentityType.ANONYMOUS_ID, "u_alice", IdentityType.USER_ID, NOW)
+    )
+    # A different tenant must not see t-acme's edges (no cross-tenant leak).
+    assert g.resolve_identity("t-other", "u_anon") == {"u_anon"}
+
+
+def test_resolve_as_of_ignores_future_edges() -> None:
+    g = _g()
+    later = NOW + timedelta(days=1)
+    g.add_edge(
+        T, IdentityEdge("u_anon", IdentityType.ANONYMOUS_ID, "u_alice", IdentityType.USER_ID, later)
+    )
+    # An edge observed after the as_of cutoff must not leak into a historical resolution.
+    assert g.resolve_identity(T, "u_anon", as_of=NOW) == {"u_anon"}
+    assert g.resolve_identity(T, "u_anon", as_of=later) == {"u_anon", "u_alice"}
+
+
+def test_resolve_alias_is_back_compat() -> None:
+    g = _g()
+    g.add_edge(T, IdentityEdge("a", IdentityType.USER_ID, "b", IdentityType.USER_ID, NOW))
+    assert g.resolve(T, "a") == g.resolve_identity(T, "a")  # stitcher calls .resolve
+
+
+# --- ingestion ------------------------------------------------------------------------------------
+
+
+def test_ingest_identify_links_anonymous_and_session_to_user() -> None:
+    g = _g()
+    n = g.ingest_identify(
+        T,
+        IdentifyEvent(
+            user_id="u_alice", anonymous_id="anon_1", session_id="sess_1", observed_at=NOW
+        ),
+    )
+    assert n == 2
+    resolved = g.resolve_identity(T, "anon_1", max_depth=2)
+    assert {"anon_1", "u_alice", "sess_1"} <= resolved
+
+
+def test_ingest_identify_without_anonymous_only_session() -> None:
+    g = _g()
+    n = g.ingest_identify(T, IdentifyEvent(user_id="u_alice", session_id="sess_1", observed_at=NOW))
+    assert n == 1
+    assert g.resolve_identity(T, "sess_1") == {"sess_1", "u_alice"}
+
+
+def test_ingest_alias_merges_two_ids() -> None:
+    g = _g()
+    g.ingest_alias(
+        T,
+        AliasEvent(
+            previous_id="anon_1",
+            previous_type=IdentityType.ANONYMOUS_ID,
+            new_id="u_alice",
+            new_type=IdentityType.USER_ID,
+            observed_at=NOW,
+        ),
+    )
+    assert g.resolve_identity(T, "anon_1") == {"anon_1", "u_alice"}
+
+
+# --- key-version bridge ---------------------------------------------------------------------------
+
+
+def test_bridge_key_versions_relinks_rotated_hashes() -> None:
+    g = _g()
+    # Same user, hashed under v1 then v2 after a key rotation (CTO-74).
+    g.bridge_key_versions(
+        T, "u_alice_v1", "u_alice_v2", NOW, old_key_version="v1", new_key_version="v2"
+    )
+    assert g.resolve_identity(T, "u_alice_v1") == {"u_alice_v1", "u_alice_v2"}
+    assert g.edge_type_between(T, "u_alice_v1", "u_alice_v2") is IdentityType.USER_ID
+
+
+def test_key_rotation_edge_tagged_with_source() -> None:
+    g = _g()
+    g.bridge_key_versions(T, "old", "new", NOW)
+    # Bridge transitively reaches conversion traces hashed under either key version.
+    g.add_edge(T, IdentityEdge("anon", IdentityType.ANONYMOUS_ID, "old", IdentityType.USER_ID, NOW))
+    assert {"anon", "old", "new"} <= g.resolve_identity(T, "anon", max_depth=2)
+    assert KEY_ROTATION_SOURCE == "key_rotation"
+
+
+# --- late alias re-links prior identity (the headline CTO-67 case) --------------------------------
+
+
+def test_late_alias_relinks_anonymous_to_authenticated() -> None:
+    g = _g()
+    # Before login, only the anonymous id is known — resolution is just itself.
+    assert g.resolve_identity(T, "anon_1") == {"anon_1"}
+    # An identify/alias arrives after the conversion: now the prior anonymous traces re-link.
+    g.ingest_identify(T, IdentifyEvent(user_id="u_alice", anonymous_id="anon_1", observed_at=NOW))
+    assert g.resolve_identity(T, "anon_1") == {"anon_1", "u_alice"}
+    assert g.resolve_identity(T, "u_alice") == {"u_alice", "anon_1"}


### PR DESCRIPTION
## Summary
- Promotes `IdentityType` / `IdentityEdge` / `IdentityGraph` out of `stitcher.py` into a canonical `tally.identity` module (re-exported from `tally.stitcher`, so the stitcher and its tests are untouched).
- Adds the CTO-67 surface the stitcher didn't cover: **identify/alias event ingestion** (`IdentifyEvent`, `AliasEvent` → edges) and explicit **cross-HMAC-key-version bridging** (`bridge_key_versions`) so a key rotation (CTO-74) doesn't fork a user into pre/post-rotation identities.
- `resolve_identity` does a transitive bounded-depth (default 2) walk: tenant-scoped (no cross-tenant leak), cycle-safe, with `as_of` edge filtering so historical attribution never leaks a link learned after the fact.

## Behavior
- Headline case covered: a late anonymous→authenticated alias re-links prior anonymous traces.
- `resolve` retained as a back-compat alias (the stitcher calls `.resolve`).

## What's deferred (out of scope here)
- ClickHouse `identity_graph` table population and CDP webhook ingestion (tracked under CTO-68) — this PR is the pure, transport-agnostic graph + resolution logic only.

## Test plan
- [x] `uv run --extra dev pytest -q` in sdk/python — 190 passing
- [x] `uv run --extra dev ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)