### PR TITLE
sdk: context-faithful replay engine (CTO-59)

### DIFF
--- a/sdk/python/src/tally/replay.py
+++ b/sdk/python/src/tally/replay.py
@@ -1,0 +1,396 @@
+"""Replay engine — context-faithful pre-deploy model comparison, no live retrieval.
+
+Implements CTO-59.
+
+Pre-deploy model comparison is worthless if the replayed prompt's retrieved context differs from
+the original. Quality and cost deltas would then be noise rather than signal. So replay injects the
+EXACT captured context from the original trace (a ``ResolvedContextRef``) and bypasses live
+retrieval entirely: the resolved prompt, retrieved-context blobs, and captured tool-call responses
+are all replayed verbatim from the original span events. No network, no live LLM call, no live tool
+execution happens in this module — the model is an INJECTED callable the caller supplies (exactly
+like the judge callable in evals and the model in sampling), which keeps the engine pure and tests
+deterministic and offline.
+
+Sampling is STRATIFIED (not random) and deterministic: the same workload + seed always selects the
+same items, reusing the seeded-hash approach from :mod:`tally.sampling`. We sample stratified
+because prod prompts are not uniform — cost bands / features must each be represented so a candidate
+model is judged on the real mix, not whatever a uniform draw happened to surface.
+
+Execution is sandboxed by cost: a per-comparison cap and a per-tenant cap are enforced. Once a cap
+would be exceeded the engine stops admitting further replays gracefully (it reports how many ran vs.
+were skipped — it never raises). Replay cost is surfaced as integer micro-USD throughout (Decimal
+for any rate math, never float dollars — mirrors :mod:`tally.pricing` / :mod:`tally.schema`).
+
+Clean seams (out of scope here):
+- Rate-limit governance lives in ``tally.governor`` (CTO-60); this engine does not couple to it.
+- Eval scoring lives in ``tally.evals`` (CTO-61); :class:`ReplayResult` carries raw output for it.
+- Comparison UI / projection (CTO-62 / CTO-72) consume :meth:`ReplayReport.as_dict` only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
+
+# --- Captured context (the ResolvedContextRef payload) ------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedToolCall:
+    """One tool call replayed VERBATIM from a captured span event.
+
+    The ``response`` is the exact output the tool produced on the original trace. The engine never
+    re-executes the tool — it hands these captured responses to the injected model unchanged.
+    """
+
+    tool_name: str
+    request: str
+    response: str
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedContext:
+    """The ``ResolvedContextRef`` payload injected in place of live retrieval.
+
+    Carries the resolved prompt messages, the retrieved-context blobs, and the captured tool-call
+    responses. This is the *whole* faithful context; nothing here is re-fetched at replay time.
+    """
+
+    resolved_messages: tuple[str, ...] = ()
+    retrieved_blobs: tuple[str, ...] = ()
+    tool_calls: tuple[CapturedToolCall, ...] = ()
+    resolved_context_ref: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "resolved_messages": list(self.resolved_messages),
+            "retrieved_blobs": list(self.retrieved_blobs),
+            "tool_calls": [
+                {"tool_name": t.tool_name, "request": t.request, "response": t.response}
+                for t in self.tool_calls
+            ],
+            "resolved_context_ref": self.resolved_context_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayItem:
+    """One prompt to replay: an id, its captured context, and a stratum signal.
+
+    ``stratum`` is the stratification key (e.g. a cost band or feature tag). ``original_model`` and
+    ``original_cost_micro_usd`` are optional and only carried through for downstream delta work.
+    """
+
+    item_id: str
+    context: CapturedContext
+    stratum: str = "default"
+    original_model: str | None = None
+    original_cost_micro_usd: int | None = None
+
+
+# --- Injected model (never hits a network) ------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayOutcome:
+    """What the injected model produced for one replay: output text + token usage.
+
+    The engine prices the usage via the catalog; ``ReplayOutcome`` itself carries no cost so the
+    model stub stays trivial. ``provider`` lets the engine look up the right rate.
+    """
+
+    output: str
+    usage: Usage
+    provider: str = "openai"
+
+
+@runtime_checkable
+class ReplayModel(Protocol):
+    """Injected, offline model. Given a candidate ``model`` and the captured context, return a
+    :class:`ReplayOutcome`. Implementations MUST NOT perform live retrieval or tool execution — the
+    captured tool responses on ``context`` are authoritative. May raise; the engine absorbs it."""
+
+    def __call__(self, model: str, context: CapturedContext) -> ReplayOutcome: ...
+
+
+# --- Configuration ------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayConfig:
+    """Candidate models, deterministic stratified-sample knobs, and cost caps.
+
+    A cap of ``None`` means unbounded. ``sample_size`` is the target number of items to replay
+    (across all strata) before per-candidate fan-out; larger than the workload replays everything.
+    """
+
+    candidate_models: tuple[str, ...]
+    sample_size: int = 50
+    seed: str = "replay"
+    per_comparison_cap_micro_usd: int | None = None
+    per_tenant_cap_micro_usd: int | None = None
+    tenant_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.candidate_models:
+            raise ValueError("candidate_models must not be empty")
+        if any(not m for m in self.candidate_models):
+            raise ValueError("candidate_models must not contain empty model names")
+        if self.sample_size < 0:
+            raise ValueError(f"sample_size must be >= 0, got {self.sample_size}")
+        for name in ("per_comparison_cap_micro_usd", "per_tenant_cap_micro_usd"):
+            v = getattr(self, name)
+            if v is not None and v < 0:
+                raise ValueError(f"{name} must be >= 0 or None, got {v}")
+
+
+# --- Results ------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayResult:
+    """Per-item, per-candidate replay outcome."""
+
+    item_id: str
+    model: str
+    stratum: str
+    output: str
+    replay_cost_micro_usd: int
+    capped: bool = False
+    failed: bool = False
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "model": self.model,
+            "stratum": self.stratum,
+            "output": self.output,
+            "replay_cost_micro_usd": self.replay_cost_micro_usd,
+            "capped": self.capped,
+            "failed": self.failed,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayReport:
+    """Aggregate report for one replay run across the selected sample and all candidate models."""
+
+    workload_size: int
+    sample_size: int
+    sample_composition: dict[str, int]
+    results: tuple[ReplayResult, ...]
+    total_replay_cost_micro_usd: int
+    per_model_cost_micro_usd: dict[str, int]
+    replayed_count: int
+    skipped_by_cap_count: int
+    failed_count: int
+    bound_by_cap: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "workload_size": self.workload_size,
+            "sample_size": self.sample_size,
+            "sample_composition": dict(self.sample_composition),
+            "results": [r.as_dict() for r in self.results],
+            "total_replay_cost_micro_usd": self.total_replay_cost_micro_usd,
+            "per_model_cost_micro_usd": dict(self.per_model_cost_micro_usd),
+            "replayed_count": self.replayed_count,
+            "skipped_by_cap_count": self.skipped_by_cap_count,
+            "failed_count": self.failed_count,
+            "bound_by_cap": self.bound_by_cap,
+        }
+
+
+# --- Deterministic seeded-hash selection (mirrors tally.sampling) -------------------------------
+
+
+def _unit_hash(seed: str, key: str) -> float:
+    """Map ``(seed, key)`` deterministically to a float in [0, 1). Same input → same output."""
+    digest = hashlib.sha256(f"{seed}\x00{key}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") / 2**64
+
+
+def select_stratified(
+    items: list[ReplayItem], sample_size: int, seed: str
+) -> list[ReplayItem]:
+    """Pick a deterministic, stratified sample of ``items``.
+
+    Each stratum receives a share of ``sample_size`` proportional to its size (largest-remainder
+    apportionment, so the total lands exactly on the target). Within a stratum, items are ranked by
+    a seeded hash and the top-k taken — deterministic for a given (workload, seed). A sample size
+    that meets or exceeds the workload returns everything (in stratum order for stable output).
+    """
+    if sample_size <= 0:
+        return []
+
+    strata: dict[str, list[ReplayItem]] = {}
+    for it in items:
+        strata.setdefault(it.stratum, []).append(it)
+
+    total = len(items)
+    if sample_size >= total:
+        # everything is selected; emit in stable stratum order for reproducible reports
+        out: list[ReplayItem] = []
+        for stratum in sorted(strata):
+            out.extend(sorted(strata[stratum], key=lambda i: _unit_hash(seed, i.item_id)))
+        return out
+
+    # Largest-remainder apportionment of sample_size across strata, proportional to size.
+    quotas: dict[str, int] = {}
+    remainders: list[tuple[float, str]] = []
+    assigned = 0
+    for stratum in sorted(strata):
+        exact = sample_size * len(strata[stratum]) / total
+        base = int(exact)
+        quotas[stratum] = base
+        assigned += base
+        remainders.append((exact - base, stratum))
+
+    # distribute the leftover seats to the largest remainders (ties broken by stratum name)
+    leftover = sample_size - assigned
+    remainders.sort(key=lambda r: (-r[0], r[1]))
+    for i in range(leftover):
+        quotas[remainders[i][1]] += 1
+
+    selected: list[ReplayItem] = []
+    for stratum in sorted(strata):
+        ranked = sorted(strata[stratum], key=lambda i: _unit_hash(seed, i.item_id))
+        selected.extend(ranked[: quotas[stratum]])
+    return selected
+
+
+def _compose(items: list[ReplayItem]) -> dict[str, int]:
+    """Per-stratum counts for a selection (sorted for stable reporting)."""
+    comp: dict[str, int] = {}
+    for it in items:
+        comp[it.stratum] = comp.get(it.stratum, 0) + 1
+    return {k: comp[k] for k in sorted(comp)}
+
+
+# --- Engine -------------------------------------------------------------------------------------
+
+
+class ReplayEngine:
+    """Context-faithful replay engine. Pure-logic: the model is injected, nothing is re-fetched.
+
+    Selects a deterministic stratified sample, replays each selected item against every candidate
+    model via the injected model callable, accumulates replay cost, and enforces the per-comparison
+    and per-tenant caps. It never raises on a bad workload, a missing price, or a model that throws.
+    """
+
+    def __init__(self, catalog: PriceCatalog, config: ReplayConfig) -> None:
+        self.catalog = catalog
+        self.config = config
+
+    def run(self, workload: object, model: ReplayModel) -> ReplayReport:
+        items = [it for it in _iter(workload) if isinstance(it, ReplayItem)]
+        selected = select_stratified(items, self.config.sample_size, self.config.seed)
+        composition = _compose(selected)
+
+        results: list[ReplayResult] = []
+        per_model: dict[str, int] = {m: 0 for m in self.config.candidate_models}
+        comparison_spend = 0
+        tenant_spend = 0
+        replayed = 0
+        skipped = 0
+        failed = 0
+        bound_by: str | None = None
+
+        comp_cap = self.config.per_comparison_cap_micro_usd
+        tenant_cap = self.config.per_tenant_cap_micro_usd
+
+        for item in selected:
+            for candidate in self.config.candidate_models:
+                cost, output, did_fail = self._replay_one(candidate, item, model)
+
+                # Admission control: a replay is admitted only if it keeps BOTH caps satisfied.
+                would_comparison = comparison_spend + cost
+                would_tenant = tenant_spend + cost
+                over_comparison = comp_cap is not None and would_comparison > comp_cap
+                over_tenant = tenant_cap is not None and would_tenant > tenant_cap
+
+                if over_comparison or over_tenant:
+                    bound_by = "per_comparison" if over_comparison else "per_tenant"
+                    skipped += 1
+                    results.append(
+                        ReplayResult(
+                            item_id=item.item_id,
+                            model=candidate,
+                            stratum=item.stratum,
+                            output="",
+                            replay_cost_micro_usd=0,
+                            capped=True,
+                        )
+                    )
+                    continue
+
+                comparison_spend = would_comparison
+                tenant_spend = would_tenant
+                per_model[candidate] = per_model.get(candidate, 0) + cost
+                replayed += 1
+                if did_fail:
+                    failed += 1
+                results.append(
+                    ReplayResult(
+                        item_id=item.item_id,
+                        model=candidate,
+                        stratum=item.stratum,
+                        output=output,
+                        replay_cost_micro_usd=cost,
+                        failed=did_fail,
+                    )
+                )
+
+        return ReplayReport(
+            workload_size=len(items),
+            sample_size=len(selected),
+            sample_composition=composition,
+            results=tuple(results),
+            total_replay_cost_micro_usd=comparison_spend,
+            per_model_cost_micro_usd=per_model,
+            replayed_count=replayed,
+            skipped_by_cap_count=skipped,
+            failed_count=failed,
+            bound_by_cap=bound_by,
+        )
+
+    def _replay_one(
+        self, candidate: str, item: ReplayItem, model: ReplayModel
+    ) -> tuple[int, str, bool]:
+        """Invoke the injected model for one (item, candidate) and price it. Never raises.
+
+        Returns ``(cost_micro_usd, output, failed)``. A model that throws yields zero cost and an
+        empty output, recorded as failed — the run continues.
+        """
+        try:
+            outcome = model(candidate, item.context)
+        except Exception:
+            return 0, "", True
+        if not isinstance(outcome, ReplayOutcome):
+            return 0, "", True
+        try:
+            cost, _version = compute_cost_micro_usd(
+                self.catalog,
+                outcome.provider,
+                candidate,
+                outcome.usage,
+                tenant_id=self.config.tenant_id,
+            )
+        except Exception:
+            cost = 0
+        return cost, outcome.output, False
+
+
+def _iter(workload: object) -> list[object]:
+    """Coerce an arbitrary workload to a list, never raising on a non-iterable."""
+    if workload is None:
+        return []
+    if isinstance(workload, (str, bytes)):
+        return []
+    try:
+        return list(workload)  # type: ignore[arg-type]
+    except TypeError:
+        return []

--- a/sdk/python/tests/test_replay.py
+++ b/sdk/python/tests/test_replay.py
@@ -1,0 +1,341 @@
+"""Tests for the context-faithful replay engine (CTO-59)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tally.pricing import Usage, seed_catalog
+from tally.replay import (
+    CapturedContext,
+    CapturedToolCall,
+    ReplayConfig,
+    ReplayEngine,
+    ReplayItem,
+    ReplayModel,
+    ReplayOutcome,
+    ReplayReport,
+    ReplayResult,
+    select_stratified,
+)
+
+# --- Fixtures / stubs ---------------------------------------------------------------------------
+
+
+def _ctx(*, ref: str = "ctx", tools: tuple[CapturedToolCall, ...] = ()) -> CapturedContext:
+    return CapturedContext(
+        resolved_messages=("system: you are a bot", "user: hi"),
+        retrieved_blobs=("doc-a", "doc-b"),
+        tool_calls=tools,
+        resolved_context_ref=ref,
+    )
+
+
+def _item(item_id: str, stratum: str = "default", **kw: object) -> ReplayItem:
+    return ReplayItem(item_id=item_id, context=_ctx(ref=item_id), stratum=stratum, **kw)
+
+
+class FixedCostModel:
+    """Stub model: constant token usage so cost per replay is deterministic and known."""
+
+    def __init__(self, output_tokens: int = 100) -> None:
+        self.output_tokens = output_tokens
+        self.calls: list[tuple[str, CapturedContext]] = []
+
+    def __call__(self, model: str, context: CapturedContext) -> ReplayOutcome:
+        self.calls.append((model, context))
+        return ReplayOutcome(
+            output=f"{model}:{context.resolved_context_ref}",
+            usage=Usage(input_tokens=1_000, output_tokens=self.output_tokens),
+        )
+
+
+def _config(**kw: object) -> ReplayConfig:
+    base: dict[str, object] = {"candidate_models": ("gpt-5-mini",), "seed": "s", "sample_size": 100}
+    base.update(kw)
+    return ReplayConfig(**base)  # type: ignore[arg-type]
+
+
+# --- Config validation --------------------------------------------------------------------------
+
+
+def test_config_rejects_empty_models() -> None:
+    with pytest.raises(ValueError):
+        ReplayConfig(candidate_models=())
+
+
+def test_config_rejects_blank_model_name() -> None:
+    with pytest.raises(ValueError):
+        ReplayConfig(candidate_models=("gpt-5", ""))
+
+
+def test_config_rejects_negative_sample_size() -> None:
+    with pytest.raises(ValueError):
+        ReplayConfig(candidate_models=("gpt-5",), sample_size=-1)
+
+
+def test_config_rejects_negative_caps() -> None:
+    with pytest.raises(ValueError):
+        ReplayConfig(candidate_models=("gpt-5",), per_comparison_cap_micro_usd=-5)
+    with pytest.raises(ValueError):
+        ReplayConfig(candidate_models=("gpt-5",), per_tenant_cap_micro_usd=-5)
+
+
+def test_protocol_runtime_checkable() -> None:
+    assert isinstance(FixedCostModel(), ReplayModel)
+
+
+# --- Stratified selection: determinism + composition --------------------------------------------
+
+
+def _workload() -> list[ReplayItem]:
+    items: list[ReplayItem] = []
+    for i in range(60):
+        items.append(_item(f"body-{i}", stratum="body"))
+    for i in range(30):
+        items.append(_item(f"mid-{i}", stratum="mid"))
+    for i in range(10):
+        items.append(_item(f"tail-{i}", stratum="tail"))
+    return items
+
+
+def test_selection_is_deterministic() -> None:
+    wl = _workload()
+    a = select_stratified(wl, 20, "seed-x")
+    b = select_stratified(wl, 20, "seed-x")
+    assert [i.item_id for i in a] == [i.item_id for i in b]
+
+
+def test_selection_changes_with_seed() -> None:
+    wl = _workload()
+    a = {i.item_id for i in select_stratified(wl, 20, "seed-x")}
+    b = {i.item_id for i in select_stratified(wl, 20, "seed-y")}
+    assert a != b
+
+
+def test_selection_is_stratified_proportional() -> None:
+    wl = _workload()  # 60 / 30 / 10
+    sel = select_stratified(wl, 20, "seed")
+    comp: dict[str, int] = {}
+    for it in sel:
+        comp[it.stratum] = comp.get(it.stratum, 0) + 1
+    assert sum(comp.values()) == 20
+    # proportional apportionment of 20 over 60/30/10 → 12/6/2
+    assert comp == {"body": 12, "mid": 6, "tail": 2}
+
+
+def test_sample_larger_than_workload_returns_all() -> None:
+    wl = _workload()
+    sel = select_stratified(wl, 1_000, "seed")
+    assert len(sel) == len(wl)
+
+
+def test_zero_sample_size_selects_nothing() -> None:
+    assert select_stratified(_workload(), 0, "seed") == []
+
+
+# --- Engine: cost surfacing ---------------------------------------------------------------------
+
+
+def test_replay_surfaces_integer_micro_usd_cost() -> None:
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run([_item("a"), _item("b")], FixedCostModel())
+    # gpt-5-mini: input 0.25/Mtok * 1000 = 250 micro; output 2.00/Mtok * 100 = 200 micro -> 450
+    assert isinstance(report.total_replay_cost_micro_usd, int)
+    assert report.total_replay_cost_micro_usd == 900  # 2 items * 450
+    assert report.per_model_cost_micro_usd == {"gpt-5-mini": 900}
+    assert all(isinstance(r.replay_cost_micro_usd, int) for r in report.results)
+
+
+def test_report_composition_and_counts() -> None:
+    engine = ReplayEngine(seed_catalog(), _config(sample_size=20, seed="seed"))
+    report = engine.run(_workload(), FixedCostModel())
+    assert report.workload_size == 100
+    assert report.sample_size == 20
+    assert report.sample_composition == {"body": 12, "mid": 6, "tail": 2}
+    assert report.replayed_count == 20
+    assert report.skipped_by_cap_count == 0
+
+
+def test_multiple_candidates_fan_out() -> None:
+    cfg = _config(candidate_models=("gpt-5-mini", "gpt-5"))
+    engine = ReplayEngine(seed_catalog(), cfg)
+    report = engine.run([_item("a")], FixedCostModel())
+    assert report.replayed_count == 2
+    assert set(report.per_model_cost_micro_usd) == {"gpt-5-mini", "gpt-5"}
+    # gpt-5 is pricier than gpt-5-mini for identical usage
+    assert report.per_model_cost_micro_usd["gpt-5"] > report.per_model_cost_micro_usd["gpt-5-mini"]
+
+
+# --- Verbatim tool replay (no live execution) ---------------------------------------------------
+
+
+class ToolRecordingModel:
+    """Records the captured tool responses handed to it; never executes a tool itself."""
+
+    def __init__(self) -> None:
+        self.seen_tool_responses: list[str] = []
+
+    def __call__(self, model: str, context: CapturedContext) -> ReplayOutcome:
+        for tc in context.tool_calls:
+            self.seen_tool_responses.append(tc.response)
+        return ReplayOutcome(output="ok", usage=Usage(input_tokens=10, output_tokens=10))
+
+
+def test_tool_responses_replayed_verbatim_not_executed() -> None:
+    tool = CapturedToolCall(
+        tool_name="search", request="q=cats", response="CAPTURED_RESULT_42"
+    )
+    item = ReplayItem(item_id="t1", context=_ctx(ref="t1", tools=(tool,)), stratum="default")
+    model = ToolRecordingModel()
+    engine = ReplayEngine(seed_catalog(), _config())
+    engine.run([item], model)
+    # The engine handed the captured response through verbatim; it never invoked a live tool.
+    assert model.seen_tool_responses == ["CAPTURED_RESULT_42"]
+
+
+def test_captured_context_injected_not_refetched() -> None:
+    model = FixedCostModel()
+    item = _item("x")
+    ReplayEngine(seed_catalog(), _config()).run([item], model)
+    # the exact captured context object is what the model received
+    assert model.calls[0][1] is item.context
+
+
+# --- Cap enforcement ----------------------------------------------------------------------------
+
+
+def test_per_comparison_cap_stops_admission() -> None:
+    # each replay costs 450 micro; cap at 1000 admits 2, skips the 3rd
+    cfg = _config(per_comparison_cap_micro_usd=1_000)
+    engine = ReplayEngine(seed_catalog(), cfg)
+    report = engine.run([_item("a"), _item("b"), _item("c")], FixedCostModel())
+    assert report.replayed_count == 2
+    assert report.skipped_by_cap_count == 1
+    assert report.total_replay_cost_micro_usd == 900
+    assert report.bound_by_cap == "per_comparison"
+    capped = [r for r in report.results if r.capped]
+    assert len(capped) == 1
+    assert capped[0].replay_cost_micro_usd == 0
+
+
+def test_per_tenant_cap_stops_admission() -> None:
+    cfg = _config(per_tenant_cap_micro_usd=450, tenant_id="acme")
+    engine = ReplayEngine(seed_catalog(), cfg)
+    report = engine.run([_item("a"), _item("b")], FixedCostModel())
+    assert report.replayed_count == 1
+    assert report.skipped_by_cap_count == 1
+    assert report.bound_by_cap == "per_tenant"
+
+
+def test_zero_cap_admits_nothing() -> None:
+    cfg = _config(per_comparison_cap_micro_usd=0)
+    engine = ReplayEngine(seed_catalog(), cfg)
+    report = engine.run([_item("a")], FixedCostModel())
+    assert report.replayed_count == 0
+    assert report.skipped_by_cap_count == 1
+
+
+def test_no_cap_runs_everything() -> None:
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run([_item("a"), _item("b"), _item("c")], FixedCostModel())
+    assert report.replayed_count == 3
+    assert report.bound_by_cap is None
+
+
+# --- Defensiveness ------------------------------------------------------------------------------
+
+
+def test_empty_workload_yields_empty_report() -> None:
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run([], FixedCostModel())
+    assert isinstance(report, ReplayReport)
+    assert report.workload_size == 0
+    assert report.sample_size == 0
+    assert report.results == ()
+    assert report.total_replay_cost_micro_usd == 0
+
+
+def test_none_workload_is_safe() -> None:
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run(None, FixedCostModel())
+    assert report.workload_size == 0
+
+
+def test_non_replayitem_entries_ignored() -> None:
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run([_item("a"), "garbage", 42, None, _item("b")], FixedCostModel())
+    assert report.workload_size == 2
+    assert report.replayed_count == 2
+
+
+def test_model_that_raises_is_recorded_failed_zero_cost() -> None:
+    class Boom:
+        def __call__(self, model: str, context: CapturedContext) -> ReplayOutcome:
+            raise RuntimeError("model exploded")
+
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run([_item("a"), _item("b")], Boom())
+    assert report.failed_count == 2
+    assert report.replayed_count == 2  # they still "ran", just failed
+    assert report.total_replay_cost_micro_usd == 0
+    assert all(r.failed for r in report.results)
+
+
+def test_model_returning_garbage_is_failed() -> None:
+    class Bad:
+        def __call__(self, model: str, context: CapturedContext) -> ReplayOutcome:
+            return "not an outcome"  # type: ignore[return-value]
+
+    engine = ReplayEngine(seed_catalog(), _config())
+    report = engine.run([_item("a")], Bad())
+    assert report.failed_count == 1
+    assert report.total_replay_cost_micro_usd == 0
+
+
+def test_missing_price_yields_zero_cost_not_crash() -> None:
+    # unknown model has no catalog entry -> cost 0, no raise
+    cfg = _config(candidate_models=("totally-unknown-model",))
+    engine = ReplayEngine(seed_catalog(), cfg)
+    report = engine.run([_item("a")], FixedCostModel())
+    assert report.replayed_count == 1
+    assert report.total_replay_cost_micro_usd == 0
+    assert report.failed_count == 0
+
+
+# --- Serialization ------------------------------------------------------------------------------
+
+
+def test_as_dict_round_trips_shape() -> None:
+    engine = ReplayEngine(seed_catalog(), _config(sample_size=5, seed="seed"))
+    report = engine.run(_workload(), FixedCostModel())
+    d = report.as_dict()
+    assert set(d) == {
+        "workload_size",
+        "sample_size",
+        "sample_composition",
+        "results",
+        "total_replay_cost_micro_usd",
+        "per_model_cost_micro_usd",
+        "replayed_count",
+        "skipped_by_cap_count",
+        "failed_count",
+        "bound_by_cap",
+    }
+    assert isinstance(d["results"], list)
+    assert isinstance(d["results"][0], dict)
+
+
+def test_result_as_dict_shape() -> None:
+    r = ReplayResult(
+        item_id="a", model="m", stratum="body", output="o", replay_cost_micro_usd=5
+    )
+    assert r.as_dict()["replay_cost_micro_usd"] == 5
+    assert r.as_dict()["capped"] is False
+
+
+def test_captured_context_as_dict() -> None:
+    tool = CapturedToolCall(tool_name="t", request="r", response="resp")
+    ctx = _ctx(ref="z", tools=(tool,))
+    d = ctx.as_dict()
+    assert d["resolved_context_ref"] == "z"
+    assert d["tool_calls"] == [{"tool_name": "t", "request": "r", "response": "resp"}]


