### PR TITLE
CTO-112: instrument the chatbot's real /api/chat route

### DIFF
--- a/examples/vercel-chatbot/app/app/(chat)/actions.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/actions.ts
@@ -29,9 +29,9 @@ export async function generateTitleFromUserMessage({
     model: getTitleModel(),
     system: titlePrompt,
     prompt: getTextFromMessage(message),
-    providerOptions: {
-      gateway: { order: titleModel.gatewayOrder },
-    },
+    // ai-tally: CTO-105 swapped Vercel AI Gateway for direct SDK providers,
+    // so `providerOptions.gateway` no longer applies. getTitleModel() already
+    // returns a real provider client; nothing else is needed here.
   });
   return text
     .replace(/^[#*"\s]+/, "")

--- a/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
@@ -44,6 +44,16 @@ import type { ChatMessage } from "@/lib/types";
 import { convertToUIMessages, generateUUID } from "@/lib/utils";
 import { generateTitleFromUserMessage } from "../../actions";
 import { type PostRequestBody, postRequestBodySchema } from "./schema";
+// ai-tally: instrumentation for the real chatbot UI route. The synthetic
+// driver hits /api/demo-chat; manual browser sessions land here, and without
+// this they'd never produce telemetry. resolveProvider() infers the real
+// provider from the picker's "<provider>/<model>" id; falls back to anthropic
+// because that's the local-demo default in lib/ai/providers.ts.
+import { postSpan, sessionUserHash } from "@/lib/tally";
+
+function resolveRealProvider(modelId: string): "openai" | "anthropic" {
+  return modelId.startsWith("openai/") ? "openai" : "anthropic";
+}
 
 export const maxDuration = 60;
 
@@ -236,6 +246,35 @@ export async function POST(request: Request) {
           experimental_telemetry: {
             isEnabled: isProductionEnvironment,
             functionId: "stream-text",
+          },
+          // ai-tally: emit a span per completed turn so the manual chatbot UI
+          // (not just the synthetic driver) produces dashboard telemetry. The
+          // last user message text drives feature-tag classification; usage
+          // tokens drive the gateway's cost computation. Failure here is
+          // swallowed inside postSpan — never breaks the user's stream.
+          onFinish: async ({ usage, text }) => {
+            const lastUserMessage = [...modelMessages]
+              .reverse()
+              .find((m) => m.role === "user");
+            const promptText =
+              typeof lastUserMessage?.content === "string"
+                ? lastUserMessage.content
+                : Array.isArray(lastUserMessage?.content)
+                  ? lastUserMessage.content
+                      .filter((p) => "text" in p)
+                      .map((p) => (p as { text: string }).text)
+                      .join(" ")
+                  : text ?? "";
+            await postSpan({
+              sessionId: id,
+              userHash: sessionUserHash(session.user.id ?? id),
+              realProvider: resolveRealProvider(chatModel),
+              realModel: chatModel,
+              promptText,
+              inputTokens: usage?.inputTokens ?? 0,
+              outputTokens: usage?.outputTokens ?? 0,
+              runId: id,
+            });
           },
         });
 


### PR DESCRIPTION
## Summary

Implements [CTO-112](https://linear.app/cto-assist/issue/CTO-112) — closes the telemetry gap discovered live: [CTO-105](https://linear.app/cto-assist/issue/CTO-105) instrumented the side-channel \`/api/demo-chat\` route used by the synthetic driver, but the **real** \`/api/chat\` route used by the browser UI at \`:3001\` was never patched. Manual chats produced **zero spans** even though the LLM call succeeded.

Verified live before opening: sent a chat at \`http://localhost:3001\` with \`claude-sonnet-4-5\`, a \`vercel-chatbot\` / \`chatbot.*\` span landed in ClickHouse within 5s.

## Commits

| # | What |
|---|---|
| \`dfde5be\` | Add \`onFinish\` callback to \`streamText({...})\` in \`(chat)/api/chat/route.ts\`. Extracts the last user message for feature-tag classification, resolves the real provider from the picker's \`<provider>/<model>\` id, and calls \`postSpan()\` from \`@/lib/tally\`. All patched lines marked \`// ai-tally:\` per CTO-105 convention. |
| \`e61e5de\` | Drop the stale \`providerOptions.gateway\` reference in \`actions.ts\` — leftover from CTO-105's Vercel AI Gateway → direct SDK swap. Was breaking \`npx tsc --noEmit\` (TS2339); preventing CI from going green on the next chatbot-related PR. |

## What this does NOT do (in this PR)

These are the remaining acceptance-criteria items from [CTO-112](https://linear.app/cto-assist/issue/CTO-112) — explicitly out of scope for this commit, will land in a follow-up:

- **Vote-button CDP events**: thumbs-up / thumbs-down should POST a \`cdp.event\` of \`positive_feedback\`/\`negative_feedback\`. UI wiring deferred.
- **Grep guard test**: prevent future template updates from re-introducing the gap (assert every \`streamText(\`/\`generateText(\` call site has a \`postSpan\` in its \`onFinish\`).
- **PATCHES.md update** listing the new patched lines.

The \`onFinish\` patch is the load-bearing fix — the rest is hardening. Opening narrow to get the fix out of the way and unblock the cost dashboard for manual UI sessions.

## Test plan

- [ ] \`cd web && npm run build && npx vitest run\` — green (2 pre-existing failures in \`api.test.ts\` are environment-dependent: they pass in CI without ClickHouse but fail locally with a live stack; unrelated to CTO-112)
- [ ] \`cd examples/vercel-chatbot/app && npx tsc --noEmit -p .\` — clean (was failing on \`gatewayOrder\` before the second commit)
- [ ] \`cd infra && make up && make seed\` — bring up stack
- [ ] \`bash examples/vercel-chatbot/run.sh -- --provider anthropic --dry-run\` — verify the existing demo-chat path still emits spans
- [ ] Open \`http://localhost:3001\`, send a chat — within ~5s a \`ServiceName='vercel-chatbot'\` span lands in ClickHouse with the right \`FeatureTag\` (one of \`chatbot.code\` / \`chatbot.support\` / \`chatbot.brainstorm\`) and \`chatbot.real_provider\` matching the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)