### PR TITLE
CTO-91: guided onboarding UX (5-min time-to-value)

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -10,6 +10,11 @@ import { GET as CostGET } from "./cost/route";
 import { GET as FeaturesGET } from "./features/route";
 import { GET as DataQualityGET } from "./data-quality/route";
 import { GET as EstimateGET } from "./estimate/route";
+import { GET as OnboardingGET, POST as OnboardingPOST } from "./onboarding/route";
+import {
+  GET as FirstTraceGET,
+  POST as FirstTracePOST,
+} from "./onboarding/first-trace/route";
 
 async function json<T = unknown>(res: Response): Promise<T> {
   return (await res.json()) as T;
@@ -64,5 +69,30 @@ describe("api routes", () => {
     const body = await json<{ workload: string; blowUpRisk: number }>(EstimateGET());
     expect(body.workload).toBeTypeOf("string");
     expect(body.blowUpRisk).toBeGreaterThanOrEqual(0);
+  });
+
+  it("GET /api/onboarding returns progress + creds (no OpenAI key leaked)", async () => {
+    const body = await json<{
+      progress: { signedUpAt: number };
+      creds: { tenantKey: string; proxyBaseUrl: string };
+    }>(await OnboardingGET());
+    expect(body.progress.signedUpAt).toBeGreaterThan(0);
+    expect(body.creds.tenantKey).toBeTypeOf("string");
+    expect(body.creds.proxyBaseUrl).toContain("/v1");
+  });
+
+  it("POST /api/onboarding rejects an unknown funnel stage", async () => {
+    const bad = await OnboardingPOST(
+      new Request("http://test/x", { method: "POST", body: JSON.stringify({ stage: "nope" }) }),
+    );
+    expect(bad.status).toBe(400);
+  });
+
+  it("POST /api/onboarding/first-trace marks the trace received", async () => {
+    const res = await FirstTracePOST();
+    const body = await json<{ received: boolean }>(res);
+    expect(body.received).toBe(true);
+    const poll = await json<{ received: boolean }>(await FirstTraceGET());
+    expect(poll.received).toBe(true);
   });
 });

--- a/web/app/api/onboarding/first-trace/route.ts
+++ b/web/app/api/onboarding/first-trace/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { getProgress, markFirstTrace } from "@/lib/onboardingStore";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// The live detector polls this. Returns whether the first trace has been observed yet.
+export async function GET() {
+  const p = getProgress();
+  return NextResponse.json({
+    received: p.firstTraceAt !== null,
+    firstTraceAt: p.firstTraceAt,
+    signedUpAt: p.signedUpAt,
+  });
+}
+
+// "Send a test trace" — stands in for the customer's first proxied request arriving at ingest.
+export async function POST() {
+  const p = markFirstTrace();
+  return NextResponse.json({ received: true, firstTraceAt: p.firstTraceAt });
+}

