### PR TITLE
sdk: cost connector framework + v1 connectors (CTO-63)

### DIFF
--- a/sdk/python/src/tally/cost_connectors.py
+++ b/sdk/python/src/tally/cost_connectors.py
@@ -1,0 +1,600 @@
+"""Cost connector framework + v1 connectors.
+
+Implements CTO-63. Spec section 9 W5.
+
+End-to-end cost lives or dies on connector *breadth*: LLM spend is only the visible tip of the
+iceberg. The real bill also includes vector DBs, cloud infra, tool/search APIs and hosting. A
+pluggable connector framework lets new cost sources be added incrementally without touching the
+core, so coverage can grow one provider at a time.
+
+A connector NEVER fetches anything. The caller is responsible for fetching the raw payload from a
+provider's billing/usage API (keys, pagination, retries live there); a connector's only job is to
+*normalize* an injected raw payload into a sequence of :class:`CostRecord` -- the one cost model
+everything maps to. Each record carries (tenant, feature, time) plus an integer micro-USD cost.
+This keeps the module pure-logic, offline and deterministic, matching the house style where
+dependencies are injected (see ``tally.evals`` judge, ``tally.egress`` Protocol transport,
+``tally.replay`` injected model).
+
+Money is integer micro-USD everywhere (see ``tally.schema.usd_to_micro`` / ``micro_to_usd``); rate
+math uses :class:`~decimal.Decimal`, never float dollars.
+
+Adding a new cost source = writing a new class that satisfies the :class:`CostConnector` Protocol
+and registering it. The :class:`ConnectorRegistry` / :class:`CostIngestRunner` need no change.
+
+Out of scope (clean seams left for follow-ups):
+  - Reconciler logic / cloud-billing true-up (CTO-64): this module emits *estimated* normalized
+    records; reconciling them against authoritative invoices is the reconciler's job.
+  - Cost workflow UI (CTO-65 / CTO-66): :meth:`CostIngestRunner.health` surfaces health/last-sync
+    for the UI to render, but no UI lives here.
+  - Real network fetching: the caller fetches; connectors only parse injected payloads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
+from tally.schema import DEFAULT_CURRENCY, usd_to_micro
+
+# Feature tag applied when a row carries no usable feature attribution.
+DEFAULT_FEATURE_TAG = "unattributed"
+
+# Match the safety-boundary contract (tally.safety): never swallow these.
+_NEVER_SWALLOW = (KeyboardInterrupt, SystemExit)
+
+
+# --- the normalized cost model -----------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CostRecord:
+    """The normalized output of every connector -- the one cost model everything maps to.
+
+    A record attributes a cost to ``(tenant_id, feature_tag, occurred_at)`` with an integer
+    micro-USD amount. ``occurred_at`` is the event's *own* timestamp (when the spend happened),
+    never ingest time, so cost lands in the right time bucket.
+    """
+
+    source: str
+    tenant_id: str
+    feature_tag: str
+    occurred_at: datetime
+    cost_micro_usd: int
+    currency: str = DEFAULT_CURRENCY
+    quantity: Decimal | None = None
+    unit: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        """A plain JSON-friendly dict (Decimal/datetime rendered as strings)."""
+        return {
+            "source": self.source,
+            "tenant_id": self.tenant_id,
+            "feature_tag": self.feature_tag,
+            "occurred_at": self.occurred_at.isoformat(),
+            "cost_micro_usd": self.cost_micro_usd,
+            "currency": self.currency,
+            "quantity": str(self.quantity) if self.quantity is not None else None,
+            "unit": self.unit,
+            "metadata": dict(self.metadata),
+        }
+
+
+# --- the stable connector interface ------------------------------------------------------------
+
+
+@runtime_checkable
+class CostConnector(Protocol):
+    """Pluggable cost source. A connector turns ONE already-fetched raw payload into zero or more
+    :class:`CostRecord`s. It must never fetch and should never raise (the runner is the boundary,
+    but well-behaved connectors skip junk rows rather than blowing up the batch).
+
+    Adding a source = a new class satisfying this Protocol; the registry/runner are untouched.
+    """
+
+    @property
+    def name(self) -> str: ...
+
+    def parse(self, raw: object, *, tenant_id: str) -> Sequence[CostRecord]: ...
+
+
+# --- small defensive helpers -------------------------------------------------------------------
+
+
+def _rows(raw: object) -> list[object]:
+    """Best-effort extraction of an iterable of rows from a raw payload.
+
+    Accepts a list/tuple of rows, or a mapping wrapping them under common keys. Anything else
+    yields an empty list (never raises). Strings/bytes are not treated as row iterables.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, Mapping):
+        for key in ("rows", "data", "items", "results", "usage", "line_items"):
+            inner = raw.get(key)
+            if isinstance(inner, (list, tuple)):
+                return list(inner)
+        return []
+    if isinstance(raw, (list, tuple)):
+        return list(raw)
+    return []
+
+
+def _as_mapping(row: object) -> Mapping[str, object] | None:
+    return row if isinstance(row, Mapping) else None
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (str, float)):
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return default
+    return default
+
+
+def _decimal(value: object) -> Decimal | None:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, str, float)):
+        try:
+            return Decimal(str(value))
+        except Exception:  # noqa: BLE001 - malformed money string; skip the row
+            return None
+    return None
+
+
+def _str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _feature(row: Mapping[str, object], *keys: str) -> str:
+    for key in keys:
+        tag = _str(row.get(key))
+        if tag is not None:
+            return tag
+    return DEFAULT_FEATURE_TAG
+
+
+def _timestamp(row: Mapping[str, object], *keys: str) -> datetime | None:
+    """Parse the event's own timestamp from the first present key. ISO-8601 strings, epoch
+    seconds (int/float), or an existing ``datetime``. Returns None (skip) if unparseable.
+    """
+    for key in keys:
+        value = row.get(key)
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str) and value:
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            try:
+                return datetime.fromtimestamp(float(value), tz=timezone.utc)
+            except (OverflowError, OSError, ValueError):
+                continue
+    return None
+
+
+# --- v1 connectors -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LLMProxyConnector:
+    """OpenAI/Anthropic LLM spend via the proxy.
+
+    Parses proxy usage rows (provider, model, prompt/completion tokens, feature tag, timestamp)
+    and prices them through the injected :class:`~tally.pricing.PriceCatalog` -- reusing the real
+    catalog rather than re-deriving rates. A row with no usable catalog price is skipped (no
+    record), so an estimated record is never fabricated. Provider is carried in metadata.
+    """
+
+    catalog: PriceCatalog
+    name: str = "llm_proxy"
+
+    def parse(self, raw: object, *, tenant_id: str) -> Sequence[CostRecord]:
+        out: list[CostRecord] = []
+        for row in _rows(raw):
+            mapping = _as_mapping(row)
+            if mapping is None:
+                continue
+            provider = _str(mapping.get("provider")) or _str(mapping.get("system"))
+            model = _str(mapping.get("model")) or _str(mapping.get("response_model"))
+            occurred_at = _timestamp(mapping, "occurred_at", "timestamp", "ts", "start_time")
+            if provider is None or model is None or occurred_at is None:
+                continue
+            usage = Usage(
+                input_tokens=_int(mapping.get("prompt_tokens", mapping.get("input_tokens"))),
+                output_tokens=_int(
+                    mapping.get("completion_tokens", mapping.get("output_tokens"))
+                ),
+                cached_input_tokens=_int(mapping.get("cached_input_tokens")),
+            )
+            cost_micro, version = compute_cost_micro_usd(
+                self.catalog,
+                provider,
+                model,
+                usage,
+                at=occurred_at.date(),
+                tenant_id=tenant_id,
+            )
+            if not version:
+                # catalog miss -> skip rather than assert a zero/partial cost
+                continue
+            out.append(
+                CostRecord(
+                    source=self.name,
+                    tenant_id=tenant_id,
+                    feature_tag=_feature(mapping, "feature_tag", "feature"),
+                    occurred_at=occurred_at,
+                    cost_micro_usd=cost_micro,
+                    quantity=Decimal(usage.input_tokens + usage.output_tokens),
+                    unit="tokens",
+                    metadata={
+                        "provider": provider,
+                        "model": model,
+                        "price_catalog_version": version,
+                    },
+                )
+            )
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class PineconeConnector:
+    """Pinecone vector DB billing rows -> micro-USD via injected Decimal unit rates.
+
+    Rows carry per-index read-units / write-units; rates are USD per unit (Decimal). Cost is the
+    sum of (units x rate) across the row, converted at the end with ``usd_to_micro``.
+    """
+
+    read_unit_usd: Decimal
+    write_unit_usd: Decimal
+    name: str = "pinecone"
+
+    def parse(self, raw: object, *, tenant_id: str) -> Sequence[CostRecord]:
+        out: list[CostRecord] = []
+        for row in _rows(raw):
+            mapping = _as_mapping(row)
+            if mapping is None:
+                continue
+            occurred_at = _timestamp(mapping, "occurred_at", "timestamp", "date", "ts")
+            if occurred_at is None:
+                continue
+            read_units = _int(mapping.get("read_units"))
+            write_units = _int(mapping.get("write_units"))
+            usd = self.read_unit_usd * Decimal(read_units) + self.write_unit_usd * Decimal(
+                write_units
+            )
+            out.append(
+                CostRecord(
+                    source=self.name,
+                    tenant_id=tenant_id,
+                    feature_tag=_feature(mapping, "feature_tag", "feature", "index"),
+                    occurred_at=occurred_at,
+                    cost_micro_usd=usd_to_micro(usd),
+                    quantity=Decimal(read_units + write_units),
+                    unit="units",
+                    metadata={
+                        "index": _str(mapping.get("index")) or "",
+                        "read_units": read_units,
+                        "write_units": write_units,
+                    },
+                )
+            )
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class AWSCostExplorerConnector:
+    """AWS Cost Explorer ``ResultsByTime`` -> micro-USD.
+
+    Walks the standard Cost Explorer shape: each ``ResultsByTime`` entry has a ``TimePeriod`` and a
+    list of ``Groups`` keyed by a tag (we map the resource tag -> feature_tag), each with an
+    ``UnblendedCost`` ``{Amount, Unit}`` in dollars. ``usd_to_micro`` converts at the boundary.
+    """
+
+    name: str = "aws_cost_explorer"
+
+    def parse(self, raw: object, *, tenant_id: str) -> Sequence[CostRecord]:
+        mapping = _as_mapping(raw)
+        if mapping is None:
+            return []
+        results = mapping.get("ResultsByTime")
+        if not isinstance(results, (list, tuple)):
+            return []
+        out: list[CostRecord] = []
+        for entry in results:
+            entry_map = _as_mapping(entry)
+            if entry_map is None:
+                continue
+            period = _as_mapping(entry_map.get("TimePeriod")) or {}
+            occurred_at = _timestamp(period, "Start", "start")
+            if occurred_at is None:
+                continue
+            groups = entry_map.get("Groups")
+            if not isinstance(groups, (list, tuple)):
+                continue
+            for group in groups:
+                group_map = _as_mapping(group)
+                if group_map is None:
+                    continue
+                metrics = _as_mapping(group_map.get("Metrics")) or {}
+                unblended = _as_mapping(metrics.get("UnblendedCost")) or {}
+                amount = _decimal(unblended.get("Amount"))
+                if amount is None:
+                    continue
+                keys = group_map.get("Keys")
+                tag = ""
+                if isinstance(keys, (list, tuple)) and keys:
+                    tag = _str(keys[0]) or ""
+                currency = _str(unblended.get("Unit")) or DEFAULT_CURRENCY
+                out.append(
+                    CostRecord(
+                        source=self.name,
+                        tenant_id=tenant_id,
+                        feature_tag=tag or DEFAULT_FEATURE_TAG,
+                        occurred_at=occurred_at,
+                        cost_micro_usd=usd_to_micro(amount),
+                        currency=currency,
+                        metadata={"resource_tag": tag},
+                    )
+                )
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class TavilyConnector:
+    """Tavily tool/search API: per-search-call rows (count x price) -> micro-USD.
+
+    Rows carry a search ``count`` and a per-call USD price (Decimal). A row may override the
+    default price via ``price_per_call_usd``; otherwise the injected default applies.
+    """
+
+    price_per_call_usd: Decimal
+    name: str = "tavily"
+
+    def parse(self, raw: object, *, tenant_id: str) -> Sequence[CostRecord]:
+        out: list[CostRecord] = []
+        for row in _rows(raw):
+            mapping = _as_mapping(row)
+            if mapping is None:
+                continue
+            occurred_at = _timestamp(mapping, "occurred_at", "timestamp", "ts")
+            if occurred_at is None:
+                continue
+            count = _int(mapping.get("count", mapping.get("searches")), default=0)
+            price = _decimal(mapping.get("price_per_call_usd")) or self.price_per_call_usd
+            usd = price * Decimal(count)
+            out.append(
+                CostRecord(
+                    source=self.name,
+                    tenant_id=tenant_id,
+                    feature_tag=_feature(mapping, "feature_tag", "feature"),
+                    occurred_at=occurred_at,
+                    cost_micro_usd=usd_to_micro(usd),
+                    quantity=Decimal(count),
+                    unit="searches",
+                    metadata={"count": count},
+                )
+            )
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class VercelConnector:
+    """Vercel hosting usage line items -> micro-USD via injected Decimal rates.
+
+    Each line item has a ``metric`` (e.g. ``bandwidth`` in GB, ``function_invocations`` count) and
+    a numeric ``quantity``. The injected ``rates`` map metric -> USD per unit (Decimal). An unknown
+    metric (no rate) is skipped rather than priced at zero.
+    """
+
+    rates: Mapping[str, Decimal]
+    name: str = "vercel"
+
+    def parse(self, raw: object, *, tenant_id: str) -> Sequence[CostRecord]:
+        out: list[CostRecord] = []
+        for row in _rows(raw):
+            mapping = _as_mapping(row)
+            if mapping is None:
+                continue
+            metric = _str(mapping.get("metric"))
+            occurred_at = _timestamp(mapping, "occurred_at", "timestamp", "ts", "period_start")
+            quantity = _decimal(mapping.get("quantity"))
+            if metric is None or occurred_at is None or quantity is None:
+                continue
+            rate = self.rates.get(metric)
+            if rate is None:
+                # unknown metric -> skip rather than fabricate a zero-cost record
+                continue
+            usd = rate * quantity
+            out.append(
+                CostRecord(
+                    source=self.name,
+                    tenant_id=tenant_id,
+                    feature_tag=_feature(mapping, "feature_tag", "feature", "project"),
+                    occurred_at=occurred_at,
+                    cost_micro_usd=usd_to_micro(usd),
+                    quantity=quantity,
+                    unit=metric,
+                    metadata={"metric": metric, "project": _str(mapping.get("project")) or ""},
+                )
+            )
+        return out
+
+
+# --- registry + runner + health ----------------------------------------------------------------
+
+
+class ConnectorRegistry:
+    """Register connectors by name. Adding a source needs no change here -- just ``register`` it."""
+
+    def __init__(self) -> None:
+        self._connectors: dict[str, CostConnector] = {}
+
+    def register(self, connector: CostConnector) -> CostConnector:
+        self._connectors[connector.name] = connector
+        return connector
+
+    def get(self, name: str) -> CostConnector | None:
+        return self._connectors.get(name)
+
+    def names(self) -> list[str]:
+        return sorted(self._connectors)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._connectors
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorHealth:
+    """Connector health / last-sync, surfaced for the cost workflow UI (CTO-65/66).
+
+    ``ok`` is True when the last run completed with no errors. ``last_sync`` is the wall-clock time
+    of the most recent run (None if never run).
+    """
+
+    name: str
+    last_sync: datetime | None = None
+    records_emitted: int = 0
+    errors_count: int = 0
+    last_error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.errors_count == 0
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "last_sync": self.last_sync.isoformat() if self.last_sync else None,
+            "records_emitted": self.records_emitted,
+            "errors_count": self.errors_count,
+            "last_error": self.last_error,
+            "ok": self.ok,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IngestResult:
+    """Outcome of running a connector over a batch: the records plus the resulting health."""
+
+    records: list[CostRecord]
+    health: ConnectorHealth
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def run_connector(
+    connector: CostConnector,
+    payloads: Sequence[object],
+    *,
+    tenant_id: str,
+    now: datetime | None = None,
+) -> IngestResult:
+    """Apply ``connector`` to a batch of already-fetched raw ``payloads``.
+
+    NEVER raises if a payload is malformed: the error is counted in health and the batch
+    continues (mirrors the never-crash invariant in ``tally.safety``). An empty batch yields an
+    empty result and a healthy zero-sync health.
+    """
+    records: list[CostRecord] = []
+    errors = 0
+    last_error: str | None = None
+    for payload in payloads:
+        try:
+            parsed = connector.parse(payload, tenant_id=tenant_id)
+        except _NEVER_SWALLOW:
+            raise
+        except BaseException as exc:  # noqa: BLE001 - connector boundary; must never escape
+            errors += 1
+            last_error = f"{type(exc).__name__}: {exc}"
+            continue
+        for record in parsed or ():
+            if isinstance(record, CostRecord):
+                records.append(record)
+    health = ConnectorHealth(
+        name=connector.name,
+        last_sync=now or _now(),
+        records_emitted=len(records),
+        errors_count=errors,
+        last_error=last_error,
+    )
+    return IngestResult(records=records, health=health)
+
+
+class CostIngestRunner:
+    """Drives a registry of connectors over batches of injected payloads, collecting normalized
+    :class:`CostRecord`s and per-connector :class:`ConnectorHealth`.
+
+    Stateless except for the latest health per connector (surfaced via :meth:`health`). Never
+    raises on malformed input.
+    """
+
+    def __init__(self, registry: ConnectorRegistry | None = None) -> None:
+        self.registry = registry or ConnectorRegistry()
+        self._health: dict[str, ConnectorHealth] = {}
+
+    def register(self, connector: CostConnector) -> CostConnector:
+        return self.registry.register(connector)
+
+    def run(
+        self,
+        name: str,
+        payloads: Sequence[object],
+        *,
+        tenant_id: str,
+        now: datetime | None = None,
+    ) -> IngestResult:
+        """Run a single named connector over a batch. Records its health. Unknown name yields an
+        empty result with an error-flagged health (never raises)."""
+        connector = self.registry.get(name)
+        if connector is None:
+            health = ConnectorHealth(
+                name=name,
+                last_sync=now or _now(),
+                records_emitted=0,
+                errors_count=1,
+                last_error=f"unknown connector: {name!r}",
+            )
+            self._health[name] = health
+            return IngestResult(records=[], health=health)
+        result = run_connector(connector, payloads, tenant_id=tenant_id, now=now)
+        self._health[name] = result.health
+        return result
+
+    def run_all(
+        self,
+        batches: Mapping[str, Sequence[object]],
+        *,
+        tenant_id: str,
+        now: datetime | None = None,
+    ) -> list[CostRecord]:
+        """Run several connectors, one batch each (keyed by connector name). Returns all records;
+        health is recorded per connector and available via :meth:`health`."""
+        records: list[CostRecord] = []
+        for name, payloads in batches.items():
+            records.extend(self.run(name, payloads, tenant_id=tenant_id, now=now).records)
+        return records
+
+    def health(self, name: str | None = None) -> ConnectorHealth | dict[str, ConnectorHealth]:
+        """Surface connector health / last-sync. With a name, that connector's latest health (a
+        never-run connector reports a healthy zero-sync). Without, a copy of all recorded health."""
+        if name is not None:
+            return self._health.get(name, ConnectorHealth(name=name))
+        return dict(self._health)

