### PR TITLE
feat(web): build Connectors page (CTO-63/68 cost + revenue connectors)

### DIFF
--- a/web/app/api/connectors/route.ts
+++ b/web/app/api/connectors/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { queryConnectorActivity } from "@/lib/clickhouse";
+import { CONNECTORS, applyActivity, mockActivity } from "@/lib/connectors";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const activity = await queryConnectorActivity();
+  const live = activity !== null;
+  const connectors = applyActivity(CONNECTORS, activity ?? mockActivity);
+  return NextResponse.json({ connectors, live });
+}

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -1,4 +1,122 @@
-import { Placeholder } from "@/components/Placeholder";
-export default function Page() {
-  return <Placeholder title="Connectors" ticket="CTO-63 / CTO-68" />;
+import { Card } from "@/components/Card";
+import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { apiGet } from "@/lib/api";
+import { relativeAge } from "@/lib/dataState";
+import {
+  type ConnectorCategory,
+  type ConnectorStatus,
+  connectedCount,
+} from "@/lib/connectors";
+
+interface ConnectorsPayload {
+  connectors: ConnectorStatus[];
+  live: boolean;
+}
+
+const SECTIONS: { category: ConnectorCategory; title: string; blurb: string }[] = [
+  {
+    category: "cost",
+    title: "Cost sources",
+    blurb: "All-in spend — beyond LLM tokens — attributed to features (CTO-63).",
+  },
+  {
+    category: "revenue",
+    title: "Revenue & CDP",
+    blurb: "Value events that turn cost into ROI via attribution (CTO-68).",
+  },
+];
+
+function StateBadge({ row }: { row: ConnectorStatus }) {
+  if (row.state === "connected") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-good/40 bg-good/10 px-2 py-0.5 text-xs font-medium text-good">
+        <span className="h-1.5 w-1.5 rounded-full bg-good" />
+        Connected
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink/40 px-2 py-0.5 text-xs font-medium text-muted">
+      <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+      Available
+    </span>
+  );
+}
+
+function ConnectorTable({ rows }: { rows: ConnectorStatus[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase text-muted">
+          <tr>
+            <th className="py-1 text-left font-medium">Source</th>
+            <th className="py-1 text-left font-medium">Feeds</th>
+            <th className="py-1 text-left font-medium">Status</th>
+            <th className="py-1 text-right font-medium">Records (30d)</th>
+            <th className="py-1 text-right font-medium">Last sync</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className="border-t border-edge align-top">
+              <td className="py-2">
+                <div className="font-medium">{r.name}</div>
+                <div className="max-w-prose text-xs text-muted">{r.description}</div>
+              </td>
+              <td className="py-2 text-muted">{r.feeds}</td>
+              <td className="py-2">
+                <StateBadge row={r} />
+              </td>
+              <td className="py-2 text-right tabular-nums">
+                {r.records > 0 ? r.records.toLocaleString() : "—"}
+              </td>
+              <td className="py-2 text-right tabular-nums text-muted">
+                {r.lastAt ? relativeAge(r.lastAt) : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default async function ConnectorsPage() {
+  const { connectors, live } = await apiGet<ConnectorsPayload>("/api/connectors");
+  const connected = connectedCount(connectors);
+
+  const body = (
+    <div className="space-y-6">
+      {SECTIONS.map((s) => {
+        const rows = connectors.filter((c) => c.category === s.category);
+        const n = connectedCount(rows);
+        return (
+          <Card key={s.category} title={`${s.title} — ${n}/${rows.length} connected`}>
+            <p className="mb-3 max-w-prose text-xs text-muted">{s.blurb}</p>
+            <ConnectorTable rows={rows} />
+          </Card>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Connectors</h1>
+        <span className="text-sm text-muted">
+          {connected} of {connectors.length} sources connected
+        </span>
+      </div>
+
+      <p className="max-w-prose text-sm text-muted">
+        Pluggable cost and revenue sources. Each normalizes one provider into the shared cost /
+        business-event model; credentials and sync schedules are configured in the backend connector
+        runner. A source shows <span className="text-good">Connected</span> once it has produced
+        data.
+      </p>
+
+      {live ? body : <SyntheticPreviewBanner workflow="Connectors">{body}</SyntheticPreviewBanner>}
+    </div>
+  );
 }

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -32,6 +32,7 @@ import type {
   SampleByStratum,
 } from "./dq";
 import type { AgentRun, AgentSummary, RunSpan } from "./agents";
+import { CONNECTORS, type ConnectorActivity } from "./connectors";
 
 const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
@@ -564,5 +565,59 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
     const agentMedian = median(peers.map((p) => micro(p.cost)));
     const spans = (await fetchSpansFor(db, tenant, [runId]))[runId] ?? [];
     return buildRun(agg, spans, agentMedian);
+  });
+}
+
+// Connector activity (CTO-63/68): which supported cost/revenue sources are actually producing data.
+// Cost sources are read off otel_spans cost layers; revenue sources off business_events.Source. The
+// result is keyed by connector id so applyActivity() can mark each catalog entry connected/available.
+export async function queryConnectorActivity(): Promise<ConnectorActivity | null> {
+  return tryLive(async (db, tenant) => {
+    const records: Record<string, number> = {};
+    const lastAt: Record<string, string> = {};
+
+    // Cost layers from telemetry. Map each layer back to the connector that feeds it.
+    const layerToId = new Map<Layer, string>();
+    for (const c of CONNECTORS) {
+      if (c.liveKey.kind === "cost-layer") layerToId.set(c.liveKey.layer, c.id);
+    }
+    const costRows = await rows<{ layer: Layer; n: string; last: string | null }>(
+      db,
+      `SELECT ${LAYER_CASE} AS layer, count() AS n, toString(max(Timestamp)) AS last
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
+       GROUP BY layer`,
+      tenant,
+    );
+    for (const r of costRows) {
+      const id = layerToId.get(r.layer);
+      if (!id) continue;
+      const n = parseInt(r.n, 10) || 0;
+      if (n <= 0) continue;
+      records[id] = (records[id] ?? 0) + n;
+      if (r.last && (!lastAt[id] || r.last > lastAt[id])) lastAt[id] = r.last;
+    }
+
+    // Revenue/CDP sources from business_events. Source value matches the connector id.
+    const knownSources = new Set(
+      CONNECTORS.filter((c) => c.liveKey.kind === "revenue-source").map((c) => c.id),
+    );
+    const revRows = await rows<{ src: string; n: string; last: string | null }>(
+      db,
+      `SELECT lower(Source) AS src, count() AS n, toString(max(OccurredAt)) AS last
+       FROM business_events
+       WHERE TenantId = {tenant:String}
+       GROUP BY src`,
+      tenant,
+    );
+    for (const r of revRows) {
+      if (!knownSources.has(r.src)) continue;
+      const n = parseInt(r.n, 10) || 0;
+      if (n <= 0) continue;
+      records[r.src] = (records[r.src] ?? 0) + n;
+      if (r.last) lastAt[r.src] = r.last;
+    }
+
+    return { records, lastAt };
   });
 }

--- a/web/lib/connectors.test.ts
+++ b/web/lib/connectors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONNECTORS,
+  applyActivity,
+  connectedCount,
+  mockConnectorStatuses,
+} from "./connectors";
+
+describe("connector catalog", () => {
+  it("ids are unique and match a backend category", () => {
+    const ids = CONNECTORS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const c of CONNECTORS) {
+      expect(["cost", "revenue"]).toContain(c.category);
+    }
+  });
+
+  it("covers the v1 cost + CDP connectors", () => {
+    const ids = new Set(CONNECTORS.map((c) => c.id));
+    for (const id of ["llm_proxy", "pinecone", "tavily", "aws_cost_explorer", "vercel"]) {
+      expect(ids.has(id)).toBe(true);
+    }
+    for (const id of ["segment", "rudderstack", "stripe", "hubspot"]) {
+      expect(ids.has(id)).toBe(true);
+    }
+  });
+});
+
+describe("applyActivity", () => {
+  it("marks sources with records connected and the rest available", () => {
+    const rows = applyActivity(CONNECTORS, {
+      records: { llm_proxy: 10, stripe: 2 },
+      lastAt: { llm_proxy: "2026-05-31T18:00:00Z" },
+    });
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+    expect(byId.llm_proxy.state).toBe("connected");
+    expect(byId.llm_proxy.records).toBe(10);
+    expect(byId.stripe.state).toBe("connected");
+    expect(byId.pinecone.state).toBe("available");
+    expect(byId.pinecone.records).toBe(0);
+    expect(byId.pinecone.lastAt).toBeNull();
+  });
+
+  it("an empty activity map leaves every source available", () => {
+    const rows = applyActivity(CONNECTORS, { records: {}, lastAt: {} });
+    expect(connectedCount(rows)).toBe(0);
+    expect(rows.every((r) => r.state === "available")).toBe(true);
+  });
+
+  it("preserves the full catalog (no source dropped or duplicated)", () => {
+    const rows = applyActivity(CONNECTORS, { records: {}, lastAt: {} });
+    expect(rows.map((r) => r.id).sort()).toEqual(CONNECTORS.map((c) => c.id).sort());
+  });
+
+  it("mock statuses show a populated example", () => {
+    expect(connectedCount(mockConnectorStatuses)).toBeGreaterThan(0);
+  });
+});

--- a/web/lib/connectors.ts
+++ b/web/lib/connectors.ts
@@ -1,0 +1,158 @@
+// Connectors workflow (CTO-63 cost sources + CTO-68 revenue/CDP sources).
+//
+// The backend ships pluggable connector frameworks (tally.cost_connectors, tally.cdp_connectors):
+// each connector normalizes one provider's payload into the shared cost/business-event model. This
+// module is the UI's view of that catalog — the supported sources and whether each is currently
+// producing data — so the page reflects the real frameworks rather than inventing providers.
+//
+// "Connected" is derived honestly from telemetry: a cost source counts as connected when its cost
+// layer has rows in otel_spans; a revenue source when business_events carries its Source. Nothing
+// is fetched here — configuration/credentials live in the backend runner, not the dashboard.
+
+import type { Layer } from "./cost";
+
+export type ConnectorCategory = "cost" | "revenue";
+
+/** How a connector's live activity is found in the telemetry store. */
+export type LiveKey =
+  | { kind: "cost-layer"; layer: Layer }
+  | { kind: "revenue-source"; source: string };
+
+export interface ConnectorDef {
+  /** Stable id — matches the backend connector's `name`. */
+  id: string;
+  name: string;
+  category: ConnectorCategory;
+  /** Short label for what this source feeds (e.g. "Vector DB cost", "Revenue events"). */
+  feeds: string;
+  description: string;
+  liveKey: LiveKey;
+}
+
+export type ConnectorState = "connected" | "available";
+
+export interface ConnectorStatus extends ConnectorDef {
+  state: ConnectorState;
+  /** Records ingested from this source in the trailing window (0 when not connected). */
+  records: number;
+  /** ISO timestamp of the most recent record, or null when never synced. */
+  lastAt: string | null;
+}
+
+/** The supported-connector catalog. Mirrors tally.cost_connectors / tally.cdp_connectors. */
+export const CONNECTORS: ConnectorDef[] = [
+  {
+    id: "llm_proxy",
+    name: "LLM proxy / SDK",
+    category: "cost",
+    feeds: "LLM cost",
+    description: "Token usage from the edge proxy or SDK — the primary spend signal.",
+    liveKey: { kind: "cost-layer", layer: "llm" },
+  },
+  {
+    id: "pinecone",
+    name: "Pinecone",
+    category: "cost",
+    feeds: "Vector DB cost",
+    description: "Vector database read/write/storage usage attributed to features.",
+    liveKey: { kind: "cost-layer", layer: "vector" },
+  },
+  {
+    id: "tavily",
+    name: "Tavily",
+    category: "cost",
+    feeds: "Tool-call cost",
+    description: "Search / tool API usage billed per call.",
+    liveKey: { kind: "cost-layer", layer: "tools" },
+  },
+  {
+    id: "aws_cost_explorer",
+    name: "AWS Cost Explorer",
+    category: "cost",
+    feeds: "Compute cost",
+    description: "Cloud billing line items for compute backing the AI workload.",
+    liveKey: { kind: "cost-layer", layer: "compute" },
+  },
+  {
+    id: "vercel",
+    name: "Vercel",
+    category: "cost",
+    feeds: "Egress cost",
+    description: "Edge/serverless and bandwidth usage for the serving tier.",
+    liveKey: { kind: "cost-layer", layer: "egress" },
+  },
+  {
+    id: "segment",
+    name: "Segment",
+    category: "revenue",
+    feeds: "Revenue events",
+    description: "CDP track events — the value side of ROI attribution.",
+    liveKey: { kind: "revenue-source", source: "segment" },
+  },
+  {
+    id: "rudderstack",
+    name: "RudderStack",
+    category: "revenue",
+    feeds: "Revenue events",
+    description: "Open-source CDP track events (Segment-compatible payloads).",
+    liveKey: { kind: "revenue-source", source: "rudderstack" },
+  },
+  {
+    id: "stripe",
+    name: "Stripe",
+    category: "revenue",
+    feeds: "Monetary events",
+    description: "Payments, subscriptions and refunds as monetary business events.",
+    liveKey: { kind: "revenue-source", source: "stripe" },
+  },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    category: "revenue",
+    feeds: "Lifecycle events",
+    description: "Deal-stage / lifecycle changes (e.g. closed-won) for attribution.",
+    liveKey: { kind: "revenue-source", source: "hubspot" },
+  },
+];
+
+/** Per-connector activity pulled from the telemetry store, keyed by connector id. */
+export interface ConnectorActivity {
+  records: Record<string, number>;
+  lastAt: Record<string, string>;
+}
+
+/**
+ * Merge the static catalog with observed activity into display rows. A source is "connected" when
+ * it has produced at least one record; otherwise it's "available" (supported, not yet wired). Pure
+ * and deterministic so it can be unit-tested without a database.
+ */
+export function applyActivity(
+  catalog: ConnectorDef[],
+  activity: ConnectorActivity,
+): ConnectorStatus[] {
+  return catalog.map((def) => {
+    const records = activity.records[def.id] ?? 0;
+    const lastAt = activity.lastAt[def.id] ?? null;
+    return {
+      ...def,
+      records,
+      lastAt,
+      state: records > 0 ? "connected" : "available",
+    };
+  });
+}
+
+export function connectedCount(rows: ConnectorStatus[]): number {
+  return rows.filter((r) => r.state === "connected").length;
+}
+
+/** Mock activity for when ClickHouse is unreachable — shows a populated, plausible example. */
+export const mockActivity: ConnectorActivity = {
+  records: { llm_proxy: 4120, stripe: 86 },
+  lastAt: {
+    llm_proxy: "2026-05-31T18:40:00Z",
+    stripe: "2026-05-31T17:05:00Z",
+  },
+};
+
+export const mockConnectorStatuses: ConnectorStatus[] = applyActivity(CONNECTORS, mockActivity);


### PR DESCRIPTION
## Summary
- Replaces the Connectors stub with a real screen that surfaces the backend **cost** (CTO-63) and **revenue/CDP** (CTO-68) connector frameworks.
- "Connected" is derived honestly from telemetry — a cost source counts as connected once its layer has rows in `otel_spans`; a revenue source once `business_events` carries its `Source`. Nothing is fetched in the UI; credentials/sync live in the backend runner.
- Falls back to a synthetic-preview banner with mock activity when ClickHouse is unreachable, consistent with the other workflows.

## Changes
- `web/lib/connectors.ts` — connector catalog + `applyActivity`/`connectedCount` (pure, unit-tested).
- `web/lib/clickhouse.ts` — `queryConnectorActivity()` reads live records/lastAt per connector.
- `web/app/api/connectors/route.ts` — live-or-mock payload with a `live` flag.
- `web/app/connectors/page.tsx` — cost + revenue sections with Connected/Available status badges.
- `web/lib/connectors.test.ts` — catalog + `applyActivity` unit tests.

## Verification
- `npm run typecheck` clean, `npm run lint` clean, `npx vitest run` → all tests pass (+6 new).
- Verified live against the local stack: with 41 `local-dev` spans, `LLM proxy / SDK` shows **Connected / 41 / just now** and the rest **Available**; section headers compute 1/5 cost and 0/4 revenue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)