### PR TITLE
CTO-107: per-tenant connector declarations stop the false-alarm Partial Data banner

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -185,7 +185,6 @@ When you're done: `make chatbot-demo-stop` kills the chatbot dev server.
 | `Database tally does not exist` | Gateway pointed at the wrong DB. Use `TALLY_CLICKHOUSE_DB=default` (the compose gateway already does). |
 | Dashboard shows the **"mock data"** badge | A page's ClickHouse query failed and fell back to mock. Check `make logs` and that step 3's count is non-zero. |
 | Dashboard empty despite ingested rows | Tenant mismatch — the UI reads `local-dev`. Post with `tenant_id: local-dev` (or set `TALLY_TENANT_ID` for the web app). |
-| **"Partial data"** banner | Expected: only LLM spans exist, so vector/tools/compute cost layers are zero until those connectors are wired. Not an error. |
 
 ## Make targets (run from `infra/`)
 

--- a/db/postgres/0002_tenant_connectors.sql
+++ b/db/postgres/0002_tenant_connectors.sql
@@ -1,0 +1,22 @@
+-- Per-tenant declared cost-layer connectors (CTO-107).
+--
+-- The dashboard "Partial data" banner used to fire whenever any cost layer reported zero, which
+-- made it permanent on every demo (only the LLM connector is wired today) and trained users to
+-- ignore it. We fix that by declaring which connectors a tenant has actually enabled: the banner
+-- now fires only for *declared* layers that go silent.
+--
+-- One row per (tenant_id, layer). A NULL disabled_at means the connector is currently enabled;
+-- a non-NULL disabled_at means the tenant turned it off (kept as a tombstone for audit). The row
+-- itself is the audit trail — enabled_at / disabled_at / notes — so toggles never delete history.
+
+CREATE TABLE IF NOT EXISTS tenant_connectors (
+    tenant_id    UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    layer        TEXT NOT NULL
+                     CHECK (layer IN ('llm','vector','tools','compute','embeddings','egress')),
+    enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    disabled_at  TIMESTAMPTZ,
+    notes        TEXT,
+    PRIMARY KEY (tenant_id, layer)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_connectors_tenant ON tenant_connectors(tenant_id);

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ../db/postgres/0001_control_plane.sql:/docker-entrypoint-initdb.d/0001_control_plane.sql:ro
+      - ../db/postgres/0002_tenant_connectors.sql:/docker-entrypoint-initdb.d/0002_tenant_connectors.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -50,6 +50,7 @@ from gateway.protocol import (
 )
 from gateway.ratelimit import RateLimiter
 from gateway.store import ClickHouseStore
+from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.validation import SpanValidator, span_item_id
 
 logger = logging.getLogger("tally.gateway")
@@ -61,6 +62,7 @@ async def lifespan(app: FastAPI):
     app.state.settings = settings
     app.state.store = ClickHouseStore(settings)
     app.state.auth = ApiKeyAuth(settings)
+    app.state.tenant_connectors = TenantConnectorStore(settings)
     app.state.catalog = seed_catalog()
     app.state.idempotency = IdempotencyCache(ttl_seconds=settings.idempotency_ttl_s)
     app.state.limiter = RateLimiter(
@@ -469,6 +471,87 @@ def get_usage(
 
     record = metering.usage(tenant_id, period)
     return JSONResponse(record.as_dict(), status_code=200)
+
+
+def _resolve_tenant_for_control_plane(
+    authorization: str | None, x_tenant_id: str | None
+) -> str:
+    """Shared tenant-resolution for read/write control-plane endpoints.
+
+    Same pattern as :func:`get_usage`: bearer key when auth is on, ``X-Tenant-Id`` header in dev.
+    Refuses ambiguity so the caller can never accidentally cross tenants.
+    """
+    settings = app.state.settings
+    auth: ApiKeyAuth = app.state.auth
+    if settings.require_api_key:
+        if not authorization or not authorization.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="missing bearer token")
+        token = authorization.split(" ", 1)[1].strip()
+        tenant_id = auth.tenant_for_key(token)
+        if tenant_id is None:
+            raise HTTPException(status_code=403, detail="invalid api key")
+        return tenant_id
+    if not x_tenant_id:
+        raise HTTPException(status_code=422, detail="X-Tenant-Id required when auth is disabled")
+    return x_tenant_id
+
+
+@app.get("/v1/tenant/connectors")
+def list_tenant_connectors(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """List declared cost-layer connectors for the caller's tenant (CTO-107).
+
+    The dashboard consumes this to decide whether the "Partial data" banner should fire: only
+    *enabled* layers count as a real gap when they report zero. Layers the tenant never enabled
+    don't appear in the response and don't contribute to partiality.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantConnectorStore = app.state.tenant_connectors
+    rows = store.list(tenant_id)
+    return JSONResponse(
+        {
+            "tenant_id": tenant_id,
+            "connectors": [r.as_dict() for r in rows],
+            "enabled_layers": [r.layer for r in rows if r.enabled],
+        },
+        status_code=200,
+    )
+
+
+@app.post("/v1/tenant/connectors")
+async def set_tenant_connector(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Enable or disable one cost-layer connector for the caller's tenant.
+
+    Body: ``{"layer": "vector", "enabled": true, "notes": "optional"}``. Idempotent — re-enabling an
+    already-enabled connector is a no-op, disabling an absent one stamps a tombstone row.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    layer = body.get("layer")
+    enabled = body.get("enabled")
+    notes = body.get("notes")
+    if not isinstance(layer, str) or layer not in ALLOWED_LAYERS:
+        raise HTTPException(
+            status_code=422, detail=f"layer must be one of {sorted(ALLOWED_LAYERS)}"
+        )
+    if not isinstance(enabled, bool):
+        raise HTTPException(status_code=422, detail="enabled must be a boolean")
+    if notes is not None and not isinstance(notes, str):
+        raise HTTPException(status_code=422, detail="notes must be a string when provided")
+    store: TenantConnectorStore = app.state.tenant_connectors
+    row = store.set(tenant_id, layer, enabled=enabled, notes=notes)
+    return JSONResponse({"tenant_id": tenant_id, "connector": row.as_dict()}, status_code=200)
 
 
 def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, Any]:

--- a/infra/gateway/src/gateway/seed.py
+++ b/infra/gateway/src/gateway/seed.py
@@ -19,6 +19,9 @@ from gateway.config import get_settings
 _TENANT_NAME = "local-dev"
 _REGION = "local"
 _FEATURE_TAGS = ["assistant", "search", "summarize"]
+# Cost-layer connectors enabled out of the box. Only `llm` is wired today — the rest stay un-enabled
+# so the "Partial data" banner doesn't fire on a fresh stack (CTO-107).
+_ENABLED_LAYERS = ["llm"]
 
 
 def seed() -> None:
@@ -70,6 +73,15 @@ def seed() -> None:
                 ON CONFLICT (tenant_id, tag) DO NOTHING
                 """,
                 (tenant_id, tag, f"{tag} feature (seeded)"),
+            )
+        for layer in _ENABLED_LAYERS:
+            cur.execute(
+                """
+                INSERT INTO tenant_connectors (tenant_id, layer, notes)
+                VALUES (%s, %s, 'seeded')
+                ON CONFLICT (tenant_id, layer) DO UPDATE SET disabled_at = NULL
+                """,
+                (tenant_id, layer),
             )
         conn.commit()
 

--- a/infra/gateway/src/gateway/tenant_connectors.py
+++ b/infra/gateway/src/gateway/tenant_connectors.py
@@ -1,0 +1,132 @@
+"""Per-tenant cost-layer connector declarations (CTO-107).
+
+The dashboard "Partial data" banner used to fire whenever any cost layer reported zero. With only
+the LLM connector wired today, the banner was permanent — useless as a signal. We fix that by
+declaring per-tenant which connectors are *enabled*; the banner now fires only when an enabled
+connector goes silent. A layer that was never enabled doesn't contribute to partiality.
+
+This module is the small Postgres surface the gateway exposes to the dashboard. Reads and writes
+both go through ``GET/POST /v1/tenant/connectors`` — the web app never touches Postgres directly.
+The row itself is the audit trail: ``enabled_at`` / ``disabled_at`` / ``notes`` are kept around so
+toggles never delete history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import psycopg
+
+from gateway.config import Settings
+
+# The cost-layer enum mirrors the same six layers the web app and ClickHouse use.
+Layer = Literal["llm", "vector", "tools", "compute", "embeddings", "egress"]
+ALLOWED_LAYERS: frozenset[str] = frozenset(
+    {"llm", "vector", "tools", "compute", "embeddings", "egress"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorDeclaration:
+    """One (tenant, layer) row — enabled when ``disabled_at is None``."""
+
+    layer: str
+    enabled: bool
+    enabled_at: str
+    disabled_at: str | None
+    notes: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "layer": self.layer,
+            "enabled": self.enabled,
+            "enabled_at": self.enabled_at,
+            "disabled_at": self.disabled_at,
+            "notes": self.notes,
+        }
+
+
+class TenantConnectorStore:
+    """Tiny Postgres-backed CRUD over ``tenant_connectors``.
+
+    Kept narrow on purpose: every method takes the tenant_id resolved by upstream auth, so the SQL
+    can't accidentally cross tenants.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def list(self, tenant_id: str) -> list[ConnectorDeclaration]:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT layer, enabled_at, disabled_at, notes
+                FROM tenant_connectors
+                WHERE tenant_id = %s
+                ORDER BY layer
+                """,
+                (tenant_id,),
+            )
+            return [
+                ConnectorDeclaration(
+                    layer=str(row[0]),
+                    enabled=row[2] is None,
+                    enabled_at=row[1].isoformat() if row[1] is not None else "",
+                    disabled_at=row[2].isoformat() if row[2] is not None else None,
+                    notes=row[3],
+                )
+                for row in cur.fetchall()
+            ]
+
+    def set(
+        self,
+        tenant_id: str,
+        layer: str,
+        *,
+        enabled: bool,
+        notes: str | None = None,
+    ) -> ConnectorDeclaration:
+        """Enable or disable one layer for a tenant. Idempotent.
+
+        Enabling re-uses the existing row (clears ``disabled_at``, keeps the original ``enabled_at``)
+        so the row remains a single audit-friendly record of intent. Disabling stamps ``disabled_at``
+        with ``now()`` — we never delete, so the history is intact.
+        """
+        if layer not in ALLOWED_LAYERS:
+            raise ValueError(f"unknown layer '{layer}'")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            if enabled:
+                cur.execute(
+                    """
+                    INSERT INTO tenant_connectors (tenant_id, layer, notes)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (tenant_id, layer) DO UPDATE
+                      SET disabled_at = NULL,
+                          notes = COALESCE(EXCLUDED.notes, tenant_connectors.notes)
+                    RETURNING layer, enabled_at, disabled_at, notes
+                    """,
+                    (tenant_id, layer, notes),
+                )
+            else:
+                cur.execute(
+                    """
+                    INSERT INTO tenant_connectors (tenant_id, layer, disabled_at, notes)
+                    VALUES (%s, %s, now(), %s)
+                    ON CONFLICT (tenant_id, layer) DO UPDATE
+                      SET disabled_at = now(),
+                          notes = COALESCE(EXCLUDED.notes, tenant_connectors.notes)
+                    RETURNING layer, enabled_at, disabled_at, notes
+                    """,
+                    (tenant_id, layer, notes),
+                )
+            row = cur.fetchone()
+            conn.commit()
+            assert row is not None
+            return ConnectorDeclaration(
+                layer=str(row[0]),
+                enabled=row[2] is None,
+                enabled_at=row[1].isoformat() if row[1] is not None else "",
+                disabled_at=row[2].isoformat() if row[2] is not None else None,
+                notes=row[3],
+            )

--- a/infra/gateway/tests/test_app_tenant_connectors.py
+++ b/infra/gateway/tests/test_app_tenant_connectors.py
@@ -1,0 +1,176 @@
+"""GET/POST /v1/tenant/connectors — list + toggle declared cost-layer connectors (CTO-107)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_connectors import ALLOWED_LAYERS, ConnectorDeclaration
+
+T = "t-acme"
+
+
+class FakeStore:
+    """In-memory stand-in for :class:`TenantConnectorStore` — no Postgres required."""
+
+    def __init__(self) -> None:
+        # (tenant_id, layer) -> ConnectorDeclaration
+        self._rows: dict[tuple[str, str], ConnectorDeclaration] = {}
+
+    def list(self, tenant_id: str) -> list[ConnectorDeclaration]:
+        return sorted(
+            [r for (t, _), r in self._rows.items() if t == tenant_id],
+            key=lambda r: r.layer,
+        )
+
+    def set(
+        self,
+        tenant_id: str,
+        layer: str,
+        *,
+        enabled: bool,
+        notes: str | None = None,
+    ) -> ConnectorDeclaration:
+        if layer not in ALLOWED_LAYERS:
+            raise ValueError(f"unknown layer '{layer}'")
+        now = datetime.now(tz=timezone.utc).isoformat()
+        existing = self._rows.get((tenant_id, layer))
+        enabled_at = existing.enabled_at if existing else now
+        if enabled:
+            disabled_at = None
+        else:
+            disabled_at = now
+        row = ConnectorDeclaration(
+            layer=layer,
+            enabled=enabled,
+            enabled_at=enabled_at,
+            disabled_at=disabled_at,
+            notes=notes if notes is not None else (existing.notes if existing else None),
+        )
+        self._rows[(tenant_id, layer)] = row
+        return row
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_connectors = FakeStore()
+        yield c
+
+
+def test_list_empty_for_fresh_tenant(client: TestClient) -> None:
+    r = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": T})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["tenant_id"] == T
+    assert body["connectors"] == []
+    assert body["enabled_layers"] == []
+
+
+def test_enable_disable_round_trip(client: TestClient) -> None:
+    # Enable two layers
+    r = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "llm", "enabled": True, "notes": "primary"},
+    )
+    assert r.status_code == 200
+    assert r.json()["connector"]["enabled"] is True
+
+    r = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "vector", "enabled": True},
+    )
+    assert r.status_code == 200
+
+    listing = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": T}).json()
+    assert sorted(listing["enabled_layers"]) == ["llm", "vector"]
+
+    # Disable vector — it should remain in the list as a tombstone, but not in enabled_layers
+    r = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "vector", "enabled": False, "notes": "turned off"},
+    )
+    assert r.status_code == 200
+    assert r.json()["connector"]["enabled"] is False
+    assert r.json()["connector"]["disabled_at"] is not None
+
+    listing = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": T}).json()
+    assert listing["enabled_layers"] == ["llm"]
+    # The disabled row is still present in the audit list.
+    vector_rows = [c for c in listing["connectors"] if c["layer"] == "vector"]
+    assert len(vector_rows) == 1
+    assert vector_rows[0]["enabled"] is False
+    assert vector_rows[0]["notes"] == "turned off"
+
+
+def test_re_enable_clears_disabled_at(client: TestClient) -> None:
+    client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "vector", "enabled": True},
+    )
+    client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "vector", "enabled": False},
+    )
+    r = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "vector", "enabled": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["connector"]["enabled"] is True
+    assert r.json()["connector"]["disabled_at"] is None
+
+
+def test_unknown_layer_is_rejected(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "quantum", "enabled": True},
+    )
+    assert r.status_code == 422
+
+
+def test_missing_enabled_is_rejected(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": T},
+        json={"layer": "llm"},
+    )
+    assert r.status_code == 422
+
+
+def test_requires_tenant_when_auth_disabled(client: TestClient) -> None:
+    assert client.get("/v1/tenant/connectors").status_code == 422
+    assert (
+        client.post(
+            "/v1/tenant/connectors", json={"layer": "llm", "enabled": True}
+        ).status_code
+        == 422
+    )
+
+
+def test_tenant_isolation(client: TestClient) -> None:
+    client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": "t-a"},
+        json={"layer": "llm", "enabled": True},
+    )
+    client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": "t-b"},
+        json={"layer": "vector", "enabled": True},
+    )
+    a = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": "t-a"}).json()
+    b = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": "t-b"}).json()
+    assert a["enabled_layers"] == ["llm"]
+    assert b["enabled_layers"] == ["vector"]

