### PR TITLE
sdk: versioned + audited per-tenant price overrides (CTO-54)

### DIFF
--- a/sdk/python/src/tally/overrides.py
+++ b/sdk/python/src/tally/overrides.py
@@ -1,0 +1,290 @@
+"""Per-tenant price overrides — versioned + audited (CTO-54, spec §6).
+
+Enterprise / committed-use customers negotiate custom provider rates; their cost must reflect their
+*contract*, not list price. :mod:`tally.pricing` already supports per-tenant override entries that
+take precedence over the public catalog (see :meth:`PriceCatalog.add_override` /
+:meth:`PriceCatalog.lookup`). What it lacks — and what this module adds — is the **governance
+layer**:
+
+* **Versioned.** Every override slot ``(tenant_id, provider, model, price_type)`` carries a
+  monotonic integer version. Re-pricing the same slot bumps the version and records which prior
+  version it supersedes, so historical cost can be recomputed against the rate that was in force and
+  a later correction never silently rewrites the past.
+* **Audited.** Changes are an **append-only ledger** — nothing is ever mutated or deleted in
+  place. Each entry captures *who* (``actor``), *why* (``reason``), and *when* (``recorded_at``,
+  UTC). A revocation is a tombstone entry, not a deletion, so the audit trail is complete and
+  tamper-evident by construction (append-only + monotonic versions).
+
+The ledger is the source of truth; :meth:`OverrideLedger.apply_to_catalog` materializes the
+currently *active* overrides onto a freshly-seeded :class:`~tally.pricing.PriceCatalog` so the cost
+path (:func:`tally.enrichment.enrich_cost`, which already threads ``tenant_id``) picks them up with
+no further wiring. Pure logic — no infra, no clock except an injectable ``now`` for deterministic
+tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from tally.pricing import PriceCatalog, PriceEntry, PriceType, Unit
+from tally.schema import DEFAULT_CURRENCY
+
+__all__ = [
+    "OverrideRecord",
+    "OverrideLedger",
+]
+
+# A slot is the unique target of an override: one rate for one tenant/provider/model/price_type.
+_Slot = tuple[str, str, str, PriceType]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_decimal(value: Decimal | str | int) -> Decimal:
+    """Coerce a price to :class:`~decimal.Decimal` — never via float (this is money)."""
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+@dataclass(frozen=True, slots=True)
+class OverrideRecord:
+    """One immutable, audited entry in the override ledger.
+
+    A record either sets a rate (``price_per_unit`` is a :class:`~decimal.Decimal`) or *revokes* the
+    slot (``price_per_unit is None`` — a tombstone). Records are never mutated; a change appends a
+    new record with the next ``version`` for its slot and a ``supersedes`` back-reference.
+    """
+
+    tenant_id: str
+    provider: str
+    model: str
+    price_type: PriceType
+    version: int
+    unit: Unit
+    price_per_unit: Decimal | None
+    valid_from: date
+    valid_to: date | None
+    actor: str
+    reason: str
+    recorded_at: datetime
+    supersedes: int | None
+    currency: str = DEFAULT_CURRENCY
+
+    @property
+    def slot(self) -> _Slot:
+        return (self.tenant_id, self.provider, self.model, self.price_type)
+
+    @property
+    def revoked(self) -> bool:
+        """True when this entry revokes the slot (a tombstone) rather than setting a rate."""
+        return self.price_per_unit is None
+
+    def to_price_entry(self) -> PriceEntry | None:
+        """Project an active rate onto a :class:`~tally.pricing.PriceEntry`; ``None`` if revoked.
+
+        The catalog version is the slot's audit version, stringified, so a span's recorded
+        ``price_catalog_version`` distinguishes an override-priced cost from a public-catalog one.
+        """
+        if self.price_per_unit is None:
+            return None
+        return PriceEntry(
+            version=f"override-{self.tenant_id}-v{self.version}",
+            valid_from=self.valid_from,
+            provider=self.provider,
+            model=self.model,
+            price_type=self.price_type,
+            unit=self.unit,
+            price_per_unit=self.price_per_unit,
+            currency=self.currency,
+            valid_to=self.valid_to,
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        """JSON-friendly audit view (Decimal/date/datetime rendered as strings)."""
+        return {
+            "tenant_id": self.tenant_id,
+            "provider": self.provider,
+            "model": self.model,
+            "price_type": self.price_type.value,
+            "version": self.version,
+            "unit": self.unit.value,
+            "price_per_unit": None if self.price_per_unit is None else str(self.price_per_unit),
+            "valid_from": self.valid_from.isoformat(),
+            "valid_to": None if self.valid_to is None else self.valid_to.isoformat(),
+            "actor": self.actor,
+            "reason": self.reason,
+            "recorded_at": self.recorded_at.isoformat(),
+            "supersedes": self.supersedes,
+            "currency": self.currency,
+            "revoked": self.revoked,
+        }
+
+
+class OverrideLedger:
+    """Append-only, versioned ledger of per-tenant price overrides.
+
+    Mutations (:meth:`upsert`, :meth:`revoke`) only ever *append* a new :class:`OverrideRecord`; the
+    full history is retained for audit. :meth:`active` returns the current effective overrides
+    (latest non-revoked record per slot), and :meth:`apply_to_catalog` materializes them onto a
+    catalog.
+    """
+
+    def __init__(self, *, now: Callable[[], datetime] = _utcnow) -> None:
+        self._now = now
+        self._records: list[OverrideRecord] = []
+        # latest version assigned per slot (monotonic; never reused even across revoke→re-add)
+        self._version: dict[_Slot, int] = {}
+
+    # --- mutation (append-only) ------------------------------------------------------------------
+
+    def upsert(
+        self,
+        tenant_id: str,
+        provider: str,
+        model: str,
+        price_type: PriceType,
+        price_per_unit: Decimal | str | int,
+        *,
+        actor: str,
+        reason: str,
+        unit: Unit = Unit.PER_MILLION_TOKENS,
+        valid_from: date | None = None,
+        valid_to: date | None = None,
+        currency: str = DEFAULT_CURRENCY,
+    ) -> OverrideRecord:
+        """Set (or re-price) a tenant's override for a slot. Appends a new versioned record.
+
+        ``price_per_unit`` is coerced to :class:`~decimal.Decimal` (accepts str/int) — never a
+        float, because this is money. ``actor`` and ``reason`` are required for the audit trail.
+        """
+        now = self._now()
+        return self._append(
+            tenant_id, provider, model, price_type,
+            unit=unit, price_per_unit=_to_decimal(price_per_unit),
+            valid_from=valid_from or now.date(), valid_to=valid_to,
+            actor=actor, reason=reason, currency=currency, now=now,
+        )
+
+    def revoke(
+        self,
+        tenant_id: str,
+        provider: str,
+        model: str,
+        price_type: PriceType,
+        *,
+        actor: str,
+        reason: str,
+    ) -> OverrideRecord:
+        """Revoke a tenant's override for a slot (records a tombstone; cost falls back to public).
+
+        Idempotent in effect: revoking an already-absent/revoked slot still appends an audited
+        tombstone (the request itself is part of the trail), but :meth:`active` will simply not
+        surface the slot.
+        """
+        prev = self._current(tenant_id, provider, model, price_type)
+        unit = prev.unit if prev is not None else Unit.PER_MILLION_TOKENS
+        currency = prev.currency if prev is not None else DEFAULT_CURRENCY
+        now = self._now()
+        return self._append(
+            tenant_id, provider, model, price_type,
+            unit=unit, price_per_unit=None,
+            valid_from=now.date(), valid_to=None,
+            actor=actor, reason=reason, currency=currency, now=now,
+        )
+
+    def _append(
+        self,
+        tenant_id: str,
+        provider: str,
+        model: str,
+        price_type: PriceType,
+        *,
+        unit: Unit,
+        price_per_unit: Decimal | None,
+        valid_from: date,
+        valid_to: date | None,
+        actor: str,
+        reason: str,
+        currency: str,
+        now: datetime,
+    ) -> OverrideRecord:
+        slot: _Slot = (tenant_id, provider, model, price_type)
+        prev_version = self._version.get(slot)
+        version = (prev_version or 0) + 1
+        record = OverrideRecord(
+            tenant_id=tenant_id,
+            provider=provider,
+            model=model,
+            price_type=price_type,
+            version=version,
+            unit=unit,
+            price_per_unit=price_per_unit,
+            valid_from=valid_from,
+            valid_to=valid_to,
+            actor=actor,
+            reason=reason,
+            recorded_at=now,
+            supersedes=prev_version,
+            currency=currency,
+        )
+        self._records.append(record)
+        self._version[slot] = version
+        return record
+
+    # --- query -----------------------------------------------------------------------------------
+
+    def _current(
+        self, tenant_id: str, provider: str, model: str, price_type: PriceType
+    ) -> OverrideRecord | None:
+        slot: _Slot = (tenant_id, provider, model, price_type)
+        for record in reversed(self._records):
+            if record.slot == slot:
+                return record
+        return None
+
+    def current(
+        self, tenant_id: str, provider: str, model: str, price_type: PriceType
+    ) -> OverrideRecord | None:
+        """Latest record for a slot (set *or* tombstone), or ``None`` if the slot is untouched."""
+        return self._current(tenant_id, provider, model, price_type)
+
+    def active(self, tenant_id: str | None = None) -> list[OverrideRecord]:
+        """Currently effective overrides — latest non-revoked record per slot.
+
+        Pass ``tenant_id`` to scope to one tenant. A slot whose latest record is a tombstone is
+        omitted (it has fallen back to the public catalog).
+        """
+        latest: dict[_Slot, OverrideRecord] = {}
+        for record in self._records:
+            if tenant_id is not None and record.tenant_id != tenant_id:
+                continue
+            latest[record.slot] = record  # records are appended in order → last write wins
+        return [r for r in latest.values() if not r.revoked]
+
+    def history(
+        self, tenant_id: str | None = None, *, slot: _Slot | None = None
+    ) -> list[OverrideRecord]:
+        """Append-only audit trail, in insertion order. Optionally filtered by tenant or slot."""
+        out = self._records
+        if tenant_id is not None:
+            out = [r for r in out if r.tenant_id == tenant_id]
+        if slot is not None:
+            out = [r for r in out if r.slot == slot]
+        return list(out)
+
+    # --- integration -----------------------------------------------------------------------------
+
+    def apply_to_catalog(self, catalog: PriceCatalog, *, tenant_id: str | None = None) -> None:
+        """Materialize the active overrides onto ``catalog`` via :meth:`PriceCatalog.add_override`.
+
+        Intended for a *freshly seeded* catalog (the override entries are appended, so calling twice
+        on the same catalog would double-register). Rebuild the catalog when the ledger changes.
+        """
+        for record in self.active(tenant_id):
+            entry = record.to_price_entry()
+            if entry is not None:
+                catalog.add_override(record.tenant_id, entry)

--- a/sdk/python/tests/test_overrides.py
+++ b/sdk/python/tests/test_overrides.py
@@ -1,0 +1,245 @@
+"""Versioned + audited per-tenant price overrides (CTO-54)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from tally.overrides import OverrideLedger, OverrideRecord
+from tally.pricing import (
+    PriceType,
+    Unit,
+    Usage,
+    compute_cost_micro_usd,
+    seed_catalog,
+)
+
+
+class _Clock:
+    """Deterministic, monotonic injectable clock."""
+
+    def __init__(self, start: datetime) -> None:
+        self._t = start
+
+    def __call__(self) -> datetime:
+        t = self._t
+        self._t = t.replace(microsecond=(t.microsecond + 1))
+        return t
+
+
+def _ledger(*, when: datetime | None = None) -> OverrideLedger:
+    return OverrideLedger(now=_Clock(when or datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)))
+
+
+# --- versioning ----------------------------------------------------------------------------------
+
+
+def test_first_override_is_version_1_with_no_supersedes() -> None:
+    led = _ledger()
+    rec = led.upsert("tenant_a", "openai", "gpt-5", PriceType.INPUT, "1.00",
+                     actor="alice", reason="committed-use contract")
+    assert rec.version == 1
+    assert rec.supersedes is None
+    assert rec.price_per_unit == Decimal("1.00")
+
+
+def test_repricing_same_slot_bumps_version_and_links_supersedes() -> None:
+    led = _ledger()
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.00", actor="a", reason="v1")
+    v2 = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "0.80", actor="b", reason="renego")
+    assert v2.version == 2
+    assert v2.supersedes == 1
+    assert led.current("t", "openai", "gpt-5", PriceType.INPUT).price_per_unit == Decimal("0.80")
+
+
+def test_versions_are_monotonic_across_revoke_and_readd() -> None:
+    led = _ledger()
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.00", actor="a", reason="v1")
+    led.revoke("t", "openai", "gpt-5", PriceType.INPUT, actor="a", reason="contract ended")
+    readd = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "0.90", actor="a", reason="renewed")
+    # never reused: v1 set, v2 tombstone, v3 set
+    assert readd.version == 3
+    assert readd.supersedes == 2
+
+
+def test_distinct_slots_version_independently() -> None:
+    led = _ledger()
+    a = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="a", reason="r")
+    b = led.upsert("t", "openai", "gpt-5", PriceType.OUTPUT, "5.0", actor="a", reason="r")
+    assert a.version == 1 and b.version == 1  # separate slots, separate counters
+
+
+# --- money is Decimal, never float ---------------------------------------------------------------
+
+
+def test_price_coerced_to_decimal_not_float() -> None:
+    led = _ledger()
+    rec = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, 2, actor="a", reason="int input")
+    assert isinstance(rec.price_per_unit, Decimal)
+    assert rec.price_per_unit == Decimal("2")
+
+
+# --- revoke is a tombstone, not a deletion -------------------------------------------------------
+
+
+def test_revoke_records_tombstone_and_drops_from_active() -> None:
+    led = _ledger()
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.00", actor="a", reason="v1")
+    tomb = led.revoke("t", "openai", "gpt-5", PriceType.INPUT, actor="a", reason="ended")
+    assert tomb.revoked is True
+    assert tomb.price_per_unit is None
+    assert led.active("t") == []  # no longer effective
+    # but the trail is intact
+    assert len(led.history("t")) == 2
+
+
+def test_active_returns_latest_nonrevoked_per_slot() -> None:
+    led = _ledger()
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.00", actor="a", reason="v1")
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "0.50", actor="a", reason="v2")
+    active = led.active("t")
+    assert len(active) == 1
+    assert active[0].price_per_unit == Decimal("0.50")
+    assert active[0].version == 2
+
+
+# --- audit trail ---------------------------------------------------------------------------------
+
+
+def test_history_is_append_only_and_ordered() -> None:
+    led = _ledger()
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="a", reason="first")
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "0.9", actor="b", reason="second")
+    led.revoke("t", "openai", "gpt-5", PriceType.INPUT, actor="c", reason="third")
+    hist = led.history("t")
+    assert [r.version for r in hist] == [1, 2, 3]
+    assert [r.actor for r in hist] == ["a", "b", "c"]
+    assert [r.reason for r in hist] == ["first", "second", "third"]
+
+
+def test_audit_fields_captured_who_why_when() -> None:
+    ts = datetime(2026, 6, 1, 9, 30, 0, tzinfo=timezone.utc)
+    led = _ledger(when=ts)
+    rec = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.0",
+                     actor="cfo@acme.test", reason="Q3 committed-use amendment")
+    assert rec.actor == "cfo@acme.test"
+    assert rec.reason == "Q3 committed-use amendment"
+    assert rec.recorded_at == ts
+
+
+def test_record_as_dict_is_json_friendly() -> None:
+    led = _ledger()
+    rec = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.25", actor="a", reason="r")
+    d = rec.as_dict()
+    assert d["price_per_unit"] == "1.25"  # Decimal rendered as string
+    assert d["price_type"] == "input"
+    assert d["revoked"] is False
+    assert isinstance(d["recorded_at"], str)
+
+
+# --- tenant scoping ------------------------------------------------------------------------------
+
+
+def test_active_scopes_by_tenant() -> None:
+    led = _ledger()
+    led.upsert("tenant_a", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="a", reason="r")
+    led.upsert("tenant_b", "openai", "gpt-5", PriceType.INPUT, "2.0", actor="a", reason="r")
+    assert {r.tenant_id for r in led.active("tenant_a")} == {"tenant_a"}
+    assert len(led.active()) == 2  # unscoped sees both
+
+
+# --- validity window -----------------------------------------------------------------------------
+
+
+def test_valid_from_defaults_to_now_and_window_honored() -> None:
+    ts = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+    led = _ledger(when=ts)
+    rec = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="a", reason="r")
+    assert rec.valid_from == date(2026, 7, 1)
+    entry = rec.to_price_entry()
+    assert entry is not None
+    assert entry.is_valid_at(date(2026, 7, 1))
+    assert not entry.is_valid_at(date(2026, 6, 30))
+
+
+def test_revoked_record_has_no_price_entry() -> None:
+    led = _ledger()
+    led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="a", reason="r")
+    tomb = led.revoke("t", "openai", "gpt-5", PriceType.INPUT, actor="a", reason="r")
+    assert tomb.to_price_entry() is None
+
+
+# --- integration: override precedence in the real cost path --------------------------------------
+
+
+def test_override_takes_precedence_over_public_catalog_in_cost() -> None:
+    cat = seed_catalog()
+    led = _ledger()
+    # public gpt-5 input is 2.50/Mtok; this tenant negotiated 1.00.
+    rec = led.upsert("vip", "openai", "gpt-5", PriceType.INPUT, "1.00", actor="a", reason="deal")
+    led.apply_to_catalog(cat)
+
+    usage = Usage(input_tokens=1_000_000, output_tokens=0)
+    at = date(2026, 5, 15)
+    vip_cost, _ = compute_cost_micro_usd(
+        cat, "openai", "gpt-5", usage, at=at, tenant_id="vip"
+    )
+    public_cost, _ = compute_cost_micro_usd(
+        cat, "openai", "gpt-5", usage, at=at, tenant_id="other"
+    )
+    assert vip_cost < public_cost  # override is cheaper
+    assert vip_cost == 1_000_000  # 1.00 USD == 1_000_000 micro-USD for 1M tokens
+    # the materialized override entry carries the audit version, distinguishing it from list price.
+    entry = rec.to_price_entry()
+    assert entry is not None and entry.version == "override-vip-v1"
+
+
+def test_apply_to_catalog_skips_revoked_so_cost_falls_back() -> None:
+    cat = seed_catalog()
+    led = _ledger()
+    led.upsert("vip", "openai", "gpt-5", PriceType.INPUT, "1.00", actor="a", reason="c")
+    led.revoke("vip", "openai", "gpt-5", PriceType.INPUT, actor="a", reason="ended")
+    led.apply_to_catalog(cat)
+
+    usage = Usage(input_tokens=1_000_000, output_tokens=0)
+    at = date(2026, 5, 15)
+    vip_cost, _ = compute_cost_micro_usd(cat, "openai", "gpt-5", usage, at=at, tenant_id="vip")
+    public_cost, _ = compute_cost_micro_usd(cat, "openai", "gpt-5", usage, at=at, tenant_id="x")
+    assert vip_cost == public_cost  # revoked → back to list price
+
+
+def test_apply_to_catalog_can_scope_to_one_tenant() -> None:
+    cat = seed_catalog()
+    led = _ledger()
+    led.upsert("a", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="x", reason="r")
+    led.upsert("b", "openai", "gpt-5", PriceType.INPUT, "0.5", actor="x", reason="r")
+    led.apply_to_catalog(cat, tenant_id="b")
+    at = date(2026, 5, 15)
+    usage = Usage(input_tokens=1_000_000)
+    # tenant a not applied → public 2.50; tenant b applied → 0.50
+    a_cost, _ = compute_cost_micro_usd(cat, "openai", "gpt-5", usage, at=at, tenant_id="a")
+    b_cost, _ = compute_cost_micro_usd(cat, "openai", "gpt-5", usage, at=at, tenant_id="b")
+    assert a_cost == 2_500_000
+    assert b_cost == 500_000
+
+
+# --- record immutability -------------------------------------------------------------------------
+
+
+def test_override_record_is_frozen() -> None:
+    led = _ledger()
+    rec = led.upsert("t", "openai", "gpt-5", PriceType.INPUT, "1.0", actor="a", reason="r")
+    with pytest.raises(FrozenInstanceError):
+        rec.price_per_unit = Decimal("9.99")  # type: ignore[misc]
+
+
+def test_unit_per_call_override_supported() -> None:
+    led = _ledger()
+    rec = led.upsert("t", "openai", "gpt-5", PriceType.TOOL_CALL, "0.01",
+                     actor="a", reason="tool pricing", unit=Unit.PER_CALL)
+    assert isinstance(rec, OverrideRecord)
+    entry = rec.to_price_entry()
+    assert entry is not None and entry.unit is Unit.PER_CALL


