### PR TITLE
CTO-90: Stripe billing integration (metered usage, lifecycle, invoices)

### DIFF
--- a/sdk/python/src/tally/stripe_billing.py
+++ b/sdk/python/src/tally/stripe_billing.py
@@ -1,0 +1,691 @@
+"""Stripe billing integration (CTO-90).
+
+Why this module exists
+----------------------
+Self-serve only works if the loop closes without a human: **usage → invoice →
+payment**. This module turns the abstract billable usage a tenant accrues into
+Stripe metered-billing calls, drives the subscription lifecycle (create,
+upgrade/downgrade, cancel, dunning on failed payment), and reconciles the
+resulting invoice back against the source usage so we can prove the customer was
+charged for exactly what they used.
+
+Design
+------
+* **Injected client.** Every Stripe side effect goes through the
+  :class:`StripeClient` Protocol. The default :class:`FakeStripeClient`
+  simulates Stripe entirely in memory, so the whole signup → usage → invoice
+  path runs in tests (and local dev) with no network and no secret key. Wire a
+  real adapter in production.
+* **Independent.** Consumes an abstract :class:`BillableUsage` record rather
+  than importing the ledger/meter modules (which live on their own branches), so
+  this ships off ``main`` on its own.
+* **Money.** Amounts are integer **micro-USD** internally (the codebase-wide
+  invariant — see :mod:`tally.schema`). They convert to integer **cents** only
+  at the Stripe boundary, since Stripe charges in the smallest currency unit.
+* **Idempotency.** Usage reporting is keyed by the record's idempotency key, so
+  retries never double-bill — mirroring the ledger's guarantee.
+
+Nothing here logs or persists a Stripe secret key; the real client adapter is
+responsible for holding credentials out of this layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from tally.schema import DEFAULT_CURRENCY, micro_to_usd
+
+#: micro-USD per cent (1 cent = 1e-2 USD = 10_000 micro-USD).
+_MICRO_PER_CENT = Decimal(10_000)
+
+
+def micro_to_cents(micro_usd: int) -> int:
+    """Convert integer micro-USD to integer cents (Stripe's smallest unit).
+
+    Rounds half-up at the cent boundary. Stripe wants whole cents; sub-cent
+    precision is carried in micro-USD right up to this boundary.
+    """
+    return int((Decimal(micro_usd) / _MICRO_PER_CENT).quantize(Decimal(1), rounding=ROUND_HALF_UP))
+
+
+# --------------------------------------------------------------------------- #
+# Meters, prices, plans
+# --------------------------------------------------------------------------- #
+class Meter(str, Enum):
+    """The two billable meters (per spec CTO-81: per-trace + per-feature)."""
+
+    TRACE_COUNT = "trace_count"
+    FEATURE_COUNT = "feature_count"
+
+
+@dataclass(frozen=True, slots=True)
+class BillingPlan:
+    """A purchasable plan mapped to its Stripe price + per-unit metered prices.
+
+    ``price_id`` is the Stripe Price object id for the subscription. ``metered``
+    maps each :class:`Meter` to a per-unit price in micro-USD. Limits/tiers are
+    CTO-89's concern and deliberately not modelled here.
+    """
+
+    name: str
+    price_id: str
+    metered: Mapping[Meter, int]
+    currency: str = DEFAULT_CURRENCY
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("plan name must be non-empty")
+        if not self.price_id:
+            raise ValueError("price_id must be non-empty")
+        for meter, unit in self.metered.items():
+            if not isinstance(meter, Meter):
+                raise ValueError(f"metered keys must be Meter, got {meter!r}")
+            if not isinstance(unit, int) or isinstance(unit, bool) or unit < 0:
+                raise ValueError(f"unit price for {meter} must be a non-negative int")
+
+    def unit_price_micro(self, meter: Meter) -> int:
+        """Per-unit price in micro-USD for *meter* (0 if the plan omits it)."""
+        return int(self.metered.get(meter, 0))
+
+
+# --------------------------------------------------------------------------- #
+# Billable usage (abstract input)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class BillableUsage:
+    """One usage quantity for a tenant+meter over a billing period.
+
+    ``idempotency_key`` makes reporting safe to retry. ``quantity`` is a count
+    (traces or distinct features), never money.
+    """
+
+    tenant_id: str
+    meter: Meter
+    quantity: int
+    period_start: datetime
+    period_end: datetime
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        if not self.tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if not isinstance(self.meter, Meter):
+            raise ValueError(f"meter must be a Meter, got {self.meter!r}")
+        if not isinstance(self.quantity, int) or isinstance(self.quantity, bool):
+            raise ValueError("quantity must be an int")
+        if self.quantity < 0:
+            raise ValueError("quantity must be non-negative")
+        if not self.idempotency_key:
+            raise ValueError("idempotency_key must be non-empty")
+
+
+# --------------------------------------------------------------------------- #
+# Subscription lifecycle
+# --------------------------------------------------------------------------- #
+class SubscriptionStatus(str, Enum):
+    """Lifecycle states a subscription moves through."""
+
+    TRIALING = "trialing"
+    ACTIVE = "active"
+    PAST_DUE = "past_due"
+    CANCELED = "canceled"
+
+
+@dataclass(frozen=True, slots=True)
+class Subscription:
+    """Immutable subscription snapshot. Transitions return new instances."""
+
+    id: str
+    tenant_id: str
+    customer_id: str
+    plan_name: str
+    status: SubscriptionStatus
+    current_period_start: datetime
+    current_period_end: datetime
+    failed_payment_attempts: int = 0
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in (SubscriptionStatus.ACTIVE, SubscriptionStatus.TRIALING)
+
+    @property
+    def is_canceled(self) -> bool:
+        return self.status is SubscriptionStatus.CANCELED
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "tenant_id": self.tenant_id,
+            "customer_id": self.customer_id,
+            "plan_name": self.plan_name,
+            "status": self.status.value,
+            "current_period_start": self.current_period_start.isoformat(),
+            "current_period_end": self.current_period_end.isoformat(),
+            "failed_payment_attempts": self.failed_payment_attempts,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DunningPolicy:
+    """How failed payments are retried before the subscription is canceled.
+
+    ``retry_schedule_days`` is the delay (days from the failed charge) for each
+    successive attempt. Once attempts exceed ``max_attempts`` the subscription
+    is canceled. A customer is **never** silently dropped — cancellation is an
+    explicit, surfaced state.
+    """
+
+    max_attempts: int = 4
+    retry_schedule_days: tuple[int, ...] = (1, 3, 5, 7)
+
+    def __post_init__(self) -> None:
+        if self.max_attempts <= 0:
+            raise ValueError("max_attempts must be positive")
+
+    def next_retry_day(self, attempt: int) -> int | None:
+        """Delay (days) before retry *attempt* (1-based), or None if past max."""
+        if attempt < 1 or attempt > self.max_attempts:
+            return None
+        idx = min(attempt - 1, len(self.retry_schedule_days) - 1)
+        return self.retry_schedule_days[idx]
+
+
+class DunningAction(str, Enum):
+    """What dunning decided after a failed payment."""
+
+    RETRY = "retry"
+    CANCEL = "cancel"
+
+
+@dataclass(frozen=True, slots=True)
+class DunningOutcome:
+    """Result of processing a failed payment."""
+
+    subscription: Subscription
+    action: DunningAction
+    attempt: int
+    retry_in_days: int | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "action": self.action.value,
+            "attempt": self.attempt,
+            "retry_in_days": self.retry_in_days,
+            "subscription": self.subscription.as_dict(),
+        }
+
+
+def activate(sub: Subscription) -> Subscription:
+    """Move a subscription to ACTIVE and clear any failed-payment counter."""
+    return replace(sub, status=SubscriptionStatus.ACTIVE, failed_payment_attempts=0)
+
+
+def change_plan(sub: Subscription, new_plan_name: str) -> Subscription:
+    """Upgrade/downgrade: swap the plan; limits take effect immediately.
+
+    A canceled subscription cannot be re-planned (must re-subscribe).
+    """
+    if not new_plan_name:
+        raise ValueError("new_plan_name must be non-empty")
+    if sub.is_canceled:
+        raise ValueError("cannot change plan on a canceled subscription")
+    return replace(sub, plan_name=new_plan_name)
+
+
+def cancel(sub: Subscription) -> Subscription:
+    """Cancel the subscription (idempotent)."""
+    return replace(sub, status=SubscriptionStatus.CANCELED)
+
+
+def record_payment_success(sub: Subscription) -> Subscription:
+    """A successful charge clears dunning and (re)activates the subscription."""
+    if sub.is_canceled:
+        return sub
+    return activate(sub)
+
+
+def record_payment_failure(
+    sub: Subscription, policy: DunningPolicy | None = None
+) -> DunningOutcome:
+    """Process a failed charge through the dunning policy.
+
+    Increments the attempt counter, moves to PAST_DUE and schedules a retry
+    until ``max_attempts`` is exceeded, at which point the subscription is
+    canceled. Never raises on a canceled input — returns a CANCEL no-op.
+    """
+    pol = policy if policy is not None else DunningPolicy()
+    if sub.is_canceled:
+        return DunningOutcome(sub, DunningAction.CANCEL, sub.failed_payment_attempts, None)
+    attempt = sub.failed_payment_attempts + 1
+    if attempt > pol.max_attempts:
+        return DunningOutcome(cancel(sub), DunningAction.CANCEL, attempt, None)
+    updated = replace(
+        sub,
+        status=SubscriptionStatus.PAST_DUE,
+        failed_payment_attempts=attempt,
+    )
+    return DunningOutcome(updated, DunningAction.RETRY, attempt, pol.next_retry_day(attempt))
+
+
+# --------------------------------------------------------------------------- #
+# Invoices
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class InvoiceLine:
+    """One metered line on an invoice."""
+
+    meter: Meter
+    quantity: int
+    unit_amount_micro_usd: int
+    amount_micro_usd: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "meter": self.meter.value,
+            "quantity": self.quantity,
+            "unit_amount_micro_usd": self.unit_amount_micro_usd,
+            "amount_micro_usd": self.amount_micro_usd,
+            "amount_usd": str(micro_to_usd(self.amount_micro_usd)),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Invoice:
+    """A finalized invoice for one tenant over one period."""
+
+    id: str
+    tenant_id: str
+    customer_id: str
+    lines: tuple[InvoiceLine, ...]
+    currency: str = DEFAULT_CURRENCY
+
+    @property
+    def total_micro_usd(self) -> int:
+        return sum(line.amount_micro_usd for line in self.lines)
+
+    @property
+    def total_cents(self) -> int:
+        return micro_to_cents(self.total_micro_usd)
+
+    def summary(self) -> str:
+        return (
+            f"invoice {self.id} for {self.tenant_id}: "
+            f"{len(self.lines)} line(s), total ${micro_to_usd(self.total_micro_usd)}"
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "tenant_id": self.tenant_id,
+            "customer_id": self.customer_id,
+            "currency": self.currency,
+            "lines": [line.as_dict() for line in self.lines],
+            "total_micro_usd": self.total_micro_usd,
+            "total_cents": self.total_cents,
+            "total_usd": str(micro_to_usd(self.total_micro_usd)),
+        }
+
+
+def build_invoice(
+    invoice_id: str,
+    tenant_id: str,
+    customer_id: str,
+    usage_by_meter: Mapping[Meter, int],
+    plan: BillingPlan,
+) -> Invoice:
+    """Price *usage_by_meter* against *plan* into an :class:`Invoice`.
+
+    Lines are emitted in :class:`Meter` declaration order for determinism. A
+    meter with zero quantity is still emitted (a $0 line) so the invoice mirrors
+    the meters the plan bills on.
+    """
+    lines: list[InvoiceLine] = []
+    for meter in Meter:
+        if meter not in usage_by_meter:
+            continue
+        qty = int(usage_by_meter[meter])
+        unit = plan.unit_price_micro(meter)
+        lines.append(
+            InvoiceLine(
+                meter=meter,
+                quantity=qty,
+                unit_amount_micro_usd=unit,
+                amount_micro_usd=qty * unit,
+            )
+        )
+    return Invoice(
+        id=invoice_id,
+        tenant_id=tenant_id,
+        customer_id=customer_id,
+        lines=tuple(lines),
+        currency=plan.currency,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationResult:
+    """Whether an invoice matches the expected usage priced against the plan."""
+
+    ok: bool
+    expected_total_micro_usd: int
+    invoice_total_micro_usd: int
+    line_drifts: Mapping[str, int]
+
+    @property
+    def total_drift_micro_usd(self) -> int:
+        return self.invoice_total_micro_usd - self.expected_total_micro_usd
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "expected_total_micro_usd": self.expected_total_micro_usd,
+            "invoice_total_micro_usd": self.invoice_total_micro_usd,
+            "total_drift_micro_usd": self.total_drift_micro_usd,
+            "line_drifts": dict(self.line_drifts),
+        }
+
+
+def reconcile_invoice(
+    invoice: Invoice,
+    expected_usage: Mapping[Meter, int],
+    plan: BillingPlan,
+) -> ReconciliationResult:
+    """Verify *invoice* charges exactly what *expected_usage* priced on *plan*.
+
+    Computes the expected per-line amount and reports any drift (invoice minus
+    expected) per meter and in total. ``ok`` is True iff every line and the
+    total match to the micro-USD.
+    """
+    invoiced: dict[Meter, int] = {line.meter: line.amount_micro_usd for line in invoice.lines}
+    meters = set(invoiced) | set(expected_usage)
+    line_drifts: dict[str, int] = {}
+    expected_total = 0
+    for meter in meters:
+        expected_amount = int(expected_usage.get(meter, 0)) * plan.unit_price_micro(meter)
+        expected_total += expected_amount
+        drift = invoiced.get(meter, 0) - expected_amount
+        if drift != 0:
+            line_drifts[meter.value] = drift
+    return ReconciliationResult(
+        ok=not line_drifts and invoice.total_micro_usd == expected_total,
+        expected_total_micro_usd=expected_total,
+        invoice_total_micro_usd=invoice.total_micro_usd,
+        line_drifts=line_drifts,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Stripe client boundary
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class StripeClient(Protocol):
+    """The Stripe side effects this integration needs. Real adapter in prod."""
+
+    def create_customer(self, tenant_id: str, email: str) -> str: ...
+
+    def create_subscription(self, customer_id: str, price_id: str) -> str: ...
+
+    def update_subscription(self, subscription_id: str, price_id: str) -> None: ...
+
+    def cancel_subscription(self, subscription_id: str) -> None: ...
+
+    def report_usage(
+        self, subscription_id: str, meter: Meter, quantity: int, idempotency_key: str
+    ) -> bool: ...
+
+
+class FakeStripeClient:
+    """In-memory Stripe simulator so the full path runs without network.
+
+    Records customers/subscriptions and deduplicates usage by idempotency key.
+    ``reported_quantity`` lets tests assert the metered total that reached
+    "Stripe".
+    """
+
+    __slots__ = ("_customers", "_subscriptions", "_usage", "_seen_keys", "_seq")
+
+    def __init__(self) -> None:
+        self._customers: dict[str, dict[str, str]] = {}
+        self._subscriptions: dict[str, dict[str, str]] = {}
+        self._usage: dict[tuple[str, Meter], int] = {}
+        self._seen_keys: set[str] = set()
+        self._seq = 0
+
+    def _next_id(self, prefix: str) -> str:
+        self._seq += 1
+        return f"{prefix}_{self._seq:06d}"
+
+    def create_customer(self, tenant_id: str, email: str) -> str:
+        cid = self._next_id("cus")
+        self._customers[cid] = {"tenant_id": tenant_id, "email": email}
+        return cid
+
+    def create_subscription(self, customer_id: str, price_id: str) -> str:
+        sid = self._next_id("sub")
+        self._subscriptions[sid] = {"customer_id": customer_id, "price_id": price_id}
+        return sid
+
+    def update_subscription(self, subscription_id: str, price_id: str) -> None:
+        if subscription_id in self._subscriptions:
+            self._subscriptions[subscription_id]["price_id"] = price_id
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        self._subscriptions.pop(subscription_id, None)
+
+    def report_usage(
+        self, subscription_id: str, meter: Meter, quantity: int, idempotency_key: str
+    ) -> bool:
+        if idempotency_key in self._seen_keys:
+            return False  # duplicate — already counted
+        self._seen_keys.add(idempotency_key)
+        key = (subscription_id, meter)
+        self._usage[key] = self._usage.get(key, 0) + quantity
+        return True
+
+    # --- test/inspection helpers ---
+    def reported_quantity(self, subscription_id: str, meter: Meter) -> int:
+        return self._usage.get((subscription_id, meter), 0)
+
+    def customer_count(self) -> int:
+        return len(self._customers)
+
+    def has_subscription(self, subscription_id: str) -> bool:
+        return subscription_id in self._subscriptions
+
+
+# --------------------------------------------------------------------------- #
+# Subscription store
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class SubscriptionStore(Protocol):
+    """Persists the current subscription per tenant."""
+
+    def get(self, tenant_id: str) -> Subscription | None: ...
+
+    def put(self, subscription: Subscription) -> None: ...
+
+
+class InMemorySubscriptionStore:
+    """Default in-memory subscription store."""
+
+    __slots__ = ("_by_tenant",)
+
+    def __init__(self) -> None:
+        self._by_tenant: dict[str, Subscription] = {}
+
+    def get(self, tenant_id: str) -> Subscription | None:
+        return self._by_tenant.get(tenant_id)
+
+    def put(self, subscription: Subscription) -> None:
+        self._by_tenant[subscription.tenant_id] = subscription
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+class PaymentEvent(str, Enum):
+    """Inbound Stripe webhook events we react to."""
+
+    PAYMENT_SUCCEEDED = "payment_succeeded"
+    PAYMENT_FAILED = "payment_failed"
+
+
+class BillingService:
+    """Orchestrates signup → usage reporting → invoicing → payment lifecycle.
+
+    Holds a :class:`StripeClient`, a :class:`SubscriptionStore`, a plan
+    catalog, and a :class:`DunningPolicy`. All default to in-memory/fake impls
+    so a test can drive the whole loop with zero configuration.
+    """
+
+    __slots__ = ("_client", "_store", "_plans", "_dunning", "_usage", "_invoice_seq")
+
+    def __init__(
+        self,
+        client: StripeClient | None = None,
+        store: SubscriptionStore | None = None,
+        plans: Iterable[BillingPlan] = (),
+        dunning: DunningPolicy | None = None,
+    ) -> None:
+        self._client: StripeClient = client if client is not None else FakeStripeClient()
+        self._store: SubscriptionStore = store if store is not None else InMemorySubscriptionStore()
+        self._plans: dict[str, BillingPlan] = {p.name: p for p in plans}
+        self._dunning = dunning if dunning is not None else DunningPolicy()
+        # accumulated reported usage per (tenant, meter) for invoicing
+        self._usage: dict[tuple[str, Meter], int] = {}
+        self._invoice_seq = 0
+
+    def register_plan(self, plan: BillingPlan) -> None:
+        self._plans[plan.name] = plan
+
+    def _plan(self, name: str) -> BillingPlan:
+        if name not in self._plans:
+            raise ValueError(f"unknown plan: {name!r}")
+        return self._plans[name]
+
+    def signup(
+        self,
+        tenant_id: str,
+        email: str,
+        plan_name: str,
+        *,
+        period_start: datetime,
+        period_end: datetime,
+        trial: bool = False,
+    ) -> Subscription:
+        """Provision a customer + subscription for a new tenant."""
+        plan = self._plan(plan_name)
+        customer_id = self._client.create_customer(tenant_id, email)
+        sub_id = self._client.create_subscription(customer_id, plan.price_id)
+        status = SubscriptionStatus.TRIALING if trial else SubscriptionStatus.ACTIVE
+        sub = Subscription(
+            id=sub_id,
+            tenant_id=tenant_id,
+            customer_id=customer_id,
+            plan_name=plan_name,
+            status=status,
+            current_period_start=_as_utc(period_start),
+            current_period_end=_as_utc(period_end),
+        )
+        self._store.put(sub)
+        return sub
+
+    def report_usage(self, usage: BillableUsage) -> bool:
+        """Report one usage record to Stripe (idempotent) and accumulate it.
+
+        Returns True if newly counted, False if the idempotency key was a
+        duplicate. Billable data is never dropped: an unknown tenant still
+        accumulates locally so a later invoice is complete.
+        """
+        sub = self._store.get(usage.tenant_id)
+        sub_id = sub.id if sub is not None else f"unbound:{usage.tenant_id}"
+        counted = self._client.report_usage(
+            sub_id, usage.meter, usage.quantity, usage.idempotency_key
+        )
+        if counted:
+            key = (usage.tenant_id, usage.meter)
+            self._usage[key] = self._usage.get(key, 0) + usage.quantity
+        return counted
+
+    def usage_for(self, tenant_id: str) -> dict[Meter, int]:
+        """Accumulated reported usage per meter for a tenant."""
+        return {
+            meter: qty for (tid, meter), qty in self._usage.items() if tid == tenant_id and qty
+        }
+
+    def finalize_invoice(self, tenant_id: str) -> Invoice:
+        """Price the tenant's accumulated usage into an invoice."""
+        sub = self._store.get(tenant_id)
+        if sub is None:
+            raise ValueError(f"no subscription for tenant {tenant_id!r}")
+        plan = self._plan(sub.plan_name)
+        self._invoice_seq += 1
+        return build_invoice(
+            invoice_id=f"in_{self._invoice_seq:06d}",
+            tenant_id=tenant_id,
+            customer_id=sub.customer_id,
+            usage_by_meter=self.usage_for(tenant_id),
+            plan=plan,
+        )
+
+    def change_plan(self, tenant_id: str, new_plan_name: str) -> Subscription:
+        """Upgrade/downgrade a tenant; new metered prices take effect at once."""
+        sub = self._require_sub(tenant_id)
+        plan = self._plan(new_plan_name)
+        self._client.update_subscription(sub.id, plan.price_id)
+        updated = change_plan(sub, new_plan_name)
+        self._store.put(updated)
+        return updated
+
+    def cancel(self, tenant_id: str) -> Subscription:
+        """Cancel a tenant's subscription."""
+        sub = self._require_sub(tenant_id)
+        self._client.cancel_subscription(sub.id)
+        updated = cancel(sub)
+        self._store.put(updated)
+        return updated
+
+    def handle_payment_event(self, tenant_id: str, event: PaymentEvent) -> Subscription:
+        """Drive the lifecycle from an inbound payment webhook.
+
+        Success → ACTIVE (dunning cleared). Failure → dunning, which either
+        retries (PAST_DUE) or cancels once attempts are exhausted.
+        """
+        sub = self._require_sub(tenant_id)
+        if event is PaymentEvent.PAYMENT_SUCCEEDED:
+            updated = record_payment_success(sub)
+        else:
+            outcome = record_payment_failure(sub, self._dunning)
+            updated = outcome.subscription
+            if outcome.action is DunningAction.CANCEL and updated.is_canceled:
+                self._client.cancel_subscription(sub.id)
+        self._store.put(updated)
+        return updated
+
+    def _require_sub(self, tenant_id: str) -> Subscription:
+        sub = self._store.get(tenant_id)
+        if sub is None:
+            raise ValueError(f"no subscription for tenant {tenant_id!r}")
+        return sub
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Treat naive datetimes as UTC; normalise aware ones to UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+#: A small default catalog usable in dev/tests (prices in micro-USD per unit).
+DEFAULT_PLANS: tuple[BillingPlan, ...] = (
+    BillingPlan(
+        name="pro",
+        price_id="price_pro",
+        metered={Meter.TRACE_COUNT: 50, Meter.FEATURE_COUNT: 1_000_000},
+    ),
+)

--- a/sdk/python/tests/test_stripe_billing.py
+++ b/sdk/python/tests/test_stripe_billing.py
@@ -1,0 +1,351 @@
+"""Tests for tally.stripe_billing (CTO-90): metered billing, lifecycle, invoices."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tally.stripe_billing import (
+    BillableUsage,
+    BillingPlan,
+    BillingService,
+    DunningAction,
+    DunningPolicy,
+    FakeStripeClient,
+    Invoice,
+    Meter,
+    PaymentEvent,
+    SubscriptionStatus,
+    build_invoice,
+    cancel,
+    change_plan,
+    micro_to_cents,
+    reconcile_invoice,
+    record_payment_failure,
+    record_payment_success,
+)
+
+UTC = timezone.utc
+P_START = datetime(2026, 5, 1, tzinfo=UTC)
+P_END = datetime(2026, 6, 1, tzinfo=UTC)
+
+PRO = BillingPlan(
+    name="pro",
+    price_id="price_pro",
+    metered={Meter.TRACE_COUNT: 50, Meter.FEATURE_COUNT: 1_000_000},
+)
+SCALE = BillingPlan(
+    name="scale",
+    price_id="price_scale",
+    metered={Meter.TRACE_COUNT: 30, Meter.FEATURE_COUNT: 800_000},
+)
+
+
+def _usage(tenant, meter, qty, key):
+    return BillableUsage(
+        tenant_id=tenant,
+        meter=meter,
+        quantity=qty,
+        period_start=P_START,
+        period_end=P_END,
+        idempotency_key=key,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Money conversion
+# --------------------------------------------------------------------------- #
+def test_micro_to_cents():
+    assert micro_to_cents(10_000) == 1  # 1 cent
+    assert micro_to_cents(1_000_000) == 100  # $1
+    assert micro_to_cents(0) == 0
+    assert micro_to_cents(15_000) == 2  # 1.5 cents -> round half up to 2
+    assert micro_to_cents(14_999) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Plan validation
+# --------------------------------------------------------------------------- #
+def test_plan_validation():
+    with pytest.raises(ValueError):
+        BillingPlan(name="", price_id="p", metered={})
+    with pytest.raises(ValueError):
+        BillingPlan(name="x", price_id="", metered={})
+    with pytest.raises(ValueError):
+        BillingPlan(name="x", price_id="p", metered={Meter.TRACE_COUNT: -1})
+    with pytest.raises(ValueError):
+        BillingPlan(name="x", price_id="p", metered={"trace": 1})  # type: ignore[dict-item]
+
+
+def test_plan_unit_price():
+    assert PRO.unit_price_micro(Meter.TRACE_COUNT) == 50
+    assert PRO.unit_price_micro(Meter.FEATURE_COUNT) == 1_000_000
+
+
+# --------------------------------------------------------------------------- #
+# BillableUsage validation
+# --------------------------------------------------------------------------- #
+def test_usage_validation():
+    with pytest.raises(ValueError):
+        _usage("", Meter.TRACE_COUNT, 1, "k")
+    with pytest.raises(ValueError):
+        _usage("t", Meter.TRACE_COUNT, -1, "k")
+    with pytest.raises(ValueError):
+        _usage("t", Meter.TRACE_COUNT, 1, "")
+    with pytest.raises(ValueError):
+        _usage("t", "trace", 1, "k")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        _usage("t", Meter.TRACE_COUNT, True, "k")  # bool rejected
+
+
+# --------------------------------------------------------------------------- #
+# Invoices
+# --------------------------------------------------------------------------- #
+def test_build_invoice_prices_usage():
+    usage = {Meter.TRACE_COUNT: 1000, Meter.FEATURE_COUNT: 3}
+    inv = build_invoice("in_1", "t1", "cus_1", usage, PRO)
+    assert inv.total_micro_usd == 1000 * 50 + 3 * 1_000_000
+    assert len(inv.lines) == 2
+    # lines emitted in Meter declaration order
+    assert inv.lines[0].meter is Meter.TRACE_COUNT
+    assert inv.lines[1].meter is Meter.FEATURE_COUNT
+
+
+def test_invoice_total_cents_and_summary_and_as_dict():
+    inv = build_invoice("in_1", "t1", "cus_1", {Meter.TRACE_COUNT: 2000}, PRO)
+    assert inv.total_micro_usd == 100_000
+    assert inv.total_cents == 10
+    assert "in_1" in inv.summary()
+    d = inv.as_dict()
+    assert d["total_micro_usd"] == 100_000
+    assert d["total_cents"] == 10
+    assert d["lines"][0]["meter"] == "trace_count"
+
+
+def test_build_invoice_zero_quantity_line_kept():
+    inv = build_invoice("in_1", "t1", "cus_1", {Meter.TRACE_COUNT: 0}, PRO)
+    assert len(inv.lines) == 1
+    assert inv.lines[0].amount_micro_usd == 0
+
+
+# --------------------------------------------------------------------------- #
+# Reconciliation
+# --------------------------------------------------------------------------- #
+def test_reconcile_matches():
+    usage = {Meter.TRACE_COUNT: 1000, Meter.FEATURE_COUNT: 3}
+    inv = build_invoice("in_1", "t1", "cus_1", usage, PRO)
+    res = reconcile_invoice(inv, usage, PRO)
+    assert res.ok is True
+    assert res.total_drift_micro_usd == 0
+    assert res.line_drifts == {}
+
+
+def test_reconcile_detects_drift():
+    inv = build_invoice("in_1", "t1", "cus_1", {Meter.TRACE_COUNT: 1000}, PRO)
+    # expected fewer traces than invoiced -> positive drift
+    res = reconcile_invoice(inv, {Meter.TRACE_COUNT: 900}, PRO)
+    assert res.ok is False
+    assert res.line_drifts["trace_count"] == (1000 - 900) * 50
+    assert res.total_drift_micro_usd == 5000
+    assert res.as_dict()["ok"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Subscription lifecycle (pure transitions)
+# --------------------------------------------------------------------------- #
+def _sub(status=SubscriptionStatus.ACTIVE, attempts=0, plan="pro"):
+    from tally.stripe_billing import Subscription
+
+    return Subscription(
+        id="sub_1",
+        tenant_id="t1",
+        customer_id="cus_1",
+        plan_name=plan,
+        status=status,
+        current_period_start=P_START,
+        current_period_end=P_END,
+        failed_payment_attempts=attempts,
+    )
+
+
+def test_change_plan_swaps_and_rejects_canceled():
+    s = change_plan(_sub(), "scale")
+    assert s.plan_name == "scale"
+    with pytest.raises(ValueError):
+        change_plan(_sub(status=SubscriptionStatus.CANCELED), "scale")
+    with pytest.raises(ValueError):
+        change_plan(_sub(), "")
+
+
+def test_cancel_is_idempotent():
+    s = cancel(_sub())
+    assert s.is_canceled
+    assert cancel(s).is_canceled
+
+
+def test_payment_success_reactivates_and_clears_dunning():
+    s = record_payment_success(_sub(status=SubscriptionStatus.PAST_DUE, attempts=2))
+    assert s.status is SubscriptionStatus.ACTIVE
+    assert s.failed_payment_attempts == 0
+
+
+def test_payment_success_noop_on_canceled():
+    s = _sub(status=SubscriptionStatus.CANCELED)
+    assert record_payment_success(s) is s
+
+
+def test_dunning_retries_then_cancels():
+    pol = DunningPolicy(max_attempts=3, retry_schedule_days=(1, 3, 5))
+    s = _sub()
+    out1 = record_payment_failure(s, pol)
+    assert out1.action is DunningAction.RETRY
+    assert out1.attempt == 1
+    assert out1.retry_in_days == 1
+    assert out1.subscription.status is SubscriptionStatus.PAST_DUE
+
+    out2 = record_payment_failure(out1.subscription, pol)
+    assert out2.attempt == 2
+    assert out2.retry_in_days == 3
+
+    out3 = record_payment_failure(out2.subscription, pol)
+    assert out3.attempt == 3
+    assert out3.retry_in_days == 5
+    assert out3.action is DunningAction.RETRY
+
+    # 4th failure exceeds max_attempts -> cancel
+    out4 = record_payment_failure(out3.subscription, pol)
+    assert out4.action is DunningAction.CANCEL
+    assert out4.subscription.is_canceled
+
+
+def test_dunning_noop_on_canceled():
+    out = record_payment_failure(_sub(status=SubscriptionStatus.CANCELED))
+    assert out.action is DunningAction.CANCEL
+    assert out.retry_in_days is None
+
+
+def test_dunning_policy_validation_and_schedule():
+    with pytest.raises(ValueError):
+        DunningPolicy(max_attempts=0)
+    pol = DunningPolicy(max_attempts=5, retry_schedule_days=(2,))
+    assert pol.next_retry_day(1) == 2
+    assert pol.next_retry_day(5) == 2  # clamps to last entry
+    assert pol.next_retry_day(6) is None
+    assert pol.next_retry_day(0) is None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: signup -> usage -> invoice (test mode)
+# --------------------------------------------------------------------------- #
+def test_end_to_end_signup_usage_invoice():
+    client = FakeStripeClient()
+    svc = BillingService(client=client, plans=[PRO])
+    sub = svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    assert sub.status is SubscriptionStatus.ACTIVE
+    assert client.customer_count() == 1
+    assert client.has_subscription(sub.id)
+
+    assert svc.report_usage(_usage("t1", Meter.TRACE_COUNT, 1000, "k1")) is True
+    assert svc.report_usage(_usage("t1", Meter.FEATURE_COUNT, 3, "k2")) is True
+
+    inv = svc.finalize_invoice("t1")
+    assert isinstance(inv, Invoice)
+    assert inv.total_micro_usd == 1000 * 50 + 3 * 1_000_000
+    res = reconcile_invoice(inv, svc.usage_for("t1"), PRO)
+    assert res.ok is True
+
+
+def test_report_usage_idempotent():
+    svc = BillingService(plans=[PRO])
+    svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    assert svc.report_usage(_usage("t1", Meter.TRACE_COUNT, 100, "dup")) is True
+    assert svc.report_usage(_usage("t1", Meter.TRACE_COUNT, 100, "dup")) is False  # no double
+    assert svc.usage_for("t1")[Meter.TRACE_COUNT] == 100
+
+
+def test_trial_signup():
+    svc = BillingService(plans=[PRO])
+    sub = svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END, trial=True)
+    assert sub.status is SubscriptionStatus.TRIALING
+    assert sub.is_active
+
+
+def test_change_plan_through_service_updates_stripe():
+    client = FakeStripeClient()
+    svc = BillingService(client=client, plans=[PRO, SCALE])
+    svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    updated = svc.change_plan("t1", "scale")
+    assert updated.plan_name == "scale"
+    # subsequent invoice uses the new plan's prices
+    svc.report_usage(_usage("t1", Meter.TRACE_COUNT, 100, "k"))
+    inv = svc.finalize_invoice("t1")
+    assert inv.total_micro_usd == 100 * 30  # SCALE trace price
+
+
+def test_cancel_through_service():
+    client = FakeStripeClient()
+    svc = BillingService(client=client, plans=[PRO])
+    sub = svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    updated = svc.cancel("t1")
+    assert updated.is_canceled
+    assert client.has_subscription(sub.id) is False
+
+
+def test_handle_payment_events_drive_lifecycle():
+    svc = BillingService(plans=[PRO], dunning=DunningPolicy(max_attempts=1))
+    svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    s = svc.handle_payment_event("t1", PaymentEvent.PAYMENT_FAILED)
+    assert s.status is SubscriptionStatus.PAST_DUE
+    # max_attempts=1 -> next failure cancels
+    s = svc.handle_payment_event("t1", PaymentEvent.PAYMENT_FAILED)
+    assert s.is_canceled
+    # success after cancel is a no-op
+    s = svc.handle_payment_event("t1", PaymentEvent.PAYMENT_SUCCEEDED)
+    assert s.is_canceled
+
+
+def test_payment_success_recovers_past_due():
+    svc = BillingService(plans=[PRO])
+    svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    svc.handle_payment_event("t1", PaymentEvent.PAYMENT_FAILED)
+    s = svc.handle_payment_event("t1", PaymentEvent.PAYMENT_SUCCEEDED)
+    assert s.status is SubscriptionStatus.ACTIVE
+    assert s.failed_payment_attempts == 0
+
+
+def test_unknown_plan_and_missing_sub_raise():
+    svc = BillingService(plans=[PRO])
+    with pytest.raises(ValueError):
+        svc.signup("t1", "a@b.co", "nope", period_start=P_START, period_end=P_END)
+    with pytest.raises(ValueError):
+        svc.finalize_invoice("ghost")
+    with pytest.raises(ValueError):
+        svc.cancel("ghost")
+
+
+def test_report_usage_unbound_tenant_still_accumulates():
+    # Billable data is never dropped, even with no subscription yet.
+    svc = BillingService(plans=[PRO])
+    assert svc.report_usage(_usage("t1", Meter.TRACE_COUNT, 7, "k")) is True
+    assert svc.usage_for("t1")[Meter.TRACE_COUNT] == 7
+
+
+def test_fake_client_dedupes_usage():
+    c = FakeStripeClient()
+    assert c.report_usage("sub_1", Meter.TRACE_COUNT, 10, "k") is True
+    assert c.report_usage("sub_1", Meter.TRACE_COUNT, 10, "k") is False
+    assert c.reported_quantity("sub_1", Meter.TRACE_COUNT) == 10
+
+
+def test_subscription_as_dict():
+    d = _sub().as_dict()
+    assert d["status"] == "active"
+    assert d["tenant_id"] == "t1"
+
+
+def test_register_plan_after_construction():
+    svc = BillingService()
+    svc.register_plan(PRO)
+    sub = svc.signup("t1", "a@b.co", "pro", period_start=P_START, period_end=P_END)
+    assert sub.plan_name == "pro"


### PR DESCRIPTION
## Summary

Closes the self-serve loop — **usage → invoice → payment** — in a self-contained new module `tally.stripe_billing`, off `main` and independent of the ledger/meter branches (consumes an abstract `BillableUsage` record).

- **Metered billing.** `BillableUsage` → Stripe usage reports via a `UsageReporter`/`BillingService`, idempotent by the record's key so retries never double-bill (mirrors the ledger guarantee). Money stays integer **micro-USD** internally; converts to integer **cents** only at the Stripe boundary (`micro_to_cents`).
- **Subscription lifecycle.** `create` (`signup`), `upgrade/downgrade` (`change_plan` — new metered prices take effect immediately), `cancel`, and **dunning** on failed payment. `DunningPolicy` retries on a schedule (`retry_schedule_days`) then cancels once `max_attempts` is exceeded — a customer is never *silently* dropped; cancellation is an explicit, surfaced state.
- **Invoices + reconciliation.** `build_invoice` prices accumulated usage against a `BillingPlan`; `reconcile_invoice` proves the invoice matches source usage to the micro-USD (per-line + total drift).
- **Test mode end-to-end.** `StripeClient` Protocol with an in-memory `FakeStripeClient` so the full `signup → usage → invoice` path runs with no network and no secret key. Webhook `payment_succeeded` / `payment_failed` events drive the lifecycle via `handle_payment_event`.

**Billable-data invariant:** `report_usage` accepts usage even for an unbound tenant (accumulates locally) so no paid-for telemetry is ever dropped.

## Out of scope (per ticket)

- Meters/ledger (CTO-84/85/87); plan-tier *definitions* + limit enforcement (CTO-89).
- A real Stripe API adapter (production wires one behind the `StripeClient` Protocol; secrets stay out of this layer).

## Test plan

- [x] 28 unit tests in `tests/test_stripe_billing.py` (money conversion incl. rounding, plan/usage validation, invoice pricing + zero-line, reconciliation match/drift, all lifecycle transitions, dunning retry→cancel ladder, end-to-end signup→usage→invoice, idempotent reporting, plan change re-prices, webhook-driven lifecycle, unbound-tenant accumulation).
- [x] Full SDK suite green (~250 tests); `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)