### PR TITLE
CTO-118: context-drop detection — SDK signal + DQ surface (real drops24h)

### DIFF
--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -49,6 +49,12 @@ CREATE TABLE IF NOT EXISTS otel_spans
     AgentRunId             String                   CODEC(ZSTD(1)),
     AgentStepIndex         UInt16,
 
+    -- Context-window drops (CTO-118). Counts only — never the dropped message text.
+    -- All three default to 0 so existing rows survive an additive ALTER without backfill.
+    ContextDroppedMessages UInt32 DEFAULT 0         CODEC(T64, ZSTD(1)),
+    ContextDroppedTokens   UInt32 DEFAULT 0         CODEC(T64, ZSTD(1)),
+    ContextWindowUsedPct   Float32 DEFAULT 0        CODEC(ZSTD(1)),
+
     -- Replay (Workflow 1)
     ResolvedPromptHash     FixedString(64),
     ResolvedContextRef     String,
@@ -83,3 +89,11 @@ TTL
     toDateTime(Timestamp) + INTERVAL 7 DAY  TO VOLUME 'warm',
     toDateTime(Timestamp) + INTERVAL 30 DAY TO VOLUME 'cold',
     toDateTime(Timestamp) + INTERVAL 90 DAY DELETE;
+
+-- CTO-118 additive migration. Idempotent: `ADD COLUMN IF NOT EXISTS` plus a `DEFAULT 0`
+-- so the operation is metadata-only and non-blocking; existing rows show 0 until they're
+-- naturally aged out. Counts only — there is no body field here, and never will be.
+ALTER TABLE otel_spans
+    ADD COLUMN IF NOT EXISTS ContextDroppedMessages UInt32  DEFAULT 0 CODEC(T64, ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS ContextDroppedTokens   UInt32  DEFAULT 0 CODEC(T64, ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS ContextWindowUsedPct   Float32 DEFAULT 0 CODEC(ZSTD(1));

--- a/infra/gateway/src/gateway/mapping.py
+++ b/infra/gateway/src/gateway/mapping.py
@@ -36,8 +36,37 @@ _PROMOTED_GENAI = frozenset(
         GenAI.AGENT_RUN_ID,
         GenAI.AGENT_STEP_INDEX,
         GenAI.RESOLVED_CONTEXT_REF,
+        GenAI.CONTEXT_DROPPED_MESSAGES,
+        GenAI.CONTEXT_DROPPED_TOKENS,
+        GenAI.CONTEXT_WINDOW_USED_PCT,
     }
 )
+
+# Hard PII guard (CTO-118): any incoming attribute whose key tail-segment matches one of
+# these is dropped on the floor. The contract is "counts only, never bodies"; if a caller
+# tries to sneak a message body through under a familiar name, we refuse to persist it.
+# Match by suffix so nested namespaces (e.g. "gen_ai.prompt.text") are caught too.
+_BODY_KEY_SUFFIXES = frozenset(
+    {
+        "message_text",
+        "messages",
+        "prompt",
+        "prompt_text",
+        "completion",
+        "completion_text",
+        "input_text",
+        "output_text",
+        "content",
+        "text",
+        "body",
+    }
+)
+
+
+def _is_body_key(key: str) -> bool:
+    """Return True if the key's last dot-segment looks like it could carry a message body."""
+    tail = key.rsplit(".", 1)[-1].lower()
+    return tail in _BODY_KEY_SUFFIXES
 
 # Structural keys recognised on the raw span dict (snake_case or ClickHouse-case both accepted).
 _STRUCTURAL = frozenset(
@@ -78,6 +107,9 @@ COLUMNS: tuple[str, ...] = (
     "PriceCatalogVersion",
     "AgentRunId",
     "AgentStepIndex",
+    "ContextDroppedMessages",
+    "ContextDroppedTokens",
+    "ContextWindowUsedPct",
     "SpanAttributes",
     "SampleRate",
 )
@@ -104,6 +136,18 @@ def _fixed64(v: object | None) -> str:
     return s[:64]
 
 
+def _f(v: object | None) -> float:
+    """Coerce to float, defaulting to 0.0, clamped to [0, 1] (we only promote a fraction)."""
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return 0.0
+    f = float(v)
+    if f < 0.0:
+        return 0.0
+    if f > 1.0:
+        return 1.0
+    return f
+
+
 def span_to_row(
     span: dict[str, object],
     *,
@@ -125,9 +169,12 @@ def span_to_row(
     )
 
     # Long-tail attributes: anything not promoted and not structural, stringified for Map(String,String).
+    # PII guard (CTO-118): refuse to persist any key that looks like it could carry a message body.
     extra: dict[str, str] = {}
     for k, v in span.items():
         if k in _PROMOTED_GENAI or k in _STRUCTURAL or v is None:
+            continue
+        if _is_body_key(str(k)):
             continue
         extra[str(k)] = str(v)
 
@@ -160,6 +207,9 @@ def span_to_row(
         _s(span.get(GenAI.COST_PRICE_CATALOG_VERSION)),
         _s(span.get(GenAI.AGENT_RUN_ID)),
         _i(span.get(GenAI.AGENT_STEP_INDEX)),
+        _i(span.get(GenAI.CONTEXT_DROPPED_MESSAGES)),
+        _i(span.get(GenAI.CONTEXT_DROPPED_TOKENS)),
+        _f(span.get(GenAI.CONTEXT_WINDOW_USED_PCT)),
         extra,
         float(sample_rate),
     )

--- a/infra/gateway/tests/test_app_buffer.py
+++ b/infra/gateway/tests/test_app_buffer.py
@@ -67,11 +67,13 @@ def _buffered_client(store: FakeStore) -> Iterator[TestClient]:
         settings.ingest_buffer_poll_interval_s = prev_poll
 
 
-def _spans(n: int) -> list[dict]:
+def _spans(n: int, batch: int = 0) -> list[dict]:
+    # Unique (trace_id, span_id) per call — the buffer's BufferConsumer dedups on that pair, so
+    # repeating IDs across batches makes the drained-store count race with chunk boundaries.
     return [
         {
-            "trace_id": f"t{i}",
-            "span_id": f"s{i}",
+            "trace_id": f"t-{batch}-{i}",
+            "span_id": f"s-{batch}-{i}",
             GenAI.SYSTEM: "openai",
             GenAI.OPERATION_NAME: "chat",
             GenAI.USAGE_INPUT_TOKENS: 10,
@@ -101,8 +103,8 @@ def test_buffered_burst_is_accepted_and_persisted() -> None:
     with _buffered_client(store) as c:
         # Several batches in quick succession — a burst the synchronous path would push through CH.
         total = 0
-        for _ in range(5):
-            r = _post(c, _spans(40))
+        for batch in range(5):
+            r = _post(c, _spans(40, batch=batch))
             assert r.status_code == 200
             body = r.json()
             assert body["status"] == "accepted"
@@ -129,8 +131,8 @@ def test_burst_returns_no_5xx_even_when_clickhouse_down() -> None:
     # buffered and retried in the background; the client sees 200 the whole time.
     store = FakeStore(span_fail=True)
     with _buffered_client(store) as c:
-        for _ in range(5):
-            r = _post(c, _spans(20))
+        for batch in range(5):
+            r = _post(c, _spans(20, batch=batch))
             assert r.status_code == 200  # never 503, even though CH insert raises
             assert r.json()["status"] == "accepted"
         # Rows are retained in the buffer (not lost, not written) while CH is down.

--- a/infra/gateway/tests/test_mapping_context.py
+++ b/infra/gateway/tests/test_mapping_context.py
@@ -1,0 +1,117 @@
+"""Span -> row promotion of the CTO-118 context-drop attributes.
+
+Two contracts checked here:
+
+1. Presence — the three ``gen_ai.context.*`` attributes land in their typed columns,
+   absent ones default to 0.
+2. The hard "no bodies in telemetry" guard — even if a caller sends a key like
+   ``message_text`` or ``gen_ai.prompt.text`` carrying a real prompt, the gateway
+   does NOT persist it (neither as a column nor in ``SpanAttributes``).
+"""
+
+from __future__ import annotations
+
+from gateway.mapping import COLUMNS, _is_body_key, span_to_row
+
+
+def _row_dict(row: tuple[object, ...]) -> dict[str, object]:
+    assert len(row) == len(COLUMNS)
+    return dict(zip(COLUMNS, row, strict=True))
+
+
+def test_context_drop_attrs_promoted_to_columns() -> None:
+    span = {
+        "gen_ai.context.dropped_messages": 4,
+        "gen_ai.context.dropped_tokens": 1800,
+        "gen_ai.context.window_used_pct": 0.93,
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    assert row["ContextDroppedMessages"] == 4
+    assert row["ContextDroppedTokens"] == 1800
+    assert row["ContextWindowUsedPct"] == 0.93
+
+
+def test_context_drop_columns_default_to_zero_when_absent() -> None:
+    """A span without any drop attrs must produce zeros, not garbage."""
+    row = _row_dict(span_to_row({}, tenant_id="t1", effective_ts_ns=0))
+    assert row["ContextDroppedMessages"] == 0
+    assert row["ContextDroppedTokens"] == 0
+    assert row["ContextWindowUsedPct"] == 0.0
+
+
+def test_context_drop_attrs_not_duplicated_in_span_attributes_map() -> None:
+    """Promoted keys must not also appear in the SpanAttributes long-tail map."""
+    span = {
+        "gen_ai.context.dropped_messages": 1,
+        "gen_ai.context.dropped_tokens": 50,
+        "gen_ai.context.window_used_pct": 0.4,
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    extra = row["SpanAttributes"]
+    assert isinstance(extra, dict)
+    assert "gen_ai.context.dropped_messages" not in extra
+    assert "gen_ai.context.dropped_tokens" not in extra
+    assert "gen_ai.context.window_used_pct" not in extra
+
+
+def test_window_pct_out_of_range_clamped() -> None:
+    """Float coercion clamps to [0, 1] — a buggy/malicious caller can't poison the column."""
+    span = {"gen_ai.context.window_used_pct": 1.7}
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    assert row["ContextWindowUsedPct"] == 1.0
+
+    span2 = {"gen_ai.context.window_used_pct": -0.5}
+    row2 = _row_dict(span_to_row(span2, tenant_id="t1", effective_ts_ns=0))
+    assert row2["ContextWindowUsedPct"] == 0.0
+
+
+# --- No bodies in telemetry (the load-bearing PII guard) ----------------------------------------
+
+
+def test_pii_guard_drops_message_text_key() -> None:
+    """A caller that tries to ship the actual dropped prompt under a familiar name must
+    have it stripped — not stored in any column, not stored in the long-tail map."""
+    leaked = "The user's full medical history: ..."
+    span = {
+        "gen_ai.context.dropped_messages": 2,
+        "gen_ai.context.dropped_tokens": 400,
+        "message_text": leaked,
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    extra = row["SpanAttributes"]
+    assert isinstance(extra, dict)
+    # Counts present.
+    assert row["ContextDroppedMessages"] == 2
+    assert row["ContextDroppedTokens"] == 400
+    # Body absent — not in the map, not anywhere.
+    assert "message_text" not in extra
+    for v in extra.values():
+        assert leaked not in v
+
+
+def test_pii_guard_drops_namespaced_body_keys() -> None:
+    """Nested namespaces don't bypass the guard — we match by trailing segment."""
+    leaked = "secret prompt body"
+    span = {
+        "gen_ai.prompt.text": leaked,
+        "tally.completion": leaked,
+        "anything.content": leaked,
+        "user.input_text": leaked,
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    extra = row["SpanAttributes"]
+    assert isinstance(extra, dict)
+    for v in extra.values():
+        assert leaked not in v
+
+
+def test_is_body_key_unit() -> None:
+    """Direct unit on the helper — defends against well-meaning refactors."""
+    assert _is_body_key("message_text")
+    assert _is_body_key("gen_ai.prompt.text")
+    assert _is_body_key("X.Y.completion")
+    assert _is_body_key("MESSAGES")
+    # Negatives — counts and metadata must pass.
+    assert not _is_body_key("gen_ai.context.dropped_messages")
+    assert not _is_body_key("gen_ai.usage.input_tokens")
+    assert not _is_body_key("gen_ai.feature_tag")

--- a/sdk/python/src/tally/context.py
+++ b/sdk/python/src/tally/context.py
@@ -11,8 +11,12 @@ Public surface:
 - :func:`with_trace_context` — context manager to set/restore explicitly (the escape hatch for
   places where automatic propagation fails: Celery, Temporal, Lambda cold starts, etc.).
 - :func:`current_context` — read the active context.
-- :func:`note_context_drop` — record that an expected context was missing (feeds
-  ``SelfObservability.context_drop_count``).
+- :func:`note_context_drop` — two modes (CTO-118):
+    (a) record that an expected trace context was missing (feeds
+        ``SelfObservability.context_drop_count``); or
+    (b) emit ``gen_ai.context.*`` span attributes describing how many messages /
+        tokens were trimmed to fit the model's context window. Counts only — never
+        the dropped message text.
 """
 
 from __future__ import annotations
@@ -96,9 +100,65 @@ def start_trace(
     )
 
 
-def note_context_drop(obs: SelfObservability, *, where: str = "context") -> None:
-    """Record that a span was produced with no active trace context where one was expected."""
-    obs.context_drop_count += 1
-    obs.last_errors.append(f"{where}: context drop (no active trace_id)")
-    if len(obs.last_errors) > obs._max_errors:
-        del obs.last_errors[0]
+def note_context_drop(
+    obs: SelfObservability,
+    *,
+    where: str = "context",
+    dropped_messages: int | None = None,
+    dropped_tokens: int | None = None,
+    window_used_pct: float | None = None,
+    attrs: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Record a context drop and (optionally) emit span attributes describing the drop.
+
+    Two related signals share this entrypoint (CTO-118):
+
+    1. **Trace-context drop** — no active ``trace_id`` where one was expected. The existing
+       no-arg call path (``note_context_drop(obs, where="record_llm_call")``) keeps working
+       and bumps :attr:`SelfObservability.context_drop_count`.
+
+    2. **Context-window drop** — caller trimmed messages before sending to the model to
+       fit the context window. Pass ``dropped_messages`` (count), ``dropped_tokens``
+       (total tokens of trimmed content), and ``window_used_pct`` (0..1 — how close the
+       request got to the window). These are promoted to three span attributes:
+
+       - ``gen_ai.context.dropped_messages`` (int)
+       - ``gen_ai.context.dropped_tokens`` (int)
+       - ``gen_ai.context.window_used_pct`` (float)
+
+       Counts only — never the dropped message text. This is the contract.
+
+    Args:
+        obs: self-observability sink for the trace-drop counter.
+        where: caller identifier (used in ``last_errors`` for trace-drop case).
+        dropped_messages: count of messages trimmed before send. Negative → clamped to 0.
+        dropped_tokens: total token count of trimmed content. Negative → clamped to 0.
+        window_used_pct: 0..1 fraction of the model's context window used. Clamped to [0, 1].
+        attrs: an optional attribute dict to mutate in place. If provided, the three
+            context-drop attributes are added to it. A new dict is also returned either way.
+
+    Returns:
+        The (possibly mutated) attribute dict. Empty when no drop fields were provided.
+    """
+    out = attrs if attrs is not None else {}
+    if dropped_messages is None and dropped_tokens is None and window_used_pct is None:
+        # Legacy trace-context drop path — unchanged behaviour.
+        obs.context_drop_count += 1
+        obs.last_errors.append(f"{where}: context drop (no active trace_id)")
+        if len(obs.last_errors) > obs._max_errors:
+            del obs.last_errors[0]
+        return out
+
+    # Context-window drop path. Normalize: never trust the caller blindly.
+    if dropped_messages is not None:
+        out["gen_ai.context.dropped_messages"] = max(0, int(dropped_messages))
+    if dropped_tokens is not None:
+        out["gen_ai.context.dropped_tokens"] = max(0, int(dropped_tokens))
+    if window_used_pct is not None:
+        pct = float(window_used_pct)
+        if pct < 0.0:
+            pct = 0.0
+        elif pct > 1.0:
+            pct = 1.0
+        out["gen_ai.context.window_used_pct"] = pct
+    return out

--- a/sdk/python/src/tally/schema.py
+++ b/sdk/python/src/tally/schema.py
@@ -54,6 +54,12 @@ class GenAI:
 
     RESOLVED_CONTEXT_REF = "gen_ai.resolved_context_ref"
 
+    # Context-window drop signals (CTO-118). Counts/token counts ONLY — never the dropped
+    # message text. Matches the bar set by the edge-proxy: no field here could hold a prompt.
+    CONTEXT_DROPPED_MESSAGES = "gen_ai.context.dropped_messages"  # int, count of trimmed messages
+    CONTEXT_DROPPED_TOKENS = "gen_ai.context.dropped_tokens"  # int, total tokens trimmed
+    CONTEXT_WINDOW_USED_PCT = "gen_ai.context.window_used_pct"  # float, 0..1
+
 
 # Known operation names (open set — unknown values are allowed but should be lowercase tokens).
 OPERATIONS = frozenset({"chat", "completion", "embeddings", "tool", "agent", "rerank"})
@@ -71,8 +77,12 @@ _INT_KEYS = frozenset(
         GenAI.TOOL_COST_MICRO_USD,
         GenAI.AGENT_STEP_INDEX,
         GenAI.AGENT_STEP_MAX,
+        GenAI.CONTEXT_DROPPED_MESSAGES,
+        GenAI.CONTEXT_DROPPED_TOKENS,
     }
 )
+# Float keys — currently just the context-window utilization signal (CTO-118).
+_FLOAT_KEYS = frozenset({GenAI.CONTEXT_WINDOW_USED_PCT})
 _STR_KEYS = frozenset(
     {
         GenAI.SYSTEM,
@@ -92,7 +102,7 @@ _STR_KEYS = frozenset(
         GenAI.RESOLVED_CONTEXT_REF,
     }
 )
-_ALL_KEYS = _INT_KEYS | _STR_KEYS
+_ALL_KEYS = _INT_KEYS | _STR_KEYS | _FLOAT_KEYS
 
 _MICRO = Decimal(1_000_000)
 
@@ -201,6 +211,11 @@ def validate_span_attributes(attrs: dict[str, object]) -> list[str]:
                 violations.append(f"{key} must be str, got {type(value).__name__}")
             elif value == "":
                 violations.append(f"{key} must be non-empty")
+        elif key in _FLOAT_KEYS:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                violations.append(f"{key} must be float, got {type(value).__name__}")
+            elif not (0.0 <= float(value) <= 1.0):
+                violations.append(f"{key} must be in [0, 1], got {value}")
 
     op = attrs.get(GenAI.OPERATION_NAME)
     if isinstance(op, str) and op and op != op.lower():

--- a/sdk/python/tests/test_context_drops.py
+++ b/sdk/python/tests/test_context_drops.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for context-window drop signalling (CTO-118).
+
+These cover the *new* second mode of ``note_context_drop``: emitting span attributes
+for messages trimmed before send. The legacy trace-drop path is covered in
+``test_context.py``; here we verify it remains backwards-compatible.
+"""
+
+from __future__ import annotations
+
+from tally.context import note_context_drop
+from tally.safety import SelfObservability
+
+
+def test_emits_three_attributes() -> None:
+    """All three drop fields populate the expected span attribute keys."""
+    obs = SelfObservability()
+    attrs = note_context_drop(
+        obs,
+        dropped_messages=3,
+        dropped_tokens=1200,
+        window_used_pct=0.92,
+    )
+    assert attrs["gen_ai.context.dropped_messages"] == 3
+    assert attrs["gen_ai.context.dropped_tokens"] == 1200
+    assert attrs["gen_ai.context.window_used_pct"] == 0.92
+    # Window-drop path must NOT bump the trace-drop counter — different semantic.
+    assert obs.context_drop_count == 0
+
+
+def test_mutates_caller_attrs() -> None:
+    """When given an attrs dict, the function writes into it (so the caller can
+    splice into a span-being-built without an extra merge step)."""
+    obs = SelfObservability()
+    existing: dict[str, object] = {"gen_ai.system": "openai"}
+    out = note_context_drop(
+        obs,
+        dropped_messages=2,
+        dropped_tokens=500,
+        window_used_pct=0.5,
+        attrs=existing,
+    )
+    assert out is existing
+    assert existing["gen_ai.system"] == "openai"  # preserved
+    assert existing["gen_ai.context.dropped_messages"] == 2
+
+
+def test_backwards_compatible_no_args() -> None:
+    """Legacy call site (no drop fields) still works — bumps the obs counter."""
+    obs = SelfObservability()
+    note_context_drop(obs, where="record_llm_call")
+    assert obs.context_drop_count == 1
+    assert "context drop" in obs.last_errors[-1]
+
+
+def test_partial_call_one_field() -> None:
+    """Caller may supply any subset of the three fields."""
+    obs = SelfObservability()
+    attrs = note_context_drop(obs, window_used_pct=0.81)
+    assert attrs == {"gen_ai.context.window_used_pct": 0.81}
+    assert obs.context_drop_count == 0  # not a trace drop
+
+
+def test_negative_values_clamped_to_zero() -> None:
+    """Don't trust the caller blindly — negatives become 0, not negatives."""
+    obs = SelfObservability()
+    attrs = note_context_drop(
+        obs,
+        dropped_messages=-5,
+        dropped_tokens=-100,
+        window_used_pct=-0.3,
+    )
+    assert attrs["gen_ai.context.dropped_messages"] == 0
+    assert attrs["gen_ai.context.dropped_tokens"] == 0
+    assert attrs["gen_ai.context.window_used_pct"] == 0.0
+
+
+def test_pct_above_one_clamped() -> None:
+    """A caller reporting >100% utilization is buggy; clamp rather than reject."""
+    obs = SelfObservability()
+    attrs = note_context_drop(obs, window_used_pct=1.4)
+    assert attrs["gen_ai.context.window_used_pct"] == 1.0
+
+
+def test_attributes_pass_schema_validation() -> None:
+    """The emitted attribute dict must be conformant under validate_span_attributes."""
+    from tally.schema import validate_span_attributes
+
+    obs = SelfObservability()
+    attrs = note_context_drop(
+        obs,
+        dropped_messages=4,
+        dropped_tokens=2000,
+        window_used_pct=0.75,
+    )
+    assert validate_span_attributes(attrs) == []

--- a/web/app/data-quality/page.tsx
+++ b/web/app/data-quality/page.tsx
@@ -96,17 +96,26 @@ export default async function DataQualityPage() {
             </tr>
           </thead>
           <tbody>
-            {contextDrops.map((d) => (
-              <tr key={`${d.service}-${d.sdkVersion}`} className="border-t border-edge">
-                <td className="py-2">{d.service}</td>
-                <td className="py-2 font-mono text-xs text-gray-300">{d.sdkVersion}</td>
-                <td className="py-2 text-right tabular-nums">
-                  <HealthText h={classify("drops", d.drops24h)}>
-                    {d.drops24h.toLocaleString()}
-                  </HealthText>
-                </td>
-              </tr>
-            ))}
+            {contextDrops.map((d) => {
+              // CTO-118: distinguish "service inactive" (no spans in 24h) from "real zero drops".
+              // Inactive → "—" with tooltip; active+zero → green "0"; active+>0 → red count.
+              const inactive = (d.spans24h ?? 1) === 0;
+              return (
+                <tr key={`${d.service}-${d.sdkVersion}`} className="border-t border-edge">
+                  <td className="py-2">{d.service}</td>
+                  <td className="py-2 font-mono text-xs text-gray-300">{d.sdkVersion}</td>
+                  <td className="py-2 text-right tabular-nums">
+                    {inactive ? (
+                      <span className="text-muted" title="no spans in the last 24h">—</span>
+                    ) : (
+                      <HealthText h={classify("drops", d.drops24h)}>
+                        {d.drops24h.toLocaleString()}
+                      </HealthText>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </Card>

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -365,20 +365,27 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
       events7d: parseInt(r.events, 10) || 0,
     }));
 
-    const svc = await rows<{ service: string; sdk: string }>(
+    // CTO-118: ContextDroppedMessages now a typed column (default 0 on legacy rows). Drops count
+    // is per-service over 24h. We also pull `total_spans` so the page can distinguish a clean
+    // "0 drops in green" (service active, no drops) from "no data this week" (service inactive).
+    const svc = await rows<{ service: string; sdk: string; drops: string; spans: string }>(
       db,
-      `SELECT ServiceName AS service, any(SpanAttributes['telemetry.sdk.version']) AS sdk
+      `SELECT ServiceName AS service,
+              any(SpanAttributes['telemetry.sdk.version']) AS sdk,
+              countIf(ContextDroppedMessages > 0) AS drops,
+              count() AS spans
        FROM otel_spans
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 24 HOUR
        GROUP BY service`,
       tenant,
     );
-    // Context-drop detection isn't instrumented yet → 0 drops, but the service inventory is real.
     const contextDrops: ContextDropsByService[] = svc.map((r) => ({
       service: r.service || "unknown",
       sdkVersion: r.sdk || "unknown",
-      drops24h: 0,
+      drops24h: parseInt(r.drops, 10) || 0,
+      spans24h: parseInt(r.spans, 10) || 0,
     }));
+    const contextDropCount24h = contextDrops.reduce((s, c) => s + c.drops24h, 0);
 
     const cal = await rows<{ date: string; est: string; recon: string }>(
       db,
@@ -402,7 +409,8 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
     return {
       overall: {
         attributionRate: totalEvents > 0 ? attributed / totalEvents : 1,
-        contextDropCount24h: 0,
+        // CTO-118: real count from typed columns above (sum across services).
+        contextDropCount24h,
         estimateCalibration: 0,
         effectiveSampleRate,
       },

--- a/web/lib/dq.ts
+++ b/web/lib/dq.ts
@@ -13,6 +13,8 @@ export interface ContextDropsByService {
   service: string;
   sdkVersion: string;
   drops24h: number;
+  /** CTO-118: total span count over the same 24h window. 0 → service inactive → render "—". */
+  spans24h?: number;
 }
 
 export interface CalibrationDay {


### PR DESCRIPTION
## Summary

Implements [CTO-118](https://linear.app/cto-assist/issue/CTO-118). The `/data-quality` "Context drops by service" table no longer renders a hardcoded `0` for every row — it pulls real per-service drop counts from the new typed column on `otel_spans`.

## Commits

| # | What |
|---|---|
| `cbae1ee` | SDK `note_context_drop()` now emits `gen_ai.context.dropped_messages` (int), `dropped_tokens` (int), `window_used_pct` (float). Backwards-compatible — the no-args call path still works. |
| `67b1e41` | Gateway promotes the three new `gen_ai.context.*` attributes to typed columns on `otel_spans` (`ContextDroppedMessages`, `ContextDroppedTokens`, `ContextWindowUsedPct`, all `DEFAULT 0`). Additive `ALTER TABLE ADD COLUMN` so existing rows show 0. Mapping respects "no bodies in telemetry" — counts only, never message text. |
| `c53feb6` | Web wires `queryDataQualityReport` to `countIf(ContextDroppedMessages > 0)` per service + total spans count. `overall.contextDropCount24h` sums across services. Page distinguishes three states: inactive service ("—" with tooltip), active+zero (green), active+>0 (red). |

## Tests
- SDK + gateway: 220 passed, 1 pytest warning (deprecation, unrelated)
- Web: 144/145 pass; the 1 failure is the pre-existing environment-dependent attribution mock-fallback test

## Honest gap

The DQ page also already differentiated "real zero" from "no data" in its banner logic (CTO-107). This PR's three-state cell rendering extends the same honesty bar to per-row drop counts.

## Out of scope (per ticket)

- Drop categorization (sliding-window vs explicit truncate)
- Per-message diff (would fight "no bodies in telemetry")
- Auto-mitigation
- Real-time alerting

🤖 Generated with [Claude Code](https://claude.com/claude-code)