### PR TITLE
CTO-88: zero-touch tenant bootstrap (self-serve provisioning planner)

### DIFF
--- a/sdk/python/src/tally/provisioning.py
+++ b/sdk/python/src/tally/provisioning.py
@@ -1,0 +1,465 @@
+"""Zero-touch tenant bootstrap for self-serve signup (CTO-88 / spec §15).
+
+Self-serve GTM needs a new customer to go from "click signup" to "send my first trace" with **zero
+manual steps**. That means the moment a :class:`SignupRequest` arrives we must deterministically
+plan every control-plane row the tenant needs — the ``tenants`` row, a scoped ``api_keys`` row, the
+per-tenant HMAC key set (CTO-74), and a sane default config — onto the shared cluster, in the
+region the customer picked for data residency (CTO-76).
+
+This module is the **pure planner** for that: given a signup request it produces a
+:class:`TenantBootstrapPlan` (the exact rows to INSERT, matching ``db/postgres/0001_control_plane``)
+plus a one-time :class:`ApiKeyIssue`. Performing the INSERTs / KMS calls is the infra layer's job;
+keeping the decision logic here makes it unit-testable with no Postgres, no KMS, and no network.
+
+Security invariants enforced structurally (never just by convention):
+
+* The **raw API key is returned exactly once** (in :class:`ApiKeyIssue`) and is *never* stored in
+  the plan — the plan carries only its SHA-256 hash, mirroring the ``api_keys.key_hash`` column.
+* The **HMAC key set is a KMS reference** (``hash_salt_kek_ref``), never raw key material, and is
+  checked against the same ``no_raw_secret`` shape the DDL's CHECK constraint enforces.
+* :meth:`TenantBootstrapPlan.assert_no_raw_secret` is a belt-and-suspenders guard so a refactor
+  can't accidentally leak a secret into a serialized plan.
+
+Idempotency is first-class: :class:`TenantRegistry` keys provisioning on a stable
+``idempotency_key`` derived from the normalized org + admin email, so a double-clicked signup (or a
+retried request) returns the *same* tenant instead of double-provisioning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+# --------------------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------------------
+
+#: Default plan a self-serve tenant lands on (matches ``tenants.plan`` default; see CTO-89).
+DEFAULT_PLAN = "free"
+
+#: Human-visible prefix on every issued key. The body is high-entropy and never reconstructable
+#: from anything we persist.
+API_KEY_PREFIX = "tk_live_"
+
+#: Bytes of entropy in the random portion of an API key. 32 bytes → 256 bits.
+API_KEY_ENTROPY_BYTES = 32
+
+#: Default analytics sample rate for a fresh tenant (billing counts head traces *before* sampling,
+#: so this only affects analytics fidelity, never the bill — see CTO-87).
+DEFAULT_SAMPLE_RATE = 1.0
+
+#: Default guardrail posture for a brand-new tenant: watch, never block (CTO-51/58).
+DEFAULT_GUARDRAIL_MODE = "observe"
+
+
+def _utc(value: datetime | None) -> datetime:
+    """Coerce to an aware UTC datetime; default to now()."""
+    if value is None:
+        return datetime.now(timezone.utc)
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# --------------------------------------------------------------------------------------
+# Region / scope enums
+# --------------------------------------------------------------------------------------
+
+
+class Region(str, Enum):
+    """A data-residency region chosen at signup (CTO-76). Value matches ``tenants.region``."""
+
+    US_EAST = "us-east"
+    EU_WEST = "eu-west"
+    AP_SOUTH = "ap-south"
+
+    @property
+    def residency(self) -> str:
+        """Coarse legal residency bucket, for "where does this tenant's data live" copy."""
+        return {
+            Region.US_EAST: "US",
+            Region.EU_WEST: "EU",
+            Region.AP_SOUTH: "IN",
+        }[self]
+
+    @property
+    def ingest_host(self) -> str:
+        """Region-pinned ingest endpoint a fresh tenant points its proxy/SDK at."""
+        return f"ingest.{self.value}.ai-tally.dev"
+
+
+class Scope(str, Enum):
+    """API-key scope. Value matches the ``api_keys.scope`` CHECK constraint."""
+
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+# --------------------------------------------------------------------------------------
+# Signup request
+# --------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SignupRequest:
+    """An inbound self-serve signup. Validated on construction so a bad request never provisions."""
+
+    org_name: str
+    admin_email: str
+    region: Region
+
+    def __post_init__(self) -> None:
+        if not self.org_name or not self.org_name.strip():
+            raise ValueError("org_name must be non-empty")
+        if len(self.org_name) > 200:
+            raise ValueError("org_name too long (max 200)")
+        email = (self.admin_email or "").strip()
+        # Deliberately permissive: one '@' with non-empty local + domain, and a dot in the domain.
+        # We gate provisioning, not RFC 5322 — over-strict validation rejects real users.
+        if email.count("@") != 1:
+            raise ValueError("admin_email must contain exactly one '@'")
+        local, _, domain = email.partition("@")
+        if not local or not domain or "." not in domain:
+            raise ValueError("admin_email is not a valid address")
+        if not isinstance(self.region, Region):
+            raise ValueError("region must be a Region")
+
+    @property
+    def normalized_email(self) -> str:
+        """Lowercased, trimmed email — the identity we dedup signups on."""
+        return self.admin_email.strip().lower()
+
+    @property
+    def normalized_org(self) -> str:
+        return " ".join(self.org_name.split()).lower()
+
+    @property
+    def idempotency_key(self) -> str:
+        """Stable key for "is this the same signup". Same org + email + region → same key."""
+        material = f"{self.normalized_org}\x1f{self.normalized_email}\x1f{self.region.value}"
+        return _sha256_hex(material)
+
+
+# --------------------------------------------------------------------------------------
+# Issued secrets (returned once) vs. stored rows (no secrets)
+# --------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyIssue:
+    """The one-time secret handed back to the customer. NEVER persisted as-is.
+
+    Only :attr:`key_hash` (which mirrors ``api_keys.key_hash``) is stored. :attr:`raw` exists solely
+    to show the customer their key once at signup; drop it immediately after.
+    """
+
+    raw: str
+    key_hash: str
+    display_prefix: str
+    scope: Scope
+
+    @staticmethod
+    def mint(scope: Scope = Scope.WRITE, *, token: str | None = None) -> ApiKeyIssue:
+        """Mint a fresh key. ``token`` is injectable for deterministic tests; otherwise CSPRNG."""
+        body = token if token is not None else secrets.token_urlsafe(API_KEY_ENTROPY_BYTES)
+        raw = f"{API_KEY_PREFIX}{body}"
+        return ApiKeyIssue(
+            raw=raw,
+            key_hash=_sha256_hex(raw),
+            # Enough to recognize the key in a list UI, not enough to reconstruct it.
+            display_prefix=raw[: len(API_KEY_PREFIX) + 4],
+            scope=scope,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HmacKeyRef:
+    """A KMS reference to the per-tenant HMAC key set (CTO-74). Holds NO raw key material."""
+
+    kek_ref: str
+    version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.version < 1:
+            raise ValueError("version must be >= 1")
+        if not self.kek_ref:
+            raise ValueError("kek_ref must be non-empty")
+        # Same guard as the DDL's no_raw_secret CHECK: a KMS ref is short and never an obvious key.
+        if self.kek_ref.startswith("sk-") or len(self.kek_ref) >= 512:
+            raise ValueError("kek_ref looks like raw secret material, not a KMS reference")
+
+    @staticmethod
+    def for_tenant(tenant_id: str, version: int = 1) -> HmacKeyRef:
+        return HmacKeyRef(kek_ref=f"kms://tenant/{tenant_id}/hmac/v{version}", version=version)
+
+
+@dataclass(frozen=True, slots=True)
+class TenantRow:
+    """The ``tenants`` row to INSERT. Mirrors db/postgres/0001_control_plane.sql."""
+
+    id: str
+    name: str
+    region: str
+    plan: str
+    hash_salt_kek_ref: str
+    created_at: datetime
+
+    def as_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "region": self.region,
+            "plan": self.plan,
+            "hash_salt_kek_ref": self.hash_salt_kek_ref,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyRow:
+    """The ``api_keys`` row to INSERT — hash only, never the token."""
+
+    tenant_id: str
+    key_hash: str
+    scope: str
+    created_at: datetime
+
+    def as_dict(self) -> dict:
+        return {
+            "tenant_id": self.tenant_id,
+            "key_hash": self.key_hash,
+            "scope": self.scope,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+# --------------------------------------------------------------------------------------
+# The bootstrap plan
+# --------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TenantBootstrapPlan:
+    """Everything needed to provision a tenant zero-touch. Contains NO raw secrets.
+
+    The infra layer applies :attr:`tenant_row` + :attr:`api_key_row` as INSERTs and resolves
+    :attr:`hmac_key` against KMS. The matching raw API key travels separately in
+    :class:`ProvisionResult.api_key` and is shown once.
+    """
+
+    tenant_id: str
+    region: Region
+    tenant_row: TenantRow
+    api_key_row: ApiKeyRow
+    hmac_key: HmacKeyRef
+    default_config: dict
+    idempotency_key: str
+    created_at: datetime
+
+    def assert_no_raw_secret(self) -> None:
+        """Guard: a serialized plan must never carry raw key material. Raises if it does."""
+        for value in (self.tenant_row.hash_salt_kek_ref, self.hmac_key.kek_ref):
+            if value.startswith(API_KEY_PREFIX) or value.startswith("sk-"):
+                raise ValueError(f"plan leaks raw secret material: {value!r}")
+        # The api_key_row must hold a hash, not a token. A token would carry the visible prefix.
+        if self.api_key_row.key_hash.startswith(API_KEY_PREFIX):
+            raise ValueError("api_key_row.key_hash holds a raw token, not a hash")
+
+    def ingest_credentials(self) -> dict:
+        """The minimal config a fresh tenant points its proxy/SDK at to send its first trace.
+
+        Note: this returns the *key hash* and host, not the raw key — the raw key is delivered once
+        via :class:`ProvisionResult`. Callers compose the env from that.
+        """
+        return {
+            "tenant_id": self.tenant_id,
+            "ingest_host": self.region.ingest_host,
+            "region": self.region.value,
+            "key_scope": self.api_key_row.scope,
+        }
+
+    def as_dict(self) -> dict:
+        self.assert_no_raw_secret()
+        return {
+            "tenant_id": self.tenant_id,
+            "region": self.region.value,
+            "tenant_row": self.tenant_row.as_dict(),
+            "api_key_row": self.api_key_row.as_dict(),
+            "hmac_key": {"kek_ref": self.hmac_key.kek_ref, "version": self.hmac_key.version},
+            "default_config": dict(self.default_config),
+            "idempotency_key": self.idempotency_key,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionResult:
+    """Output of provisioning: the storable plan + the one-time raw key + whether it was new."""
+
+    plan: TenantBootstrapPlan
+    api_key: ApiKeyIssue
+    reused: bool = False
+
+    @property
+    def first_trace_env(self) -> dict:
+        """Ready-to-paste env so the tenant can send its first trace immediately (AC: zero steps).
+
+        This is the only place the raw key surfaces. It is intentionally not stored anywhere.
+        """
+        return {
+            "OPENAI_BASE_URL": f"https://{self.plan.region.ingest_host}/v1",
+            "TALLY_TENANT_KEY": self.api_key.raw,
+        }
+
+
+# --------------------------------------------------------------------------------------
+# Provisioning
+# --------------------------------------------------------------------------------------
+
+
+def _default_config(region: Region) -> dict:
+    return {
+        "sample_rate": DEFAULT_SAMPLE_RATE,
+        "guardrail_mode": DEFAULT_GUARDRAIL_MODE,
+        "region": region.value,
+        "residency": region.residency,
+    }
+
+
+def provision_tenant(
+    request: SignupRequest,
+    *,
+    now: datetime | None = None,
+    tenant_id: str | None = None,
+    api_token: str | None = None,
+    scope: Scope = Scope.WRITE,
+) -> ProvisionResult:
+    """Plan a brand-new tenant from a validated signup request. Pure: no I/O, no global state.
+
+    ``tenant_id`` / ``api_token`` are injectable for deterministic tests; in production both default
+    to fresh high-entropy values. The result's :attr:`ProvisionResult.plan` is safe to serialize and
+    hand to the infra layer; the raw key lives only on :attr:`ProvisionResult.api_key`.
+    """
+    created_at = _utc(now)
+    tid = tenant_id if tenant_id is not None else f"t_{secrets.token_hex(8)}"
+
+    hmac_key = HmacKeyRef.for_tenant(tid, version=1)
+    issue = ApiKeyIssue.mint(scope, token=api_token)
+
+    tenant_row = TenantRow(
+        id=tid,
+        name=request.org_name.strip(),
+        region=request.region.value,
+        plan=DEFAULT_PLAN,
+        hash_salt_kek_ref=hmac_key.kek_ref,
+        created_at=created_at,
+    )
+    api_key_row = ApiKeyRow(
+        tenant_id=tid,
+        key_hash=issue.key_hash,
+        scope=issue.scope.value,
+        created_at=created_at,
+    )
+    plan = TenantBootstrapPlan(
+        tenant_id=tid,
+        region=request.region,
+        tenant_row=tenant_row,
+        api_key_row=api_key_row,
+        hmac_key=hmac_key,
+        default_config=_default_config(request.region),
+        idempotency_key=request.idempotency_key,
+        created_at=created_at,
+    )
+    plan.assert_no_raw_secret()
+    return ProvisionResult(plan=plan, api_key=issue, reused=False)
+
+
+# --------------------------------------------------------------------------------------
+# Idempotent registry + isolation verification
+# --------------------------------------------------------------------------------------
+
+
+@dataclass
+class TenantRegistry:
+    """In-memory, idempotent provisioning front-end.
+
+    Stands in for the unique constraint the real control plane enforces: provisioning the *same*
+    signup twice (double-click, client retry) returns the original tenant rather than creating a
+    second one. The raw key is only returned on the first call — a reused result has no key to show,
+    because the original was already delivered once and is not stored.
+    """
+
+    _by_idempotency: dict[str, TenantBootstrapPlan] = field(default_factory=dict)
+    _ids: set[str] = field(default_factory=set)
+
+    def provision(
+        self,
+        request: SignupRequest,
+        *,
+        now: datetime | None = None,
+        tenant_id: str | None = None,
+        api_token: str | None = None,
+        scope: Scope = Scope.WRITE,
+    ) -> ProvisionResult:
+        existing = self._by_idempotency.get(request.idempotency_key)
+        if existing is not None:
+            # Idempotent replay: no new key minted, no second tenant created.
+            return ProvisionResult(plan=existing, api_key=_REDACTED_KEY, reused=True)
+
+        result = provision_tenant(
+            request, now=now, tenant_id=tenant_id, api_token=api_token, scope=scope
+        )
+        if result.plan.tenant_id in self._ids:
+            raise ValueError(f"tenant id collision: {result.plan.tenant_id}")
+        self._by_idempotency[request.idempotency_key] = result.plan
+        self._ids.add(result.plan.tenant_id)
+        return result
+
+    def __len__(self) -> int:
+        return len(self._by_idempotency)
+
+
+# Sentinel returned when a registry replay has no fresh key to surface (the original was delivered
+# once at first provision and is never stored).
+_REDACTED_KEY = ApiKeyIssue(raw="", key_hash="", display_prefix="", scope=Scope.WRITE)
+
+
+def verify_isolation(plans: list[TenantBootstrapPlan]) -> list[str]:
+    """Verify freshly-provisioned tenants share no isolation-critical material (AC).
+
+    Returns a list of human-readable violations; empty means isolation holds. We check that across
+    every pair of tenants the tenant id, API-key hash, and HMAC KMS reference are all distinct —
+    the three things that, if shared, would let one tenant read or be billed for another's data.
+    """
+    violations: list[str] = []
+    seen_ids: dict[str, int] = {}
+    seen_hashes: dict[str, int] = {}
+    seen_keks: dict[str, int] = {}
+
+    for plan in plans:
+        if plan.tenant_id in seen_ids:
+            violations.append(f"duplicate tenant_id {plan.tenant_id!r}")
+        seen_ids[plan.tenant_id] = seen_ids.get(plan.tenant_id, 0) + 1
+
+        kh = plan.api_key_row.key_hash
+        if kh in seen_hashes:
+            violations.append(f"shared api key hash across tenants ({plan.tenant_id!r})")
+        seen_hashes[kh] = 1
+
+        kek = plan.hmac_key.kek_ref
+        if kek in seen_keks:
+            violations.append(f"shared HMAC kek_ref across tenants ({plan.tenant_id!r})")
+        seen_keks[kek] = 1
+
+        # Each tenant's HMAC ref must be namespaced under its own id — a cross-namespaced ref would
+        # mean two tenants could resolve to the same key.
+        if f"/tenant/{plan.tenant_id}/" not in kek:
+            violations.append(f"HMAC kek_ref not namespaced to tenant {plan.tenant_id!r}")
+
+    return violations

--- a/sdk/python/tests/test_provisioning.py
+++ b/sdk/python/tests/test_provisioning.py
@@ -1,0 +1,247 @@
+"""Tests for zero-touch tenant bootstrap (CTO-88).
+
+These assert the spec invariants without any Postgres/KMS: a signup deterministically plans the
+right control-plane rows, secrets are never raw, provisioning is idempotent, and freshly-minted
+tenants are isolated from each other.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tally.provisioning import (
+    API_KEY_PREFIX,
+    DEFAULT_GUARDRAIL_MODE,
+    DEFAULT_PLAN,
+    ApiKeyIssue,
+    HmacKeyRef,
+    Region,
+    Scope,
+    SignupRequest,
+    TenantRegistry,
+    provision_tenant,
+    verify_isolation,
+)
+
+NOW = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def _request(org: str = "Acme Inc", email: str = "admin@acme.com", region: Region = Region.US_EAST):
+    return SignupRequest(org_name=org, admin_email=email, region=region)
+
+
+# --- SignupRequest validation ---------------------------------------------------------
+
+
+def test_valid_request_constructs():
+    req = _request()
+    assert req.region is Region.US_EAST
+
+
+@pytest.mark.parametrize("org", ["", "   ", "x" * 201])
+def test_bad_org_rejected(org):
+    with pytest.raises(ValueError):
+        _request(org=org)
+
+
+@pytest.mark.parametrize("email", ["", "no-at", "two@@at.com", "a@nodot", "@acme.com", "a@"])
+def test_bad_email_rejected(email):
+    with pytest.raises(ValueError):
+        _request(email=email)
+
+
+def test_region_must_be_enum():
+    with pytest.raises(ValueError):
+        SignupRequest(org_name="Acme", admin_email="a@b.com", region="us-east")  # type: ignore[arg-type]
+
+
+def test_normalization_is_case_and_whitespace_insensitive():
+    a = _request(org="  Acme   Inc ", email="Admin@Acme.com")
+    b = _request(org="acme inc", email="admin@acme.com")
+    assert a.idempotency_key == b.idempotency_key
+
+
+def test_idempotency_key_changes_with_region():
+    us = _request(region=Region.US_EAST)
+    eu = _request(region=Region.EU_WEST)
+    assert us.idempotency_key != eu.idempotency_key
+
+
+# --- Region --------------------------------------------------------------------------------------
+
+
+def test_region_residency_and_host():
+    assert Region.EU_WEST.residency == "EU"
+    assert Region.EU_WEST.ingest_host == "ingest.eu-west.ai-tally.dev"
+
+
+# --- API key minting ------------------------------------------------------------------
+
+
+def test_minted_key_hash_matches_raw_and_prefix():
+    issue = ApiKeyIssue.mint(Scope.WRITE, token="deadbeef")
+    assert issue.raw == f"{API_KEY_PREFIX}deadbeef"
+    # hash is sha256 of the raw token, 64 hex chars
+    assert len(issue.key_hash) == 64
+    assert issue.key_hash != issue.raw
+    assert issue.display_prefix.startswith(API_KEY_PREFIX)
+
+
+def test_minted_keys_are_unique_without_injection():
+    a = ApiKeyIssue.mint()
+    b = ApiKeyIssue.mint()
+    assert a.raw != b.raw
+    assert a.key_hash != b.key_hash
+
+
+# --- HmacKeyRef -----------------------------------------------------------------------
+
+
+def test_hmac_ref_is_namespaced_and_versioned():
+    ref = HmacKeyRef.for_tenant("t_123", version=2)
+    assert "/tenant/t_123/" in ref.kek_ref
+    assert ref.version == 2
+
+
+@pytest.mark.parametrize("bad", ["sk-rawsecretmaterial", "x" * 512])
+def test_hmac_ref_rejects_rawlike_material(bad):
+    with pytest.raises(ValueError):
+        HmacKeyRef(kek_ref=bad, version=1)
+
+
+def test_hmac_ref_rejects_bad_version():
+    with pytest.raises(ValueError):
+        HmacKeyRef(kek_ref="kms://x", version=0)
+
+
+# --- provision_tenant -----------------------------------------------------------------
+
+
+def test_provision_plans_all_rows():
+    res = provision_tenant(_request(), now=NOW, tenant_id="t_abc", api_token="tok")
+    plan = res.plan
+    assert plan.tenant_row.id == "t_abc"
+    assert plan.tenant_row.name == "Acme Inc"
+    assert plan.tenant_row.region == "us-east"
+    assert plan.tenant_row.plan == DEFAULT_PLAN
+    assert plan.api_key_row.tenant_id == "t_abc"
+    assert plan.api_key_row.scope == "write"
+    assert plan.hmac_key.kek_ref == plan.tenant_row.hash_salt_kek_ref
+    assert res.reused is False
+
+
+def test_default_config_is_observe_and_full_sample():
+    plan = provision_tenant(_request(), now=NOW).plan
+    assert plan.default_config["guardrail_mode"] == DEFAULT_GUARDRAIL_MODE
+    assert plan.default_config["sample_rate"] == 1.0
+    assert plan.default_config["residency"] == "US"
+
+
+def test_raw_key_returned_once_and_not_in_plan():
+    res = provision_tenant(_request(), now=NOW, tenant_id="t_x", api_token="secret-body")
+    # The raw key is on the result, only as a hash on the plan.
+    assert res.api_key.raw == f"{API_KEY_PREFIX}secret-body"
+    serialized = res.plan.as_dict()
+    flat = repr(serialized)
+    assert "secret-body" not in flat
+    assert res.api_key.key_hash in flat  # the hash *is* stored
+
+
+def test_plan_assert_no_raw_secret_passes_for_clean_plan():
+    plan = provision_tenant(_request(), now=NOW).plan
+    plan.assert_no_raw_secret()  # should not raise
+
+
+def test_first_trace_env_uses_region_host_and_raw_key():
+    res = provision_tenant(_request(region=Region.EU_WEST), now=NOW, api_token="tok")
+    env = res.first_trace_env
+    assert env["OPENAI_BASE_URL"] == "https://ingest.eu-west.ai-tally.dev/v1"
+    assert env["TALLY_TENANT_KEY"] == f"{API_KEY_PREFIX}tok"
+
+
+def test_ingest_credentials_carry_no_raw_key():
+    plan = provision_tenant(_request(), now=NOW, api_token="tok").plan
+    creds = plan.ingest_credentials()
+    assert "tok" not in repr(creds)
+    assert creds["ingest_host"] == "ingest.us-east.ai-tally.dev"
+
+
+def test_admin_scope_propagates():
+    plan = provision_tenant(_request(), now=NOW, scope=Scope.ADMIN).plan
+    assert plan.api_key_row.scope == "admin"
+
+
+def test_provision_defaults_generate_random_ids_and_keys():
+    a = provision_tenant(_request())
+    b = provision_tenant(_request())
+    assert a.plan.tenant_id != b.plan.tenant_id
+    assert a.api_key.raw != b.api_key.raw
+
+
+# --- TenantRegistry idempotency -------------------------------------------------------
+
+
+def test_registry_provisions_once_then_replays():
+    reg = TenantRegistry()
+    first = reg.provision(_request(), now=NOW, tenant_id="t_1", api_token="tok")
+    second = reg.provision(_request(), now=NOW, tenant_id="t_2", api_token="tok2")
+    assert first.reused is False
+    assert second.reused is True
+    # Same tenant returned; the second tenant_id/token were never used.
+    assert second.plan.tenant_id == "t_1"
+    assert len(reg) == 1
+
+
+def test_registry_replay_has_no_raw_key():
+    reg = TenantRegistry()
+    reg.provision(_request(), now=NOW, tenant_id="t_1", api_token="tok")
+    replay = reg.provision(_request(), now=NOW)
+    assert replay.reused is True
+    assert replay.api_key.raw == ""  # nothing to re-show; original was delivered once
+
+
+def test_registry_distinct_signups_create_distinct_tenants():
+    reg = TenantRegistry()
+    reg.provision(_request(org="Acme"), now=NOW, tenant_id="t_1")
+    reg.provision(_request(org="Globex"), now=NOW, tenant_id="t_2")
+    assert len(reg) == 2
+
+
+def test_registry_rejects_id_collision():
+    reg = TenantRegistry()
+    reg.provision(_request(org="Acme"), now=NOW, tenant_id="dup")
+    with pytest.raises(ValueError):
+        reg.provision(_request(org="Globex"), now=NOW, tenant_id="dup")
+
+
+# --- Isolation verification -----------------------------------------------------------
+
+
+def test_isolation_holds_for_fresh_tenants():
+    plans = [
+        provision_tenant(_request(org="A"), now=NOW, tenant_id="t_a", api_token="a").plan,
+        provision_tenant(_request(org="B"), now=NOW, tenant_id="t_b", api_token="b").plan,
+        provision_tenant(_request(org="C"), now=NOW, tenant_id="t_c", api_token="c").plan,
+    ]
+    assert verify_isolation(plans) == []
+
+
+def test_isolation_flags_shared_key_hash():
+    # Two tenants minted with the SAME token → same key hash → isolation violation.
+    plans = [
+        provision_tenant(_request(org="A"), now=NOW, tenant_id="t_a", api_token="same").plan,
+        provision_tenant(_request(org="B"), now=NOW, tenant_id="t_b", api_token="same").plan,
+    ]
+    violations = verify_isolation(plans)
+    assert any("api key hash" in v for v in violations)
+
+
+def test_isolation_flags_duplicate_tenant_id():
+    plans = [
+        provision_tenant(_request(org="A"), now=NOW, tenant_id="dup", api_token="a").plan,
+        provision_tenant(_request(org="B"), now=NOW, tenant_id="dup", api_token="b").plan,
+    ]
+    violations = verify_isolation(plans)
+    assert any("duplicate tenant_id" in v for v in violations)


