### PR TITLE
CTO-58: guardrail config UI (observe-only "fires/wk")

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -10,6 +10,7 @@ import { GET as CostGET } from "./cost/route";
 import { GET as FeaturesGET } from "./features/route";
 import { GET as DataQualityGET } from "./data-quality/route";
 import { GET as EstimateGET } from "./estimate/route";
+import { GET as GuardrailsGET, PUT as GuardrailsPUT } from "./guardrails/route";
 
 async function json<T = unknown>(res: Response): Promise<T> {
   return (await res.json()) as T;
@@ -64,5 +65,31 @@ describe("api routes", () => {
     const body = await json<{ workload: string; blowUpRisk: number }>(EstimateGET());
     expect(body.workload).toBeTypeOf("string");
     expect(body.blowUpRisk).toBeGreaterThanOrEqual(0);
+  });
+
+  it("GET /api/guardrails returns rules + refresh window", async () => {
+    const body = await json<{ rules: unknown[]; configRefreshSeconds: number }>(
+      await GuardrailsGET(),
+    );
+    expect(body.rules.length).toBeGreaterThan(0);
+    expect(body.configRefreshSeconds).toBeGreaterThan(0);
+  });
+
+  it("PUT /api/guardrails echoes a valid rule, rejects an unconstrained one", async () => {
+    const ok = await GuardrailsPUT(
+      new Request("http://test/x", {
+        method: "PUT",
+        body: JSON.stringify({ id: "gr_x", scope: "a", mode: "warn", maxSteps: 10 }),
+      }),
+    );
+    expect(ok.status).toBe(200);
+
+    const bad = await GuardrailsPUT(
+      new Request("http://test/x", {
+        method: "PUT",
+        body: JSON.stringify({ id: "gr_x", scope: "a", mode: "warn" }),
+      }),
+    );
+    expect(bad.status).toBe(422);
   });
 });

