### PR TITLE
CTO-112 follow-up: home outliers window 24h→30d + ServiceName

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -63,7 +63,7 @@ export default async function HomePage() {
           </div>
         </Card>
 
-        <Card title="Top cost outliers (24h)">
+        <Card title="Top cost outliers (30d)">
           <ul className="space-y-2 text-sm">
             {outliers.map((o) => (
               <li key={o.runId} className="flex items-center justify-between gap-3">

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -159,9 +159,10 @@ export async function queryOutliers(): Promise<CostOutlier[] | null> {
     const out = await rows<{ runId: string; agent: string; cost: string; mult: string | null }>(
       db,
       `WITH runs AS (
-         SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost
+         SELECT TraceId AS runId, any(ServiceName) AS agent, sum(EstimatedCost) AS cost
          FROM otel_spans
-         WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 24 HOUR
+         WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
+           AND ServiceName != '' AND ServiceName != 'unknown'
          GROUP BY TraceId
        )
        SELECT runId, agent, cost,


### PR DESCRIPTION
## Summary

Follow-up to PR #77 ([CTO-112](https://linear.app/cto-assist/issue/CTO-112)). The home page "Top cost outliers" widget had two issues that #77 didn't catch:

1. **Window mismatch with /agents** — home used 24h, /agents used 30d. On a sparse demo deployment with no recent expensive runs, the home widget showed a flat carpet of synthetic-driver clones at \`$0.000526\` each, while the *same data* on /agents correctly surfaced \`$0.0041\` / \`$0.0032\` outliers from earlier aider runs. Two surfaces showing different answers to "what's the most expensive run?"
2. **Same `any(FeatureTag) → any(ServiceName)` bug** that we already fixed in \`queryAgents\` during CTO-105 — the outliers query was still labeling runs by feature tag instead of the agent's ServiceName. So "agent" column read \`chatbot.code\` instead of \`vercel-chatbot\`.

## Changes

| File | What |
|---|---|
| \`web/lib/clickhouse.ts\` (queryOutliers) | \`INTERVAL 24 HOUR\` → \`INTERVAL 30 DAY\`; \`any(FeatureTag)\` → \`any(ServiceName)\` (with \`ServiceName != ''\` guard) |
| \`web/app/page.tsx\` | Card title \`(24h)\` → \`(30d)\` to keep the UI honest |

Verified live against the local stack before this PR: home now shows the same three top-cost aider runs as /agents (\`$0.0041\` @ 7.9×, two \`$0.0032\` @ 6.2×) with the agent column reading \`aider\` / \`vercel-chatbot\`.

## Test plan

- [ ] \`cd web && npm run build && npx vitest run\` — green
- [ ] Visit \`/\` — Top cost outliers (30d) lists 5 runs ordered by cost desc, agent labels are ServiceName values
- [ ] \`/\` and \`/agents\` Pathological runs agree on which IDs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)