### PR TITLE
sdk: reconciler — cloud-billing true-up (CTO-64)

### DIFF
--- a/sdk/python/src/tally/reconciler.py
+++ b/sdk/python/src/tally/reconciler.py
@@ -1,0 +1,403 @@
+"""Reconciler — cloud-billing true-up (CTO-64).
+
+We bill and display two cost tracks and keep them honest by never conflating them:
+
+- **estimated** cost is computed live at ingest from the price catalog (cheap, instant, but a
+  model — it can drift from what the cloud actually charges);
+- **reconciled** cost is the truth from the provider's invoice, which lags 24–48h.
+
+This module trues the first up against the second. A daily job feeds it (a) the estimated
+per-feature cost for a day and (b) the actual cloud-billing line items for that day; it maps each
+billing line's resource tag to a feature tag, allocates genuinely shared infrastructure across
+features by query volume, and emits a **reconciled** cost per feature plus a human-readable delta
+event ("est \\$X → reconciled \\$Y, +Z%").
+
+Two honesty rules drive the design:
+
+1. **Respect the billing lag.** A day whose invoice has not settled yet (less than ``lag_hours``
+   since the day closed) is *not* trued up — its rows stay ``CostSource.ESTIMATED`` and the day is
+   reported as skipped, so we never publish a half-arrived invoice as final.
+2. **Shared cost is allocated, not double-counted.** Billing lines that map to no single feature
+   (shared DB, NAT gateway, …) go into a pool that is split across the day's features in
+   proportion to their query count, with integer micro-USD and a largest-remainder split so the
+   parts sum back to the pool exactly.
+
+Money is integer micro-USD throughout (see :mod:`tally.schema`); proportional math uses
+:class:`~decimal.Decimal`. Pure functions over plain dataclasses — no infra, no network (the
+caller fetches billing; cf. the connector framework CTO-63). Deliberately self-contained: it does
+not import the connector module, so it consumes abstract cost rows rather than a specific source.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from enum import Enum
+
+from tally.schema import DEFAULT_CURRENCY, micro_to_usd
+
+#: Feature tag used when shared cost cannot be attributed to any real feature.
+UNATTRIBUTED = "unattributed"
+
+
+class CostSource(str, Enum):
+    """Which track a cost figure comes from. Written alongside the amount so the UI and billing
+    never mistake a still-estimated number for a settled one."""
+
+    ESTIMATED = "estimated"
+    RECONCILED = "reconciled"
+
+
+# --- inputs -------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EstimatedCostRow:
+    """The estimated cost for one feature on one day, plus the query count used to allocate shared
+    infrastructure cost. ``query_count`` is the number of traces/queries the feature drove that
+    day — the weight by which a shared bill is split."""
+
+    feature_tag: str
+    day: date
+    estimated_micro_usd: int
+    query_count: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.feature_tag:
+            raise ValueError("feature_tag must be non-empty")
+        if not isinstance(self.day, date):
+            raise ValueError("day must be a datetime.date")
+        if isinstance(self.estimated_micro_usd, bool) or not isinstance(
+            self.estimated_micro_usd, int
+        ):
+            raise ValueError("estimated_micro_usd must be an int (micro-USD)")
+        if self.estimated_micro_usd < 0:
+            raise ValueError("estimated_micro_usd must be >= 0")
+        if isinstance(self.query_count, bool) or not isinstance(self.query_count, int):
+            raise ValueError("query_count must be an int")
+        if self.query_count < 0:
+            raise ValueError("query_count must be >= 0")
+
+
+@dataclass(frozen=True, slots=True)
+class CloudBillingLineItem:
+    """One actual cloud-billing line for a day: a resource tag and its real cost. ``resource_tag``
+    is mapped to a feature tag via the reconciler's ``tag_map``; a line that maps to nothing is
+    treated as shared and allocated by query count."""
+
+    resource_tag: str
+    day: date
+    cost_micro_usd: int
+    currency: str = DEFAULT_CURRENCY
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.day, date):
+            raise ValueError("day must be a datetime.date")
+        if isinstance(self.cost_micro_usd, bool) or not isinstance(self.cost_micro_usd, int):
+            raise ValueError("cost_micro_usd must be an int (micro-USD)")
+        if self.cost_micro_usd < 0:
+            raise ValueError("cost_micro_usd must be >= 0")
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcilerConfig:
+    """Tuning. ``lag_hours`` is how long after a day closes we wait before trusting its invoice as
+    final (default 48h, the upper end of the typical cloud-billing lag)."""
+
+    lag_hours: int = 48
+
+    def __post_init__(self) -> None:
+        if self.lag_hours < 0:
+            raise ValueError("lag_hours must be >= 0")
+
+
+# --- outputs ------------------------------------------------------------------------------------
+
+
+def _pct_change(base: int, new: int) -> float | None:
+    """Percent change from ``base`` to ``new``; None when ``base`` is zero (undefined)."""
+    if base == 0:
+        return None
+    return (new - base) / base * 100.0
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciledCostRow:
+    """Reconciled cost for one feature on one day. ``cost_source`` is RECONCILED once the day has
+    settled, otherwise ESTIMATED (the true-up has not happened yet)."""
+
+    feature_tag: str
+    day: date
+    estimated_micro_usd: int
+    reconciled_micro_usd: int
+    cost_source: CostSource
+    settled: bool
+
+    @property
+    def delta_micro_usd(self) -> int:
+        return self.reconciled_micro_usd - self.estimated_micro_usd
+
+    @property
+    def delta_pct(self) -> float | None:
+        return _pct_change(self.estimated_micro_usd, self.reconciled_micro_usd)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "feature_tag": self.feature_tag,
+            "day": self.day.isoformat(),
+            "estimated_micro_usd": self.estimated_micro_usd,
+            "reconciled_micro_usd": self.reconciled_micro_usd,
+            "cost_source": self.cost_source.value,
+            "settled": self.settled,
+            "delta_micro_usd": self.delta_micro_usd,
+            "delta_pct": self.delta_pct,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationDelta:
+    """A settled change worth surfacing: "est \\$X → reconciled \\$Y, +Z%"."""
+
+    feature_tag: str
+    day: date
+    estimated_micro_usd: int
+    reconciled_micro_usd: int
+
+    @property
+    def delta_micro_usd(self) -> int:
+        return self.reconciled_micro_usd - self.estimated_micro_usd
+
+    @property
+    def delta_pct(self) -> float | None:
+        return _pct_change(self.estimated_micro_usd, self.reconciled_micro_usd)
+
+    def summary(self) -> str:
+        est = micro_to_usd(self.estimated_micro_usd)
+        rec = micro_to_usd(self.reconciled_micro_usd)
+        pct = self.delta_pct
+        if pct is None:
+            change = "new" if self.reconciled_micro_usd else "0%"
+        else:
+            change = f"{pct:+.1f}%"
+        return (
+            f"{self.feature_tag} on {self.day.isoformat()}: "
+            f"est ${est} → reconciled ${rec}, {change}"
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "feature_tag": self.feature_tag,
+            "day": self.day.isoformat(),
+            "estimated_micro_usd": self.estimated_micro_usd,
+            "reconciled_micro_usd": self.reconciled_micro_usd,
+            "delta_micro_usd": self.delta_micro_usd,
+            "delta_pct": self.delta_pct,
+            "summary": self.summary(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationReport:
+    """Everything the daily job produced: per-(feature, day) reconciled rows, the notable delta
+    events, and the days held back because their invoice has not settled."""
+
+    rows: tuple[ReconciledCostRow, ...] = ()
+    deltas: tuple[ReconciliationDelta, ...] = ()
+    skipped_unsettled_days: tuple[date, ...] = ()
+
+    @property
+    def total_estimated_micro_usd(self) -> int:
+        return sum(r.estimated_micro_usd for r in self.rows)
+
+    @property
+    def total_reconciled_micro_usd(self) -> int:
+        return sum(r.reconciled_micro_usd for r in self.rows)
+
+    def summary(self) -> str:
+        est = micro_to_usd(self.total_estimated_micro_usd)
+        rec = micro_to_usd(self.total_reconciled_micro_usd)
+        settled = sum(1 for r in self.rows if r.settled)
+        return (
+            f"{len(self.rows)} rows ({settled} reconciled), "
+            f"est ${est} → reconciled ${rec}, "
+            f"{len(self.deltas)} deltas, {len(self.skipped_unsettled_days)} day(s) pending"
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "rows": [r.as_dict() for r in self.rows],
+            "deltas": [d.as_dict() for d in self.deltas],
+            "skipped_unsettled_days": [d.isoformat() for d in self.skipped_unsettled_days],
+            "total_estimated_micro_usd": self.total_estimated_micro_usd,
+            "total_reconciled_micro_usd": self.total_reconciled_micro_usd,
+            "summary": self.summary(),
+        }
+
+
+# --- helpers ------------------------------------------------------------------------------------
+
+
+def _is_settled(day: date, as_of: datetime, lag_hours: int) -> bool:
+    """A day's invoice is final once ``lag_hours`` have passed since the day *closed* (midnight
+    UTC after ``day``). Before that, the true-up is premature."""
+    as_of_utc = as_of if as_of.tzinfo else as_of.replace(tzinfo=timezone.utc)
+    day_close = datetime(day.year, day.month, day.day, tzinfo=timezone.utc) + timedelta(days=1)
+    return as_of_utc >= day_close + timedelta(hours=lag_hours)
+
+
+def _allocate_by_weight(total_micro: int, weights: Mapping[str, int]) -> dict[str, int]:
+    """Split ``total_micro`` across keys in proportion to integer ``weights``, summing back to
+    ``total_micro`` exactly (largest-remainder method). With no positive weight, split evenly.
+
+    Used to spread a shared bill across the features that drove it, by query count.
+    """
+    keys = list(weights)
+    if not keys or total_micro == 0:
+        return {k: 0 for k in keys}
+
+    total_weight = sum(max(0, weights[k]) for k in keys)
+    if total_weight == 0:
+        # no usage signal — divide as evenly as possible, remainder to the first keys
+        base, rem = divmod(total_micro, len(keys))
+        return {k: base + (1 if i < rem else 0) for i, k in enumerate(keys)}
+
+    exact = {k: Decimal(total_micro) * Decimal(max(0, weights[k])) / Decimal(total_weight)
+             for k in keys}
+    floors = {k: int(exact[k]) for k in keys}
+    remainder = total_micro - sum(floors.values())
+    # hand out the leftover micro-USD to the largest fractional parts first
+    order = sorted(keys, key=lambda k: exact[k] - floors[k], reverse=True)
+    for k in order[:remainder]:
+        floors[k] += 1
+    return floors
+
+
+def _coerce_estimated(rows: Iterable[object]) -> list[EstimatedCostRow]:
+    return [r for r in rows if isinstance(r, EstimatedCostRow)]
+
+
+def _coerce_billing(items: Iterable[object]) -> list[CloudBillingLineItem]:
+    return [b for b in items if isinstance(b, CloudBillingLineItem)]
+
+
+# --- the reconciler -----------------------------------------------------------------------------
+
+
+def reconcile(
+    estimated: Iterable[object],
+    billing: Iterable[object],
+    *,
+    tag_map: Mapping[str, str] | None = None,
+    as_of: datetime,
+    config: ReconcilerConfig | None = None,
+) -> ReconciliationReport:
+    """True estimated cost up against actual cloud billing, day by day.
+
+    ``tag_map`` maps a billing line's ``resource_tag`` to a feature tag; any line whose tag is not
+    in the map is treated as shared and allocated across the day's features by query count.
+    ``as_of`` is the wall-clock time the job runs (used with ``lag_hours`` to decide settlement).
+
+    Never raises on malformed input — non-dataclass entries are skipped. Returns a
+    :class:`ReconciliationReport`.
+    """
+    cfg = config or ReconcilerConfig()
+    mapping = dict(tag_map or {})
+    est_rows = _coerce_estimated(estimated)
+    bill_rows = _coerce_billing(billing)
+
+    # index by day
+    days = sorted({r.day for r in est_rows} | {b.day for b in bill_rows})
+    est_by_day: dict[date, dict[str, EstimatedCostRow]] = {}
+    for r in est_rows:
+        # if a (feature, day) repeats, fold the amounts/weights together
+        bucket = est_by_day.setdefault(r.day, {})
+        prior = bucket.get(r.feature_tag)
+        if prior is None:
+            bucket[r.feature_tag] = r
+        else:
+            bucket[r.feature_tag] = EstimatedCostRow(
+                feature_tag=r.feature_tag,
+                day=r.day,
+                estimated_micro_usd=prior.estimated_micro_usd + r.estimated_micro_usd,
+                query_count=prior.query_count + r.query_count,
+            )
+
+    bill_by_day: dict[date, list[CloudBillingLineItem]] = {}
+    for b in bill_rows:
+        bill_by_day.setdefault(b.day, []).append(b)
+
+    out_rows: list[ReconciledCostRow] = []
+    deltas: list[ReconciliationDelta] = []
+    skipped: list[date] = []
+
+    for day in days:
+        est_features = est_by_day.get(day, {})
+        settled = _is_settled(day, as_of, cfg.lag_hours)
+
+        if not settled:
+            # leave the day on the estimated track; nothing to true up yet
+            skipped.append(day)
+            for feature, row in est_features.items():
+                out_rows.append(
+                    ReconciledCostRow(
+                        feature_tag=feature,
+                        day=day,
+                        estimated_micro_usd=row.estimated_micro_usd,
+                        reconciled_micro_usd=row.estimated_micro_usd,
+                        cost_source=CostSource.ESTIMATED,
+                        settled=False,
+                    )
+                )
+            continue
+
+        # settled: split billing into directly-attributed vs shared pool
+        direct: dict[str, int] = {}
+        shared_pool = 0
+        for line in bill_by_day.get(day, ()):
+            feature = mapping.get(line.resource_tag)
+            if feature:
+                direct[feature] = direct.get(feature, 0) + line.cost_micro_usd
+            else:
+                shared_pool += line.cost_micro_usd
+
+        # features in play this day = those with an estimate or any direct billing
+        feature_set = set(est_features) | set(direct)
+        if not feature_set and shared_pool:
+            feature_set = {UNATTRIBUTED}
+
+        weights = {f: (est_features[f].query_count if f in est_features else 0)
+                   for f in feature_set}
+        allocation = _allocate_by_weight(shared_pool, weights)
+
+        for feature in sorted(feature_set):
+            estimated_micro = (
+                est_features[feature].estimated_micro_usd if feature in est_features else 0
+            )
+            reconciled_micro = direct.get(feature, 0) + allocation.get(feature, 0)
+            out_rows.append(
+                ReconciledCostRow(
+                    feature_tag=feature,
+                    day=day,
+                    estimated_micro_usd=estimated_micro,
+                    reconciled_micro_usd=reconciled_micro,
+                    cost_source=CostSource.RECONCILED,
+                    settled=True,
+                )
+            )
+            if reconciled_micro != estimated_micro:
+                deltas.append(
+                    ReconciliationDelta(
+                        feature_tag=feature,
+                        day=day,
+                        estimated_micro_usd=estimated_micro,
+                        reconciled_micro_usd=reconciled_micro,
+                    )
+                )
+
+    return ReconciliationReport(
+        rows=tuple(out_rows),
+        deltas=tuple(deltas),
+        skipped_unsettled_days=tuple(skipped),
+    )

--- a/sdk/python/tests/test_reconciler.py
+++ b/sdk/python/tests/test_reconciler.py
@@ -1,0 +1,279 @@
+"""Reconciler: tag→feature mapping, shared-cost allocation, billing-lag gating, deltas (CTO-64)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from tally.reconciler import (
+    UNATTRIBUTED,
+    CloudBillingLineItem,
+    CostSource,
+    EstimatedCostRow,
+    ReconciledCostRow,
+    ReconcilerConfig,
+    ReconciliationDelta,
+    ReconciliationReport,
+    reconcile,
+)
+
+DAY = date(2026, 5, 1)
+# 48h+ after DAY closed (midnight 2026-05-02) → settled under the default lag
+SETTLED_AS_OF = datetime(2026, 5, 5, tzinfo=timezone.utc)
+
+
+def _rows(report: ReconciliationReport) -> dict[tuple[str, date], ReconciledCostRow]:
+    return {(r.feature_tag, r.day): r for r in report.rows}
+
+
+# --- direct mapping -----------------------------------------------------------------------------
+
+
+def test_directly_tagged_billing_trues_up_the_feature() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000_000, query_count=10)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_250_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    row = _rows(report)[("chat", DAY)]
+    assert row.cost_source is CostSource.RECONCILED
+    assert row.settled
+    assert row.estimated_micro_usd == 1_000_000
+    assert row.reconciled_micro_usd == 1_250_000
+    assert row.delta_micro_usd == 250_000
+    assert row.delta_pct == pytest.approx(25.0)
+
+
+def test_emits_delta_event_with_summary() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000_000)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_500_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    assert len(report.deltas) == 1
+    delta = report.deltas[0]
+    assert isinstance(delta, ReconciliationDelta)
+    s = delta.summary()
+    assert "est $1" in s
+    assert "reconciled $1.50" in s
+    assert "+50.0%" in s
+
+
+def test_no_delta_when_reconciled_equals_estimated() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=900_000)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=900_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    assert report.deltas == ()
+    assert _rows(report)[("chat", DAY)].delta_micro_usd == 0
+
+
+# --- shared-cost allocation by query count ------------------------------------------------------
+
+
+def test_shared_pool_allocated_by_query_count() -> None:
+    # untagged "shared-db" bill of 3.00 split across two features by query weight 3:1
+    est = [
+        EstimatedCostRow("chat", DAY, estimated_micro_usd=0, query_count=30),
+        EstimatedCostRow("search", DAY, estimated_micro_usd=0, query_count=10),
+    ]
+    billing = [CloudBillingLineItem("shared-db", DAY, cost_micro_usd=3_000_000)]
+    report = reconcile(est, billing, tag_map={}, as_of=SETTLED_AS_OF)
+    rows = _rows(report)
+    assert rows[("chat", DAY)].reconciled_micro_usd == 2_250_000  # 3/4
+    assert rows[("search", DAY)].reconciled_micro_usd == 750_000  # 1/4
+    # allocation conserves the pool exactly
+    assert (
+        rows[("chat", DAY)].reconciled_micro_usd
+        + rows[("search", DAY)].reconciled_micro_usd
+        == 3_000_000
+    )
+
+
+def test_allocation_remainder_is_conserved() -> None:
+    # 1 micro-USD split 3 ways by equal weight → parts must still sum to 1
+    est = [
+        EstimatedCostRow("a", DAY, estimated_micro_usd=0, query_count=1),
+        EstimatedCostRow("b", DAY, estimated_micro_usd=0, query_count=1),
+        EstimatedCostRow("c", DAY, estimated_micro_usd=0, query_count=1),
+    ]
+    billing = [CloudBillingLineItem("shared", DAY, cost_micro_usd=1)]
+    report = reconcile(est, billing, tag_map={}, as_of=SETTLED_AS_OF)
+    total = sum(r.reconciled_micro_usd for r in report.rows)
+    assert total == 1
+
+
+def test_shared_pool_with_no_query_signal_splits_evenly() -> None:
+    est = [
+        EstimatedCostRow("a", DAY, estimated_micro_usd=0, query_count=0),
+        EstimatedCostRow("b", DAY, estimated_micro_usd=0, query_count=0),
+    ]
+    billing = [CloudBillingLineItem("shared", DAY, cost_micro_usd=1_000_000)]
+    report = reconcile(est, billing, tag_map={}, as_of=SETTLED_AS_OF)
+    rows = _rows(report)
+    assert rows[("a", DAY)].reconciled_micro_usd == 500_000
+    assert rows[("b", DAY)].reconciled_micro_usd == 500_000
+
+
+def test_shared_pool_with_no_features_goes_unattributed() -> None:
+    billing = [CloudBillingLineItem("mystery", DAY, cost_micro_usd=400_000)]
+    report = reconcile([], billing, tag_map={}, as_of=SETTLED_AS_OF)
+    rows = _rows(report)
+    assert rows[(UNATTRIBUTED, DAY)].reconciled_micro_usd == 400_000
+
+
+def test_direct_plus_shared_combine() -> None:
+    est = [
+        EstimatedCostRow("chat", DAY, estimated_micro_usd=500_000, query_count=10),
+        EstimatedCostRow("search", DAY, estimated_micro_usd=200_000, query_count=10),
+    ]
+    billing = [
+        CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=600_000),  # direct → chat
+        CloudBillingLineItem("shared-db", DAY, cost_micro_usd=200_000),  # split 50/50
+    ]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    rows = _rows(report)
+    assert rows[("chat", DAY)].reconciled_micro_usd == 700_000  # 600k direct + 100k shared
+    assert rows[("search", DAY)].reconciled_micro_usd == 100_000  # 0 direct + 100k shared
+
+
+# --- billing lag gating -------------------------------------------------------------------------
+
+
+def test_unsettled_day_stays_estimated_and_is_skipped() -> None:
+    # job runs only 1h after the day closed — invoice not final yet
+    as_of = datetime(2026, 5, 2, 1, tzinfo=timezone.utc)
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000_000)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=9_999_999)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=as_of)
+    row = _rows(report)[("chat", DAY)]
+    assert row.cost_source is CostSource.ESTIMATED
+    assert not row.settled
+    assert row.reconciled_micro_usd == 1_000_000  # untouched by the not-yet-final bill
+    assert DAY in report.skipped_unsettled_days
+    assert report.deltas == ()
+
+
+def test_custom_lag_hours_gates_settlement() -> None:
+    # with a 0h lag, a day is settled the moment it closes
+    as_of = datetime(2026, 5, 2, 0, tzinfo=timezone.utc)
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000_000)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_200_000)]
+    report = reconcile(
+        est, billing, tag_map={"svc-chat": "chat"}, as_of=as_of,
+        config=ReconcilerConfig(lag_hours=0),
+    )
+    assert _rows(report)[("chat", DAY)].cost_source is CostSource.RECONCILED
+
+
+def test_mixed_settled_and_unsettled_days() -> None:
+    old_day = date(2026, 5, 1)
+    new_day = date(2026, 5, 4)
+    as_of = datetime(2026, 5, 5, tzinfo=timezone.utc)  # old settled, new not (only ~1 day)
+    est = [
+        EstimatedCostRow("chat", old_day, estimated_micro_usd=1_000_000),
+        EstimatedCostRow("chat", new_day, estimated_micro_usd=1_000_000),
+    ]
+    billing = [
+        CloudBillingLineItem("svc-chat", old_day, cost_micro_usd=1_100_000),
+        CloudBillingLineItem("svc-chat", new_day, cost_micro_usd=1_100_000),
+    ]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=as_of)
+    rows = _rows(report)
+    assert rows[("chat", old_day)].settled
+    assert not rows[("chat", new_day)].settled
+    assert new_day in report.skipped_unsettled_days
+    assert old_day not in report.skipped_unsettled_days
+
+
+# --- aggregation / folding ----------------------------------------------------------------------
+
+
+def test_repeated_feature_day_rows_are_folded() -> None:
+    est = [
+        EstimatedCostRow("chat", DAY, estimated_micro_usd=400_000, query_count=4),
+        EstimatedCostRow("chat", DAY, estimated_micro_usd=600_000, query_count=6),
+    ]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_000_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    row = _rows(report)[("chat", DAY)]
+    assert row.estimated_micro_usd == 1_000_000  # folded
+
+
+def test_report_totals_and_summary() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000_000)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_200_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    assert report.total_estimated_micro_usd == 1_000_000
+    assert report.total_reconciled_micro_usd == 1_200_000
+    s = report.summary()
+    assert "reconciled" in s
+    d = report.as_dict()
+    assert isinstance(d["rows"], list)
+    assert isinstance(d["deltas"], list)
+    assert "summary" in d
+
+
+# --- delta percentage edge cases ----------------------------------------------------------------
+
+
+def test_delta_pct_none_when_estimate_is_zero() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=0, query_count=1)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=500_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)
+    delta = report.deltas[0]
+    assert delta.delta_pct is None
+    assert "new" in delta.summary()
+
+
+# --- never-crash / validation -------------------------------------------------------------------
+
+
+def test_empty_inputs_return_empty_report() -> None:
+    report = reconcile([], [], as_of=SETTLED_AS_OF)
+    assert isinstance(report, ReconciliationReport)
+    assert report.rows == ()
+    assert report.deltas == ()
+    assert report.total_reconciled_micro_usd == 0
+
+
+def test_garbage_entries_ignored() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000), "junk", None]
+    billing = ["nope", CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_000)]
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=SETTLED_AS_OF)  # type: ignore[list-item]
+    assert len(report.rows) == 1
+
+
+def test_naive_as_of_is_treated_as_utc() -> None:
+    est = [EstimatedCostRow("chat", DAY, estimated_micro_usd=1_000_000)]
+    billing = [CloudBillingLineItem("svc-chat", DAY, cost_micro_usd=1_000_000)]
+    naive = datetime(2026, 5, 5)  # no tzinfo
+    report = reconcile(est, billing, tag_map={"svc-chat": "chat"}, as_of=naive)
+    assert _rows(report)[("chat", DAY)].settled
+
+
+def test_invalid_estimated_cost_raises() -> None:
+    with pytest.raises(ValueError):
+        EstimatedCostRow("chat", DAY, estimated_micro_usd=-1)
+
+
+def test_invalid_query_count_raises() -> None:
+    with pytest.raises(ValueError):
+        EstimatedCostRow("chat", DAY, estimated_micro_usd=0, query_count=-5)
+
+
+def test_bool_cost_rejected() -> None:
+    with pytest.raises(ValueError):
+        CloudBillingLineItem("svc", DAY, cost_micro_usd=True)  # type: ignore[arg-type]
+
+
+def test_empty_feature_tag_raises() -> None:
+    with pytest.raises(ValueError):
+        EstimatedCostRow("", DAY, estimated_micro_usd=0)
+
+
+def test_invalid_lag_raises() -> None:
+    with pytest.raises(ValueError):
+        ReconcilerConfig(lag_hours=-1)
+
+
+def test_types_are_frozen() -> None:
+    assert ReconciledCostRow.__hash__ is not None
+    assert ReconciliationDelta.__hash__ is not None
+    assert EstimatedCostRow.__hash__ is not None


