### PR TITLE
CTO-115: live latency p95 + error rate for /compare current row

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -50,12 +50,20 @@ describe("api routes", () => {
 
   it("GET /api/compare returns a comparison", async () => {
     // CompareGET is async since the live "current model from traffic" wiring;
-    // without a live stack the route returns the mock comparison untouched.
-    const body = await json<{ workload: string; current: unknown; candidates: unknown[] }>(
-      await CompareGET(new Request("http://test/api/compare") as never),
-    );
+    // without a live stack the route returns the mock comparison untouched. The mock keeps
+    // numeric latency/error on current — CTO-115's null path is exercised in route.test.ts.
+    const body = await json<{
+      workload: string;
+      current: { latencyP95Ms: number | null; errorRate: number | null };
+      candidates: unknown[];
+    }>(await CompareGET(new Request("http://test/api/compare") as never));
     expect(body.workload).toBeTypeOf("string");
     expect(body.candidates.length).toBeGreaterThan(0);
+    // CTO-115: shape check only. The live path returns either numbers (n ≥ 50) or null (n < 50);
+    // the mock-fallback path returns numbers. The route.test.ts unit tests cover both branches
+    // explicitly with mocked queryCurrentModel — this smoke test just asserts the field exists.
+    expect("latencyP95Ms" in body.current).toBe(true);
+    expect("errorRate" in body.current).toBe(true);
   });
 
   it("GET /api/cost returns series + featureRows + alerts", async () => {

--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -2,7 +2,7 @@
 // Route tests for /api/compare — exercises both the replay-backed and mock-fallback branches
 // (CTO-113).
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock the clickhouse module before importing the route so the route picks up our stubs.
 vi.mock("@/lib/clickhouse", () => ({
@@ -36,6 +36,9 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 1_310_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
     });
     queryReplayCandidates.mockResolvedValueOnce(null);
 
@@ -43,9 +46,31 @@ describe("/api/compare", () => {
     const body = await res.json();
     expect(body.replay_source).toBe("mock");
     expect(body.current.model).toBe("claude-sonnet-4-5");
+    // CTO-115: live p95/error spliced through.
+    expect(body.current.latencyP95Ms).toBe(2400);
+    expect(body.current.errorRate).toBeCloseTo(0.004, 6);
     // Candidate costs should be rescaled small (off the live $1.31/mo baseline), not the
     // original $1,780/mo mock value.
     expect(body.candidates[0].monthlyCostMicroUsd).toBeLessThan(2_000_000);
+  });
+
+  // CTO-115: n < 50 in the 7-day window → queryCurrentModel returns nulls for latency/error,
+  // and the route surfaces them on the wire as null so the page can render "—".
+  it("surfaces null latency/error when n < 50 (mock-fallback branch)", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 1_310_000,
+      latencyP95Ms: null,
+      errorRate: null,
+      sampleCount: 12,
+    });
+    queryReplayCandidates.mockResolvedValueOnce(null);
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    expect(body.current.latencyP95Ms).toBeNull();
+    expect(body.current.errorRate).toBeNull();
   });
 
   it("uses replay candidates when /v1/replay returns samples", async () => {
@@ -53,6 +78,9 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
     });
     queryReplayCandidates.mockResolvedValueOnce({
       samples_available: 50,
@@ -107,6 +135,9 @@ describe("/api/compare", () => {
       model: "claude-haiku-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 1_000_000,
+      latencyP95Ms: 1500,
+      errorRate: 0.005,
+      sampleCount: 100,
     });
     queryReplayCandidates.mockResolvedValueOnce({
       samples_available: 30,

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -67,6 +67,10 @@ export async function GET(req: Request) {
         model: live.model,
         provider: live.provider,
         monthlyCostMicroUsd: live.monthlyCostMicroUsd,
+        // CTO-115: live p95 / error from otel_spans over the same 7-day window. `null` when
+        // fewer than 50 spans landed — page renders "—" so we never fabricate.
+        latencyP95Ms: live.latencyP95Ms,
+        errorRate: live.errorRate,
       },
       candidates,
       recommendation: {
@@ -117,6 +121,9 @@ export async function GET(req: Request) {
       model: live.model,
       provider: live.provider,
       monthlyCostMicroUsd: live.monthlyCostMicroUsd,
+      // CTO-115: live p95 / error from otel_spans. `null` when n < 50 in the 7-day window.
+      latencyP95Ms: live.latencyP95Ms,
+      errorRate: live.errorRate,
     },
     candidates,
     recommendation: {

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -119,10 +119,24 @@ function Row({
   highlight,
 }: {
   label: string;
-  m: { monthlyCostMicroUsd: MicroUSD; qualityScore: number; latencyP95Ms: number; errorRate: number };
-  current?: { monthlyCostMicroUsd: MicroUSD; qualityScore: number; latencyP95Ms: number; errorRate: number };
+  m: {
+    monthlyCostMicroUsd: MicroUSD;
+    qualityScore: number;
+    latencyP95Ms: number | null;
+    errorRate: number | null;
+  };
+  current?: {
+    monthlyCostMicroUsd: MicroUSD;
+    qualityScore: number;
+    latencyP95Ms: number | null;
+    errorRate: number | null;
+  };
   highlight?: boolean;
 }) {
+  // CTO-115: latency/error on the live `current` row are null when fewer than 50 spans landed
+  // in the 7-day window. Render "—" rather than fabricating a placeholder, and skip deltas
+  // against a null baseline.
+  const lowSampleTitle = "needs ≥50 spans in 7d";
   return (
     <tr className={`border-t border-edge ${highlight ? "font-medium" : ""}`}>
       <td className="py-2">{label}</td>
@@ -135,12 +149,28 @@ function Row({
         {current && <DeltaPp v={(m.qualityScore - current.qualityScore) * 100} betterWhenPositive />}
       </td>
       <td className="py-2 text-right tabular-nums">
-        {m.latencyP95Ms} ms
-        {current && <Delta v={deltaPct(current.latencyP95Ms, m.latencyP95Ms)} betterWhenNegative />}
+        {m.latencyP95Ms === null ? (
+          <span className="text-muted" title={lowSampleTitle}>
+            —
+          </span>
+        ) : (
+          <>{m.latencyP95Ms} ms</>
+        )}
+        {current && current.latencyP95Ms !== null && m.latencyP95Ms !== null && (
+          <Delta v={deltaPct(current.latencyP95Ms, m.latencyP95Ms)} betterWhenNegative />
+        )}
       </td>
       <td className="py-2 text-right tabular-nums">
-        {(m.errorRate * 100).toFixed(2)}%
-        {current && <DeltaPp v={(m.errorRate - current.errorRate) * 100} betterWhenPositive={false} />}
+        {m.errorRate === null ? (
+          <span className="text-muted" title={lowSampleTitle}>
+            —
+          </span>
+        ) : (
+          <>{(m.errorRate * 100).toFixed(2)}%</>
+        )}
+        {current && current.errorRate !== null && m.errorRate !== null && (
+          <DeltaPp v={(m.errorRate - current.errorRate) * 100} betterWhenPositive={false} />
+        )}
       </td>
     </tr>
   );

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// CTO-115: queryCurrentModel latency/error suppression.
+//
+// We exercise the SUT by stubbing the @clickhouse/client query() method through vi.mock —
+// the function under test is the small adapter that converts rows into the typed return value
+// (and applies the n < 50 suppression rule), so we don't need a real ClickHouse to test it.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type RowShape = Record<string, unknown>;
+
+const queryMock = vi.fn<(args: unknown) => Promise<{ json: () => Promise<RowShape[]> }>>();
+
+vi.mock("@clickhouse/client", () => ({
+  createClient: () => ({
+    query: (args: unknown) => queryMock(args),
+  }),
+}));
+
+async function freshSut() {
+  // Reset the module cache so the `_client` singleton in clickhouse.ts is recreated and picks
+  // up the new mock state per test.
+  vi.resetModules();
+  return await import("./clickhouse");
+}
+
+function respond(row: RowShape | null) {
+  queryMock.mockResolvedValueOnce({
+    json: async () => (row ? [row] : []),
+  });
+}
+
+beforeEach(() => {
+  queryMock.mockReset();
+});
+
+describe("queryCurrentModel — latency/error suppression (CTO-115)", () => {
+  it("returns null when ClickHouse has no rows (route falls back to mock)", async () => {
+    const { queryCurrentModel } = await freshSut();
+    respond(null);
+    const out = await queryCurrentModel();
+    expect(out).toBeNull();
+  });
+
+  it("suppresses latencyP95Ms and errorRate to null when sampleCount < 50", async () => {
+    const { queryCurrentModel } = await freshSut();
+    respond({
+      model: "claude-sonnet-4.5",
+      provider: "anthropic",
+      cost7d: "1.40",
+      p95Ms: 2400,
+      errRate: 0.02,
+      sampleCount: 12,
+    });
+    const out = await queryCurrentModel();
+    expect(out).not.toBeNull();
+    expect(out!.model).toBe("claude-sonnet-4.5");
+    expect(out!.sampleCount).toBe(12);
+    expect(out!.latencyP95Ms).toBeNull();
+    expect(out!.errorRate).toBeNull();
+    // Cost projection still runs — it's a sum, not a quantile.
+    expect(out!.monthlyCostMicroUsd).toBe(Math.round((1_400_000 * 30) / 7));
+  });
+
+  it("returns real numbers when sampleCount >= 50", async () => {
+    const { queryCurrentModel } = await freshSut();
+    respond({
+      model: "claude-sonnet-4.5",
+      provider: "anthropic",
+      cost7d: "1.40",
+      p95Ms: 2400.7,
+      errRate: 0.004,
+      sampleCount: 500,
+    });
+    const out = await queryCurrentModel();
+    expect(out).not.toBeNull();
+    expect(out!.latencyP95Ms).toBe(2401);
+    expect(out!.errorRate).toBeCloseTo(0.004, 6);
+    expect(out!.sampleCount).toBe(500);
+  });
+
+  it("handles ClickHouse string-encoded numerics", async () => {
+    const { queryCurrentModel } = await freshSut();
+    respond({
+      model: "gpt-5-mini",
+      provider: "openai",
+      cost7d: "0.50",
+      p95Ms: "1800.0",
+      errRate: "0.01",
+      sampleCount: "75",
+    });
+    const out = await queryCurrentModel();
+    expect(out!.latencyP95Ms).toBe(1800);
+    expect(out!.errorRate).toBeCloseTo(0.01, 6);
+    expect(out!.sampleCount).toBe(75);
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -795,18 +795,37 @@ export async function queryAttribution(
 // GenAiResponseModel). The SpanAttributes['chatbot.real_provider'] / ['chatbot.real_model']
 // reads below are a transitional fallback for historical rows emitted before CTO-106 retired
 // the workaround and can be removed once the 30-day window has rolled.
+// CTO-115: suppress live p95 / error rate when the 7-day window has fewer than this many spans.
+// Small samples produce noisy quantiles and error rates we shouldn't display as if real.
+export const MIN_SPANS_FOR_LATENCY_ERROR = 50;
+
 export async function queryCurrentModel(): Promise<{
   model: string;
   provider: string;
   monthlyCostMicroUsd: number;
+  // null when sampleCount < MIN_SPANS_FOR_LATENCY_ERROR — the route surfaces these as "—" on the
+  // page rather than fabricating numbers off a too-small window.
+  latencyP95Ms: number | null;
+  errorRate: number | null;
+  sampleCount: number;
 } | null> {
   return tryLive(async (db, tenant) => {
     const out = await rows<{
       model: string;
       provider: string;
       cost7d: string;
+      // ClickHouse can serialize numeric aggregates as either JSON numbers or strings
+      // (count() over UInt64 frequently lands as a string). Accept both at the boundary.
+      p95Ms: string | number | null;
+      errRate: string | number | null;
+      sampleCount: string | number;
     }>(
       db,
+      // StatusCode is OTel semconv (UInt8): 0=Unset, 1=Ok, 2=Error — so an error span is
+      // `StatusCode = 2`. (The ticket suggested HTTP-style `>= 400`; the codebase already
+      // uses `=== 2` for OTel error semantics, e.g. agents.ts toRunSpan().)
+      // DurationNs is wrapped in `if(... > 0, ..., NULL)` because some insertion paths land
+      // 0-ns durations (mid-stream / early-fail) which would otherwise drag the p95 down.
       `SELECT
          coalesce(
            nullIf(any(SpanAttributes['chatbot.real_model']), ''),
@@ -817,7 +836,10 @@ export async function queryCurrentModel(): Promise<{
            nullIf(any(SpanAttributes['chatbot.real_provider']), ''),
            any(GenAiSystem)
          ) AS provider,
-         sum(EstimatedCost) AS cost7d
+         sum(EstimatedCost) AS cost7d,
+         quantileExact(0.95)(if(DurationNs > 0, DurationNs, NULL)) / 1e6 AS p95Ms,
+         countIf(StatusCode = 2) / count() AS errRate,
+         count() AS sampleCount
        FROM otel_spans
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 7 DAY
@@ -830,10 +852,38 @@ export async function queryCurrentModel(): Promise<{
     if (out.length === 0 || !out[0].model) return null;
     // Cost over 7 days → linearly projected to a 30-day month. Honest about what this is.
     const monthlyCostMicroUsd = Math.round((micro(out[0].cost7d) * 30) / 7);
+    const sampleCount =
+      typeof out[0].sampleCount === "number"
+        ? out[0].sampleCount
+        : parseInt(out[0].sampleCount, 10) || 0;
+    const enoughSamples = sampleCount >= MIN_SPANS_FOR_LATENCY_ERROR;
+    const p95Raw = out[0].p95Ms;
+    const errRaw = out[0].errRate;
+    const p95Num =
+      p95Raw === null
+        ? null
+        : typeof p95Raw === "number"
+          ? p95Raw
+          : parseFloat(p95Raw);
+    const errNum =
+      errRaw === null
+        ? null
+        : typeof errRaw === "number"
+          ? errRaw
+          : parseFloat(errRaw);
+    const latencyP95Ms =
+      enoughSamples && p95Num !== null && Number.isFinite(p95Num)
+        ? Math.round(p95Num)
+        : null;
+    const errorRate =
+      enoughSamples && errNum !== null && Number.isFinite(errNum) ? errNum : null;
     return {
       model: out[0].model,
       provider: out[0].provider || "unknown",
       monthlyCostMicroUsd,
+      latencyP95Ms,
+      errorRate,
+      sampleCount,
     };
   });
 }

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -3,6 +3,14 @@
 // from /v1/replay (CTO-113); this module's `comparison` value is the rescaled-mock fallback
 // used by the /api/compare route when the gateway has no opted-in samples yet (or is
 // unreachable). The CandidateMetrics / Comparison types are the wire shape for both branches.
+//
+// CTO-115: the `current` row's `latencyP95Ms` and `errorRate` are now derived from live
+// otel_spans over the same 7-day window the cost query uses (see queryCurrentModel in
+// clickhouse.ts). They carry `null` when the live window has fewer than 50 spans, and the
+// page renders "—" in that case. Everything else on this row (qualityScore) and every
+// candidate row stays mock until CTO-114 (eval harness) and the per-candidate
+// CTO-113-extension land. The numeric mocks in `comparison.current` below are the unreachable-
+// ClickHouse fallback (CI / fresh clones); that path keeps showing numbers, not nulls.
 
 import type { MicroUSD } from "./types";
 
@@ -14,9 +22,14 @@ export interface CandidateMetrics {
   monthlyCostMicroUsd: MicroUSD;
   /** pass rate from default LLM-judge eval (0..1) */
   qualityScore: number;
-  /** p95 latency in milliseconds */
-  latencyP95Ms: number;
-  errorRate: number; // 0..1
+  /**
+   * p95 latency in milliseconds. `null` on the `current` row when the live 7-day window has
+   * fewer than 50 spans (rendered as "—" — CTO-115). Candidate rows keep numeric mocks until
+   * per-candidate replay latency lands.
+   */
+  latencyP95Ms: number | null;
+  /** 0..1. `null` on the `current` row under the same low-sample suppression rule. */
+  errorRate: number | null;
 }
 
 export interface Comparison {


### PR DESCRIPTION
## Summary

Implements [CTO-115](https://linear.app/cto-assist/issue/CTO-115) — replaces the hardcoded \`latencyP95Ms: 2400\` / \`errorRate: 0.004\` on the \`/compare\` current row with real numbers from \`otel_spans.DurationNs\` + \`StatusCode\` over the same 7-day slice the cost query uses.

Half-step ticket — no new infra, single query extension, ships in one PR. Independent of [CTO-114](https://linear.app/cto-assist/issue/CTO-114) (which runs in parallel and handles \`qualityScore\`).

## Single commit

\`f53feae\` — extends \`queryCurrentModel()\` aggregation with \`quantileExact(0.95)(if(DurationNs > 0, DurationNs, NULL)) / 1e6\`, \`countIf(StatusCode = 2) / count()\` (used OTel status code \`= 2\` per existing \`agents.ts\` convention, not HTTP-style \`>= 400\`), and \`count()\` so we can suppress when \`sampleCount < 50\`. Type widened to \`{ latencyP95Ms, errorRate, sampleCount }: number | null\`.

Wired into \`/api/compare\` on both branches (replay-backed + rescaled-mock); page renders \`—\` with tooltip "needs ≥50 spans in 7d" when null, skips deltas against a null baseline.

## Tests

- **4 new ClickHouse tests** in \`web/lib/clickhouse.test.ts\`: no rows → null, n<50 → fields null, n≥50 → real numbers, string-encoded numerics
- **\`/api/compare\` route test** extended for the null suppression branch
- **140/142 pass**; the 2 pre-existing failures (\`/api/data-quality\` attributionRate, \`/api/attribution\` mock fallback) are the environment-dependent ones present on main

## Verification

```bash
cd web && npx vitest run lib/clickhouse.test.ts app/api/compare/route.test.ts
# With stack hosting <50 spans in 7d → /compare cells render '—' with the tooltip
# With ≥50 spans → real numbers; stop ClickHouse → mock fallback (numeric)
```

## Out of scope

- Per-candidate latency / error rate (needs CTO-113 replay; partially landed)
- TTFT / streaming-level instrumentation
- Error categorization (rate-limit vs context-window vs server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)