### PR TITLE
CTO-80: stale-data state consistent across all five workflows

### DIFF
--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -2,27 +2,36 @@ import Link from "next/link";
 import { Card } from "@/components/Card";
 import {
   PartialDataBanner,
+  StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
 import { Histogram } from "@/components/Histogram";
 import { type AgentRun, type AgentSummary, p99Ratio } from "@/lib/agents";
 import { apiGet } from "@/lib/api";
-import { deriveDataState } from "@/lib/dataState";
+import { asOfLabel, boundaryFromMinutesAgo, deriveDataState, relativeAge } from "@/lib/dataState";
 import { formatUSD } from "@/lib/types";
 
 interface AgentsPayload {
   agents: AgentSummary[];
   runs: AgentRun[];
+  reconcilerLastRunMinutesAgo: number;
 }
 
 export default async function AgentsPage() {
-  const { agents, runs } = await apiGet<AgentsPayload>("/api/agents");
+  const { agents, runs, reconcilerLastRunMinutesAgo } =
+    await apiGet<AgentsPayload>("/api/agents");
 
-  // Agents has no reconciliation boundary — only empty/partial states apply.
+  // Agents presents reconciled per-agent cost, so it carries a freshness boundary like Cost/Features.
+  const reconciledThrough = boundaryFromMinutesAgo(reconcilerLastRunMinutesAgo);
   const noAgents = agents.length === 0 || agents.every((a) => a.costPerDayMicroUsd === 0);
   const someEmptyAgents =
     agents.some((a) => a.runsPerDay === 0) && agents.some((a) => a.runsPerDay > 0);
-  const state = deriveDataState({ isEmpty: noAgents, isPartial: someEmptyAgents });
+  const state = deriveDataState({
+    isEmpty: noAgents,
+    isPartial: someEmptyAgents,
+    reconciledThrough,
+  });
+  const asOf = asOfLabel(reconciledThrough);
 
   const body = (
     <div className="space-y-6">
@@ -92,7 +101,12 @@ export default async function AgentsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Agents</h1>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Agents</h1>
+        {state !== "empty" && asOf && (
+          <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
+        )}
+      </div>
 
       {state === "partial" && <PartialDataBanner missing="telemetry for some agents" />}
 

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { agents, runs } from "@/lib/agents";
+import { agents, RECONCILER_LAST_RUN_MINUTES_AGO, runs } from "@/lib/agents";
 import { queryAgents } from "@/lib/clickhouse";
 
 // Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
@@ -12,5 +12,6 @@ export async function GET() {
   return NextResponse.json({
     agents: live && live.agents.length > 0 ? live.agents : agents,
     runs: live && live.runs.length > 0 ? live.runs : runs,
+    reconcilerLastRunMinutesAgo: RECONCILER_LAST_RUN_MINUTES_AGO,
   });
 }

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -24,10 +24,13 @@ describe("api routes", () => {
     expect(body.dq).toBeDefined();
   });
 
-  it("GET /api/agents returns agents + runs", async () => {
-    const body = await json<{ agents: unknown[]; runs: unknown[] }>(await AgentsGET());
+  it("GET /api/agents returns agents + runs + reconciler freshness", async () => {
+    const body = await json<{ agents: unknown[]; runs: unknown[]; reconcilerLastRunMinutesAgo: number }>(
+      await AgentsGET(),
+    );
     expect(body.agents.length).toBeGreaterThan(0);
     expect(body.runs.length).toBeGreaterThan(0);
+    expect(body.reconcilerLastRunMinutesAgo).toBeTypeOf("number");
   });
 
   it("GET /api/agents/runs/:runId returns the run, 404 on miss", async () => {

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -1,21 +1,29 @@
 import { Card } from "@/components/Card";
 import {
   PartialDataBanner,
+  StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
 import { type Comparison, deltaPct } from "@/lib/compare";
-import { deriveDataState } from "@/lib/dataState";
+import { asOfLabel, boundaryFromMinutesAgo, deriveDataState, relativeAge } from "@/lib/dataState";
 import { formatUSD, type MicroUSD } from "@/lib/types";
 
 export default async function ComparePage() {
   const comparison = await apiGet<Comparison>("/api/compare");
   const { workload, current, candidates, recommendation, diagnostics } = comparison;
 
-  // No reconciliation boundary on this what-if surface — only empty/partial apply.
+  // This projection is built off reconciled baseline traffic — surface that baseline's freshness so
+  // a comparison off a stale window is never shown as fresh (CTO-80).
+  const reconciledThrough = boundaryFromMinutesAgo(diagnostics.reconcilerLastRunMinutesAgo);
   const noBaseline = current.monthlyCostMicroUsd === 0 || candidates.length === 0;
   const noReplay = diagnostics.samplesReplayed === 0 && diagnostics.samplesAvailable > 0;
-  const state = deriveDataState({ isEmpty: noBaseline, isPartial: noReplay });
+  const state = deriveDataState({
+    isEmpty: noBaseline,
+    isPartial: noReplay,
+    reconciledThrough,
+  });
+  const asOf = asOfLabel(reconciledThrough);
 
   const body = (
     <div className="space-y-6">
@@ -72,11 +80,16 @@ export default async function ComparePage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold">Compare</h1>
-        <p className="mt-1 text-sm text-muted">
-          Workload: <span className="font-mono text-gray-300">{workload}</span>
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">Compare</h1>
+          <p className="mt-1 text-sm text-muted">
+            Workload: <span className="font-mono text-gray-300">{workload}</span>
+          </p>
+        </div>
+        {state !== "empty" && asOf && (
+          <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
+        )}
       </div>
 
       {state === "partial" && <PartialDataBanner missing="the replay sampler" />}

--- a/web/app/estimate/page.tsx
+++ b/web/app/estimate/page.tsx
@@ -1,10 +1,11 @@
 import { Card } from "@/components/Card";
 import {
   PartialDataBanner,
+  StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
-import { deriveDataState } from "@/lib/dataState";
+import { asOfLabel, boundaryFromMinutesAgo, deriveDataState, relativeAge } from "@/lib/dataState";
 import { pctDelta, type Projection } from "@/lib/estimate";
 import { formatUSD } from "@/lib/types";
 
@@ -17,10 +18,17 @@ export default async function EstimatePage() {
   const riskSeverity =
     blowUpRisk >= 0.3 ? "bad" : blowUpRisk >= 0.1 ? "warn" : "good";
 
-  // No reconciliation boundary on this what-if surface — only empty/partial apply.
+  // This projection samples a reconciled historical window — surface that window's freshness so a
+  // forecast off a stale baseline is never shown as fresh (CTO-80).
+  const reconciledThrough = boundaryFromMinutesAgo(projection.reconcilerLastRunMinutesAgo);
   const noBaseline = current.monthlyCostMicroUsd === 0;
   const thinSample = sample.used > 0 && sample.pathologicalIncluded === 0;
-  const state = deriveDataState({ isEmpty: noBaseline, isPartial: thinSample });
+  const state = deriveDataState({
+    isEmpty: noBaseline,
+    isPartial: thinSample,
+    reconciledThrough,
+  });
+  const asOf = asOfLabel(reconciledThrough);
 
   const body = (
     <div className="space-y-6">
@@ -96,11 +104,16 @@ export default async function EstimatePage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold">Estimate</h1>
-        <p className="mt-1 text-sm text-muted">
-          Workload: <span className="font-mono text-gray-300">{workload}</span>
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">Estimate</h1>
+          <p className="mt-1 text-sm text-muted">
+            Workload: <span className="font-mono text-gray-300">{workload}</span>
+          </p>
+        </div>
+        {state !== "empty" && asOf && (
+          <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
+        )}
       </div>
 
       {state === "partial" && <PartialDataBanner missing="tail-weighted sampling" />}

--- a/web/lib/agents.ts
+++ b/web/lib/agents.ts
@@ -16,6 +16,13 @@ export function p99Ratio(a: AgentSummary): number {
   return a.p50MicroUsd === 0 ? 0 : a.p99MicroUsd / a.p50MicroUsd;
 }
 
+/**
+ * Minutes since the reconciler last trued-up these per-agent cost numbers. Agents presents
+ * reconciled cost (cost/day, p50/p99), so it carries the same freshness signal as Cost/Features
+ * and must surface staleness the same way (CTO-80, "never show stale as fresh").
+ */
+export const RECONCILER_LAST_RUN_MINUTES_AGO = 23;
+
 export interface RunSpan {
   spanId: string;
   parentSpanId: string | null;

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -32,6 +32,11 @@ export interface Comparison {
     excludedRateLimited: number;
     replayCostMicroUsd: MicroUSD;
     contextFidelity: "resolved-context replay (no live retrieval)" | "live retrieval";
+    /**
+     * Minutes since the reconciler last trued-up the baseline traffic this comparison is built
+     * from. A projection off a stale baseline must not be presented as fresh (CTO-80).
+     */
+    reconcilerLastRunMinutesAgo: number;
   };
 }
 
@@ -89,5 +94,6 @@ export const comparison: Comparison = {
     excludedRateLimited: 312,
     replayCostMicroUsd: 14_200_000,
     contextFidelity: "resolved-context replay (no live retrieval)",
+    reconcilerLastRunMinutesAgo: 36,
   },
 };

--- a/web/lib/dataState.test.ts
+++ b/web/lib/dataState.test.ts
@@ -3,6 +3,7 @@ import {
   allZero,
   asOfLabel,
   ageMs,
+  boundaryFromMinutesAgo,
   deriveDataState,
   isSentinelBoundary,
   isStale,
@@ -12,6 +13,23 @@ import {
 } from "./dataState";
 
 const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+describe("boundaryFromMinutesAgo", () => {
+  it("produces a boundary that reads fresh when within the 2h window", () => {
+    const boundary = boundaryFromMinutesAgo(23, NOW);
+    expect(isStale(boundary, NOW)).toBe(false);
+    expect(deriveDataState({ isEmpty: false, isPartial: false, reconciledThrough: boundary, now: NOW })).toBe("fresh");
+  });
+  it("produces a boundary that reads stale past the 2h window", () => {
+    const boundary = boundaryFromMinutesAgo(3 * 60, NOW); // 3h ago
+    expect(isStale(boundary, NOW)).toBe(true);
+    expect(deriveDataState({ isEmpty: false, isPartial: false, reconciledThrough: boundary, now: NOW })).toBe("stale");
+  });
+  it("stale outranks partial (never present stale as fresh)", () => {
+    const boundary = boundaryFromMinutesAgo(180, NOW);
+    expect(deriveDataState({ isEmpty: false, isPartial: true, reconciledThrough: boundary, now: NOW })).toBe("stale");
+  });
+});
 
 describe("isSentinelBoundary", () => {
   it("treats the 1970 epoch sentinel as pre-data, not a real boundary", () => {

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -23,6 +23,15 @@ export function ageMs(reconciledThrough: string, now: number = Date.now()): numb
   return now - Date.parse(reconciledThrough);
 }
 
+/**
+ * Build a reconciliation-boundary ISO timestamp from "minutes since the reconciler last ran".
+ * Surfaces that don't carry an explicit boundary date (Agents, Compare, Estimate) report freshness
+ * as a minutes-ago number instead; this converts it so they share the same stale/fresh logic.
+ */
+export function boundaryFromMinutesAgo(minutesAgo: number, now: number = Date.now()): string {
+  return new Date(now - minutesAgo * 60_000).toISOString();
+}
+
 /** A far-past sentinel boundary means nothing has reconciled yet (pre-data), not stale. */
 export function isSentinelBoundary(reconciledThrough: string): boolean {
   const t = Date.parse(reconciledThrough);

--- a/web/lib/estimate.ts
+++ b/web/lib/estimate.ts
@@ -24,6 +24,11 @@ export interface Projection {
     pathologicalIncluded: number;
     ciHalfWidthPct: number; // on p99
   };
+  /**
+   * Minutes since the reconciler last trued-up the historical window this projection samples.
+   * An estimate built on a stale baseline must not be presented as fresh (CTO-80).
+   */
+  reconcilerLastRunMinutesAgo: number;
 }
 
 export function pctDelta(cur: number, prop: number): number {
@@ -56,4 +61,5 @@ export const projection: Projection = {
     pathologicalIncluded: 18,
     ciHalfWidthPct: 0.18,
   },
+  reconcilerLastRunMinutesAgo: 51,
 };


### PR DESCRIPTION
## Summary
Closes the remaining gap in CTO-80 (empty / partial / stale states, spec §13.8). Empty and partial states were already wired into all five workflows, but the **stale-data** guard — *"never present stale numbers as fresh"* — only lived on **Cost** and **Features**. **Agents**, **Compare**, and **Estimate** present reconciled cost numbers / projections built off reconciled baselines, so they must surface the same `>2h` freshness warning to be consistent (AC #3 and AC #4).

- Add a reconciler-freshness signal (`reconcilerLastRunMinutesAgo`) to the Agents, Compare, and Estimate payloads.
- New shared helper `boundaryFromMinutesAgo()` in `lib/dataState.ts` converts that signal into a reconciliation boundary, so all five surfaces share the same `deriveDataState` stale/fresh logic.
- Render `StaleBadge` on Agents, Compare, and Estimate — a muted "data as of" badge that flips to a warning past the 2h window — matching Cost/Features.

## Acceptance criteria
- [x] Pre-data synthetic preview + single connector CTA — all five (already present).
- [x] Partial-data banner pointing at the missing connector — all five (already present).
- [x] Stale-data: `>2h` since the reconciler ran is surfaced explicitly; stale never shown as fresh — **now on all five** (was Cost/Features only).
- [x] States consistent across all five workflows.

## Test plan
- [x] `npm run test` — 63 passing (new `boundaryFromMinutesAgo` cases: fresh vs stale, stale-outranks-partial; `/api/agents` freshness field asserted).
- [x] `npm run typecheck` — clean (after fresh build).
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)