### PR DESCRIPTION
## Summary
Implements CTO-59: a pure-logic, offline replay engine for pre-deploy model comparison.

- Injects the EXACT captured context (`ResolvedContextRef` → `CapturedContext`) from the original trace; live retrieval is bypassed, never re-fetched.
- Tool-call responses replayed verbatim from captured span events (`CapturedToolCall`); no live tool execution — the model is an injected `ReplayModel` callable (no network), mirroring the evals/sampling injection pattern.
- Deterministic stratified sampling (seeded-hash, largest-remainder apportionment, reusing the `tally.sampling` approach); sample size + per-stratum composition reported.
- Per-comparison AND per-tenant cost caps enforced via graceful admission control — over-cap replays are skipped (reported), never raised. Replay cost surfaced as integer micro-USD (Decimal rate math via `tally.pricing`).
- Defensive: empty/None/garbage workloads → empty report; a model that raises or returns garbage is recorded failed/zero-cost and the run continues; missing price → zero cost.

## Clean seams (out of scope)
- No coupling to `tally.governor` (CTO-60).
- `ReplayResult` carries raw output for eval scoring (CTO-61).
- `ReplayReport.as_dict()` / `CapturedContext.as_dict()` for UI / projection (CTO-62 / CTO-72).

## Test plan
- [x] `uv run --extra dev ruff check .` — clean
- [x] `uv run --extra dev pytest -q` — 218 passed (35 new), full suite green
- [x] Determinism / reproducibility, stratified composition, verbatim tool replay (no execution), per-comparison + per-tenant cap enforcement, cost surfacing, config validation, all defensive edge cases.

Files added: `sdk/python/src/tally/replay.py`, `sdk/python/tests/test_replay.py`