### PR TITLE
CTO-116: guardrails control-plane (Postgres + gateway + SDK refresh)

### DIFF
--- a/db/postgres/0006_tenant_guardrails.sql
+++ b/db/postgres/0006_tenant_guardrails.sql
@@ -1,0 +1,40 @@
+-- Per-tenant guardrail control-plane (CTO-116).
+--
+-- Replaces the mock guardrail rules with a real registry. Each row is one rule scoped to a
+-- tenant; `kind` is the enforcement category, `params` is the kind-specific config (jsonb),
+-- `state` is the rollout stage. Companion table `tenant_guardrail_changes` is an audit trail —
+-- every upsert appends one row keyed by client-supplied `change_id` for idempotent replay.
+--
+-- The SDK polls the gateway for the active rule set and enforces matching rules in-process; the
+-- web app reads through the gateway, never Postgres directly. Same shape as CTO-107.
+
+CREATE TABLE IF NOT EXISTS tenant_guardrails (
+    tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    rule_id     TEXT NOT NULL,
+    kind        TEXT NOT NULL
+                    CHECK (kind IN ('pii_gate','cost_cap','loop_limit','model_deprecation')),
+    params      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    state       TEXT NOT NULL DEFAULT 'shadow'
+                    CHECK (state IN ('enabled','shadow','disabled')),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by  TEXT,
+    notes       TEXT,
+    PRIMARY KEY (tenant_id, rule_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_guardrails_tenant ON tenant_guardrails(tenant_id);
+
+CREATE TABLE IF NOT EXISTS tenant_guardrail_changes (
+    change_id   UUID NOT NULL,
+    tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    rule_id     TEXT NOT NULL,
+    actor       TEXT,
+    before      JSONB,
+    after       JSONB,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, change_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_guardrail_changes_tenant_rule
+    ON tenant_guardrail_changes(tenant_id, rule_id, changed_at DESC);

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -78,6 +78,11 @@ from gateway.eval_executor import (
 )
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.tenant_eval import TenantEvalStore
+from gateway.tenant_guardrails import (
+    ALLOWED_KINDS as GUARDRAIL_KINDS,
+    ALLOWED_STATES as GUARDRAIL_STATES,
+    TenantGuardrailStore,
+)
 from gateway.tenant_integrations import TenantIntegrationStore
 from gateway.tenant_replay import TenantReplayStore
 from gateway.tenant_stripe import TenantStripeStore
@@ -95,6 +100,10 @@ async def lifespan(app: FastAPI):
     app.state.store = ClickHouseStore(settings)
     app.state.auth = ApiKeyAuth(settings)
     app.state.tenant_connectors = TenantConnectorStore(settings)
+    # Per-tenant guardrail registry (CTO-116) — the SDK polls /v1/tenant/guardrails on its
+    # config-refresh window and enforces matching rules in-process. Shadow rules emit span
+    # attrs but never alter the call; enabled rules do.
+    app.state.tenant_guardrails = TenantGuardrailStore(settings)
     app.state.tenant_stripe = TenantStripeStore(settings)
     # Per-tenant third-party integration run status (CTO-117): Stripe / Segment / HubSpot / Pendo.
     # Workers call .record_run after each cycle; the dashboard reads via /v1/tenant/integrations/status.
@@ -622,6 +631,97 @@ async def set_tenant_connector(
     store: TenantConnectorStore = app.state.tenant_connectors
     row = store.set(tenant_id, layer, enabled=enabled, notes=notes)
     return JSONResponse({"tenant_id": tenant_id, "connector": row.as_dict()}, status_code=200)
+
+
+@app.get("/v1/tenant/guardrails")
+def list_tenant_guardrails(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """List guardrail rules for the caller's tenant (CTO-116).
+
+    The SDK polls this on its config-refresh interval; the dashboard renders the same payload.
+    Rules in 'shadow' state are evaluated and observed but never alter agent behavior — that's the
+    safe staging step before flipping to 'enabled'.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantGuardrailStore = app.state.tenant_guardrails
+    rules = store.list(tenant_id)
+    return JSONResponse({
+        "tenant_id": tenant_id,
+        "rules": [r.as_dict() for r in rules],
+    })
+
+
+@app.post("/v1/tenant/guardrails")
+async def upsert_tenant_guardrail(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Upsert a guardrail rule. Idempotent on client-supplied change_id (CTO-116).
+
+    Body: ``{rule_id, kind, params, state, change_id, actor?, notes?}``. Replaying the same
+    change_id is a no-op (returns the existing rule unchanged).
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    rule_id = body.get("rule_id")
+    kind = body.get("kind")
+    state = body.get("state")
+    params = body.get("params") or {}
+    change_id = body.get("change_id")
+    if not isinstance(rule_id, str) or not rule_id:
+        raise HTTPException(status_code=422, detail="rule_id required")
+    if kind not in GUARDRAIL_KINDS:
+        raise HTTPException(
+            status_code=422, detail=f"kind must be one of {sorted(GUARDRAIL_KINDS)}"
+        )
+    if state not in GUARDRAIL_STATES:
+        raise HTTPException(
+            status_code=422, detail=f"state must be one of {sorted(GUARDRAIL_STATES)}"
+        )
+    if not isinstance(params, dict):
+        raise HTTPException(status_code=422, detail="params must be an object")
+    if not isinstance(change_id, str) or not change_id:
+        raise HTTPException(status_code=422, detail="change_id required (uuid)")
+    store: TenantGuardrailStore = app.state.tenant_guardrails
+    try:
+        rule = store.upsert(
+            tenant_id,
+            rule_id,
+            kind=kind,
+            params=params,
+            state=state,
+            change_id=change_id,
+            actor=body.get("actor"),
+            notes=body.get("notes"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse({"tenant_id": tenant_id, "rule": rule.as_dict()})
+
+
+@app.get("/v1/tenant/guardrails/audit")
+def list_tenant_guardrail_audit(
+    rule_id: str | None = None,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Recent guardrail rule changes for the caller's tenant (CTO-116)."""
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantGuardrailStore = app.state.tenant_guardrails
+    changes = store.audit(tenant_id, rule_id=rule_id)
+    return JSONResponse({
+        "tenant_id": tenant_id,
+        "rule_id": rule_id,
+        "changes": [c.as_dict() for c in changes],
+    })
 
 
 @app.post("/v1/tenant/stripe/connect")

--- a/infra/gateway/src/gateway/tenant_guardrails.py
+++ b/infra/gateway/src/gateway/tenant_guardrails.py
@@ -1,0 +1,255 @@
+"""Per-tenant guardrail control-plane (CTO-116).
+
+Companion to :mod:`gateway.tenant_connectors`. Each row in ``tenant_guardrails`` is one rule scoped
+to one tenant; the SDK polls the gateway on its config-refresh window and enforces matching rules
+in-process. Every upsert appends a row to ``tenant_guardrail_changes``, keyed by a client-supplied
+``change_id`` UUID so a retried request is idempotent — both the rule write and the audit row are
+no-ops on replay.
+
+Reads and writes both go through ``GET/POST /v1/tenant/guardrails`` — the web app never touches
+Postgres directly. The audit log is exposed via ``GET /v1/tenant/guardrails/audit``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Json
+
+from gateway.config import Settings
+
+ALLOWED_KINDS: frozenset[str] = frozenset(
+    {"pii_gate", "cost_cap", "loop_limit", "model_deprecation"}
+)
+ALLOWED_STATES: frozenset[str] = frozenset({"enabled", "shadow", "disabled"})
+
+
+@dataclass(frozen=True, slots=True)
+class GuardrailRule:
+    """One (tenant, rule_id) row."""
+
+    rule_id: str
+    kind: str
+    params: dict[str, Any]
+    state: str
+    created_at: str
+    updated_at: str
+    created_by: str | None
+    notes: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "rule_id": self.rule_id,
+            "kind": self.kind,
+            "params": self.params,
+            "state": self.state,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "created_by": self.created_by,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GuardrailChange:
+    """One audit row — before/after JSON snapshots of the rule around a change."""
+
+    change_id: str
+    rule_id: str
+    actor: str | None
+    before: dict[str, Any] | None
+    after: dict[str, Any] | None
+    changed_at: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "change_id": self.change_id,
+            "rule_id": self.rule_id,
+            "actor": self.actor,
+            "before": self.before,
+            "after": self.after,
+            "changed_at": self.changed_at,
+        }
+
+
+def _row_to_rule(row: tuple) -> GuardrailRule:
+    return GuardrailRule(
+        rule_id=str(row[0]),
+        kind=str(row[1]),
+        params=row[2] if isinstance(row[2], dict) else dict(row[2] or {}),
+        state=str(row[3]),
+        created_at=row[4].isoformat() if row[4] is not None else "",
+        updated_at=row[5].isoformat() if row[5] is not None else "",
+        created_by=row[6],
+        notes=row[7],
+    )
+
+
+class TenantGuardrailStore:
+    """Tiny Postgres-backed CRUD over ``tenant_guardrails`` + audit log.
+
+    Every method takes the ``tenant_id`` resolved by upstream auth so the SQL never crosses tenants.
+    Upserts are idempotent on the client-supplied ``change_id`` — the second call with the same id
+    is a no-op and returns the existing rule unchanged.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def list(self, tenant_id: str) -> list[GuardrailRule]:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT rule_id, kind, params, state, created_at, updated_at, created_by, notes
+                FROM tenant_guardrails
+                WHERE tenant_id = %s
+                ORDER BY rule_id
+                """,
+                (tenant_id,),
+            )
+            return [_row_to_rule(row) for row in cur.fetchall()]
+
+    def upsert(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        *,
+        kind: str,
+        params: dict[str, Any],
+        state: str,
+        change_id: str,
+        actor: str | None = None,
+        notes: str | None = None,
+    ) -> GuardrailRule:
+        """Upsert a rule. Idempotent on ``change_id``.
+
+        On a new change_id: capture the current row as ``before`` (NULL if absent), apply the
+        upsert, then append an audit row with both before/after JSON. On a replayed change_id:
+        no SQL writes — just return the existing rule.
+        """
+        if kind not in ALLOWED_KINDS:
+            raise ValueError(f"unknown kind '{kind}'")
+        if state not in ALLOWED_STATES:
+            raise ValueError(f"unknown state '{state}'")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT rule_id, kind, params, state, created_at, updated_at, created_by, notes
+                FROM tenant_guardrails
+                WHERE tenant_id = %s AND rule_id = %s
+                """,
+                (tenant_id, rule_id),
+            )
+            existing_row = cur.fetchone()
+            before_rule = _row_to_rule(existing_row) if existing_row else None
+
+            cur.execute(
+                """
+                INSERT INTO tenant_guardrail_changes
+                    (change_id, tenant_id, rule_id, actor, before, after)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, change_id) DO NOTHING
+                RETURNING change_id
+                """,
+                (
+                    change_id,
+                    tenant_id,
+                    rule_id,
+                    actor,
+                    Json(before_rule.as_dict()) if before_rule is not None else None,
+                    None,
+                ),
+            )
+            reserved = cur.fetchone()
+            if reserved is None:
+                conn.commit()
+                if before_rule is None:
+                    cur.execute(
+                        """
+                        SELECT rule_id, kind, params, state, created_at, updated_at,
+                               created_by, notes
+                        FROM tenant_guardrails
+                        WHERE tenant_id = %s AND rule_id = %s
+                        """,
+                        (tenant_id, rule_id),
+                    )
+                    row = cur.fetchone()
+                    if row is None:
+                        raise RuntimeError(
+                            "change_id reserved but rule absent — out-of-band delete?"
+                        )
+                    return _row_to_rule(row)
+                return before_rule
+
+            cur.execute(
+                """
+                INSERT INTO tenant_guardrails
+                    (tenant_id, rule_id, kind, params, state, created_by, notes)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, rule_id) DO UPDATE
+                  SET kind = EXCLUDED.kind,
+                      params = EXCLUDED.params,
+                      state = EXCLUDED.state,
+                      notes = COALESCE(EXCLUDED.notes, tenant_guardrails.notes),
+                      updated_at = now()
+                RETURNING rule_id, kind, params, state, created_at, updated_at, created_by, notes
+                """,
+                (tenant_id, rule_id, kind, Json(params), state, actor, notes),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            after_rule = _row_to_rule(row)
+
+            cur.execute(
+                """
+                UPDATE tenant_guardrail_changes
+                SET after = %s
+                WHERE tenant_id = %s AND change_id = %s
+                """,
+                (Json(after_rule.as_dict()), tenant_id, change_id),
+            )
+            conn.commit()
+            return after_rule
+
+    def audit(
+        self,
+        tenant_id: str,
+        rule_id: str | None = None,
+        limit: int = 100,
+    ) -> list[GuardrailChange]:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            if rule_id is None:
+                cur.execute(
+                    """
+                    SELECT change_id, rule_id, actor, before, after, changed_at
+                    FROM tenant_guardrail_changes
+                    WHERE tenant_id = %s
+                    ORDER BY changed_at DESC
+                    LIMIT %s
+                    """,
+                    (tenant_id, limit),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT change_id, rule_id, actor, before, after, changed_at
+                    FROM tenant_guardrail_changes
+                    WHERE tenant_id = %s AND rule_id = %s
+                    ORDER BY changed_at DESC
+                    LIMIT %s
+                    """,
+                    (tenant_id, rule_id, limit),
+                )
+            return [
+                GuardrailChange(
+                    change_id=str(row[0]),
+                    rule_id=str(row[1]),
+                    actor=row[2],
+                    before=row[3] if (row[3] is None or isinstance(row[3], dict)) else dict(row[3]),
+                    after=row[4] if (row[4] is None or isinstance(row[4], dict)) else dict(row[4]),
+                    changed_at=row[5].isoformat() if row[5] is not None else "",
+                )
+                for row in cur.fetchall()
+            ]

--- a/infra/gateway/tests/test_app_buffer.py
+++ b/infra/gateway/tests/test_app_buffer.py
@@ -67,11 +67,13 @@ def _buffered_client(store: FakeStore) -> Iterator[TestClient]:
         settings.ingest_buffer_poll_interval_s = prev_poll
 
 
-def _spans(n: int) -> list[dict]:
+def _spans(n: int, batch: int = 0) -> list[dict]:
+    # Unique (trace_id, span_id) per call — the buffer's BufferConsumer dedups on that pair, so
+    # repeating IDs across batches makes the drained-store count race with chunk boundaries.
     return [
         {
-            "trace_id": f"t{i}",
-            "span_id": f"s{i}",
+            "trace_id": f"t-{batch}-{i}",
+            "span_id": f"s-{batch}-{i}",
             GenAI.SYSTEM: "openai",
             GenAI.OPERATION_NAME: "chat",
             GenAI.USAGE_INPUT_TOKENS: 10,
@@ -101,8 +103,8 @@ def test_buffered_burst_is_accepted_and_persisted() -> None:
     with _buffered_client(store) as c:
         # Several batches in quick succession — a burst the synchronous path would push through CH.
         total = 0
-        for _ in range(5):
-            r = _post(c, _spans(40))
+        for batch in range(5):
+            r = _post(c, _spans(40, batch=batch))
             assert r.status_code == 200
             body = r.json()
             assert body["status"] == "accepted"
@@ -129,8 +131,8 @@ def test_burst_returns_no_5xx_even_when_clickhouse_down() -> None:
     # buffered and retried in the background; the client sees 200 the whole time.
     store = FakeStore(span_fail=True)
     with _buffered_client(store) as c:
-        for _ in range(5):
-            r = _post(c, _spans(20))
+        for batch in range(5):
+            r = _post(c, _spans(20, batch=batch))
             assert r.status_code == 200  # never 503, even though CH insert raises
             assert r.json()["status"] == "accepted"
         # Rows are retained in the buffer (not lost, not written) while CH is down.

--- a/infra/gateway/tests/test_app_guardrails.py
+++ b/infra/gateway/tests/test_app_guardrails.py
@@ -1,0 +1,307 @@
+"""GET/POST /v1/tenant/guardrails — control-plane CRUD + idempotent audit (CTO-116)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_guardrails import (
+    ALLOWED_KINDS,
+    ALLOWED_STATES,
+    GuardrailChange,
+    GuardrailRule,
+)
+
+T = "t-acme"
+
+
+class FakeStore:
+    """In-memory stand-in for :class:`TenantGuardrailStore` — no Postgres required.
+
+    Mirrors the idempotency contract: a repeated ``change_id`` is a no-op and returns the
+    existing rule unchanged.
+    """
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], GuardrailRule] = {}
+        self._audit: list[tuple[str, GuardrailChange]] = []  # (tenant_id, change)
+        self._seen_changes: set[tuple[str, str]] = set()  # (tenant_id, change_id)
+
+    def list(self, tenant_id: str) -> list[GuardrailRule]:
+        return sorted(
+            [r for (t, _), r in self._rows.items() if t == tenant_id],
+            key=lambda r: r.rule_id,
+        )
+
+    def upsert(
+        self,
+        tenant_id: str,
+        rule_id: str,
+        *,
+        kind: str,
+        params: dict,
+        state: str,
+        change_id: str,
+        actor: str | None = None,
+        notes: str | None = None,
+    ) -> GuardrailRule:
+        if kind not in ALLOWED_KINDS:
+            raise ValueError(f"unknown kind '{kind}'")
+        if state not in ALLOWED_STATES:
+            raise ValueError(f"unknown state '{state}'")
+        key = (tenant_id, change_id)
+        if key in self._seen_changes:
+            # Replay — return the existing rule unchanged.
+            existing = self._rows.get((tenant_id, rule_id))
+            assert existing is not None, "change_id seen but rule missing"
+            return existing
+        self._seen_changes.add(key)
+        before = self._rows.get((tenant_id, rule_id))
+        now = datetime.now(tz=timezone.utc).isoformat()
+        created_at = before.created_at if before else now
+        rule = GuardrailRule(
+            rule_id=rule_id,
+            kind=kind,
+            params=dict(params),
+            state=state,
+            created_at=created_at,
+            updated_at=now,
+            created_by=actor if before is None else before.created_by,
+            notes=notes if notes is not None else (before.notes if before else None),
+        )
+        self._rows[(tenant_id, rule_id)] = rule
+        self._audit.append(
+            (
+                tenant_id,
+                GuardrailChange(
+                    change_id=change_id,
+                    rule_id=rule_id,
+                    actor=actor,
+                    before=before.as_dict() if before else None,
+                    after=rule.as_dict(),
+                    changed_at=now,
+                ),
+            )
+        )
+        return rule
+
+    def audit(
+        self,
+        tenant_id: str,
+        rule_id: str | None = None,
+        limit: int = 100,
+    ) -> list[GuardrailChange]:
+        rows = [c for (t, c) in self._audit if t == tenant_id]
+        if rule_id is not None:
+            rows = [c for c in rows if c.rule_id == rule_id]
+        rows.sort(key=lambda c: c.changed_at, reverse=True)
+        return rows[:limit]
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_guardrails = FakeStore()
+        yield c
+
+
+def _post(client: TestClient, body: dict, tenant: str = T):
+    return client.post(
+        "/v1/tenant/guardrails",
+        headers={"X-Tenant-Id": tenant},
+        json=body,
+    )
+
+
+def test_list_empty_for_fresh_tenant(client: TestClient) -> None:
+    r = client.get("/v1/tenant/guardrails", headers={"X-Tenant-Id": T})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["tenant_id"] == T
+    assert body["rules"] == []
+
+
+def test_upsert_then_list_round_trip(client: TestClient) -> None:
+    r = _post(
+        client,
+        {
+            "rule_id": "gr_cost",
+            "kind": "cost_cap",
+            "state": "shadow",
+            "params": {"max_cost_micro_usd": 1_000_000},
+            "change_id": "11111111-1111-1111-1111-111111111111",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["rule"]["rule_id"] == "gr_cost"
+    assert r.json()["rule"]["state"] == "shadow"
+
+    listing = client.get("/v1/tenant/guardrails", headers={"X-Tenant-Id": T}).json()
+    assert len(listing["rules"]) == 1
+    assert listing["rules"][0]["kind"] == "cost_cap"
+    assert listing["rules"][0]["params"] == {"max_cost_micro_usd": 1_000_000}
+
+
+def test_double_post_same_change_id_is_idempotent(client: TestClient) -> None:
+    body = {
+        "rule_id": "gr_pii",
+        "kind": "pii_gate",
+        "state": "shadow",
+        "params": {},
+        "change_id": "22222222-2222-2222-2222-222222222222",
+    }
+    r1 = _post(client, body)
+    r2 = _post(client, body)
+    assert r1.status_code == 200 and r2.status_code == 200
+    # Listing is stable.
+    listing = client.get("/v1/tenant/guardrails", headers={"X-Tenant-Id": T}).json()
+    assert len(listing["rules"]) == 1
+    # Audit has only one row for this rule.
+    audit = client.get(
+        "/v1/tenant/guardrails/audit",
+        headers={"X-Tenant-Id": T},
+        params={"rule_id": "gr_pii"},
+    ).json()
+    assert len(audit["changes"]) == 1
+
+
+def test_state_transition_shadow_to_enabled(client: TestClient) -> None:
+    r = _post(
+        client,
+        {
+            "rule_id": "gr_loop",
+            "kind": "loop_limit",
+            "state": "shadow",
+            "params": {"max_steps": 50},
+            "change_id": "33333333-3333-3333-3333-333333333333",
+        },
+    )
+    assert r.status_code == 200
+    r = _post(
+        client,
+        {
+            "rule_id": "gr_loop",
+            "kind": "loop_limit",
+            "state": "enabled",
+            "params": {"max_steps": 50},
+            "change_id": "44444444-4444-4444-4444-444444444444",
+        },
+    )
+    assert r.status_code == 200
+    listing = client.get("/v1/tenant/guardrails", headers={"X-Tenant-Id": T}).json()
+    assert len(listing["rules"]) == 1
+    assert listing["rules"][0]["state"] == "enabled"
+
+
+def test_audit_log_appended(client: TestClient) -> None:
+    for i, state in enumerate(["shadow", "enabled", "disabled"], start=1):
+        r = _post(
+            client,
+            {
+                "rule_id": "gr_dep",
+                "kind": "model_deprecation",
+                "state": state,
+                "params": {"deprecated_models": ["claude-2"]},
+                "change_id": f"5555555{i}-5555-5555-5555-555555555555",
+            },
+        )
+        assert r.status_code == 200
+    audit = client.get(
+        "/v1/tenant/guardrails/audit",
+        headers={"X-Tenant-Id": T},
+        params={"rule_id": "gr_dep"},
+    ).json()
+    assert len(audit["changes"]) == 3
+    # Newest first.
+    assert audit["changes"][0]["after"]["state"] == "disabled"
+
+
+def test_unknown_kind_rejected(client: TestClient) -> None:
+    r = _post(
+        client,
+        {
+            "rule_id": "gr_x",
+            "kind": "quantum_gate",
+            "state": "shadow",
+            "params": {},
+            "change_id": "66666666-6666-6666-6666-666666666666",
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_unknown_state_rejected(client: TestClient) -> None:
+    r = _post(
+        client,
+        {
+            "rule_id": "gr_x",
+            "kind": "cost_cap",
+            "state": "yelling",
+            "params": {},
+            "change_id": "77777777-7777-7777-7777-777777777777",
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_missing_change_id_rejected(client: TestClient) -> None:
+    r = _post(
+        client,
+        {
+            "rule_id": "gr_x",
+            "kind": "cost_cap",
+            "state": "shadow",
+            "params": {},
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_tenant_isolation(client: TestClient) -> None:
+    _post(
+        client,
+        {
+            "rule_id": "gr_a",
+            "kind": "cost_cap",
+            "state": "shadow",
+            "params": {},
+            "change_id": "88888888-8888-8888-8888-888888888888",
+        },
+        tenant="t-a",
+    )
+    _post(
+        client,
+        {
+            "rule_id": "gr_b",
+            "kind": "pii_gate",
+            "state": "enabled",
+            "params": {},
+            "change_id": "99999999-9999-9999-9999-999999999999",
+        },
+        tenant="t-b",
+    )
+    a = client.get("/v1/tenant/guardrails", headers={"X-Tenant-Id": "t-a"}).json()
+    b = client.get("/v1/tenant/guardrails", headers={"X-Tenant-Id": "t-b"}).json()
+    assert [r["rule_id"] for r in a["rules"]] == ["gr_a"]
+    assert [r["rule_id"] for r in b["rules"]] == ["gr_b"]
+
+
+def test_requires_tenant_when_auth_disabled(client: TestClient) -> None:
+    assert client.get("/v1/tenant/guardrails").status_code == 422
+    assert (
+        client.post(
+            "/v1/tenant/guardrails",
+            json={
+                "rule_id": "x",
+                "kind": "cost_cap",
+                "state": "shadow",
+                "params": {},
+                "change_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            },
+        ).status_code
+        == 422
+    )

--- a/sdk/python/src/tally/guardrails.py
+++ b/sdk/python/src/tally/guardrails.py
@@ -21,6 +21,11 @@ is ``agent_run.cross_process_ratio`` — see CTO-83.
 
 from __future__ import annotations
 
+import json
+import logging
+import threading
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -128,12 +133,6 @@ def _near_breach(state: GuardrailState, config: GuardrailConfig) -> str | None:
 # the call. The dashboard counts shadow_observed/wk as the graduation signal.
 # --------------------------------------------------------------------------------------------
 
-import json
-import logging
-import threading
-import urllib.error
-import urllib.request
-
 CONFIG_REFRESH_SECONDS = 60
 
 _logger = logging.getLogger("tally.guardrails")
@@ -236,7 +235,7 @@ class GuardrailEngine:
         *,
         refresh_seconds: int = CONFIG_REFRESH_SECONDS,
         start: bool = True,
-    ) -> "GuardrailEngine":
+    ) -> GuardrailEngine:
         """Build an engine bound to a gateway tenant, sync rules once, optionally start the loop.
 
         Fail-soft: an unreachable gateway is logged but does not raise — the engine is returned
@@ -252,7 +251,7 @@ class GuardrailEngine:
         return engine
 
     def _refresh_once(self) -> None:
-        """One sync attempt. Replaces ``self.rules`` on success; on any error, keeps current rules."""
+        """One sync attempt. Replaces ``self.rules`` on success; on error, keeps current rules."""
         import time as _time
 
         if not self._gateway_url or not self._tenant_id:

--- a/sdk/python/src/tally/guardrails.py
+++ b/sdk/python/src/tally/guardrails.py
@@ -114,11 +114,90 @@ def _near_breach(state: GuardrailState, config: GuardrailConfig) -> str | None:
     return None
 
 
+# --------------------------------------------------------------------------------------------
+# Control-plane refresh (CTO-116) — pull the active rule set from the gateway periodically.
+#
+# The gateway is the canonical source of truth. We poll on CONFIG_REFRESH_SECONDS (mirroring
+# web/lib/guardrails.ts) and fail soft: if the gateway is unreachable, we keep enforcing the
+# last-known config. A rule that hasn't loaded yet is a no-op — never a hard fail.
+#
+# Each rule emits two span attributes when it fires:
+#   gen_ai.guardrail.{rule_id}.verdict in {"enforced","shadow_observed","passed"}
+#   gen_ai.guardrail.{rule_id}.kind    in pii_gate | cost_cap | loop_limit | model_deprecation
+# Shadow-state rules emit "shadow_observed" — they record what would have fired without altering
+# the call. The dashboard counts shadow_observed/wk as the graduation signal.
+# --------------------------------------------------------------------------------------------
+
+import json
+import logging
+import threading
+import urllib.error
+import urllib.request
+
+CONFIG_REFRESH_SECONDS = 60
+
+_logger = logging.getLogger("tally.guardrails")
+
+
+class RuleKind(str, Enum):
+    PII_GATE = "pii_gate"
+    COST_CAP = "cost_cap"
+    LOOP_LIMIT = "loop_limit"
+    MODEL_DEPRECATION = "model_deprecation"
+
+
+class RuleState(str, Enum):
+    ENABLED = "enabled"
+    SHADOW = "shadow"
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True, slots=True)
+class ControlPlaneRule:
+    rule_id: str
+    kind: RuleKind
+    state: RuleState
+    params: dict
+
+
+@dataclass(frozen=True, slots=True)
+class RuleVerdict:
+    """Per-rule outcome for span-attr emission.
+
+    verdict is one of:
+      - "enforced"        rule fired AND state=enabled, behavior altered
+      - "shadow_observed" rule fired AND state=shadow, behavior NOT altered
+      - "passed"          rule evaluated but did not fire
+    """
+
+    rule_id: str
+    kind: RuleKind
+    verdict: str
+
+    def attrs(self) -> dict[str, str]:
+        return {
+            f"gen_ai.guardrail.{self.rule_id}.verdict": self.verdict,
+            f"gen_ai.guardrail.{self.rule_id}.kind": self.kind.value,
+        }
+
+
 @dataclass(slots=True)
 class GuardrailEngine:
-    """Evaluates guardrails against per-trace state. Holds the OBSERVE-mode would-fire tally."""
+    """Evaluates guardrails against per-trace state. Holds the OBSERVE-mode would-fire tally.
+
+    For CTO-116, also pulls a tenant-scoped rule set from the gateway on a refresh interval and
+    exposes :meth:`apply_rules` which evaluates the cached rules against a per-call context.
+    """
 
     would_fire_counts: dict[Limit, int] = field(default_factory=dict)
+    rules: list[ControlPlaneRule] = field(default_factory=list)
+    shadow_fire_counts: dict[str, int] = field(default_factory=dict)
+    _last_refresh_at: float = 0.0
+    _refresh_seconds: int = CONFIG_REFRESH_SECONDS
+    _gateway_url: str | None = None
+    _tenant_id: str | None = None
+    _stop: threading.Event | None = None
+    _thread: threading.Thread | None = None
 
     def evaluate(self, state: GuardrailState, config: GuardrailConfig) -> Verdict:
         """Consult the guardrail. Call BEFORE the next LLM/tool call.
@@ -141,8 +220,142 @@ class GuardrailEngine:
             return Verdict(
                 proceed=True,
                 breached=limit,
-                warning=f"guardrail '{limit.value}' exceeded ({value}/{cap})",
+                warning=f"guardrail \'{limit.value}\' exceeded ({value}/{cap})",
             )
 
         # GRACEFUL or HARD_STOP — localized exception, never a process kill.
         raise CostLimitExceededException(limit, value, cap, state.trace_id)
+
+    # ---- Control-plane refresh (CTO-116) -----------------------------------------------------
+
+    @classmethod
+    def from_gateway(
+        cls,
+        gateway_url: str,
+        tenant_id: str,
+        *,
+        refresh_seconds: int = CONFIG_REFRESH_SECONDS,
+        start: bool = True,
+    ) -> "GuardrailEngine":
+        """Build an engine bound to a gateway tenant, sync rules once, optionally start the loop.
+
+        Fail-soft: an unreachable gateway is logged but does not raise — the engine is returned
+        with an empty rule list and the next refresh will retry.
+        """
+        engine = cls()
+        engine._gateway_url = gateway_url.rstrip("/")
+        engine._tenant_id = tenant_id
+        engine._refresh_seconds = refresh_seconds
+        engine._refresh_once()
+        if start:
+            engine.start_refresh()
+        return engine
+
+    def _refresh_once(self) -> None:
+        """One sync attempt. Replaces ``self.rules`` on success; on any error, keeps current rules."""
+        import time as _time
+
+        if not self._gateway_url or not self._tenant_id:
+            return
+        url = f"{self._gateway_url}/v1/tenant/guardrails"
+        req = urllib.request.Request(url, headers={"x-tenant-id": self._tenant_id})
+        try:
+            with urllib.request.urlopen(req, timeout=4) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            raw_rules = payload.get("rules") or []
+            parsed: list[ControlPlaneRule] = []
+            for r in raw_rules:
+                try:
+                    parsed.append(
+                        ControlPlaneRule(
+                            rule_id=str(r["rule_id"]),
+                            kind=RuleKind(r["kind"]),
+                            state=RuleState(r["state"]),
+                            params=dict(r.get("params") or {}),
+                        )
+                    )
+                except (KeyError, ValueError) as exc:
+                    _logger.warning("guardrails: skipping malformed rule: %s", exc)
+            self.rules = parsed
+        except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+            _logger.warning(
+                "guardrails: refresh failed, keeping last-known rules (%d): %s",
+                len(self.rules),
+                exc,
+            )
+        finally:
+            self._last_refresh_at = _time.time()
+
+    def _run_refresh_loop(self) -> None:
+        assert self._stop is not None
+        while not self._stop.is_set():
+            if self._stop.wait(self._refresh_seconds):
+                return
+            self._refresh_once()
+
+    def start_refresh(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run_refresh_loop, name="guardrail-refresh", daemon=True
+        )
+        self._thread.start()
+
+    def stop_refresh(self) -> None:
+        if self._stop is not None:
+            self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        self._thread = None
+        self._stop = None
+
+    def apply_rules(self, call_context: dict) -> list[RuleVerdict]:
+        """Evaluate each loaded rule against ``call_context``.
+
+        Returns one :class:`RuleVerdict` per non-disabled rule. The verdict string is:
+          - "enforced"        rule fired and state=enabled (caller should alter behavior)
+          - "shadow_observed" rule fired and state=shadow  (record only)
+          - "passed"          rule did not fire
+
+        Shadow firings increment ``shadow_fire_counts[rule_id]`` so the dashboard can count
+        would-have-fired/wk before flipping to enabled.
+        """
+        out: list[RuleVerdict] = []
+        for rule in self.rules:
+            if rule.state == RuleState.DISABLED:
+                continue
+            fired = _rule_fires(rule, call_context)
+            if fired:
+                if rule.state == RuleState.ENABLED:
+                    verdict = "enforced"
+                else:
+                    verdict = "shadow_observed"
+                    self.shadow_fire_counts[rule.rule_id] = (
+                        self.shadow_fire_counts.get(rule.rule_id, 0) + 1
+                    )
+            else:
+                verdict = "passed"
+            out.append(RuleVerdict(rule_id=rule.rule_id, kind=rule.kind, verdict=verdict))
+        return out
+
+
+def _rule_fires(rule: ControlPlaneRule, ctx: dict) -> bool:
+    """Heuristic per-kind firing predicate. Keep these dumb on purpose — the gateway is the
+    source of truth for what each kind means, the SDK just evaluates the cached predicate."""
+    if rule.kind == RuleKind.PII_GATE:
+        return bool(ctx.get("contains_pii"))
+    if rule.kind == RuleKind.COST_CAP:
+        cap = rule.params.get("max_cost_micro_usd")
+        if cap is None:
+            return False
+        return float(ctx.get("cost_micro_usd", 0)) > float(cap)
+    if rule.kind == RuleKind.LOOP_LIMIT:
+        cap = rule.params.get("max_steps")
+        if cap is None:
+            return False
+        return int(ctx.get("step_count", 0)) > int(cap)
+    if rule.kind == RuleKind.MODEL_DEPRECATION:
+        deprecated = rule.params.get("deprecated_models") or []
+        return ctx.get("model") in deprecated
+    return False

--- a/sdk/python/tests/test_guardrails_refresh.py
+++ b/sdk/python/tests/test_guardrails_refresh.py
@@ -14,7 +14,6 @@ import pytest
 
 from tally.guardrails import (
     CONFIG_REFRESH_SECONDS,
-    ControlPlaneRule,
     GuardrailEngine,
     RuleKind,
     RuleState,
@@ -28,7 +27,7 @@ class _FakeResp:
     def read(self) -> bytes:
         return self._buf
 
-    def __enter__(self) -> "_FakeResp":
+    def __enter__(self) -> _FakeResp:
         return self
 
     def __exit__(self, *a: object) -> None:

--- a/sdk/python/tests/test_guardrails_refresh.py
+++ b/sdk/python/tests/test_guardrails_refresh.py
@@ -1,0 +1,200 @@
+"""SDK guardrails control-plane refresh (CTO-116).
+
+Covers the engine's gateway-poll fail-soft behavior and the shadow/enforce span-attr emission.
+Uses a monkeypatched ``urllib.request.urlopen`` — no real network.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+
+import pytest
+
+from tally.guardrails import (
+    CONFIG_REFRESH_SECONDS,
+    ControlPlaneRule,
+    GuardrailEngine,
+    RuleKind,
+    RuleState,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload: dict) -> None:
+        self._buf = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._buf
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        return None
+
+
+def _ok_response(rules: list[dict]):
+    def fake(req, timeout=None):  # noqa: ARG001
+        return _FakeResp({"tenant_id": "t-acme", "rules": rules})
+
+    return fake
+
+
+def test_config_refresh_seconds_mirrors_web() -> None:
+    # The web side advertises a 60s window — keep them in lockstep.
+    assert CONFIG_REFRESH_SECONDS == 60
+
+
+def test_initial_refresh_loads_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    rules = [
+        {
+            "rule_id": "gr_cost",
+            "kind": "cost_cap",
+            "state": "enabled",
+            "params": {"max_cost_micro_usd": 1_000_000},
+        },
+        {
+            "rule_id": "gr_pii",
+            "kind": "pii_gate",
+            "state": "shadow",
+            "params": {},
+        },
+    ]
+    monkeypatch.setattr(
+        "tally.guardrails.urllib.request.urlopen", _ok_response(rules)
+    )
+    engine = GuardrailEngine.from_gateway(
+        "http://gw.local", "t-acme", start=False
+    )
+    assert len(engine.rules) == 2
+    assert engine.rules[0].kind == RuleKind.COST_CAP
+    assert engine.rules[1].state == RuleState.SHADOW
+
+
+def test_fail_soft_on_gateway_unreachable_keeps_last_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rules = [
+        {
+            "rule_id": "gr_loop",
+            "kind": "loop_limit",
+            "state": "shadow",
+            "params": {"max_steps": 50},
+        }
+    ]
+    monkeypatch.setattr(
+        "tally.guardrails.urllib.request.urlopen", _ok_response(rules)
+    )
+    engine = GuardrailEngine.from_gateway(
+        "http://gw.local", "t-acme", start=False
+    )
+    assert len(engine.rules) == 1
+    # Next refresh blows up — engine should keep the cached rule set.
+    def boom(req, timeout=None):  # noqa: ARG001
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("tally.guardrails.urllib.request.urlopen", boom)
+    engine._refresh_once()
+    assert len(engine.rules) == 1
+    assert engine.rules[0].rule_id == "gr_loop"
+
+
+def test_enabled_rule_emits_enforced_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    rules = [
+        {
+            "rule_id": "gr_cost",
+            "kind": "cost_cap",
+            "state": "enabled",
+            "params": {"max_cost_micro_usd": 1000},
+        }
+    ]
+    monkeypatch.setattr(
+        "tally.guardrails.urllib.request.urlopen", _ok_response(rules)
+    )
+    engine = GuardrailEngine.from_gateway("http://gw.local", "t-acme", start=False)
+    verdicts = engine.apply_rules({"cost_micro_usd": 5000})
+    assert len(verdicts) == 1
+    v = verdicts[0]
+    assert v.verdict == "enforced"
+    attrs = v.attrs()
+    assert attrs["gen_ai.guardrail.gr_cost.verdict"] == "enforced"
+    assert attrs["gen_ai.guardrail.gr_cost.kind"] == "cost_cap"
+
+
+def test_shadow_rule_emits_shadow_observed_and_does_not_alter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rules = [
+        {
+            "rule_id": "gr_cost",
+            "kind": "cost_cap",
+            "state": "shadow",
+            "params": {"max_cost_micro_usd": 1000},
+        }
+    ]
+    monkeypatch.setattr(
+        "tally.guardrails.urllib.request.urlopen", _ok_response(rules)
+    )
+    engine = GuardrailEngine.from_gateway("http://gw.local", "t-acme", start=False)
+    verdicts = engine.apply_rules({"cost_micro_usd": 5000})
+    assert verdicts[0].verdict == "shadow_observed"
+    assert engine.shadow_fire_counts["gr_cost"] == 1
+    # Firing again increments the counter — apply_rules itself never raises.
+    engine.apply_rules({"cost_micro_usd": 5000})
+    assert engine.shadow_fire_counts["gr_cost"] == 2
+
+
+def test_passed_when_not_fired(monkeypatch: pytest.MonkeyPatch) -> None:
+    rules = [
+        {
+            "rule_id": "gr_cost",
+            "kind": "cost_cap",
+            "state": "enabled",
+            "params": {"max_cost_micro_usd": 1_000_000},
+        }
+    ]
+    monkeypatch.setattr(
+        "tally.guardrails.urllib.request.urlopen", _ok_response(rules)
+    )
+    engine = GuardrailEngine.from_gateway("http://gw.local", "t-acme", start=False)
+    verdicts = engine.apply_rules({"cost_micro_usd": 100})
+    assert verdicts[0].verdict == "passed"
+    assert "gr_cost" not in engine.shadow_fire_counts
+
+
+def test_disabled_rule_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    rules = [
+        {
+            "rule_id": "gr_off",
+            "kind": "cost_cap",
+            "state": "disabled",
+            "params": {"max_cost_micro_usd": 1},
+        }
+    ]
+    monkeypatch.setattr(
+        "tally.guardrails.urllib.request.urlopen", _ok_response(rules)
+    )
+    engine = GuardrailEngine.from_gateway("http://gw.local", "t-acme", start=False)
+    verdicts = engine.apply_rules({"cost_micro_usd": 999_999})
+    assert verdicts == []
+
+
+def test_refresh_loop_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    def fake(req, timeout=None):  # noqa: ARG001
+        calls["n"] += 1
+        return _FakeResp({"tenant_id": "t-acme", "rules": []})
+
+    monkeypatch.setattr("tally.guardrails.urllib.request.urlopen", fake)
+    engine = GuardrailEngine.from_gateway(
+        "http://gw.local", "t-acme", refresh_seconds=0.1, start=True  # type: ignore[arg-type]
+    )
+    try:
+        time.sleep(0.35)
+    finally:
+        engine.stop_refresh()
+    # 1 initial + at least 2 loop iterations within 0.35s.
+    assert calls["n"] >= 3, f"expected >=3 refresh calls, got {calls['n']}"


### PR DESCRIPTION
## Summary

Implements the data + enforcement layer of [CTO-116](https://linear.app/cto-assist/issue/CTO-116). The web `/guardrails` UI wiring is deferred to a follow-up — the load-bearing pieces (persistent config, gateway API, SDK refresh + span attributes) are all here. The existing `/guardrails` mock page continues to render via the fallback path until the UI is wired.

## Commits

| # | What |
|---|---|
| `af43e7f` | Postgres `tenant_guardrails` table (PK `(tenant_id, rule_id)`, jsonb params, state enum: enabled/shadow/disabled) + `tenant_guardrail_changes` audit table with client-supplied `change_id` UUID for idempotency. |
| `212826d` | Gateway `GET/POST /v1/tenant/guardrails` + `GET /v1/tenant/guardrails/audit`. Upserts log diffs to audit on every state change. ON CONFLICT DO NOTHING on `change_id` makes UI double-clicks safe. |
| `aced229` | SDK `GuardrailEngine.from_gateway()` factory with periodic refresh thread. When a rule fires the engine emits `gen_ai.guardrail.{rule_id}.verdict` (= "enforced" \| "shadow_observed" \| "passed") and `gen_ai.guardrail.{rule_id}.kind` on the span. Fail-soft: gateway unreachable → keep last-known config. |

## Tests
- Gateway: 223 passed (added test_app_guardrails.py: list, upsert, idempotent double-POST, audit append)
- SDK: 858 passed (added test_guardrails_refresh.py: refresh-on-interval, fail-soft, shadow-vs-enforce verdict emission)

## Honest gap

**`/guardrails` web UI not in this PR.** The agent died before the route + page rewiring (mock fallback continues to render). Will file CTO-116-followup. Plumbing this in is mechanical: replace the route handler's mock fallback with `queryGuardrailRules()` via the new gateway endpoints, add a "shadow" visual state to the toggle UI, and surface the audit-log column per rule.

## Out of scope (per ticket)

- Custom rule kinds beyond pii_gate/cost_cap/loop_limit/model_deprecation
- Per-feature-tag rule scoping
- Approval workflows
- Rule simulation (would need CTO-113 replay infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)