### PR TITLE
CTO-89: plan tiers + graceful usage-limit enforcement + upgrade prompts

### DIFF
--- a/sdk/python/src/tally/plan_limits.py
+++ b/sdk/python/src/tally/plan_limits.py
@@ -1,0 +1,472 @@
+"""Plan tiers + graceful usage-limit enforcement + upgrade prompts (CTO-89).
+
+Why this module exists
+----------------------
+ai-tally bills on **billable telemetry the customer is paying to send us**.
+That creates a hard product constraint: a usage limit must *never* become a
+reason to drop that telemetry. If a customer blows past their plan's
+trace-count or active-feature-count for the period, the correct response is to
+**accept the data and prompt them to upgrade** — not to silently lose the very
+events they are paying for. Dropping billable data would both break their
+observability and quietly undercharge us; both are unacceptable.
+
+So enforcement here is a **graceful, escalating ladder**, not a gate:
+
+    OK  →  WARN (>=80% of cap)  →  SOFT_CAP (>=100%, still accepting)  →
+    UPGRADE_REQUIRED (well over, upgrade strongly indicated)
+
+Every level above ``OK`` carries a human-readable upgrade prompt. The crucial
+invariant is encoded as :attr:`EnforcementDecision.drops_data`, which is
+**always False**: no decision this module can produce ever instructs a caller
+to drop billable data.
+
+Two meters are tracked per billing period:
+
+* **head trace-count** — every trace counted at HEAD (before sampling), the
+  canonical billable unit (mirrors :class:`tally.sampling.BillingMeter`).
+* **distinct active feature-count** — the number of distinct feature tags seen
+  in the period (plan tiers cap how many product features a customer may meter).
+
+Built-in tiers FREE / PRO / SCALE / ENTERPRISE are provided (enterprise =
+effectively unlimited, represented as ``None`` per limit), and custom tiers can
+be defined. A :class:`PlanRegistry` protocol (with an in-memory default impl)
+resolves a tenant's tier so callers can inject their own billing source.
+
+Nothing here raises on boundary junk in the hot-path classify function:
+negative usage is clamped to zero rather than crashing a metering callback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+#: Fraction of a cap at or above which we start warning (but stay fully OK to send).
+WARN_THRESHOLD = 0.8
+#: Multiple of a cap at or above which we escalate SOFT_CAP -> UPGRADE_REQUIRED.
+#: i.e. once usage is >=150% of the cap, an upgrade is strongly indicated.
+UPGRADE_REQUIRED_MULTIPLE = 1.5
+
+
+# --------------------------------------------------------------------------- #
+# Meters
+# --------------------------------------------------------------------------- #
+class Meter(str, Enum):
+    """The two metered dimensions a plan tier caps, per billing period."""
+
+    TRACES = "traces"  # head trace-count (billable unit)
+    FEATURES = "features"  # distinct active feature tags
+
+
+# --------------------------------------------------------------------------- #
+# Plan tiers
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class PlanTier:
+    """A named plan tier with per-meter caps for a billing period.
+
+    ``max_traces_per_period`` caps head trace-count; ``max_features`` caps the
+    number of distinct active feature tags. ``None`` for either means
+    **unlimited** for that meter (enterprise tiers use this). ``rank`` orders
+    tiers for upgrade computation (cheaper/smaller first); ``price_micro_usd``
+    is the monthly list price in micro-USD, used only to break ties when picking
+    the cheapest qualifying upgrade.
+    """
+
+    name: str
+    max_traces_per_period: int | None
+    max_features: int | None
+    rank: int = 0
+    price_micro_usd: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ValueError("PlanTier.name must be non-empty")
+        if self.max_traces_per_period is not None and self.max_traces_per_period < 0:
+            raise ValueError(
+                f"max_traces_per_period must be >= 0 or None, got {self.max_traces_per_period}"
+            )
+        if self.max_features is not None and self.max_features < 0:
+            raise ValueError(f"max_features must be >= 0 or None, got {self.max_features}")
+        if self.rank < 0:
+            raise ValueError(f"rank must be >= 0, got {self.rank}")
+        if self.price_micro_usd < 0:
+            raise ValueError(f"price_micro_usd must be >= 0, got {self.price_micro_usd}")
+
+    def limit_for(self, meter: Meter) -> int | None:
+        """Return this tier's cap for *meter* (``None`` == unlimited)."""
+        if meter is Meter.TRACES:
+            return self.max_traces_per_period
+        return self.max_features
+
+    def is_unlimited(self, meter: Meter) -> bool:
+        """True iff this tier places no cap on *meter*."""
+        return self.limit_for(meter) is None
+
+    def covers(self, usage: UsageSnapshot) -> bool:
+        """True iff *usage* fits within this tier's caps on **both** meters."""
+        for meter in Meter:
+            limit = self.limit_for(meter)
+            if limit is not None and usage.value_for(meter) > limit:
+                return False
+        return True
+
+
+# Built-in tiers. Numbers are illustrative-but-sensible monthly caps; enterprise
+# is effectively unlimited (None per meter).
+FREE = PlanTier(
+    name="FREE",
+    max_traces_per_period=10_000,
+    max_features=3,
+    rank=0,
+    price_micro_usd=0,
+)
+PRO = PlanTier(
+    name="PRO",
+    max_traces_per_period=1_000_000,
+    max_features=25,
+    rank=1,
+    price_micro_usd=99_000_000,
+)
+SCALE = PlanTier(
+    name="SCALE",
+    max_traces_per_period=25_000_000,
+    max_features=200,
+    rank=2,
+    price_micro_usd=499_000_000,
+)
+ENTERPRISE = PlanTier(
+    name="ENTERPRISE",
+    max_traces_per_period=None,  # unlimited
+    max_features=None,  # unlimited
+    rank=3,
+    price_micro_usd=2_500_000_000,
+)
+
+#: Built-in tiers, ordered cheapest/smallest -> largest.
+BUILTIN_TIERS: tuple[PlanTier, ...] = (FREE, PRO, SCALE, ENTERPRISE)
+
+
+# --------------------------------------------------------------------------- #
+# Usage
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class UsageSnapshot:
+    """Abstract meter readings for a tenant in the current billing period.
+
+    Deliberately plain ints so this module is independent of any metering
+    submodule: a caller feeds in whatever head trace-count and distinct
+    feature-count it has. Negative inputs are clamped to zero (boundary junk
+    must not crash a metering callback).
+    """
+
+    traces: int
+    features: int
+
+    def __post_init__(self) -> None:
+        # Clamp rather than raise: this rides the metering hot path.
+        if self.traces < 0:
+            object.__setattr__(self, "traces", 0)
+        if self.features < 0:
+            object.__setattr__(self, "features", 0)
+
+    def value_for(self, meter: Meter) -> int:
+        return self.traces if meter is Meter.TRACES else self.features
+
+
+# --------------------------------------------------------------------------- #
+# Enforcement
+# --------------------------------------------------------------------------- #
+class EnforcementLevel(str, Enum):
+    """Escalating ladder. Crucially, **none** of these means "drop data"."""
+
+    OK = "ok"  # comfortably under cap
+    WARN = "warn"  # >=80% of cap — surface a heads-up
+    SOFT_CAP = "soft_cap"  # >=100% of cap — still accepting, prompt to upgrade
+    UPGRADE_REQUIRED = "upgrade_required"  # well over — upgrade strongly indicated
+
+    @property
+    def severity(self) -> int:
+        """Numeric ordering so the worse of two levels can be selected."""
+        return {
+            EnforcementLevel.OK: 0,
+            EnforcementLevel.WARN: 1,
+            EnforcementLevel.SOFT_CAP: 2,
+            EnforcementLevel.UPGRADE_REQUIRED: 3,
+        }[self]
+
+
+@dataclass(frozen=True, slots=True)
+class EnforcementDecision:
+    """Outcome of classifying one tenant's usage against one tier.
+
+    Carries the level, which meter tripped (the worst one), the usage/limit
+    numbers, percent-used and a human-readable upgrade prompt. ``limit`` is
+    ``None`` when the tripped meter is unlimited (only possible at ``OK``).
+    """
+
+    level: EnforcementLevel
+    tier_name: str
+    meter: Meter
+    usage: int
+    limit: int | None
+    percent_used: float
+    message: str
+
+    @property
+    def drops_data(self) -> bool:
+        """**Always False.** Billable telemetry is never dropped — this module
+        only ever warns or prompts an upgrade. The invariant exists so callers
+        can assert on it and never gate ingestion on a plan limit.
+        """
+        return False
+
+    @property
+    def needs_upgrade(self) -> bool:
+        """True once the customer is at or over a cap (SOFT_CAP or beyond)."""
+        return self.level.severity >= EnforcementLevel.SOFT_CAP.severity
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "level": self.level.value,
+            "tier_name": self.tier_name,
+            "meter": self.meter.value,
+            "usage": self.usage,
+            "limit": self.limit,
+            "percent_used": self.percent_used,
+            "needs_upgrade": self.needs_upgrade,
+            "drops_data": self.drops_data,
+            "message": self.message,
+        }
+
+    def summary(self) -> str:
+        cap = "unlimited" if self.limit is None else str(self.limit)
+        return (
+            f"[{self.level.value}] {self.tier_name} {self.meter.value}: "
+            f"{self.usage}/{cap} ({self.percent_used:.0f}%)"
+        )
+
+
+def _percent(usage: int, limit: int | None) -> float:
+    """Percent of cap used. Unlimited -> 0.0; zero cap with usage -> inf."""
+    if limit is None:
+        return 0.0
+    if limit == 0:
+        return float("inf") if usage > 0 else 0.0
+    return (usage / limit) * 100.0
+
+
+def _classify_meter(tier: PlanTier, usage: UsageSnapshot, meter: Meter) -> EnforcementDecision:
+    """Classify a single meter against the tier's cap for it."""
+    value = usage.value_for(meter)
+    limit = tier.limit_for(meter)
+    pct = _percent(value, limit)
+
+    if limit is None:
+        level = EnforcementLevel.OK
+    elif limit == 0:
+        # A zero cap means the feature is disabled on this tier: any usage is
+        # immediately over. Still never drops data — prompt to upgrade.
+        level = EnforcementLevel.UPGRADE_REQUIRED if value > 0 else EnforcementLevel.OK
+    elif value >= limit * UPGRADE_REQUIRED_MULTIPLE:
+        level = EnforcementLevel.UPGRADE_REQUIRED
+    elif value >= limit:
+        level = EnforcementLevel.SOFT_CAP
+    elif value >= limit * WARN_THRESHOLD:
+        level = EnforcementLevel.WARN
+    else:
+        level = EnforcementLevel.OK
+
+    return EnforcementDecision(
+        level=level,
+        tier_name=tier.name,
+        meter=meter,
+        usage=value,
+        limit=limit,
+        percent_used=pct,
+        message=_message_for(level, tier, meter, value, limit, pct),
+    )
+
+
+def _message_for(
+    level: EnforcementLevel,
+    tier: PlanTier,
+    meter: Meter,
+    usage: int,
+    limit: int | None,
+    pct: float,
+) -> str:
+    """Human-readable prompt for a level. Always upgrade-oriented, never punitive."""
+    label = "traces" if meter is Meter.TRACES else "active features"
+    if level is EnforcementLevel.OK:
+        return f"{tier.name}: {usage} {label} used — within plan limits."
+    if level is EnforcementLevel.WARN:
+        return (
+            f"{tier.name}: {usage} of {limit} {label} used ({pct:.0f}%). "
+            f"Approaching your plan limit — consider upgrading to avoid surprises."
+        )
+    if level is EnforcementLevel.SOFT_CAP:
+        return (
+            f"{tier.name}: {usage} {label} used, over your plan limit of {limit}. "
+            f"We're still accepting all your data — upgrade to raise this limit."
+        )
+    # UPGRADE_REQUIRED
+    return (
+        f"{tier.name}: {usage} {label} used, well over your plan limit of {limit}. "
+        f"Your data is still being collected — please upgrade your plan."
+    )
+
+
+def classify(tier: PlanTier, usage: UsageSnapshot) -> EnforcementDecision:
+    """Classify *usage* against *tier*, returning the **worst** meter's decision.
+
+    Both meters are evaluated; the decision for the meter with the higher
+    severity is returned (ties break to TRACES, the billable unit). Never raises
+    — :class:`UsageSnapshot` has already clamped boundary junk.
+    """
+    decisions = [_classify_meter(tier, usage, meter) for meter in Meter]
+    # Higher severity wins; on a tie keep the first (TRACES, evaluated first).
+    return max(decisions, key=lambda d: d.level.severity)
+
+
+# --------------------------------------------------------------------------- #
+# Limit-state visibility
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class MeterState:
+    """Per-meter usage-vs-cap line for a UI/customer summary."""
+
+    meter: Meter
+    usage: int
+    limit: int | None
+    percent_used: float
+    level: EnforcementLevel
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "meter": self.meter.value,
+            "usage": self.usage,
+            "limit": self.limit,
+            "percent_used": self.percent_used,
+            "level": self.level.value,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LimitState:
+    """Full limit-state summary for a tenant: overall level + per-meter lines.
+
+    This is what a "usage vs cap" UI renders. ``overall`` is the worst meter's
+    decision (same as :func:`classify`); ``meters`` carries every meter so a
+    dashboard can show both bars.
+    """
+
+    tier_name: str
+    overall: EnforcementDecision
+    meters: tuple[MeterState, ...]
+
+    @property
+    def needs_upgrade(self) -> bool:
+        return self.overall.needs_upgrade
+
+    @property
+    def drops_data(self) -> bool:
+        """Always False — surfaced here too so the UI can state it plainly."""
+        return False
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tier_name": self.tier_name,
+            "overall": self.overall.as_dict(),
+            "meters": [m.as_dict() for m in self.meters],
+            "needs_upgrade": self.needs_upgrade,
+            "drops_data": self.drops_data,
+        }
+
+    def summary(self) -> str:
+        lines = "; ".join(
+            f"{m.meter.value} {m.usage}/"
+            f"{'unlimited' if m.limit is None else m.limit} ({m.percent_used:.0f}%)"
+            for m in self.meters
+        )
+        return f"{self.tier_name} [{self.overall.level.value}]: {lines}"
+
+
+def build_limit_state(tier: PlanTier, usage: UsageSnapshot) -> LimitState:
+    """Build a full :class:`LimitState` (overall + per-meter) for a UI."""
+    per_meter = [_classify_meter(tier, usage, meter) for meter in Meter]
+    overall = max(per_meter, key=lambda d: d.level.severity)
+    meters = tuple(
+        MeterState(
+            meter=d.meter,
+            usage=d.usage,
+            limit=d.limit,
+            percent_used=d.percent_used,
+            level=d.level,
+        )
+        for d in per_meter
+    )
+    return LimitState(tier_name=tier.name, overall=overall, meters=meters)
+
+
+# --------------------------------------------------------------------------- #
+# Upgrade flow
+# --------------------------------------------------------------------------- #
+def next_tier_up(
+    current: PlanTier,
+    usage: UsageSnapshot,
+    *,
+    tiers: tuple[PlanTier, ...] = BUILTIN_TIERS,
+) -> PlanTier | None:
+    """Cheapest tier strictly above *current* whose caps clear *usage*.
+
+    "Cheapest" = lowest ``(rank, price_micro_usd)`` among qualifying tiers ranked
+    above ``current``. Returns ``None`` when the customer is already on the top
+    tier (or no higher tier clears their usage). Pure: no side effects.
+    """
+    candidates = [
+        t
+        for t in tiers
+        if t.rank > current.rank and t.covers(usage)
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda t: (t.rank, t.price_micro_usd))
+
+
+def apply_tier_change(new_tier: PlanTier, usage: UsageSnapshot) -> EnforcementDecision:
+    """Re-classify *usage* under *new_tier* so the change "takes effect promptly".
+
+    Pure function: returns the decision a caller would see immediately after
+    switching plans, without mutating anything.
+    """
+    return classify(new_tier, usage)
+
+
+# --------------------------------------------------------------------------- #
+# Tier registry
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class PlanRegistry(Protocol):
+    """Resolves a tenant's current plan tier (billing-source backed in prod)."""
+
+    def tier_for(self, tenant_id: str) -> PlanTier: ...
+
+
+class InMemoryPlanRegistry:
+    """Per-tenant tier registry with a configurable default (defaults to FREE)."""
+
+    __slots__ = ("_by_tenant", "_default")
+
+    def __init__(self, default: PlanTier | None = None) -> None:
+        self._default = default if default is not None else FREE
+        self._by_tenant: dict[str, PlanTier] = {}
+
+    def set_tier(self, tenant_id: str, tier: PlanTier) -> None:
+        if not tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        self._by_tenant[tenant_id] = tier
+
+    def tier_for(self, tenant_id: str) -> PlanTier:
+        return self._by_tenant.get(tenant_id, self._default)

