### PR TITLE
CTO-77: backup/DR policy + restore-drill RTO/RPO verification

### DIFF
--- a/sdk/python/src/tally/backups.py
+++ b/sdk/python/src/tally/backups.py
@@ -1,0 +1,331 @@
+"""Backup & disaster-recovery policy logic — schedule, restore-drill, IR runbook (CTO-77).
+
+Durability is a promise we make about *other people's data*. This module is the pure-logic layer
+that encodes that promise so it can be tested without standing up real backup infra (spec §12):
+
+* :class:`BackupPolicy` — what gets backed up, how often, how long it's retained, and that it lands
+  in a *different* region (cross-region is the point — a region loss must not lose the backup).
+* :class:`BackupSchedule` — given a policy and a clock, when the next backup is due and whether the
+  most recent one is overdue (a silently-stalled backup is the classic DR failure).
+* :class:`RestoreDrill` — the actual test of the promise: take a backup, restore it, measure the
+  RTO (time-to-restore) and RPO (data-loss window) and check them against the contractual targets
+  (4h RTO / 1h RPO, spec §12.2). A backup you've never restored is a hope, not a backup.
+* :class:`Environment` / :func:`synthetic_record` — dev/staging/prod isolation and synthetic-data
+  generation so non-prod environments never hold real customer data.
+* :class:`IncidentClass` / :func:`runbook_steps` — the incident-response runbook keyed by incident
+  class, so the on-call has a documented path per failure mode.
+
+The cluster-side backup execution (ClickHouse ``BACKUP``, Postgres ``pg_dump``/WAL archiving,
+cross-region object replication), the scheduler that fires these, the annual tabletop exercise, the
+public subprocessor list / pentest / VDP — all infra and ops follow-ups. This module owns the
+*policy and the verification logic*: the targets, the overdue math, the pass/fail of a drill.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+
+# Contractual disaster-recovery targets (spec §12.2).
+DEFAULT_RTO = timedelta(hours=4)  # max acceptable time to restore service
+DEFAULT_RPO = timedelta(hours=1)  # max acceptable data-loss window
+
+DEFAULT_BACKUP_INTERVAL = timedelta(days=1)  # daily backups
+DEFAULT_RETENTION_DAYS = 35  # keep ~5 weeks of daily backups
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalize a datetime to timezone-aware UTC (naive is assumed UTC)."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+# --------------------------------------------------------------------------------------------- #
+# What we back up
+# --------------------------------------------------------------------------------------------- #
+class BackupTarget(str, Enum):
+    """The stores that must be backed up (each has its own native backup mechanism)."""
+
+    CLICKHOUSE = "clickhouse"  # span telemetry store
+    POSTGRES = "postgres"  # control-plane / metadata
+
+
+# --------------------------------------------------------------------------------------------- #
+# Backup policy
+# --------------------------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class BackupPolicy:
+    """How a single store is backed up: cadence, retention, encryption, and where it lands.
+
+    Cross-region is mandatory: ``destination_region`` must differ from ``source_region`` so the loss
+    of the source region cannot also lose its backups. Backups are always encrypted at rest.
+    """
+
+    target: BackupTarget
+    source_region: str
+    destination_region: str
+    interval: timedelta = DEFAULT_BACKUP_INTERVAL
+    retention_days: int = DEFAULT_RETENTION_DAYS
+    encrypted: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.source_region:
+            raise ValueError("source_region must be non-empty")
+        if not self.destination_region:
+            raise ValueError("destination_region must be non-empty")
+        if self.destination_region == self.source_region:
+            raise ValueError("destination_region must differ from source_region (cross-region)")
+        if self.interval <= timedelta(0):
+            raise ValueError("interval must be positive")
+        if isinstance(self.retention_days, bool) or not isinstance(self.retention_days, int):
+            raise ValueError("retention_days must be an int")
+        if self.retention_days <= 0:
+            raise ValueError("retention_days must be positive")
+        if not self.encrypted:
+            raise ValueError("backups must be encrypted at rest")
+
+    @property
+    def retention(self) -> timedelta:
+        return timedelta(days=self.retention_days)
+
+    def expires_at(self, taken_at: datetime) -> datetime:
+        """When a backup taken at ``taken_at`` ages out of retention."""
+        return _as_utc(taken_at) + self.retention
+
+    def is_expired(self, taken_at: datetime, *, as_of: datetime) -> bool:
+        return _as_utc(as_of) >= self.expires_at(taken_at)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "target": self.target.value,
+            "source_region": self.source_region,
+            "destination_region": self.destination_region,
+            "interval_seconds": int(self.interval.total_seconds()),
+            "retention_days": self.retention_days,
+            "encrypted": self.encrypted,
+        }
+
+
+# --------------------------------------------------------------------------------------------- #
+# Schedule / overdue detection
+# --------------------------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class BackupSchedule:
+    """Pairs a policy with the timestamp of the last successful backup to answer 'are we current?'.
+
+    A backup that silently stops firing is the classic DR failure mode — the data looks safe right
+    up until you need it. ``is_overdue`` makes the stall observable.
+    """
+
+    policy: BackupPolicy
+    last_backup_at: datetime | None = None
+
+    def next_due_at(self) -> datetime | None:
+        """When the next backup should run, or ``None`` if none has ever run (run immediately)."""
+        if self.last_backup_at is None:
+            return None
+        return _as_utc(self.last_backup_at) + self.policy.interval
+
+    def is_overdue(self, *, as_of: datetime, grace: timedelta = timedelta(0)) -> bool:
+        """True if no backup has run, or the next one is past due (beyond an optional grace)."""
+        if grace < timedelta(0):
+            raise ValueError("grace must be non-negative")
+        due = self.next_due_at()
+        if due is None:
+            return True  # never backed up -> overdue by definition
+        return _as_utc(as_of) > due + grace
+
+    def age(self, *, as_of: datetime) -> timedelta | None:
+        """How long since the last backup, or ``None`` if none has run."""
+        if self.last_backup_at is None:
+            return None
+        return _as_utc(as_of) - _as_utc(self.last_backup_at)
+
+
+# --------------------------------------------------------------------------------------------- #
+# Restore-drill verification (the actual test of the promise)
+# --------------------------------------------------------------------------------------------- #
+@dataclass(frozen=True, slots=True)
+class RestoreDrill:
+    """A single restore exercise and its measured outcome against the RTO/RPO targets.
+
+    * achieved **RTO** = ``restore_completed_at - restore_started_at`` (how long recovery took).
+    * achieved **RPO** = ``restore_started_at - backup_taken_at`` (the data-loss window — everything
+      written after the backup snapshot is lost on restore).
+
+    The drill *passes* only if both achieved values are within their targets. A failed drill is a
+    finding, not an error — it's exactly what the exercise exists to surface.
+    """
+
+    target: BackupTarget
+    backup_taken_at: datetime
+    restore_started_at: datetime
+    restore_completed_at: datetime
+    rto_target: timedelta = DEFAULT_RTO
+    rpo_target: timedelta = DEFAULT_RPO
+    restored_rows: int = 0
+
+    def __post_init__(self) -> None:
+        started = _as_utc(self.restore_started_at)
+        completed = _as_utc(self.restore_completed_at)
+        taken = _as_utc(self.backup_taken_at)
+        if completed < started:
+            raise ValueError("restore_completed_at must be >= restore_started_at")
+        if started < taken:
+            raise ValueError("restore_started_at must be >= backup_taken_at")
+        if self.rto_target <= timedelta(0) or self.rpo_target <= timedelta(0):
+            raise ValueError("rto_target and rpo_target must be positive")
+        if isinstance(self.restored_rows, bool) or not isinstance(self.restored_rows, int):
+            raise ValueError("restored_rows must be an int")
+        if self.restored_rows < 0:
+            raise ValueError("restored_rows must be non-negative")
+
+    @property
+    def achieved_rto(self) -> timedelta:
+        return _as_utc(self.restore_completed_at) - _as_utc(self.restore_started_at)
+
+    @property
+    def achieved_rpo(self) -> timedelta:
+        return _as_utc(self.restore_started_at) - _as_utc(self.backup_taken_at)
+
+    @property
+    def rto_met(self) -> bool:
+        return self.achieved_rto <= self.rto_target
+
+    @property
+    def rpo_met(self) -> bool:
+        return self.achieved_rpo <= self.rpo_target
+
+    @property
+    def passed(self) -> bool:
+        """Drill passes only if it actually restored data AND met both targets."""
+        return self.restored_rows > 0 and self.rto_met and self.rpo_met
+
+    def failures(self) -> tuple[str, ...]:
+        """Human-readable reasons the drill failed (empty tuple if it passed)."""
+        reasons: list[str] = []
+        if self.restored_rows <= 0:
+            reasons.append("no rows restored")
+        if not self.rto_met:
+            reasons.append(
+                f"RTO breach: {self.achieved_rto} > {self.rto_target}"
+            )
+        if not self.rpo_met:
+            reasons.append(
+                f"RPO breach: {self.achieved_rpo} > {self.rpo_target}"
+            )
+        return tuple(reasons)
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "target": self.target.value,
+            "passed": self.passed,
+            "achieved_rto_seconds": int(self.achieved_rto.total_seconds()),
+            "achieved_rpo_seconds": int(self.achieved_rpo.total_seconds()),
+            "rto_target_seconds": int(self.rto_target.total_seconds()),
+            "rpo_target_seconds": int(self.rpo_target.total_seconds()),
+            "restored_rows": self.restored_rows,
+            "failures": list(self.failures()),
+        }
+
+
+# --------------------------------------------------------------------------------------------- #
+# Environment separation + synthetic data
+# --------------------------------------------------------------------------------------------- #
+class Environment(str, Enum):
+    """Deployment environments. Only PROD may hold real customer data."""
+
+    DEV = "dev"
+    STAGING = "staging"
+    PROD = "prod"
+
+    @property
+    def allows_real_data(self) -> bool:
+        return self is Environment.PROD
+
+
+def assert_no_real_data(environment: Environment) -> None:
+    """Guard: raise if a caller is about to load real customer data into a non-prod environment."""
+    if not environment.allows_real_data:
+        raise ValueError(
+            f"environment {environment.value!r} must use synthetic data, not real customer data"
+        )
+
+
+def synthetic_record(environment: Environment, seed: int) -> dict[str, str]:
+    """Deterministic synthetic span-ish record for a non-prod environment (never real PII).
+
+    Keyed on ``(environment, seed)`` so test fixtures are reproducible. Refuses to run for PROD —
+    synthetic data has no place in production, and producing it there would be a footgun.
+    """
+    if environment is Environment.PROD:
+        raise ValueError("synthetic data must not be generated for prod")
+    if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+        raise ValueError("seed must be a non-negative int")
+    digest = hashlib.sha256(f"{environment.value}:{seed}".encode()).hexdigest()
+    return {
+        "tenant_id": f"synthetic-{environment.value}-{digest[:8]}",
+        "user_id_hash": digest,
+        "feature_tag": f"synthetic-feature-{seed % 8}",
+        "environment": environment.value,
+    }
+
+
+# --------------------------------------------------------------------------------------------- #
+# Incident-response runbook
+# --------------------------------------------------------------------------------------------- #
+class IncidentClass(str, Enum):
+    """Incident classes, each with a distinct documented response path."""
+
+    DATA_LOSS = "data_loss"  # backup/restore territory
+    DATA_BREACH = "data_breach"  # unauthorized access / exfiltration
+    REGION_OUTAGE = "region_outage"  # cloud region unavailable
+    INTEGRITY = "integrity"  # data corruption / bad deploy
+
+
+_RUNBOOK: dict[IncidentClass, tuple[str, ...]] = {
+    IncidentClass.DATA_LOSS: (
+        "Declare incident; page on-call DRI.",
+        "Identify last good backup for the affected store.",
+        "Run restore drill against an isolated environment to confirm integrity.",
+        "Cut over to restored data; verify RTO/RPO against targets.",
+        "Post-incident review; file backup-gap findings.",
+    ),
+    IncidentClass.DATA_BREACH: (
+        "Declare incident; page security DRI; preserve evidence.",
+        "Revoke/rotate affected credentials and HMAC keys.",
+        "Scope blast radius; identify affected tenants.",
+        "Notify per contractual/regulatory SLA.",
+        "Post-incident review; remediate access path.",
+    ),
+    IncidentClass.REGION_OUTAGE: (
+        "Declare incident; confirm scope with cloud status.",
+        "Fail reads over to cross-region replica/backup.",
+        "Throttle writes; queue for replay.",
+        "Restore service in healthy region; verify RTO.",
+        "Post-incident review; validate cross-region capacity.",
+    ),
+    IncidentClass.INTEGRITY: (
+        "Declare incident; freeze the suspect pipeline/deploy.",
+        "Quarantine corrupted partitions; identify last-good snapshot.",
+        "Restore affected ranges from backup; reconcile.",
+        "Re-enable pipeline behind validation.",
+        "Post-incident review; add integrity check.",
+    ),
+}
+
+
+def runbook_steps(incident_class: IncidentClass) -> tuple[str, ...]:
+    """The documented response steps for an incident class."""
+    return _RUNBOOK[incident_class]
+
+
+def overdue_schedules(
+    schedules: Iterable[BackupSchedule], *, as_of: datetime, grace: timedelta = timedelta(0)
+) -> tuple[BackupSchedule, ...]:
+    """Filter a set of schedules down to those that are overdue — the alerting surface."""
+    return tuple(s for s in schedules if s.is_overdue(as_of=as_of, grace=grace))

--- a/sdk/python/tests/test_backups.py
+++ b/sdk/python/tests/test_backups.py
@@ -1,0 +1,297 @@
+"""Tests for tally.backups (CTO-77): policy, schedule, restore-drill RTO/RPO, env, runbook."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tally.backups import (
+    DEFAULT_RPO,
+    DEFAULT_RTO,
+    BackupPolicy,
+    BackupSchedule,
+    BackupTarget,
+    Environment,
+    IncidentClass,
+    RestoreDrill,
+    assert_no_real_data,
+    overdue_schedules,
+    runbook_steps,
+    synthetic_record,
+)
+
+UTC = timezone.utc
+
+
+def _policy(**kw) -> BackupPolicy:
+    base = dict(
+        target=BackupTarget.CLICKHOUSE,
+        source_region="us-east-1",
+        destination_region="us-west-2",
+    )
+    base.update(kw)
+    return BackupPolicy(**base)
+
+
+# --------------------------------------------------------------------------- #
+# BackupPolicy
+# --------------------------------------------------------------------------- #
+def test_policy_defaults_are_daily_encrypted_cross_region():
+    p = _policy()
+    assert p.interval == timedelta(days=1)
+    assert p.encrypted is True
+    assert p.retention_days == 35
+
+
+def test_policy_requires_cross_region():
+    with pytest.raises(ValueError):
+        _policy(destination_region="us-east-1")  # same as source
+
+
+def test_policy_rejects_unencrypted():
+    with pytest.raises(ValueError):
+        _policy(encrypted=False)
+
+
+def test_policy_rejects_empty_regions():
+    with pytest.raises(ValueError):
+        _policy(source_region="")
+    with pytest.raises(ValueError):
+        _policy(destination_region="")
+
+
+def test_policy_rejects_bad_retention():
+    with pytest.raises(ValueError):
+        _policy(retention_days=0)
+    with pytest.raises(ValueError):
+        _policy(retention_days=True)
+
+
+def test_policy_rejects_nonpositive_interval():
+    with pytest.raises(ValueError):
+        _policy(interval=timedelta(0))
+
+
+def test_policy_expiry():
+    p = _policy(retention_days=10)
+    taken = datetime(2026, 1, 1, tzinfo=UTC)
+    assert p.expires_at(taken) == datetime(2026, 1, 11, tzinfo=UTC)
+    assert p.is_expired(taken, as_of=datetime(2026, 1, 11, tzinfo=UTC)) is True
+    assert p.is_expired(taken, as_of=datetime(2026, 1, 10, tzinfo=UTC)) is False
+
+
+def test_policy_as_dict():
+    d = _policy().as_dict()
+    assert d["target"] == "clickhouse"
+    assert d["destination_region"] == "us-west-2"
+    assert d["encrypted"] is True
+
+
+# --------------------------------------------------------------------------- #
+# BackupSchedule
+# --------------------------------------------------------------------------- #
+def test_schedule_never_run_is_overdue():
+    s = BackupSchedule(_policy())
+    assert s.next_due_at() is None
+    assert s.is_overdue(as_of=datetime(2026, 1, 1, tzinfo=UTC)) is True
+    assert s.age(as_of=datetime(2026, 1, 1, tzinfo=UTC)) is None
+
+
+def test_schedule_within_interval_not_overdue():
+    last = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    s = BackupSchedule(_policy(), last_backup_at=last)
+    assert s.next_due_at() == datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
+    assert s.is_overdue(as_of=datetime(2026, 1, 1, 12, 0, tzinfo=UTC)) is False
+
+
+def test_schedule_past_interval_is_overdue():
+    last = datetime(2026, 1, 1, tzinfo=UTC)
+    s = BackupSchedule(_policy(), last_backup_at=last)
+    assert s.is_overdue(as_of=datetime(2026, 1, 2, 1, 0, tzinfo=UTC)) is True
+
+
+def test_schedule_grace_window():
+    last = datetime(2026, 1, 1, tzinfo=UTC)
+    s = BackupSchedule(_policy(), last_backup_at=last)
+    # 30min past due but within a 1h grace -> not overdue
+    as_of = datetime(2026, 1, 2, 0, 30, tzinfo=UTC)
+    assert s.is_overdue(as_of=as_of, grace=timedelta(hours=1)) is False
+    assert s.is_overdue(as_of=as_of) is True
+
+
+def test_schedule_rejects_negative_grace():
+    s = BackupSchedule(_policy(), last_backup_at=datetime(2026, 1, 1, tzinfo=UTC))
+    with pytest.raises(ValueError):
+        s.is_overdue(as_of=datetime(2026, 1, 2, tzinfo=UTC), grace=timedelta(seconds=-1))
+
+
+def test_schedule_age():
+    last = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    s = BackupSchedule(_policy(), last_backup_at=last)
+    assert s.age(as_of=datetime(2026, 1, 1, 6, 0, tzinfo=UTC)) == timedelta(hours=6)
+
+
+def test_overdue_schedules_filter():
+    last_ok = datetime(2026, 1, 2, tzinfo=UTC)
+    last_stale = datetime(2026, 1, 1, tzinfo=UTC)
+    ok = BackupSchedule(_policy(), last_backup_at=last_ok)
+    stale = BackupSchedule(_policy(target=BackupTarget.POSTGRES), last_backup_at=last_stale)
+    never = BackupSchedule(_policy())
+    result = overdue_schedules(
+        [ok, stale, never], as_of=datetime(2026, 1, 2, 12, 0, tzinfo=UTC)
+    )
+    assert ok not in result
+    assert stale in result
+    assert never in result
+
+
+# --------------------------------------------------------------------------- #
+# RestoreDrill
+# --------------------------------------------------------------------------- #
+def test_restore_drill_passes_within_targets():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 0, 30, tzinfo=UTC)  # RPO = 30m (<=1h)
+    completed = datetime(2026, 1, 1, 2, 30, tzinfo=UTC)  # RTO = 2h (<=4h)
+    d = RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=1000)
+    assert d.achieved_rpo == timedelta(minutes=30)
+    assert d.achieved_rto == timedelta(hours=2)
+    assert d.passed is True
+    assert d.failures() == ()
+
+
+def test_restore_drill_rto_breach():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    completed = datetime(2026, 1, 1, 5, 10, tzinfo=UTC)  # RTO = 5h > 4h
+    d = RestoreDrill(BackupTarget.POSTGRES, taken, started, completed, restored_rows=10)
+    assert d.rto_met is False
+    assert d.passed is False
+    assert any("RTO breach" in f for f in d.failures())
+
+
+def test_restore_drill_rpo_breach():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 2, 0, tzinfo=UTC)  # RPO = 2h > 1h
+    completed = datetime(2026, 1, 1, 2, 30, tzinfo=UTC)
+    d = RestoreDrill(BackupTarget.POSTGRES, taken, started, completed, restored_rows=10)
+    assert d.rpo_met is False
+    assert d.passed is False
+    assert any("RPO breach" in f for f in d.failures())
+
+
+def test_restore_drill_no_rows_fails():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    completed = datetime(2026, 1, 1, 0, 20, tzinfo=UTC)
+    d = RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=0)
+    assert d.passed is False
+    assert "no rows restored" in d.failures()
+
+
+def test_restore_drill_uses_default_targets():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 0, 30, tzinfo=UTC)
+    completed = datetime(2026, 1, 1, 1, 0, tzinfo=UTC)
+    d = RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=5)
+    assert d.rto_target == DEFAULT_RTO == timedelta(hours=4)
+    assert d.rpo_target == DEFAULT_RPO == timedelta(hours=1)
+
+
+def test_restore_drill_rejects_impossible_timeline():
+    taken = datetime(2026, 1, 1, 1, 0, tzinfo=UTC)
+    # restore started before backup taken
+    with pytest.raises(ValueError):
+        RestoreDrill(
+            BackupTarget.CLICKHOUSE,
+            taken,
+            datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+            datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
+        )
+    # completed before started
+    with pytest.raises(ValueError):
+        RestoreDrill(
+            BackupTarget.CLICKHOUSE,
+            taken,
+            datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
+            datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
+        )
+
+
+def test_restore_drill_rejects_bad_rows():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    completed = datetime(2026, 1, 1, 0, 20, tzinfo=UTC)
+    with pytest.raises(ValueError):
+        RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=-1)
+    with pytest.raises(ValueError):
+        RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=True)
+
+
+def test_restore_drill_summary():
+    taken = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    started = datetime(2026, 1, 1, 0, 30, tzinfo=UTC)
+    completed = datetime(2026, 1, 1, 2, 30, tzinfo=UTC)
+    s = RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=7).summary()
+    assert s["passed"] is True
+    assert s["achieved_rto_seconds"] == 2 * 3600
+    assert s["achieved_rpo_seconds"] == 30 * 60
+    assert s["restored_rows"] == 7
+
+
+def test_restore_drill_naive_datetimes_treated_as_utc():
+    taken = datetime(2026, 1, 1, 0, 0)  # naive
+    started = datetime(2026, 1, 1, 0, 30)
+    completed = datetime(2026, 1, 1, 1, 0)
+    d = RestoreDrill(BackupTarget.CLICKHOUSE, taken, started, completed, restored_rows=1)
+    assert d.achieved_rpo == timedelta(minutes=30)
+
+
+# --------------------------------------------------------------------------- #
+# Environment / synthetic data
+# --------------------------------------------------------------------------- #
+def test_only_prod_allows_real_data():
+    assert Environment.PROD.allows_real_data is True
+    assert Environment.DEV.allows_real_data is False
+    assert Environment.STAGING.allows_real_data is False
+
+
+def test_assert_no_real_data_blocks_nonprod():
+    assert_no_real_data(Environment.PROD)  # no raise
+    with pytest.raises(ValueError):
+        assert_no_real_data(Environment.STAGING)
+
+
+def test_synthetic_record_is_deterministic():
+    a = synthetic_record(Environment.DEV, 1)
+    b = synthetic_record(Environment.DEV, 1)
+    assert a == b
+    assert a["environment"] == "dev"
+    assert a != synthetic_record(Environment.DEV, 2)
+
+
+def test_synthetic_record_refuses_prod():
+    with pytest.raises(ValueError):
+        synthetic_record(Environment.PROD, 1)
+
+
+def test_synthetic_record_rejects_bad_seed():
+    with pytest.raises(ValueError):
+        synthetic_record(Environment.DEV, -1)
+    with pytest.raises(ValueError):
+        synthetic_record(Environment.DEV, True)
+
+
+# --------------------------------------------------------------------------- #
+# Incident runbook
+# --------------------------------------------------------------------------- #
+def test_every_incident_class_has_runbook():
+    for ic in IncidentClass:
+        steps = runbook_steps(ic)
+        assert len(steps) >= 3
+        assert all(isinstance(s, str) and s for s in steps)
+
+
+def test_data_loss_runbook_mentions_restore():
+    steps = " ".join(runbook_steps(IncidentClass.DATA_LOSS)).lower()
+    assert "restore" in steps and "backup" in steps


