### PR TITLE
sdk: provider extractor framework, versioned and fixture-tested (CTO-41)

### DIFF
--- a/sdk/python/src/tally/extractors/__init__.py
+++ b/sdk/python/src/tally/extractors/__init__.py
@@ -1,0 +1,102 @@
+"""Provider extractor framework — versioned, pluggable, fixture-tested.
+
+Implements CTO-41.
+
+An *extractor* turns a raw provider response (the OpenAI Chat Completions object, etc.) into a list
+of conformant ``gen_ai.*`` attribute dicts (see :mod:`tally.schema`). It is deliberately narrower
+than the instrumentation layer: pure logic over a response payload, no pricing, no context, no
+network. This makes extractors trivially fixture-testable and lets us version provider quirks
+independently of the rest of the SDK.
+
+Design goals (per CTO-41):
+
+* **Versioned** — each extractor carries an explicit version in its registry key (``"openai_v1"``),
+  so a breaking change in a provider's response shape becomes ``"openai_v2"`` without disturbing
+  callers pinned to v1.
+* **Pluggable** — :class:`ProviderExtractor` is a structural :class:`~typing.Protocol`; new
+  providers register via :func:`register` (or the :func:`extractor` decorator). Adding a provider
+  requires *zero* changes to dispatch — :func:`get_extractor` is a pure registry lookup.
+* **Never crash** — extractors honour the SDK's "never break the host app" invariant: malformed,
+  missing, or wrongly-typed provider data yields whatever subset of attributes can be salvaged,
+  never an exception.
+
+A single response may yield multiple attribute dicts (e.g. one per tool call in a tool-calling
+turn), so :meth:`ProviderExtractor.extract` returns a ``list[dict[str, object]]``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProviderExtractor(Protocol):
+    """Per-provider, per-version response extractor.
+
+    Implementations are pure functions over a provider response object. They MUST NOT raise on
+    malformed input — return whatever subset of attributes is available instead.
+    """
+
+    #: Registry key carrying provider + version, e.g. ``"openai_v1"``.
+    key: str
+
+    def extract(self, response: object) -> list[dict[str, object]]:
+        """Map a provider response to one or more conformant ``gen_ai.*`` attribute dicts."""
+        ...
+
+
+_REGISTRY: dict[str, ProviderExtractor] = {}
+
+
+def register(extractor_obj: ProviderExtractor) -> ProviderExtractor:
+    """Register ``extractor_obj`` under its ``.key``. Returns it (so it can be used as a value).
+
+    Raises :class:`ValueError` on a missing/empty key or a duplicate registration — these are
+    programmer errors at import time, not host-app runtime data, so failing loudly is correct.
+    """
+    key = getattr(extractor_obj, "key", None)
+    if not isinstance(key, str) or not key:
+        raise ValueError("extractor must have a non-empty str .key")
+    if key in _REGISTRY:
+        raise ValueError(f"extractor already registered for key {key!r}")
+    _REGISTRY[key] = extractor_obj
+    return extractor_obj
+
+
+def extractor(cls: type) -> type:
+    """Class decorator: instantiate ``cls`` and register the instance under its ``.key``."""
+    register(cls())
+    return cls
+
+
+def get_extractor(provider_version: str) -> ProviderExtractor:
+    """Look up a registered extractor by its versioned key (e.g. ``"openai_v1"``).
+
+    Raises :class:`KeyError` for an unknown key (a configuration error, not host-app data).
+    """
+    try:
+        return _REGISTRY[provider_version]
+    except KeyError:
+        raise KeyError(
+            f"no extractor registered for {provider_version!r}; "
+            f"known: {sorted(_REGISTRY)}"
+        ) from None
+
+
+def available_extractors() -> list[str]:
+    """Return the sorted list of registered extractor keys."""
+    return sorted(_REGISTRY)
+
+
+# Importing the provider modules triggers their registration side effects. Keep these imports at the
+# bottom so the registry primitives above are fully defined first.
+from tally.extractors.openai import OpenAIExtractorV1  # noqa: E402
+
+__all__ = [
+    "ProviderExtractor",
+    "register",
+    "extractor",
+    "get_extractor",
+    "available_extractors",
+    "OpenAIExtractorV1",
+]

--- a/sdk/python/src/tally/extractors/openai.py
+++ b/sdk/python/src/tally/extractors/openai.py
@@ -1,0 +1,115 @@
+"""OpenAI Chat Completions extractor — version 1 (``openai_v1``).
+
+Implements CTO-41.
+
+Maps an OpenAI Chat Completions *response* ``usage`` object into the internal ``gen_ai.*`` attribute
+dict defined by :mod:`tally.schema`:
+
+* ``usage.prompt_tokens``                       -> ``gen_ai.usage.input_tokens``
+* ``usage.completion_tokens``                   -> ``gen_ai.usage.output_tokens``
+* ``usage.prompt_tokens_details.cached_tokens`` -> ``gen_ai.usage.cached_input_tokens``
+
+Tool-call accounting: each tool/function call present in ``choices[].message.tool_calls`` is emitted
+as its own attribute dict carrying ``gen_ai.tool.name`` / ``gen_ai.tool.call_id`` and the
+``gen_ai.operation.name == "tool"``, alongside the primary ``chat`` dict. This represents the
+cost/usage shape of tool-calling turns within the existing schema — the schema has a home for a tool
+name and id, but *not* for a raw tool-call count, so a count is intentionally omitted rather than
+fabricated as a new key (noted in the PR body).
+
+Defensive by construction: missing/null ``usage``, missing fields, and unexpected types never raise
+— the extractor returns whatever subset it can salvage. No message content or secrets are ever read,
+only usage/metadata.
+"""
+
+from __future__ import annotations
+
+from tally.schema import GenAI
+
+_SYSTEM = "openai"
+
+
+def _get(obj: object, key: str, default: object = None) -> object:
+    """Attribute-or-key accessor (supports SDK objects and plain dicts); never raises."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _as_int(value: object) -> int | None:
+    """Coerce to a non-negative int, or ``None`` if not a sane integer. ``bool`` is rejected."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value >= 0 else None
+
+
+def _as_str(value: object) -> str | None:
+    """Return ``value`` if it is a non-empty str, else ``None``."""
+    return value if isinstance(value, str) and value else None
+
+
+class OpenAIExtractorV1:
+    """Extractor for OpenAI Chat Completions responses (response shape v1)."""
+
+    key = "openai_v1"
+
+    def extract(self, response: object) -> list[dict[str, object]]:
+        """Return ``[chat_attrs, *tool_attrs]``. Never raises on malformed input."""
+        attrs: list[dict[str, object]] = [self._chat_attrs(response)]
+        attrs.extend(self._tool_attrs(response))
+        return attrs
+
+    def _chat_attrs(self, response: object) -> dict[str, object]:
+        """Primary ``chat`` attribute dict: system, model, and token usage."""
+        out: dict[str, object] = {GenAI.SYSTEM: _SYSTEM, GenAI.OPERATION_NAME: "chat"}
+
+        model = _as_str(_get(response, "model"))
+        if model is not None:
+            out[GenAI.RESPONSE_MODEL] = model
+
+        usage = _get(response, "usage")
+        prompt = _as_int(_get(usage, "prompt_tokens"))
+        if prompt is not None:
+            out[GenAI.USAGE_INPUT_TOKENS] = prompt
+        completion = _as_int(_get(usage, "completion_tokens"))
+        if completion is not None:
+            out[GenAI.USAGE_OUTPUT_TOKENS] = completion
+
+        details = _get(usage, "prompt_tokens_details")
+        cached = _as_int(_get(details, "cached_tokens"))
+        if cached is not None:
+            out[GenAI.USAGE_CACHED_INPUT_TOKENS] = cached
+
+        return out
+
+    def _tool_attrs(self, response: object) -> list[dict[str, object]]:
+        """One attribute dict per tool call across all choices; empty when there are none."""
+        out: list[dict[str, object]] = []
+        choices = _get(response, "choices")
+        if not isinstance(choices, (list, tuple)):
+            return out
+        for choice in choices:
+            message = _get(choice, "message")
+            tool_calls = _get(message, "tool_calls")
+            if not isinstance(tool_calls, (list, tuple)):
+                continue
+            for call in tool_calls:
+                attrs: dict[str, object] = {
+                    GenAI.SYSTEM: _SYSTEM,
+                    GenAI.OPERATION_NAME: "tool",
+                }
+                call_id = _as_str(_get(call, "id"))
+                if call_id is not None:
+                    attrs[GenAI.TOOL_CALL_ID] = call_id
+                name = _as_str(_get(_get(call, "function"), "name"))
+                if name is not None:
+                    attrs[GenAI.TOOL_NAME] = name
+                out.append(attrs)
+        return out
+
+
+# Register on import (the package __init__ imports this module for its side effect).
+from tally.extractors import register  # noqa: E402
+
+register(OpenAIExtractorV1())

--- a/sdk/python/tests/fixtures/openai/chat_completion_cached.json
+++ b/sdk/python/tests/fixtures/openai/chat_completion_cached.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Bx7Qe2cached0000000000000",
+  "object": "chat.completion",
+  "created": 1740000100,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Based on the lengthy document above, the answer is 42.",
+        "refusal": null,
+        "tool_calls": null
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 4096,
+    "completion_tokens": 16,
+    "total_tokens": 4112,
+    "prompt_tokens_details": {
+      "cached_tokens": 3840,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_cached00"
+}

--- a/sdk/python/tests/fixtures/openai/chat_completion_plain.json
+++ b/sdk/python/tests/fixtures/openai/chat_completion_plain.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-Bx7Qe2plain00000000000000",
+  "object": "chat.completion",
+  "created": 1740000000,
+  "model": "gpt-4o-mini-2024-07-18",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The capital of France is Paris.",
+        "refusal": null,
+        "tool_calls": null
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 24,
+    "completion_tokens": 8,
+    "total_tokens": 32,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_plain00"
+}

--- a/sdk/python/tests/fixtures/openai/chat_completion_tool_calls.json
+++ b/sdk/python/tests/fixtures/openai/chat_completion_tool_calls.json
@@ -1,0 +1,53 @@
+{
+  "id": "chatcmpl-Bx7Qe2tools0000000000000",
+  "object": "chat.completion",
+  "created": 1740000200,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "refusal": null,
+        "tool_calls": [
+          {
+            "id": "call_abc123weather",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\": \"Paris, FR\"}"
+            }
+          },
+          {
+            "id": "call_def456time",
+            "type": "function",
+            "function": {
+              "name": "get_current_time",
+              "arguments": "{\"timezone\": \"Europe/Paris\"}"
+            }
+          }
+        ]
+      },
+      "logprobs": null,
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 88,
+    "completion_tokens": 42,
+    "total_tokens": 130,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_tools00"
+}

--- a/sdk/python/tests/test_extractors.py
+++ b/sdk/python/tests/test_extractors.py
@@ -1,0 +1,168 @@
+"""CTO-41 — provider extractor framework, exercised against recorded OpenAI fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tally.extractors import (
+    ProviderExtractor,
+    available_extractors,
+    get_extractor,
+    register,
+)
+from tally.extractors.openai import OpenAIExtractorV1
+from tally.schema import GenAI, validate_span_attributes
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "openai"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text())
+
+
+# --- registry / pluggability -------------------------------------------------
+
+
+def test_get_extractor_returns_versioned_singleton():
+    ext = get_extractor("openai_v1")
+    assert isinstance(ext, OpenAIExtractorV1)
+    assert ext.key == "openai_v1"
+    assert ext is get_extractor("openai_v1")
+
+
+def test_openai_v1_is_listed():
+    assert "openai_v1" in available_extractors()
+
+
+def test_get_extractor_unknown_key_raises_keyerror():
+    with pytest.raises(KeyError):
+        get_extractor("does_not_exist_v9")
+
+
+def test_satisfies_protocol():
+    assert isinstance(OpenAIExtractorV1(), ProviderExtractor)
+
+
+def test_register_rejects_empty_key_and_duplicates():
+    class _NoKey:
+        key = ""
+
+        def extract(self, response):
+            return []
+
+    with pytest.raises(ValueError):
+        register(_NoKey())
+
+    class _Dup:
+        key = "openai_v1"
+
+        def extract(self, response):
+            return []
+
+    with pytest.raises(ValueError):
+        register(_Dup())
+
+
+def test_new_provider_registers_without_core_change():
+    """Adding a provider is registration-only; dispatch needs no edit."""
+
+    class _AcmeV1:
+        key = "acme_test_v1"
+
+        def extract(self, response):
+            return [{GenAI.SYSTEM: "acme"}]
+
+    register(_AcmeV1())
+    try:
+        assert get_extractor("acme_test_v1").extract(None) == [{GenAI.SYSTEM: "acme"}]
+    finally:
+        from tally.extractors import _REGISTRY
+
+        _REGISTRY.pop("acme_test_v1", None)
+
+
+# --- fixture-driven extraction -----------------------------------------------
+
+
+def test_plain_completion_maps_usage():
+    [chat] = get_extractor("openai_v1").extract(_load("chat_completion_plain.json"))
+    assert chat[GenAI.SYSTEM] == "openai"
+    assert chat[GenAI.OPERATION_NAME] == "chat"
+    assert chat[GenAI.RESPONSE_MODEL] == "gpt-4o-mini-2024-07-18"
+    assert chat[GenAI.USAGE_INPUT_TOKENS] == 24
+    assert chat[GenAI.USAGE_OUTPUT_TOKENS] == 8
+    assert chat[GenAI.USAGE_CACHED_INPUT_TOKENS] == 0
+    assert validate_span_attributes(chat) == []
+
+
+def test_cached_completion_maps_cached_input_tokens():
+    [chat] = get_extractor("openai_v1").extract(_load("chat_completion_cached.json"))
+    assert chat[GenAI.USAGE_INPUT_TOKENS] == 4096
+    assert chat[GenAI.USAGE_CACHED_INPUT_TOKENS] == 3840
+    assert validate_span_attributes(chat) == []
+
+
+def test_tool_calls_produce_one_attr_dict_each():
+    attrs = get_extractor("openai_v1").extract(_load("chat_completion_tool_calls.json"))
+    chat = attrs[0]
+    tools = attrs[1:]
+    assert chat[GenAI.OPERATION_NAME] == "chat"
+    assert chat[GenAI.USAGE_INPUT_TOKENS] == 88
+    assert len(tools) == 2
+    assert {t[GenAI.TOOL_NAME] for t in tools} == {"get_weather", "get_current_time"}
+    assert {t[GenAI.TOOL_CALL_ID] for t in tools} == {"call_abc123weather", "call_def456time"}
+    for t in tools:
+        assert t[GenAI.OPERATION_NAME] == "tool"
+        assert t[GenAI.SYSTEM] == "openai"
+        assert validate_span_attributes(t) == []
+
+
+def test_no_pii_or_secrets_in_attributes():
+    """Message content / arguments must never leak into attributes."""
+    attrs = get_extractor("openai_v1").extract(_load("chat_completion_tool_calls.json"))
+    blob = json.dumps(attrs)
+    assert "Paris" not in blob
+    assert "arguments" not in blob
+    assert "Europe/Paris" not in blob
+
+
+# --- never crash on malformed input ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        {},
+        {"usage": None},
+        {"usage": {}},
+        {"usage": {"prompt_tokens": "lots", "completion_tokens": 1.5}},
+        {"usage": {"prompt_tokens": True}},
+        {"usage": {"prompt_tokens": -5}},
+        {"usage": {"prompt_tokens_details": "nope"}},
+        {"model": 123, "usage": {"prompt_tokens": 10}},
+        {"choices": "not-a-list"},
+        {"choices": [None]},
+        {"choices": [{"message": {"tool_calls": "nope"}}]},
+        {"choices": [{"message": {"tool_calls": [None, {}]}}]},
+        "totally-wrong-type",
+        42,
+    ],
+)
+def test_never_raises_on_malformed_input(response):
+    out = get_extractor("openai_v1").extract(response)
+    assert isinstance(out, list)
+    for attrs in out:
+        # whatever subset survives must still be schema-conformant
+        assert validate_span_attributes(attrs) == []
+
+
+def test_malformed_usage_omits_bad_fields_but_keeps_system():
+    ext = OpenAIExtractorV1()
+    [chat] = ext.extract({"usage": {"prompt_tokens": "x", "completion_tokens": 9}})
+    assert chat[GenAI.SYSTEM] == "openai"
+    assert GenAI.USAGE_INPUT_TOKENS not in chat  # bad type dropped
+    assert chat[GenAI.USAGE_OUTPUT_TOKENS] == 9  # good field kept


