### PR TITLE
CTO-68: CDP/revenue connectors (Segment, Rudderstack, Stripe, HubSpot)

### DIFF
--- a/sdk/python/src/tally/cdp_connectors.py
+++ b/sdk/python/src/tally/cdp_connectors.py
@@ -1,0 +1,509 @@
+"""CDP / revenue connectors — Segment, Rudderstack, Stripe, HubSpot (CTO-68).
+
+Why this module exists
+----------------------
+ROI has two halves: the **cost** of an AI feature (the telemetry spine) and the
+**value** it produced. The value half lives in CDPs and CRMs — a Segment
+``track`` of a conversion, a Stripe ``invoice.paid``, a HubSpot deal moving to
+closed-won. This module turns those provider-specific webhook payloads into two
+normalized streams the rest of the platform understands:
+
+* :class:`BusinessEvent` — a value event (revenue or a named conversion) written
+  to ``business_events``.
+* :class:`~tally.identity.IdentifyEvent` / :class:`~tally.identity.AliasEvent` —
+  identity links fed into the identity graph (CTO-67) so an anonymous→known
+  conversion can reach back to pre-login traces.
+
+Correctness rules baked in
+--------------------------
+* **occurred_at, not ingest time.** Windowing uses the event's own timestamp.
+  Providers are late: Stripe webhooks can trail the real charge by hours. Using
+  ingest time would smear revenue into the wrong day and break reconciliation.
+* **Idempotent on ``business_event_id``.** Every provider has a stable unique id
+  (Segment ``messageId``, Stripe event ``id``, HubSpot ``eventId``). The
+  :class:`EventDeduplicator` drops replays so a re-delivered webhook never
+  double-counts revenue.
+* **Never raises on junk.** A malformed payload yields an empty
+  :class:`ConnectorResult` (skipped), not an exception — a bad webhook must not
+  take down the ingest path.
+
+Scope: parsing/normalization + dedup only. Stitching (CTO-69) and the ROI UI
+(CTO-70) are out of scope. This module is self-contained apart from the
+identity event types it reuses from :mod:`tally.identity`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Protocol, runtime_checkable
+
+from tally.identity import AliasEvent, IdentifyEvent, IdentityType
+from tally.schema import DEFAULT_CURRENCY, usd_to_micro
+
+#: micro-USD per cent — Stripe amounts arrive in the smallest currency unit.
+_MICRO_PER_CENT = 10_000
+
+
+# --------------------------------------------------------------------------- #
+# Normalized value event
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class BusinessEvent:
+    """A normalized value event destined for ``business_events``.
+
+    ``value_micro_usd`` is the revenue attached to the event in integer
+    micro-USD (0 for a non-revenue conversion). ``occurred_at`` is the event's
+    own timestamp (UTC), never ingest time. ``business_event_id`` is the
+    provider's stable id and the idempotency key.
+    """
+
+    business_event_id: str
+    tenant_id: str
+    source: str
+    event_name: str
+    occurred_at: datetime
+    value_micro_usd: int = 0
+    currency: str = DEFAULT_CURRENCY
+    user_id: str | None = None
+    anonymous_id: str | None = None
+    properties: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.business_event_id:
+            raise ValueError("business_event_id must be non-empty")
+        if not self.tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if not isinstance(self.value_micro_usd, int) or isinstance(self.value_micro_usd, bool):
+            raise ValueError("value_micro_usd must be an int")
+        if self.value_micro_usd < 0:
+            raise ValueError("value_micro_usd must be non-negative")
+
+    @property
+    def is_revenue(self) -> bool:
+        return self.value_micro_usd > 0
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "business_event_id": self.business_event_id,
+            "tenant_id": self.tenant_id,
+            "source": self.source,
+            "event_name": self.event_name,
+            "occurred_at": self.occurred_at.isoformat(),
+            "value_micro_usd": self.value_micro_usd,
+            "currency": self.currency,
+            "user_id": self.user_id,
+            "anonymous_id": self.anonymous_id,
+            "properties": dict(self.properties),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorResult:
+    """What a connector extracted from one webhook payload.
+
+    A payload may yield a value event, identity links, or both (e.g. a Segment
+    ``identify`` with revenue traits). Any of these tuples may be empty.
+    """
+
+    business_events: tuple[BusinessEvent, ...] = ()
+    identifies: tuple[IdentifyEvent, ...] = ()
+    aliases: tuple[AliasEvent, ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.business_events or self.identifies or self.aliases)
+
+
+# --------------------------------------------------------------------------- #
+# Parsing helpers (all tolerant — return None on junk)
+# --------------------------------------------------------------------------- #
+def _as_str(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _parse_iso(value: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp (accepts trailing ``Z``). UTC-normalized."""
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return _as_utc(dt)
+
+
+def _epoch_to_dt(value: object, *, unit: str) -> datetime | None:
+    """Parse a numeric epoch (``unit`` = 's' or 'ms') to a UTC datetime."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    seconds = value / 1000.0 if unit == "ms" else float(value)
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _revenue_micro_from_usd(value: object) -> int:
+    """Convert a dollar amount (number or numeric string) to micro-USD; 0 on junk."""
+    if value is None or isinstance(value, bool):
+        return 0
+    try:
+        micro = usd_to_micro(Decimal(str(value)))
+    except (InvalidOperation, ValueError, TypeError):
+        return 0
+    return micro if micro > 0 else 0
+
+
+def _revenue_micro_from_cents(value: object) -> int:
+    """Convert an integer-cents amount to micro-USD; 0 on junk/negative."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    cents = int(value)
+    return cents * _MICRO_PER_CENT if cents > 0 else 0
+
+
+# --------------------------------------------------------------------------- #
+# Connector protocol
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class CDPConnector(Protocol):
+    """Parses one provider's webhook payload into a :class:`ConnectorResult`."""
+
+    source: str
+
+    def parse(self, tenant_id: str, payload: Mapping[str, object]) -> ConnectorResult: ...
+
+
+# --------------------------------------------------------------------------- #
+# Segment (and Rudderstack, which mirrors the Segment spec)
+# --------------------------------------------------------------------------- #
+class SegmentConnector:
+    """Segment HTTP API / webhook payloads.
+
+    Handles ``track`` (→ value event; ``properties.revenue`` is the amount in
+    USD), ``identify`` (→ identity link), and ``alias`` (→ identity link). Other
+    types (``page``/``screen``/``group``) produce no events.
+    """
+
+    source = "segment"
+
+    def parse(self, tenant_id: str, payload: Mapping[str, object]) -> ConnectorResult:
+        if not isinstance(payload, Mapping):
+            return ConnectorResult()
+        msg_type = _as_str(payload.get("type"))
+        occurred_at = _parse_iso(payload.get("timestamp")) or _parse_iso(payload.get("sentAt"))
+        event_id = _as_str(payload.get("messageId"))
+        user_id = _as_str(payload.get("userId"))
+        anon_id = _as_str(payload.get("anonymousId"))
+
+        if msg_type == "track" and event_id and occurred_at is not None:
+            props = payload.get("properties")
+            props = props if isinstance(props, Mapping) else {}
+            value = _revenue_micro_from_usd(props.get("revenue"))
+            return ConnectorResult(
+                business_events=(
+                    BusinessEvent(
+                        business_event_id=event_id,
+                        tenant_id=tenant_id,
+                        source=self.source,
+                        event_name=_as_str(payload.get("event")) or "track",
+                        occurred_at=occurred_at,
+                        value_micro_usd=value,
+                        currency=_as_str(props.get("currency")) or DEFAULT_CURRENCY,
+                        user_id=user_id,
+                        anonymous_id=anon_id,
+                        properties=dict(props),
+                    ),
+                ),
+            )
+
+        if msg_type == "identify" and user_id and occurred_at is not None:
+            return ConnectorResult(
+                identifies=(
+                    IdentifyEvent(
+                        user_id=user_id,
+                        observed_at=occurred_at,
+                        anonymous_id=anon_id,
+                        source=self.source,
+                    ),
+                ),
+            )
+
+        if msg_type == "alias" and occurred_at is not None:
+            prev = _as_str(payload.get("previousId"))
+            if prev and user_id:
+                return ConnectorResult(
+                    aliases=(
+                        AliasEvent(
+                            previous_id=prev,
+                            previous_type=IdentityType.ANONYMOUS_ID,
+                            new_id=user_id,
+                            new_type=IdentityType.USER_ID,
+                            observed_at=occurred_at,
+                            source=self.source,
+                        ),
+                    ),
+                )
+        return ConnectorResult()
+
+
+class RudderstackConnector(SegmentConnector):
+    """Rudderstack emits the Segment event spec; only the source tag differs."""
+
+    source = "rudderstack"
+
+
+# --------------------------------------------------------------------------- #
+# Stripe
+# --------------------------------------------------------------------------- #
+class StripeConnector:
+    """Stripe ``Event`` webhooks (e.g. ``invoice.paid``, ``charge.succeeded``).
+
+    Amounts arrive in integer **cents**. The event ``id`` is the idempotency
+    key; ``created`` (epoch seconds) is the occurred_at. The customer id becomes
+    an external user identity so revenue can be attributed.
+    """
+
+    source = "stripe"
+
+    #: Event types we treat as revenue, mapped to the amount field on the object.
+    _REVENUE_TYPES = {
+        "invoice.paid": "amount_paid",
+        "invoice.payment_succeeded": "amount_paid",
+        "charge.succeeded": "amount",
+        "payment_intent.succeeded": "amount",
+        "checkout.session.completed": "amount_total",
+    }
+
+    def parse(self, tenant_id: str, payload: Mapping[str, object]) -> ConnectorResult:
+        if not isinstance(payload, Mapping):
+            return ConnectorResult()
+        event_id = _as_str(payload.get("id"))
+        event_type = _as_str(payload.get("type"))
+        occurred_at = _epoch_to_dt(payload.get("created"), unit="s")
+        if not event_id or not event_type or occurred_at is None:
+            return ConnectorResult()
+
+        data = payload.get("data")
+        obj = data.get("object") if isinstance(data, Mapping) else None
+        obj = obj if isinstance(obj, Mapping) else {}
+
+        amount_field = self._REVENUE_TYPES.get(event_type)
+        value = _revenue_micro_from_cents(obj.get(amount_field)) if amount_field else 0
+        customer = _as_str(obj.get("customer"))
+        currency = _as_str(obj.get("currency"))
+
+        return ConnectorResult(
+            business_events=(
+                BusinessEvent(
+                    business_event_id=event_id,
+                    tenant_id=tenant_id,
+                    source=self.source,
+                    event_name=event_type,
+                    occurred_at=occurred_at,
+                    value_micro_usd=value,
+                    currency=(currency or DEFAULT_CURRENCY).upper(),
+                    user_id=customer,
+                    properties={"stripe_object": _as_str(obj.get("object"))},
+                ),
+            ),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# HubSpot
+# --------------------------------------------------------------------------- #
+class HubSpotConnector:
+    """HubSpot webhook subscription payloads (deal/contact property changes).
+
+    ``eventId`` is the idempotency key; ``occurredAt`` is epoch milliseconds.
+    A deal ``amount`` (USD) becomes the value; the object id becomes an external
+    user identity.
+    """
+
+    source = "hubspot"
+
+    def parse(self, tenant_id: str, payload: Mapping[str, object]) -> ConnectorResult:
+        if not isinstance(payload, Mapping):
+            return ConnectorResult()
+        event_id = _as_str(payload.get("eventId"))
+        occurred_at = _epoch_to_dt(payload.get("occurredAt"), unit="ms")
+        if not event_id or occurred_at is None:
+            return ConnectorResult()
+
+        subscription = _as_str(payload.get("subscriptionType")) or "hubspot.event"
+        props = payload.get("properties")
+        props = props if isinstance(props, Mapping) else {}
+        value = _revenue_micro_from_usd(props.get("amount"))
+        object_id = _as_str(payload.get("objectId"))
+
+        return ConnectorResult(
+            business_events=(
+                BusinessEvent(
+                    business_event_id=event_id,
+                    tenant_id=tenant_id,
+                    source=self.source,
+                    event_name=subscription,
+                    occurred_at=occurred_at,
+                    value_micro_usd=value,
+                    user_id=object_id,
+                    properties=dict(props),
+                ),
+            ),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Deduplication (idempotency + replay safety)
+# --------------------------------------------------------------------------- #
+class EventDeduplicator:
+    """Tracks seen ``business_event_id`` s per tenant to drop replays.
+
+    A re-delivered or replayed webhook carries the same provider id; marking it
+    once means subsequent deliveries are ignored, so revenue is never
+    double-counted regardless of how late or how often it arrives.
+    """
+
+    __slots__ = ("_seen",)
+
+    def __init__(self) -> None:
+        self._seen: dict[str, set[str]] = {}
+
+    def is_duplicate(self, tenant_id: str, business_event_id: str) -> bool:
+        return business_event_id in self._seen.get(tenant_id, set())
+
+    def mark(self, tenant_id: str, business_event_id: str) -> bool:
+        """Record an id. Returns True if newly seen, False if it was a duplicate."""
+        bucket = self._seen.setdefault(tenant_id, set())
+        if business_event_id in bucket:
+            return False
+        bucket.add(business_event_id)
+        return True
+
+    def count(self, tenant_id: str) -> int:
+        return len(self._seen.get(tenant_id, set()))
+
+
+# --------------------------------------------------------------------------- #
+# Registry + ingestor
+# --------------------------------------------------------------------------- #
+class ConnectorRegistry:
+    """Maps a source name to its connector."""
+
+    __slots__ = ("_by_source",)
+
+    def __init__(self, connectors: tuple[CDPConnector, ...] = ()) -> None:
+        self._by_source: dict[str, CDPConnector] = {c.source: c for c in connectors}
+
+    def register(self, connector: CDPConnector) -> None:
+        self._by_source[connector.source] = connector
+
+    def get(self, source: str) -> CDPConnector | None:
+        return self._by_source.get(source)
+
+    @property
+    def sources(self) -> tuple[str, ...]:
+        return tuple(sorted(self._by_source))
+
+
+def default_registry() -> ConnectorRegistry:
+    """A registry wired with all four v1 connectors."""
+    return ConnectorRegistry(
+        (
+            SegmentConnector(),
+            RudderstackConnector(),
+            StripeConnector(),
+            HubSpotConnector(),
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class IngestResult:
+    """Outcome of ingesting one webhook.
+
+    ``accepted`` are the newly-seen value events; ``duplicates`` is how many
+    value events were dropped as replays. Identity events are passed through
+    (the identity graph is itself idempotent on edges).
+    """
+
+    accepted: tuple[BusinessEvent, ...]
+    duplicates: int
+    identifies: tuple[IdentifyEvent, ...]
+    aliases: tuple[AliasEvent, ...]
+
+    @property
+    def accepted_count(self) -> int:
+        return len(self.accepted)
+
+    @property
+    def total_value_micro_usd(self) -> int:
+        return sum(e.value_micro_usd for e in self.accepted)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "accepted_count": self.accepted_count,
+            "duplicates": self.duplicates,
+            "total_value_micro_usd": self.total_value_micro_usd,
+            "identifies": len(self.identifies),
+            "aliases": len(self.aliases),
+        }
+
+
+class WebhookIngestor:
+    """Routes a webhook to its connector, dedupes value events, returns results.
+
+    Stateless except for the injected :class:`EventDeduplicator`. Unknown
+    sources and unparseable payloads yield an empty :class:`IngestResult` rather
+    than raising — a bad webhook is skipped, never fatal.
+    """
+
+    __slots__ = ("_registry", "_dedup")
+
+    def __init__(
+        self,
+        registry: ConnectorRegistry | None = None,
+        deduplicator: EventDeduplicator | None = None,
+    ) -> None:
+        self._registry = registry if registry is not None else default_registry()
+        self._dedup = deduplicator if deduplicator is not None else EventDeduplicator()
+
+    def ingest(
+        self, source: str, tenant_id: str, payload: Mapping[str, object]
+    ) -> IngestResult:
+        connector = self._registry.get(source)
+        if connector is None or not tenant_id:
+            return IngestResult((), 0, (), ())
+        try:
+            result = connector.parse(tenant_id, payload)
+        except Exception:
+            # Defensive: a connector bug must not break ingest.
+            return IngestResult((), 0, (), ())
+
+        accepted: list[BusinessEvent] = []
+        duplicates = 0
+        for event in result.business_events:
+            if self._dedup.mark(tenant_id, event.business_event_id):
+                accepted.append(event)
+            else:
+                duplicates += 1
+        return IngestResult(
+            accepted=tuple(accepted),
+            duplicates=duplicates,
+            identifies=result.identifies,
+            aliases=result.aliases,
+        )

--- a/sdk/python/tests/test_cdp_connectors.py
+++ b/sdk/python/tests/test_cdp_connectors.py
@@ -1,0 +1,374 @@
+"""Tests for tally.cdp_connectors (CTO-68): CDP/revenue webhook connectors."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tally.cdp_connectors import (
+    BusinessEvent,
+    ConnectorRegistry,
+    EventDeduplicator,
+    HubSpotConnector,
+    RudderstackConnector,
+    SegmentConnector,
+    StripeConnector,
+    WebhookIngestor,
+    default_registry,
+)
+from tally.identity import IdentityGraph
+
+UTC = timezone.utc
+
+
+# --------------------------------------------------------------------------- #
+# BusinessEvent
+# --------------------------------------------------------------------------- #
+def test_business_event_validation():
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    with pytest.raises(ValueError):
+        BusinessEvent("", "t1", "segment", "e", now)
+    with pytest.raises(ValueError):
+        BusinessEvent("id", "", "segment", "e", now)
+    with pytest.raises(ValueError):
+        BusinessEvent("id", "t1", "segment", "e", now, value_micro_usd=-1)
+    with pytest.raises(ValueError):
+        BusinessEvent("id", "t1", "segment", "e", now, value_micro_usd=True)
+
+
+def test_business_event_is_revenue_and_as_dict():
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    e = BusinessEvent("id", "t1", "segment", "Purchase", now, value_micro_usd=5_000_000)
+    assert e.is_revenue is True
+    d = e.as_dict()
+    assert d["value_micro_usd"] == 5_000_000
+    assert d["event_name"] == "Purchase"
+    assert BusinessEvent("id", "t1", "segment", "Signup", now).is_revenue is False
+
+
+# --------------------------------------------------------------------------- #
+# Segment
+# --------------------------------------------------------------------------- #
+def test_segment_track_with_revenue():
+    c = SegmentConnector()
+    payload = {
+        "type": "track",
+        "messageId": "m1",
+        "event": "Order Completed",
+        "timestamp": "2026-05-01T12:00:00Z",
+        "userId": "u1",
+        "anonymousId": "a1",
+        "properties": {"revenue": 49.99, "currency": "USD"},
+    }
+    res = c.parse("t1", payload)
+    assert len(res.business_events) == 1
+    ev = res.business_events[0]
+    assert ev.business_event_id == "m1"
+    assert ev.event_name == "Order Completed"
+    assert ev.value_micro_usd == 49_990_000
+    assert ev.user_id == "u1"
+    assert ev.anonymous_id == "a1"
+    assert ev.occurred_at == datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+
+
+def test_segment_track_without_revenue_is_zero_value():
+    c = SegmentConnector()
+    res = c.parse(
+        "t1",
+        {
+            "type": "track",
+            "messageId": "m2",
+            "event": "Signed Up",
+            "timestamp": "2026-05-01T00:00:00Z",
+        },
+    )
+    assert res.business_events[0].value_micro_usd == 0
+    assert res.business_events[0].is_revenue is False
+
+
+def test_segment_identify_makes_identify_event():
+    c = SegmentConnector()
+    res = c.parse(
+        "t1",
+        {
+            "type": "identify",
+            "messageId": "m3",
+            "userId": "u1",
+            "anonymousId": "a1",
+            "timestamp": "2026-05-01T00:00:00Z",
+        },
+    )
+    assert len(res.identifies) == 1
+    assert res.identifies[0].user_id == "u1"
+    assert res.identifies[0].anonymous_id == "a1"
+    assert res.business_events == ()
+
+
+def test_segment_alias_makes_alias_event():
+    c = SegmentConnector()
+    res = c.parse(
+        "t1",
+        {
+            "type": "alias",
+            "messageId": "m4",
+            "userId": "u1",
+            "previousId": "a1",
+            "timestamp": "2026-05-01T00:00:00Z",
+        },
+    )
+    assert len(res.aliases) == 1
+    assert res.aliases[0].previous_id == "a1"
+    assert res.aliases[0].new_id == "u1"
+
+
+def test_segment_page_type_yields_nothing():
+    c = SegmentConnector()
+    res = c.parse("t1", {"type": "page", "messageId": "m5", "timestamp": "2026-05-01T00:00:00Z"})
+    assert res.is_empty
+
+
+def test_segment_junk_payload_is_empty():
+    c = SegmentConnector()
+    assert c.parse("t1", {}).is_empty
+    assert c.parse("t1", {"type": "track"}).is_empty  # no id/timestamp
+    assert c.parse("t1", "not a dict").is_empty  # type: ignore[arg-type]
+
+
+def test_rudderstack_shares_segment_spec_with_own_source():
+    c = RudderstackConnector()
+    res = c.parse(
+        "t1",
+        {
+            "type": "track",
+            "messageId": "m1",
+            "event": "Converted",
+            "timestamp": "2026-05-01T00:00:00Z",
+            "properties": {"revenue": 10},
+        },
+    )
+    assert res.business_events[0].source == "rudderstack"
+    assert res.business_events[0].value_micro_usd == 10_000_000
+
+
+# --------------------------------------------------------------------------- #
+# Stripe
+# --------------------------------------------------------------------------- #
+def test_stripe_invoice_paid_revenue_from_cents():
+    c = StripeConnector()
+    payload = {
+        "id": "evt_1",
+        "type": "invoice.paid",
+        "created": 1_777_000_000,  # epoch seconds
+        "data": {"object": {"amount_paid": 2500, "currency": "usd", "customer": "cus_1"}},
+    }
+    res = c.parse("t1", payload)
+    ev = res.business_events[0]
+    assert ev.business_event_id == "evt_1"
+    assert ev.value_micro_usd == 2500 * 10_000  # 25.00 USD
+    assert ev.currency == "USD"
+    assert ev.user_id == "cus_1"
+    assert ev.occurred_at.tzinfo is UTC
+
+
+def test_stripe_non_revenue_event_zero_value():
+    c = StripeConnector()
+    res = c.parse(
+        "t1",
+        {
+            "id": "evt_2",
+            "type": "customer.created",
+            "created": 1_777_000_000,
+            "data": {"object": {"id": "cus_1"}},
+        },
+    )
+    assert res.business_events[0].value_micro_usd == 0
+
+
+def test_stripe_charge_succeeded_uses_amount():
+    c = StripeConnector()
+    res = c.parse(
+        "t1",
+        {
+            "id": "evt_3",
+            "type": "charge.succeeded",
+            "created": 1_777_000_000,
+            "data": {"object": {"amount": 999, "currency": "usd"}},
+        },
+    )
+    assert res.business_events[0].value_micro_usd == 999 * 10_000
+
+
+def test_stripe_junk_is_empty():
+    c = StripeConnector()
+    assert c.parse("t1", {}).is_empty
+    assert c.parse("t1", {"id": "evt", "type": "invoice.paid"}).is_empty  # no created
+
+
+# --------------------------------------------------------------------------- #
+# HubSpot
+# --------------------------------------------------------------------------- #
+def test_hubspot_deal_amount():
+    c = HubSpotConnector()
+    payload = {
+        "eventId": "h1",
+        "subscriptionType": "deal.propertyChange",
+        "occurredAt": 1_777_000_000_000,  # epoch ms
+        "objectId": "deal_1",
+        "properties": {"amount": "1200.50"},
+    }
+    res = c.parse("t1", payload)
+    ev = res.business_events[0]
+    assert ev.business_event_id == "h1"
+    assert ev.value_micro_usd == 1_200_500_000
+    assert ev.user_id == "deal_1"
+    assert ev.occurred_at.tzinfo is UTC
+
+
+def test_hubspot_junk_is_empty():
+    c = HubSpotConnector()
+    assert c.parse("t1", {}).is_empty
+    assert c.parse("t1", {"eventId": "h1"}).is_empty  # no occurredAt
+
+
+# --------------------------------------------------------------------------- #
+# Deduplicator
+# --------------------------------------------------------------------------- #
+def test_deduplicator_marks_and_detects():
+    d = EventDeduplicator()
+    assert d.mark("t1", "e1") is True
+    assert d.mark("t1", "e1") is False  # replay
+    assert d.is_duplicate("t1", "e1") is True
+    assert d.is_duplicate("t1", "e2") is False
+    assert d.count("t1") == 1
+
+
+def test_deduplicator_is_tenant_scoped():
+    d = EventDeduplicator()
+    d.mark("t1", "e1")
+    assert d.is_duplicate("t2", "e1") is False  # different tenant
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+def test_default_registry_has_four_sources():
+    reg = default_registry()
+    assert reg.sources == ("hubspot", "rudderstack", "segment", "stripe")
+    assert reg.get("segment") is not None
+    assert reg.get("unknown") is None
+
+
+def test_registry_register():
+    reg = ConnectorRegistry()
+    reg.register(SegmentConnector())
+    assert reg.get("segment") is not None
+
+
+# --------------------------------------------------------------------------- #
+# Ingestor — idempotency, late/replay, routing
+# --------------------------------------------------------------------------- #
+def _track(mid, revenue, ts="2026-05-01T00:00:00Z"):
+    return {
+        "type": "track",
+        "messageId": mid,
+        "event": "Purchase",
+        "timestamp": ts,
+        "properties": {"revenue": revenue},
+    }
+
+
+def test_ingest_accepts_then_dedupes_replays():
+    ing = WebhookIngestor()
+    r1 = ing.ingest("segment", "t1", _track("m1", 10))
+    assert r1.accepted_count == 1
+    assert r1.total_value_micro_usd == 10_000_000
+    # exact replay (same messageId) is dropped
+    r2 = ing.ingest("segment", "t1", _track("m1", 10))
+    assert r2.accepted_count == 0
+    assert r2.duplicates == 1
+
+
+def test_ingest_late_arriving_event_still_accepted_once():
+    # A late event (old occurred_at) is accepted; only a duplicate id is dropped.
+    ing = WebhookIngestor()
+    late = _track("late1", 5, ts="2026-04-01T00:00:00Z")
+    r = ing.ingest("segment", "t1", late)
+    assert r.accepted_count == 1
+    assert r.accepted[0].occurred_at == datetime(2026, 4, 1, tzinfo=UTC)
+    # redelivery of the same late event is a no-op
+    assert ing.ingest("segment", "t1", late).accepted_count == 0
+
+
+def test_ingest_unknown_source_is_empty():
+    ing = WebhookIngestor()
+    r = ing.ingest("mailchimp", "t1", {"foo": "bar"})
+    assert r.accepted_count == 0
+    assert r.duplicates == 0
+
+
+def test_ingest_empty_tenant_is_empty():
+    ing = WebhookIngestor()
+    assert ing.ingest("segment", "", _track("m1", 1)).accepted_count == 0
+
+
+def test_ingest_routes_identity_events_through():
+    ing = WebhookIngestor()
+    r = ing.ingest(
+        "segment",
+        "t1",
+        {
+            "type": "identify",
+            "messageId": "m1",
+            "userId": "u1",
+            "anonymousId": "a1",
+            "timestamp": "2026-05-01T00:00:00Z",
+        },
+    )
+    assert len(r.identifies) == 1
+    assert r.accepted_count == 0
+
+
+def test_ingest_result_as_dict():
+    ing = WebhookIngestor()
+    r = ing.ingest("segment", "t1", _track("m1", 3))
+    d = r.as_dict()
+    assert d["accepted_count"] == 1
+    assert d["total_value_micro_usd"] == 3_000_000
+
+
+def test_ingest_identity_events_feed_identity_graph():
+    # End-to-end: an identify webhook populates the real identity graph, linking
+    # the anonymous id to the user id so a later conversion can reach back.
+    ing = WebhookIngestor()
+    graph = IdentityGraph()
+    r = ing.ingest(
+        "segment",
+        "t1",
+        {
+            "type": "identify",
+            "messageId": "m1",
+            "userId": "u1",
+            "anonymousId": "a1",
+            "timestamp": "2026-05-01T00:00:00Z",
+        },
+    )
+    for ev in r.identifies:
+        graph.ingest_identify("t1", ev)
+    resolved = graph.resolve_identity("t1", "a1")
+    assert "u1" in resolved
+
+
+def test_ingest_stripe_revenue_end_to_end():
+    ing = WebhookIngestor()
+    payload = {
+        "id": "evt_1",
+        "type": "invoice.paid",
+        "created": 1_777_000_000,
+        "data": {"object": {"amount_paid": 10_000, "currency": "usd", "customer": "cus_1"}},
+    }
+    r = ing.ingest("stripe", "t1", payload)
+    assert r.accepted_count == 1
+    assert r.total_value_micro_usd == 10_000 * 10_000  # $100
+    # Stripe re-sends the same event id on retry -> deduped
+    assert ing.ingest("stripe", "t1", payload).accepted_count == 0


### PR DESCRIPTION
## Summary

The "value" half of ROI: a self-contained new module `tally.cdp_connectors` that turns CDP/CRM webhook payloads into two normalized streams — value events (`BusinessEvent` → `business_events`) and identity links (reusing `tally.identity`'s `IdentifyEvent`/`AliasEvent` → the merged CTO-67 identity graph). Off `main`, independent.

- **Four v1 connectors.** `SegmentConnector` (`track`/`identify`/`alias`), `RudderstackConnector` (same Segment spec, own source tag), `StripeConnector` (`invoice.paid`, `charge.succeeded`, `payment_intent.succeeded`, `checkout.session.completed`), `HubSpotConnector` (deal/contact property changes).
- **occurred_at, not ingest time.** Windowing uses each event's own timestamp (Segment ISO-8601, Stripe `created` epoch-s, HubSpot `occurredAt` epoch-ms), so late providers (Stripe ~6h) land on the correct day.
- **Idempotent on `business_event_id`.** `EventDeduplicator` (tenant-scoped) drops replays / re-deliveries so revenue is never double-counted, however late or however often a webhook arrives.
- **Money in integer micro-USD.** Segment/HubSpot dollar amounts via `usd_to_micro`; Stripe integer cents × 10_000.
- **Never raises on junk.** Unknown sources and malformed payloads yield an empty result and are skipped — a bad webhook can't break ingest. `WebhookIngestor` wraps connector parsing defensively.

## Out of scope (per ticket)

- Stitching logic (CTO-69) and ROI UI (CTO-70).
- Actual webhook HTTP endpoints / persistence (this is the parsing + dedup core).

## Test plan

- [x] 27 unit tests in `tests/test_cdp_connectors.py` (per-connector parsing incl. revenue/non-revenue/identity/alias, junk→empty, dedup tenant-scoping, late-arrival accepted-once, replay dropped, registry routing, end-to-end identify → real `IdentityGraph.resolve_identity`, Stripe retry dedup).
- [x] Full SDK suite green (~277 tests); `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)