### PR TITLE
sdk: tamper-evident audit log + short-lived access tokens (CTO-75)

### DIFF
--- a/sdk/python/src/tally/audit_log.py
+++ b/sdk/python/src/tally/audit_log.py
@@ -1,0 +1,462 @@
+"""Tamper-evident audit log + short-lived access tokens for privileged admin actions.
+
+Implements CTO-75 (Access control + audit log).
+
+Privileged admin actions (tenant create, config change, deletion, key rotation) and every
+production data read must leave an immutable trail that an auditor can later trust and query.
+"Trust" here means tamper-evidence: if anyone edits, reorders, or drops a record after the fact,
+verification must surface it. We get that with a per-entry SHA-256 **hash chain** — each entry
+commits to the previous entry's hash, so a single altered field invalidates every link after it.
+The log is **append-only**: even retention (7 years) is reported, never enforced by deletion, so
+the chain can always be re-verified end-to-end.
+
+The companion concern is *who* may touch production data. We model the policy, not the infra:
+production DB access is granted through **short-lived STS-style tokens** (max TTL 1h, scoped),
+there are no shared standing admin credentials, and the **break-glass** path that mints an
+elevated token ALWAYS forces a ``BREAK_GLASS`` audit entry — emergency access is allowed but never
+silent.
+
+Everything is pure Python over injected stores/clocks so dev and test run offline with no database.
+Out of scope (other tickets): encryption/KMS (CTO-74), real STS/cloud wiring, pentest/IR (CTO-77).
+
+Time is integer **seconds** since the Unix epoch throughout this module (audit and tokens both),
+chosen over nanoseconds for readability of human-scale durations like TTLs and the 7-year window.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+GENESIS_PREV_HASH = "0" * 64
+MAX_TOKEN_TTL_S = 3600  # short-lived STS-style tokens: at most one hour
+SEVEN_YEARS_S = 7 * 365 * 24 * 3600  # retention window (ignores leap days — coarse on purpose)
+
+
+class AuditAction(str, Enum):
+    """The privileged actions worth an immutable record. ``str`` mixin keeps values JSON-safe."""
+
+    TENANT_CREATE = "tenant_create"
+    CONFIG_CHANGE = "config_change"
+    DELETION = "deletion"
+    KEY_ROTATION = "key_rotation"
+    DATA_ACCESS = "data_access"  # "all production data reads logged"
+    BREAK_GLASS = "break_glass"
+
+
+def _canonical_json(obj: object) -> str:
+    """Stable serialization for hashing: sorted keys, no incidental whitespace."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True, slots=True)
+class AuditEntry:
+    """One link in the hash chain. Immutable once recorded.
+
+    ``entry_hash`` is derived from every other field (including ``prev_hash``) and is therefore
+    excluded from the hashed payload — it is the output, not an input.
+    """
+
+    sequence: int
+    actor: str
+    action: AuditAction
+    tenant_id: str
+    target: str
+    occurred_at_s: int
+    prev_hash: str
+    entry_hash: str
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.sequence < 0:
+            raise ValueError(f"sequence must be >= 0, got {self.sequence}")
+        if not isinstance(self.action, AuditAction):
+            raise ValueError(f"action must be an AuditAction, got {type(self.action).__name__}")
+        if not self.actor:
+            raise ValueError("actor must be non-empty")
+        if not self.tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+
+    def canonical_payload(self) -> dict[str, object]:
+        """The fields the chain commits to — everything except the derived ``entry_hash``."""
+        return {
+            "sequence": self.sequence,
+            "actor": self.actor,
+            "action": self.action.value,
+            "tenant_id": self.tenant_id,
+            "target": self.target,
+            "occurred_at_s": self.occurred_at_s,
+            "prev_hash": self.prev_hash,
+            "metadata": self.metadata,
+        }
+
+    def recompute_hash(self) -> str:
+        """Recompute ``entry_hash`` from the canonical payload — the verification primitive."""
+        return hashlib.sha256(_canonical_json(self.canonical_payload()).encode()).hexdigest()
+
+    def as_dict(self) -> dict[str, object]:
+        d = self.canonical_payload()
+        d["entry_hash"] = self.entry_hash
+        return d
+
+
+@runtime_checkable
+class AuditStore(Protocol):
+    """Append-only persistence boundary. Implementations MUST NOT mutate or drop entries."""
+
+    def append(self, entry: AuditEntry) -> None: ...
+
+    def all(self) -> list[AuditEntry]:
+        """Entries in insertion (sequence) order."""
+        ...
+
+
+class InMemoryAuditStore:
+    """Default offline store — a list nobody outside this class may reorder."""
+
+    __slots__ = ("_entries",)
+
+    def __init__(self) -> None:
+        self._entries: list[AuditEntry] = []
+
+    def append(self, entry: AuditEntry) -> None:
+        self._entries.append(entry)
+
+    def all(self) -> list[AuditEntry]:
+        return list(self._entries)
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationResult:
+    """Outcome of a full chain walk."""
+
+    ok: bool
+    entries_checked: int
+    broken_at_sequence: int | None = None
+    reason: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "entries_checked": self.entries_checked,
+            "broken_at_sequence": self.broken_at_sequence,
+            "reason": self.reason,
+        }
+
+    def summary(self) -> str:
+        if self.ok:
+            return f"audit chain OK ({self.entries_checked} entries verified)"
+        return (
+            f"audit chain BROKEN at sequence {self.broken_at_sequence}: "
+            f"{self.reason} (checked {self.entries_checked})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionReport:
+    """Which entries have aged past the 7-year window. Informational only — nothing is deleted."""
+
+    now_s: int
+    window_s: int
+    expired_sequences: tuple[int, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "now_s": self.now_s,
+            "window_s": self.window_s,
+            "expired_sequences": list(self.expired_sequences),
+        }
+
+
+def _default_clock() -> int:
+    import time
+
+    return int(time.time())
+
+
+class AuditLog:
+    """Append-only, hash-chained audit log over an injected :class:`AuditStore`."""
+
+    __slots__ = ("_store", "_clock")
+
+    def __init__(
+        self,
+        store: AuditStore | None = None,
+        *,
+        clock: Callable[[], int] = _default_clock,
+    ) -> None:
+        self._store = store if store is not None else InMemoryAuditStore()
+        self._clock = clock
+
+    def record(
+        self,
+        actor: str,
+        action: AuditAction,
+        tenant_id: str,
+        *,
+        target: str = "",
+        occurred_at_s: int | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> AuditEntry:
+        """Append a new chained entry and return it.
+
+        Raises ``ValueError`` on programmer misuse (empty actor/tenant, unknown action).
+        """
+        if not actor:
+            raise ValueError("actor must be non-empty")
+        if not tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if not isinstance(action, AuditAction):
+            raise ValueError(f"action must be an AuditAction, got {type(action).__name__}")
+
+        existing = self._store.all()
+        sequence = len(existing)
+        prev_hash = existing[-1].entry_hash if existing else GENESIS_PREV_HASH
+        when = occurred_at_s if occurred_at_s is not None else self._clock()
+
+        scaffold = AuditEntry(
+            sequence=sequence,
+            actor=actor,
+            action=action,
+            tenant_id=tenant_id,
+            target=target,
+            occurred_at_s=when,
+            prev_hash=prev_hash,
+            entry_hash="",
+            metadata=dict(metadata) if metadata else {},
+        )
+        entry = AuditEntry(
+            sequence=scaffold.sequence,
+            actor=scaffold.actor,
+            action=scaffold.action,
+            tenant_id=scaffold.tenant_id,
+            target=scaffold.target,
+            occurred_at_s=scaffold.occurred_at_s,
+            prev_hash=scaffold.prev_hash,
+            entry_hash=scaffold.recompute_hash(),
+            metadata=scaffold.metadata,
+        )
+        self._store.append(entry)
+        return entry
+
+    def entries(self) -> list[AuditEntry]:
+        return self._store.all()
+
+    def verify(self) -> VerificationResult:
+        """Walk the chain, recomputing each link. Detects tamper, reorder, and sequence gaps.
+
+        Defensive on the boundary: a malformed/unhashable record is reported as a broken link
+        rather than allowed to crash the walk.
+        """
+        entries = self._store.all()
+        expected_prev = GENESIS_PREV_HASH
+        for index, entry in enumerate(entries):
+            if entry.sequence != index:
+                return VerificationResult(
+                    ok=False,
+                    entries_checked=index,
+                    broken_at_sequence=entry.sequence,
+                    reason=f"sequence gap/reorder: expected {index}, found {entry.sequence}",
+                )
+            if entry.prev_hash != expected_prev:
+                return VerificationResult(
+                    ok=False,
+                    entries_checked=index,
+                    broken_at_sequence=entry.sequence,
+                    reason="prev_hash does not match preceding entry (reorder or insertion)",
+                )
+            try:
+                recomputed = entry.recompute_hash()
+            except (TypeError, ValueError):
+                return VerificationResult(
+                    ok=False,
+                    entries_checked=index,
+                    broken_at_sequence=entry.sequence,
+                    reason="entry payload is not hashable (malformed record)",
+                )
+            if recomputed != entry.entry_hash:
+                return VerificationResult(
+                    ok=False,
+                    entries_checked=index,
+                    broken_at_sequence=entry.sequence,
+                    reason="entry_hash mismatch (tampered field)",
+                )
+            expected_prev = entry.entry_hash
+        return VerificationResult(ok=True, entries_checked=len(entries))
+
+    def query(
+        self,
+        *,
+        actor: str | None = None,
+        action: AuditAction | None = None,
+        tenant_id: str | None = None,
+        since_s: int | None = None,
+        until_s: int | None = None,
+    ) -> list[AuditEntry]:
+        """Auditor query: filter by actor, action, tenant, and an inclusive time range."""
+        results: list[AuditEntry] = []
+        for entry in self._store.all():
+            if actor is not None and entry.actor != actor:
+                continue
+            if action is not None and entry.action != action:
+                continue
+            if tenant_id is not None and entry.tenant_id != tenant_id:
+                continue
+            if since_s is not None and entry.occurred_at_s < since_s:
+                continue
+            if until_s is not None and entry.occurred_at_s > until_s:
+                continue
+            results.append(entry)
+        return results
+
+    def retention_report(
+        self,
+        *,
+        now_s: int | None = None,
+        window_s: int = SEVEN_YEARS_S,
+    ) -> RetentionReport:
+        """Report entries older than the window. Never deletes — the log stays append-only."""
+        now = now_s if now_s is not None else self._clock()
+        cutoff = now - window_s
+        expired = tuple(
+            entry.sequence for entry in self._store.all() if entry.occurred_at_s < cutoff
+        )
+        return RetentionReport(now_s=now, window_s=window_s, expired_sequences=expired)
+
+
+@dataclass(frozen=True, slots=True)
+class AccessToken:
+    """A short-lived, scoped credential for production access. No standing admin accounts."""
+
+    token_id: str
+    subject: str
+    scopes: frozenset[str]
+    issued_at_s: int
+    expires_at_s: int
+    elevated: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.subject:
+            raise ValueError("subject must be non-empty")
+        if self.expires_at_s <= self.issued_at_s:
+            raise ValueError("expires_at_s must be after issued_at_s")
+
+    @property
+    def ttl_s(self) -> int:
+        return self.expires_at_s - self.issued_at_s
+
+    def is_expired(self, now_s: int) -> bool:
+        return now_s >= self.expires_at_s
+
+    def is_valid(self, now_s: int, *, required_scope: str | None = None) -> bool:
+        """True only if unexpired and (when given) carrying the required scope."""
+        if self.is_expired(now_s):
+            return False
+        if required_scope is not None and required_scope not in self.scopes:
+            return False
+        return True
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "token_id": self.token_id,
+            "subject": self.subject,
+            "scopes": sorted(self.scopes),
+            "issued_at_s": self.issued_at_s,
+            "expires_at_s": self.expires_at_s,
+            "elevated": self.elevated,
+        }
+
+
+class TokenIssuer:
+    """Mints short-lived scoped tokens, capping TTL at :data:`MAX_TOKEN_TTL_S` (1h).
+
+    The **break-glass** path issues an elevated token for emergencies but ALWAYS writes a
+    ``BREAK_GLASS`` audit entry first — emergency access is permitted, never silent.
+    """
+
+    __slots__ = ("_max_ttl_s", "_clock", "_token_id_factory")
+
+    def __init__(
+        self,
+        *,
+        max_ttl_s: int = MAX_TOKEN_TTL_S,
+        clock: Callable[[], int] = _default_clock,
+        token_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        if max_ttl_s <= 0:
+            raise ValueError(f"max_ttl_s must be > 0, got {max_ttl_s}")
+        if max_ttl_s > MAX_TOKEN_TTL_S:
+            raise ValueError(
+                f"max_ttl_s must be <= {MAX_TOKEN_TTL_S}s (1h policy cap), got {max_ttl_s}"
+            )
+        self._max_ttl_s = max_ttl_s
+        self._clock = clock
+        self._token_id_factory = token_id_factory or (lambda: uuid.uuid4().hex)
+
+    def issue(
+        self,
+        subject: str,
+        scopes: set[str] | frozenset[str],
+        ttl_s: int,
+        *,
+        elevated: bool = False,
+    ) -> AccessToken:
+        """Issue a scoped token. ``ValueError`` if ``ttl_s`` is non-positive or over the cap."""
+        if not subject:
+            raise ValueError("subject must be non-empty")
+        if ttl_s <= 0:
+            raise ValueError(f"ttl_s must be > 0, got {ttl_s}")
+        if ttl_s > self._max_ttl_s:
+            raise ValueError(
+                f"ttl_s {ttl_s}s exceeds max {self._max_ttl_s}s (short-lived-token policy)"
+            )
+        now = self._clock()
+        return AccessToken(
+            token_id=self._token_id_factory(),
+            subject=subject,
+            scopes=frozenset(scopes),
+            issued_at_s=now,
+            expires_at_s=now + ttl_s,
+            elevated=elevated,
+        )
+
+    def break_glass(
+        self,
+        subject: str,
+        reason: str,
+        audit_log: AuditLog,
+        *,
+        scopes: set[str] | frozenset[str] | None = None,
+        ttl_s: int | None = None,
+        tenant_id: str = "*",
+    ) -> AccessToken:
+        """Emergency elevated access. Records a ``BREAK_GLASS`` entry, THEN returns the token.
+
+        ``reason`` is mandatory (the documented break-glass procedure requires justification).
+        """
+        if not reason:
+            raise ValueError("break-glass requires a non-empty reason")
+        granted = ttl_s if ttl_s is not None else self._max_ttl_s
+
+        before = len(audit_log.entries())
+        audit_log.record(
+            actor=subject,
+            action=AuditAction.BREAK_GLASS,
+            tenant_id=tenant_id,
+            target="production",
+            metadata={"reason": reason, "ttl_s": granted},
+        )
+        # The whole point of break-glass is that it can never be silent.
+        assert len(audit_log.entries()) == before + 1, "break-glass failed to write an audit entry"
+
+        return self.issue(
+            subject,
+            scopes if scopes is not None else {"admin"},
+            granted,
+            elevated=True,
+        )

--- a/sdk/python/tests/test_audit_log.py
+++ b/sdk/python/tests/test_audit_log.py
@@ -1,0 +1,386 @@
+import dataclasses
+
+import pytest
+
+from tally.audit_log import (
+    GENESIS_PREV_HASH,
+    MAX_TOKEN_TTL_S,
+    SEVEN_YEARS_S,
+    AccessToken,
+    AuditAction,
+    AuditEntry,
+    AuditLog,
+    InMemoryAuditStore,
+    TokenIssuer,
+    VerificationResult,
+)
+
+
+class FakeClock:
+    """Deterministic injectable clock."""
+
+    def __init__(self, start: int = 1_000_000) -> None:
+        self.now = start
+
+    def __call__(self) -> int:
+        return self.now
+
+    def advance(self, seconds: int) -> None:
+        self.now += seconds
+
+
+def _log(clock: FakeClock | None = None) -> AuditLog:
+    return AuditLog(InMemoryAuditStore(), clock=clock or FakeClock())
+
+
+# --- recording + chain integrity ---
+
+
+def test_first_entry_uses_genesis_prev_hash():
+    log = _log()
+    entry = log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    assert entry.sequence == 0
+    assert entry.prev_hash == GENESIS_PREV_HASH
+
+
+def test_each_entry_links_to_previous():
+    log = _log()
+    e0 = log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    e1 = log.record("bob", AuditAction.CONFIG_CHANGE, "t1")
+    assert e1.prev_hash == e0.entry_hash
+    assert e1.sequence == 1
+
+
+def test_entry_hash_is_deterministic():
+    e = AuditEntry(
+        sequence=0,
+        actor="alice",
+        action=AuditAction.DELETION,
+        tenant_id="t1",
+        target="x",
+        occurred_at_s=5,
+        prev_hash=GENESIS_PREV_HASH,
+        entry_hash="",
+    )
+    assert e.recompute_hash() == e.recompute_hash()
+
+
+def test_clean_chain_verifies():
+    log = _log()
+    for i in range(10):
+        log.record(f"user{i}", AuditAction.DATA_ACCESS, "t1", target=f"row{i}")
+    result = log.verify()
+    assert result.ok is True
+    assert result.entries_checked == 10
+    assert result.broken_at_sequence is None
+    assert "OK" in result.summary()
+
+
+def test_empty_log_verifies():
+    assert _log().verify().ok is True
+
+
+# --- tamper / reorder / gap detection ---
+
+
+def test_detects_tampered_field():
+    store = InMemoryAuditStore()
+    log = AuditLog(store, clock=FakeClock())
+    log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    log.record("bob", AuditAction.CONFIG_CHANGE, "t1")
+    # Mutate the underlying list: replace entry 0's actor but keep its (now stale) hash.
+    bad = dataclasses.replace(store._entries[0], actor="mallory")
+    store._entries[0] = bad
+    result = log.verify()
+    assert result.ok is False
+    assert result.broken_at_sequence == 0
+    assert "tampered" in result.reason
+    assert "BROKEN" in result.summary()
+
+
+def test_detects_reorder():
+    store = InMemoryAuditStore()
+    log = AuditLog(store, clock=FakeClock())
+    log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    log.record("bob", AuditAction.CONFIG_CHANGE, "t1")
+    log.record("carol", AuditAction.KEY_ROTATION, "t1")
+    store._entries[1], store._entries[2] = store._entries[2], store._entries[1]
+    result = log.verify()
+    assert result.ok is False
+    assert result.broken_at_sequence is not None
+
+
+def test_detects_sequence_gap():
+    store = InMemoryAuditStore()
+    log = AuditLog(store, clock=FakeClock())
+    log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    log.record("bob", AuditAction.CONFIG_CHANGE, "t1")
+    del store._entries[0]  # drop the genesis entry -> first remaining has sequence 1
+    result = log.verify()
+    assert result.ok is False
+    assert "gap" in result.reason or "reorder" in result.reason
+
+
+def test_detects_tamper_in_metadata():
+    store = InMemoryAuditStore()
+    log = AuditLog(store, clock=FakeClock())
+    log.record("alice", AuditAction.CONFIG_CHANGE, "t1", metadata={"old": 1, "new": 2})
+    bad = dataclasses.replace(store._entries[0], metadata={"old": 1, "new": 999})
+    store._entries[0] = bad
+    assert log.verify().ok is False
+
+
+# --- query ---
+
+
+def test_query_by_actor():
+    clock = FakeClock()
+    log = _log(clock)
+    log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    log.record("bob", AuditAction.CONFIG_CHANGE, "t1")
+    log.record("alice", AuditAction.DELETION, "t2")
+    got = log.query(actor="alice")
+    assert len(got) == 2
+    assert all(e.actor == "alice" for e in got)
+
+
+def test_query_by_action():
+    log = _log()
+    log.record("alice", AuditAction.DATA_ACCESS, "t1")
+    log.record("bob", AuditAction.DATA_ACCESS, "t1")
+    log.record("alice", AuditAction.DELETION, "t1")
+    assert len(log.query(action=AuditAction.DATA_ACCESS)) == 2
+
+
+def test_query_by_tenant():
+    log = _log()
+    log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    log.record("bob", AuditAction.TENANT_CREATE, "t2")
+    assert len(log.query(tenant_id="t2")) == 1
+
+
+def test_query_by_time_range_inclusive():
+    log = _log()
+    log.record("a", AuditAction.DATA_ACCESS, "t1", occurred_at_s=100)
+    log.record("b", AuditAction.DATA_ACCESS, "t1", occurred_at_s=200)
+    log.record("c", AuditAction.DATA_ACCESS, "t1", occurred_at_s=300)
+    got = log.query(since_s=100, until_s=200)
+    assert {e.actor for e in got} == {"a", "b"}
+
+
+def test_query_combined_filters():
+    log = _log()
+    log.record("alice", AuditAction.DATA_ACCESS, "t1", occurred_at_s=10)
+    log.record("alice", AuditAction.DATA_ACCESS, "t2", occurred_at_s=20)
+    log.record("alice", AuditAction.DELETION, "t1", occurred_at_s=30)
+    got = log.query(actor="alice", action=AuditAction.DATA_ACCESS, tenant_id="t1")
+    assert len(got) == 1
+    assert got[0].occurred_at_s == 10
+
+
+def test_query_no_filters_returns_all():
+    log = _log()
+    log.record("a", AuditAction.DATA_ACCESS, "t1")
+    log.record("b", AuditAction.DATA_ACCESS, "t1")
+    assert len(log.query()) == 2
+
+
+# --- retention (never deletes) ---
+
+
+def test_retention_flags_old_entries():
+    clock = FakeClock(start=0)
+    log = _log(clock)
+    log.record("a", AuditAction.DATA_ACCESS, "t1", occurred_at_s=0)
+    log.record("b", AuditAction.DATA_ACCESS, "t1", occurred_at_s=SEVEN_YEARS_S + 10)
+    report = log.retention_report(now_s=SEVEN_YEARS_S + 10)
+    assert report.expired_sequences == (0,)
+
+
+def test_retention_does_not_delete():
+    log = _log()
+    log.record("a", AuditAction.DATA_ACCESS, "t1", occurred_at_s=0)
+    log.retention_report(now_s=SEVEN_YEARS_S * 2)
+    assert len(log.entries()) == 1  # still there
+    assert log.verify().ok is True
+
+
+def test_retention_nothing_expired_when_recent():
+    log = _log()
+    log.record("a", AuditAction.DATA_ACCESS, "t1", occurred_at_s=1000)
+    report = log.retention_report(now_s=2000)
+    assert report.expired_sequences == ()
+
+
+# --- validation / immutability ---
+
+
+def test_record_rejects_empty_actor():
+    with pytest.raises(ValueError):
+        _log().record("", AuditAction.DELETION, "t1")
+
+
+def test_record_rejects_empty_tenant():
+    with pytest.raises(ValueError):
+        _log().record("alice", AuditAction.DELETION, "")
+
+
+def test_record_rejects_non_action():
+    with pytest.raises(ValueError):
+        _log().record("alice", "deletion", "t1")  # type: ignore[arg-type]
+
+
+def test_entry_rejects_negative_sequence():
+    with pytest.raises(ValueError):
+        AuditEntry(
+            sequence=-1,
+            actor="a",
+            action=AuditAction.DELETION,
+            tenant_id="t1",
+            target="",
+            occurred_at_s=0,
+            prev_hash=GENESIS_PREV_HASH,
+            entry_hash="",
+        )
+
+
+def test_audit_entry_is_frozen():
+    e = _log().record("alice", AuditAction.TENANT_CREATE, "t1")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.actor = "mallory"  # type: ignore[misc]
+
+
+def test_entry_as_dict_roundtrips_fields():
+    e = _log().record("alice", AuditAction.TENANT_CREATE, "t1", target="acme")
+    d = e.as_dict()
+    assert d["actor"] == "alice"
+    assert d["action"] == "tenant_create"
+    assert d["entry_hash"] == e.entry_hash
+
+
+def test_verification_result_as_dict():
+    r = VerificationResult(ok=True, entries_checked=3)
+    assert r.as_dict()["ok"] is True
+
+
+def test_store_protocol_satisfied():
+    from tally.audit_log import AuditStore
+
+    assert isinstance(InMemoryAuditStore(), AuditStore)
+
+
+# --- access tokens ---
+
+
+def test_issue_token_within_ttl():
+    clock = FakeClock(start=1000)
+    issuer = TokenIssuer(clock=clock)
+    tok = issuer.issue("svc-reader", {"read:prod"}, ttl_s=600)
+    assert tok.issued_at_s == 1000
+    assert tok.expires_at_s == 1600
+    assert tok.ttl_s == 600
+
+
+def test_issue_rejects_ttl_over_one_hour():
+    issuer = TokenIssuer(clock=FakeClock())
+    with pytest.raises(ValueError):
+        issuer.issue("svc", {"read:prod"}, ttl_s=MAX_TOKEN_TTL_S + 1)
+
+
+def test_issue_rejects_non_positive_ttl():
+    issuer = TokenIssuer(clock=FakeClock())
+    with pytest.raises(ValueError):
+        issuer.issue("svc", {"read:prod"}, ttl_s=0)
+    with pytest.raises(ValueError):
+        issuer.issue("svc", {"read:prod"}, ttl_s=-5)
+
+
+def test_issuer_rejects_max_ttl_over_cap():
+    with pytest.raises(ValueError):
+        TokenIssuer(max_ttl_s=MAX_TOKEN_TTL_S + 1)
+
+
+def test_issue_rejects_empty_subject():
+    with pytest.raises(ValueError):
+        TokenIssuer(clock=FakeClock()).issue("", {"read:prod"}, ttl_s=60)
+
+
+def test_token_valid_before_expiry():
+    clock = FakeClock(start=1000)
+    tok = TokenIssuer(clock=clock).issue("svc", {"read:prod"}, ttl_s=600)
+    assert tok.is_valid(1500) is True
+
+
+def test_token_invalid_after_expiry():
+    clock = FakeClock(start=1000)
+    tok = TokenIssuer(clock=clock).issue("svc", {"read:prod"}, ttl_s=600)
+    assert tok.is_expired(1600) is True
+    assert tok.is_valid(1600) is False
+
+
+def test_token_scope_check():
+    clock = FakeClock(start=1000)
+    tok = TokenIssuer(clock=clock).issue("svc", {"read:prod"}, ttl_s=600)
+    assert tok.is_valid(1100, required_scope="read:prod") is True
+    assert tok.is_valid(1100, required_scope="write:prod") is False
+
+
+def test_token_rejects_inverted_window():
+    with pytest.raises(ValueError):
+        AccessToken(
+            token_id="x",
+            subject="svc",
+            scopes=frozenset(),
+            issued_at_s=100,
+            expires_at_s=100,
+        )
+
+
+def test_token_is_frozen():
+    tok = TokenIssuer(clock=FakeClock()).issue("svc", {"read:prod"}, ttl_s=60)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        tok.subject = "other"  # type: ignore[misc]
+
+
+def test_token_as_dict_sorts_scopes():
+    tok = TokenIssuer(clock=FakeClock()).issue("svc", {"b", "a"}, ttl_s=60)
+    assert tok.as_dict()["scopes"] == ["a", "b"]
+
+
+# --- break-glass ---
+
+
+def test_break_glass_issues_elevated_token():
+    clock = FakeClock(start=1000)
+    issuer = TokenIssuer(clock=clock)
+    log = AuditLog(InMemoryAuditStore(), clock=clock)
+    tok = issuer.break_glass("oncall", "prod outage debug", log)
+    assert tok.elevated is True
+    assert tok.ttl_s == MAX_TOKEN_TTL_S
+
+
+def test_break_glass_writes_audit_entry():
+    clock = FakeClock(start=1000)
+    issuer = TokenIssuer(clock=clock)
+    log = AuditLog(InMemoryAuditStore(), clock=clock)
+    issuer.break_glass("oncall", "prod outage debug", log)
+    entries = log.query(action=AuditAction.BREAK_GLASS)
+    assert len(entries) == 1
+    assert entries[0].actor == "oncall"
+    assert entries[0].metadata["reason"] == "prod outage debug"
+
+
+def test_break_glass_requires_reason():
+    issuer = TokenIssuer(clock=FakeClock())
+    log = AuditLog(InMemoryAuditStore(), clock=FakeClock())
+    with pytest.raises(ValueError):
+        issuer.break_glass("oncall", "", log)
+
+
+def test_break_glass_keeps_chain_valid():
+    clock = FakeClock(start=1000)
+    issuer = TokenIssuer(clock=clock)
+    log = AuditLog(InMemoryAuditStore(), clock=clock)
+    log.record("alice", AuditAction.TENANT_CREATE, "t1")
+    issuer.break_glass("oncall", "incident", log)
+    assert log.verify().ok is True


### PR DESCRIPTION
## Summary
- **Append-only, tamper-evident audit log** (`audit_log.py`) for privileged admin actions — TENANT_CREATE, CONFIG_CHANGE, DELETION, KEY_ROTATION, DATA_ACCESS, BREAK_GLASS — backed by an injectable `AuditStore` Protocol (`InMemoryAuditStore` default), no infra required.
- **SHA-256 hash chain**: each `AuditEntry` commits to `prev_hash`; `verify()` walks the chain and pinpoints the first broken sequence, detecting tampered fields, reorders, and sequence gaps.
- **"All production data reads logged"** modeled via the `DATA_ACCESS` action type.
- **Auditor query** API: filter by actor, action, tenant, and inclusive time range.
- **7-year retention** reported (never enforced by deletion) so the chain stays end-to-end verifiable.
- **Short-lived STS-style tokens**: `TokenIssuer` caps TTL at 1h (rejects TTL > 1h and <= 0), `AccessToken.is_valid()` checks expiry + scope. No standing admin accounts.
- **Break-glass**: `break_glass()` mints an elevated token but ALWAYS writes a `BREAK_GLASS` audit entry first (asserted) — emergency access is never silent.
- Pure logic, offline, deterministic via injected clock. Encryption/KMS (CTO-74) and real STS wiring out of scope.

## Test plan
- [x] Clean chain verifies; empty log verifies
- [x] Detects tampered field, tampered metadata, reorder, and sequence gap (names first broken sequence)
- [x] Query filters by actor / action / tenant / time range and combined
- [x] Retention flags entries past the 7-year window and never deletes
- [x] Token TTL cap (ValueError on > 1h, <= 0); issuer rejects max_ttl over cap
- [x] Token expiry + scope validation
- [x] Break-glass forces an audit entry and requires a reason; chain stays valid
- [x] Frozen dataclasses; `__post_init__` validation errors
- [x] 41 new tests pass; full suite 218 pass; `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)