### PR TITLE
gateway: in-memory customer provider-key vault (CTO-42)

### DIFF
--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "clickhouse-connect>=0.7.16",
     "psycopg[binary]>=3.2",
     "pydantic-settings>=2.4",
-    "tally",
+    "tally-sdk",
 ]
 
 [project.optional-dependencies]
@@ -21,7 +21,7 @@ dev = [
 
 [tool.uv.sources]
 # The gateway reuses the SDK's wire/enrichment/timekeeping/pricing logic directly.
-tally = { path = "../../sdk/python", editable = true }
+tally-sdk = { path = "../../sdk/python", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/infra/gateway/src/gateway/keyvault.py
+++ b/infra/gateway/src/gateway/keyvault.py
@@ -1,0 +1,191 @@
+"""In-memory customer provider-key vault — CTO-42 (spec §4.2 / §14.12).
+
+These are the *customer's* outbound provider bearer keys (OpenAI/Anthropic/etc.) that transit our
+proxy on their way to the upstream LLM. They are the top trust concern in the system, so this module
+exists as a single, small, auditable surface that guarantees:
+
+NEVER-LOG / NEVER-PERSIST GUARANTEE
+-----------------------------------
+* Raw key material lives **only in process memory**, keyed by ``(tenant_id, provider)``. It is never
+  written to logs, disk, or the control-plane DB. (Mirrors ``auth.py``, where ``api_keys.key_hash``
+  stores only a SHA-256 hash — keys are never stored raw.)
+* The secret is wrapped in :class:`pydantic.SecretStr`. Its ``repr``/``str`` render as ``**********``,
+  so the value cannot leak via accidental f-strings, logging, or exception messages.
+* :class:`ProviderKey` (the container) has a redacting ``__repr__``/``__str__`` of the form
+  ``ProviderKey(tenant=..., provider='openai', value='***redacted***')``.
+* The raw value is reachable through exactly **one** explicit, named accessor,
+  :meth:`ProviderKey.reveal`, which is intended to be called at the single point of egress: building
+  the outbound provider request. No other method returns raw key material.
+
+ROTATION (config-refresh channel; spec §4.2)
+--------------------------------------------
+:meth:`ProviderKeyVault.apply_refresh` performs an atomic per-tenant swap so the control plane can
+rotate or revoke keys without a redeploy. :meth:`upsert`, :meth:`revoke`, and :meth:`rotate` are thin
+helpers over it. A rotation takes effect immediately for subsequent lookups; in-flight requests
+already holding a revealed value are out of scope.
+
+CONTROL-PLANE PARTITION POLICY (spec §14.12)
+--------------------------------------------
+When the control plane is unreachable we apply an asymmetric, deliberately-conservative policy:
+
+* **Fail-open on routing** — keep serving with the last-known-good cached key. Losing the control
+  plane should not take down a customer's traffic (availability). See :func:`should_allow_routing`.
+* **Fail-closed on guardrails** — a newly-added guardrail/deny must block even while partitioned. A
+  safety control we *intended* to apply must never be silently dropped because we couldn't confirm it
+  (safety). See :func:`should_apply_guardrail`.
+
+The asymmetry is the whole point: availability is recoverable, a leaked/unguarded request is not.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+
+from pydantic import SecretStr
+
+__all__ = [
+    "ProviderKey",
+    "ProviderKeyVault",
+    "GuardrailState",
+    "should_allow_routing",
+    "should_apply_guardrail",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderKey:
+    """A single customer provider key held in memory.
+
+    The raw secret is wrapped in :class:`~pydantic.SecretStr`; obtain it only via :meth:`reveal`,
+    which is the sole egress accessor. ``repr``/``str`` are redacted so this object is safe to log.
+    """
+
+    tenant_id: str
+    provider: str
+    _secret: SecretStr
+
+    @classmethod
+    def create(cls, tenant_id: str, provider: str, value: str) -> ProviderKey:
+        """Build a key from a raw string, wrapping it immediately so it is never stored bare."""
+        return cls(tenant_id=tenant_id, provider=provider, _secret=SecretStr(value))
+
+    def reveal(self) -> str:
+        """Return the raw secret. **Only** call this at the point of egress (outbound request).
+
+        This is the single named accessor for raw key material. Do not log, store, or pass its
+        return value anywhere it could be persisted.
+        """
+        return self._secret.get_secret_value()
+
+    def __repr__(self) -> str:
+        return (
+            f"ProviderKey(tenant={self.tenant_id!r}, provider={self.provider!r}, "
+            "value='***redacted***')"
+        )
+
+    __str__ = __repr__
+
+
+@dataclass(slots=True)
+class ProviderKeyVault:
+    """Thread-safe, in-memory store of provider keys keyed by ``(tenant_id, provider)``.
+
+    Nothing here touches disk, the DB, or a logger. Mutations take a lock so refresh/rotate swaps are
+    atomic with respect to lookups.
+    """
+
+    _keys: dict[tuple[str, str], ProviderKey] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def get(self, tenant_id: str, provider: str) -> ProviderKey | None:
+        """Return the cached key for ``(tenant_id, provider)``, or ``None`` if absent/revoked."""
+        with self._lock:
+            return self._keys.get((tenant_id, provider))
+
+    def has_key(self, tenant_id: str, provider: str) -> bool:
+        """Whether a usable cached key exists — used by :func:`should_allow_routing`."""
+        return self.get(tenant_id, provider) is not None
+
+    def upsert(self, tenant_id: str, provider: str, value: str) -> ProviderKey:
+        """Insert or replace a single key. Returns the stored (redacting) :class:`ProviderKey`."""
+        key = ProviderKey.create(tenant_id, provider, value)
+        with self._lock:
+            self._keys[(tenant_id, provider)] = key
+        return key
+
+    def revoke(self, tenant_id: str, provider: str) -> None:
+        """Remove a key so subsequent lookups miss. Idempotent."""
+        with self._lock:
+            self._keys.pop((tenant_id, provider), None)
+
+    def rotate(self, tenant_id: str, provider: str, new_value: str) -> ProviderKey:
+        """Atomically replace a tenant's key for ``provider``; effective for the next lookup."""
+        return self.upsert(tenant_id, provider, new_value)
+
+    def apply_refresh(
+        self,
+        tenant_id: str,
+        keys: dict[str, str],
+        *,
+        prune: bool = True,
+    ) -> None:
+        """Atomically swap *all* of a tenant's provider keys to ``keys`` ({provider: raw_value}).
+
+        This is the config-refresh entry point that lets the control plane rotate/revoke without a
+        redeploy. The swap holds the lock for the whole tenant so a lookup never observes a partial
+        update. When ``prune`` is true (default), providers absent from ``keys`` are revoked,
+        matching the control plane's full-snapshot semantics.
+        """
+        # Wrap secrets before taking the lock to keep the critical section tiny.
+        rebuilt = {
+            provider: ProviderKey.create(tenant_id, provider, value)
+            for provider, value in keys.items()
+        }
+        with self._lock:
+            if prune:
+                stale = [k for k in self._keys if k[0] == tenant_id and k[1] not in keys]
+                for k in stale:
+                    del self._keys[k]
+            for provider, key in rebuilt.items():
+                self._keys[(tenant_id, provider)] = key
+
+
+class GuardrailState(Enum):
+    """Intended state of a guardrail as last known from the control plane.
+
+    ``PENDING`` means a guardrail was newly added/changed but we could not confirm it because the
+    control plane is partitioned — we must fail closed on it.
+    """
+
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+    PENDING = "pending"
+
+
+def should_allow_routing(partitioned: bool, have_cached_key: bool) -> bool:
+    """Fail-open on routing: serve as long as a last-known-good cached key exists.
+
+    A control-plane partition must not take down customer traffic, so when ``partitioned`` we keep
+    routing on the last-known-good cached key. Routing always requires an actual cached key to be
+    present — there is nothing to serve without one, partitioned or not. The fail-*open* property is
+    precisely that a partition does **not** flip a present key to a deny.
+    """
+    return have_cached_key
+
+
+def should_apply_guardrail(partitioned: bool, guardrail_state: GuardrailState) -> bool:
+    """Fail-closed on guardrails: apply (block) whenever the guardrail isn't confirmed-disabled.
+
+    A guardrail explicitly known to be ``DISABLED`` is not applied. Anything else — ``ENABLED``, or a
+    ``PENDING`` change we couldn't confirm because we're ``partitioned`` — is applied. A safety
+    control we *meant* to enforce must never be dropped just because the control plane is unreachable.
+    """
+    if guardrail_state is GuardrailState.DISABLED:
+        return False
+    if guardrail_state is GuardrailState.ENABLED:
+        return True
+    # PENDING: apply if we can't confirm it (partitioned). If we're connected, a still-PENDING state
+    # means the control plane hasn't promoted it to ENABLED yet, so don't apply.
+    return partitioned

--- a/infra/gateway/tests/test_keyvault.py
+++ b/infra/gateway/tests/test_keyvault.py
@@ -1,0 +1,172 @@
+"""Pure tests for the in-memory provider-key vault (CTO-42, spec §4.2 / §14.12).
+
+No infra, network, or filesystem — this is the audit surface for the never-log/never-persist
+guarantee and the fail-open-routing / fail-closed-guardrail policy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.keyvault import (
+    GuardrailState,
+    ProviderKey,
+    ProviderKeyVault,
+    should_allow_routing,
+    should_apply_guardrail,
+)
+
+SECRET = "sk-super-secret-customer-key-1234567890"
+
+
+# --- never-log / never-persist guarantee ---------------------------------------------------------
+
+
+def test_repr_and_str_redact_the_secret() -> None:
+    key = ProviderKey.create("t1", "openai", SECRET)
+    for rendered in (repr(key), str(key), f"{key}", f"{key!r}"):
+        assert SECRET not in rendered
+        assert "redacted" in rendered
+    assert "openai" in repr(key)  # non-secret metadata is fine to show
+
+
+def test_secret_does_not_leak_via_exception_message() -> None:
+    key = ProviderKey.create("t1", "openai", SECRET)
+    try:
+        raise ValueError(f"failed to use {key}")  # accidental f-string of the container
+    except ValueError as exc:
+        assert SECRET not in str(exc)
+
+
+def test_pydantic_secret_wrapper_is_redacted_in_repr() -> None:
+    key = ProviderKey.create("t1", "openai", SECRET)
+    # The wrapped SecretStr itself must not render the value.
+    assert SECRET not in repr(key._secret)
+
+
+def test_only_explicit_accessor_returns_raw_value() -> None:
+    key = ProviderKey.create("t1", "openai", SECRET)
+    assert key.reveal() == SECRET
+    # No other zero-arg public attribute/method exposes the raw value.
+    for name in dir(key):
+        if name in ("reveal", "create") or name.startswith("__"):
+            continue
+        attr = getattr(key, name)
+        try:
+            value = attr() if callable(attr) else attr
+        except TypeError:
+            continue  # requires args; not a passive leak
+        assert value != SECRET, f"raw secret leaked via {name!r}"
+
+
+# --- vault CRUD + lookups ------------------------------------------------------------------------
+
+
+def test_upsert_and_get_roundtrip() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t1", "openai", SECRET)
+    got = vault.get("t1", "openai")
+    assert got is not None
+    assert got.reveal() == SECRET
+    assert vault.has_key("t1", "openai")
+
+
+def test_get_miss_returns_none() -> None:
+    vault = ProviderKeyVault()
+    assert vault.get("t1", "openai") is None
+    assert not vault.has_key("t1", "openai")
+
+
+def test_revoke_is_idempotent() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t1", "openai", SECRET)
+    vault.revoke("t1", "openai")
+    vault.revoke("t1", "openai")  # no error second time
+    assert vault.get("t1", "openai") is None
+
+
+def test_keys_are_partitioned_by_tenant_and_provider() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t1", "openai", "a-key")
+    vault.upsert("t1", "anthropic", "b-key")
+    vault.upsert("t2", "openai", "c-key")
+    assert vault.get("t1", "openai").reveal() == "a-key"
+    assert vault.get("t1", "anthropic").reveal() == "b-key"
+    assert vault.get("t2", "openai").reveal() == "c-key"
+
+
+# --- rotation (config-refresh channel) -----------------------------------------------------------
+
+
+def test_rotate_takes_effect_immediately() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t1", "openai", "old-key")
+    vault.rotate("t1", "openai", "new-key")
+    assert vault.get("t1", "openai").reveal() == "new-key"
+
+
+def test_apply_refresh_swaps_all_tenant_keys_and_prunes() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t1", "openai", "old-openai")
+    vault.upsert("t1", "anthropic", "old-anthropic")
+    vault.apply_refresh("t1", {"openai": "new-openai"})
+    assert vault.get("t1", "openai").reveal() == "new-openai"
+    # anthropic was absent from the snapshot -> pruned (revoked).
+    assert vault.get("t1", "anthropic") is None
+
+
+def test_apply_refresh_no_prune_keeps_unlisted() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t1", "anthropic", "keep-me")
+    vault.apply_refresh("t1", {"openai": "new-openai"}, prune=False)
+    assert vault.get("t1", "anthropic").reveal() == "keep-me"
+    assert vault.get("t1", "openai").reveal() == "new-openai"
+
+
+def test_apply_refresh_does_not_touch_other_tenants() -> None:
+    vault = ProviderKeyVault()
+    vault.upsert("t2", "openai", "tenant-2-key")
+    vault.apply_refresh("t1", {"openai": "tenant-1-key"})
+    assert vault.get("t2", "openai").reveal() == "tenant-2-key"
+
+
+# --- control-plane partition policy --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("partitioned", "have_cached_key", "expected"),
+    [
+        (False, True, True),  # connected + key -> allow
+        (False, False, False),  # connected, no key -> deny (nothing to serve)
+        (True, True, True),  # partitioned but cached key -> fail open (availability)
+        (True, False, False),  # partitioned, no cached key -> deny
+    ],
+)
+def test_should_allow_routing_fails_open_with_cached_key(
+    partitioned: bool, have_cached_key: bool, expected: bool
+) -> None:
+    assert should_allow_routing(partitioned, have_cached_key) is expected
+
+
+@pytest.mark.parametrize(
+    ("partitioned", "state", "expected"),
+    [
+        (False, GuardrailState.DISABLED, False),
+        (True, GuardrailState.DISABLED, False),  # explicitly disabled -> never apply
+        (False, GuardrailState.ENABLED, True),
+        (True, GuardrailState.ENABLED, True),  # enabled -> always apply
+        (True, GuardrailState.PENDING, True),  # partitioned + unconfirmed -> fail closed
+        (False, GuardrailState.PENDING, False),  # connected + not yet promoted -> not applied
+    ],
+)
+def test_should_apply_guardrail_fails_closed(
+    partitioned: bool, state: GuardrailState, expected: bool
+) -> None:
+    assert should_apply_guardrail(partitioned, state) is expected
+
+
+def test_partition_policy_is_asymmetric() -> None:
+    # The defining property: under partition with no confirmation, routing stays up (open) while a
+    # pending guardrail still blocks (closed).
+    assert should_allow_routing(partitioned=True, have_cached_key=True) is True
+    assert should_apply_guardrail(True, GuardrailState.PENDING) is True


### PR DESCRIPTION
## Summary
Implements **CTO-42 — Customer API key handling (never persist/log, in-memory only)**. Adds a single, auditable module, `infra/gateway/src/gateway/keyvault.py`, that holds customers' outbound provider bearer keys (OpenAI/etc.) in process memory only, plus pure partition-policy helpers. Tests in `infra/gateway/tests/test_keyvault.py` (29 cases, all passing).

Also fixes the gateway's broken SDK dependency so `uv` can build the package: `"tally"` → `"tally-sdk"` and the `[tool.uv.sources]` key `tally` → `tally-sdk` (the SDK's distribution name is `tally-sdk`). This same fix exists on other open branches and merges cleanly.

## Security guarantee
- **In-memory only, never persisted/logged.** Keys live in a `dict` keyed by `(tenant_id, provider)` — never written to logs, disk, or the DB. Mirrors `auth.py`, where `api_keys.key_hash` stores only a SHA-256 hash.
- Secrets wrapped in `pydantic.SecretStr`. `ProviderKey.__repr__`/`__str__` render `value='***redacted***'`, so the value can't leak via f-strings, logging, or exception messages.
- Raw value reachable only via one explicit egress accessor, `ProviderKey.reveal()`. A secret-scan-style test asserts `repr`/`str`/exception messages never contain the secret, and that no other passive accessor returns it.
- **Rotation without redeploy:** `apply_refresh()` (atomic per-tenant snapshot swap) plus `upsert`/`revoke`/`rotate`; effective on the next lookup. In-flight requests out of scope per ticket.
- **Partition policy (asymmetric, pure + unit-tested):** `should_allow_routing()` fails *open* (serve on last-known-good cached key for availability); `should_apply_guardrail()` fails *closed* (a pending/unconfirmed guardrail still blocks while partitioned, for safety).

## Deferred (out of scope per ticket)
- Vertex GCP-OAuth token mint/refresh.
- BYO-deployment.
- Wiring into `app.py` / a config-refresh HTTP endpoint — ticket scope is the vault + policy primitives; delivered standalone.

## Test plan
- [x] `uv run --extra dev ruff check .` from `infra/gateway` — clean (line-length 100).
- [x] `uv run --extra dev pytest -q` from `infra/gateway` — 29 passed; existing gateway suite unbroken.
- [x] Secret-scan test: `repr`/`str`/exception messages never contain the raw key.
- [x] Only `reveal()` returns the raw value.
- [x] Rotation/refresh takes effect immediately; tenant/provider partitioning verified.
- [x] Fail-open routing / fail-closed guardrail truth tables parametrized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)