--- a/web/app/api/onboarding/route.ts
+++ b/web/app/api/onboarding/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { FUNNEL_STAGES, type FunnelStage } from "@/lib/onboarding";
+import { getCreds, getFunnel, getProgress, recordFunnel } from "@/lib/onboardingStore";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json({
+    progress: getProgress(),
+    creds: getCreds(),
+    funnel: getFunnel(),
+  });
+}
+
+// Record an activation-funnel event (e.g. the client reports the config was copied).
+export async function POST(req: Request) {
+  let body: { stage?: string };
+  try {
+    body = (await req.json()) as { stage?: string };
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  const stage = body.stage as FunnelStage | undefined;
+  if (!stage || !FUNNEL_STAGES.includes(stage)) {
+    return NextResponse.json({ error: "unknown funnel stage" }, { status: 400 });
+  }
+  const event = recordFunnel(stage);
+  return NextResponse.json({ event, progress: getProgress() });
+}

--- a/web/app/onboarding/Onboarding.tsx
+++ b/web/app/onboarding/Onboarding.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  type FunnelStage,
+  type OnboardingProgress,
+  type TenantProxyCredentials,
+  activationStatus,
+  deriveChecklist,
+  formatDuration,
+  proxyEnvSnippet,
+  proxyPythonSnippet,
+} from "@/lib/onboarding";
+
+const POLL_MS = 2000;
+
+async function postFunnel(stage: FunnelStage): Promise<void> {
+  try {
+    await fetch("/api/onboarding", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ stage }),
+    });
+  } catch {
+    /* funnel tracking is best-effort */
+  }
+}
+
+export function Onboarding({
+  initialProgress,
+  creds,
+}: {
+  initialProgress: OnboardingProgress;
+  creds: TenantProxyCredentials;
+}) {
+  const [progress, setProgress] = useState<OnboardingProgress>(initialProgress);
+  const [tab, setTab] = useState<"env" | "python">("env");
+  const [copied, setCopied] = useState(false);
+
+  const status = activationStatus(progress);
+  const steps = deriveChecklist(progress);
+
+  // Live "waiting for first trace" detector: poll until a trace is observed, then stop.
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (progress.firstTraceAt !== null) return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch("/api/onboarding/first-trace", { cache: "no-store" });
+        const data = (await res.json()) as { received: boolean; firstTraceAt: number | null };
+        if (data.received && data.firstTraceAt !== null) {
+          setProgress((p) => ({ ...p, firstTraceAt: data.firstTraceAt }));
+        }
+      } catch {
+        /* keep polling */
+      }
+    }, POLL_MS);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [progress.firstTraceAt]);
+
+  const snippet = tab === "env" ? proxyEnvSnippet(creds) : proxyPythonSnippet(creds);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+    } catch {
+      /* clipboard may be unavailable; still record intent */
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+    if (progress.copiedConfigAt === null) {
+      setProgress((p) => ({ ...p, copiedConfigAt: Date.now() }));
+      void postFunnel("copied_config");
+    }
+  }, [snippet, progress.copiedConfigAt]);
+
+  const onSendTestTrace = useCallback(async () => {
+    try {
+      const res = await fetch("/api/onboarding/first-trace", { method: "POST" });
+      const data = (await res.json()) as { firstTraceAt: number | null };
+      if (data.firstTraceAt !== null) {
+        setProgress((p) => ({ ...p, firstTraceAt: data.firstTraceAt }));
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="space-y-6">
+        {/* Step 1 — proxy config */}
+        <section className="rounded-xl border border-edge bg-panel p-5">
+          <h2 className="mb-1 text-sm font-medium uppercase tracking-wide text-muted">
+            1 · Point your app at the proxy
+          </h2>
+          <p className="mb-3 text-sm text-muted">
+            Set two environment variables. Your <code className="text-gray-300">OPENAI_API_KEY</code>{" "}
+            stays in your environment — we never see it.
+          </p>
+
+          <div className="mb-2 flex gap-1 text-xs">
+            <TabButton active={tab === "env"} onClick={() => setTab("env")}>
+              Shell / env
+            </TabButton>
+            <TabButton active={tab === "python"} onClick={() => setTab("python")}>
+              Python
+            </TabButton>
+          </div>
+
+          <div className="relative">
+            <pre className="overflow-x-auto rounded-lg border border-edge bg-ink p-3 font-mono text-xs leading-relaxed text-gray-200">
+              {snippet}
+            </pre>
+            <button
+              type="button"
+              onClick={onCopy}
+              className="absolute right-2 top-2 rounded-md border border-edge bg-panel px-2 py-1 text-xs text-gray-300 hover:text-accent"
+            >
+              {copied ? "Copied ✓" : "Copy"}
+            </button>
+          </div>
+        </section>
+
+        {/* Step 2 — live first-trace detector */}
+        <section className="rounded-xl border border-edge bg-panel p-5">
+          <h2 className="mb-1 text-sm font-medium uppercase tracking-wide text-muted">
+            2 · Send your first request
+          </h2>
+          <p className="mb-3 text-sm text-muted">
+            Make any OpenAI call from your app. We detect the first trace automatically.
+          </p>
+
+          {progress.firstTraceAt === null ? (
+            <div className="flex items-center justify-between gap-4 rounded-lg border border-edge bg-ink p-4">
+              <span className="flex items-center gap-2 text-sm text-gray-200">
+                <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" />
+                Waiting for your first trace…
+              </span>
+              <button
+                type="button"
+                onClick={onSendTestTrace}
+                className="rounded-md border border-edge px-3 py-1.5 text-xs text-muted hover:text-accent"
+              >
+                Send a test trace
+              </button>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-good/40 bg-good/10 p-4 text-sm text-good">
+              First trace received{" "}
+              {status.timeToFirstTraceMs !== null && (
+                <>
+                  in <strong>{formatDuration(status.timeToFirstTraceMs)}</strong>
+                  {status.withinTarget ? " — under the 5-minute target ✓" : ""}
+                </>
+              )}
+              . Your dashboards will populate as traces flow in.
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* Right rail — activation checklist */}
+      <aside className="space-y-3">
+        <section className="rounded-xl border border-edge bg-panel p-4">
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted">
+            Getting started
+          </h2>
+          <ol className="space-y-3">
+            {steps.map((s) => (
+              <li key={s.id} className="flex gap-3">
+                <span
+                  className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs ${
+                    s.done
+                      ? "border-good bg-good/20 text-good"
+                      : "border-edge text-muted"
+                  }`}
+                >
+                  {s.done ? "✓" : ""}
+                </span>
+                <div>
+                  <div className={`text-sm ${s.done ? "text-gray-200" : "text-gray-300"}`}>
+                    {s.title}
+                  </div>
+                  <div className="text-xs text-muted">{s.hint}</div>
+                </div>
+              </li>
+            ))}
+          </ol>
+          <div className="mt-4 border-t border-edge pt-3 text-xs text-muted">
+            {status.completedSteps}/{status.totalSteps} complete
+          </div>
+        </section>
+      </aside>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md px-2 py-1 ${
+        active ? "bg-edge text-white" : "text-muted hover:text-gray-200"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -1,0 +1,28 @@
+import { apiGet } from "@/lib/api";
+import type { FunnelEvent, OnboardingProgress, TenantProxyCredentials } from "@/lib/onboarding";
+
+import { Onboarding } from "./Onboarding";
+
+interface OnboardingPayload {
+  progress: OnboardingProgress;
+  creds: TenantProxyCredentials;
+  funnel: FunnelEvent[];
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function OnboardingPage() {
+  const { progress, creds } = await apiGet<OnboardingPayload>("/api/onboarding");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Get started</h1>
+        <p className="mt-1 text-sm text-muted">
+          Two steps to your first dashboard. Most teams see their first trace in under five minutes.
+        </p>
+      </div>
+      <Onboarding initialProgress={progress} creds={creds} />
+    </div>
+  );
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 const NAV: { label: string; href: string }[] = [
+  { label: "Get started", href: "/onboarding" },
   { label: "Home", href: "/" },
   { label: "Cost", href: "/cost" },
   { label: "Features", href: "/features" },

--- a/web/lib/onboarding.test.ts
+++ b/web/lib/onboarding.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TIME_TO_FIRST_TRACE_TARGET_MS,
+  type OnboardingProgress,
+  activationStatus,
+  deriveChecklist,
+  formatDuration,
+  proxyEnvSnippet,
+  proxyPythonSnippet,
+  timeToFirstTraceMs,
+} from "./onboarding";
+
+const creds = { tenantKey: "tk_test_123", proxyBaseUrl: "https://proxy.example/v1" };
+
+function progress(over: Partial<OnboardingProgress> = {}): OnboardingProgress {
+  return {
+    signedUpAt: 1_000_000,
+    copiedConfigAt: null,
+    firstTraceAt: null,
+    firstDashboardAt: null,
+    ...over,
+  };
+}
+
+describe("proxy snippets", () => {
+  it("env snippet sets base URL + tenant key, never the OpenAI key", () => {
+    const s = proxyEnvSnippet(creds);
+    expect(s).toContain('OPENAI_BASE_URL="https://proxy.example/v1"');
+    expect(s).toContain('TALLY_TENANT_KEY="tk_test_123"');
+    expect(s.toLowerCase()).toContain("never sent to us");
+    expect(s).not.toContain("OPENAI_API_KEY=");
+  });
+
+  it("python snippet wires base_url + X-Tenant-Key header", () => {
+    const s = proxyPythonSnippet(creds);
+    expect(s).toContain('base_url="https://proxy.example/v1"');
+    expect(s).toContain('"X-Tenant-Key": "tk_test_123"');
+  });
+});
+
+describe("checklist", () => {
+  it("signed_up always done; others gated on timestamps", () => {
+    const steps = deriveChecklist(progress());
+    expect(steps.find((s) => s.id === "signed_up")!.done).toBe(true);
+    expect(steps.find((s) => s.id === "copied_config")!.done).toBe(false);
+    expect(steps.find((s) => s.id === "first_trace")!.done).toBe(false);
+  });
+
+  it("steps flip to done as progress fills in", () => {
+    const steps = deriveChecklist(
+      progress({ copiedConfigAt: 1_001_000, firstTraceAt: 1_002_000 }),
+    );
+    expect(steps.find((s) => s.id === "copied_config")!.done).toBe(true);
+    expect(steps.find((s) => s.id === "first_trace")!.done).toBe(true);
+    expect(steps.find((s) => s.id === "first_dashboard")!.done).toBe(false);
+  });
+});
+
+describe("activation status", () => {
+  it("not activated before first trace", () => {
+    const s = activationStatus(progress());
+    expect(s.activated).toBe(false);
+    expect(s.timeToFirstTraceMs).toBeNull();
+    expect(s.completedSteps).toBe(1);
+  });
+
+  it("activated + within target when trace arrives quickly", () => {
+    const s = activationStatus(progress({ firstTraceAt: 1_000_000 + 30_000 }));
+    expect(s.activated).toBe(true);
+    expect(s.withinTarget).toBe(true);
+    expect(s.timeToFirstTraceMs).toBe(30_000);
+  });
+
+  it("activated but over target when trace is late", () => {
+    const late = 1_000_000 + TIME_TO_FIRST_TRACE_TARGET_MS + 1;
+    const s = activationStatus(progress({ firstTraceAt: late }));
+    expect(s.activated).toBe(true);
+    expect(s.withinTarget).toBe(false);
+  });
+});
+
+describe("timeToFirstTraceMs", () => {
+  it("null without a trace; clamped non-negative", () => {
+    expect(timeToFirstTraceMs(progress())).toBeNull();
+    expect(timeToFirstTraceMs(progress({ firstTraceAt: 999_999 }))).toBe(0);
+  });
+});
+
+describe("formatDuration", () => {
+  it("renders ms, seconds, and minutes", () => {
+    expect(formatDuration(800)).toBe("800ms");
+    expect(formatDuration(3_400)).toBe("3.4s");
+    expect(formatDuration(130_000)).toBe("2m 10s");
+  });
+});

--- a/web/lib/onboarding.ts
+++ b/web/lib/onboarding.ts
@@ -1,0 +1,145 @@
+// Guided-onboarding model + helpers (CTO-91). The activation funnel that makes self-serve work:
+// signup → copy the proxy config → first trace arrives (<5 min) → first dashboard (<24h).
+//
+// Pure helpers here (typed like the eventual control-plane shapes); the live first-trace detector
+// and funnel-event sink live in the server-only store + route handlers.
+
+// The activation targets from spec §15. These are the success metrics the checklist is tied to.
+export const TIME_TO_FIRST_TRACE_TARGET_MS = 5 * 60 * 1000; // 5 minutes
+export const TIME_TO_FIRST_DASHBOARD_TARGET_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Ordered funnel stages. Order is load-bearing: each implies the previous is done.
+export const FUNNEL_STAGES = [
+  "signed_up",
+  "viewed_setup",
+  "copied_config",
+  "first_trace",
+  "first_dashboard",
+] as const;
+export type FunnelStage = (typeof FUNNEL_STAGES)[number];
+
+export interface FunnelEvent {
+  stage: FunnelStage;
+  /** epoch ms when the stage was reached */
+  at: number;
+}
+
+export interface TenantProxyCredentials {
+  tenantKey: string; // X-Tenant-Key — scoped ingest key, never the customer's OpenAI key
+  proxyBaseUrl: string; // OPENAI_BASE_URL the customer points their SDK at
+}
+
+/**
+ * The copy-paste env block a new tenant pastes to route OpenAI traffic through the proxy (CTO-39).
+ * We only ever set the *base URL* and our *tenant key*; the customer's real OpenAI key stays theirs
+ * and never appears here.
+ */
+export function proxyEnvSnippet(creds: TenantProxyCredentials): string {
+  return [
+    `export OPENAI_BASE_URL="${creds.proxyBaseUrl}"`,
+    `export TALLY_TENANT_KEY="${creds.tenantKey}"`,
+    `# Your OPENAI_API_KEY is unchanged — it stays in your environment and is never sent to us.`,
+  ].join("\n");
+}
+
+/** Same config as a Python SDK snippet, for teams who instrument in-process instead of via proxy. */
+export function proxyPythonSnippet(creds: TenantProxyCredentials): string {
+  return [
+    `from openai import OpenAI`,
+    ``,
+    `client = OpenAI(`,
+    `    base_url="${creds.proxyBaseUrl}",`,
+    `    default_headers={"X-Tenant-Key": "${creds.tenantKey}"},`,
+    `)`,
+  ].join("\n");
+}
+
+export type ChecklistStepId =
+  | "signed_up"
+  | "copied_config"
+  | "first_trace"
+  | "first_dashboard";
+
+export interface ChecklistStep {
+  id: ChecklistStepId;
+  title: string;
+  hint: string;
+  done: boolean;
+  /** an activation deadline for this step, if it has one */
+  targetMs?: number;
+}
+
+export interface OnboardingProgress {
+  signedUpAt: number;
+  copiedConfigAt: number | null;
+  firstTraceAt: number | null;
+  firstDashboardAt: number | null;
+}
+
+/** Build the checklist from raw progress timestamps. */
+export function deriveChecklist(p: OnboardingProgress): ChecklistStep[] {
+  return [
+    {
+      id: "signed_up",
+      title: "Create your account",
+      hint: "Done — welcome.",
+      done: true,
+    },
+    {
+      id: "copied_config",
+      title: "Point your app at the proxy",
+      hint: "Copy the config below into your environment.",
+      done: p.copiedConfigAt !== null,
+    },
+    {
+      id: "first_trace",
+      title: "Send your first request",
+      hint: "We'll detect the first trace automatically — target under 5 minutes.",
+      done: p.firstTraceAt !== null,
+      targetMs: TIME_TO_FIRST_TRACE_TARGET_MS,
+    },
+    {
+      id: "first_dashboard",
+      title: "See your first dashboard",
+      hint: "Cost and agent views populate as traces flow in — target within 24 hours.",
+      done: p.firstDashboardAt !== null,
+      targetMs: TIME_TO_FIRST_DASHBOARD_TARGET_MS,
+    },
+  ];
+}
+
+/** ms from signup to first trace, or null if no trace yet. */
+export function timeToFirstTraceMs(p: OnboardingProgress): number | null {
+  if (p.firstTraceAt === null) return null;
+  return Math.max(0, p.firstTraceAt - p.signedUpAt);
+}
+
+export interface ActivationStatus {
+  activated: boolean; // first trace received
+  withinTarget: boolean; // ...and within the 5-min target
+  timeToFirstTraceMs: number | null;
+  completedSteps: number;
+  totalSteps: number;
+}
+
+export function activationStatus(p: OnboardingProgress): ActivationStatus {
+  const steps = deriveChecklist(p);
+  const ttft = timeToFirstTraceMs(p);
+  return {
+    activated: p.firstTraceAt !== null,
+    withinTarget: ttft !== null && ttft <= TIME_TO_FIRST_TRACE_TARGET_MS,
+    timeToFirstTraceMs: ttft,
+    completedSteps: steps.filter((s) => s.done).length,
+    totalSteps: steps.length,
+  };
+}
+
+/** Format a short ms duration as "3.4s" / "2m 10s" for the activation readout. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 100) / 10;
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(ms / 60000);
+  const rem = Math.round((ms - m * 60000) / 1000);
+  return `${m}m ${rem}s`;
+}

--- a/web/lib/onboardingStore.test.ts
+++ b/web/lib/onboardingStore.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetOnboarding,
+  getFunnel,
+  getProgress,
+  markFirstTrace,
+  recordFunnel,
+} from "./onboardingStore";
+
+describe("onboarding store", () => {
+  beforeEach(() => __resetOnboarding());
+
+  it("starts signed_up with no later milestones", () => {
+    const p = getProgress();
+    expect(p.signedUpAt).toBeGreaterThan(0);
+    expect(p.copiedConfigAt).toBeNull();
+    expect(p.firstTraceAt).toBeNull();
+    expect(getFunnel().map((e) => e.stage)).toEqual(["signed_up"]);
+  });
+
+  it("recordFunnel mirrors stages onto progress timestamps (first wins)", () => {
+    recordFunnel("copied_config");
+    const first = getProgress().copiedConfigAt;
+    expect(first).not.toBeNull();
+    recordFunnel("copied_config"); // second occurrence must not overwrite
+    expect(getProgress().copiedConfigAt).toBe(first);
+  });
+
+  it("markFirstTrace is idempotent and sets firstTraceAt once", () => {
+    const p1 = markFirstTrace();
+    expect(p1.firstTraceAt).not.toBeNull();
+    const p2 = markFirstTrace();
+    expect(p2.firstTraceAt).toBe(p1.firstTraceAt);
+    expect(getFunnel().filter((e) => e.stage === "first_trace")).toHaveLength(1);
+  });
+});

--- a/web/lib/onboardingStore.ts
+++ b/web/lib/onboardingStore.ts
@@ -1,0 +1,82 @@
+// Server-only in-memory onboarding store backing the live first-trace detector and funnel sink.
+//
+// In production these are control-plane rows + an ingest signal. In the prototype we keep a single
+// in-process record so the "waiting for first trace → received" transition is real and demonstrable
+// (the "Send a test trace" button stands in for the customer's first proxied request). State resets
+// on server restart — fine for a mock; `npm run dev/build/test` never need infra.
+
+import {
+  type FunnelEvent,
+  type FunnelStage,
+  type OnboardingProgress,
+  type TenantProxyCredentials,
+} from "./onboarding";
+
+interface StoreState {
+  progress: OnboardingProgress;
+  funnel: FunnelEvent[];
+  creds: TenantProxyCredentials;
+}
+
+function freshState(): StoreState {
+  return {
+    progress: {
+      signedUpAt: Date.now(),
+      copiedConfigAt: null,
+      firstTraceAt: null,
+      firstDashboardAt: null,
+    },
+    funnel: [{ stage: "signed_up", at: Date.now() }],
+    creds: {
+      tenantKey: "tk_demo_3f9c2a7b",
+      proxyBaseUrl: "https://proxy.ai-tally.dev/v1",
+    },
+  };
+}
+
+// Survive Next.js dev hot-reload by stashing on globalThis.
+const g = globalThis as unknown as { __tallyOnboarding?: StoreState };
+function state(): StoreState {
+  if (!g.__tallyOnboarding) g.__tallyOnboarding = freshState();
+  return g.__tallyOnboarding;
+}
+
+export function getProgress(): OnboardingProgress {
+  return { ...state().progress };
+}
+
+export function getCreds(): TenantProxyCredentials {
+  return { ...state().creds };
+}
+
+export function getFunnel(): FunnelEvent[] {
+  return [...state().funnel];
+}
+
+export function recordFunnel(stage: FunnelStage): FunnelEvent {
+  const ev: FunnelEvent = { stage, at: Date.now() };
+  const s = state();
+  s.funnel.push(ev);
+  // Mirror the stage onto progress timestamps (first occurrence wins).
+  if (stage === "copied_config" && s.progress.copiedConfigAt === null) {
+    s.progress.copiedConfigAt = ev.at;
+  }
+  if (stage === "first_trace" && s.progress.firstTraceAt === null) {
+    s.progress.firstTraceAt = ev.at;
+  }
+  if (stage === "first_dashboard" && s.progress.firstDashboardAt === null) {
+    s.progress.firstDashboardAt = ev.at;
+  }
+  return ev;
+}
+
+/** The "Send a test trace" action — stands in for the customer's first proxied request. */
+export function markFirstTrace(): OnboardingProgress {
+  if (state().progress.firstTraceAt === null) recordFunnel("first_trace");
+  return getProgress();
+}
+
+/** Test-only: reset the in-memory store. */
+export function __resetOnboarding(): void {
+  g.__tallyOnboarding = freshState();
+}


### PR DESCRIPTION
## Summary
Post-signup "Get started" page that drives the self-serve activation funnel (CTO-91, spec §15) — from signup to first dashboard in minutes.

- **Copy-paste proxy config** (CTO-39): shell/env and Python tabs that set `OPENAI_BASE_URL` + a scoped `X-Tenant-Key`. The customer's `OPENAI_API_KEY` stays in their environment and is **never sent to us** (asserted in tests). One-click copy records the `copied_config` funnel event.
- **Live "waiting for first trace" detector**: the page polls `/api/onboarding/first-trace` every 2s and flips to "first trace received in *Ns* — under the 5-minute target ✓" the moment data arrives. An in-memory store makes the waiting→received transition *real*; the "Send a test trace" button stands in for the customer's first proxied request.
- **Activation checklist** tied to the success metrics: time-to-first-trace < 5 min, first dashboard < 24h. Steps flip to done as progress timestamps fill in.
- **Funnel events** tracked through the ordered stages `signed_up → viewed_setup → copied_config → first_trace → first_dashboard` via `POST /api/onboarding`.
- Adds a "Get started" entry at the top of the left nav.

## Implementation notes
- `lib/onboarding.ts` — pure model + helpers (`proxyEnvSnippet`/`proxyPythonSnippet`, `deriveChecklist`, `activationStatus`, `timeToFirstTraceMs`, `formatDuration`), fully unit-tested.
- `lib/onboardingStore.ts` — server-only in-memory store (first-trace signal + funnel sink), hot-reload-safe via `globalThis`; resets on restart.
- `app/onboarding/{page,Onboarding}.tsx` — server fetch + interactive client component (copy button, live poller, test-trace button).
- Mock-served: `npm run dev/build/test` need no infra, consistent with the rest of the dashboard.

## Still open (backend integration — out of scope per ticket)
- [ ] Real tenant credentials + first-trace signal from the proxy/ingest path (currently in-memory mock) — provisioning is CTO-88, billing CTO-90.
- [ ] Persist funnel events to an analytics sink for the cohort activation metrics (events are emitted; durable storage is pending the control plane).

## Test plan
- [x] `lib/onboarding.test.ts` (9) + `lib/onboardingStore.test.ts` (3) + 3 new `/api/onboarding*` route tests — web suite **75 passed**
- [x] `npm run typecheck`, `npm run lint`, `npm run build` clean
- [x] Smoke: `/onboarding` renders 200; `first-trace` poll returns `received:false` → `POST` → `received:true` (live transition verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)