### PR TITLE
CTO-76: SDK PII redactors + per-tenant payload policy + deletion planning

### DIFF
--- a/sdk/python/src/tally/redaction.py
+++ b/sdk/python/src/tally/redaction.py
@@ -1,0 +1,510 @@
+"""PII redaction + per-tenant payload policy + right-to-deletion planning (CTO-76).
+
+Why this module exists
+----------------------
+ai-tally runs as a **shared multi-tenant** service, which means one tenant's
+payloads (prompts, completions, tool arguments) sit next to strangers'. Three
+controls keep that safe, and this module implements the parts that are pure
+logic and therefore belong in the SDK / a shared library:
+
+1. **Configurable redactors** — detect and strip common PII (emails, phone
+   numbers, card numbers, government IDs, IP addresses, secrets) from free-text
+   payload fields *before* they leave the customer process.
+2. **Per-tenant payload policy** — every tenant chooses how much payload we
+   retain at all: ``FULL`` (keep, but still redact detected PII), ``HASHED``
+   (keep only a tenant-scoped HMAC of the content so equality/joins survive but
+   the plaintext does not), or ``NONE`` (drop content entirely).
+3. **Right-to-deletion planning** — a tenant submits subject identifiers; we
+   hash them (a raw identifier is never stored) and produce a deterministic
+   :class:`DeletionPlan` enumerating the tables a worker must purge and the
+   30-day SLA deadline. Executing the DML is a storage-plane concern and lives
+   outside this module (see "Deferred" below).
+
+Security invariants honoured here
+---------------------------------
+* HMAC keys are **per-tenant** and supplied by an injected
+  :class:`HmacKeyProvider` (KMS-backed in production). The default in-memory
+  provider exists only so dev/test never need running infra. Raw keys are never
+  logged or embedded.
+* Raw subject identifiers are **never** retained — deletion plans carry only the
+  hashed forms.
+
+Deferred (still infra-bound, tracked on CTO-76)
+-----------------------------------------------
+* The actual ``DELETE`` mutations across ClickHouse/Postgres tables.
+* Region-pinned shared clusters + gateway routing by tenant region.
+
+Nothing here raises on boundary junk: unknown attribute types pass through and
+``None`` text redacts to an empty result. The whole point is to be safe to call
+on the hot path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+#: Default right-to-deletion SLA (GDPR/CCPA practice: act within 30 days).
+DEFAULT_DELETION_SLA_DAYS = 30
+
+#: Tables that hold tenant subject data and must be purged on deletion.
+#: Mirrors the storage schema (otel_spans + the business/identity tables).
+DELETION_TARGET_TABLES: tuple[str, ...] = (
+    "otel_spans",
+    "business_events",
+    "attribution_records",
+    "identity_graph",
+    "last_touch_index",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Detectors
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class Detector:
+    """A named PII pattern and the token that replaces each match.
+
+    ``token`` is the placeholder written in place of a match, e.g.
+    ``[REDACTED:EMAIL]``. ``pattern`` is a compiled, case-insensitive regex.
+    """
+
+    name: str
+    pattern: re.Pattern[str]
+    token: str
+
+    def find_count(self, text: str) -> int:
+        """Number of (non-overlapping) matches in *text*."""
+        return len(self.pattern.findall(text))
+
+
+def _d(name: str, regex: str, *, flags: int = re.IGNORECASE) -> Detector:
+    return Detector(name=name, pattern=re.compile(regex, flags), token=f"[REDACTED:{name}]")
+
+
+# Order matters: more specific / higher-entropy patterns first so they win
+# before a broader pattern (e.g. a card number) can partially consume them.
+_EMAIL = _d("EMAIL", r"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}")
+# JWT: three base64url segments separated by dots.
+_JWT = _d("JWT", r"\beyJ[A-Z0-9_\-]+\.[A-Z0-9_\-]+\.[A-Z0-9_\-]+\b")
+# AWS access key id.
+_AWS_KEY = _d("AWS_ACCESS_KEY", r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
+# 13-16 digit card numbers, optional spaces/dashes between 4-digit groups.
+_CREDIT_CARD = _d("CREDIT_CARD", r"\b(?:\d[ \-]?){13,16}\b")
+# US SSN.
+_SSN = _d("SSN", r"\b\d{3}-\d{2}-\d{4}\b")
+# IPv4.
+_IPV4 = _d("IPV4", r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+# Loose international phone: optional +, then 7-15 digits with separators.
+_PHONE = _d("PHONE", r"\+?\d[\d \-().]{6,}\d")
+
+#: Built-in detectors applied (in order) by a default :class:`Redactor`.
+DEFAULT_DETECTORS: tuple[Detector, ...] = (
+    _EMAIL,
+    _JWT,
+    _AWS_KEY,
+    _CREDIT_CARD,
+    _SSN,
+    _IPV4,
+    _PHONE,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Redactor
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class RedactionResult:
+    """Outcome of redacting one string.
+
+    ``text`` is the redacted string. ``findings`` maps detector name -> number
+    of matches replaced. ``redacted`` is True iff anything was replaced.
+    """
+
+    text: str
+    findings: Mapping[str, int]
+
+    @property
+    def redacted(self) -> bool:
+        return bool(self.findings)
+
+    @property
+    def total_findings(self) -> int:
+        return sum(self.findings.values())
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "findings": dict(self.findings),
+            "redacted": self.redacted,
+            "total_findings": self.total_findings,
+        }
+
+
+class Redactor:
+    """Applies an ordered set of :class:`Detector` s to free text.
+
+    Construct with the default detector set, or pass ``detectors`` to override.
+    ``disable`` names detectors to drop from whatever set is active — handy for
+    tenants who, say, legitimately store IP addresses.
+    """
+
+    __slots__ = ("_detectors",)
+
+    def __init__(
+        self,
+        detectors: Iterable[Detector] | None = None,
+        *,
+        disable: Iterable[str] = (),
+    ) -> None:
+        base = tuple(detectors) if detectors is not None else DEFAULT_DETECTORS
+        disabled = {name.upper() for name in disable}
+        self._detectors = tuple(d for d in base if d.name.upper() not in disabled)
+
+    @property
+    def detector_names(self) -> tuple[str, ...]:
+        return tuple(d.name for d in self._detectors)
+
+    def redact_text(self, text: object) -> RedactionResult:
+        """Redact a single value. Non-strings (and ``None``) become ``""``.
+
+        Never raises; on the hot path a junk value must not take down a span.
+        """
+        if not isinstance(text, str) or not text:
+            return RedactionResult(text="" if text is None else _coerce_str(text), findings={})
+        findings: dict[str, int] = {}
+        out = text
+        for det in self._detectors:
+            count = det.find_count(out)
+            if count:
+                findings[det.name] = findings.get(det.name, 0) + count
+                out = det.pattern.sub(det.token, out)
+        return RedactionResult(text=out, findings=findings)
+
+
+def _coerce_str(value: object) -> str:
+    try:
+        return str(value)
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+# --------------------------------------------------------------------------- #
+# HMAC hashing (for the HASHED payload policy)
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class HmacKeyProvider(Protocol):
+    """Supplies a per-tenant HMAC key. KMS-backed in production."""
+
+    def key_for(self, tenant_id: str) -> bytes: ...
+
+    def key_version(self, tenant_id: str) -> str: ...
+
+
+class InMemoryHmacKeyProvider:
+    """Default provider so dev/test never need KMS.
+
+    Derives a deterministic per-tenant key from a process-local root secret.
+    The root secret is held in memory only and is never persisted or logged.
+    """
+
+    __slots__ = ("_root", "_version")
+
+    def __init__(self, root_secret: bytes | None = None, *, key_version: str = "v1") -> None:
+        # A random root each process unless one is injected (tests pin it).
+        self._root = root_secret if root_secret is not None else _random_root()
+        self._version = key_version
+
+    def key_for(self, tenant_id: str) -> bytes:
+        return hmac.new(self._root, tenant_id.encode("utf-8"), hashlib.sha256).digest()
+
+    def key_version(self, tenant_id: str) -> str:
+        return self._version
+
+
+def _random_root() -> bytes:
+    import os
+
+    return os.urandom(32)
+
+
+def hmac_hash(value: str, key: bytes) -> str:
+    """Tenant-scoped HMAC-SHA256 of *value*, hex-encoded."""
+    return hmac.new(key, value.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Per-tenant payload policy
+# --------------------------------------------------------------------------- #
+class PayloadMode(str, Enum):
+    """How much payload content a tenant retains.
+
+    * ``FULL`` — keep content, but still strip detected PII via the redactor.
+    * ``HASHED`` — replace content with a tenant-scoped HMAC; plaintext gone,
+      equality/joins on identical content still work.
+    * ``NONE`` — drop content fields entirely.
+    """
+
+    FULL = "full"
+    HASHED = "hashed"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadPolicy:
+    """A tenant's content-handling policy.
+
+    ``content_keys`` names the attribute keys that hold payload/free-text
+    content (prompts, completions, tool args). Everything else passes through
+    untouched regardless of mode. ``drop_marker`` is the placeholder written for
+    dropped content under ``NONE`` (set to ``None`` to remove the key instead).
+    """
+
+    mode: PayloadMode = PayloadMode.FULL
+    content_keys: frozenset[str] = field(
+        default_factory=lambda: frozenset(
+            {
+                "gen_ai.prompt",
+                "gen_ai.completion",
+                "gen_ai.tool.arguments",
+                "input",
+                "output",
+                "prompt",
+                "completion",
+            }
+        )
+    )
+    drop_marker: str | None = "[DROPPED]"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.mode, PayloadMode):
+            raise ValueError(f"mode must be a PayloadMode, got {self.mode!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyApplication:
+    """Result of applying a :class:`PayloadPolicy` to an attribute dict.
+
+    ``attributes`` is the transformed dict. ``mode`` echoes the policy mode.
+    ``findings`` aggregates redactor hits across all content keys (only
+    populated for ``FULL``). ``hashed_keys`` / ``dropped_keys`` record which
+    content keys were transformed.
+    """
+
+    attributes: dict[str, object]
+    mode: PayloadMode
+    findings: Mapping[str, int]
+    hashed_keys: tuple[str, ...]
+    dropped_keys: tuple[str, ...]
+
+    @property
+    def total_findings(self) -> int:
+        return sum(self.findings.values())
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "mode": self.mode.value,
+            "findings": dict(self.findings),
+            "total_findings": self.total_findings,
+            "hashed_keys": list(self.hashed_keys),
+            "dropped_keys": list(self.dropped_keys),
+        }
+
+
+class PayloadPolicyEnforcer:
+    """Applies a :class:`PayloadPolicy` to span/event attribute dicts.
+
+    Construct with a :class:`Redactor` (for ``FULL`` mode) and an
+    :class:`HmacKeyProvider` (for ``HASHED`` mode). Both default to the
+    in-memory implementations so the SDK works with zero configuration.
+    """
+
+    __slots__ = ("_redactor", "_keys")
+
+    def __init__(
+        self,
+        redactor: Redactor | None = None,
+        key_provider: HmacKeyProvider | None = None,
+    ) -> None:
+        self._redactor = redactor if redactor is not None else Redactor()
+        self._keys = key_provider if key_provider is not None else InMemoryHmacKeyProvider()
+
+    def apply(
+        self,
+        tenant_id: str,
+        attributes: Mapping[str, object],
+        policy: PayloadPolicy,
+    ) -> PolicyApplication:
+        """Transform *attributes* per *policy*. Never mutates the input."""
+        out: dict[str, object] = dict(attributes)
+        findings: dict[str, int] = {}
+        hashed: list[str] = []
+        dropped: list[str] = []
+
+        for key in policy.content_keys:
+            if key not in out:
+                continue
+            value = out[key]
+            if policy.mode is PayloadMode.NONE:
+                if policy.drop_marker is None:
+                    del out[key]
+                else:
+                    out[key] = policy.drop_marker
+                dropped.append(key)
+            elif policy.mode is PayloadMode.HASHED:
+                key_bytes = self._keys.key_for(tenant_id)
+                version = self._keys.key_version(tenant_id)
+                digest = hmac_hash(_coerce_str(value), key_bytes)
+                out[key] = f"hmac:{version}:{digest}"
+                hashed.append(key)
+            else:  # FULL — keep, but redact detected PII
+                result = self._redactor.redact_text(value)
+                out[key] = result.text
+                for name, count in result.findings.items():
+                    findings[name] = findings.get(name, 0) + count
+
+        return PolicyApplication(
+            attributes=out,
+            mode=policy.mode,
+            findings=findings,
+            hashed_keys=tuple(hashed),
+            dropped_keys=tuple(dropped),
+        )
+
+
+@runtime_checkable
+class TenantPolicyStore(Protocol):
+    """Resolves a tenant's payload policy."""
+
+    def policy_for(self, tenant_id: str) -> PayloadPolicy: ...
+
+
+class InMemoryTenantPolicyStore:
+    """Per-tenant policy registry with a configurable default."""
+
+    __slots__ = ("_by_tenant", "_default")
+
+    def __init__(self, default: PayloadPolicy | None = None) -> None:
+        self._by_tenant: dict[str, PayloadPolicy] = {}
+        self._default = default if default is not None else PayloadPolicy()
+
+    def set_policy(self, tenant_id: str, policy: PayloadPolicy) -> None:
+        if not tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        self._by_tenant[tenant_id] = policy
+
+    def policy_for(self, tenant_id: str) -> PayloadPolicy:
+        return self._by_tenant.get(tenant_id, self._default)
+
+
+# --------------------------------------------------------------------------- #
+# Right-to-deletion planning
+# --------------------------------------------------------------------------- #
+def hash_subject_id(subject_id: str) -> str:
+    """SHA-256 hex of a subject identifier.
+
+    Deletion targets are matched on this hash; a raw identifier is never stored.
+    Plain SHA-256 (not HMAC) so the hash is reproducible across services and key
+    rotations — it's an opaque lookup token, not a secret-bearing value.
+    """
+    return hashlib.sha256(subject_id.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class DeletionRequest:
+    """A tenant's right-to-deletion submission.
+
+    ``subject_ids`` are raw identifiers (user ids, emails, anonymous ids). They
+    are hashed during planning and never retained in the resulting plan.
+    """
+
+    tenant_id: str
+    subject_ids: tuple[str, ...]
+    received_at: datetime
+
+    def __post_init__(self) -> None:
+        if not self.tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if not self.subject_ids:
+            raise ValueError("subject_ids must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class DeletionPlan:
+    """Deterministic plan a storage worker executes to satisfy a request.
+
+    Carries only **hashed** subject ids, the target tables, and the SLA
+    deadline. The actual DML is out of scope for this module (CTO-76 infra).
+    """
+
+    tenant_id: str
+    hashed_subject_ids: tuple[str, ...]
+    target_tables: tuple[str, ...]
+    received_at: datetime
+    sla_deadline: datetime
+
+    @property
+    def subject_count(self) -> int:
+        return len(self.hashed_subject_ids)
+
+    def is_overdue(self, now: datetime) -> bool:
+        return _as_utc(now) > self.sla_deadline
+
+    def summary(self) -> str:
+        return (
+            f"deletion for {self.tenant_id}: {self.subject_count} subject(s) across "
+            f"{len(self.target_tables)} table(s), due {self.sla_deadline.isoformat()}"
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tenant_id": self.tenant_id,
+            "hashed_subject_ids": list(self.hashed_subject_ids),
+            "target_tables": list(self.target_tables),
+            "received_at": self.received_at.isoformat(),
+            "sla_deadline": self.sla_deadline.isoformat(),
+            "subject_count": self.subject_count,
+        }
+
+
+def build_deletion_plan(
+    request: DeletionRequest,
+    *,
+    target_tables: Iterable[str] = DELETION_TARGET_TABLES,
+    sla_days: int = DEFAULT_DELETION_SLA_DAYS,
+) -> DeletionPlan:
+    """Turn a :class:`DeletionRequest` into a :class:`DeletionPlan`.
+
+    Subject ids are hashed (deduplicated, order-stable) and the SLA deadline is
+    ``received_at + sla_days``. Naive ``received_at`` is treated as UTC.
+    """
+    if sla_days <= 0:
+        raise ValueError("sla_days must be positive")
+    received = _as_utc(request.received_at)
+    seen: set[str] = set()
+    hashed: list[str] = []
+    for sid in request.subject_ids:
+        h = hash_subject_id(sid)
+        if h not in seen:
+            seen.add(h)
+            hashed.append(h)
+    return DeletionPlan(
+        tenant_id=request.tenant_id,
+        hashed_subject_ids=tuple(hashed),
+        target_tables=tuple(target_tables),
+        received_at=received,
+        sla_deadline=received + timedelta(days=sla_days),
+    )
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Treat naive datetimes as UTC; normalise aware ones to UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)

--- a/sdk/python/tests/test_redaction.py
+++ b/sdk/python/tests/test_redaction.py
@@ -1,0 +1,330 @@
+"""Tests for tally.redaction (CTO-76): redactors, payload policy, deletion plans."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tally.redaction import (
+    DEFAULT_DELETION_SLA_DAYS,
+    DELETION_TARGET_TABLES,
+    DeletionRequest,
+    InMemoryHmacKeyProvider,
+    InMemoryTenantPolicyStore,
+    PayloadMode,
+    PayloadPolicy,
+    PayloadPolicyEnforcer,
+    Redactor,
+    build_deletion_plan,
+    hash_subject_id,
+    hmac_hash,
+)
+
+UTC = timezone.utc
+
+
+# --------------------------------------------------------------------------- #
+# Redactor
+# --------------------------------------------------------------------------- #
+def test_redacts_email():
+    r = Redactor()
+    res = r.redact_text("contact me at jane.doe@example.com please")
+    assert "jane.doe@example.com" not in res.text
+    assert "[REDACTED:EMAIL]" in res.text
+    assert res.findings["EMAIL"] == 1
+    assert res.redacted is True
+    assert res.total_findings == 1
+
+
+def test_redacts_multiple_pii_types():
+    r = Redactor()
+    text = "email a@b.co ssn 123-45-6789 ip 10.0.0.1"
+    res = r.redact_text(text)
+    assert res.findings["EMAIL"] == 1
+    assert res.findings["SSN"] == 1
+    assert res.findings["IPV4"] == 1
+    assert "a@b.co" not in res.text
+    assert "123-45-6789" not in res.text
+    assert "10.0.0.1" not in res.text
+
+
+def test_redacts_credit_card_and_jwt_and_aws_key():
+    r = Redactor()
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc123"
+    res = r.redact_text(f"card 4111 1111 1111 1111 token {jwt} key AKIAIOSFODNN7EXAMPLE")
+    assert res.findings.get("CREDIT_CARD") == 1
+    assert res.findings.get("JWT") == 1
+    assert res.findings.get("AWS_ACCESS_KEY") == 1
+
+
+def test_no_pii_means_no_findings():
+    r = Redactor()
+    res = r.redact_text("the quick brown fox")
+    assert res.text == "the quick brown fox"
+    assert res.findings == {}
+    assert res.redacted is False
+
+
+def test_disable_detector():
+    # Disable IPV4 (and PHONE, which also fuzzily matches dotted digit runs) and
+    # confirm the IP literal survives untouched.
+    r = Redactor(disable=["IPV4", "PHONE"])
+    assert "IPV4" not in r.detector_names
+    assert "PHONE" not in r.detector_names
+    res = r.redact_text("ip 192.168.1.1")
+    assert "192.168.1.1" in res.text  # not redacted
+    assert "IPV4" not in res.findings
+
+
+def test_custom_detector_set():
+    import re
+
+    from tally.redaction import Detector
+
+    only_email = Detector("EMAIL", re.compile(r"\S+@\S+", re.IGNORECASE), "[X]")
+    r = Redactor(detectors=[only_email])
+    assert r.detector_names == ("EMAIL",)
+    res = r.redact_text("a@b.com 123-45-6789")
+    assert "a@b.com" not in res.text
+    assert "123-45-6789" in res.text  # ssn detector not present
+
+
+def test_non_string_and_none_never_raise():
+    r = Redactor()
+    assert r.redact_text(None).text == ""
+    assert r.redact_text(None).findings == {}
+    assert r.redact_text(12345).text == "12345"
+    assert r.redact_text("").text == ""
+
+
+def test_result_as_dict():
+    r = Redactor()
+    d = r.redact_text("a@b.co").as_dict()
+    assert d["redacted"] is True
+    assert d["total_findings"] == 1
+    assert d["findings"] == {"EMAIL": 1}
+
+
+# --------------------------------------------------------------------------- #
+# HMAC hashing
+# --------------------------------------------------------------------------- #
+def test_hmac_hash_deterministic_and_keyed():
+    assert hmac_hash("secret", b"k1") == hmac_hash("secret", b"k1")
+    assert hmac_hash("secret", b"k1") != hmac_hash("secret", b"k2")
+    assert len(hmac_hash("x", b"k")) == 64  # sha256 hex
+
+
+def test_key_provider_per_tenant_distinct():
+    p = InMemoryHmacKeyProvider(root_secret=b"root", key_version="v3")
+    assert p.key_for("t1") != p.key_for("t2")
+    assert p.key_for("t1") == p.key_for("t1")
+    assert p.key_version("t1") == "v3"
+
+
+# --------------------------------------------------------------------------- #
+# Payload policy
+# --------------------------------------------------------------------------- #
+def _enforcer():
+    return PayloadPolicyEnforcer(
+        redactor=Redactor(),
+        key_provider=InMemoryHmacKeyProvider(root_secret=b"fixed", key_version="v1"),
+    )
+
+
+def test_full_mode_redacts_content_keys_only():
+    e = _enforcer()
+    attrs = {"prompt": "email me a@b.co", "gen_ai.system": "openai"}
+    res = e.apply("t1", attrs, PayloadPolicy(mode=PayloadMode.FULL))
+    assert "a@b.co" not in res.attributes["prompt"]
+    assert res.attributes["gen_ai.system"] == "openai"  # untouched
+    assert res.findings["EMAIL"] == 1
+    assert res.total_findings == 1
+
+
+def test_full_mode_does_not_mutate_input():
+    e = _enforcer()
+    attrs = {"prompt": "a@b.co"}
+    e.apply("t1", attrs, PayloadPolicy(mode=PayloadMode.FULL))
+    assert attrs["prompt"] == "a@b.co"  # original intact
+
+
+def test_hashed_mode_replaces_content_with_hmac():
+    e = _enforcer()
+    attrs = {"prompt": "sensitive text", "gen_ai.system": "openai"}
+    res = e.apply("t1", attrs, PayloadPolicy(mode=PayloadMode.HASHED))
+    assert res.attributes["prompt"].startswith("hmac:v1:")
+    assert "sensitive text" not in res.attributes["prompt"]
+    assert res.attributes["gen_ai.system"] == "openai"
+    assert "prompt" in res.hashed_keys
+
+
+def test_hashed_mode_is_tenant_scoped():
+    e = _enforcer()
+    pol = PayloadPolicy(mode=PayloadMode.HASHED)
+    a = e.apply("t1", {"prompt": "x"}, pol).attributes["prompt"]
+    b = e.apply("t2", {"prompt": "x"}, pol).attributes["prompt"]
+    assert a != b  # same content, different tenant -> different hash
+
+
+def test_none_mode_drops_with_marker():
+    e = _enforcer()
+    res = e.apply("t1", {"prompt": "secret", "x": 1}, PayloadPolicy(mode=PayloadMode.NONE))
+    assert res.attributes["prompt"] == "[DROPPED]"
+    assert res.attributes["x"] == 1
+    assert "prompt" in res.dropped_keys
+
+
+def test_none_mode_removes_key_when_marker_is_none():
+    e = _enforcer()
+    pol = PayloadPolicy(mode=PayloadMode.NONE, drop_marker=None)
+    res = e.apply("t1", {"prompt": "secret"}, pol)
+    assert "prompt" not in res.attributes
+    assert "prompt" in res.dropped_keys
+
+
+def test_missing_content_key_is_noop():
+    e = _enforcer()
+    res = e.apply("t1", {"gen_ai.system": "openai"}, PayloadPolicy(mode=PayloadMode.NONE))
+    assert res.attributes == {"gen_ai.system": "openai"}
+    assert res.dropped_keys == ()
+
+
+def test_policy_application_as_dict():
+    e = _enforcer()
+    res = e.apply("t1", {"prompt": "a@b.co"}, PayloadPolicy(mode=PayloadMode.FULL))
+    d = res.as_dict()
+    assert d["mode"] == "full"
+    assert d["total_findings"] == 1
+
+
+def test_invalid_mode_raises():
+    with pytest.raises(ValueError):
+        PayloadPolicy(mode="full")  # type: ignore[arg-type]
+
+
+def test_enforcer_zero_config():
+    e = PayloadPolicyEnforcer()  # all defaults
+    res = e.apply("t1", {"prompt": "a@b.co"}, PayloadPolicy())
+    assert "a@b.co" not in res.attributes["prompt"]
+
+
+# --------------------------------------------------------------------------- #
+# Tenant policy store
+# --------------------------------------------------------------------------- #
+def test_policy_store_default_and_override():
+    store = InMemoryTenantPolicyStore(default=PayloadPolicy(mode=PayloadMode.NONE))
+    assert store.policy_for("unknown").mode is PayloadMode.NONE
+    store.set_policy("t1", PayloadPolicy(mode=PayloadMode.HASHED))
+    assert store.policy_for("t1").mode is PayloadMode.HASHED
+    assert store.policy_for("t2").mode is PayloadMode.NONE
+
+
+def test_policy_store_empty_tenant_raises():
+    store = InMemoryTenantPolicyStore()
+    with pytest.raises(ValueError):
+        store.set_policy("", PayloadPolicy())
+
+
+def test_policy_store_default_full():
+    store = InMemoryTenantPolicyStore()
+    assert store.policy_for("anyone").mode is PayloadMode.FULL
+
+
+# --------------------------------------------------------------------------- #
+# Right-to-deletion planning
+# --------------------------------------------------------------------------- #
+def test_hash_subject_id_deterministic():
+    assert hash_subject_id("user-1") == hash_subject_id("user-1")
+    assert hash_subject_id("user-1") != hash_subject_id("user-2")
+    assert len(hash_subject_id("x")) == 64
+
+
+def test_build_deletion_plan_hashes_and_sets_sla():
+    req = DeletionRequest(
+        tenant_id="t1",
+        subject_ids=("user-1", "user-2"),
+        received_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    plan = build_deletion_plan(req)
+    assert plan.tenant_id == "t1"
+    assert plan.subject_count == 2
+    # raw ids never appear
+    assert "user-1" not in plan.hashed_subject_ids
+    assert plan.hashed_subject_ids[0] == hash_subject_id("user-1")
+    assert plan.target_tables == DELETION_TARGET_TABLES
+    assert plan.sla_deadline == datetime(2026, 5, 1, tzinfo=UTC) + timedelta(
+        days=DEFAULT_DELETION_SLA_DAYS
+    )
+
+
+def test_deletion_plan_dedups_subject_ids():
+    req = DeletionRequest(
+        tenant_id="t1",
+        subject_ids=("a", "a", "b"),
+        received_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    plan = build_deletion_plan(req)
+    assert plan.subject_count == 2
+
+
+def test_deletion_plan_naive_received_at_treated_utc():
+    req = DeletionRequest(
+        tenant_id="t1",
+        subject_ids=("a",),
+        received_at=datetime(2026, 5, 1, 12, 0, 0),  # naive
+    )
+    plan = build_deletion_plan(req)
+    assert plan.received_at.tzinfo is UTC
+
+
+def test_deletion_plan_overdue():
+    req = DeletionRequest(
+        tenant_id="t1",
+        subject_ids=("a",),
+        received_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    plan = build_deletion_plan(req, sla_days=30)
+    assert plan.is_overdue(datetime(2026, 6, 5, tzinfo=UTC)) is True
+    assert plan.is_overdue(datetime(2026, 5, 10, tzinfo=UTC)) is False
+
+
+def test_deletion_plan_custom_tables_and_sla():
+    req = DeletionRequest(
+        tenant_id="t1",
+        subject_ids=("a",),
+        received_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    plan = build_deletion_plan(req, target_tables=("otel_spans",), sla_days=7)
+    assert plan.target_tables == ("otel_spans",)
+    assert plan.sla_deadline == datetime(2026, 5, 8, tzinfo=UTC)
+
+
+def test_deletion_plan_summary_and_as_dict():
+    req = DeletionRequest(
+        tenant_id="t1",
+        subject_ids=("a", "b"),
+        received_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    plan = build_deletion_plan(req)
+    assert "t1" in plan.summary()
+    assert "2 subject" in plan.summary()
+    d = plan.as_dict()
+    assert d["subject_count"] == 2
+    assert d["tenant_id"] == "t1"
+    assert "user" not in str(d)  # only hashes
+
+
+def test_deletion_request_validation():
+    with pytest.raises(ValueError):
+        DeletionRequest(tenant_id="", subject_ids=("a",), received_at=datetime.now(UTC))
+    with pytest.raises(ValueError):
+        DeletionRequest(tenant_id="t1", subject_ids=(), received_at=datetime.now(UTC))
+
+
+def test_build_plan_rejects_nonpositive_sla():
+    req = DeletionRequest(
+        tenant_id="t1", subject_ids=("a",), received_at=datetime(2026, 5, 1, tzinfo=UTC)
+    )
+    with pytest.raises(ValueError):
+        build_deletion_plan(req, sla_days=0)


### PR DESCRIPTION
## Summary

Pure-logic slice of **CTO-76** (right-to-deletion + PII redaction + data residency). Self-contained new module `tally.redaction` — no dependency on unmerged branches.

- **Configurable redactors** — `Redactor` with built-in detectors (email, JWT, AWS access key, credit card, SSN, IPv4, loose phone). Per-tenant `disable` list and fully custom detector sets. Never raises on the hot path (non-strings/`None` are safe).
- **Per-tenant payload policy** — `PayloadPolicy` with modes `FULL` (keep but strip detected PII), `HASHED` (replace content with tenant-scoped HMAC so joins survive, plaintext doesn't), `NONE` (drop). `PayloadPolicyEnforcer` applies it to attribute dicts without mutating the input. HMAC keys come from an injected `HmacKeyProvider` (KMS-backed in prod; in-memory default so dev/test need no infra). `InMemoryTenantPolicyStore` resolves per-tenant policy with a configurable default.
- **Right-to-deletion planning** — `DeletionRequest` → `build_deletion_plan` hashes subject ids (raw identifiers **never** retained), enumerates target tables (`otel_spans`, `business_events`, `attribution_records`, `identity_graph`, `last_touch_index`) and computes a 30-day SLA deadline. `is_overdue()` for the worker.

## Still open (deferred — infra-bound, tracked on CTO-76)

- [ ] Actual `DELETE` DML across ClickHouse/Postgres stores (storage plane).
- [ ] Region-pinned shared clusters + gateway routing by tenant region; in-region connectors.

## Test plan

- [x] 32 unit tests in `tests/test_redaction.py` (detectors, disable/custom sets, all three policy modes incl. tenant-scoped hashing + no-mutation, policy store default/override, deletion hashing/dedup/SLA/overdue/validation).
- [x] Full SDK suite green (~222 tests); `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)