--- a/sdk/python/tests/test_plan_limits.py
+++ b/sdk/python/tests/test_plan_limits.py
@@ -1,0 +1,376 @@
+"""Tests for plan tiers + graceful usage-limit enforcement (CTO-89)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from tally.plan_limits import (
+    BUILTIN_TIERS,
+    ENTERPRISE,
+    FREE,
+    PRO,
+    SCALE,
+    EnforcementDecision,
+    EnforcementLevel,
+    InMemoryPlanRegistry,
+    LimitState,
+    Meter,
+    PlanRegistry,
+    PlanTier,
+    UsageSnapshot,
+    apply_tier_change,
+    build_limit_state,
+    classify,
+    next_tier_up,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Tier definitions + validation
+# --------------------------------------------------------------------------- #
+def test_builtin_tiers_present_and_ordered() -> None:
+    assert BUILTIN_TIERS == (FREE, PRO, SCALE, ENTERPRISE)
+    ranks = [t.rank for t in BUILTIN_TIERS]
+    assert ranks == sorted(ranks)
+    assert FREE.max_traces_per_period < PRO.max_traces_per_period < SCALE.max_traces_per_period
+
+
+def test_enterprise_is_unlimited_on_both_meters() -> None:
+    assert ENTERPRISE.is_unlimited(Meter.TRACES)
+    assert ENTERPRISE.is_unlimited(Meter.FEATURES)
+    assert ENTERPRISE.limit_for(Meter.TRACES) is None
+    assert ENTERPRISE.limit_for(Meter.FEATURES) is None
+
+
+def test_custom_tier_definition() -> None:
+    tier = PlanTier(name="CUSTOM", max_traces_per_period=500, max_features=7, rank=5)
+    assert tier.limit_for(Meter.TRACES) == 500
+    assert tier.limit_for(Meter.FEATURES) == 7
+    assert not tier.is_unlimited(Meter.TRACES)
+
+
+def test_empty_tier_name_raises() -> None:
+    with pytest.raises(ValueError):
+        PlanTier(name="", max_traces_per_period=10, max_features=1)
+    with pytest.raises(ValueError):
+        PlanTier(name="   ", max_traces_per_period=10, max_features=1)
+
+
+def test_negative_limits_raise() -> None:
+    with pytest.raises(ValueError):
+        PlanTier(name="X", max_traces_per_period=-1, max_features=1)
+    with pytest.raises(ValueError):
+        PlanTier(name="X", max_traces_per_period=1, max_features=-1)
+    with pytest.raises(ValueError):
+        PlanTier(name="X", max_traces_per_period=1, max_features=1, rank=-1)
+    with pytest.raises(ValueError):
+        PlanTier(name="X", max_traces_per_period=1, max_features=1, price_micro_usd=-1)
+
+
+def test_unlimited_meter_allowed() -> None:
+    tier = PlanTier(name="U", max_traces_per_period=None, max_features=5)
+    assert tier.is_unlimited(Meter.TRACES)
+    assert not tier.is_unlimited(Meter.FEATURES)
+
+
+def test_plan_tier_is_frozen() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        FREE.name = "MUTATED"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# UsageSnapshot
+# --------------------------------------------------------------------------- #
+def test_usage_clamps_negatives() -> None:
+    u = UsageSnapshot(traces=-5, features=-3)
+    assert u.traces == 0
+    assert u.features == 0
+
+
+def test_usage_value_for() -> None:
+    u = UsageSnapshot(traces=42, features=7)
+    assert u.value_for(Meter.TRACES) == 42
+    assert u.value_for(Meter.FEATURES) == 7
+
+
+# --------------------------------------------------------------------------- #
+# Enforcement levels at the boundaries (cap = 100 traces on a custom tier)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def cap100() -> PlanTier:
+    return PlanTier(name="CAP100", max_traces_per_period=100, max_features=1000)
+
+
+@pytest.mark.parametrize(
+    "traces,expected",
+    [
+        (0, EnforcementLevel.OK),
+        (79, EnforcementLevel.OK),  # just under 80%
+        (80, EnforcementLevel.WARN),  # exactly 80%
+        (99, EnforcementLevel.WARN),  # just under 100%
+        (100, EnforcementLevel.SOFT_CAP),  # exactly at cap
+        (149, EnforcementLevel.SOFT_CAP),  # over but under 150%
+        (150, EnforcementLevel.UPGRADE_REQUIRED),  # 150% of cap
+        (1000, EnforcementLevel.UPGRADE_REQUIRED),  # way over
+    ],
+)
+def test_trace_boundaries(cap100: PlanTier, traces: int, expected: EnforcementLevel) -> None:
+    decision = classify(cap100, UsageSnapshot(traces=traces, features=0))
+    assert decision.level is expected
+
+
+def test_warn_at_eighty_percent_carries_numbers(cap100: PlanTier) -> None:
+    d = classify(cap100, UsageSnapshot(traces=80, features=0))
+    assert d.meter is Meter.TRACES
+    assert d.usage == 80
+    assert d.limit == 100
+    assert d.percent_used == pytest.approx(80.0)
+    assert "upgrad" in d.message.lower()
+
+
+def test_soft_cap_message_promises_data_kept(cap100: PlanTier) -> None:
+    d = classify(cap100, UsageSnapshot(traces=120, features=0))
+    assert d.level is EnforcementLevel.SOFT_CAP
+    assert "still accepting" in d.message.lower()
+
+
+# --------------------------------------------------------------------------- #
+# The never-drops-data invariant
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("traces", [0, 80, 100, 200, 10_000_000])
+def test_decision_never_drops_data(cap100: PlanTier, traces: int) -> None:
+    d = classify(cap100, UsageSnapshot(traces=traces, features=0))
+    assert d.drops_data is False
+
+
+def test_limit_state_never_drops_data(cap100: PlanTier) -> None:
+    state = build_limit_state(cap100, UsageSnapshot(traces=99999, features=99999))
+    assert state.drops_data is False
+
+
+def test_every_level_reports_no_drop() -> None:
+    tier = PlanTier(name="T", max_traces_per_period=10, max_features=10)
+    for traces in (0, 8, 10, 20):
+        assert classify(tier, UsageSnapshot(traces=traces, features=0)).drops_data is False
+
+
+# --------------------------------------------------------------------------- #
+# Both meters + which-meter-tripped
+# --------------------------------------------------------------------------- #
+def test_features_meter_can_trip() -> None:
+    tier = PlanTier(name="T", max_traces_per_period=1_000_000, max_features=5)
+    d = classify(tier, UsageSnapshot(traces=0, features=6))
+    assert d.meter is Meter.FEATURES
+    assert d.level is EnforcementLevel.SOFT_CAP
+
+
+def test_worst_meter_wins_when_both_exceed() -> None:
+    # traces at SOFT_CAP, features at UPGRADE_REQUIRED -> features should win.
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=10)
+    d = classify(tier, UsageSnapshot(traces=110, features=100))
+    assert d.level is EnforcementLevel.UPGRADE_REQUIRED
+    assert d.meter is Meter.FEATURES
+
+
+def test_tie_breaks_to_traces() -> None:
+    # both meters at SOFT_CAP -> TRACES (billable unit) reported.
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=10)
+    d = classify(tier, UsageSnapshot(traces=100, features=10))
+    assert d.level is EnforcementLevel.SOFT_CAP
+    assert d.meter is Meter.TRACES
+
+
+def test_traces_trip_while_features_ok() -> None:
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=1000)
+    d = classify(tier, UsageSnapshot(traces=200, features=1))
+    assert d.meter is Meter.TRACES
+    assert d.level is EnforcementLevel.UPGRADE_REQUIRED
+
+
+# --------------------------------------------------------------------------- #
+# Unlimited / enterprise never trips
+# --------------------------------------------------------------------------- #
+def test_enterprise_never_trips() -> None:
+    d = classify(ENTERPRISE, UsageSnapshot(traces=10**12, features=10**6))
+    assert d.level is EnforcementLevel.OK
+    assert d.percent_used == 0.0
+    assert d.needs_upgrade is False
+
+
+def test_partial_unlimited_tier() -> None:
+    tier = PlanTier(name="P", max_traces_per_period=None, max_features=4)
+    over = classify(tier, UsageSnapshot(traces=10**9, features=4))
+    assert over.meter is Meter.FEATURES
+    assert over.level is EnforcementLevel.SOFT_CAP
+
+
+def test_zero_cap_disables_meter() -> None:
+    # A zero cap means the feature is off on this tier: any usage -> upgrade.
+    tier = PlanTier(name="Z", max_traces_per_period=100, max_features=0)
+    none_used = classify(tier, UsageSnapshot(traces=0, features=0))
+    assert none_used.level is EnforcementLevel.OK
+    used = classify(tier, UsageSnapshot(traces=0, features=1))
+    assert used.meter is Meter.FEATURES
+    assert used.level is EnforcementLevel.UPGRADE_REQUIRED
+    assert used.percent_used == float("inf")
+
+
+# --------------------------------------------------------------------------- #
+# Next tier up
+# --------------------------------------------------------------------------- #
+def test_next_tier_up_from_free() -> None:
+    usage = UsageSnapshot(traces=50_000, features=4)  # over FREE on both
+    nxt = next_tier_up(FREE, usage)
+    assert nxt is PRO
+
+
+def test_next_tier_up_skips_insufficient_tier() -> None:
+    # Usage clears SCALE but not PRO -> jump to SCALE.
+    usage = UsageSnapshot(traces=5_000_000, features=4)
+    nxt = next_tier_up(FREE, usage)
+    assert nxt is SCALE
+
+
+def test_next_tier_up_returns_enterprise_for_huge_usage() -> None:
+    usage = UsageSnapshot(traces=10**11, features=10_000)
+    nxt = next_tier_up(FREE, usage)
+    assert nxt is ENTERPRISE
+
+
+def test_next_tier_up_on_top_tier_returns_none() -> None:
+    usage = UsageSnapshot(traces=10**9, features=500)
+    assert next_tier_up(ENTERPRISE, usage) is None
+
+
+def test_next_tier_up_none_when_no_higher_clears() -> None:
+    # On PRO, usage that not even ENTERPRISE could fail to clear — but here
+    # construct a registry where the only higher tier doesn't cover usage.
+    small_top = PlanTier(name="SMALL_TOP", max_traces_per_period=10, max_features=1, rank=9)
+    usage = UsageSnapshot(traces=1000, features=50)
+    assert next_tier_up(PRO, usage, tiers=(PRO, small_top)) is None
+
+
+# --------------------------------------------------------------------------- #
+# Tier change takes effect
+# --------------------------------------------------------------------------- #
+def test_apply_tier_change_clears_after_upgrade() -> None:
+    usage = UsageSnapshot(traces=50_000, features=4)
+    before = classify(FREE, usage)
+    assert before.needs_upgrade is True
+    after = apply_tier_change(PRO, usage)
+    assert after.level is EnforcementLevel.OK
+    assert after.tier_name == "PRO"
+
+
+def test_apply_tier_change_is_pure() -> None:
+    usage = UsageSnapshot(traces=120, features=0)
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=10)
+    d1 = apply_tier_change(tier, usage)
+    d2 = apply_tier_change(tier, usage)
+    assert d1 == d2
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot / summary / as_dict
+# --------------------------------------------------------------------------- #
+def test_decision_as_dict_and_summary(cap100: PlanTier) -> None:
+    d = classify(cap100, UsageSnapshot(traces=120, features=0))
+    data = d.as_dict()
+    assert data["level"] == "soft_cap"
+    assert data["meter"] == "traces"
+    assert data["usage"] == 120
+    assert data["limit"] == 100
+    assert data["drops_data"] is False
+    assert data["needs_upgrade"] is True
+    assert "soft_cap" in d.summary()
+    assert "120/100" in d.summary()
+
+
+def test_limit_state_structure() -> None:
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=10)
+    state = build_limit_state(tier, UsageSnapshot(traces=90, features=11))
+    assert isinstance(state, LimitState)
+    assert len(state.meters) == 2
+    assert state.overall.level is EnforcementLevel.SOFT_CAP  # features over
+    assert state.needs_upgrade is True
+
+
+def test_limit_state_as_dict_and_summary() -> None:
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=10)
+    state = build_limit_state(tier, UsageSnapshot(traces=85, features=5))
+    data = state.as_dict()
+    assert data["tier_name"] == "T"
+    assert data["drops_data"] is False
+    assert len(data["meters"]) == 2  # type: ignore[arg-type]
+    assert "traces 85/100" in state.summary()
+
+
+def test_limit_state_summary_shows_unlimited() -> None:
+    state = build_limit_state(ENTERPRISE, UsageSnapshot(traces=999, features=999))
+    assert "unlimited" in state.summary()
+
+
+def test_meter_state_as_dict() -> None:
+    tier = PlanTier(name="T", max_traces_per_period=100, max_features=10)
+    state = build_limit_state(tier, UsageSnapshot(traces=50, features=5))
+    m = state.meters[0]
+    d = m.as_dict()
+    assert d["meter"] in ("traces", "features")
+    assert "percent_used" in d
+
+
+# --------------------------------------------------------------------------- #
+# Immutability of results
+# --------------------------------------------------------------------------- #
+def test_decision_is_frozen(cap100: PlanTier) -> None:
+    d = classify(cap100, UsageSnapshot(traces=10, features=0))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        d.level = EnforcementLevel.OK  # type: ignore[misc]
+
+
+def test_decision_drops_data_cannot_be_overridden(cap100: PlanTier) -> None:
+    d = classify(cap100, UsageSnapshot(traces=10, features=0))
+    assert isinstance(d, EnforcementDecision)
+    # drops_data is a property — there is no settable attribute backing it.
+    assert d.drops_data is False
+
+
+# --------------------------------------------------------------------------- #
+# Registry default + override
+# --------------------------------------------------------------------------- #
+def test_registry_default_is_free() -> None:
+    reg = InMemoryPlanRegistry()
+    assert reg.tier_for("tenant-a") is FREE
+
+
+def test_registry_custom_default() -> None:
+    reg = InMemoryPlanRegistry(default=PRO)
+    assert reg.tier_for("unknown") is PRO
+
+
+def test_registry_override_per_tenant() -> None:
+    reg = InMemoryPlanRegistry()
+    reg.set_tier("big-co", SCALE)
+    assert reg.tier_for("big-co") is SCALE
+    assert reg.tier_for("other") is FREE
+
+
+def test_registry_rejects_empty_tenant() -> None:
+    reg = InMemoryPlanRegistry()
+    with pytest.raises(ValueError):
+        reg.set_tier("", PRO)
+
+
+def test_registry_satisfies_protocol() -> None:
+    reg = InMemoryPlanRegistry()
+    assert isinstance(reg, PlanRegistry)
+
+
+def test_registry_integration_with_classify() -> None:
+    reg = InMemoryPlanRegistry()
+    reg.set_tier("t1", PlanTier(name="T1", max_traces_per_period=100, max_features=10))
+    tier = reg.tier_for("t1")
+    d = classify(tier, UsageSnapshot(traces=200, features=1))
+    assert d.level is EnforcementLevel.UPGRADE_REQUIRED


### PR DESCRIPTION
## Summary
- New pure-logic module `sdk/python/src/tally/plan_limits.py` (no imports from other tally submodules — branches off `main` cleanly).
- `PlanTier` (frozen, slotted) with per-billing-period caps on two meters: head trace-count and distinct active feature-count. Built-in `FREE`/`PRO`/`SCALE`/`ENTERPRISE` tiers (enterprise = unlimited via `None`) plus custom tiers, with `__post_init__` validation.
- Graceful enforcement ladder `OK -> WARN (>=80%) -> SOFT_CAP (>=100%) -> UPGRADE_REQUIRED`. `EnforcementDecision` carries level, tripped meter, usage/limit, percent-used, and a human-readable upgrade prompt.
- **Never-drop-billable-data invariant**: `drops_data` is always `False` (documented) — enforcement only warns/prompts, never gates ingestion. `classify()` returns the worst meter's decision (ties to `TRACES`), and never raises on boundary junk (negative usage clamps to zero).
- Upgrade flow: `next_tier_up()` returns the cheapest higher tier whose caps clear current usage (`None` when already on top); `apply_tier_change()` re-classifies promptly under a new tier.
- Limit-state visibility: `LimitState`/`MeterState` with `as_dict()` and `summary()` for "usage vs cap" UI.
- `PlanRegistry` protocol (`@runtime_checkable`) + `InMemoryPlanRegistry` default impl (defaults to `FREE`).

This is a **pure-logic module off `main`**, fully independent — its PR can merge without depending on any unmerged metering/ledger/redaction branch.

## Test plan
- [x] `ruff check` clean on both new files (line-length 100).
- [x] `pytest tests/test_plan_limits.py` — 53 passed.
- [x] Full suite `pytest -q` — 243 passed, no regressions.
- [x] Boundary coverage: 79/80/99/100/149/150/over for all four levels.
- [x] Both meters, which-meter-tripped when both exceed, tie-breaks to TRACES.
- [x] Never-drops-data invariant across every level.
- [x] Unlimited/enterprise never trips; next-tier-up incl. already-on-top; tier-change takes effect; snapshot/summary/as_dict; custom tier; frozen immutability; registry default + override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)