--- a/web/app/connectors/ConnectorToggle.tsx
+++ b/web/app/connectors/ConnectorToggle.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// Client toggle for one cost-layer connector (CTO-107). Posts to the gateway via a server action,
+// then shows an inline confirmation. Disabled layers stop contributing to the "Partial data" banner
+// on /cost and /home — that's the whole behavior change this ticket ships.
+import { useState, useTransition } from "react";
+
+import { toggleConnectorAction } from "./actions";
+
+interface Props {
+  layer: string;
+  /** Initial enabled state from the gateway, used to seed the toggle on first render. */
+  initialEnabled: boolean;
+}
+
+export function ConnectorToggle({ layer, initialEnabled }: Props) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [status, setStatus] = useState<{ tone: "ok" | "err"; text: string } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    const next = !enabled;
+    setEnabled(next); // optimistic
+    setStatus(null);
+    startTransition(async () => {
+      const res = await toggleConnectorAction(layer, next);
+      if (res.ok) {
+        setStatus({ tone: "ok", text: next ? "Enabled — banner will respect this layer." : "Disabled — layer no longer counts." });
+      } else {
+        setEnabled(!next); // rollback
+        setStatus({ tone: "err", text: res.error ?? "Failed to update connector." });
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        aria-pressed={enabled}
+        className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs font-medium transition ${
+          enabled
+            ? "border-accent/50 bg-accent/15 text-accent hover:bg-accent/25"
+            : "border-edge bg-ink/40 text-muted hover:bg-ink/60"
+        } ${pending ? "opacity-50" : ""}`}
+      >
+        <span
+          aria-hidden
+          className={`h-1.5 w-1.5 rounded-full ${enabled ? "bg-accent" : "bg-muted"}`}
+        />
+        {pending ? "Saving…" : enabled ? "Enabled" : "Disabled"}
+      </button>
+      {status && (
+        <span className={`text-[11px] ${status.tone === "ok" ? "text-good" : "text-warn"}`}>
+          {status.text}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/app/connectors/actions.ts
+++ b/web/app/connectors/actions.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+"use server";
+
+// Server actions for the connectors page (CTO-107). Toggling a cost-layer connector here flips a
+// row in the gateway's tenant_connectors table; the dashboard's "Partial data" banner reads the
+// same table, so the next page render reflects the change.
+import { revalidatePath } from "next/cache";
+
+import { LAYERS, type Layer } from "@/lib/cost";
+import { setConnectorEnabled } from "@/lib/tenant";
+
+export interface ToggleResult {
+  ok: boolean;
+  error?: string;
+}
+
+/** Server action invoked from the client toggle. Revalidates so banners refresh on next load. */
+export async function toggleConnectorAction(
+  layer: string,
+  enabled: boolean,
+): Promise<ToggleResult> {
+  if (!(LAYERS as readonly string[]).includes(layer)) {
+    return { ok: false, error: `unknown layer: ${layer}` };
+  }
+  const result = await setConnectorEnabled(layer as Layer, enabled);
+  if (!result.ok) return { ok: false, error: result.error };
+  // Both surfaces (Home, Cost) consult the banner state — revalidate everything served by the
+  // dashboard so a toggle is visible without a hard refresh.
+  revalidatePath("/", "layout");
+  return { ok: true };
+}

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -8,6 +8,8 @@ import {
   type ConnectorStatus,
   connectedCount,
 } from "@/lib/connectors";
+import { queryEnabledConnectors } from "@/lib/tenant";
+import { ConnectorToggle } from "./ConnectorToggle";
 
 interface ConnectorsPayload {
   connectors: ConnectorStatus[];
@@ -44,7 +46,13 @@ function StateBadge({ row }: { row: ConnectorStatus }) {
   );
 }
 
-function ConnectorTable({ rows }: { rows: ConnectorStatus[] }) {
+function ConnectorTable({
+  rows,
+  enabledLayers,
+}: {
+  rows: ConnectorStatus[];
+  enabledLayers: readonly string[];
+}) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
@@ -55,27 +63,41 @@ function ConnectorTable({ rows }: { rows: ConnectorStatus[] }) {
             <th className="py-1 text-left font-medium">Status</th>
             <th className="py-1 text-right font-medium">Records (30d)</th>
             <th className="py-1 text-right font-medium">Last sync</th>
+            <th className="py-1 text-right font-medium">Banner</th>
           </tr>
         </thead>
         <tbody>
-          {rows.map((r) => (
-            <tr key={r.id} className="border-t border-edge align-top">
-              <td className="py-2">
-                <div className="font-medium">{r.name}</div>
-                <div className="max-w-prose text-xs text-muted">{r.description}</div>
-              </td>
-              <td className="py-2 text-muted">{r.feeds}</td>
-              <td className="py-2">
-                <StateBadge row={r} />
-              </td>
-              <td className="py-2 text-right tabular-nums">
-                {r.records > 0 ? r.records.toLocaleString() : "—"}
-              </td>
-              <td className="py-2 text-right tabular-nums text-muted">
-                {r.lastAt ? relativeAge(r.lastAt) : "—"}
-              </td>
-            </tr>
-          ))}
+          {rows.map((r) => {
+            // Only cost-layer connectors participate in the per-tenant declaration; revenue
+            // connectors have their own connectivity story that doesn't drive the layer banner.
+            const layer = r.liveKey.kind === "cost-layer" ? r.liveKey.layer : null;
+            const isEnabled = layer ? enabledLayers.includes(layer) : false;
+            return (
+              <tr key={r.id} className="border-t border-edge align-top">
+                <td className="py-2">
+                  <div className="font-medium">{r.name}</div>
+                  <div className="max-w-prose text-xs text-muted">{r.description}</div>
+                </td>
+                <td className="py-2 text-muted">{r.feeds}</td>
+                <td className="py-2">
+                  <StateBadge row={r} />
+                </td>
+                <td className="py-2 text-right tabular-nums">
+                  {r.records > 0 ? r.records.toLocaleString() : "—"}
+                </td>
+                <td className="py-2 text-right tabular-nums text-muted">
+                  {r.lastAt ? relativeAge(r.lastAt) : "—"}
+                </td>
+                <td className="py-2 text-right">
+                  {layer ? (
+                    <ConnectorToggle layer={layer} initialEnabled={isEnabled} />
+                  ) : (
+                    <span className="text-xs text-muted">—</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -83,7 +105,10 @@ function ConnectorTable({ rows }: { rows: ConnectorStatus[] }) {
 }
 
 export default async function ConnectorsPage() {
-  const { connectors, live } = await apiGet<ConnectorsPayload>("/api/connectors");
+  const [{ connectors, live }, enabledLayers] = await Promise.all([
+    apiGet<ConnectorsPayload>("/api/connectors"),
+    queryEnabledConnectors(),
+  ]);
   const connected = connectedCount(connectors);
 
   const body = (
@@ -94,7 +119,7 @@ export default async function ConnectorsPage() {
         return (
           <Card key={s.category} title={`${s.title} — ${n}/${rows.length} connected`}>
             <p className="mb-3 max-w-prose text-xs text-muted">{s.blurb}</p>
-            <ConnectorTable rows={rows} />
+            <ConnectorTable rows={rows} enabledLayers={enabledLayers} />
           </Card>
         );
       })}

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/DataStateBanner";
 import { Legend, StackedBarChart } from "@/components/StackedBarChart";
 import { apiGet } from "@/lib/api";
-import { asOfLabel, deriveDataState, relativeAge, someZero } from "@/lib/dataState";
+import { asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
 import {
   LAYER_LABEL,
   LAYERS,
@@ -19,6 +19,7 @@ import {
   reconciledTotal,
   totalRange,
 } from "@/lib/cost";
+import { queryEnabledConnectors } from "@/lib/tenant";
 import { formatUSD, type SpendByLayer } from "@/lib/types";
 
 interface CostPayload {
@@ -39,8 +40,11 @@ export default async function CostPage({
   // Forward ?tag= to the API so the breakdown is pre-filtered to one feature (CTO-104).
   const sp = (await searchParams) ?? {};
   const query = sp.tag ? `?tag=${encodeURIComponent(sp.tag)}` : "";
-  const { series: costSeries, featureRows, alerts: hiddenCostAlerts } =
-    await apiGet<CostPayload>(`/api/cost${query}`);
+  const [{ series: costSeries, featureRows, alerts: hiddenCostAlerts }, enabledLayers] =
+    await Promise.all([
+      apiGet<CostPayload>(`/api/cost${query}`),
+      queryEnabledConnectors(),
+    ]);
   const total = totalRange(costSeries);
   const reconciled = reconciledTotal(costSeries);
   const estimated = estimatedTotal(costSeries);
@@ -52,9 +56,11 @@ export default async function CostPage({
     },
     { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 },
   );
+  // Connector-aware partiality (CTO-107): a layer the tenant never enabled isn't a gap.
+  const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
   const state = deriveDataState({
     isEmpty: total === 0,
-    isPartial: someZero({ ...layerTotals }),
+    isPartial: trippedLayers.length > 0,
     reconciledThrough: costSeries.reconciledThrough,
   });
   const asOf = asOfLabel(costSeries.reconciledThrough);
@@ -136,7 +142,7 @@ export default async function CostPage({
         )}
       </div>
 
-      {state === "partial" && <PartialDataBanner missing="a cost layer connector" />}
+      {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
       {state === "empty" ? (
         <SyntheticPreviewBanner workflow="Cost">{body}</SyntheticPreviewBanner>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -11,8 +11,10 @@ import {
   asOfLabel,
   deriveDataState,
   relativeAge,
-  someZero,
+  zeroEnabledLayers,
 } from "@/lib/dataState";
+import { LAYERS, type Layer } from "@/lib/cost";
+import { queryEnabledConnectors } from "@/lib/tenant";
 import type { CostOutlier, DataQuality, FeatureRoi, SpendSummary } from "@/lib/types";
 import { formatUSD } from "@/lib/types";
 
@@ -24,14 +26,26 @@ interface HomePayload {
 }
 
 export default async function HomePage() {
-  const { spend: s, outliers, roi, dq } = await apiGet<HomePayload>("/api/home");
+  const [{ spend: s, outliers, roi, dq }, enabledLayers] = await Promise.all([
+    apiGet<HomePayload>("/api/home"),
+    queryEnabledConnectors(),
+  ]);
   const hidden = s.byLayer.vector + s.byLayer.tools + s.byLayer.compute + s.byLayer.embeddings + s.byLayer.egress;
   const hiddenPct = s.totalMicroUsd === 0 ? 0 : Math.round((hidden / s.totalMicroUsd) * 100);
 
   const layers: Record<string, number> = { ...s.byLayer };
+  // Connector-aware partiality (CTO-107): only enabled layers reporting zero count as a gap.
+  const layerTotals = LAYERS.reduce<Record<Layer, number>>(
+    (acc, l) => {
+      acc[l] = s.byLayer[l];
+      return acc;
+    },
+    { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 },
+  );
+  const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
   const state = deriveDataState({
     isEmpty: s.totalMicroUsd === 0 && allZero(layers),
-    isPartial: someZero(layers),
+    isPartial: trippedLayers.length > 0,
     reconciledThrough: s.reconciledThrough,
   });
   const asOf = asOfLabel(s.reconciledThrough);
@@ -117,7 +131,7 @@ export default async function HomePage() {
         )}
       </div>
 
-      {state === "partial" && <PartialDataBanner missing="a cost layer connector" />}
+      {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
       {state === "empty" ? (
         <SyntheticPreviewBanner workflow="Home">{grid}</SyntheticPreviewBanner>

--- a/web/components/DataStateBanner.test.tsx
+++ b/web/components/DataStateBanner.test.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PartialDataBanner } from "./DataStateBanner";
+
+describe("PartialDataBanner (CTO-107)", () => {
+  it("renders the actionable layer-specific text when given trippedLayers", () => {
+    render(<PartialDataBanner trippedLayers={["vector"]} />);
+    expect(screen.getByText(/Partial data/i)).toBeTruthy();
+    expect(
+      screen.getByText(/vector is reporting zero — that connector isn’t producing data/i),
+    ).toBeTruthy();
+  });
+
+  it("pluralises and joins when multiple layers are tripped", () => {
+    render(<PartialDataBanner trippedLayers={["vector", "tools"]} />);
+    expect(
+      screen.getByText(/vector, tools are reporting zero/i),
+    ).toBeTruthy();
+  });
+
+  it("falls back to the legacy `missing` copy when trippedLayers is empty", () => {
+    render(<PartialDataBanner trippedLayers={[]} missing="a value-event source" />);
+    expect(screen.getByText(/a value-event source isn’t connected yet/i)).toBeTruthy();
+  });
+
+  it("supports the legacy `missing` prop unchanged for non-layer surfaces", () => {
+    render(<PartialDataBanner missing="the replay sampler" />);
+    expect(screen.getByText(/the replay sampler isn’t connected yet/i)).toBeTruthy();
+  });
+});

--- a/web/components/DataStateBanner.tsx
+++ b/web/components/DataStateBanner.tsx
@@ -57,13 +57,34 @@ export function SyntheticPreviewBanner({
 /**
  * Partial-data state. A banner pointing at the missing connector, rendered above whatever real
  * data does exist.
+ *
+ * Two call styles:
+ *   - ``trippedLayers={["vector","tools"]}`` (CTO-107): a *declared* connector is reporting zero,
+ *     so we name the layer(s) the customer is actually waiting on. This is the actionable variant.
+ *   - ``missing="…"``: free-form fallback for surfaces whose partiality isn't layer-based (e.g.
+ *     the value-event / attribution-rate signals on /features, /data-quality, /agents). These
+ *     surfaces are unrelated to the connector model, so they keep their existing message.
  */
-export function PartialDataBanner({ missing }: { missing: string }) {
+export function PartialDataBanner({
+  trippedLayers,
+  missing,
+}: {
+  trippedLayers?: readonly string[];
+  missing?: string;
+}) {
+  let body: string;
+  if (trippedLayers && trippedLayers.length > 0) {
+    const names = trippedLayers.join(", ");
+    const verb = trippedLayers.length === 1 ? "is" : "are";
+    body = `${names} ${verb} reporting zero — that connector isn’t producing data right now.`;
+  } else {
+    body = `Showing what we have, but ${missing ?? "a data source"} isn’t connected yet — some numbers are incomplete.`;
+  }
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-warn/40 bg-warn/10 px-4 py-3 text-sm">
       <div className="text-warn">
         <span className="font-medium">Partial data. </span>
-        <span>Showing what we have, but {missing} isn&apos;t connected yet — some numbers are incomplete.</span>
+        <span>{body}</span>
       </div>
       <ConnectorCta label="Finish setup" />
     </div>

--- a/web/lib/dataState.test.ts
+++ b/web/lib/dataState.test.ts
@@ -11,6 +11,7 @@ import {
   relativeAge,
   someZero,
   STALE_AFTER_MS,
+  zeroEnabledLayers,
 } from "./dataState";
 
 const NOW = Date.parse("2026-05-30T12:00:00Z");
@@ -126,5 +127,24 @@ describe("labels", () => {
   });
   it("ageMs is positive for past boundaries", () => {
     expect(ageMs("2026-05-30T10:00:00Z", NOW)).toBeGreaterThan(0);
+  });
+});
+
+describe("zeroEnabledLayers (CTO-107)", () => {
+  it("stays silent when only the enabled layer has data", () => {
+    expect(zeroEnabledLayers({ llm: 100, vector: 0 }, ["llm"])).toEqual([]);
+  });
+  it("fires for an enabled layer reporting zero", () => {
+    expect(zeroEnabledLayers({ llm: 100, vector: 0 }, ["llm", "vector"])).toEqual(["vector"]);
+  });
+  it("stays silent when every enabled layer has data", () => {
+    expect(zeroEnabledLayers({ llm: 100, vector: 100 }, ["llm", "vector"])).toEqual([]);
+  });
+  it("returns empty when no connectors are declared (LLM-only demos)", () => {
+    expect(zeroEnabledLayers({}, [])).toEqual([]);
+  });
+  it("ignores layers that aren't declared, even when zero", () => {
+    // tools is zero but never declared — it's by-design partial, not a real gap.
+    expect(zeroEnabledLayers({ llm: 5, vector: 0, tools: 0 }, ["llm"])).toEqual([]);
   });
 });

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -102,3 +102,18 @@ export function someZero(values: Record<string, number>): boolean {
   const hasNonZero = xs.some((v) => v !== 0);
   return hasZero && hasNonZero;
 }
+
+/**
+ * Connector-aware partial detection (CTO-107).
+ *
+ * Returns the subset of *enabled* layers that report zero — those are the real gaps. Layers the
+ * tenant never enabled don't count: a tenant who only declared the LLM connector should never see
+ * the banner for vector/tools/etc., because they were never expected to fire. With the empty
+ * input (no enabled connectors declared) we return [], i.e. nothing partial — by design.
+ */
+export function zeroEnabledLayers<L extends string>(
+  byLayer: Record<L, number>,
+  enabled: readonly L[],
+): L[] {
+  return enabled.filter((l) => (byLayer[l] ?? 0) === 0);
+}

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -112,7 +112,11 @@ export function someZero(values: Record<string, number>): boolean {
  * input (no enabled connectors declared) we return [], i.e. nothing partial — by design.
  */
 export function zeroEnabledLayers<L extends string>(
-  byLayer: Record<L, number>,
+  // Keys are decoupled from L: byLayer carries every layer the system knows
+  // about (LLM/vector/tools/…); `enabled` is just the subset we're checking.
+  // Without the widening the call site would have to narrow byLayer to the
+  // exact enabled set, which is the opposite of how the data flows.
+  byLayer: Readonly<Record<string, number>>,
   enabled: readonly L[],
 ): L[] {
   return enabled.filter((l) => (byLayer[l] ?? 0) === 0);

--- a/web/lib/tenant.test.ts
+++ b/web/lib/tenant.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_ENABLED_LAYERS, queryEnabledConnectors } from "./tenant";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("queryEnabledConnectors", () => {
+  it("parses the gateway response and filters to known layers", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          tenant_id: "t",
+          connectors: [],
+          enabled_layers: ["llm", "vector", "bogus"],
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+    const layers = await queryEnabledConnectors();
+    expect(layers).toEqual(["llm", "vector"]);
+  });
+
+  it("falls back to ['llm'] when the gateway returns an error", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("boom", { status: 500 }),
+    ) as typeof fetch;
+    expect(await queryEnabledConnectors()).toEqual(DEFAULT_ENABLED_LAYERS);
+  });
+
+  it("falls back to ['llm'] when the gateway is unreachable", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    expect(await queryEnabledConnectors()).toEqual(DEFAULT_ENABLED_LAYERS);
+  });
+
+  it("falls back to ['llm'] when no connectors are declared at all", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ tenant_id: "t", connectors: [], enabled_layers: [] }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+    expect(await queryEnabledConnectors()).toEqual(DEFAULT_ENABLED_LAYERS);
+  });
+});

--- a/web/lib/tenant.ts
+++ b/web/lib/tenant.ts
@@ -76,3 +76,35 @@ export async function queryEnabledConnectors(): Promise<Layer[]> {
     return [...DEFAULT_ENABLED_LAYERS];
   }
 }
+
+/**
+ * Enable or disable a single cost-layer connector for the current tenant.
+ *
+ * POSTs to the gateway's /v1/tenant/connectors. Returns ``{ ok: true }`` on success and
+ * ``{ ok: false, error: "..." }`` when the gateway is unreachable or rejects the layer — callers
+ * use this to render an inline confirmation/error without taking down the page.
+ */
+export async function setConnectorEnabled(
+  layer: Layer,
+  enabled: boolean,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/connectors`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-tenant-id": TENANT,
+      },
+      body: JSON.stringify({ layer, enabled }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, error: `gateway HTTP ${res.status}${text ? `: ${text}` : ""}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}

--- a/web/lib/tenant.ts
+++ b/web/lib/tenant.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Per-tenant cost-layer connector declarations (CTO-107).
+//
+// The "Partial data" banner used to fire whenever any cost layer reported zero, which made it
+// permanent on every demo (only the LLM connector is wired today) and trained users to ignore it.
+// We fix that by asking the gateway which connectors this tenant has *declared* enabled, and only
+// counting those layers when computing partiality.
+//
+// Server-only: imported by Route Handlers. The gateway is the source of truth for the per-tenant
+// config — we never read Postgres directly from the dashboard. Failures fall back to ["llm"] so
+// demos and CI (where the gateway may be unreachable) keep working and the banner stays quiet.
+//
+// Tenant scoping mirrors web/lib/clickhouse.ts: TALLY_TENANT_ID || "local-dev".
+import { LAYERS, type Layer } from "./cost";
+
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+interface TenantConnectorsResponse {
+  tenant_id: string;
+  connectors: Array<{
+    layer: string;
+    enabled: boolean;
+    enabled_at: string;
+    disabled_at: string | null;
+    notes: string | null;
+  }>;
+  enabled_layers: string[];
+}
+
+/** Fallback used when the gateway is unreachable — matches the only connector wired today. */
+export const DEFAULT_ENABLED_LAYERS: Layer[] = ["llm"];
+
+function asLayer(s: string): Layer | null {
+  return (LAYERS as readonly string[]).includes(s) ? (s as Layer) : null;
+}
+
+/**
+ * Ask the gateway which cost-layer connectors this tenant has declared enabled.
+ *
+ * The dashboard uses this list — and only this list — to decide whether the "Partial data" banner
+ * should fire. A layer that was never declared isn't a gap; it's by design.
+ *
+ * When the gateway is unreachable (CI, fresh clone with nothing running, transient outage) we
+ * return ``["llm"]`` so a demo doesn't suddenly start screaming "partial data" — which would
+ * defeat the purpose of this whole ticket.
+ */
+export async function queryEnabledConnectors(): Promise<Layer[]> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/connectors`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      // Short timeout: a slow gateway shouldn't block every page render.
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) {
+      console.warn(`[tenant] /v1/tenant/connectors HTTP ${res.status}; falling back`);
+      return [...DEFAULT_ENABLED_LAYERS];
+    }
+    const body = (await res.json()) as TenantConnectorsResponse;
+    const layers: Layer[] = [];
+    for (const s of body.enabled_layers ?? []) {
+      const l = asLayer(s);
+      if (l) layers.push(l);
+    }
+    // A tenant that exists but has declared nothing is treated like the fallback — otherwise the
+    // banner would fire for *every* layer the moment any data lands. The intent is "no declared
+    // connectors = no expectations", and the LLM connector is the implicit baseline.
+    if (layers.length === 0) return [...DEFAULT_ENABLED_LAYERS];
+    return layers;
+  } catch (err) {
+    console.warn(
+      "[tenant] /v1/tenant/connectors unreachable, falling back:",
+      (err as Error).message,
+    );
+    return [...DEFAULT_ENABLED_LAYERS];
+  }
+}


