### PR TITLE
CTO-104: live aider-demo via the edge proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ uv.lock
 
 # Claude Code worktrees
 .claude/worktrees/
+.aider.*

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ cd infra && make up && make seed && make demo   # stack + tenant + sample teleme
 cd web && npm install && npm run dev            # dashboard at http://localhost:3000
 ```
 
+Want to see real agent traffic, not just a seeded batch? Run the Aider
+fixture demo — it drives Aider against a small Python repo through the edge
+proxy and pre-filters the dashboard to those traces:
+
+```bash
+export OPENAI_API_KEY=sk-...
+cd infra && make aider-demo                     # ~3 min, three multi-turn tasks
+```
+
+See [examples/aider-demo/README.md](examples/aider-demo/README.md) for the
+walkthrough.
+
 ## Development
 
 The Python SDK uses [uv](https://docs.astral.sh/uv/), `ruff`, and `pytest`.

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -129,6 +129,28 @@ until ClickHouse returns. Knobs (all `TALLY_`-prefixed): `INGEST_BUFFER_CAPACITY
 rows past this are shed as *retryable*, never 5xx), `INGEST_BUFFER_DRAIN_BATCH` (`2000`),
 `INGEST_BUFFER_POLL_INTERVAL_S` (`0.05`).
 
+## Step 5: real traffic via Aider
+
+`make demo` posts a hand-crafted batch. To see ai-tally with **real agent
+traffic** — same path a customer's app would take — run the Aider fixture
+demo:
+
+```bash
+export OPENAI_API_KEY=sk-...   # or ANTHROPIC_API_KEY + PROVIDER=anthropic
+cd infra && make aider-demo
+```
+
+Aider edits a small Python fixture across three multi-turn tasks. All LLM
+requests transit the ai-tally edge proxy with `X-Tally-Feature-Tag:
+aider-demo`, and the dashboard auto-opens to `/agents?tag=aider-demo` showing
+the just-recorded runs.
+
+Full walkthrough — including the cross-provider variant, what each task does,
+and the architecture diagram — is in
+[examples/aider-demo/README.md](examples/aider-demo/README.md).
+
+When you're done: `make aider-demo-stop` kills the background proxy.
+
 ## Troubleshooting
 
 | Symptom | Cause / fix |
@@ -145,6 +167,8 @@ rows past this are shed as *retryable*, never 5xx), `INGEST_BUFFER_DRAIN_BATCH` 
 | `make up` | Start the full stack (build gateway image) |
 | `make seed` | Create the `local-dev` tenant + API key |
 | `make demo` | Send a sample batch through the gateway into ClickHouse |
+| `make aider-demo` | Run Aider against a fixture repo through the edge proxy (needs `OPENAI_API_KEY`) |
+| `make aider-demo-stop` | Kill the background edge proxy started by `aider-demo` |
 | `make ps` / `make logs` | Status / tail gateway logs |
 | `make ch` / `make psql` | ClickHouse / Postgres SQL shell |
 | `make down` | Stop the stack (keep data volumes) |

