### PR TITLE
sdk: tamper-evident usage ledger + invoice export (CTO-87)

### DIFF
--- a/sdk/python/src/tally/ledger.py
+++ b/sdk/python/src/tally/ledger.py
@@ -1,0 +1,462 @@
+"""Tamper-evident usage ledger + invoice export (CTO-87).
+
+Billing has to be defensible. When a customer disputes an invoice we need to show, line by line,
+exactly which usage was billed and prove the record was not altered after the fact. This module
+is the append-only book of record that sits between *finalized usage* (whatever upstream metering
+produced — this module is deliberately agnostic about how usage is measured) and the billing
+integration (Stripe, CTO-90).
+
+Three properties, each load-bearing:
+
+- **Append-only + tamper-evident.** Every entry carries a hash chain: ``entry_hash = H(prev_hash
+  || canonical(entry))``. Changing any past entry (amount, tenant, timestamp) breaks the chain
+  from that point forward, and :meth:`UsageLedger.verify` localizes the first broken link. This is
+  the same construction as a blockchain / Merkle log, minus distribution — one writer, one chain
+  per tenant scope.
+- **Reconcilable.** :meth:`UsageLedger.reconcile` compares ledger totals against an independent
+  ingest count so we can detect dropped or duplicated usage before it reaches an invoice.
+- **Idempotent export.** Each usage record carries an ``idempotency_key``; appending the same key
+  twice is a no-op, and exporting an already-exported entry never bills it again. Re-running an
+  export job is safe — no double-billing.
+
+Money is integer micro-USD throughout (see :mod:`tally.schema`). Pure-Python, no infra: the
+backing store is an injected :class:`LedgerStore` (in-memory by default) so dev/test never needs a
+database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Protocol, runtime_checkable
+
+from tally.schema import DEFAULT_CURRENCY, micro_to_usd
+
+#: Genesis link — the ``prev_hash`` of the very first entry in a chain.
+GENESIS_HASH = "0" * 64
+
+
+# --- inputs -------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class UsageRecord:
+    """A finalized, billable unit of usage handed to the ledger.
+
+    This is intentionally abstract: it is whatever upstream metering finalized. The ledger does not
+    care how ``cost_micro_usd`` was computed, only that it is final and uniquely identified by
+    ``idempotency_key`` (so re-submitting the same record is a no-op).
+    """
+
+    idempotency_key: str
+    tenant_id: str
+    cost_micro_usd: int
+    occurred_at_ns: int
+    feature_tag: str = ""
+    quantity: int = 0
+    unit: str = ""
+    currency: str = DEFAULT_CURRENCY
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.idempotency_key:
+            raise ValueError("idempotency_key must be non-empty")
+        if not self.tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if isinstance(self.cost_micro_usd, bool) or not isinstance(self.cost_micro_usd, int):
+            raise ValueError("cost_micro_usd must be an int (micro-USD)")
+        if self.cost_micro_usd < 0:
+            raise ValueError("cost_micro_usd must be >= 0")
+
+
+# --- ledger entries -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerEntry:
+    """One immutable link in the hash chain.
+
+    ``entry_hash`` is derived from ``prev_hash`` and the canonical payload; it is never set by a
+    caller. ``sequence`` is the 0-based position in the tenant's chain.
+    """
+
+    sequence: int
+    tenant_id: str
+    idempotency_key: str
+    cost_micro_usd: int
+    occurred_at_ns: int
+    appended_at_ns: int
+    feature_tag: str
+    currency: str
+    prev_hash: str
+    entry_hash: str
+    exported: bool = False
+    export_ref: str = ""
+
+    def canonical_payload(self) -> str:
+        """Deterministic, hash-input serialization of the billed fields (excludes the hashes
+        themselves and the mutable export markers)."""
+        return json.dumps(
+            {
+                "sequence": self.sequence,
+                "tenant_id": self.tenant_id,
+                "idempotency_key": self.idempotency_key,
+                "cost_micro_usd": self.cost_micro_usd,
+                "occurred_at_ns": self.occurred_at_ns,
+                "appended_at_ns": self.appended_at_ns,
+                "feature_tag": self.feature_tag,
+                "currency": self.currency,
+                "prev_hash": self.prev_hash,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def recompute_hash(self) -> str:
+        """Recompute ``entry_hash`` from the payload — used by :meth:`UsageLedger.verify`."""
+        return hashlib.sha256(self.canonical_payload().encode("utf-8")).hexdigest()
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "sequence": self.sequence,
+            "tenant_id": self.tenant_id,
+            "idempotency_key": self.idempotency_key,
+            "cost_micro_usd": self.cost_micro_usd,
+            "cost_usd": str(micro_to_usd(self.cost_micro_usd)),
+            "occurred_at_ns": self.occurred_at_ns,
+            "appended_at_ns": self.appended_at_ns,
+            "feature_tag": self.feature_tag,
+            "currency": self.currency,
+            "prev_hash": self.prev_hash,
+            "entry_hash": self.entry_hash,
+            "exported": self.exported,
+            "export_ref": self.export_ref,
+        }
+
+
+# --- store --------------------------------------------------------------------------------------
+
+
+@runtime_checkable
+class LedgerStore(Protocol):
+    """Persistence boundary. The default is in-memory; a production impl would back this with an
+    append-only table. The ledger only ever appends and updates the export marker — it never
+    deletes or rewrites billed fields."""
+
+    def append(self, entry: LedgerEntry) -> None: ...
+
+    def last(self, tenant_id: str) -> LedgerEntry | None: ...
+
+    def entries(self, tenant_id: str) -> Sequence[LedgerEntry]: ...
+
+    def has_key(self, tenant_id: str, idempotency_key: str) -> bool: ...
+
+    def mark_exported(self, tenant_id: str, sequence: int, export_ref: str) -> None: ...
+
+
+class InMemoryLedgerStore:
+    """Default :class:`LedgerStore` — a per-tenant list. No infra; safe for dev/test."""
+
+    __slots__ = ("_by_tenant", "_keys")
+
+    def __init__(self) -> None:
+        self._by_tenant: dict[str, list[LedgerEntry]] = {}
+        self._keys: dict[str, set[str]] = {}
+
+    def append(self, entry: LedgerEntry) -> None:
+        self._by_tenant.setdefault(entry.tenant_id, []).append(entry)
+        self._keys.setdefault(entry.tenant_id, set()).add(entry.idempotency_key)
+
+    def last(self, tenant_id: str) -> LedgerEntry | None:
+        chain = self._by_tenant.get(tenant_id)
+        return chain[-1] if chain else None
+
+    def entries(self, tenant_id: str) -> Sequence[LedgerEntry]:
+        return tuple(self._by_tenant.get(tenant_id, ()))
+
+    def has_key(self, tenant_id: str, idempotency_key: str) -> bool:
+        return idempotency_key in self._keys.get(tenant_id, ())
+
+    def mark_exported(self, tenant_id: str, sequence: int, export_ref: str) -> None:
+        chain = self._by_tenant.get(tenant_id)
+        if chain is None or not (0 <= sequence < len(chain)):
+            return
+        chain[sequence] = replace(chain[sequence], exported=True, export_ref=export_ref)
+
+
+# --- results ------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationResult:
+    """Outcome of a chain integrity check."""
+
+    tenant_id: str
+    ok: bool
+    entries_checked: int
+    broken_at_sequence: int | None = None
+    reason: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tenant_id": self.tenant_id,
+            "ok": self.ok,
+            "entries_checked": self.entries_checked,
+            "broken_at_sequence": self.broken_at_sequence,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationResult:
+    """Ledger totals vs. an independent ingest count."""
+
+    tenant_id: str
+    ledger_count: int
+    ingest_count: int
+    ledger_total_micro_usd: int
+    reconciled: bool
+
+    @property
+    def count_drift(self) -> int:
+        """``ledger_count - ingest_count`` — positive means the ledger has extra (possible double
+        count), negative means usage was dropped before reaching the ledger."""
+        return self.ledger_count - self.ingest_count
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tenant_id": self.tenant_id,
+            "ledger_count": self.ledger_count,
+            "ingest_count": self.ingest_count,
+            "count_drift": self.count_drift,
+            "ledger_total_micro_usd": self.ledger_total_micro_usd,
+            "reconciled": self.reconciled,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class InvoiceLine:
+    """A single billable line on an exported invoice."""
+
+    feature_tag: str
+    quantity: int
+    cost_micro_usd: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "feature_tag": self.feature_tag,
+            "quantity": self.quantity,
+            "cost_micro_usd": self.cost_micro_usd,
+            "cost_usd": str(micro_to_usd(self.cost_micro_usd)),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class InvoiceExport:
+    """An idempotent billing export — the shape Stripe (CTO-90) consumes.
+
+    ``newly_exported_sequences`` are the entries this call actually marked as exported; on a re-run
+    it is empty and ``total_micro_usd`` reflects only the (zero) new charges, so re-export never
+    double-bills.
+    """
+
+    tenant_id: str
+    export_ref: str
+    currency: str
+    total_micro_usd: int
+    lines: tuple[InvoiceLine, ...]
+    newly_exported_sequences: tuple[int, ...]
+    entry_count: int
+
+    @property
+    def total_usd(self) -> str:
+        return str(micro_to_usd(self.total_micro_usd))
+
+    def summary(self) -> str:
+        n = len(self.newly_exported_sequences)
+        return (
+            f"invoice {self.export_ref} for {self.tenant_id}: "
+            f"${self.total_usd} {self.currency} across {self.entry_count} entries "
+            f"({n} newly billed)"
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tenant_id": self.tenant_id,
+            "export_ref": self.export_ref,
+            "currency": self.currency,
+            "total_micro_usd": self.total_micro_usd,
+            "total_usd": self.total_usd,
+            "lines": [line.as_dict() for line in self.lines],
+            "newly_exported_sequences": list(self.newly_exported_sequences),
+            "entry_count": self.entry_count,
+            "summary": self.summary(),
+        }
+
+
+# --- ledger -------------------------------------------------------------------------------------
+
+
+class UsageLedger:
+    """Append-only, hash-chained, tamper-evident usage ledger.
+
+    One hash chain per ``tenant_id``. Construct with an optional :class:`LedgerStore`; the default
+    is in-memory so nothing external is required.
+    """
+
+    __slots__ = ("_store",)
+
+    def __init__(self, store: LedgerStore | None = None) -> None:
+        self._store = store if store is not None else InMemoryLedgerStore()
+
+    # -- append --------------------------------------------------------------------------------
+
+    def append(self, record: UsageRecord, *, appended_at_ns: int | None = None) -> LedgerEntry:
+        """Append a finalized usage record, returning its (possibly pre-existing) ledger entry.
+
+        Idempotent: if ``record.idempotency_key`` was already appended for this tenant, the
+        original entry is returned unchanged and no new link is created.
+        """
+        existing = self._find_by_key(record.tenant_id, record.idempotency_key)
+        if existing is not None:
+            return existing
+
+        prev = self._store.last(record.tenant_id)
+        prev_hash = prev.entry_hash if prev is not None else GENESIS_HASH
+        sequence = (prev.sequence + 1) if prev is not None else 0
+        stamp = appended_at_ns if appended_at_ns is not None else record.occurred_at_ns
+
+        draft = LedgerEntry(
+            sequence=sequence,
+            tenant_id=record.tenant_id,
+            idempotency_key=record.idempotency_key,
+            cost_micro_usd=record.cost_micro_usd,
+            occurred_at_ns=record.occurred_at_ns,
+            appended_at_ns=stamp,
+            feature_tag=record.feature_tag,
+            currency=record.currency,
+            prev_hash=prev_hash,
+            entry_hash="",
+        )
+        entry = replace(draft, entry_hash=draft.recompute_hash())
+        self._store.append(entry)
+        return entry
+
+    def extend(
+        self, records: Iterable[UsageRecord], *, appended_at_ns: int | None = None
+    ) -> list[LedgerEntry]:
+        """Append many records in order; skips non-:class:`UsageRecord` items defensively."""
+        out: list[LedgerEntry] = []
+        for record in records:
+            if not isinstance(record, UsageRecord):
+                continue
+            out.append(self.append(record, appended_at_ns=appended_at_ns))
+        return out
+
+    # -- read ----------------------------------------------------------------------------------
+
+    def entries(self, tenant_id: str) -> Sequence[LedgerEntry]:
+        """All entries for a tenant, in chain order."""
+        return self._store.entries(tenant_id)
+
+    def total_micro_usd(self, tenant_id: str) -> int:
+        return sum(e.cost_micro_usd for e in self._store.entries(tenant_id))
+
+    def _find_by_key(self, tenant_id: str, idempotency_key: str) -> LedgerEntry | None:
+        if not self._store.has_key(tenant_id, idempotency_key):
+            return None
+        for entry in self._store.entries(tenant_id):
+            if entry.idempotency_key == idempotency_key:
+                return entry
+        return None
+
+    # -- verify --------------------------------------------------------------------------------
+
+    def verify(self, tenant_id: str) -> VerificationResult:
+        """Walk the chain and confirm every link. Returns the first break, if any.
+
+        A tamper (changed amount/tenant/timestamp) changes that entry's recomputed hash, so either
+        its own ``entry_hash`` no longer matches or the *next* entry's ``prev_hash`` no longer
+        matches — both are caught here.
+        """
+        entries = self._store.entries(tenant_id)
+        expected_prev = GENESIS_HASH
+        for i, entry in enumerate(entries):
+            if entry.sequence != i:
+                return VerificationResult(
+                    tenant_id, False, i, i, f"sequence gap: expected {i}, got {entry.sequence}"
+                )
+            if entry.prev_hash != expected_prev:
+                return VerificationResult(
+                    tenant_id, False, i, i, "prev_hash does not match preceding entry_hash"
+                )
+            if entry.recompute_hash() != entry.entry_hash:
+                return VerificationResult(
+                    tenant_id, False, i, i, "entry_hash does not match payload (tampered)"
+                )
+            expected_prev = entry.entry_hash
+        return VerificationResult(tenant_id, True, len(entries))
+
+    # -- reconcile -----------------------------------------------------------------------------
+
+    def reconcile(self, tenant_id: str, ingest_count: int) -> ReconciliationResult:
+        """Compare the ledger entry count against an independent ingest count.
+
+        ``reconciled`` is true only when the counts match exactly *and* the chain verifies — a
+        broken chain can never be considered reconciled.
+        """
+        entries = self._store.entries(tenant_id)
+        chain_ok = self.verify(tenant_id).ok
+        return ReconciliationResult(
+            tenant_id=tenant_id,
+            ledger_count=len(entries),
+            ingest_count=ingest_count,
+            ledger_total_micro_usd=sum(e.cost_micro_usd for e in entries),
+            reconciled=chain_ok and len(entries) == ingest_count,
+        )
+
+    # -- export --------------------------------------------------------------------------------
+
+    def export_invoice(self, tenant_id: str, export_ref: str) -> InvoiceExport:
+        """Export all not-yet-exported entries as an invoice and mark them exported.
+
+        Idempotent on ``export_ref`` semantics: only entries still flagged ``exported=False`` are
+        billed and marked; a second call with fresh entries bills only those, and a call with no
+        new entries returns a zero-total invoice. Already-billed usage is never re-charged.
+        """
+        if not export_ref:
+            raise ValueError("export_ref must be non-empty")
+
+        entries = self._store.entries(tenant_id)
+        pending = [e for e in entries if not e.exported]
+
+        currency = pending[0].currency if pending else DEFAULT_CURRENCY
+        by_feature: dict[str, list[int]] = {}
+        total = 0
+        newly: list[int] = []
+        for entry in pending:
+            total += entry.cost_micro_usd
+            by_feature.setdefault(entry.feature_tag, [0, 0])
+            bucket = by_feature[entry.feature_tag]
+            bucket[0] += 1
+            bucket[1] += entry.cost_micro_usd
+            self._store.mark_exported(tenant_id, entry.sequence, export_ref)
+            newly.append(entry.sequence)
+
+        lines = tuple(
+            InvoiceLine(feature_tag=tag, quantity=count, cost_micro_usd=cost)
+            for tag, (count, cost) in sorted(
+                by_feature.items(), key=lambda kv: kv[1][1], reverse=True
+            )
+        )
+        return InvoiceExport(
+            tenant_id=tenant_id,
+            export_ref=export_ref,
+            currency=currency,
+            total_micro_usd=total,
+            lines=lines,
+            newly_exported_sequences=tuple(newly),
+            entry_count=len(entries),
+        )

--- a/sdk/python/tests/test_ledger.py
+++ b/sdk/python/tests/test_ledger.py
@@ -1,0 +1,278 @@
+"""Tamper-evident usage ledger: hash chain, reconciliation, idempotent export (CTO-87)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from tally.ledger import (
+    GENESIS_HASH,
+    InMemoryLedgerStore,
+    InvoiceExport,
+    LedgerEntry,
+    ReconciliationResult,
+    UsageLedger,
+    UsageRecord,
+    VerificationResult,
+)
+
+
+def _rec(key: str, *, tenant: str = "t1", cost: int = 1_000, feature: str = "chat",
+         at: int = 1_000) -> UsageRecord:
+    return UsageRecord(
+        idempotency_key=key,
+        tenant_id=tenant,
+        cost_micro_usd=cost,
+        occurred_at_ns=at,
+        feature_tag=feature,
+    )
+
+
+# --- append + chain -----------------------------------------------------------------------------
+
+
+def test_first_entry_chains_from_genesis() -> None:
+    ledger = UsageLedger()
+    entry = ledger.append(_rec("k1"))
+    assert entry.sequence == 0
+    assert entry.prev_hash == GENESIS_HASH
+    assert entry.entry_hash == entry.recompute_hash()
+
+
+def test_entries_chain_prev_to_entry_hash() -> None:
+    ledger = UsageLedger()
+    a = ledger.append(_rec("k1"))
+    b = ledger.append(_rec("k2"))
+    c = ledger.append(_rec("k3"))
+    assert b.prev_hash == a.entry_hash
+    assert c.prev_hash == b.entry_hash
+    assert [e.sequence for e in (a, b, c)] == [0, 1, 2]
+
+
+def test_chain_is_per_tenant() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1", tenant="t1"))
+    other = ledger.append(_rec("k1", tenant="t2"))
+    # independent chains: t2's first entry also starts from genesis
+    assert other.sequence == 0
+    assert other.prev_hash == GENESIS_HASH
+
+
+# --- idempotency --------------------------------------------------------------------------------
+
+
+def test_duplicate_idempotency_key_is_noop() -> None:
+    ledger = UsageLedger()
+    first = ledger.append(_rec("dup", cost=500))
+    again = ledger.append(_rec("dup", cost=999))  # same key, different cost
+    assert again == first  # original returned unchanged
+    assert len(ledger.entries("t1")) == 1
+    assert ledger.total_micro_usd("t1") == 500
+
+
+def test_extend_appends_in_order_and_skips_garbage() -> None:
+    ledger = UsageLedger()
+    out = ledger.extend([_rec("k1"), "garbage", None, _rec("k2")])  # type: ignore[list-item]
+    assert [e.idempotency_key for e in out] == ["k1", "k2"]
+    assert len(ledger.entries("t1")) == 2
+
+
+# --- verify / tamper-evidence -------------------------------------------------------------------
+
+
+def test_verify_passes_for_clean_chain() -> None:
+    ledger = UsageLedger()
+    ledger.extend([_rec(f"k{i}") for i in range(5)])
+    result = ledger.verify("t1")
+    assert isinstance(result, VerificationResult)
+    assert result.ok
+    assert result.entries_checked == 5
+    assert result.broken_at_sequence is None
+
+
+def test_verify_detects_tampered_amount() -> None:
+    store = InMemoryLedgerStore()
+    ledger = UsageLedger(store)
+    ledger.extend([_rec(f"k{i}", cost=1_000) for i in range(4)])
+    # tamper: rewrite entry #1's cost without recomputing its hash
+    chain = store._by_tenant["t1"]
+    chain[1] = replace(chain[1], cost_micro_usd=999_999)
+    result = ledger.verify("t1")
+    assert not result.ok
+    assert result.broken_at_sequence == 1
+
+
+def test_verify_detects_reordering() -> None:
+    store = InMemoryLedgerStore()
+    ledger = UsageLedger(store)
+    ledger.extend([_rec(f"k{i}") for i in range(3)])
+    chain = store._by_tenant["t1"]
+    chain[0], chain[1] = chain[1], chain[0]  # swap breaks sequence + prev_hash
+    result = ledger.verify("t1")
+    assert not result.ok
+    assert result.broken_at_sequence == 0
+
+
+def test_empty_chain_verifies() -> None:
+    ledger = UsageLedger()
+    assert ledger.verify("nobody").ok
+
+
+# --- reconciliation -----------------------------------------------------------------------------
+
+
+def test_reconcile_matches_ingest_count() -> None:
+    ledger = UsageLedger()
+    ledger.extend([_rec(f"k{i}", cost=2_000) for i in range(10)])
+    result = ledger.reconcile("t1", ingest_count=10)
+    assert isinstance(result, ReconciliationResult)
+    assert result.reconciled
+    assert result.count_drift == 0
+    assert result.ledger_total_micro_usd == 20_000
+
+
+def test_reconcile_flags_dropped_usage() -> None:
+    ledger = UsageLedger()
+    ledger.extend([_rec(f"k{i}") for i in range(8)])
+    result = ledger.reconcile("t1", ingest_count=10)  # ingest saw 10, ledger has 8
+    assert not result.reconciled
+    assert result.count_drift == -2
+
+
+def test_reconcile_fails_on_broken_chain_even_if_counts_match() -> None:
+    store = InMemoryLedgerStore()
+    ledger = UsageLedger(store)
+    ledger.extend([_rec(f"k{i}") for i in range(5)])
+    store._by_tenant["t1"][2] = replace(store._by_tenant["t1"][2], cost_micro_usd=7)
+    result = ledger.reconcile("t1", ingest_count=5)
+    assert result.count_drift == 0
+    assert not result.reconciled  # chain integrity gates reconciliation
+
+
+# --- export idempotency -------------------------------------------------------------------------
+
+
+def test_export_bills_all_pending_entries() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1", cost=1_000, feature="chat"))
+    ledger.append(_rec("k2", cost=3_000, feature="search"))
+    invoice = ledger.export_invoice("t1", "inv-2026-05")
+    assert isinstance(invoice, InvoiceExport)
+    assert invoice.total_micro_usd == 4_000
+    assert invoice.entry_count == 2
+    assert set(invoice.newly_exported_sequences) == {0, 1}
+    # lines sorted by cost desc
+    assert invoice.lines[0].feature_tag == "search"
+    assert invoice.lines[0].cost_micro_usd == 3_000
+
+
+def test_re_export_does_not_double_bill() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1", cost=1_000))
+    ledger.append(_rec("k2", cost=2_000))
+    first = ledger.export_invoice("t1", "inv-1")
+    second = ledger.export_invoice("t1", "inv-1-rerun")
+    assert first.total_micro_usd == 3_000
+    assert second.total_micro_usd == 0  # nothing new to bill
+    assert second.newly_exported_sequences == ()
+
+
+def test_export_then_new_usage_bills_only_the_new() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1", cost=1_000))
+    ledger.export_invoice("t1", "inv-1")
+    ledger.append(_rec("k2", cost=5_000))
+    invoice = ledger.export_invoice("t1", "inv-2")
+    assert invoice.total_micro_usd == 5_000
+    assert invoice.newly_exported_sequences == (1,)
+    assert invoice.entry_count == 2  # full history reported
+
+
+def test_export_marks_entries_exported_with_ref() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1"))
+    ledger.export_invoice("t1", "inv-xyz")
+    entry = ledger.entries("t1")[0]
+    assert entry.exported
+    assert entry.export_ref == "inv-xyz"
+
+
+def test_export_requires_ref() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1"))
+    with pytest.raises(ValueError):
+        ledger.export_invoice("t1", "")
+
+
+def test_export_empty_tenant_is_zero_invoice() -> None:
+    ledger = UsageLedger()
+    invoice = ledger.export_invoice("nobody", "inv-0")
+    assert invoice.total_micro_usd == 0
+    assert invoice.lines == ()
+    assert invoice.entry_count == 0
+
+
+# --- export marking does not break the chain ----------------------------------------------------
+
+
+def test_chain_still_verifies_after_export() -> None:
+    ledger = UsageLedger()
+    ledger.extend([_rec(f"k{i}") for i in range(4)])
+    ledger.export_invoice("t1", "inv-1")
+    # export mutates only the export markers, which are excluded from the hash payload
+    assert ledger.verify("t1").ok
+
+
+# --- validation ---------------------------------------------------------------------------------
+
+
+def test_record_rejects_empty_key() -> None:
+    with pytest.raises(ValueError):
+        UsageRecord(idempotency_key="", tenant_id="t1", cost_micro_usd=1, occurred_at_ns=0)
+
+
+def test_record_rejects_empty_tenant() -> None:
+    with pytest.raises(ValueError):
+        UsageRecord(idempotency_key="k", tenant_id="", cost_micro_usd=1, occurred_at_ns=0)
+
+
+def test_record_rejects_negative_cost() -> None:
+    with pytest.raises(ValueError):
+        UsageRecord(idempotency_key="k", tenant_id="t1", cost_micro_usd=-1, occurred_at_ns=0)
+
+
+def test_record_rejects_bool_cost() -> None:
+    with pytest.raises(ValueError):
+        UsageRecord(idempotency_key="k", tenant_id="t1", cost_micro_usd=True, occurred_at_ns=0)
+
+
+# --- serialization --------------------------------------------------------------------------------
+
+
+def test_entry_as_dict_round_trips_money() -> None:
+    ledger = UsageLedger()
+    entry = ledger.append(_rec("k1", cost=1_500_000))
+    d = entry.as_dict()
+    assert d["cost_micro_usd"] == 1_500_000
+    assert d["cost_usd"] == "1.50000000"
+    assert d["entry_hash"] == entry.entry_hash
+
+
+def test_invoice_summary_and_as_dict() -> None:
+    ledger = UsageLedger()
+    ledger.append(_rec("k1", cost=2_500_000, feature="chat"))
+    invoice = ledger.export_invoice("t1", "inv-9")
+    s = invoice.summary()
+    assert "inv-9" in s
+    assert "2.50000000" in s
+    d = invoice.as_dict()
+    assert d["total_micro_usd"] == 2_500_000
+    assert isinstance(d["lines"], list)
+    assert "summary" in d
+
+
+def test_types_are_frozen() -> None:
+    assert LedgerEntry.__hash__ is not None
+    assert UsageRecord.__hash__ is not None
+    assert InvoiceExport.__hash__ is not None


