### PR TITLE
sdk: tail-weighted sampling for estimation (CTO-71)

### DIFF
--- a/sdk/python/src/tally/tail_sampling.py
+++ b/sdk/python/src/tally/tail_sampling.py
@@ -1,0 +1,230 @@
+"""Tail-weighted sampling for pre-deploy estimation (CTO-71, spec §9 W3).
+
+Pre-deploy estimation answers "what will switching model/prompt cost and how will quality move?" by
+*replaying* a representative sample of a workload's historical prompts. The trap: agent cost and
+failure are a power law — the blow-ups (retry loops, step-cap hits, long-context premium calls) live
+in the **tail**. A sample drawn from *average* prompts would systematically under-predict both cost
+and risk, because the expensive tail is exactly what it misses.
+
+So this sampler deliberately **over-indexes the expensive end**:
+
+* It defines the "tail" as runs at/above a configurable cost percentile (P90 by default) and draws
+  the bulk of the budget from there.
+* It **mandatorily includes** the top-K most expensive runs and any run that hit a retry loop or a
+  step cap — the pathological cases an estimate must never skip.
+* The rest of the budget is a random body sample, so the composition still reflects ordinary
+  traffic.
+
+It is **deterministic and reproducible**: selection within each pool is ranked by a seeded hash of
+``run_id``, so the same workload + seed always yields the same sample — reruns and CI are stable.
+Pure logic; no infra. The projection math that consumes this sample is CTO-72 (out of scope here).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+__all__ = [
+    "HistoricalRun",
+    "TailSampleConfig",
+    "SampleComposition",
+    "TailSample",
+    "tail_weighted_sample",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalRun:
+    """One historical run in a workload, with the signals that drive tail weighting.
+
+    ``cost_micro_usd`` is the expense signal (integer micro-USD, consistent with
+    :mod:`tally.pricing` — never float). ``hit_retry_loop`` / ``hit_step_cap`` flag
+    pathological runs that must always be included in an estimation sample regardless of cost.
+    """
+
+    run_id: str
+    cost_micro_usd: int = 0
+    hit_retry_loop: bool = False
+    hit_step_cap: bool = False
+
+    @property
+    def is_pathological(self) -> bool:
+        return self.hit_retry_loop or self.hit_step_cap
+
+
+@dataclass(frozen=True, slots=True)
+class TailSampleConfig:
+    """Sampling budget + tail-weighting knobs.
+
+    ``sample_size`` is the target number of runs to select. Of the budget left after mandatory
+    inclusions, ``tail_fraction`` is drawn from the tail (cost >= the ``tail_percentile``
+    cutoff) and the remainder is a random body sample. ``top_k_expensive`` runs are always included.
+    """
+
+    sample_size: int = 180
+    tail_fraction: float = 0.7
+    tail_percentile: float = 90.0
+    top_k_expensive: int = 10
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.tail_fraction <= 1.0):
+            raise ValueError(f"tail_fraction must be in [0, 1], got {self.tail_fraction}")
+        if not (0.0 <= self.tail_percentile <= 100.0):
+            raise ValueError(f"tail_percentile must be in [0, 100], got {self.tail_percentile}")
+
+
+@dataclass(frozen=True, slots=True)
+class SampleComposition:
+    """Human-readable breakdown of how a sample was assembled (reported to the user)."""
+
+    total: int
+    mandatory_top_k: int
+    mandatory_retry_or_cap: int
+    tail_weighted: int
+    random: int
+    tail_percentile: float
+    tail_cost_cutoff: int
+
+    @property
+    def mandatory(self) -> int:
+        return self.mandatory_top_k + self.mandatory_retry_or_cap
+
+    def summary(self) -> str:
+        """e.g. ``"140 tail-weighted + 40 random (+12 mandatory: 10 top-cost, 2 cap)"``."""
+        return (
+            f"{self.tail_weighted} tail-weighted + {self.random} random "
+            f"(+{self.mandatory} mandatory: {self.mandatory_top_k} top-cost, "
+            f"{self.mandatory_retry_or_cap} retry/step-cap)"
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "total": self.total,
+            "mandatory_top_k": self.mandatory_top_k,
+            "mandatory_retry_or_cap": self.mandatory_retry_or_cap,
+            "mandatory": self.mandatory,
+            "tail_weighted": self.tail_weighted,
+            "random": self.random,
+            "tail_percentile": self.tail_percentile,
+            "tail_cost_cutoff": self.tail_cost_cutoff,
+            "summary": self.summary(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TailSample:
+    """The selected sample plus its composition report."""
+
+    runs: tuple[HistoricalRun, ...]
+    composition: SampleComposition
+
+    @property
+    def run_ids(self) -> tuple[str, ...]:
+        return tuple(r.run_id for r in self.runs)
+
+
+def _seeded_rank(seed: int, run_id: str) -> float:
+    """Deterministic [0, 1) rank for a run under a seed — stable across runs, varies with seed."""
+    digest = hashlib.sha256(f"{seed}:{run_id}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") / 2**64
+
+
+def _percentile_cutoff(sorted_costs: list[int], percentile: float) -> int:
+    """Nearest-rank percentile cutoff over ascending ``sorted_costs``. Empty → 0.
+
+    Returns the smallest cost value at/above which a run is considered "tail". Deterministic; no
+    interpolation so the cutoff is always an actual observed cost.
+    """
+    if not sorted_costs:
+        return 0
+    if percentile <= 0:
+        return sorted_costs[0]
+    if percentile >= 100:
+        return sorted_costs[-1]
+    # nearest-rank: rank = ceil(p/100 * N), 1-based
+    rank = -(-int(percentile) * len(sorted_costs) // 100)  # ceil division
+    rank = min(max(rank, 1), len(sorted_costs))
+    return sorted_costs[rank - 1]
+
+
+def _pick(pool: list[HistoricalRun], count: int, seed: int) -> list[HistoricalRun]:
+    """Deterministically take ``count`` runs from ``pool`` ranked by seeded hash (lowest first)."""
+    if count <= 0 or not pool:
+        return []
+    ranked = sorted(pool, key=lambda r: (_seeded_rank(seed, r.run_id), r.run_id))
+    return ranked[:count]
+
+
+def tail_weighted_sample(
+    runs: list[HistoricalRun] | tuple[HistoricalRun, ...],
+    config: TailSampleConfig | None = None,
+) -> TailSample:
+    """Select a tail-weighted, reproducible estimation sample from a workload's historical runs.
+
+    Order of selection:
+
+    1. **Mandatory** — the ``top_k_expensive`` most expensive runs, plus every run that hit a retry
+       loop or step cap. These are always included (capped at ``sample_size``).
+    2. **Tail-weighted** — ``tail_fraction`` of the remaining budget, drawn from runs at/above the
+       ``tail_percentile`` cost cutoff.
+    3. **Random body** — the rest of the budget, drawn from the cheaper body.
+
+    Pools 2 and 3 are sampled by seeded hash for determinism. Shortfalls cascade (a thin tail pool
+    spills its budget to the body and vice-versa) so the sample reaches ``sample_size`` whenever the
+    workload is large enough. Never raises on empty/degenerate input.
+    """
+    config = config or TailSampleConfig()
+    pool = [r for r in runs if isinstance(r, HistoricalRun)]
+    n = len(pool)
+    cutoff = _percentile_cutoff(sorted(r.cost_micro_usd for r in pool), config.tail_percentile)
+
+    # Whole workload fits in the budget → take everything (still report composition honestly).
+    target = min(config.sample_size, n)
+
+    # --- 1. mandatory: top-K most expensive ∪ retry/step-cap runs --------------------------------
+    by_cost_desc = sorted(pool, key=lambda r: (-r.cost_micro_usd, r.run_id))
+    top_k_ids = {r.run_id for r in by_cost_desc[: max(0, config.top_k_expensive)]}
+    mandatory: list[HistoricalRun] = []
+    mandatory_ids: set[str] = set()
+    for r in pool:
+        if r.run_id in top_k_ids or r.is_pathological:
+            mandatory.append(r)
+            mandatory_ids.add(r.run_id)
+    # If mandatory alone overflows the budget, keep the most expensive of them.
+    if len(mandatory) > target:
+        mandatory = sorted(mandatory, key=lambda r: (-r.cost_micro_usd, r.run_id))[:target]
+        mandatory_ids = {r.run_id for r in mandatory}
+
+    n_top_k = sum(1 for r in mandatory if r.run_id in top_k_ids)
+    n_retry_cap = len(mandatory) - n_top_k
+
+    # --- 2/3. fill the rest from tail then body --------------------------------------------------
+    remaining = target - len(mandatory)
+    tail_pool = [r for r in pool if r.run_id not in mandatory_ids and r.cost_micro_usd >= cutoff]
+    body_pool = [r for r in pool if r.run_id not in mandatory_ids and r.cost_micro_usd < cutoff]
+
+    want_tail = min(round(remaining * config.tail_fraction), remaining)
+    tail_pick = _pick(tail_pool, want_tail, config.seed)
+    # body gets the remainder, including any tail shortfall.
+    want_body = remaining - len(tail_pick)
+    body_pick = _pick(body_pool, want_body, config.seed)
+    # if the body pool was also thin, spill the remaining budget back to the tail pool.
+    if len(body_pick) < want_body:
+        leftover = want_body - len(body_pick)
+        already = {r.run_id for r in tail_pick}
+        spill_pool = [r for r in tail_pool if r.run_id not in already]
+        tail_pick = tail_pick + _pick(spill_pool, leftover, config.seed)
+
+    selected = mandatory + tail_pick + body_pick
+    composition = SampleComposition(
+        total=len(selected),
+        mandatory_top_k=n_top_k,
+        mandatory_retry_or_cap=n_retry_cap,
+        tail_weighted=len(tail_pick),
+        random=len(body_pick),
+        tail_percentile=config.tail_percentile,
+        tail_cost_cutoff=cutoff,
+    )
+    return TailSample(runs=tuple(selected), composition=composition)

--- a/sdk/python/tests/test_tail_sampling.py
+++ b/sdk/python/tests/test_tail_sampling.py
@@ -1,0 +1,170 @@
+"""Tail-weighted estimation sampling: tail over-indexing, mandatory includes, determinism."""
+
+from __future__ import annotations
+
+import pytest
+
+from tally.tail_sampling import (
+    HistoricalRun,
+    TailSampleConfig,
+    tail_weighted_sample,
+)
+
+
+def _workload(n: int, *, base: int = 100) -> list[HistoricalRun]:
+    """n runs with linearly increasing cost (run i costs base*(i+1) micro-USD)."""
+    return [HistoricalRun(run_id=f"r{i:04d}", cost_micro_usd=base * (i + 1)) for i in range(n)]
+
+
+# --- determinism / reproducibility ---------------------------------------------------------------
+
+
+def test_same_workload_and_seed_is_reproducible() -> None:
+    runs = _workload(1000)
+    cfg = TailSampleConfig(sample_size=180, seed=42)
+    a = tail_weighted_sample(runs, cfg)
+    b = tail_weighted_sample(runs, cfg)
+    assert a.run_ids == b.run_ids
+
+
+def test_different_seed_changes_the_random_body_selection() -> None:
+    runs = _workload(1000)
+    a = tail_weighted_sample(runs, TailSampleConfig(sample_size=180, seed=1))
+    b = tail_weighted_sample(runs, TailSampleConfig(sample_size=180, seed=2))
+    assert a.run_ids != b.run_ids  # body picks are seed-dependent
+
+
+# --- over-indexing the expensive tail ------------------------------------------------------------
+
+
+def test_sample_over_indexes_the_tail() -> None:
+    runs = _workload(1000)  # costs 100..100000; P90 cutoff ~ run 900
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=200, tail_percentile=90.0))
+    cutoff = sample.composition.tail_cost_cutoff
+    in_tail = sum(1 for r in sample.runs if r.cost_micro_usd >= cutoff)
+    # The tail is only 10% of the population but should be the majority of the sample.
+    assert in_tail > sample.composition.total // 2
+
+
+def test_composition_counts_are_consistent() -> None:
+    runs = _workload(1000)
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=180, tail_fraction=0.7))
+    c = sample.composition
+    assert c.total == len(sample.runs)
+    assert c.mandatory + c.tail_weighted + c.random == c.total
+    assert c.total == 180
+
+
+# --- mandatory inclusion -------------------------------------------------------------------------
+
+
+def test_top_k_most_expensive_always_included() -> None:
+    runs = _workload(1000)
+    cfg = TailSampleConfig(sample_size=180, top_k_expensive=10)
+    sample = tail_weighted_sample(runs, cfg)
+    ids = set(sample.run_ids)
+    # the 10 priciest are r0990..r0999
+    for i in range(990, 1000):
+        assert f"r{i:04d}" in ids
+    assert sample.composition.mandatory_top_k == 10
+
+
+def test_retry_loop_and_step_cap_runs_always_included() -> None:
+    runs = _workload(1000)
+    # mark two cheap runs as pathological — they'd never survive a cost-weighted sample otherwise.
+    runs[3] = HistoricalRun("r0003", cost_micro_usd=400, hit_retry_loop=True)
+    runs[7] = HistoricalRun("r0007", cost_micro_usd=800, hit_step_cap=True)
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=180, seed=99))
+    ids = set(sample.run_ids)
+    assert "r0003" in ids
+    assert "r0007" in ids
+    assert sample.composition.mandatory_retry_or_cap == 2
+
+
+def test_pathological_run_in_top_k_not_double_counted() -> None:
+    runs = _workload(50)
+    # the most expensive run also hit a retry loop
+    runs[49] = HistoricalRun("r0049", cost_micro_usd=5000, hit_retry_loop=True)
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=50, top_k_expensive=10))
+    c = sample.composition
+    # r0049 counts once (as top-k), not in both buckets
+    assert c.mandatory == c.mandatory_top_k + c.mandatory_retry_or_cap
+    assert "r0049" in set(sample.run_ids)
+
+
+# --- composition reporting -----------------------------------------------------------------------
+
+
+def test_summary_string_is_human_readable() -> None:
+    runs = _workload(1000)
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=180))
+    s = sample.composition.summary()
+    assert "tail-weighted" in s
+    assert "random" in s
+    assert "mandatory" in s
+
+
+def test_as_dict_round_trips_counts() -> None:
+    runs = _workload(500)
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=100))
+    d = sample.composition.as_dict()
+    assert d["total"] == 100
+    assert d["mandatory"] == d["mandatory_top_k"] + d["mandatory_retry_or_cap"]
+    assert "summary" in d
+
+
+# --- edge cases / never-crash --------------------------------------------------------------------
+
+
+def test_empty_workload_returns_empty_sample() -> None:
+    sample = tail_weighted_sample([], TailSampleConfig(sample_size=180))
+    assert sample.runs == ()
+    assert sample.composition.total == 0
+
+
+def test_workload_smaller_than_budget_returns_everything() -> None:
+    runs = _workload(25)
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=180))
+    assert sample.composition.total == 25
+    assert set(sample.run_ids) == {r.run_id for r in runs}
+
+
+def test_mandatory_overflow_keeps_most_expensive() -> None:
+    runs = _workload(100)
+    # every run pathological → mandatory pool is the whole workload, but budget is 10
+    runs = [HistoricalRun(r.run_id, r.cost_micro_usd, hit_retry_loop=True) for r in runs]
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=10))
+    assert sample.composition.total == 10
+    # the 10 most expensive survive
+    assert set(sample.run_ids) == {f"r{i:04d}" for i in range(90, 100)}
+
+
+def test_thin_tail_pool_spills_budget_to_body_and_hits_target() -> None:
+    # almost all runs identical-cheap; only a few expensive → tail pool is tiny.
+    runs = [HistoricalRun(f"c{i}", cost_micro_usd=10) for i in range(500)]
+    runs += [HistoricalRun(f"x{i}", cost_micro_usd=99999) for i in range(5)]
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=180, tail_fraction=0.9))
+    assert sample.composition.total == 180  # still reaches the budget despite a thin tail
+
+
+def test_invalid_tail_fraction_raises() -> None:
+    with pytest.raises(ValueError):
+        TailSampleConfig(tail_fraction=1.5)
+
+
+def test_invalid_percentile_raises() -> None:
+    with pytest.raises(ValueError):
+        TailSampleConfig(tail_percentile=120.0)
+
+
+def test_non_historicalrun_entries_ignored() -> None:
+    runs = _workload(50) + ["garbage", None]  # type: ignore[list-item]
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=180))
+    assert sample.composition.total == 50  # only real runs counted
+
+
+def test_cutoff_reported_matches_percentile() -> None:
+    runs = _workload(100)  # costs 100..10000
+    sample = tail_weighted_sample(runs, TailSampleConfig(sample_size=50, tail_percentile=90.0))
+    # P90 nearest-rank over 100 runs → the 90th cheapest cost = 100*90 = 9000
+    assert sample.composition.tail_cost_cutoff == 9000


### PR DESCRIPTION
## Summary
- Adds `tally.tail_sampling` — a deterministic, tail-weighted sampler that selects a representative-but-tail-heavy subset of a workload's historical runs for pre-deploy estimation replay (CTO-71, spec §9 W3).
- Agent cost/failure is a power law: blow-ups (retry loops, step-cap hits, long-context premium) live in the tail. A naive average sample under-predicts cost and risk, so this sampler deliberately over-indexes the expensive end.

## Behavior
- **Mandatory inclusions:** the top-K most expensive runs ∪ every run that hit a retry loop or step cap (capped at `sample_size`, most-expensive kept on overflow; no double-counting).
- **Tail-weighted body:** `tail_fraction` of the remaining budget drawn from runs at/above the `tail_percentile` cost cutoff; the rest is a seeded random body sample.
- **Cascade spill:** a thin tail pool spills its budget to the body and vice-versa, so the sample reaches `sample_size` whenever the workload is large enough.
- **Deterministic:** selection ranked by a seeded sha256 hash of `run_id` — same workload + seed ⇒ same sample (stable reruns/CI).
- **Never raises** on empty/degenerate input; non-`HistoricalRun` entries are ignored. Cost is integer micro-USD throughout (no float dollars).
- `SampleComposition` reports the breakdown (`summary()` / `as_dict()`).

## Test plan
- [x] `uv run --extra dev pytest -q` — 194 passed (17 new)
- [x] `uv run --extra dev ruff check .` — clean
- [x] Reproducibility, seed-sensitivity, tail over-indexing, mandatory inclusion, overflow, thin-tail spill, percentile cutoff, and validation edge cases covered.

Follow-ups (out of scope): projection math that consumes this sample is CTO-72; estimate UI surfaces are CTO-73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)