--- a/sdk/python/tests/test_cost_connectors.py
+++ b/sdk/python/tests/test_cost_connectors.py
@@ -1,0 +1,439 @@
+"""Tests for the cost connector framework + v1 connectors (CTO-63)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from tally.cost_connectors import (
+    DEFAULT_FEATURE_TAG,
+    AWSCostExplorerConnector,
+    ConnectorHealth,
+    ConnectorRegistry,
+    CostIngestRunner,
+    CostRecord,
+    LLMProxyConnector,
+    PineconeConnector,
+    TavilyConnector,
+    VercelConnector,
+    run_connector,
+)
+from tally.pricing import seed_catalog
+from tally.schema import DEFAULT_CURRENCY, micro_to_usd, usd_to_micro
+
+TS = "2026-05-01T12:00:00+00:00"
+TS_DT = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+NOW = datetime(2026, 5, 30, 0, 0, 0, tzinfo=timezone.utc)
+
+
+# --- CostRecord --------------------------------------------------------------------------------
+
+
+def test_cost_record_as_dict_is_json_friendly():
+    rec = CostRecord(
+        source="x",
+        tenant_id="t1",
+        feature_tag="search",
+        occurred_at=TS_DT,
+        cost_micro_usd=1234,
+        quantity=Decimal("5"),
+        unit="searches",
+        metadata={"k": "v"},
+    )
+    d = rec.as_dict()
+    assert d["occurred_at"] == TS
+    assert d["cost_micro_usd"] == 1234
+    assert d["currency"] == DEFAULT_CURRENCY
+    assert d["quantity"] == "5"
+    assert d["metadata"] == {"k": "v"}
+
+
+def test_cost_record_is_frozen():
+    rec = CostRecord(
+        source="x", tenant_id="t", feature_tag="f", occurred_at=TS_DT, cost_micro_usd=1
+    )
+    with pytest.raises(FrozenInstanceError):
+        rec.cost_micro_usd = 2  # type: ignore[misc]
+
+
+# --- LLM proxy connector -----------------------------------------------------------------------
+
+
+def test_llm_proxy_prices_via_catalog_and_maps_tenant_feature_time():
+    conn = LLMProxyConnector(catalog=seed_catalog())
+    rows = [
+        {
+            "provider": "openai",
+            "model": "gpt-5-mini",
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "feature_tag": "chat",
+            "occurred_at": TS,
+        }
+    ]
+    records = conn.parse(rows, tenant_id="tenant-A")
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.tenant_id == "tenant-A"
+    assert rec.feature_tag == "chat"
+    assert rec.occurred_at == TS_DT
+    assert rec.metadata["provider"] == "openai"
+    # 1000 input @0.25/Mtok + 500 output @2.00/Mtok = 0.00025 + 0.001 = 0.00125 USD
+    assert rec.cost_micro_usd == usd_to_micro(Decimal("0.00125"))
+    assert micro_to_usd(rec.cost_micro_usd) == Decimal("0.00125000")
+
+
+def test_llm_proxy_skips_catalog_miss():
+    conn = LLMProxyConnector(catalog=seed_catalog())
+    rows = [
+        {
+            "provider": "openai",
+            "model": "no-such-model",
+            "prompt_tokens": 100,
+            "occurred_at": TS,
+        }
+    ]
+    assert conn.parse(rows, tenant_id="t") == []
+
+
+def test_llm_proxy_skips_rows_missing_fields():
+    conn = LLMProxyConnector(catalog=seed_catalog())
+    rows = [
+        {"model": "gpt-5-mini", "occurred_at": TS},  # no provider
+        {"provider": "openai", "occurred_at": TS},  # no model
+        {"provider": "openai", "model": "gpt-5-mini"},  # no timestamp
+    ]
+    assert conn.parse(rows, tenant_id="t") == []
+
+
+# --- Pinecone connector ------------------------------------------------------------------------
+
+
+def test_pinecone_units_to_micro():
+    conn = PineconeConnector(read_unit_usd=Decimal("0.0001"), write_unit_usd=Decimal("0.001"))
+    rows = [
+        {
+            "index": "prod-index",
+            "read_units": 100,
+            "write_units": 10,
+            "feature_tag": "rag",
+            "occurred_at": TS,
+        }
+    ]
+    records = conn.parse(rows, tenant_id="t")
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.feature_tag == "rag"
+    assert rec.occurred_at == TS_DT
+    # 100*0.0001 + 10*0.001 = 0.01 + 0.01 = 0.02 USD
+    assert rec.cost_micro_usd == usd_to_micro(Decimal("0.02"))
+    assert rec.metadata["index"] == "prod-index"
+
+
+def test_pinecone_falls_back_to_index_as_feature():
+    conn = PineconeConnector(read_unit_usd=Decimal("0.0001"), write_unit_usd=Decimal("0.001"))
+    rows = [{"index": "idx", "read_units": 1, "occurred_at": TS}]
+    records = conn.parse(rows, tenant_id="t")
+    assert records[0].feature_tag == "idx"
+
+
+# --- AWS Cost Explorer connector ---------------------------------------------------------------
+
+
+def _aws_payload():
+    return {
+        "ResultsByTime": [
+            {
+                "TimePeriod": {"Start": "2026-05-01", "End": "2026-05-02"},
+                "Groups": [
+                    {
+                        "Keys": ["feature$checkout"],
+                        "Metrics": {"UnblendedCost": {"Amount": "12.34", "Unit": "USD"}},
+                    },
+                    {
+                        "Keys": ["feature$search"],
+                        "Metrics": {"UnblendedCost": {"Amount": "0.50", "Unit": "USD"}},
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def test_aws_cost_explorer_maps_tag_to_feature_and_dollars_to_micro():
+    conn = AWSCostExplorerConnector()
+    records = conn.parse(_aws_payload(), tenant_id="tenant-A")
+    assert len(records) == 2
+    by_tag = {r.feature_tag: r for r in records}
+    assert by_tag["feature$checkout"].cost_micro_usd == usd_to_micro(Decimal("12.34"))
+    assert by_tag["feature$search"].cost_micro_usd == usd_to_micro(Decimal("0.50"))
+    assert all(r.tenant_id == "tenant-A" for r in records)
+    assert by_tag["feature$checkout"].occurred_at == datetime(
+        2026, 5, 1, tzinfo=timezone.utc
+    )
+
+
+def test_aws_skips_group_without_amount():
+    payload = {
+        "ResultsByTime": [
+            {
+                "TimePeriod": {"Start": "2026-05-01"},
+                "Groups": [{"Keys": ["x"], "Metrics": {"UnblendedCost": {}}}],
+            }
+        ]
+    }
+    assert AWSCostExplorerConnector().parse(payload, tenant_id="t") == []
+
+
+# --- Tavily connector --------------------------------------------------------------------------
+
+
+def test_tavily_count_times_price():
+    conn = TavilyConnector(price_per_call_usd=Decimal("0.005"))
+    rows = [{"count": 200, "feature_tag": "research", "occurred_at": TS}]
+    records = conn.parse(rows, tenant_id="t")
+    assert len(records) == 1
+    # 200 * 0.005 = 1.00 USD
+    assert records[0].cost_micro_usd == usd_to_micro(Decimal("1.00"))
+    assert records[0].quantity == Decimal("200")
+    assert records[0].feature_tag == "research"
+
+
+def test_tavily_row_price_override():
+    conn = TavilyConnector(price_per_call_usd=Decimal("0.005"))
+    rows = [{"count": 10, "price_per_call_usd": "0.01", "occurred_at": TS}]
+    records = conn.parse(rows, tenant_id="t")
+    assert records[0].cost_micro_usd == usd_to_micro(Decimal("0.10"))
+    assert records[0].feature_tag == DEFAULT_FEATURE_TAG
+
+
+# --- Vercel connector --------------------------------------------------------------------------
+
+
+def test_vercel_rates_per_metric():
+    conn = VercelConnector(
+        rates={"bandwidth": Decimal("0.10"), "function_invocations": Decimal("0.0000002")}
+    )
+    rows = [
+        {"metric": "bandwidth", "quantity": "5", "project": "web", "occurred_at": TS},
+        {"metric": "function_invocations", "quantity": "1000000", "occurred_at": TS},
+    ]
+    records = conn.parse(rows, tenant_id="t")
+    assert len(records) == 2
+    by_unit = {r.unit: r for r in records}
+    assert by_unit["bandwidth"].cost_micro_usd == usd_to_micro(Decimal("0.50"))
+    assert by_unit["bandwidth"].feature_tag == "web"
+    assert by_unit["function_invocations"].cost_micro_usd == usd_to_micro(Decimal("0.20"))
+
+
+def test_vercel_skips_unknown_metric():
+    conn = VercelConnector(rates={"bandwidth": Decimal("0.10")})
+    rows = [{"metric": "mystery", "quantity": "5", "occurred_at": TS}]
+    assert conn.parse(rows, tenant_id="t") == []
+
+
+# --- defensiveness -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "conn",
+    [
+        LLMProxyConnector(catalog=seed_catalog()),
+        PineconeConnector(read_unit_usd=Decimal("0.1"), write_unit_usd=Decimal("0.1")),
+        AWSCostExplorerConnector(),
+        TavilyConnector(price_per_call_usd=Decimal("0.005")),
+        VercelConnector(rates={"bandwidth": Decimal("0.1")}),
+    ],
+)
+@pytest.mark.parametrize("raw", [None, "garbage", 42, [], {}, [None, 7, "x"], {"rows": "nope"}])
+def test_connectors_never_raise_on_garbage(conn, raw):
+    out = conn.parse(raw, tenant_id="t")
+    assert list(out) == []
+
+
+def test_connectors_accept_wrapped_rows_mapping():
+    conn = TavilyConnector(price_per_call_usd=Decimal("0.01"))
+    out = conn.parse({"data": [{"count": 1, "occurred_at": TS}]}, tenant_id="t")
+    assert len(out) == 1
+
+
+def test_epoch_timestamp_parsed():
+    conn = TavilyConnector(price_per_call_usd=Decimal("0.01"))
+    epoch = int(TS_DT.timestamp())
+    out = conn.parse([{"count": 1, "occurred_at": epoch}], tenant_id="t")
+    assert out[0].occurred_at == TS_DT
+
+
+# --- registry / pluggability -------------------------------------------------------------------
+
+
+def test_registry_register_and_lookup():
+    reg = ConnectorRegistry()
+    conn = TavilyConnector(price_per_call_usd=Decimal("0.01"))
+    reg.register(conn)
+    assert "tavily" in reg
+    assert reg.get("tavily") is conn
+    assert reg.names() == ["tavily"]
+    assert reg.get("missing") is None
+
+
+def test_custom_connector_needs_no_core_change():
+    """A brand-new cost source: a class satisfying the Protocol, registered + run with no change
+    to the registry or runner."""
+
+    class S3Connector:
+        name = "s3"
+
+        def parse(self, raw, *, tenant_id):
+            rows = raw if isinstance(raw, list) else []
+            return [
+                CostRecord(
+                    source=self.name,
+                    tenant_id=tenant_id,
+                    feature_tag="storage",
+                    occurred_at=TS_DT,
+                    cost_micro_usd=usd_to_micro(Decimal(str(r["usd"]))),
+                )
+                for r in rows
+            ]
+
+    runner = CostIngestRunner()
+    runner.register(S3Connector())
+    result = runner.run("s3", [[{"usd": "1.50"}]], tenant_id="t", now=NOW)
+    assert len(result.records) == 1
+    assert result.records[0].cost_micro_usd == usd_to_micro(Decimal("1.50"))
+    assert result.health.ok
+
+
+# --- runner + health ---------------------------------------------------------------------------
+
+
+def test_run_connector_empty_batch_is_healthy_zero_sync():
+    conn = TavilyConnector(price_per_call_usd=Decimal("0.01"))
+    result = run_connector(conn, [], tenant_id="t", now=NOW)
+    assert result.records == []
+    assert result.health.records_emitted == 0
+    assert result.health.errors_count == 0
+    assert result.health.ok
+    assert result.health.last_sync == NOW
+
+
+def test_runner_records_health_and_last_sync():
+    runner = CostIngestRunner()
+    runner.register(TavilyConnector(price_per_call_usd=Decimal("0.01")))
+    runner.run(
+        "tavily",
+        [[{"count": 5, "occurred_at": TS}], [{"count": 1, "occurred_at": TS}]],
+        tenant_id="t",
+        now=NOW,
+    )
+    health = runner.health("tavily")
+    assert isinstance(health, ConnectorHealth)
+    assert health.records_emitted == 2
+    assert health.last_sync == NOW
+    assert health.ok
+
+
+def test_runner_never_raises_on_malformed_payload_and_counts_error():
+    class Exploder:
+        name = "boom"
+
+        def parse(self, raw, *, tenant_id):
+            raise ValueError("kaboom")
+
+    runner = CostIngestRunner()
+    runner.register(Exploder())
+    result = runner.run("boom", [{"x": 1}, {"y": 2}], tenant_id="t", now=NOW)
+    assert result.records == []
+    assert result.health.errors_count == 2
+    assert result.health.ok is False
+    assert "kaboom" in (result.health.last_error or "")
+
+
+def test_runner_continues_past_bad_payload():
+    """One malformed payload doesn't abort the batch; good ones still emit."""
+
+    class Picky:
+        name = "picky"
+
+        def parse(self, raw, *, tenant_id):
+            if raw == "bad":
+                raise RuntimeError("nope")
+            return [
+                CostRecord(
+                    source=self.name,
+                    tenant_id=tenant_id,
+                    feature_tag="f",
+                    occurred_at=TS_DT,
+                    cost_micro_usd=1,
+                )
+            ]
+
+    runner = CostIngestRunner()
+    runner.register(Picky())
+    result = runner.run("picky", ["bad", "good"], tenant_id="t", now=NOW)
+    assert len(result.records) == 1
+    assert result.health.errors_count == 1
+
+
+def test_runner_non_record_entries_ignored():
+    class Sloppy:
+        name = "sloppy"
+
+        def parse(self, raw, *, tenant_id):
+            return ["not a record", 42, None]
+
+    runner = CostIngestRunner()
+    runner.register(Sloppy())
+    result = runner.run("sloppy", [{}], tenant_id="t", now=NOW)
+    assert result.records == []
+    assert result.health.errors_count == 0
+
+
+def test_runner_unknown_connector_flags_error_not_raise():
+    runner = CostIngestRunner()
+    result = runner.run("ghost", [{}], tenant_id="t", now=NOW)
+    assert result.records == []
+    assert result.health.ok is False
+    assert "ghost" in (result.health.last_error or "")
+
+
+def test_runner_health_for_never_run_connector_is_healthy_zero_sync():
+    runner = CostIngestRunner()
+    health = runner.health("never")
+    assert isinstance(health, ConnectorHealth)
+    assert health.last_sync is None
+    assert health.records_emitted == 0
+    assert health.ok
+
+
+def test_runner_run_all_keyed_by_name():
+    runner = CostIngestRunner()
+    runner.register(TavilyConnector(price_per_call_usd=Decimal("0.01")))
+    runner.register(
+        PineconeConnector(read_unit_usd=Decimal("0.001"), write_unit_usd=Decimal("0.001"))
+    )
+    records = runner.run_all(
+        {
+            "tavily": [[{"count": 1, "occurred_at": TS}]],
+            "pinecone": [[{"read_units": 10, "occurred_at": TS}]],
+        },
+        tenant_id="t",
+        now=NOW,
+    )
+    sources = {r.source for r in records}
+    assert sources == {"tavily", "pinecone"}
+    all_health = runner.health()
+    assert isinstance(all_health, dict)
+    assert set(all_health) == {"tavily", "pinecone"}
+
+
+def test_health_as_dict():
+    h = ConnectorHealth(name="x", last_sync=NOW, records_emitted=3, errors_count=0)
+    d = h.as_dict()
+    assert d["name"] == "x"
+    assert d["last_sync"] == NOW.isoformat()
+    assert d["ok"] is True


