### PR TITLE
CTO-30: multi-tenant isolation (admission + scope guard)

### DIFF
--- a/sdk/python/src/tally/tenant_isolation.py
+++ b/sdk/python/src/tally/tenant_isolation.py
@@ -1,0 +1,251 @@
+"""Multi-tenant isolation — query admission, tenant-scope enforcement, resource caps (CTO-30).
+
+A shared multi-tenant cluster (CTO-18) has one non-negotiable rule: **one tenant must never starve
+another and must never read another's data** (spec §11). This module is the pure-logic layer that
+enforces it above the storage engine:
+
+* :class:`QueryConcurrencyLimiter` — caps the number of in-flight *expensive* queries per tenant
+  (default 4) so a single tenant's heavy dashboard can't monopolize the cluster.
+* :class:`TenantQueryGuard` — refuses any query that isn't scoped to exactly the requesting tenant.
+  An unscoped query (no tenant predicate) would scan the whole cluster; a query referencing another
+  tenant is a data-isolation breach. Both are blocked (the negative-test guarantee).
+* :func:`resource_group_for` — generates the per-tenant ClickHouse Resource Group settings
+  (memory + concurrency + CPU weight). The cluster applies them; this is the source of the values.
+* :func:`rank_heavy_tenants` / :func:`recommend_shard_promotions` — the documented shard-promotion
+  path: rank tenants by load and surface the top-N that should be promoted off the shared shard.
+
+Cluster-side application (real ClickHouse Resource Groups) and shard-migration tooling are infra /
+follow-ups; this module owns the policy and the decisions.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+
+DEFAULT_MAX_CONCURRENT_QUERIES = 4
+
+
+# --------------------------------------------------------------------------------------------- #
+# Per-tenant query concurrency limiting (AC: default 4 concurrent expensive queries)
+# --------------------------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class AdmissionOutcome:
+    """Result of asking the limiter for a query slot."""
+
+    admitted: bool
+    tenant_id: str
+    in_flight: int
+    limit: int
+    reason: str | None = None
+
+
+class QueryAdmissionError(RuntimeError):
+    """Raised by :meth:`QueryConcurrencyLimiter.lease` when a tenant is at its concurrency cap."""
+
+    def __init__(self, outcome: AdmissionOutcome) -> None:
+        super().__init__(
+            f"tenant {outcome.tenant_id!r} at concurrency limit "
+            f"({outcome.in_flight}/{outcome.limit})"
+        )
+        self.outcome = outcome
+
+
+class QueryConcurrencyLimiter:
+    """Thread-safe per-tenant in-flight query counter with a hard cap.
+
+    Limits are per tenant and independent — one tenant hitting its cap never affects another.
+    """
+
+    def __init__(self, max_concurrent: int = DEFAULT_MAX_CONCURRENT_QUERIES) -> None:
+        if isinstance(max_concurrent, bool) or not isinstance(max_concurrent, int):
+            raise ValueError("max_concurrent must be an int")
+        if max_concurrent <= 0:
+            raise ValueError("max_concurrent must be positive")
+        self._limit = max_concurrent
+        self._lock = threading.Lock()
+        self._in_flight: dict[str, int] = {}
+        self._overrides: dict[str, int] = {}
+
+    def set_limit(self, tenant_id: str, limit: int) -> None:
+        """Override the concurrency cap for a single tenant (e.g. enterprise gets more)."""
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("limit must be a positive int")
+        with self._lock:
+            self._overrides[tenant_id] = limit
+
+    def limit_for(self, tenant_id: str) -> int:
+        return self._overrides.get(tenant_id, self._limit)
+
+    def in_flight(self, tenant_id: str) -> int:
+        with self._lock:
+            return self._in_flight.get(tenant_id, 0)
+
+    def try_acquire(self, tenant_id: str) -> AdmissionOutcome:
+        """Reserve a slot if under the cap. Never raises — returns an outcome."""
+        if not tenant_id:
+            return AdmissionOutcome(False, tenant_id, 0, 0, reason="missing tenant_id")
+        with self._lock:
+            limit = self._overrides.get(tenant_id, self._limit)
+            current = self._in_flight.get(tenant_id, 0)
+            if current >= limit:
+                return AdmissionOutcome(
+                    False, tenant_id, current, limit, reason="at concurrency limit"
+                )
+            self._in_flight[tenant_id] = current + 1
+            return AdmissionOutcome(True, tenant_id, current + 1, limit)
+
+    def release(self, tenant_id: str) -> None:
+        """Free a previously-acquired slot. Idempotent below zero (never goes negative)."""
+        with self._lock:
+            current = self._in_flight.get(tenant_id, 0)
+            if current <= 1:
+                self._in_flight.pop(tenant_id, None)
+            else:
+                self._in_flight[tenant_id] = current - 1
+
+    @contextmanager
+    def lease(self, tenant_id: str) -> Iterator[AdmissionOutcome]:
+        """Acquire-or-raise context manager; releases the slot on exit."""
+        outcome = self.try_acquire(tenant_id)
+        if not outcome.admitted:
+            raise QueryAdmissionError(outcome)
+        try:
+            yield outcome
+        finally:
+            self.release(tenant_id)
+
+
+# --------------------------------------------------------------------------------------------- #
+# Tenant-scope enforcement (AC: cross-tenant query impossible/blocked)
+# --------------------------------------------------------------------------------------------- #
+class CrossTenantAccessError(PermissionError):
+    """Raised when a query references a tenant other than the requester, or isn't tenant-scoped."""
+
+
+@dataclass(frozen=True, slots=True)
+class ScopedQuery:
+    """A query annotated with the requester and the tenant(s) its predicates reference."""
+
+    requester_tenant_id: str
+    referenced_tenant_ids: frozenset[str]
+    sql: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.requester_tenant_id:
+            raise ValueError("requester_tenant_id must be non-empty")
+
+
+class TenantQueryGuard:
+    """Blocks any query not scoped to exactly the requesting tenant."""
+
+    def violation(self, query: ScopedQuery) -> str | None:
+        """Return a reason string if the query is unsafe, else None."""
+        refs = query.referenced_tenant_ids
+        if not refs:
+            return "query is not tenant-scoped (no tenant predicate)"
+        foreign = refs - {query.requester_tenant_id}
+        if foreign:
+            return f"query references foreign tenants: {sorted(foreign)}"
+        return None
+
+    def is_safe(self, query: ScopedQuery) -> bool:
+        return self.violation(query) is None
+
+    def check(self, query: ScopedQuery) -> None:
+        """Raise :class:`CrossTenantAccessError` if the query would breach isolation."""
+        reason = self.violation(query)
+        if reason is not None:
+            raise CrossTenantAccessError(reason)
+
+
+# --------------------------------------------------------------------------------------------- #
+# Per-tenant resource groups (AC: memory + CPU caps configured per tenant)
+# --------------------------------------------------------------------------------------------- #
+class IsolationTier(str, Enum):
+    FREE = "free"
+    PRO = "pro"
+    ENTERPRISE = "enterprise"
+
+
+_GIB = 1024**3
+
+# Caps per tier: (max_memory_bytes, max_concurrent_queries, cpu_weight).
+_TIER_CAPS: dict[IsolationTier, tuple[int, int, int]] = {
+    IsolationTier.FREE: (2 * _GIB, 2, 50),
+    IsolationTier.PRO: (8 * _GIB, 4, 100),
+    IsolationTier.ENTERPRISE: (32 * _GIB, 16, 300),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceGroup:
+    """Per-tenant ClickHouse Resource Group caps (the values the cluster enforces)."""
+
+    tenant_id: str
+    max_memory_bytes: int
+    max_concurrent_queries: int
+    cpu_weight: int
+
+    def as_settings(self) -> dict[str, object]:
+        """ClickHouse settings-profile shape for this tenant."""
+        return {
+            "profile": f"tenant_{self.tenant_id}",
+            "max_memory_usage": self.max_memory_bytes,
+            "max_concurrent_queries_for_user": self.max_concurrent_queries,
+            "priority": self.cpu_weight,
+        }
+
+
+def resource_group_for(tenant_id: str, tier: IsolationTier = IsolationTier.PRO) -> ResourceGroup:
+    if not tenant_id:
+        raise ValueError("tenant_id must be non-empty")
+    mem, conc, cpu = _TIER_CAPS[tier]
+    return ResourceGroup(tenant_id, mem, conc, cpu)
+
+
+# --------------------------------------------------------------------------------------------- #
+# Shard-promotion path (AC: documented path for top-N heavy tenants)
+# --------------------------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class TenantLoad:
+    """Observed load for a tenant over a window (drives the shard-promotion decision)."""
+
+    tenant_id: str
+    queries_per_day: int
+    bytes_scanned_per_day: int
+
+    @property
+    def load_score(self) -> float:
+        """A single comparable load number: scan volume dominates, query rate breaks ties.
+
+        bytes_scanned (in GiB) is the cluster-pressure signal; query count is secondary.
+        """
+        return self.bytes_scanned_per_day / _GIB + self.queries_per_day / 1000.0
+
+
+# Default: a tenant scanning > ~5 TiB/day of cluster reads is a shard-promotion candidate.
+DEFAULT_PROMOTION_SCORE = 5 * 1024.0
+
+
+def rank_heavy_tenants(loads: Iterable[TenantLoad], *, top_n: int = 10) -> tuple[TenantLoad, ...]:
+    """Heaviest tenants first (by load score, tenant_id as a stable tiebreaker)."""
+    ordered = sorted(loads, key=lambda t: (-t.load_score, t.tenant_id))
+    return tuple(ordered[:top_n])
+
+
+def recommend_shard_promotions(
+    loads: Iterable[TenantLoad], *, threshold_score: float = DEFAULT_PROMOTION_SCORE
+) -> tuple[str, ...]:
+    """Tenant ids whose load exceeds the promotion threshold — promote them off the shared shard.
+
+    The documented promotion path: (1) flag here, (2) provision a dedicated shard, (3) dual-write +
+    backfill, (4) cut reads over, (5) drop from the shared shard. Steps 2–5 are migration tooling
+    (out of scope per CTO-30); this function owns step 1, the decision.
+    """
+    candidates = [t for t in loads if t.load_score >= threshold_score]
+    candidates.sort(key=lambda t: (-t.load_score, t.tenant_id))
+    return tuple(t.tenant_id for t in candidates)

--- a/sdk/python/tests/test_tenant_isolation.py
+++ b/sdk/python/tests/test_tenant_isolation.py
@@ -1,0 +1,203 @@
+"""Tests for tally.tenant_isolation (CTO-30): admission, scope guard, resource groups, promotion."""
+
+from __future__ import annotations
+
+import pytest
+
+from tally.tenant_isolation import (
+    DEFAULT_MAX_CONCURRENT_QUERIES,
+    CrossTenantAccessError,
+    IsolationTier,
+    QueryAdmissionError,
+    QueryConcurrencyLimiter,
+    ScopedQuery,
+    TenantLoad,
+    TenantQueryGuard,
+    rank_heavy_tenants,
+    recommend_shard_promotions,
+    resource_group_for,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Concurrency limiter
+# --------------------------------------------------------------------------- #
+def test_limiter_admits_up_to_limit_then_rejects():
+    lim = QueryConcurrencyLimiter()  # default 4
+    outcomes = [lim.try_acquire("t1") for _ in range(DEFAULT_MAX_CONCURRENT_QUERIES)]
+    assert all(o.admitted for o in outcomes)
+    rejected = lim.try_acquire("t1")
+    assert rejected.admitted is False
+    assert rejected.in_flight == 4
+    assert rejected.reason == "at concurrency limit"
+
+
+def test_limiter_release_frees_a_slot():
+    lim = QueryConcurrencyLimiter(max_concurrent=1)
+    assert lim.try_acquire("t1").admitted is True
+    assert lim.try_acquire("t1").admitted is False
+    lim.release("t1")
+    assert lim.try_acquire("t1").admitted is True
+
+
+def test_limiter_is_per_tenant_independent():
+    lim = QueryConcurrencyLimiter(max_concurrent=1)
+    assert lim.try_acquire("t1").admitted is True
+    # t2 is unaffected by t1 saturating its own limit
+    assert lim.try_acquire("t2").admitted is True
+    assert lim.try_acquire("t1").admitted is False
+
+
+def test_limiter_release_never_negative():
+    lim = QueryConcurrencyLimiter()
+    lim.release("t1")  # no prior acquire
+    assert lim.in_flight("t1") == 0
+
+
+def test_limiter_per_tenant_override():
+    lim = QueryConcurrencyLimiter(max_concurrent=2)
+    lim.set_limit("ent", 5)
+    assert lim.limit_for("ent") == 5
+    assert lim.limit_for("free") == 2
+    for _ in range(5):
+        assert lim.try_acquire("ent").admitted is True
+    assert lim.try_acquire("ent").admitted is False
+
+
+def test_limiter_missing_tenant_rejected():
+    lim = QueryConcurrencyLimiter()
+    assert lim.try_acquire("").admitted is False
+
+
+def test_limiter_rejects_bad_max():
+    with pytest.raises(ValueError):
+        QueryConcurrencyLimiter(0)
+    with pytest.raises(ValueError):
+        QueryConcurrencyLimiter(True)
+
+
+def test_lease_context_manager_releases():
+    lim = QueryConcurrencyLimiter(max_concurrent=1)
+    with lim.lease("t1") as outcome:
+        assert outcome.admitted is True
+        assert lim.in_flight("t1") == 1
+    assert lim.in_flight("t1") == 0  # released on exit
+
+
+def test_lease_raises_when_at_limit():
+    lim = QueryConcurrencyLimiter(max_concurrent=1)
+    lim.try_acquire("t1")
+    with pytest.raises(QueryAdmissionError):
+        with lim.lease("t1"):
+            pass
+
+
+def test_lease_releases_even_on_exception():
+    lim = QueryConcurrencyLimiter(max_concurrent=1)
+    with pytest.raises(RuntimeError):
+        with lim.lease("t1"):
+            raise RuntimeError("boom")
+    assert lim.in_flight("t1") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Tenant-scope guard (the negative test)
+# --------------------------------------------------------------------------- #
+def test_query_scoped_to_own_tenant_is_safe():
+    guard = TenantQueryGuard()
+    q = ScopedQuery("t1", frozenset({"t1"}))
+    assert guard.is_safe(q) is True
+    guard.check(q)  # does not raise
+
+
+def test_cross_tenant_query_is_blocked():
+    guard = TenantQueryGuard()
+    q = ScopedQuery("t1", frozenset({"t1", "t2"}))
+    assert guard.is_safe(q) is False
+    with pytest.raises(CrossTenantAccessError):
+        guard.check(q)
+
+
+def test_foreign_only_query_is_blocked():
+    guard = TenantQueryGuard()
+    q = ScopedQuery("t1", frozenset({"t2"}))
+    with pytest.raises(CrossTenantAccessError):
+        guard.check(q)
+
+
+def test_unscoped_query_is_blocked():
+    guard = TenantQueryGuard()
+    q = ScopedQuery("t1", frozenset())  # no tenant predicate -> whole-cluster scan
+    assert guard.violation(q) == "query is not tenant-scoped (no tenant predicate)"
+    with pytest.raises(CrossTenantAccessError):
+        guard.check(q)
+
+
+def test_scoped_query_requires_requester():
+    with pytest.raises(ValueError):
+        ScopedQuery("", frozenset({"t1"}))
+
+
+# --------------------------------------------------------------------------- #
+# Resource groups
+# --------------------------------------------------------------------------- #
+def test_resource_group_tiers_scale_up():
+    free = resource_group_for("t1", IsolationTier.FREE)
+    pro = resource_group_for("t1", IsolationTier.PRO)
+    ent = resource_group_for("t1", IsolationTier.ENTERPRISE)
+    assert free.max_memory_bytes < pro.max_memory_bytes < ent.max_memory_bytes
+    assert free.max_concurrent_queries < ent.max_concurrent_queries
+
+
+def test_resource_group_default_tier_is_pro():
+    rg = resource_group_for("t1")
+    assert rg.max_concurrent_queries == 4
+
+
+def test_resource_group_as_settings():
+    rg = resource_group_for("acme", IsolationTier.ENTERPRISE)
+    s = rg.as_settings()
+    assert s["profile"] == "tenant_acme"
+    assert s["max_concurrent_queries_for_user"] == 16
+    assert s["max_memory_usage"] == 32 * (1024**3)
+
+
+def test_resource_group_rejects_empty_tenant():
+    with pytest.raises(ValueError):
+        resource_group_for("", IsolationTier.PRO)
+
+
+# --------------------------------------------------------------------------- #
+# Shard promotion
+# --------------------------------------------------------------------------- #
+def _load(tid, gib_per_day, qpd=0):
+    return TenantLoad(tid, queries_per_day=qpd, bytes_scanned_per_day=gib_per_day * (1024**3))
+
+
+def test_rank_heavy_tenants_orders_by_load():
+    loads = [_load("small", 10), _load("huge", 9000), _load("mid", 1000)]
+    ranked = rank_heavy_tenants(loads)
+    assert [t.tenant_id for t in ranked] == ["huge", "mid", "small"]
+
+
+def test_rank_top_n_limit():
+    loads = [_load(f"t{i}", i * 100) for i in range(1, 6)]
+    assert len(rank_heavy_tenants(loads, top_n=2)) == 2
+
+
+def test_recommend_shard_promotions_threshold():
+    loads = [_load("light", 100), _load("heavy", 9000)]
+    # default threshold ~5 TiB/day -> only 'heavy' qualifies
+    assert recommend_shard_promotions(loads) == ("heavy",)
+
+
+def test_recommend_none_below_threshold():
+    loads = [_load("a", 50), _load("b", 100)]
+    assert recommend_shard_promotions(loads) == ()
+
+
+def test_load_score_breaks_ties_on_query_rate():
+    a = _load("a", 1000, qpd=5000)
+    b = _load("b", 1000, qpd=1000)
+    ranked = rank_heavy_tenants([b, a])
+    assert ranked[0].tenant_id == "a"  # same scan volume, more queries -> heavier


### PR DESCRIPTION
## Summary
The pure-logic enforcement layer for the shared multi-tenant cluster (spec §11): one tenant must never starve another nor read another's data.

- **`QueryConcurrencyLimiter`** (AC1) — thread-safe per-tenant in-flight cap (default 4 expensive queries), per-tenant overrides (enterprise gets more), never-raise `try_acquire` returning an `AdmissionOutcome`, plus an acquire-or-raise `lease()` context manager that always releases (even on exception). Limits are per-tenant independent — one tenant saturating its cap never affects another.
- **`TenantQueryGuard`** (AC3, the negative test) — blocks any query not scoped to exactly the requester: both an **unscoped** query (no tenant predicate → whole-cluster scan) and a **cross-tenant** query raise `CrossTenantAccessError`. `is_safe()` / `violation()` for non-throwing checks.
- **`resource_group_for`** (AC2) — generates the per-tenant ClickHouse Resource Group caps (memory + concurrency + CPU weight) by `IsolationTier`, and the `as_settings()` profile shape the cluster applies.
- **`rank_heavy_tenants` / `recommend_shard_promotions`** (AC4) — the documented shard-promotion path: rank tenants by load score and surface the top-N that should move off the shared shard. The 5-step promotion procedure is documented in the function docstring.

## Acceptance criteria
- [x] Per-tenant query concurrency limit enforced (default 4).
- [x] Per-tenant Resource Group (memory + CPU caps) **generated** per tenant — cluster-side application is infra.
- [x] Query-time tenant scoping enforced; a cross-tenant query is blocked (negative test passes).
- [x] Documented shard-promotion path for top-N heavy tenants (decision logic here; migration tooling out of scope per ticket).

Note: cluster-side application of Resource Groups and the actual shard-migration tooling are infra / follow-ups (CTO-94 spike, out of scope per the ticket). This module owns the policy + decisions.

## Test plan
- [x] `pytest tests/test_tenant_isolation.py` — 24 tests, green
- [x] Full suite: 214 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)