--- a/web/app/api/guardrails/route.ts
+++ b/web/app/api/guardrails/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import {
+  CONFIG_REFRESH_SECONDS,
+  type GuardrailRule,
+  guardrailRules,
+} from "@/lib/guardrails";
+
+// Guardrail config lives in the control plane (Postgres, CTO-27), not ClickHouse. No live reader is
+// wired here yet, so we serve the typed mock directly — `npm run dev/build/test` never need infra.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json({
+    rules: guardrailRules,
+    configRefreshSeconds: CONFIG_REFRESH_SECONDS,
+  });
+}
+
+// Persisting an edited rule. With no control plane wired in the prototype this validates the shape
+// and echoes the rule back (the client treats the echo as the saved state). The SDK would pick the
+// change up on its next config refresh.
+export async function PUT(req: Request) {
+  let rule: Partial<GuardrailRule>;
+  try {
+    rule = (await req.json()) as Partial<GuardrailRule>;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  if (!rule.id || !rule.scope || !rule.mode) {
+    return NextResponse.json({ error: "id, scope and mode are required" }, { status: 400 });
+  }
+  if (rule.maxCostMicroUsd == null && rule.maxSteps == null) {
+    return NextResponse.json(
+      { error: "a rule must set a cost cap or a step cap" },
+      { status: 422 },
+    );
+  }
+  return NextResponse.json({ rule, configRefreshSeconds: CONFIG_REFRESH_SECONDS });
+}

--- a/web/app/settings/GuardrailConfig.tsx
+++ b/web/app/settings/GuardrailConfig.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  CONFIG_REFRESH_SECONDS,
+  GRADUATION_LABEL,
+  GUARDRAIL_MODES,
+  type GuardrailMode,
+  type GuardrailRule,
+  type GuardrailScopeKind,
+  fireRate,
+  graduationSignal,
+  isActionable,
+  modeMeta,
+  summarize,
+} from "@/lib/guardrails";
+
+let _tmp = 0;
+function tempId(): string {
+  _tmp += 1;
+  return `gr_new_${Date.now()}_${_tmp}`;
+}
+
+function microToDollarStr(micro: number | null): string {
+  return micro == null ? "" : String(micro / 1_000_000);
+}
+
+function dollarStrToMicro(s: string): number | null {
+  const t = s.trim();
+  if (t === "") return null;
+  const usd = Number(t);
+  if (!Number.isFinite(usd) || usd < 0) return null;
+  return Math.round(usd * 1_000_000);
+}
+
+function intStrOrNull(s: string): number | null {
+  const t = s.trim();
+  if (t === "") return null;
+  const n = Number(t);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+export function GuardrailConfig({ initialRules }: { initialRules: GuardrailRule[] }) {
+  const [rules, setRules] = useState<GuardrailRule[]>(initialRules);
+  const [saving, setSaving] = useState<Record<string, SaveState>>({});
+  const summary = summarize(rules);
+
+  function patch(id: string, changes: Partial<GuardrailRule>) {
+    setRules((rs) => rs.map((r) => (r.id === id ? { ...r, ...changes } : r)));
+    setSaving((s) => ({ ...s, [id]: "idle" }));
+  }
+
+  async function save(rule: GuardrailRule) {
+    setSaving((s) => ({ ...s, [rule.id]: "saving" }));
+    try {
+      const res = await fetch("/api/guardrails", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(rule),
+      });
+      setSaving((s) => ({ ...s, [rule.id]: res.ok ? "saved" : "error" }));
+    } catch {
+      setSaving((s) => ({ ...s, [rule.id]: "error" }));
+    }
+  }
+
+  function addRule() {
+    const r: GuardrailRule = {
+      id: tempId(),
+      scopeKind: "agent",
+      scope: "",
+      mode: "observe",
+      maxCostMicroUsd: 1_000_000,
+      maxSteps: null,
+      wouldHaveFiredThisWeek: 0,
+      runsThisWeek: 0,
+    };
+    setRules((rs) => [...rs, r]);
+  }
+
+  function removeRule(id: string) {
+    setRules((rs) => rs.filter((r) => r.id !== id));
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-4 gap-3">
+        <Stat label="Guardrails" value={summary.total} />
+        <Stat label="Enforcing" value={summary.enforcing} />
+        <Stat label="Observe-only" value={summary.observing} />
+        <Stat label="Ready to enforce" value={summary.readyToGraduate} accent />
+      </div>
+
+      <p className="text-xs text-muted">
+        Every rule starts in observe-only — the engine records what would have fired without touching
+        the agent. Mode changes reach the SDK within the {CONFIG_REFRESH_SECONDS}s config-refresh
+        window.
+      </p>
+
+      <div className="space-y-3">
+        {rules.map((rule) => (
+          <RuleRow
+            key={rule.id}
+            rule={rule}
+            saveState={saving[rule.id] ?? "idle"}
+            onPatch={(c) => patch(rule.id, c)}
+            onSave={() => save(rule)}
+            onRemove={() => removeRule(rule.id)}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={addRule}
+        className="rounded-md border border-dashed border-edge px-3 py-2 text-sm text-muted hover:border-accent hover:text-accent"
+      >
+        + Add guardrail
+      </button>
+    </div>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: number; accent?: boolean }) {
+  return (
+    <div className="rounded-lg border border-edge bg-panel p-3">
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold tabular-nums ${accent ? "text-accent" : ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function RuleRow({
+  rule,
+  saveState,
+  onPatch,
+  onSave,
+  onRemove,
+}: {
+  rule: GuardrailRule;
+  saveState: SaveState;
+  onPatch: (changes: Partial<GuardrailRule>) => void;
+  onSave: () => void;
+  onRemove: () => void;
+}) {
+  const meta = modeMeta(rule.mode);
+  const observing = !meta.enforcing;
+  const signal = graduationSignal(rule);
+  const actionable = isActionable(rule);
+
+  return (
+    <section className="rounded-xl border border-edge bg-panel p-4">
+      <div className="flex flex-wrap items-end gap-4">
+        <Field label="Scope">
+          <div className="flex gap-1">
+            <select
+              aria-label="scope kind"
+              value={rule.scopeKind}
+              onChange={(e) =>
+                onPatch({ scopeKind: e.target.value as GuardrailScopeKind })
+              }
+              className="rounded-md border border-edge bg-ink px-2 py-1 text-sm"
+            >
+              <option value="agent">agent</option>
+              <option value="feature">feature</option>
+            </select>
+            <input
+              aria-label="scope name"
+              value={rule.scope}
+              placeholder="name"
+              onChange={(e) => onPatch({ scope: e.target.value })}
+              className="w-40 rounded-md border border-edge bg-ink px-2 py-1 font-mono text-sm"
+            />
+          </div>
+        </Field>
+
+        <Field label="Cost cap / run ($)">
+          <input
+            aria-label="cost cap"
+            inputMode="decimal"
+            defaultValue={microToDollarStr(rule.maxCostMicroUsd)}
+            placeholder="none"
+            onChange={(e) => onPatch({ maxCostMicroUsd: dollarStrToMicro(e.target.value) })}
+            className="w-28 rounded-md border border-edge bg-ink px-2 py-1 text-sm tabular-nums"
+          />
+        </Field>
+
+        <Field label="Step cap / run">
+          <input
+            aria-label="step cap"
+            inputMode="numeric"
+            defaultValue={rule.maxSteps ?? ""}
+            placeholder="none"
+            onChange={(e) => onPatch({ maxSteps: intStrOrNull(e.target.value) })}
+            className="w-24 rounded-md border border-edge bg-ink px-2 py-1 text-sm tabular-nums"
+          />
+        </Field>
+
+        <Field label="Mode">
+          <select
+            aria-label="mode"
+            value={rule.mode}
+            onChange={(e) => onPatch({ mode: e.target.value as GuardrailMode })}
+            className="rounded-md border border-edge bg-ink px-2 py-1 text-sm"
+          >
+            {GUARDRAIL_MODES.map((m) => (
+              <option key={m.mode} value={m.mode}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <div className="ml-auto flex items-center gap-2">
+          <SaveBadge state={saveState} />
+          <button
+            type="button"
+            disabled={!actionable || !rule.scope}
+            onClick={onSave}
+            className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-ink disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label="remove guardrail"
+            className="rounded-md border border-edge px-2 py-1.5 text-sm text-muted hover:text-bad"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+        <span className="text-muted">{meta.blurb}</span>
+        {!actionable && (
+          <span className="rounded bg-bad/20 px-1.5 py-0.5 text-bad">
+            set a cost cap or a step cap
+          </span>
+        )}
+        {observing && actionable && (
+          <ObserveStats rule={rule} signal={signal} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ObserveStats({
+  rule,
+  signal,
+}: {
+  rule: GuardrailRule;
+  signal: ReturnType<typeof graduationSignal>;
+}) {
+  const rate = fireRate(rule);
+  const cls =
+    signal === "ready"
+      ? "bg-good/20 text-good"
+      : signal === "noisy"
+        ? "bg-bad/20 text-bad"
+        : "bg-edge text-muted";
+  return (
+    <>
+      <span className="rounded bg-edge px-1.5 py-0.5 tabular-nums text-gray-200">
+        would have fired{" "}
+        <strong>{rule.wouldHaveFiredThisWeek.toLocaleString()}</strong> ×/wk
+        {rule.runsThisWeek > 0 && <> ({(rate * 100).toFixed(1)}% of runs)</>}
+      </span>
+      <span className={`rounded px-1.5 py-0.5 ${cls}`}>{GRADUATION_LABEL[signal]}</span>
+    </>
+  );
+}
+
+function SaveBadge({ state }: { state: SaveState }) {
+  if (state === "saving") return <span className="text-xs text-muted">saving…</span>;
+  if (state === "saved") return <span className="text-xs text-good">saved ✓</span>;
+  if (state === "error") return <span className="text-xs text-bad">save failed</span>;
+  return null;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs uppercase tracking-wide text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,4 +1,32 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Settings" ticket="CTO-58 / CTO-89" />;
+import { Card } from "@/components/Card";
+import { apiGet } from "@/lib/api";
+import type { GuardrailRule } from "@/lib/guardrails";
+
+import { GuardrailConfig } from "./GuardrailConfig";
+
+interface GuardrailsPayload {
+  rules: GuardrailRule[];
+  configRefreshSeconds: number;
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  const { rules } = await apiGet<GuardrailsPayload>("/api/guardrails");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Settings — Guardrails</h1>
+        <p className="mt-1 text-sm text-muted">
+          Cost and step caps per agent or feature. Start in observe-only, watch what would have
+          fired, then graduate to enforcement with confidence.
+        </p>
+      </div>
+
+      <Card title="Guardrail rules">
+        <GuardrailConfig initialRules={rules} />
+      </Card>
+    </div>
+  );
 }

--- a/web/lib/guardrails.test.ts
+++ b/web/lib/guardrails.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GUARDRAIL_MODES,
+  type GuardrailRule,
+  fireRate,
+  graduationSignal,
+  guardrailRules,
+  isActionable,
+  modeMeta,
+  summarize,
+} from "./guardrails";
+
+function rule(over: Partial<GuardrailRule> = {}): GuardrailRule {
+  return {
+    id: "gr_x",
+    scopeKind: "agent",
+    scope: "x",
+    mode: "observe",
+    maxCostMicroUsd: 1_000_000,
+    maxSteps: null,
+    wouldHaveFiredThisWeek: 0,
+    runsThisWeek: 1_000,
+    ...over,
+  };
+}
+
+describe("guardrail modes", () => {
+  it("modes are ordered weakest → strongest; only observe is non-enforcing", () => {
+    expect(GUARDRAIL_MODES[0].mode).toBe("observe");
+    expect(GUARDRAIL_MODES[0].enforcing).toBe(false);
+    expect(GUARDRAIL_MODES.slice(1).every((m) => m.enforcing)).toBe(true);
+  });
+
+  it("modeMeta falls back to observe for an unknown mode", () => {
+    // @ts-expect-error testing the defensive fallback
+    expect(modeMeta("bogus").mode).toBe("observe");
+  });
+});
+
+describe("fireRate", () => {
+  it("is the fired/runs fraction, 0 when no runs", () => {
+    expect(fireRate(rule({ wouldHaveFiredThisWeek: 50, runsThisWeek: 1_000 }))).toBeCloseTo(0.05);
+    expect(fireRate(rule({ runsThisWeek: 0 }))).toBe(0);
+  });
+});
+
+describe("graduationSignal", () => {
+  it("insufficient-data below 100 runs", () => {
+    expect(graduationSignal(rule({ runsThisWeek: 99, wouldHaveFiredThisWeek: 10 }))).toBe(
+      "insufficient-data",
+    );
+  });
+
+  it("ready when a small non-zero fraction fires", () => {
+    expect(graduationSignal(rule({ runsThisWeek: 1_000, wouldHaveFiredThisWeek: 30 }))).toBe(
+      "ready",
+    );
+  });
+
+  it("review when nothing fires", () => {
+    expect(graduationSignal(rule({ runsThisWeek: 1_000, wouldHaveFiredThisWeek: 0 }))).toBe(
+      "review",
+    );
+  });
+
+  it("noisy when a large fraction fires", () => {
+    expect(graduationSignal(rule({ runsThisWeek: 1_000, wouldHaveFiredThisWeek: 400 }))).toBe(
+      "noisy",
+    );
+  });
+});
+
+describe("isActionable", () => {
+  it("requires a cost cap or a step cap", () => {
+    expect(isActionable({ maxCostMicroUsd: null, maxSteps: null })).toBe(false);
+    expect(isActionable({ maxCostMicroUsd: 1, maxSteps: null })).toBe(true);
+    expect(isActionable({ maxCostMicroUsd: null, maxSteps: 5 })).toBe(true);
+  });
+});
+
+describe("summarize", () => {
+  it("counts enforcing, observing and graduation-ready", () => {
+    const s = summarize(guardrailRules);
+    expect(s.total).toBe(guardrailRules.length);
+    expect(s.enforcing + s.observing).toBe(s.total);
+    // research_agent observe rule fires 312/8680 ≈ 3.6% -> ready
+    expect(s.readyToGraduate).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("seed rules", () => {
+  it("every rule is actionable and uses a known mode", () => {
+    for (const r of guardrailRules) {
+      expect(isActionable(r)).toBe(true);
+      expect(GUARDRAIL_MODES.some((m) => m.mode === r.mode)).toBe(true);
+      expect(r.wouldHaveFiredThisWeek).toBeLessThanOrEqual(r.runsThisWeek);
+    }
+  });
+});

--- a/web/lib/guardrails.ts
+++ b/web/lib/guardrails.ts
@@ -1,0 +1,172 @@
+// Guardrail config model + helpers for the config UI (CTO-58). Typed like the eventual control-plane
+// API (Postgres, CTO-27); the SDK guardrail engine (CTO-51) consumes the same shapes.
+//
+// The product bet: customers graduate to enforcement *with confidence*. Every rule starts in
+// observe-only, where the engine records what *would* have fired without touching agent behavior.
+// The "would-have-fired this week" count is the graduation signal — once you can see the blast
+// radius of a cap, flipping it to warn/graceful is a low-risk decision.
+
+import type { MicroUSD } from "./types";
+
+// Mirrors tally.guardrails.Mode (observe / warn / graceful / hard_stop).
+export type GuardrailMode = "observe" | "warn" | "graceful" | "hard_stop";
+
+export interface GuardrailModeMeta {
+  mode: GuardrailMode;
+  label: string;
+  blurb: string;
+  /** true = the agent's behavior is altered (enforcing); observe never alters it */
+  enforcing: boolean;
+}
+
+// Ordered weakest → strongest. Order is load-bearing for the graduation ladder.
+export const GUARDRAIL_MODES: GuardrailModeMeta[] = [
+  {
+    mode: "observe",
+    label: "Observe-only",
+    blurb: "Record what would have fired. Never alters the agent. Safe to leave on forever.",
+    enforcing: false,
+  },
+  {
+    mode: "warn",
+    label: "Warn",
+    blurb: "Proceed, but inject a budget warning the agent can act on (e.g. converge).",
+    enforcing: true,
+  },
+  {
+    mode: "graceful",
+    label: "Graceful stop",
+    blurb: "Raise a catchable limit so the framework cleans up and returns a degraded response.",
+    enforcing: true,
+  },
+  {
+    mode: "hard_stop",
+    label: "Hard stop",
+    blurb: "Abort the call outright. Opt-in only — for idempotent/read-only agents.",
+    enforcing: true,
+  },
+];
+
+export function modeMeta(mode: GuardrailMode): GuardrailModeMeta {
+  return GUARDRAIL_MODES.find((m) => m.mode === mode) ?? GUARDRAIL_MODES[0];
+}
+
+export type GuardrailScopeKind = "agent" | "feature";
+
+export interface GuardrailRule {
+  id: string;
+  scopeKind: GuardrailScopeKind;
+  /** the agent name or feature tag this rule applies to */
+  scope: string;
+  mode: GuardrailMode;
+  /** per-run cost cap; null = no cost cap on this rule */
+  maxCostMicroUsd: MicroUSD | null;
+  /** per-run step cap; null = no step cap on this rule */
+  maxSteps: number | null;
+  /** how many runs in the last 7d would have tripped this rule's caps */
+  wouldHaveFiredThisWeek: number;
+  /** total runs observed in the last 7d for this scope (denominator for the rate) */
+  runsThisWeek: number;
+}
+
+// The SDK polls the control plane for config on this cadence, so a mode change takes effect within
+// this window (AC: "changing mode takes effect on the SDK within the config-refresh window").
+export const CONFIG_REFRESH_SECONDS = 60;
+
+/** Fraction of this week's runs that would have fired (0..1). 0 when no runs observed. */
+export function fireRate(rule: GuardrailRule): number {
+  if (rule.runsThisWeek <= 0) return 0;
+  return rule.wouldHaveFiredThisWeek / rule.runsThisWeek;
+}
+
+export type GraduationSignal = "ready" | "review" | "noisy" | "insufficient-data";
+
+// The graduation heuristic the UI surfaces for observe-only rules:
+//  - insufficient-data: too few runs to judge the blast radius yet.
+//  - ready:  a small, non-zero fraction would fire — a meaningful but contained cap. Graduate.
+//  - review: nothing would fire — the cap may be set too loose to matter.
+//  - noisy:  a large fraction would fire — enforcing now would disrupt many runs; tune the cap first.
+export function graduationSignal(rule: GuardrailRule): GraduationSignal {
+  if (rule.runsThisWeek < 100) return "insufficient-data";
+  const rate = fireRate(rule);
+  if (rate === 0) return "review";
+  if (rate <= 0.05) return "ready";
+  return "noisy";
+}
+
+export const GRADUATION_LABEL: Record<GraduationSignal, string> = {
+  ready: "Ready to enforce",
+  review: "Cap never fires — review",
+  noisy: "Too noisy — tune the cap",
+  "insufficient-data": "Not enough data yet",
+};
+
+/** A rule is well-formed only if it constrains *something* (a cost cap or a step cap). */
+export function isActionable(rule: Pick<GuardrailRule, "maxCostMicroUsd" | "maxSteps">): boolean {
+  return rule.maxCostMicroUsd !== null || rule.maxSteps !== null;
+}
+
+export interface GuardrailSummary {
+  total: number;
+  enforcing: number;
+  observing: number;
+  readyToGraduate: number;
+}
+
+export function summarize(rules: GuardrailRule[]): GuardrailSummary {
+  let enforcing = 0;
+  let observing = 0;
+  let readyToGraduate = 0;
+  for (const r of rules) {
+    if (modeMeta(r.mode).enforcing) enforcing += 1;
+    else {
+      observing += 1;
+      if (graduationSignal(r) === "ready") readyToGraduate += 1;
+    }
+  }
+  return { total: rules.length, enforcing, observing, readyToGraduate };
+}
+
+// Mock rules — typed exactly like the eventual control-plane response.
+export const guardrailRules: GuardrailRule[] = [
+  {
+    id: "gr_research_cost",
+    scopeKind: "agent",
+    scope: "research_agent",
+    mode: "observe",
+    maxCostMicroUsd: 1_000_000, // $1.00 / run
+    maxSteps: 30,
+    wouldHaveFiredThisWeek: 312,
+    runsThisWeek: 8_680,
+  },
+  {
+    id: "gr_support_steps",
+    scopeKind: "agent",
+    scope: "support_triage",
+    mode: "warn",
+    maxCostMicroUsd: null,
+    maxSteps: 12,
+    wouldHaveFiredThisWeek: 1_240,
+    runsThisWeek: 58_100,
+  },
+  {
+    id: "gr_inline_cost",
+    scopeKind: "feature",
+    scope: "inline_writer",
+    mode: "graceful",
+    maxCostMicroUsd: 20_000, // $0.02 / run
+    maxSteps: null,
+    wouldHaveFiredThisWeek: 410,
+    runsThisWeek: 294_700,
+  },
+  {
+    id: "gr_smartsearch_cost",
+    scopeKind: "feature",
+    scope: "smart_search",
+    mode: "observe",
+    maxCostMicroUsd: 5_000_000, // $5.00 / run — likely too loose
+    maxSteps: null,
+    wouldHaveFiredThisWeek: 0,
+    runsThisWeek: 1_900,
+  },
+];


### PR DESCRIPTION
## Summary
Settings → Guardrails page that lets customers configure cost/step caps per agent or feature and graduate to enforcement *with confidence* (CTO-58, spec §9 W4 / §4.4).

- **Create/edit rules** per agent or feature: cost cap ($/run) + step cap, with a **mode selector** — observe-only / warn / graceful / hard-stop (mirrors `tally.guardrails.Mode`).
- **Observe-only "would-have-fired this week"**: each non-enforcing rule shows the count + % of runs that *would* have tripped, plus a **graduation signal** (`ready` / `cap never fires — review` / `too noisy — tune` / `not enough data`) so the blast radius is visible before flipping to enforce.
- **Config plumbing**: new `GET/PUT /api/guardrails` serving the control-plane shape (CTO-27) that the SDK guardrail engine (CTO-51) consumes; a mode change reaches the SDK within the **60s config-refresh window** (surfaced in the UI copy).
- Summary stats (total / enforcing / observe-only / ready-to-enforce) at the top.

## Implementation notes
- `lib/guardrails.ts` — typed model + pure helpers (`fireRate`, `graduationSignal`, `summarize`, `isActionable`, `modeMeta`), unit-tested.
- `app/settings/page.tsx` (server) fetches via `apiGet` and renders `GuardrailConfig.tsx` (client, interactive).
- Mock-served — no control-plane persistence wired in the prototype, so PUT validates + echoes; `npm run dev/build/test` never need infra (consistent with the rest of the dashboard).

## Still open (out of scope per ticket)
- [ ] Real control-plane persistence (Postgres CTO-27) behind the PUT
- [ ] Live "fires/wk" counts sourced from the SDK observe-mode telemetry (currently mock)
- Enforcement engine itself is CTO-51 (done); v2 multi-process is CTO-83.

## Test plan
- [x] `lib/guardrails.test.ts` (10 cases) + 2 new `/api/guardrails` route tests — web suite **72 passed**
- [x] `npm run typecheck`, `npm run lint`, `npm run build` all clean
- [x] Smoke: `/api/guardrails` returns rules; `/settings` renders 200 with guardrail content

🤖 Generated with [Claude Code](https://claude.com/claude-code)