### PR DESCRIPTION
## Summary
Pure-logic core for self-serve tenant provisioning (spec §15). A validated `SignupRequest` is turned into a `TenantBootstrapPlan` whose rows mirror `db/postgres/0001_control_plane.sql` exactly (`tenants`, `api_keys`), plus a one-time `ApiKeyIssue` and a region-pinned default config — so a new customer goes from signup to "send my first trace" with zero manual steps.

- **Secrets never raw:** the raw API key is returned **once** (`ApiKeyIssue.raw`) and never stored — the plan carries only its SHA-256 `key_hash`. The HMAC key set is a KMS reference (`hash_salt_kek_ref`), checked against the same `no_raw_secret` shape the DDL CHECK enforces. `TenantBootstrapPlan.assert_no_raw_secret()` guards serialization.
- **Region residency** (CTO-76): `Region` is chosen at signup; drives `tenants.region`, the residency bucket, and the region-pinned ingest host in `first_trace_env`.
- **Idempotent:** `TenantRegistry` keys on a stable `idempotency_key` (normalized org + email + region) — a double-clicked/retried signup returns the *same* tenant, no double-provisioning.
- **Isolation verified:** `verify_isolation()` asserts freshly-provisioned tenants share no tenant id, API-key hash, or HMAC KMS ref, and that each HMAC ref is namespaced to its own tenant.

## Status (honest)
This is the **decision core**, deliverable and fully tested with no infra. The actual cluster INSERTs + live KMS key creation are the infra layer's job and are **deferred** — so the ticket stays **In Progress** with that boundary called out, not marked done.

## Acceptance criteria
- [x] Signup plans tenant row + scoped API key + per-tenant HMAC key set + default config — `provision_tenant` / `TenantBootstrapPlan`.
- [x] Region selection at signup for residency — `Region` + `default_config.residency` + region-pinned host.
- [x] Zero manual steps; first trace immediately — `ProvisionResult.first_trace_env` (raw key + region base URL).
- [x] Tenant isolation verified for fresh tenants — `verify_isolation`.
- [ ] Real shared-cluster INSERTs + KMS provisioning (infra; deferred).

## Test plan
- [x] `uv run --extra dev pytest -q` — 225 passing (35 new in `test_provisioning.py`).
- [x] `ruff check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)