### PR DESCRIPTION
## Summary
- Append-only, hash-chained **tamper-evident usage ledger** (`sdk/python/src/tally/ledger.py`) — the book of record between finalized usage and billing (Stripe, CTO-90).
- One sha256 hash chain per tenant (`entry_hash = H(prev_hash || canonical(entry))`); `verify()` walks the chain and localizes the first broken link (tampered amount, reorder, sequence gap).
- `reconcile()` compares ledger totals against an independent ingest count and gates reconciliation on chain integrity.
- `export_invoice()` is **idempotent**: only un-exported entries are billed and marked, so re-runs and already-billed usage never double-charge. Export markers are excluded from the hash payload, so marking does not break the chain.
- Money is integer micro-USD throughout; pure-Python with an injected `LedgerStore` (in-memory default) — no infra needed for dev/test.

Deliberately **agnostic about how usage is measured** — consumes abstract finalized `UsageRecord`s, does not import metering (meters CTO-84/85 are out of scope).

## Test plan
- [x] `ruff check` clean (line-length 100)
- [x] 26 new tests pass (`tests/test_ledger.py`): chain-from-genesis, per-tenant chains, idempotent append, tamper/reorder detection, reconciliation drift, idempotent re-export (no double-bill), export-marking preserves chain, validation, serialization
- [ ] Reviewer: confirm export shape matches Stripe integration (CTO-90) expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)