### PR DESCRIPTION
## Summary
Pure-logic slice of the backup & disaster-recovery story (CTO-77, spec §12), testable without standing up real backup infra:
- **`BackupPolicy`** — daily, encrypted, cross-region backups per store (ClickHouse + Postgres); enforces `destination_region != source_region` and encryption-at-rest; retention + expiry math.
- **`BackupSchedule`** — next-due + overdue detection (with grace window); a silently-stalled backup is the classic DR failure, so the stall is made observable. `overdue_schedules(...)` is the alerting surface.
- **`RestoreDrill`** — the actual test of the promise: measures achieved **RTO** (time-to-restore) and **RPO** (data-loss window) against the contractual **4h RTO / 1h RPO** targets; passes only if it restored real rows AND met both targets; surfaces human-readable `failures()`.
- **`Environment` + `synthetic_record`** — dev/staging/prod isolation; only PROD may hold real data; deterministic synthetic-data generator for non-prod (refuses to run for prod).
- **`IncidentClass` + `runbook_steps`** — IR runbook keyed by incident class (data loss / breach / region outage / integrity).

## Still open (infra & ops, out of scope for this logic slice)
- [ ] Cluster-side backup execution (ClickHouse `BACKUP`, Postgres `pg_dump`/WAL archiving) + cross-region object replication
- [ ] The scheduler that fires backups and runs restore drills on a cadence
- [ ] Annual DR tabletop exercise
- [ ] Public subprocessor list, annual pentest, public VDP with response SLA

Out of scope per ticket: encryption (CTO-74), access/audit (CTO-75), deletion/residency (CTO-76).

## Test plan
- [x] 31 new tests in `tests/test_backups.py`; full suite 221 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)