### PR DESCRIPTION
## Summary
- Adds a pluggable, **versioned** provider-extractor framework in `tally.extractors` that maps raw provider responses into conformant `gen_ai.*` attribute dicts (`tally.schema`), independent of pricing/context/network.
- `ProviderExtractor` Protocol + a registry (`register` / `extractor` decorator / `get_extractor` / `available_extractors`). Adding a provider is **registration-only** — zero changes to dispatch.
- First extractor: `OpenAIExtractorV1`, registered under key `"openai_v1"`.

## What's covered
- **Usage mapping**: `usage.prompt_tokens` → `gen_ai.usage.input_tokens`, `usage.completion_tokens` → `gen_ai.usage.output_tokens`.
- **Prompt caching**: `usage.prompt_tokens_details.cached_tokens` → `gen_ai.usage.cached_input_tokens`.
- **Tool-call accounting**: one attribute dict per `choices[].message.tool_calls` entry, each with `gen_ai.tool.name`, `gen_ai.tool.call_id`, and `gen_ai.operation.name == "tool"` — so multi-tool turns produce one set of attrs per call.
- **Never crash**: missing/null `usage`, missing fields, and wrong types are coerced/dropped, never raised (parametrized over ~15 malformed inputs). Salvaged subsets still pass `validate_span_attributes`.
- **No PII / no secrets**: only usage/metadata read; message content and tool `arguments` are never touched (asserted in tests).
- **Fixture library**: hand-written realistic OpenAI Chat Completions responses under `sdk/python/tests/fixtures/openai/` — plain, cached, and tool_calls.

## Judgment calls / what's deferred
- **Tool-call count has no schema home**: the schema has `gen_ai.tool.name` / `gen_ai.tool.call_id` but no key for a raw count of tool calls in a turn. Per the ticket, I emit one attr dict per call (which makes the count derivable) rather than inventing a new schema key. The count is intentionally omitted as a standalone attribute.
- **Anthropic / Vertex extractors** are explicitly out of scope per CTO-41 — the framework is ready for them via registration alone.
- **Price lookup / cost** is CTO-52; extractors deliberately emit usage only, no cost.

## Test plan
- [x] `uv run --extra dev ruff check .` — clean (line length ≤ 100).
- [x] `uv run --extra dev pytest -q` — 203 passed (existing ~190 suite stays green).
- [x] Registry: versioned lookup, unknown-key `KeyError`, duplicate/empty-key `ValueError`, Protocol conformance, new-provider-without-core-change.
- [x] Fixture-driven: plain, cached, tool_calls assertions.
- [x] Never-crash parametrized over malformed inputs.
- [x] No PII/secrets leak assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)