### PR DESCRIPTION
## Summary
Implements CTO-63 (spec section 9 W5): a pluggable, pure-logic cost connector framework. Connectors normalize an INJECTED raw payload (caller fetches; connectors never touch the network) into a normalized `CostRecord` mapping every cost to **(tenant, feature, time)** in integer micro-USD.

- `CostRecord` (frozen) — the one normalized cost model, with `as_dict()`.
- `CostConnector` Protocol — stable interface (`name`, `parse(raw, *, tenant_id)`); adding a source needs no core change.
- Five v1 connectors: `LLMProxyConnector` (OpenAI/Anthropic, priced via injected `PriceCatalog` + `compute_cost_micro_usd`), `PineconeConnector` (vector DB, Decimal unit rates), `AWSCostExplorerConnector` (`ResultsByTime`, tag→feature, dollars→`usd_to_micro`), `TavilyConnector` (count×price), `VercelConnector` (usage line items, injected rates).
- `ConnectorRegistry` + `CostIngestRunner`/`run_connector` with `ConnectorHealth` (name, last_sync, records_emitted, errors_count, last_error, `ok`). The runner never raises on a malformed payload — it counts the error and continues, mirroring the `tally.safety` never-crash invariant.

Money is integer micro-USD throughout; Decimal for rate math; `usd_to_micro` at every dollar boundary. `occurred_at` is the event's own timestamp, never ingest time.

### Seams left (out of scope, noted in module docstring)
- Reconciler / cloud-billing true-up — CTO-64 (this emits estimates).
- Cost workflow UI — CTO-65/66 (`health()` surfaces last-sync for it).
- Real network fetching — caller's responsibility.

## Test plan
- [x] `ruff check .` clean (line-length 100)
- [x] `pytest` — 251 passed (full suite, no existing tests broken)
- [x] Pluggability: a custom `S3Connector` registered + run with no framework change
- [x] Each of the 5 connectors maps correctly to (tenant, feature, time) + micro-USD
- [x] Health / last-sync surfaced; never-run connector reports healthy zero-sync
- [x] Defensive: None/garbage/wrapped payloads, catalog miss, unknown metric, non-record entries, exploding connector — zero records + error count, never an exception