### PR DESCRIPTION
## Summary
- **Reconciler** (`sdk/python/src/tally/reconciler.py`) that trues *estimated* cost up against *actual* cloud billing, day by day — keeping the two cost tracks distinct and honest (spec §8).
- Maps each billing line's `resource_tag` → feature tag via `tag_map`; lines that map to nothing go into a shared pool **allocated across the day's features by query count** (integer micro-USD, largest-remainder split so the parts sum back to the pool exactly).
- **Respects the 24–48h billing lag**: a day whose invoice hasn't settled (`lag_hours`, default 48) stays on the `ESTIMATED` track and is reported in `skipped_unsettled_days` — we never publish a half-arrived invoice as final.
- Emits per-feature `ReconciledCostRow` (`CostSource.RECONCILED`) plus human-readable `ReconciliationDelta` events: *"est \$X → reconciled \$Y, +Z%"*.
- Pure functions over frozen dataclasses; never raises on malformed input. **Self-contained** — does not import the connector framework (CTO-63), so it consumes abstract cost rows.

Out of scope (per ticket): dual-track UI (CTO-65), connector framework (CTO-63).

## Test plan
- [x] `ruff check` clean (line-length 100)
- [x] 23 tests in `tests/test_reconciler.py`: direct tag→feature true-up, shared-pool allocation by query count + remainder conservation + even-split fallback + unattributed, direct+shared combine, lag gating (settled/unsettled/custom lag/mixed days), folding repeated rows, delta summaries + zero-base pct, totals/summary/as_dict, never-crash + validation
- [ ] Reviewer: confirm the shared-cost allocation policy (by query count) matches the spec's intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)