### PR TITLE
fix(gateway): restore lost metering wiring (unblocks all open PR builds)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -40,6 +40,7 @@ from gateway.backpressure import Backpressure
 from gateway.config import get_settings
 from gateway.errors import ErrorCode
 from gateway.mapping import span_to_row
+from gateway.metering import UsageRollup
 from gateway.protocol import (
     SUPPORTED_PROTOCOLS,
     capabilities,
@@ -70,6 +71,9 @@ async def lifespan(app: FastAPI):
     # unknown-tag flag is disabled for now — schema + PII checks are always on.
     app.state.validator = SpanValidator(max_span_bytes=settings.max_span_bytes)
     app.state.backpressure = Backpressure(soft_limit=settings.backpressure_soft_limit)
+    # HEAD-path billing meter (CTO-84/85/86): counts distinct traces + feature tags before any
+    # sampling/shed so the bill is exact regardless of analytics sample rate.
+    app.state.metering = UsageRollup()
     app.state.in_flight = 0
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
@@ -255,6 +259,7 @@ async def _run_pipeline(batch: BatchRequest, authorization: str | None) -> JSONR
 
     # --- validate (per item) + enrich + map spans ---
     validator: SpanValidator = app.state.validator
+    metering: UsageRollup = app.state.metering
     rows: list[tuple[object, ...]] = []
     drift_count = 0
     for index, span in enumerate(batch.resource_spans):


### PR DESCRIPTION
## Problem
`main` itself is failing the **gateway** CI job. When CTO-84/85/86 metering merged (#40), a merge dropped three lines from `infra/gateway/src/gateway/app.py`, leaving it referencing `metering` / `UsageRollup` with **no import, no lifespan init, and no local binding**:

```
src/gateway/app.py:281:9  F821 Undefined name `metering`
src/gateway/app.py:349:15 F821 Undefined name `UsageRollup`
```

Because every open PR's `pull_request` build tests *its merge into main*, this broke CI on all of them — e.g. **#41** (CTO-42 key vault), which only adds `keyvault.py` and never touches `app.py`. That's why #41 "fails the build."

## Fix
Restores the three lost lines:
- `from gateway.metering import UsageRollup`
- `app.state.metering = UsageRollup()` in `lifespan`
- `metering: UsageRollup = app.state.metering` binding in `ingest_batch`

This is the wiring the existing `tests/test_app_usage.py` already expects (it overrides `app.state.metering` per-test).

## Verification
- `ruff check .` → clean
- `pytest -q` → **105 passed** (incl. `test_app_usage` end-to-end HEAD metering + `/v1/usage`)

## Impact
Merging this turns the gateway job green on `main`, after which **#41 and the other open PRs** go green on re-run (none of them re-introduce the bug). Recommend merging this **first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)