### PR DESCRIPTION
## Summary
Adds `tally.overrides` — an append-only, **versioned** and **audited** ledger of per-tenant price overrides for enterprise/committed-use contracts (spec §6). The price catalog already supported per-tenant override entries that take precedence over the public catalog, and `enrich_cost` already threads `tenant_id` through the override-aware lookup — the missing piece was governance, which this delivers.

- **Versioned** — each `(tenant_id, provider, model, price_type)` slot carries a monotonic integer version. Re-pricing bumps the version and records `supersedes`, so historical cost recomputes against the rate that was in force and a later correction never silently rewrites the past.
- **Audited** — changes are an append-only ledger; every entry captures *who* (`actor`), *why* (`reason`), and *when* (`recorded_at`, UTC). A revocation is a **tombstone**, not a deletion, so the trail is complete and tamper-evident by construction (append-only + monotonic versions).
- **Integration** — `OverrideLedger.apply_to_catalog(cat)` materializes the active (latest non-revoked) overrides onto a freshly-seeded `PriceCatalog`, so the existing cost path (`compute_cost_micro_usd` / `enrich_cost`) picks them up with no further wiring. Materialized entries carry an `override-<tenant>-vN` catalog version that distinguishes an override-priced cost from a list-price one on the span.

Money is `Decimal` throughout (never float). Pure logic with an injectable clock for deterministic tests.