### PR DESCRIPTION
## Summary

Implements [CTO-107](https://linear.app/cto-assist/issue/CTO-107) — the "Partial data" banner now only fires for *declared* cost-layer connectors that report zero. Demos and early deployments (LLM-only) stay clean; a real outage of an enabled connector still surfaces.

## What changes for users

| Before | After |
|---|---|
| Banner fires on every page, on every demo, forever (only LLM is wired → 5 layers always zero) | Banner stays silent until a connector that's been *enabled* drops to zero |
| Banner text: "a cost layer connector isn't connected yet" — implies a fix-it action you can't actually take | Banner text: "vector is reporting zero — that connector isn't producing data right now" — names the layer, actionable |
| Trained users to ignore the warning; couldn't trust it for a real gap | Stays trustworthy: only fires when something a tenant has explicitly turned on stops producing data |

## Commits (read in order)

| # | What |
|---|---|
| `e202797` | Postgres `tenant_connectors` table + gateway control-plane API (\`GET\`/\`POST /v1/tenant/connectors\`); seed enables only `llm` by default |
| `6f107ee` | Web helper \`queryEnabledConnectors()\` that calls the gateway; defaults to \`['llm']\` when gateway unreachable so demos stay clean |
| `2248f4e` | \`PartialDataBanner\` accepts new \`trippedLayers\` prop (renders the actionable variant); \`dataState.zeroEnabledLayers()\` helper. Legacy \`missing\` prop still works for non-layer surfaces. |
| `e08f491` | Wire \`/cost\` and \`/\` (home) to use \`queryEnabledConnectors\` + \`zeroEnabledLayers\`. /agents, /features, /data-quality, /compare, /estimate keep their non-layer signals as-is. |
| `854103c` | Connectors UI toggles wired to the gateway via server action + \`revalidatePath\`. Optimistic UI with rollback on failure. |
| `9a331dd` | Vitest coverage for \`zeroEnabledLayers\` truth table + \`PartialDataBanner\` render; removed the "Partial data banner is expected" row from RUNNING.md troubleshooting. |

## Default behavior after this lands

Fresh seed → only \`llm\` enabled → \`queryEnabledConnectors()\` returns \`["llm"]\` → \`zeroEnabledLayers(layerTotals, ["llm"])\` returns \`[]\` whenever LLM has data → no banner on \`/cost\` or \`/\`. Demos look clean.

## Test plan

- [ ] \`cd web && npm run build && npx vitest run\` — green (2 pre-existing failures in \`api.test.ts\` are environment-dependent: they pass in CI without ClickHouse but fail locally with a live stack; unrelated to CTO-107)
- [ ] \`cd infra/gateway && uv run pytest\` — green; control-plane API round-trips
- [ ] \`cd infra && make up && make seed && cd ../web && npm run dev\` — visit http://localhost:3000/cost — no "Partial data" banner (only llm enabled by default)
- [ ] Visit \`/connectors\` → toggle "Pinecone" ON → refresh \`/cost\` → banner appears naming "vector"
- [ ] Toggle Pinecone OFF → refresh \`/cost\` → banner disappears

## Out of scope

- Building the missing connectors themselves (vector, tools, compute, embeddings, egress) — separate epics
- Per-feature-tag partiality detection — single tenant-level enabled set for now
- Email/Slack alerts on the banner firing — UI only
- Backfilling historical partiality state

🤖 Generated with [Claude Code](https://claude.com/claude-code)