--- a/examples/aider-demo/README.md
+++ b/examples/aider-demo/README.md
@@ -1,0 +1,110 @@
+# make aider-demo
+
+A one-command live demo of ai-tally: [Aider](https://aider.chat) edits a small
+Python fixture, talking to OpenAI (or Anthropic) **through the ai-tally edge
+proxy** with a per-request `X-Tally-Feature-Tag: aider-demo` header. When all
+three tasks finish, the dashboard auto-opens, pre-filtered to that tag.
+
+Goal: a stranger who just finished `make demo` can run `make aider-demo` and
+see real agent traces in under five minutes.
+
+## Prereqs
+
+1. The local stack is up:
+   ```
+   cd infra && make up && make seed
+   ```
+2. `aider-chat` on `$PATH`:
+   ```
+   pip install aider-chat
+   ```
+3. A provider API key in the environment:
+   ```
+   export OPENAI_API_KEY=sk-...
+   # or, for the cross-provider variant:
+   export ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+## Run it
+
+```
+cd infra && make aider-demo
+# cross-provider variant:
+cd infra && PROVIDER=anthropic make aider-demo
+```
+
+## What you'll see
+
+```
+▶ starting edge-proxy on :7070 → https://api.openai.com
+▶ task 1/3: Make the failing tests in test_string_utils.py pass…
+   [12s · 4 turns · $0.018]
+▶ task 2/3: Refactor string_utils.py to share a single private…
+   [18s · 5 turns · $0.024]
+▶ task 3/3: Add a new function most_common_word(s: str) -> str | None…
+   [15s · 4 turns · $0.021]
+
+─── make aider-demo: done ────────────────────────────────────
+  3 tasks · 13 turns · $0.0630 total
+
+  Workflow 1 (agents):  http://localhost:3000/agents?tag=aider-demo
+    drill into tail run: http://localhost:3000/agents?tag=aider-demo&run=…
+  Workflow 2 (compare): http://localhost:3000/compare?tag=aider-demo
+  Workflow 3 (cost):    http://localhost:3000/cost?tag=aider-demo
+
+Opening Workflow 1…
+```
+
+Workflow 1 lands you on the agent runs table, filtered to the `aider-demo`
+tag. Click the tail run to see the per-step span tree.
+
+## How it works
+
+```
+aider --message-file 01-fix-test.txt …
+   │
+   ▼  (OPENAI_API_BASE=http://localhost:7070/v1, header: X-Tally-Feature-Tag)
+edge-proxy (Go)  ──▶  api.openai.com
+   │
+   ▼ (TraceRecord — metadata only, no body)
+   (CTO-40/41: bridge to otel_spans — not wired yet)
+
+run.sh also POSTs a feature-tagged batch directly to the gateway between tasks
+(parsed cost + turn count from Aider's stdout) so the dashboard has rows the
+deep links can filter on. When the proxy→ClickHouse bridge lands this
+side-channel goes away.
+```
+
+## Reset
+
+The fixture in `target-repo/` is restored between tasks by `reset.sh`, which
+just does `git checkout HEAD -- target-repo && git clean -fd`. After the demo
+itself you can also run:
+
+```
+cd infra && make aider-demo-stop   # kills the proxy via PID file
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `ERROR: ai-tally gateway not reachable` | `cd infra && make up && make seed` first |
+| `ERROR: OPENAI_API_KEY not set` | `export OPENAI_API_KEY=…` or pass `PROVIDER=anthropic` |
+| `ERROR: aider not on PATH` | `pip install aider-chat` |
+| Edge-proxy didn't bind | Check `/tmp/ai-tally-aider-edge-proxy.log` |
+| Dashboard shows "Synthetic preview" | The gateway batch failed — check `make logs` |
+
+## What good looks like
+
+- Three tasks complete in under three minutes total
+- `Workflow 1` shows three agent runs tagged `aider-demo`, each with multi-step
+  span tree
+- `Workflow 3` shows `aider-demo` as a single-feature column in the cost
+  breakdown
+
+## Screenshots
+
+Screenshots of the three workflows go in `screenshots/`. They aren't
+committed unless they've been generated against a real run (we don't ship
+mock-looking pictures of a live demo).

--- a/examples/aider-demo/_dashboard-links.sh
+++ b/examples/aider-demo/_dashboard-links.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Helpers sourced by run.sh: deep-link builders + cross-platform URL opener.
+# No state, no side effects on source — define functions only.
+
+TALLY_WEB_URL="${TALLY_WEB_URL:-http://localhost:3000}"
+
+# Build the three workflow deep links for a given feature tag + trace id.
+# Workflow 1 = Agents (filtered by tag, optionally drilled into one run).
+# Workflow 2 = Compare (carries the tag for CTO-105's tag-scoped replay).
+# Workflow 3 = Cost (filtered by tag).
+workflow1_url() {
+  local tag="$1" trace="${2:-}"
+  if [[ -n "$trace" ]]; then
+    printf '%s/agents?tag=%s&run=%s\n' "$TALLY_WEB_URL" "$tag" "$trace"
+  else
+    printf '%s/agents?tag=%s\n' "$TALLY_WEB_URL" "$tag"
+  fi
+}
+
+workflow2_url() {
+  local tag="$1"
+  printf '%s/compare?tag=%s\n' "$TALLY_WEB_URL" "$tag"
+}
+
+workflow3_url() {
+  local tag="$1"
+  printf '%s/cost?tag=%s\n' "$TALLY_WEB_URL" "$tag"
+}
+
+# Open a URL in the default browser. macOS uses `open`, Linux uses `xdg-open`,
+# anything else just prints — never fail the demo over a missing opener.
+open_url() {
+  local url="$1"
+  if command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 || true
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+  else
+    echo "  (open this manually: $url)"
+  fi
+}

--- a/examples/aider-demo/_emit_batch.py
+++ b/examples/aider-demo/_emit_batch.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Internal helper: POST a feature-tagged span batch to the ai-tally gateway.
+
+Used by run.sh between Aider tasks to land otel_spans rows the dashboard can
+filter on. Bridging the edge-proxy's TraceRecord pipeline directly into the
+otel_spans table is CTO-40/41 territory; until that lands this side-channel
+keeps make aider-demo's deep links pointing at real data.
+
+Standalone (urllib only) so it doesn't depend on the SDK being importable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import uuid
+import urllib.request
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gateway", required=True, help="e.g. http://localhost:8080/v1/batches")
+    ap.add_argument("--tenant", required=True)
+    ap.add_argument("--feature-tag", required=True)
+    ap.add_argument("--trace-id", required=True, help="32-hex-char trace id")
+    ap.add_argument("--cost-usd", type=float, default=0.0)
+    ap.add_argument("--turns", type=int, default=1)
+    ap.add_argument("--provider", default="openai")
+    args = ap.parse_args()
+
+    cost_micro = int(round(args.cost_usd * 1_000_000))
+    # Split the run's cost across `turns` synthetic spans so the agent-run view
+    # shows multi-step traces. Each span shares the same TraceId so they roll
+    # up as one run.
+    spans = []
+    for step in range(max(1, args.turns)):
+        per_step_cost = cost_micro // max(1, args.turns)
+        attrs = {
+            "ServiceName": "aider",
+            "trace_id": args.trace_id,
+            "span_id": uuid.uuid4().hex[:16],
+            "gen_ai.system": args.provider,
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": "gpt-4o-mini" if args.provider == "openai" else "claude-sonnet-4",
+            "gen_ai.response.model": "gpt-4o-mini" if args.provider == "openai" else "claude-sonnet-4",
+            "gen_ai.usage.input_tokens": 1000,
+            "gen_ai.usage.output_tokens": 250,
+            "gen_ai.cost.estimated_micro_usd": per_step_cost,
+            "gen_ai.cost.currency": "USD",
+            "gen_ai.cost.price_catalog_version": "demo",
+            "gen_ai.feature_tag": args.feature_tag,
+            "gen_ai.session_id": args.trace_id,
+            "gen_ai.agent.step.index": step,
+        }
+        spans.append(attrs)
+
+    batch = {
+        "tenant_id": args.tenant,
+        "sdk_version": "aider-demo",
+        "batch_id": uuid.uuid4().hex,
+        "resource_spans": spans,
+    }
+
+    req = urllib.request.Request(
+        args.gateway,
+        data=json.dumps(batch).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        print(resp.status)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/aider-demo/_emit_batch.py
+++ b/examples/aider-demo/_emit_batch.py
@@ -29,25 +29,40 @@ def main() -> None:
     args = ap.parse_args()
 
     cost_micro = int(round(args.cost_usd * 1_000_000))
+    # The gateway's enrich_cost recomputes the authoritative cost from the price
+    # catalog. The seed catalog only knows gpt-5-mini / gpt-5 — anything else is
+    # a catalog miss and the cost gets dropped to 0. Until the catalog grows
+    # real provider models, we pin to gpt-5-mini and back-compute output tokens
+    # from Aider's reported cost so the dashboard number matches what Aider saw.
+    #
+    # gpt-5-mini output rate is $2.00 / 1M tokens → 2 micro-USD/token.
+    MICRO_PER_OUTPUT_TOKEN = 2  # gpt-5-mini output rate
+    DASHBOARD_MODEL = "gpt-5-mini"
+    DASHBOARD_SYSTEM = "openai"
+
     # Split the run's cost across `turns` synthetic spans so the agent-run view
     # shows multi-step traces. Each span shares the same TraceId so they roll
     # up as one run.
     spans = []
+    per_step_cost = cost_micro // max(1, args.turns)
+    output_tokens_per_step = max(1, per_step_cost // MICRO_PER_OUTPUT_TOKEN)
     for step in range(max(1, args.turns)):
-        per_step_cost = cost_micro // max(1, args.turns)
         attrs = {
             "ServiceName": "aider",
             "trace_id": args.trace_id,
             "span_id": uuid.uuid4().hex[:16],
-            "gen_ai.system": args.provider,
+            "gen_ai.system": DASHBOARD_SYSTEM,
             "gen_ai.operation.name": "chat",
-            "gen_ai.request.model": "gpt-4o-mini" if args.provider == "openai" else "claude-sonnet-4",
-            "gen_ai.response.model": "gpt-4o-mini" if args.provider == "openai" else "claude-sonnet-4",
-            "gen_ai.usage.input_tokens": 1000,
-            "gen_ai.usage.output_tokens": 250,
+            "gen_ai.request.model": DASHBOARD_MODEL,
+            "gen_ai.response.model": DASHBOARD_MODEL,
+            "gen_ai.usage.input_tokens": 0,
+            "gen_ai.usage.output_tokens": output_tokens_per_step,
             "gen_ai.cost.estimated_micro_usd": per_step_cost,
             "gen_ai.cost.currency": "USD",
-            "gen_ai.cost.price_catalog_version": "demo",
+            # NOTE: real provider was args.provider; pinned to openai/gpt-5-mini for
+            # the dashboard so the price-catalog enrichment doesn't drop the cost.
+            # Real provider preserved in the long-tail attributes below.
+            "aider.real_provider": args.provider,
             "gen_ai.feature_tag": args.feature_tag,
             "gen_ai.session_id": args.trace_id,
             "gen_ai.agent.step.index": step,

--- a/examples/aider-demo/aider-live.sh
+++ b/examples/aider-demo/aider-live.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Run Aider INTERACTIVELY through the ai-tally edge proxy, then emit one batch
+# per turn the model completed so the dashboard fills in as you work.
+#
+# Usage:   bash examples/aider-demo/aider-live.sh [PROVIDER=openai|anthropic] -- [aider args...]
+# Example: bash examples/aider-demo/aider-live.sh PROVIDER=anthropic
+#          bash examples/aider-demo/aider-live.sh -- string_utils.py test_string_utils.py
+#
+# Watch live updates at:   http://localhost:3000/agents?tag=aider-live
+# (refresh after each Aider response — the page does not stream)
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+PROVIDER="${PROVIDER:-openai}"
+FEATURE_TAG="${FEATURE_TAG:-aider-live}"
+TENANT="${TENANT:-local-dev}"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
+PROXY_PORT="${PROXY_PORT:-7070}"
+PROXY_PID_FILE="${PROXY_PID_FILE:-/tmp/ai-tally-aider-edge-proxy.pid}"
+
+# Allow "PROVIDER=anthropic --" prefix on the CLI
+while [[ $# -gt 0 && "$1" != "--" ]]; do
+  case "$1" in
+    PROVIDER=*) PROVIDER="${1#PROVIDER=}";;
+    FEATURE_TAG=*) FEATURE_TAG="${1#FEATURE_TAG=}";;
+    *) break;;
+  esac
+  shift
+done
+[[ "${1:-}" == "--" ]] && shift
+
+# 1. Validate the API key and pick a model.
+if [[ "$PROVIDER" == "anthropic" ]]; then
+  [[ -n "${ANTHROPIC_API_KEY:-}" ]] || { echo "ERROR: ANTHROPIC_API_KEY not set"; exit 1; }
+  AIDER_MODEL="${AIDER_MODEL:-anthropic/claude-sonnet-4-5}"
+  upstream="https://api.anthropic.com"
+  export ANTHROPIC_API_BASE="http://localhost:$PROXY_PORT"
+  export ANTHROPIC_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+else
+  [[ -n "${OPENAI_API_KEY:-}" ]] || { echo "ERROR: OPENAI_API_KEY not set"; exit 1; }
+  AIDER_MODEL="${AIDER_MODEL:-gpt-4o}"
+  upstream="https://api.openai.com"
+  export OPENAI_API_BASE="http://localhost:$PROXY_PORT/v1"
+  export OPENAI_BASE_URL="http://localhost:$PROXY_PORT/v1"
+  export OPENAI_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+fi
+
+# 2. Stack must be up.
+if ! curl -sf "$GATEWAY_URL/healthz" >/dev/null 2>&1; then
+  echo "ERROR: ai-tally gateway not reachable at $GATEWAY_URL"
+  echo "       Run \`cd infra && make up && make seed\` first."
+  exit 1
+fi
+if ! curl -sf http://localhost:3000 >/dev/null 2>&1; then
+  echo "WARN:  dashboard not running at http://localhost:3000 — start it with:"
+  echo "         cd web && npm run dev"
+  echo "       (you can keep going; spans will land in ClickHouse either way)"
+fi
+
+# 3. Start the edge proxy if not already running.
+if [[ -f "$PROXY_PID_FILE" ]] && kill -0 "$(cat "$PROXY_PID_FILE")" 2>/dev/null; then
+  echo "  edge-proxy already running (pid $(cat "$PROXY_PID_FILE"))"
+else
+  echo "▶ starting edge-proxy on :$PROXY_PORT → $upstream"
+  ( cd "$here/../../infra/edge-proxy" && \
+    EDGE_PROXY_LISTEN=":$PROXY_PORT" \
+    EDGE_PROXY_UPSTREAM="$upstream" \
+    go run ./cmd/edge-proxy >/tmp/ai-tally-aider-edge-proxy.log 2>&1 ) &
+  echo $! > "$PROXY_PID_FILE"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    nc -z localhost "$PROXY_PORT" 2>/dev/null && break
+    sleep 0.5
+  done
+fi
+
+# 4. Background tail: every second, scan the aider session log for new
+#    "Cost: $X message" lines and emit a feature-tagged batch per finding.
+log=$(mktemp)
+emitted_lines=0
+emit_loop() {
+  while sleep 1; do
+    [[ -f "$log" ]] || continue
+    current=$(grep -cE 'Cost: \$[0-9.]+ message' "$log" 2>/dev/null || true)
+    current=${current:-0}
+    if [[ "$current" -gt "$emitted_lines" ]]; then
+      # Emit one batch for each new turn we haven't seen yet.
+      while [[ "$emitted_lines" -lt "$current" ]]; do
+        emitted_lines=$((emitted_lines + 1))
+        cost=$(grep -oE 'Cost: \$[0-9.]+ message' "$log" | sed -n "${emitted_lines}p" | grep -oE '[0-9.]+' || true)
+        cost=${cost:-0}
+        trace_id=$(python3 -c "import uuid;print(uuid.uuid4().hex)")
+        python3 "$here/_emit_batch.py" \
+          --gateway "$GATEWAY_URL/v1/batches" \
+          --tenant "$TENANT" \
+          --feature-tag "$FEATURE_TAG" \
+          --trace-id "$trace_id" \
+          --cost-usd "$cost" \
+          --turns 1 \
+          --provider "$PROVIDER" >/dev/null 2>&1 || true
+        echo "  ▸ emitted turn $emitted_lines (\$$cost) → http://localhost:3000/agents?tag=$FEATURE_TAG" >&2
+      done
+    fi
+  done
+}
+emit_loop &
+emit_pid=$!
+trap "kill $emit_pid 2>/dev/null || true; rm -f $log" EXIT
+
+echo
+echo "─── aider-live: ai-tally edge-proxy + emit loop ready ────────────"
+echo "  feature.tag = $FEATURE_TAG    model = $AIDER_MODEL"
+echo "  dashboard:    http://localhost:3000/agents?tag=$FEATURE_TAG"
+echo "  refresh that tab after each Aider response to see live updates."
+echo "─────────────────────────────────────────────────────────────────"
+echo
+
+# 5. Run Aider interactively (no redirection of stdin — full TTY).
+#    Tee its output to $log so the emit loop can parse "Cost: $X message" lines.
+aider --no-git --yes --model "$AIDER_MODEL" "$@" 2>&1 | tee "$log"

--- a/examples/aider-demo/reset.sh
+++ b/examples/aider-demo/reset.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Restore examples/aider-demo/target-repo to its pristine fixture state between
+# demo tasks. The fixture lives in the parent ai-tally git repo (target-repo is
+# NOT a nested git repo), so we just checkout HEAD for that subtree and clean.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+target_rel="examples/aider-demo/target-repo"
+
+cd "$repo_root"
+git checkout HEAD -- "$target_rel"
+git clean -fd "$target_rel" >/dev/null
+echo "  reset: $target_rel restored"

--- a/examples/aider-demo/run.sh
+++ b/examples/aider-demo/run.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# make aider-demo entry point: run Aider against the fixture repo through the
+# ai-tally edge proxy, then deep-link the dashboard to the just-recorded traces.
+# Self-contained: see README.md for prereqs ("`make up && make seed` first").
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./_dashboard-links.sh
+source "$here/_dashboard-links.sh"
+
+PROVIDER="${PROVIDER:-openai}"
+FEATURE_TAG="${FEATURE_TAG:-aider-demo}"
+TENANT="${TENANT:-local-dev}"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
+PROXY_PORT="${PROXY_PORT:-7070}"
+PROXY_PID_FILE="${PROXY_PID_FILE:-/tmp/ai-tally-aider-edge-proxy.pid}"
+
+# 1. Validate the API key for the chosen provider.
+if [[ "$PROVIDER" == "anthropic" ]]; then
+  [[ -n "${ANTHROPIC_API_KEY:-}" ]] || { echo "ERROR: ANTHROPIC_API_KEY not set"; exit 1; }
+  upstream="https://api.anthropic.com"
+else
+  [[ -n "${OPENAI_API_KEY:-}" ]] || { echo "ERROR: OPENAI_API_KEY not set (or pass PROVIDER=anthropic)"; exit 1; }
+  upstream="https://api.openai.com"
+fi
+
+# 2. Stack must be up — fail with a helpful pointer otherwise.
+if ! curl -sf "$GATEWAY_URL/healthz" >/dev/null 2>&1; then
+  echo "ERROR: ai-tally gateway not reachable at $GATEWAY_URL"
+  echo "       Run \`cd infra && make up && make seed\` first."
+  exit 1
+fi
+
+# 3. Start the edge proxy on $PROXY_PORT if not already running.
+start_proxy() {
+  if [[ -f "$PROXY_PID_FILE" ]] && kill -0 "$(cat "$PROXY_PID_FILE")" 2>/dev/null; then
+    echo "  edge-proxy already running (pid $(cat "$PROXY_PID_FILE"))"; return
+  fi
+  echo "▶ starting edge-proxy on :$PROXY_PORT → $upstream"
+  ( cd "$here/../../infra/edge-proxy" && \
+    EDGE_PROXY_LISTEN=":$PROXY_PORT" \
+    EDGE_PROXY_UPSTREAM="$upstream" \
+    go run ./cmd/edge-proxy >/tmp/ai-tally-aider-edge-proxy.log 2>&1 ) &
+  echo $! > "$PROXY_PID_FILE"
+  # Wait up to ~5s for it to bind.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf "http://localhost:$PROXY_PORT" -o /dev/null 2>/dev/null || \
+       nc -z localhost "$PROXY_PORT" 2>/dev/null; then return; fi
+    sleep 0.5
+  done
+  echo "ERROR: edge-proxy didn't bind on :$PROXY_PORT (see /tmp/ai-tally-aider-edge-proxy.log)"; exit 1
+}
+start_proxy
+
+# 4. Point Aider at the proxy and inject the feature-tag header. We use
+#    OPENAI_API_BASE (Aider reads it via the openai sdk).
+export OPENAI_API_BASE="http://localhost:$PROXY_PORT/v1"
+export OPENAI_BASE_URL="http://localhost:$PROXY_PORT/v1"
+# Aider doesn't expose per-request headers natively; we use the OpenAI SDK env
+# OPENAI_DEFAULT_HEADERS (newer aider builds) AND set a curl-style fallback via
+# the proxy's tenant header so the feature tag still lands on every request.
+export OPENAI_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+
+# 5. Run each task. Parses Aider's "Tokens: …" cost line for the per-task summary.
+declare -a trace_ids=()
+total_cost_usd=0
+total_turns=0
+i=0
+for task_file in "$here"/tasks/*.txt; do
+  i=$((i+1))
+  total=$(ls "$here"/tasks/*.txt | wc -l | tr -d ' ')
+  first_line=$(head -n 1 "$task_file")
+  printf "▶ task %d/%d: %s\n" "$i" "$total" "${first_line:0:60}…"
+
+  start=$(date +%s)
+  log=$(mktemp)
+  if ! command -v aider >/dev/null 2>&1; then
+    echo "ERROR: aider not on PATH. Install with: pip install aider-chat"; exit 1
+  fi
+  ( cd "$here/target-repo" && \
+    aider --no-git --yes --no-stream --message-file "$task_file" \
+          string_utils.py test_string_utils.py >"$log" 2>&1 ) || {
+    echo "  (aider exited non-zero — continuing; see $log)"
+  }
+  dur=$(( $(date +%s) - start ))
+  # Aider prints "Tokens: 1.2k sent, 300 received. Cost: $0.018 message, $0.018 session."
+  cost=$(grep -oE 'Cost: \$[0-9.]+ message' "$log" | tail -1 | grep -oE '[0-9.]+' || echo 0)
+  turns=$(grep -cE '^(>|aider>)' "$log" || echo 1)
+  printf "   [%ds · %s turns · \$%s]\n" "$dur" "$turns" "${cost:-0}"
+  total_cost_usd=$(awk "BEGIN{printf \"%.4f\", $total_cost_usd + ${cost:-0}}")
+  total_turns=$((total_turns + turns))
+
+  # Synthesize a feature-tagged batch into the gateway so the dashboard has
+  # rows to filter on. The edge-proxy's TraceRecord pipeline doesn't yet bridge
+  # to otel_spans (CTO-40/41 will close that loop); until then this side-channel
+  # is what makes the deep links land on real data instead of a blank view.
+  trace_id=$(python3 -c "import uuid;print(uuid.uuid4().hex)")
+  trace_ids+=("$trace_id")
+  python3 "$here/_emit_batch.py" \
+    --gateway "$GATEWAY_URL/v1/batches" \
+    --tenant "$TENANT" \
+    --feature-tag "$FEATURE_TAG" \
+    --trace-id "$trace_id" \
+    --cost-usd "${cost:-0}" \
+    --turns "$turns" \
+    --provider "$PROVIDER" >/dev/null
+
+  bash "$here/reset.sh"
+  rm -f "$log"
+done
+
+# 6. Summary block + auto-open Workflow 1.
+last_trace="${trace_ids[-1]:-}"
+echo
+echo "─── make aider-demo: done ────────────────────────────────────"
+printf "  %d tasks · %d turns · \$%s total\n" "$i" "$total_turns" "$total_cost_usd"
+echo
+echo "  Workflow 1 (agents):  $(workflow1_url "$FEATURE_TAG")"
+[[ -n "$last_trace" ]] && echo "    drill into tail run: $(workflow1_url "$FEATURE_TAG" "$last_trace")"
+echo "  Workflow 2 (compare): $(workflow2_url "$FEATURE_TAG")"
+echo "  Workflow 3 (cost):    $(workflow3_url "$FEATURE_TAG")"
+echo
+echo "Opening Workflow 1…"
+open_url "$(workflow1_url "$FEATURE_TAG")"

--- a/examples/aider-demo/run.sh
+++ b/examples/aider-demo/run.sh
@@ -53,14 +53,20 @@ start_proxy() {
 }
 start_proxy
 
-# 4. Point Aider at the proxy and inject the feature-tag header. We use
-#    OPENAI_API_BASE (Aider reads it via the openai sdk).
-export OPENAI_API_BASE="http://localhost:$PROXY_PORT/v1"
-export OPENAI_BASE_URL="http://localhost:$PROXY_PORT/v1"
-# Aider doesn't expose per-request headers natively; we use the OpenAI SDK env
-# OPENAI_DEFAULT_HEADERS (newer aider builds) AND set a curl-style fallback via
-# the proxy's tenant header so the feature tag still lands on every request.
-export OPENAI_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+# 4. Point Aider at the proxy and pick a model that matches the provider.
+#    Aider speaks OpenAI protocol by default; for Anthropic we explicitly select
+#    a Claude model so it speaks Anthropic protocol to the proxy upstream.
+if [[ "$PROVIDER" == "anthropic" ]]; then
+  # Aider uses LiteLLM under the hood; LiteLLM requires the provider prefix.
+  AIDER_MODEL="${AIDER_MODEL:-anthropic/claude-sonnet-4-5}"
+  export ANTHROPIC_API_BASE="http://localhost:$PROXY_PORT"
+  export ANTHROPIC_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+else
+  AIDER_MODEL="${AIDER_MODEL:-gpt-4o}"
+  export OPENAI_API_BASE="http://localhost:$PROXY_PORT/v1"
+  export OPENAI_BASE_URL="http://localhost:$PROXY_PORT/v1"
+  export OPENAI_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+fi
 
 # 5. Run each task. Parses Aider's "Tokens: …" cost line for the per-task summary.
 declare -a trace_ids=()
@@ -79,14 +85,20 @@ for task_file in "$here"/tasks/*.txt; do
     echo "ERROR: aider not on PATH. Install with: pip install aider-chat"; exit 1
   fi
   ( cd "$here/target-repo" && \
-    aider --no-git --yes --no-stream --message-file "$task_file" \
+    aider --no-git --yes --no-stream --model "$AIDER_MODEL" \
+          --message-file "$task_file" \
           string_utils.py test_string_utils.py >"$log" 2>&1 ) || {
-    echo "  (aider exited non-zero — continuing; see $log)"
+    echo "  ⚠ aider exited non-zero. Last 20 lines of output:"
+    tail -n 20 "$log" | sed 's/^/    /'
+    echo "    (full log: $log)"
   }
   dur=$(( $(date +%s) - start ))
   # Aider prints "Tokens: 1.2k sent, 300 received. Cost: $0.018 message, $0.018 session."
-  cost=$(grep -oE 'Cost: \$[0-9.]+ message' "$log" | tail -1 | grep -oE '[0-9.]+' || echo 0)
-  turns=$(grep -cE '^(>|aider>)' "$log" || echo 1)
+  cost=$(grep -oE 'Cost: \$[0-9.]+ message' "$log" | tail -1 | grep -oE '[0-9.]+' || true)
+  cost=${cost:-0}
+  turns=$(grep -cE '^(>|aider>)' "$log" || true)
+  turns=${turns:-0}
+  [ "$turns" -gt 0 ] 2>/dev/null || turns=1
   printf "   [%ds · %s turns · \$%s]\n" "$dur" "$turns" "${cost:-0}"
   total_cost_usd=$(awk "BEGIN{printf \"%.4f\", $total_cost_usd + ${cost:-0}}")
   total_turns=$((total_turns + turns))
@@ -111,7 +123,10 @@ for task_file in "$here"/tasks/*.txt; do
 done
 
 # 6. Summary block + auto-open Workflow 1.
-last_trace="${trace_ids[-1]:-}"
+last_trace=""
+if [[ ${#trace_ids[@]} -gt 0 ]]; then
+  last_trace="${trace_ids[$((${#trace_ids[@]} - 1))]}"
+fi
 echo
 echo "─── make aider-demo: done ────────────────────────────────────"
 printf "  %d tasks · %d turns · \$%s total\n" "$i" "$total_turns" "$total_cost_usd"

--- a/examples/aider-demo/target-repo/README.md
+++ b/examples/aider-demo/target-repo/README.md
@@ -1,0 +1,13 @@
+# aider-demo target repo
+
+Fixture used by `make aider-demo`. Three small Python functions in
+`string_utils.py` with `pytest` coverage in `test_string_utils.py`. The
+functions ship under-implemented on purpose — Aider fixes them during the demo.
+
+Run the tests directly:
+
+```
+cd examples/aider-demo/target-repo && pytest -q
+```
+
+`../reset.sh` restores this directory to a clean state between demo tasks.

--- a/examples/aider-demo/target-repo/string_utils.py
+++ b/examples/aider-demo/target-repo/string_utils.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A tiny string-utils module used by the make aider-demo fixture.
+
+Three functions, deliberately under-implemented so Aider has something concrete
+(and bounded) to fix. The accompanying tests in test_string_utils.py describe
+the intended behavior — this is what the agent reads to figure out what to do.
+"""
+
+
+def reverse_words(s: str) -> str:
+    """Return s with the order of whitespace-separated words reversed.
+
+    Leading/trailing whitespace is collapsed and a single space joins the words.
+    """
+    # TODO: implement
+    return s
+
+
+def is_palindrome(s: str) -> bool:
+    """Return True iff s is a palindrome, ignoring case and non-alphanumerics."""
+    # TODO: implement
+    return False
+
+
+def word_count(s: str) -> dict[str, int]:
+    """Return a mapping word -> count for whitespace-separated words in s.
+
+    Words are compared case-insensitively and stripped of surrounding
+    punctuation. Empty input returns an empty dict.
+    """
+    # TODO: implement
+    return {}

--- a/examples/aider-demo/target-repo/test_string_utils.py
+++ b/examples/aider-demo/target-repo/test_string_utils.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests Aider has to make pass during the make aider-demo run."""
+
+import pytest
+
+from string_utils import is_palindrome, reverse_words, word_count
+
+
+def test_reverse_words_basic():
+    assert reverse_words("hello world") == "world hello"
+
+
+def test_reverse_words_collapses_whitespace():
+    assert reverse_words("  one  two   three  ") == "three two one"
+
+
+def test_is_palindrome_alphanumeric():
+    assert is_palindrome("A man, a plan, a canal: Panama") is True
+    assert is_palindrome("hello") is False
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", {}),
+        ("a a b", {"a": 2, "b": 1}),
+        ("Hello, hello, World!", {"hello": 2, "world": 1}),
+    ],
+)
+def test_word_count(text, expected):
+    assert word_count(text) == expected

--- a/examples/aider-demo/tasks/01-fix-test.txt
+++ b/examples/aider-demo/tasks/01-fix-test.txt
@@ -1,0 +1,3 @@
+Make the failing tests in test_string_utils.py pass by implementing the
+functions in string_utils.py. Keep the implementations small and pure —
+no new dependencies. Run `pytest -q` at the end to confirm everything is green.

--- a/examples/aider-demo/tasks/02-refactor.txt
+++ b/examples/aider-demo/tasks/02-refactor.txt
@@ -1,0 +1,6 @@
+Refactor string_utils.py to share a single private `_normalize(s: str) -> str`
+helper that lowercases and strips non-alphanumeric characters. Use it from
+both `is_palindrome` and `word_count` so the normalization rules live in
+exactly one place. Update test_string_utils.py to add one test asserting that
+`_normalize` exists and that `word_count("It's IT")` returns `{"its": 1, "it": 1}`.
+Keep `pytest -q` green.

--- a/examples/aider-demo/tasks/03-feature.txt
+++ b/examples/aider-demo/tasks/03-feature.txt
@@ -1,0 +1,7 @@
+Add a new function `most_common_word(s: str) -> str | None` to string_utils.py
+that returns the single most-common word in `s` (using the existing word_count
+logic), or None when the input has no words. Ties break in favor of the word
+that appears first.
+
+Add three tests for it in test_string_utils.py covering: the empty-string case,
+a clear winner, and a tie. Confirm `pytest -q` is green.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,7 +2,9 @@
 COMPOSE := docker compose
 GATEWAY := ai-tally-gateway
 
-.PHONY: help up down nuke logs ps seed demo gateway-shell test ch psql
+.PHONY: help up down nuke logs ps seed demo aider-demo aider-demo-stop gateway-shell test ch psql
+
+EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -30,6 +32,18 @@ seed: ## Create a local tenant + API key + feature tags in Postgres
 
 demo: ## Send a sample batch through the gateway into ClickHouse
 	$(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py
+
+aider-demo: ## Run Aider against a fixture repo through the edge proxy (needs OPENAI_API_KEY)
+	@curl -sf http://localhost:8080/healthz >/dev/null || { \
+	  echo "ai-tally stack not up — run 'make up && make seed' first"; exit 1; }
+	@PROVIDER=$${PROVIDER:-openai} bash ../examples/aider-demo/run.sh
+
+aider-demo-stop: ## Stop the background edge proxy started by aider-demo
+	@if [ -f $(EDGE_PROXY_PID) ]; then \
+	  kill $$(cat $(EDGE_PROXY_PID)) 2>/dev/null || true; \
+	  rm -f $(EDGE_PROXY_PID); \
+	  echo "edge-proxy stopped"; \
+	else echo "no edge-proxy PID file at $(EDGE_PROXY_PID)"; fi
 
 test: ## Run gateway unit tests (pure mapping logic, no infra)
 	cd gateway && uv run --extra dev pytest -q

--- a/infra/clickhouse/config.d/storage.xml
+++ b/infra/clickhouse/config.d/storage.xml
@@ -8,9 +8,10 @@
 
     hot  -> the built-in `default` disk (fresh inserts land here)
     warm -> a second local disk (parts move here after the 7d TTL)
+    cold -> a third local disk (parts move here after the 30d TTL, deleted at 90d)
 
-  In production these map to SSD vs. cheaper object/block storage; locally both are just folders
-  under /var/lib/clickhouse so the TTL expression is valid and the table creates cleanly.
+  In production these map to SSD vs. cheaper object/block storage; locally all three are just
+  folders under /var/lib/clickhouse so the TTL expression is valid and the table creates cleanly.
 -->
 <clickhouse>
     <storage_configuration>
@@ -18,6 +19,9 @@
             <warm>
                 <path>/var/lib/clickhouse/warm/</path>
             </warm>
+            <cold>
+                <path>/var/lib/clickhouse/cold/</path>
+            </cold>
         </disks>
         <policies>
             <default>
@@ -28,6 +32,9 @@
                     <warm>
                         <disk>warm</disk>
                     </warm>
+                    <cold>
+                        <disk>cold</disk>
+                    </cold>
                 </volumes>
             </default>
         </policies>

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -37,6 +37,12 @@ type Config struct {
 	// TenantHeader names the control header carrying the ai-tally tenant key (default X-Tenant-Key).
 	// It is stripped before the request leaves for the upstream provider.
 	TenantHeader string
+	// FeatureTagHeader names an optional control header carrying a per-request feature/agent tag
+	// (default X-Tally-Feature-Tag). Like TenantHeader, it is stripped before the request leaves for
+	// the upstream provider; its value is recorded on the TraceRecord so downstream telemetry can
+	// segment traffic by feature (CTO-104). Unlike the tenant key, the feature tag is purely
+	// informational — missing/empty is fine and never rejected.
+	FeatureTagHeader string
 	// RequireTenant rejects requests missing TenantHeader with 400 when true.
 	RequireTenant bool
 	// UpstreamTimeout bounds a single forwarded request end-to-end (0 = no timeout, for streaming).
@@ -61,9 +67,10 @@ type Config struct {
 
 // Defaults applied when the corresponding env var is unset.
 const (
-	DefaultListenAddr   = ":8088"
-	DefaultUpstream     = "https://api.openai.com"
-	DefaultTenantHeader = "X-Tenant-Key"
+	DefaultListenAddr       = ":8088"
+	DefaultUpstream         = "https://api.openai.com"
+	DefaultTenantHeader     = "X-Tenant-Key"
+	DefaultFeatureTagHeader = "X-Tally-Feature-Tag"
 	// DefaultUpstreamTimeout is generous because LLM completions are slow and may stream for
 	// minutes; the proxy must not be the thing that cuts a long generation short.
 	DefaultUpstreamTimeout = 10 * time.Minute
@@ -77,12 +84,13 @@ type Env func(key string) string
 // FromEnv resolves and validates a Config from the given lookup function.
 func FromEnv(lookup Env) (Config, error) {
 	cfg := Config{
-		ListenAddr:      firstNonEmpty(lookup("EDGE_PROXY_LISTEN"), DefaultListenAddr),
-		TenantHeader:    firstNonEmpty(lookup("EDGE_PROXY_TENANT_HEADER"), DefaultTenantHeader),
-		UpstreamTimeout: DefaultUpstreamTimeout,
-		Mode:            ModePassthrough,
-		BrokerTTL:       DefaultBrokerTTL,
-		TelemetryURL:    lookup("EDGE_PROXY_TELEMETRY_URL"),
+		ListenAddr:       firstNonEmpty(lookup("EDGE_PROXY_LISTEN"), DefaultListenAddr),
+		TenantHeader:     firstNonEmpty(lookup("EDGE_PROXY_TENANT_HEADER"), DefaultTenantHeader),
+		FeatureTagHeader: firstNonEmpty(lookup("EDGE_PROXY_FEATURE_TAG_HEADER"), DefaultFeatureTagHeader),
+		UpstreamTimeout:  DefaultUpstreamTimeout,
+		Mode:             ModePassthrough,
+		BrokerTTL:        DefaultBrokerTTL,
+		TelemetryURL:     lookup("EDGE_PROXY_TELEMETRY_URL"),
 	}
 
 	rawUpstream := firstNonEmpty(lookup("EDGE_PROXY_UPSTREAM"), DefaultUpstream)

--- a/infra/edge-proxy/internal/config/config_test.go
+++ b/infra/edge-proxy/internal/config/config_test.go
@@ -140,6 +140,26 @@ func TestBrokerModeAccepted(t *testing.T) {
 	}
 }
 
+func TestFeatureTagHeaderDefault(t *testing.T) {
+	cfg, err := FromEnv(envMap(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.FeatureTagHeader != DefaultFeatureTagHeader {
+		t.Errorf("FeatureTagHeader = %q, want %q", cfg.FeatureTagHeader, DefaultFeatureTagHeader)
+	}
+}
+
+func TestFeatureTagHeaderOverride(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_FEATURE_TAG_HEADER": "X-Feature"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.FeatureTagHeader != "X-Feature" {
+		t.Errorf("FeatureTagHeader = %q", cfg.FeatureTagHeader)
+	}
+}
+
 func TestInvalidMode(t *testing.T) {
 	if _, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_MODE": "sideways"})); err == nil {
 		t.Fatal("expected error for invalid mode")

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -112,6 +112,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"missing tenant key"}`+"\n", http.StatusBadRequest)
 		return
 	}
+	// Feature tag is optional: capture if present, never reject when absent.
+	var featureTag string
+	if p.cfg.FeatureTagHeader != "" {
+		featureTag = r.Header.Get(p.cfg.FeatureTagHeader)
+	}
 
 	start := p.now()
 
@@ -139,9 +144,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Body = &countingReadCloser{inner: r.Body, n: &reqBytes}
 	}
 
-	// Strip our control header so the upstream provider never sees ai-tally internals. Everything
+	// Strip our control headers so the upstream provider never sees ai-tally internals. Everything
 	// else (including the customer's Authorization key) is forwarded unmodified.
 	r.Header.Del(p.cfg.TenantHeader)
+	if p.cfg.FeatureTagHeader != "" {
+		r.Header.Del(p.cfg.FeatureTagHeader)
+	}
 
 	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 	// Mark whether the upstream was reachable so the telemetry copy can distinguish a real 502
@@ -151,6 +159,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	p.sink.Record(TraceRecord{
 		TenantKey:  tenant,
+		FeatureTag: featureTag,
 		Method:     r.Method,
 		Path:       r.URL.Path,
 		StatusCode: rec.status,

--- a/infra/edge-proxy/internal/proxy/proxy_test.go
+++ b/infra/edge-proxy/internal/proxy/proxy_test.go
@@ -305,6 +305,55 @@ func TestStreamingPassThrough(t *testing.T) {
 	}
 }
 
+// TestFeatureTagHeaderRecordedAndStripped is CTO-104's structural guarantee: a per-request
+// feature tag arriving on X-Tally-Feature-Tag is captured on the TraceRecord and stripped from
+// the upstream-bound request — mirroring the tenant-header contract.
+func TestFeatureTagHeaderRecordedAndStripped(t *testing.T) {
+	var sawFeatureHeader bool
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawFeatureHeader = r.Header["X-Tally-Feature-Tag"]
+		w.WriteHeader(http.StatusOK)
+	})
+	front, sink := newTestProxy(t, false, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	req.Header.Set("X-Tenant-Key", "tk_live_acme")
+	req.Header.Set("X-Tally-Feature-Tag", "aider-demo")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	if sawFeatureHeader {
+		t.Error("X-Tally-Feature-Tag leaked to upstream")
+	}
+	if got := sink.last().FeatureTag; got != "aider-demo" {
+		t.Errorf("FeatureTag = %q, want %q", got, "aider-demo")
+	}
+}
+
+// TestFeatureTagHeaderAbsent: when the caller omits the header, FeatureTag is empty and the
+// request still succeeds — feature tagging is purely opt-in, never required.
+func TestFeatureTagHeaderAbsent(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	front, sink := newTestProxy(t, false, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	req.Header.Set("X-Tenant-Key", "tk_live_acme")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := sink.last().FeatureTag; got != "" {
+		t.Errorf("FeatureTag = %q, want empty", got)
+	}
+}
+
 // TestTraceRecordCarriesNoBodyContent is a structural guard: the telemetry type must not gain a
 // field that could hold prompt/completion/key content. If someone adds a `Body string`, this fails.
 func TestTraceRecordCarriesNoBodyContent(t *testing.T) {

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -14,8 +14,12 @@ import (
 type TraceRecord struct {
 	// TenantKey is the ai-tally tenant identifier from the control header (X-Tenant-Key).
 	TenantKey string
-	Method    string
-	Path      string
+	// FeatureTag is the per-request feature/agent identifier from the control header
+	// (X-Tally-Feature-Tag). Optional and informational only — empty when the caller didn't tag
+	// the request. Downstream telemetry uses this to segment cost and traces by feature (CTO-104).
+	FeatureTag string
+	Method     string
+	Path       string
 	// StatusCode is the upstream response status relayed to the client (0 if the upstream failed
 	// before any status, e.g. connection refused — see Failed).
 	StatusCode int

--- a/infra/edge-proxy/internal/telemetry/telemetry.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry.go
@@ -37,6 +37,7 @@ const (
 type wireRecord struct {
 	Deployment  Deployment `json:"deployment"`
 	TenantKey   string     `json:"tenant_key"`
+	FeatureTag  string     `json:"feature_tag"`
 	Method      string     `json:"method"`
 	Path        string     `json:"path"`
 	StatusCode  int        `json:"status_code"`
@@ -51,6 +52,7 @@ func toWire(dep Deployment, rec proxy.TraceRecord) wireRecord {
 	return wireRecord{
 		Deployment:  dep,
 		TenantKey:   rec.TenantKey,
+		FeatureTag:  rec.FeatureTag,
 		Method:      rec.Method,
 		Path:        rec.Path,
 		StatusCode:  rec.StatusCode,

--- a/infra/edge-proxy/internal/telemetry/telemetry_test.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry_test.go
@@ -78,7 +78,8 @@ func TestEncodeCarriesNoBodyContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	allowed := map[string]bool{
-		"deployment": true, "tenant_key": true, "method": true, "path": true,
+		"deployment": true, "tenant_key": true, "feature_tag": true,
+		"method": true, "path": true,
 		"status_code": true, "req_bytes": true, "resp_bytes": true,
 		"duration_ns": true, "started_at_ns": true, "failed": true,
 	}

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -18,9 +18,19 @@ interface AgentsPayload {
   reconcilerLastRunMinutesAgo: number;
 }
 
-export default async function AgentsPage() {
+export default async function AgentsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ tag?: string; run?: string }>;
+}) {
+  // Forward ?tag= / ?run= to the API so the table is pre-filtered (CTO-104 deep links).
+  const sp = (await searchParams) ?? {};
+  const qs = new URLSearchParams();
+  if (sp.tag) qs.set("tag", sp.tag);
+  if (sp.run) qs.set("run", sp.run);
+  const query = qs.toString() ? `?${qs.toString()}` : "";
   const { agents, runs, reconcilerLastRunMinutesAgo } =
-    await apiGet<AgentsPayload>("/api/agents");
+    await apiGet<AgentsPayload>(`/api/agents${query}`);
 
   // Agents presents reconciled per-agent cost, so it carries a freshness boundary like Cost/Features.
   const reconciledThrough = boundaryFromMinutesAgo(reconcilerLastRunMinutesAgo);

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { agents, RECONCILER_LAST_RUN_MINUTES_AGO, runs } from "@/lib/agents";
 import { queryAgents } from "@/lib/clickhouse";
@@ -8,12 +8,14 @@ import { queryAgents } from "@/lib/clickhouse";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET(req: NextRequest) {
+export async function GET(req: Request) {
   // Optional URL filters (CTO-104): /api/agents?tag=aider-demo&run=<trace>. Empty values pass
   // through and the SQL clause is dropped. When a filter is set and live data is unavailable,
   // return empty rather than the unfiltered mock (which would mislead the demo).
-  const tag = req.nextUrl.searchParams.get("tag") ?? "";
-  const run = req.nextUrl.searchParams.get("run") ?? "";
+  // Use the standard URL API rather than NextRequest.nextUrl so unit tests can pass plain Request.
+  const { searchParams } = new URL(req.url);
+  const tag = searchParams.get("tag") ?? "";
+  const run = searchParams.get("run") ?? "";
   const hasFilter = Boolean(tag || run);
   const live = await queryAgents({ tag, run });
   return NextResponse.json({

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { agents, RECONCILER_LAST_RUN_MINUTES_AGO, runs } from "@/lib/agents";
 import { queryAgents } from "@/lib/clickhouse";
@@ -8,11 +8,17 @@ import { queryAgents } from "@/lib/clickhouse";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
-  const live = await queryAgents();
+export async function GET(req: NextRequest) {
+  // Optional URL filters (CTO-104): /api/agents?tag=aider-demo&run=<trace>. Empty values pass
+  // through and the SQL clause is dropped. When a filter is set and live data is unavailable,
+  // return empty rather than the unfiltered mock (which would mislead the demo).
+  const tag = req.nextUrl.searchParams.get("tag") ?? "";
+  const run = req.nextUrl.searchParams.get("run") ?? "";
+  const hasFilter = Boolean(tag || run);
+  const live = await queryAgents({ tag, run });
   return NextResponse.json({
-    agents: live && live.agents.length > 0 ? live.agents : agents,
-    runs: live && live.runs.length > 0 ? live.runs : runs,
+    agents: live && live.agents.length > 0 ? live.agents : hasFilter ? [] : agents,
+    runs: live && live.runs.length > 0 ? live.runs : hasFilter ? [] : runs,
     reconcilerLastRunMinutesAgo: RECONCILER_LAST_RUN_MINUTES_AGO,
   });
 }

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -33,7 +33,7 @@ describe("api routes", () => {
 
   it("GET /api/agents returns agents + runs + reconciler freshness", async () => {
     const body = await json<{ agents: unknown[]; runs: unknown[]; reconcilerLastRunMinutesAgo: number }>(
-      await AgentsGET(),
+      await AgentsGET(new Request("http://test/api/agents") as never),
     );
     expect(body.agents.length).toBeGreaterThan(0);
     expect(body.runs.length).toBeGreaterThan(0);
@@ -54,7 +54,9 @@ describe("api routes", () => {
   });
 
   it("GET /api/cost returns series + featureRows + alerts", async () => {
-    const body = await json<{ series: unknown; featureRows: unknown[]; alerts: unknown[] }>(await CostGET());
+    const body = await json<{ series: unknown; featureRows: unknown[]; alerts: unknown[] }>(
+      await CostGET(new Request("http://test/api/cost") as never),
+    );
     expect(body.series).toBeDefined();
     expect(body.featureRows.length).toBeGreaterThan(0);
   });

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { costSeries, featureRows, hiddenCostAlerts } from "@/lib/cost";
 import { queryCostSeries, queryFeatureCostRows } from "@/lib/clickhouse";
@@ -7,13 +7,21 @@ import { queryCostSeries, queryFeatureCostRows } from "@/lib/clickhouse";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
-  const [series, rows] = await Promise.all([queryCostSeries(), queryFeatureCostRows()]);
+export async function GET(req: NextRequest) {
+  // Optional ?tag=<feature> filter (CTO-104): narrows both the series and the feature-row table to
+  // a single feature tag. When the filter is set we never fall back to unfiltered mock — that would
+  // misrepresent the filtered view as real data.
+  const tag = req.nextUrl.searchParams.get("tag") ?? "";
+  const hasFilter = Boolean(tag);
+  const [series, rows] = await Promise.all([
+    queryCostSeries({ tag }),
+    queryFeatureCostRows({ tag }),
+  ]);
   return NextResponse.json({
     series: series ?? costSeries,
-    featureRows: rows && rows.length > 0 ? rows : featureRows,
+    featureRows: rows && rows.length > 0 ? rows : hasFilter ? [] : featureRows,
     // Hidden-cost alerts are derived from cross-source comparison (not wired live yet); only show
     // the canned alert when we're serving mock data.
-    alerts: rows && rows.length > 0 ? [] : hiddenCostAlerts,
+    alerts: rows && rows.length > 0 ? [] : hasFilter ? [] : hiddenCostAlerts,
   });
 }

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { costSeries, featureRows, hiddenCostAlerts } from "@/lib/cost";
 import { queryCostSeries, queryFeatureCostRows } from "@/lib/clickhouse";
@@ -7,11 +7,12 @@ import { queryCostSeries, queryFeatureCostRows } from "@/lib/clickhouse";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET(req: NextRequest) {
+export async function GET(req: Request) {
   // Optional ?tag=<feature> filter (CTO-104): narrows both the series and the feature-row table to
   // a single feature tag. When the filter is set we never fall back to unfiltered mock — that would
   // misrepresent the filtered view as real data.
-  const tag = req.nextUrl.searchParams.get("tag") ?? "";
+  // Use the standard URL API rather than NextRequest.nextUrl so unit tests can pass plain Request.
+  const tag = new URL(req.url).searchParams.get("tag") ?? "";
   const hasFilter = Boolean(tag);
   const [series, rows] = await Promise.all([
     queryCostSeries({ tag }),

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -10,7 +10,15 @@ import { type Comparison, deltaPct } from "@/lib/compare";
 import { asOfLabel, boundaryFromMinutesAgo, deriveDataState, relativeAge } from "@/lib/dataState";
 import { formatUSD, type MicroUSD } from "@/lib/types";
 
-export default async function ComparePage() {
+export default async function ComparePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ tag?: string }>;
+}) {
+  // Parse ?tag= for URL stability across the CTO-104 deep-link set. The /api/compare data is
+  // mock-only today, so the filter is captured but doesn't yet narrow the comparison — CTO-105
+  // will wire it through to a tag-scoped replay.
+  await searchParams;
   const comparison = await apiGet<Comparison>("/api/compare");
   const { workload, current, candidates, recommendation, diagnostics } = comparison;
 

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -31,9 +31,16 @@ function sumLayer(rows: FeatureCostRow[], layer: Layer) {
   return rows.reduce((s, r) => s + r.byLayer[layer], 0);
 }
 
-export default async function CostPage() {
+export default async function CostPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ tag?: string }>;
+}) {
+  // Forward ?tag= to the API so the breakdown is pre-filtered to one feature (CTO-104).
+  const sp = (await searchParams) ?? {};
+  const query = sp.tag ? `?tag=${encodeURIComponent(sp.tag)}` : "";
   const { series: costSeries, featureRows, alerts: hiddenCostAlerts } =
-    await apiGet<CostPayload>("/api/cost");
+    await apiGet<CostPayload>(`/api/cost${query}`);
   const total = totalRange(costSeries);
   const reconciled = reconciledTotal(costSeries);
   const estimated = estimatedTotal(costSeries);

--- a/web/components/StackedBarChart.tsx
+++ b/web/components/StackedBarChart.tsx
@@ -14,10 +14,21 @@ export function StackedBarChart({ series }: { series: CostSeries }) {
   const plotW = W - PAD_L - PAD_R;
   const plotH = H - PAD_T - PAD_B;
   const n = series.days.length;
+  if (n === 0) {
+    return (
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="no data" className="w-full">
+        <text x={W / 2} y={H / 2} fontSize="12" fill="#8a93a6" textAnchor="middle">
+          no data for this filter yet
+        </text>
+      </svg>
+    );
+  }
   const barW = (plotW / n) * 0.7;
   const step = plotW / n;
 
-  const maxTotal = Math.max(...series.days.map(totalForDay));
+  // Guard against an all-zero series (filtered view with no cost): avoid dividing
+  // by zero in the height calc, which produces NaN and a React warning per <rect>.
+  const maxTotal = Math.max(1, ...series.days.map(totalForDay));
 
   // boundary x: just after the last reconciled day
   const reconciledIdx = series.days.findIndex((d) => d.date > series.reconciledThrough);

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -221,16 +221,18 @@ export async function queryDataQuality(): Promise<DataQuality | null> {
 
 // --- Cost workflow ------------------------------------------------------------------------------
 
-export async function queryCostSeries(): Promise<CostSeries | null> {
+export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSeries | null> {
   return tryLive(async (db, tenant) => {
-    const out = await rows<{ day: string; layer: Layer; cost: string }>(
+    const tag = filter?.tag ?? "";
+    const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
+    const out = await rowsP<{ day: string; layer: Layer; cost: string }>(
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY ${tagClause}
        GROUP BY day, layer
        ORDER BY day`,
-      tenant,
+      { tenant, tag },
     );
     // Pivot into one CostDayPoint per calendar day (fill gaps with zero layers).
     const byDay = new Map<string, CostDayPoint>();
@@ -253,15 +255,17 @@ export async function queryCostSeries(): Promise<CostSeries | null> {
   });
 }
 
-export async function queryFeatureCostRows(): Promise<FeatureCostRow[] | null> {
+export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<FeatureCostRow[] | null> {
   return tryLive(async (db, tenant) => {
-    const out = await rows<{ feature: string; layer: Layer; cost: string }>(
+    const tag = filter?.tag ?? "";
+    const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
+    const out = await rowsP<{ feature: string; layer: Layer; cost: string }>(
       db,
       `SELECT FeatureTag AS feature, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != '' ${tagClause}
        GROUP BY feature, layer`,
-      tenant,
+      { tenant, tag },
     );
     const byFeature = new Map<string, FeatureCostRow>();
     for (const r of out) {
@@ -489,16 +493,20 @@ function buildRun(agg: RunAgg, spans: RunSpan[], agentMedian: number): AgentRun 
 }
 
 /** Per-agent summaries + the top expensive runs (with span trees), built from otel_spans. */
-export async function queryAgents(): Promise<{ agents: AgentSummary[]; runs: AgentRun[] } | null> {
+export async function queryAgents(filter?: { tag?: string; run?: string }): Promise<{ agents: AgentSummary[]; runs: AgentRun[] } | null> {
   return tryLive(async (db, tenant) => {
-    const aggs = await rows<RunAgg>(
+    const tag = filter?.tag ?? "";
+    const run = filter?.run ?? "";
+    const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
+    const runClause = run ? "AND TraceId = {run:String}" : "";
+    const aggs = await rowsP<RunAgg>(
       db,
       `SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost,
               count() AS steps, max(StatusCode) AS maxStatus, toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != '' ${tagClause} ${runClause}
        GROUP BY TraceId`,
-      tenant,
+      { tenant, tag, run },
     );
     if (aggs.length === 0) return { agents: [], runs: [] };
 

--- a/web/lib/types.test.ts
+++ b/web/lib/types.test.ts
@@ -11,4 +11,17 @@ describe("formatUSD", () => {
   it("formats large values with separators", () => {
     expect(formatUSD(14_820_000_000)).toBe("$14,820.00");
   });
+
+  it("uses 4 decimals for sub-cent values so AI per-call costs don't floor to zero", () => {
+    expect(formatUSD(3_200)).toBe("$0.0032");
+    expect(formatUSD(100)).toBe("$0.0001");
+  });
+
+  it("uses 3 decimals between one cent and one dollar", () => {
+    expect(formatUSD(125_000)).toBe("$0.125");
+  });
+
+  it("keeps zero at 2 decimals", () => {
+    expect(formatUSD(0)).toBe("$0.00");
+  });
 });

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -6,7 +6,21 @@ export type MicroUSD = number; // integer micro-dollars (1e-6 USD)
 
 export function formatUSD(micro: MicroUSD): string {
   const usd = micro / 1_000_000;
-  return usd.toLocaleString("en-US", { style: "currency", currency: "USD" });
+  // Per-call AI costs are routinely sub-cent. The default 2-decimal currency
+  // format would floor $0.0032 to "$0.00" and erase the signal. Scale precision
+  // to the value: small numbers get up to 4 decimals, large ones stay at 2.
+  const abs = Math.abs(usd);
+  let fractionDigits: number;
+  if (abs === 0) fractionDigits = 2;
+  else if (abs < 0.01) fractionDigits = 4;
+  else if (abs < 1) fractionDigits = 3;
+  else fractionDigits = 2;
+  return usd.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
 }
 
 export interface SpendByLayer {


### PR DESCRIPTION
## Summary

Implements [CTO-104](https://linear.app/cto-assist/issue/CTO-104) — a one-command live demo (\`make aider-demo\`) that runs Aider against a fixture repo through the ai-tally edge proxy and surfaces real agent-loop telemetry in the dashboard. Verified end-to-end against Anthropic.

## Commits (read in order)

| # | What |
|---|---|
| 49837ed | Thread \`X-Tally-Feature-Tag\` header through the edge proxy (config, request path, \`TraceRecord\`, tests) |
| 60b5515 | Query-param filters (\`?tag=\`, \`?run=\`) on \`/agents\`, \`/cost\`, \`/compare\` so deep links land pre-filtered |
| 539e133 | \`examples/aider-demo/\` — fixture target repo, three tasks, \`run.sh\`, \`reset.sh\`, \`_emit_batch.py\`, README |
| a72731e | \`make aider-demo\` + \`make aider-demo-stop\` in the Makefile, README/RUNNING.md wired to the new flow |
| 854f246 | Fix-ups from live verification: run.sh turn-count parsing, bash 3.2 array indexing, Anthropic provider wiring, LiteLLM model prefix, surfaced Aider failures, \`aider-live.sh\` for interactive runs |
| 0d90099 | Add \`cold\` volume to ClickHouse \`storage.xml\` (pre-existing repo mismatch — \`otel_spans.sql\` TTL referenced an undefined volume) |
| bf54869 | Dashboard: adaptive USD precision so per-call \`$0.0032\` no longer floors to \`$0.00\`; guard StackedBarChart against empty/zero filtered views |
| 8de41bc | gitignore \`.aider.*\` session artifacts |

## What works today

- \`make aider-demo\` brings up the proxy, runs three Aider tasks (single-file fix → cross-file refactor → feature+tests), emits feature-tagged spans, and auto-opens \`/agents?tag=aider-demo\`
- \`make aider-demo PROVIDER=anthropic\` runs the same tasks against Claude
- \`bash examples/aider-demo/aider-live.sh\` runs Aider interactively with a background loop that emits one batch per Aider turn — refresh the dashboard tab between turns to see live updates

## Known caveats (called out in code + commits)

- **Edge-proxy → \`otel_spans\` bridge doesn't exist yet.** The proxy still sees real traffic, but \`run.sh\` / \`aider-live.sh\` post a feature-tagged batch to \`/v1/batches\` per Aider turn so the dashboard has rows. CTO-40/41-era follow-up.
- **Price-catalog miss workaround in \`_emit_batch.py\`.** The seed catalog only knows \`gpt-5-mini\` and \`gpt-5\`. Emitted spans are pinned to \`gpt-5-mini\` with back-computed output tokens so the dashboard cost matches Aider's. Real provider stashed in \`aider.real_provider\`. Proper fix tracked in [CTO-106](https://linear.app/cto-assist/issue/CTO-106).
- **\`/compare?tag=\`** is parsed but not narrowed — that route is mock today. Param captured for URL stability so CTO-105 can wire it through.
- **Pages don't stream.** Refresh the dashboard tab to see new spans.

## Test plan

- [x] \`cd infra/edge-proxy && go test ./...\`
- [x] \`cd web && npm run build && npx vitest run\`
- [x] \`cd infra && make up && make seed && cd .. && OPENAI_API_KEY=sk-... make -C infra aider-demo\` — three tasks complete, dashboard shows \`aider-demo\` feature tag with non-zero cost
- [x] \`make -C infra aider-demo PROVIDER=anthropic\` — same, against Claude
- [x] \`bash examples/aider-demo/aider-live.sh\` — interactive Aider; emit loop posts one batch per turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)