## Acceptance criteria
- [x] Per-tenant override table; entries take precedence over the public catalog. *(ledger + existing `PriceCatalog.lookup` override precedence; integration test asserts the VIP rate beats list price)*
- [x] Cost enrichment (CTO-35) checks overrides first, falls through to public. *(already wired via `tenant_id`; covered by tests through `compute_cost_micro_usd`, incl. revoked→fallback)*
- [x] Override changes versioned + audited. *(monotonic per-slot versions, `supersedes` links, append-only history with actor/reason/recorded_at, tombstone revocation)*

## What's deferred / out of scope
- Public catalog itself (CTO-52, merged) and the negotiation/CRM workflow (per ticket).
- Persistence of the ledger to Postgres + a control-plane admin endpoint are follow-ups; this PR delivers the pure-logic core (matches the repo pattern of testable logic the gateway wires in).

## Test plan
- [x] `uv run --extra dev pytest -q` — full SDK suite green (18 new override tests).
- [x] `uv run --extra dev ruff check .` — clean (line-length 100).
- [x] Versioning: v1→reprice→v2 (`supersedes=1`); monotonic across revoke→re-add (v1,v2-tombstone,v3); distinct slots version independently.
- [x] Audit: append-only ordered history; who/why/when captured; `as_dict()` JSON-friendly.
- [x] Revoke is a tombstone (history intact, dropped from `active`, no `PriceEntry`).
- [x] Integration: override beats list price; revoked falls back; `apply_to_catalog` tenant-scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)