### PR TITLE
CTO-109: auto-discover provider model lineups on gateway startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ uv.lock
 .claude/worktrees/
 .aider.*
 keys.txt
+
+# Model auto-discovery cache (CTO-109)
+.tally/

--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ uv run ruff check .
 uv run pytest
 ```
 
+## Model auto-discovery
+
+On startup the gateway hits `GET /v1/models` on every provider whose API key it
+has (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), classifies each id into a coarse
+family (`haiku` / `sonnet` / `opus` / `mini` / `flagship` / `embedding`), and
+writes the result to `.tally/models.json` with a 24 h TTL. The demos read that
+file via `tally.models.latest_anthropic("sonnet")` (Python) or `resolveLatest()`
+(Node), so when a provider retires a SKU — `claude-3-5-haiku-latest` was the
+case that prompted this — the next boot picks up the replacement automatically.
+
+Knobs:
+
+- `TALLY_MODELS_REFRESH=1` — bypass the 24 h TTL and refetch on the next boot.
+- `TALLY_PINNED_MODELS=<path>` — skip discovery entirely, load the lineup from
+  that file (useful for CI runs that must be hermetic).
+- `TALLY_MODELS_CACHE=<path>` — Node-side override for where `resolveLatest()`
+  reads the cache from.
+
+Discovery is fail-soft: if both providers are unreachable and the cache file
+doesn't exist, the gateway boots with an empty list and a warning. The demos
+fall back to their hardcoded defaults.
+
 ## Status
 
 Early development. Decisions and the full system spec live in the project tracker.

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -45,6 +45,12 @@ curl -s localhost:8080/healthz     # {"status":"ok"}
 > The gateway waits for ClickHouse + Postgres to pass health checks before it boots, so a brief
 > "starting" is normal.
 
+> On first boot the gateway also hits `GET /v1/models` on every provider whose API key it has and
+> writes the result to `.tally/models.json` (CTO-109). Subsequent boots reuse that file for 24 h —
+> set `TALLY_MODELS_REFRESH=1` to force a refetch, or `TALLY_PINNED_MODELS=<path>` to skip discovery
+> entirely. If both providers are unreachable, boot still succeeds — you'll just see a warning in
+> the gateway log and the demos fall back to their hardcoded model defaults.
+
 The composed gateway already sets `TALLY_CLICKHOUSE_DB=default` (the official ClickHouse image loads
 unqualified DDL into the `default` database — see the note in `infra/docker-compose.yml`). Running
 the gateway *by hand* with the library default `TALLY_CLICKHOUSE_DB=tally` will fail with

--- a/examples/aider-demo/run.sh
+++ b/examples/aider-demo/run.sh
@@ -56,17 +56,48 @@ start_proxy
 # 4. Point Aider at the proxy and pick a model that matches the provider.
 #    Aider speaks OpenAI protocol by default; for Anthropic we explicitly select
 #    a Claude model so it speaks Anthropic protocol to the proxy upstream.
+#
+# CTO-109: resolve the current cheapest in-family id from the gateway's
+# auto-discovered cache (.tally/models.json) so a retired SKU doesn't break the
+# demo. Falls back to the hardcoded default if the helper errors or the cache
+# is empty. The cache lives at the repo root — same directory as `make up`.
+repo_root="$(cd "$here/../.." && pwd)"
+resolve_from_cache() {
+  # $1=provider $2=family — prints the id, or empty on miss/error.
+  TALLY_SDK_SRC="$repo_root/sdk/python/src" TALLY_CACHE="$repo_root/.tally/models.json" \
+    python3 - "$1" "$2" <<'PY' 2>/dev/null || true
+import os, sys
+from pathlib import Path
+sys.path.insert(0, os.environ["TALLY_SDK_SRC"])
+try:
+    from tally import models as M
+except Exception:
+    sys.exit(0)
+provider, family = sys.argv[1], sys.argv[2]
+cache_path = Path(os.environ["TALLY_CACHE"])
+cached = M.load_cached(cache_path) or M._load_unchecked(cache_path)
+if not cached:
+    sys.exit(0)
+pick = M.latest(provider, family, cached)
+if pick:
+    print(pick.id)
+PY
+}
+
 if [[ "$PROVIDER" == "anthropic" ]]; then
   # Aider uses LiteLLM under the hood; LiteLLM requires the provider prefix.
-  AIDER_MODEL="${AIDER_MODEL:-anthropic/claude-sonnet-4-5}"
+  resolved=$(resolve_from_cache anthropic sonnet)
+  AIDER_MODEL="${AIDER_MODEL:-anthropic/${resolved:-claude-sonnet-4-5}}"
   export ANTHROPIC_API_BASE="http://localhost:$PROXY_PORT"
   export ANTHROPIC_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
 else
-  AIDER_MODEL="${AIDER_MODEL:-gpt-4o}"
+  resolved=$(resolve_from_cache openai flagship)
+  AIDER_MODEL="${AIDER_MODEL:-${resolved:-gpt-4o}}"
   export OPENAI_API_BASE="http://localhost:$PROXY_PORT/v1"
   export OPENAI_BASE_URL="http://localhost:$PROXY_PORT/v1"
   export OPENAI_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
 fi
+echo "  using model: $AIDER_MODEL"
 
 # Strip the LiteLLM provider prefix (e.g. "anthropic/claude-sonnet-4-5" →
 # "claude-sonnet-4-5") for the gateway-facing model attribute — the price

--- a/examples/vercel-chatbot/app/app/api/demo-chat/route.ts
+++ b/examples/vercel-chatbot/app/app/api/demo-chat/route.ts
@@ -7,6 +7,7 @@
 // shape regardless of which path produced it.
 
 import { type NextRequest, NextResponse } from "next/server";
+import { resolveLatest } from "@/lib/resolveModel";
 import {
   classifyFeatureTag,
   type FeatureTag,
@@ -31,11 +32,15 @@ interface DemoChatBody {
   dryRun?: boolean;
 }
 
-const DEFAULT_OPENAI_MODEL = process.env.TALLY_OPENAI_MODEL ?? "gpt-4o-mini";
-// claude-3-5-haiku-latest was retired by Anthropic; the current cheapest model
-// in the 4-series family is claude-haiku-4-5. Override via TALLY_ANTHROPIC_MODEL.
+// CTO-109: resolve the current cheapest model in each family from the gateway's
+// auto-discovered cache (.tally/models.json) instead of hardcoding SKUs. An
+// explicit env override still wins; the literal id is the last-resort fallback
+// the resolver returns only when the cache is missing or has no in-family match.
+const DEFAULT_OPENAI_MODEL =
+  process.env.TALLY_OPENAI_MODEL ?? resolveLatest("openai", "mini", "gpt-4o-mini");
 const DEFAULT_ANTHROPIC_MODEL =
-  process.env.TALLY_ANTHROPIC_MODEL ?? "claude-haiku-4-5";
+  process.env.TALLY_ANTHROPIC_MODEL ??
+  resolveLatest("anthropic", "haiku", "claude-haiku-4-5");
 
 interface ProviderResult {
   text: string;

--- a/examples/vercel-chatbot/app/lib/ai/providers.ts
+++ b/examples/vercel-chatbot/app/lib/ai/providers.ts
@@ -6,6 +6,7 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { openai } from "@ai-sdk/openai";
 import { customProvider } from "ai";
+import { resolveLatest } from "../resolveModel";
 import { isTestEnvironment } from "../constants";
 
 export const myProvider = isTestEnvironment
@@ -27,8 +28,11 @@ export const myProvider = isTestEnvironment
 // OpenAI quota is unreliable in demo environments).
 const DEFAULT_PROVIDER = process.env.TALLY_DEMO_PROVIDER ?? "anthropic";
 
-const FALLBACK_ANTHROPIC = "claude-sonnet-4-5";
-const FALLBACK_OPENAI = "gpt-4o-mini";
+// CTO-109: prefer the gateway's auto-discovered cache so a provider retiring
+// a SKU doesn't break this route. The literal ids are last-resort fallbacks.
+const FALLBACK_ANTHROPIC = resolveLatest("anthropic", "sonnet", "claude-sonnet-4-5");
+const FALLBACK_OPENAI = resolveLatest("openai", "mini", "gpt-4o-mini");
+const FALLBACK_ANTHROPIC_TITLE = resolveLatest("anthropic", "haiku", "claude-haiku-4-5");
 
 function resolve(modelId: string) {
   // Honor an explicit anthropic/<model> id — strip the prefix; pass the rest
@@ -61,5 +65,5 @@ export function getTitleModel() {
   }
   return DEFAULT_PROVIDER === "openai"
     ? openai(FALLBACK_OPENAI)
-    : anthropic("claude-haiku-4-5");
+    : anthropic(FALLBACK_ANTHROPIC_TITLE);
 }

--- a/examples/vercel-chatbot/app/lib/resolveModel.ts
+++ b/examples/vercel-chatbot/app/lib/resolveModel.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// CTO-109: read the gateway's auto-discovered model cache so the chatbot stops
+// hardcoding SKUs that the provider may retire (e.g. claude-3-5-haiku-latest
+// got sunset and broke the demo). The Python gateway writes this file on boot;
+// here we just look up the current best id per (provider, family).
+
+import fs from "node:fs";
+import path from "node:path";
+
+type Provider = "openai" | "anthropic";
+type Family = "haiku" | "sonnet" | "opus" | "mini" | "flagship" | "embedding" | "other";
+
+interface CachedModel {
+  provider: Provider;
+  id: string;
+  family: Family;
+  created_at: string | null;
+  deprecated_at: string | null;
+}
+
+const DATE_SUFFIX = /-\d{8}$/;
+
+// Best-effort load. If the cache is missing or malformed, callers fall back to
+// their hardcoded defaults — the whole feature is quality-of-life, not critical
+// path. Honors TALLY_MODELS_CACHE so the demo can point at the gateway's mount.
+function loadCache(): CachedModel[] | null {
+  const overridePath = process.env.TALLY_MODELS_CACHE;
+  const candidates = overridePath
+    ? [overridePath]
+    : [
+        path.join(process.cwd(), ".tally", "models.json"),
+        // The chatbot demo runs from examples/vercel-chatbot/app; the gateway
+        // writes its cache at the repo root. Walk up so we find it from either cwd.
+        path.join(process.cwd(), "..", "..", "..", ".tally", "models.json"),
+      ];
+  for (const p of candidates) {
+    try {
+      const raw = fs.readFileSync(p, "utf-8");
+      const parsed = JSON.parse(raw) as CachedModel[];
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
+export function resolveLatest(
+  provider: Provider,
+  family: Family,
+  fallback: string,
+): string {
+  const cache = loadCache();
+  if (!cache) return fallback;
+  const candidates = cache.filter(
+    (m) => m.provider === provider && m.family === family && !m.deprecated_at,
+  );
+  if (candidates.length === 0) return fallback;
+  // Same tiebreaker as tally.models.latest(): undated alias beats date-stamped snapshot,
+  // then newer created_at wins.
+  candidates.sort((a, b) => {
+    const aDated = DATE_SUFFIX.test(a.id) ? 1 : 0;
+    const bDated = DATE_SUFFIX.test(b.id) ? 1 : 0;
+    if (aDated !== bDated) return aDated - bDated;
+    const aTs = a.created_at ? Date.parse(a.created_at) : 0;
+    const bTs = b.created_at ? Date.parse(b.created_at) : 0;
+    return bTs - aTs;
+  });
+  return candidates[0].id;
+}

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from tally.enrichment import enrich_cost
+from tally.models import discover_models
 from tally.pricing import seed_catalog
 from tally.schema import GenAI
 from tally.timekeeping import assess
@@ -91,6 +92,21 @@ async def lifespan(app: FastAPI):
         await buffer.start()
         app.state.ingest_buffer = buffer
         logger.info("ingest buffer enabled (capacity=%d)", settings.ingest_buffer_capacity)
+    # Auto-discover provider model lineups (CTO-109). Fail-soft: if both providers
+    # are unreachable AND there's no cached file, we still boot — just with an empty
+    # list and a WARNING. Demos read app.state.models so they don't hardcode SKUs
+    # like claude-3-5-haiku-latest that the provider may retire out from under them.
+    try:
+        app.state.models = discover_models()
+        if app.state.models:
+            openai_ids = sorted(m.id for m in app.state.models if m.provider == "openai")
+            anth_ids = sorted(m.id for m in app.state.models if m.provider == "anthropic")
+            logger.info("models: openai=%s anthropic=%s", openai_ids, anth_ids)
+        else:
+            logger.warning("models: discovery returned no entries — booting without a lineup")
+    except Exception as exc:  # noqa: BLE001 — discovery must never crash boot
+        logger.warning("models: discovery raised, defaulting to empty list: %s", exc)
+        app.state.models = []
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
     if app.state.ingest_buffer is not None:

--- a/infra/gateway/tests/test_app_models.py
+++ b/infra/gateway/tests/test_app_models.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Boot-time model discovery wiring (CTO-109).
+
+Asserts the gateway's lifespan populates ``app.state.models`` from ``tally.models``,
+falls back to the cache when live fetch raises, and still boots cleanly when both
+the live call and the cache are unavailable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from tally import models as M
+
+
+def _make(provider: str, model_id: str) -> M.ModelInfo:
+    return M.ModelInfo(
+        provider=provider,
+        id=model_id,
+        family=M.classify_family(model_id),
+        created_at=datetime(2025, 10, 15, tzinfo=timezone.utc),
+        deprecated_at=None,
+    )
+
+
+def test_lifespan_populates_state_models_from_pinned(tmp_path: Path, monkeypatch) -> None:
+    # Use TALLY_PINNED_MODELS so discovery is hermetic — no network, no cache hunt
+    # in the real .tally/ directory the developer may have on disk.
+    pinned = tmp_path / "pinned.json"
+    M.save_cache(
+        [_make("openai", "gpt-4o-mini"), _make("anthropic", "claude-sonnet-4-5")],
+        pinned,
+    )
+    monkeypatch.setenv("TALLY_PINNED_MODELS", str(pinned))
+
+    with TestClient(app) as client:
+        # /healthz forces lifespan startup to run.
+        assert client.get("/healthz").status_code == 200
+        ids = sorted(m.id for m in app.state.models)
+        assert ids == ["claude-sonnet-4-5", "gpt-4o-mini"]
+
+
+def test_lifespan_falls_back_to_cache_when_fetch_raises(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Seed a stale cache (older than the TTL) and have the live fetcher blow up.
+    # discover_models() must surface the stale entries rather than crash the boot.
+    cache = tmp_path / "models.json"
+    M.save_cache([_make("anthropic", "claude-haiku-4-5")], cache)
+    import os
+    import time as _time
+
+    old = _time.time() - (M.CACHE_TTL_SECONDS + 60)
+    os.utime(cache, (old, old))
+
+    def boom(req, timeout=None):  # noqa: ARG001
+        raise TimeoutError("network down")
+
+    monkeypatch.setattr(M.urllib.request, "urlopen", boom)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.delenv("TALLY_MODELS_REFRESH", raising=False)
+
+    # Point discover_models at our temp cache by monkeypatching the lifespan's call.
+    real_discover = M.discover_models
+    monkeypatch.setattr(
+        "gateway.app.discover_models",
+        lambda: real_discover(cache_path=cache),
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/healthz").status_code == 200
+        assert [m.id for m in app.state.models] == ["claude-haiku-4-5"]
+
+
+def test_lifespan_boots_with_empty_list_when_no_cache_and_no_network(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.delenv("TALLY_MODELS_REFRESH", raising=False)
+
+    real_discover = M.discover_models
+    absent = tmp_path / "absent.json"
+    monkeypatch.setattr(
+        "gateway.app.discover_models",
+        lambda: real_discover(cache_path=absent),
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/healthz").status_code == 200
+        assert app.state.models == []

--- a/sdk/python/src/tally/models.py
+++ b/sdk/python/src/tally/models.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model auto-discovery — fetch the live model lineup from provider APIs.
+
+Implements CTO-109. Solves the "claude-3-5-haiku-latest got retired and broke the demo"
+class of problem: callers ask for ``latest_anthropic("haiku")`` instead of naming a SKU,
+and the resolver returns whatever the provider currently advertises as the cheapest
+in-family model.
+
+Discovery flow (see :func:`discover_models`):
+    cache hit (fresh) → use it
+    cache stale       → fetch live, save, return
+    fetch fails       → use stale cache + warn
+    no cache + fail   → return empty list, caller boots fail-soft
+
+The SDK is dep-light (no ``httpx``/``requests``), so this module uses ``urllib.request``
+just like ``examples/aider-demo/_emit_batch.py``.
+
+API keys come from ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``. They are never logged.
+
+Env overrides:
+    ``TALLY_MODELS_REFRESH=1``      — bypass the cache TTL, always fetch live.
+    ``TALLY_PINNED_MODELS=<path>``  — skip discovery entirely, load this file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger("tally.models")
+
+# 24h TTL on the cached models file. Provider model lineups change in days, not seconds —
+# refreshing on every boot would just spam their /v1/models endpoint.
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+DEFAULT_CACHE_PATH = Path(".tally/models.json")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelInfo:
+    """A single model entry as returned by a provider's ``/v1/models`` endpoint."""
+
+    provider: str  # "openai" | "anthropic"
+    id: str  # canonical id, e.g. "claude-sonnet-4-5" or "gpt-4o-mini"
+    family: str  # see classify_family()
+    created_at: datetime | None
+    deprecated_at: datetime | None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["created_at"] = self.created_at.isoformat() if self.created_at else None
+        d["deprecated_at"] = self.deprecated_at.isoformat() if self.deprecated_at else None
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ModelInfo:
+        def _parse(v: str | None) -> datetime | None:
+            if not v:
+                return None
+            return datetime.fromisoformat(v)
+
+        return cls(
+            provider=d["provider"],
+            id=d["id"],
+            family=d["family"],
+            created_at=_parse(d.get("created_at")),
+            deprecated_at=_parse(d.get("deprecated_at")),
+        )
+
+
+# Family classification regexes. Order matters: the first match wins, so the more-specific
+# keywords (haiku/sonnet/opus/mini/embedding) sit ahead of the flagship catch-alls.
+_FAMILY_RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"haiku", re.I), "haiku"),
+    (re.compile(r"sonnet", re.I), "sonnet"),
+    (re.compile(r"opus", re.I), "opus"),
+    (re.compile(r"(text-embedding|embedding)", re.I), "embedding"),
+    (re.compile(r"mini", re.I), "mini"),
+    (re.compile(r"^gpt-4o(?!-mini)", re.I), "flagship"),
+    (re.compile(r"^gpt-5(?!-mini)", re.I), "flagship"),
+]
+
+
+def classify_family(model_id: str) -> str:
+    """Bucket a model id into a coarse capability/price family.
+
+    The buckets are deliberately coarse — they're consumer-facing labels ("the current
+    cheapest Claude") not a faithful model taxonomy. Anything that doesn't match one
+    of the well-known keywords lands in ``"other"`` (legacy GPT-3.5, custom fine-tunes, etc).
+    """
+    for pattern, family in _FAMILY_RULES:
+        if pattern.search(model_id):
+            return family
+    return "other"
+
+
+def _parse_unix_or_iso(value) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _http_get_json(url: str, headers: dict[str, str], timeout: float) -> dict:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - HTTPS only
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_openai_models(api_key: str, *, timeout: float = 5.0) -> list[ModelInfo]:
+    """Hit OpenAI's ``GET /v1/models`` and return the parsed lineup.
+
+    OpenAI returns ``{"data": [{"id": ..., "created": <unix-ts>}, ...]}`` — there's no
+    explicit "deprecated_at" field, so we leave it ``None``.
+    """
+    payload = _http_get_json(
+        "https://api.openai.com/v1/models",
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=timeout,
+    )
+    out: list[ModelInfo] = []
+    for row in payload.get("data", []):
+        model_id = row.get("id")
+        if not model_id:
+            continue
+        out.append(
+            ModelInfo(
+                provider="openai",
+                id=model_id,
+                family=classify_family(model_id),
+                created_at=_parse_unix_or_iso(row.get("created")),
+                deprecated_at=None,
+            )
+        )
+    return out
+
+
+def fetch_anthropic_models(api_key: str, *, timeout: float = 5.0) -> list[ModelInfo]:
+    """Hit Anthropic's ``GET /v1/models`` and return the parsed lineup.
+
+    Anthropic returns ``{"data": [{"id": ..., "created_at": <iso8601>, ...}]}``. The
+    API requires the ``anthropic-version`` header — without it the request 400s.
+    """
+    payload = _http_get_json(
+        "https://api.anthropic.com/v1/models",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+        timeout=timeout,
+    )
+    out: list[ModelInfo] = []
+    for row in payload.get("data", []):
+        model_id = row.get("id")
+        if not model_id:
+            continue
+        out.append(
+            ModelInfo(
+                provider="anthropic",
+                id=model_id,
+                family=classify_family(model_id),
+                created_at=_parse_unix_or_iso(row.get("created_at")),
+                deprecated_at=_parse_unix_or_iso(row.get("deprecated_at")),
+            )
+        )
+    return out
+
+
+def save_cache(models: list[ModelInfo], path: Path = DEFAULT_CACHE_PATH) -> None:
+    """Persist the discovered list to ``path`` (creating parent dirs)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([m.to_dict() for m in models], indent=2))
+
+
+def load_cached(path: Path = DEFAULT_CACHE_PATH) -> list[ModelInfo] | None:
+    """Return the cached list iff the file exists and is younger than the TTL.
+
+    Uses file mtime vs ``time.time()`` rather than parsing any "fetched_at" inside the
+    JSON — saves a round-trip through the body and means a manual ``touch`` is enough
+    to extend the TTL.
+    """
+    if not path.exists():
+        return None
+    age = time.time() - path.stat().st_mtime
+    if age > CACHE_TTL_SECONDS:
+        return None
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return [ModelInfo.from_dict(d) for d in raw]
+
+
+def _load_unchecked(path: Path) -> list[ModelInfo] | None:
+    """Read the cache file without applying the TTL — for fail-soft fallback."""
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return [ModelInfo.from_dict(d) for d in raw]
+
+
+# Models whose id ends in a date stamp like "-20251015" are point-in-time pins; the
+# undated id (e.g. "claude-sonnet-4-5") is the moving alias provider docs recommend.
+_DATE_SUFFIX = re.compile(r"-\d{8}$")
+
+
+def latest(provider: str, family: str, models: list[ModelInfo]) -> ModelInfo | None:
+    """Pick the current best model in ``(provider, family)``.
+
+    Rules, in order:
+        1. Skip anything marked ``deprecated_at`` — these are sunset.
+        2. Prefer ids *without* a date suffix (the moving alias beats the pinned snapshot).
+        3. Within each preference tier, sort by ``created_at`` descending so newer wins.
+    """
+    candidates = [
+        m
+        for m in models
+        if m.provider == provider and m.family == family and m.deprecated_at is None
+    ]
+    if not candidates:
+        return None
+
+    def sort_key(m: ModelInfo) -> tuple[int, float]:
+        is_dated = 1 if _DATE_SUFFIX.search(m.id) else 0  # undated (0) sorts before dated (1)
+        # Higher created_at first → negate.
+        ts = -m.created_at.timestamp() if m.created_at else 0.0
+        return (is_dated, ts)
+
+    candidates.sort(key=sort_key)
+    return candidates[0]
+
+
+def latest_anthropic(family: str, models: list[ModelInfo]) -> ModelInfo | None:
+    return latest("anthropic", family, models)
+
+
+def latest_openai(family: str, models: list[ModelInfo]) -> ModelInfo | None:
+    return latest("openai", family, models)
+
+
+def discover_models(
+    *,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    openai_api_key: str | None = None,
+    anthropic_api_key: str | None = None,
+    timeout: float = 5.0,
+) -> list[ModelInfo]:
+    """Boot-time discovery entry point. Fail-soft on every error path.
+
+    Honors:
+        - ``TALLY_PINNED_MODELS`` → load that file verbatim, skip the network.
+        - ``TALLY_MODELS_REFRESH=1`` → ignore the cache TTL and refetch live.
+
+    The gateway's lifespan calls this on startup; the demos read the saved cache directly.
+    """
+    pinned = os.environ.get("TALLY_PINNED_MODELS")
+    if pinned:
+        pinned_path = Path(pinned)
+        loaded = _load_unchecked(pinned_path)
+        if loaded is not None:
+            logger.info("models: loaded pinned list from %s (%d entries)", pinned_path, len(loaded))
+            return loaded
+        logger.warning("models: TALLY_PINNED_MODELS=%s could not be loaded", pinned_path)
+
+    force_refresh = os.environ.get("TALLY_MODELS_REFRESH") == "1"
+    if not force_refresh:
+        cached = load_cached(cache_path)
+        if cached is not None:
+            logger.info("models: cache hit (%d entries)", len(cached))
+            return cached
+
+    openai_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
+    anthropic_key = anthropic_api_key or os.environ.get("ANTHROPIC_API_KEY")
+
+    discovered: list[ModelInfo] = []
+    openai_err: Exception | None = None
+    anthropic_err: Exception | None = None
+
+    if openai_key:
+        try:
+            discovered.extend(fetch_openai_models(openai_key, timeout=timeout))
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+            openai_err = exc
+            logger.warning("models: openai fetch failed: %s", exc)
+    else:
+        logger.info("models: OPENAI_API_KEY not set — skipping openai discovery")
+
+    if anthropic_key:
+        try:
+            discovered.extend(fetch_anthropic_models(anthropic_key, timeout=timeout))
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+            anthropic_err = exc
+            logger.warning("models: anthropic fetch failed: %s", exc)
+    else:
+        logger.info("models: ANTHROPIC_API_KEY not set — skipping anthropic discovery")
+
+    if discovered:
+        try:
+            save_cache(discovered, cache_path)
+        except OSError as exc:
+            logger.warning("models: could not write cache to %s: %s", cache_path, exc)
+        _log_summary(discovered)
+        return discovered
+
+    # Both providers unreachable (or unconfigured) — fall back to whatever's on disk,
+    # even if stale. Boot must not crash just because a /v1/models call timed out.
+    stale = _load_unchecked(cache_path)
+    if stale is not None:
+        logger.warning(
+            "models: live fetch failed (openai=%s anthropic=%s) — using stale cache (%d entries)",
+            openai_err,
+            anthropic_err,
+            len(stale),
+        )
+        return stale
+
+    logger.warning(
+        "models: no live data and no cache (openai=%s anthropic=%s) — booting with empty list",
+        openai_err,
+        anthropic_err,
+    )
+    return []
+
+
+def _log_summary(models: list[ModelInfo]) -> None:
+    openai_ids = sorted(m.id for m in models if m.provider == "openai")
+    anth_ids = sorted(m.id for m in models if m.provider == "anthropic")
+    logger.info("models: openai=%s anthropic=%s", openai_ids, anth_ids)
+
+
+__all__ = [
+    "ModelInfo",
+    "classify_family",
+    "fetch_openai_models",
+    "fetch_anthropic_models",
+    "save_cache",
+    "load_cached",
+    "latest",
+    "latest_anthropic",
+    "latest_openai",
+    "discover_models",
+    "CACHE_TTL_SECONDS",
+    "DEFAULT_CACHE_PATH",
+]

--- a/sdk/python/tests/fixtures/anthropic_models.json
+++ b/sdk/python/tests/fixtures/anthropic_models.json
@@ -1,0 +1,36 @@
+{
+  "data": [
+    {
+      "id": "claude-haiku-4-5",
+      "type": "model",
+      "display_name": "Claude Haiku 4.5",
+      "created_at": "2025-10-15T00:00:00Z"
+    },
+    {
+      "id": "claude-sonnet-4-5",
+      "type": "model",
+      "display_name": "Claude Sonnet 4.5",
+      "created_at": "2025-10-15T00:00:00Z"
+    },
+    {
+      "id": "claude-sonnet-4-5-20251015",
+      "type": "model",
+      "display_name": "Claude Sonnet 4.5 (2025-10-15)",
+      "created_at": "2025-10-15T00:00:00Z"
+    },
+    {
+      "id": "claude-opus-4-8",
+      "type": "model",
+      "display_name": "Claude Opus 4.8",
+      "created_at": "2025-12-01T00:00:00Z"
+    },
+    {
+      "id": "claude-3-5-haiku-20241022",
+      "type": "model",
+      "display_name": "Claude Haiku 3.5",
+      "created_at": "2024-10-22T00:00:00Z",
+      "deprecated_at": "2025-11-01T00:00:00Z"
+    }
+  ],
+  "has_more": false
+}

--- a/sdk/python/tests/fixtures/openai_models.json
+++ b/sdk/python/tests/fixtures/openai_models.json
@@ -1,0 +1,9 @@
+{
+  "object": "list",
+  "data": [
+    {"id": "gpt-4o", "object": "model", "created": 1715367049, "owned_by": "openai"},
+    {"id": "gpt-4o-mini", "object": "model", "created": 1721172741, "owned_by": "openai"},
+    {"id": "gpt-5", "object": "model", "created": 1755000000, "owned_by": "openai"},
+    {"id": "text-embedding-3-large", "object": "model", "created": 1705948997, "owned_by": "openai"}
+  ]
+}

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -39,7 +39,13 @@ def test_classify_family_truth_table() -> None:
         assert M.classify_family(model_id) == expected, model_id
 
 
-def _make(provider: str, model_id: str, *, created: datetime | None, deprecated=None) -> M.ModelInfo:
+def _make(
+    provider: str,
+    model_id: str,
+    *,
+    created: datetime | None,
+    deprecated=None,
+) -> M.ModelInfo:
     return M.ModelInfo(
         provider=provider,
         id=model_id,
@@ -84,7 +90,11 @@ def test_cache_round_trip(tmp_path: Path) -> None:
     cache = tmp_path / "models.json"
     original = [
         _make("openai", "gpt-4o", created=datetime(2024, 5, 1, tzinfo=timezone.utc)),
-        _make("anthropic", "claude-sonnet-4-5", created=datetime(2025, 10, 15, tzinfo=timezone.utc)),
+        _make(
+            "anthropic",
+            "claude-sonnet-4-5",
+            created=datetime(2025, 10, 15, tzinfo=timezone.utc),
+        ),
     ]
     M.save_cache(original, cache)
     loaded = M.load_cached(cache)

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``tally.models`` — auto-discovery of provider model lineups.
+
+No live network is touched: ``fetch_*_models`` is exercised via ``monkeypatch`` over
+``urllib.request.urlopen`` with fixture JSON that mimics the real ``/v1/models`` shape.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tally import models as M
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_classify_family_truth_table() -> None:
+    # The truth table the resolvers depend on. Adding a row here is the right way
+    # to register a new provider naming convention.
+    cases = {
+        "gpt-4o-mini": "mini",
+        "claude-sonnet-4-5": "sonnet",
+        "claude-opus-4-8": "opus",
+        "claude-3-5-haiku-20241022": "haiku",
+        "claude-haiku-4-5": "haiku",
+        "gpt-4o": "flagship",
+        "text-embedding-3-large": "embedding",
+        "gpt-5": "flagship",
+        "ft:gpt-3.5-turbo:acme": "other",
+    }
+    for model_id, expected in cases.items():
+        assert M.classify_family(model_id) == expected, model_id
+
+
+def _make(provider: str, model_id: str, *, created: datetime | None, deprecated=None) -> M.ModelInfo:
+    return M.ModelInfo(
+        provider=provider,
+        id=model_id,
+        family=M.classify_family(model_id),
+        created_at=created,
+        deprecated_at=deprecated,
+    )
+
+
+def test_latest_prefers_undated_alias_over_dated_snapshot() -> None:
+    # Provider returns both the moving alias ("claude-sonnet-4-5") and the pinned snapshot
+    # ("claude-sonnet-4-5-20251015"). The alias is what docs and SDKs recommend, so the
+    # resolver must prefer it even when the snapshot has the same created_at.
+    same_ts = datetime(2025, 10, 15, tzinfo=timezone.utc)
+    lineup = [
+        _make("anthropic", "claude-sonnet-4-5-20251015", created=same_ts),
+        _make("anthropic", "claude-sonnet-4-5", created=same_ts),
+    ]
+    pick = M.latest_anthropic("sonnet", lineup)
+    assert pick is not None
+    assert pick.id == "claude-sonnet-4-5"
+
+
+def test_latest_skips_deprecated() -> None:
+    now = datetime.now(tz=timezone.utc)
+    lineup = [
+        # Deprecated, newer created_at — must be skipped despite being newer.
+        _make("anthropic", "claude-haiku-3-5", created=now, deprecated=now - timedelta(days=1)),
+        _make("anthropic", "claude-haiku-4-5", created=now - timedelta(days=30)),
+    ]
+    pick = M.latest_anthropic("haiku", lineup)
+    assert pick is not None
+    assert pick.id == "claude-haiku-4-5"
+
+
+def test_latest_returns_none_for_unknown_family() -> None:
+    lineup = [_make("openai", "gpt-4o", created=None)]
+    assert M.latest_openai("haiku", lineup) is None
+
+
+def test_cache_round_trip(tmp_path: Path) -> None:
+    cache = tmp_path / "models.json"
+    original = [
+        _make("openai", "gpt-4o", created=datetime(2024, 5, 1, tzinfo=timezone.utc)),
+        _make("anthropic", "claude-sonnet-4-5", created=datetime(2025, 10, 15, tzinfo=timezone.utc)),
+    ]
+    M.save_cache(original, cache)
+    loaded = M.load_cached(cache)
+    assert loaded == original
+
+
+def test_cache_staleness_returns_none(tmp_path: Path) -> None:
+    cache = tmp_path / "models.json"
+    M.save_cache([_make("openai", "gpt-4o", created=None)], cache)
+    # Force the file's mtime to look older than the TTL. The TTL check uses mtime,
+    # not any timestamp embedded in the JSON, so this is the right knob.
+    old = time.time() - (M.CACHE_TTL_SECONDS + 60)
+    os.utime(cache, (old, old))
+    assert M.load_cached(cache) is None
+
+
+def test_cache_missing_returns_none(tmp_path: Path) -> None:
+    assert M.load_cached(tmp_path / "absent.json") is None
+
+
+def test_pinned_models_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # TALLY_PINNED_MODELS lets a CI run hardcode a known-good list and bypass the network
+    # entirely. discover_models should pick it up before consulting any cache.
+    pinned = tmp_path / "pinned.json"
+    pinned_models = [_make("openai", "gpt-4o", created=None)]
+    M.save_cache(pinned_models, pinned)
+
+    other_cache = tmp_path / "should_not_be_touched.json"
+    M.save_cache([_make("anthropic", "claude-opus-4-8", created=None)], other_cache)
+
+    monkeypatch.setenv("TALLY_PINNED_MODELS", str(pinned))
+    monkeypatch.delenv("TALLY_MODELS_REFRESH", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    result = M.discover_models(cache_path=other_cache)
+    assert [m.id for m in result] == ["gpt-4o"]
+
+
+def _fake_urlopen_factory(payloads_by_url: dict[str, dict]):
+    """Returns a fake urlopen that dispatches on request URL and yields fixture JSON."""
+
+    class _Resp:
+        def __init__(self, body: bytes):
+            self._buf = io.BytesIO(body)
+
+        def read(self) -> bytes:
+            return self._buf.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for prefix, payload in payloads_by_url.items():
+            if url.startswith(prefix):
+                return _Resp(json.dumps(payload).encode("utf-8"))
+        raise AssertionError(f"unexpected URL {url}")
+
+    return fake_urlopen
+
+
+def test_fetch_anthropic_parses_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.loads((FIXTURES / "anthropic_models.json").read_text())
+    monkeypatch.setattr(
+        M.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory({"https://api.anthropic.com/v1/models": payload}),
+    )
+    out = M.fetch_anthropic_models("fake-key")
+    ids = {m.id for m in out}
+    assert "claude-sonnet-4-5" in ids
+    assert "claude-haiku-4-5" in ids
+    # The deprecated row must carry its deprecated_at through so latest() can skip it.
+    dep = next(m for m in out if m.id == "claude-3-5-haiku-20241022")
+    assert dep.deprecated_at is not None
+    # latest_anthropic("haiku") with this fixture must NOT return the retired 3.5 model.
+    pick = M.latest_anthropic("haiku", out)
+    assert pick is not None and pick.id == "claude-haiku-4-5"
+
+
+def test_fetch_openai_parses_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.loads((FIXTURES / "openai_models.json").read_text())
+    monkeypatch.setattr(
+        M.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory({"https://api.openai.com/v1/models": payload}),
+    )
+    out = M.fetch_openai_models("fake-key")
+    assert {m.id for m in out} == {"gpt-4o", "gpt-4o-mini", "gpt-5", "text-embedding-3-large"}
+    mini = M.latest_openai("mini", out)
+    assert mini is not None and mini.id == "gpt-4o-mini"
+
+
+def test_discover_falls_back_to_stale_cache_on_fetch_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Write a stale cache (older than the TTL) and have the live fetch raise. The
+    # gateway must still boot — that's the whole point of fail-soft discovery.
+    cache = tmp_path / "models.json"
+    M.save_cache([_make("anthropic", "claude-sonnet-4-5", created=None)], cache)
+    old = time.time() - (M.CACHE_TTL_SECONDS + 60)
+    os.utime(cache, (old, old))
+
+    def boom(req, timeout=None):  # noqa: ARG001
+        raise TimeoutError("network is down")
+
+    monkeypatch.setattr(M.urllib.request, "urlopen", boom)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.delenv("TALLY_MODELS_REFRESH", raising=False)
+
+    result = M.discover_models(cache_path=cache)
+    assert [m.id for m in result] == ["claude-sonnet-4-5"]
+
+
+def test_discover_returns_empty_when_no_cache_and_no_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.delenv("TALLY_MODELS_REFRESH", raising=False)
+    result = M.discover_models(cache_path=tmp_path / "absent.json")
+    assert result == []


### PR DESCRIPTION
## Summary

Implements [CTO-109](https://linear.app/cto-assist/issue/CTO-109) — the gateway now fetches the current OpenAI + Anthropic model lineup on startup, caches it to `.tally/models.json` (24h TTL), and exposes resolvers (`latest_anthropic(family="haiku")`, etc.) so callers can ask for "the current cheapest Claude" without naming a SKU. Retired model IDs stop breaking demos overnight.

**PR #2 of a 5-PR stack.** Base: \`cto-106-price-catalog\` (PR #80). Merge #80 first, then this.

## Commits

| # | What |
|---|---|
| \`30e318d\` | New \`tally.models\` SDK module — \`fetch_openai_models\`, \`fetch_anthropic_models\`, family classifier, JSON cache (mtime-based TTL), \`latest_*()\` resolvers. \`urllib\`-only — no new deps. \`TALLY_PINNED_MODELS\` override for air-gapped use. \`.tally/\` added to \`.gitignore\`. |
| \`cd2d246\` | Tests: classify truth table (8 model ids), latest-picker (deprecation skip, named-latest over date-stamped), cache round-trip + 24h staleness via mtime, pinned override, fail-soft fallback. JSON fixtures mimic provider response shapes — no live network. |
| \`1e5e582\` | Gateway lifespan calls \`discover_models()\` on startup → stores on \`app.state.models\`. Logs the resolved set. Fail-soft: provider unreachable + no cache = WARNING but boot succeeds. Tests cover pinned hit / stale-cache fallback / empty boot. |
| \`024e0d9\` | Demos read from the cache: \`examples/aider-demo/run.sh\` resolves a model id via a small Python script; \`examples/vercel-chatbot\` gets \`lib/resolveModel.ts\` plus updates to \`demo-chat/route.ts\` and \`providers.ts\`. Node helper walks up to find the gateway's cache file. |
| \`da7b790\` | README "Model auto-discovery" section + RUNNING.md note. |

## Tests

- **SDK:** 822 passed (12 new in \`test_models.py\`)
- **Gateway:** 154 passed (3 new in \`test_app_models.py\`)
- **Web:** unchanged (no UI surface touched)

## Honest caveats

- The fetcher uses the **public production API shapes** from provider docs (OpenAI: `{data:[{id, created}]}` with Unix timestamp; Anthropic: `{data:[{id, created_at ISO, deprecated_at?}]}` with `anthropic-version: 2023-06-01` header). No live API calls were made during implementation — real production payloads may include additional fields we silently ignore (harmless).
- The Node `resolveLatest()` helper tries `cwd/.tally/models.json` first, then walks up to the repo root. The chatbot demo runs from `examples/vercel-chatbot/app` but the gateway writes the cache at the repo root. Override path with `TALLY_MODELS_CACHE`.
- The model **picker** in `examples/vercel-chatbot/app/lib/ai/models.ts` (user-visible dropdown) still has hardcoded entries — that's a UI surface intentionally out of scope. The picker shows what's *available*; auto-discovery resolves what's *current*. Wiring the picker to the discovery cache is a UX follow-up if useful.

## Verification

```
cd sdk/python && uv run pytest tests/test_models.py     # 12 passed
cd infra/gateway && uv run pytest tests/test_app_models.py  # 3 passed
TALLY_MODELS_REFRESH=1 cd infra && make up              # fresh fetch on boot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)