### PR TITLE
CTO-119: stratified sampling metadata — SDK emit + DQ per-stratum table

### DIFF
--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -55,6 +55,14 @@ CREATE TABLE IF NOT EXISTS otel_spans
     ContextDroppedTokens   UInt32 DEFAULT 0         CODEC(T64, ZSTD(1)),
     ContextWindowUsedPct   Float32 DEFAULT 0        CODEC(ZSTD(1)),
 
+    -- Stratified-sampling provenance (CTO-119). SamplingStratum is the head-time classification
+    -- ('body'|'mid'|'tail'); SamplingRate is THAT stratum's configured keep rate. Distinct from
+    -- the per-span `SampleRate` weight below (which is the billing-extrapolation factor — they're
+    -- usually equal today, but conceptually independent: rate can change after a span is kept).
+    -- Default 'unsampled' / 1.0 so pre-CTO-119 rows group as a separate, honestly-labelled bucket.
+    SamplingStratum        LowCardinality(String) DEFAULT 'unsampled',
+    SamplingRate           Float32 DEFAULT 1.0     CODEC(ZSTD(1)),
+
     -- Replay (Workflow 1)
     ResolvedPromptHash     FixedString(64),
     ResolvedContextRef     String,
@@ -97,3 +105,10 @@ ALTER TABLE otel_spans
     ADD COLUMN IF NOT EXISTS ContextDroppedMessages UInt32  DEFAULT 0 CODEC(T64, ZSTD(1)),
     ADD COLUMN IF NOT EXISTS ContextDroppedTokens   UInt32  DEFAULT 0 CODEC(T64, ZSTD(1)),
     ADD COLUMN IF NOT EXISTS ContextWindowUsedPct   Float32 DEFAULT 0 CODEC(ZSTD(1));
+
+-- CTO-119 additive migration. Same idempotent pattern; default 'unsampled' / 1.0 means
+-- pre-migration rows group as their own bucket on the DQ surface rather than polluting
+-- body/mid/tail breakdowns.
+ALTER TABLE otel_spans
+    ADD COLUMN IF NOT EXISTS SamplingStratum LowCardinality(String) DEFAULT 'unsampled',
+    ADD COLUMN IF NOT EXISTS SamplingRate    Float32                DEFAULT 1.0 CODEC(ZSTD(1));

--- a/infra/gateway/src/gateway/mapping.py
+++ b/infra/gateway/src/gateway/mapping.py
@@ -39,6 +39,8 @@ _PROMOTED_GENAI = frozenset(
         GenAI.CONTEXT_DROPPED_MESSAGES,
         GenAI.CONTEXT_DROPPED_TOKENS,
         GenAI.CONTEXT_WINDOW_USED_PCT,
+        GenAI.SAMPLING_STRATUM,
+        GenAI.SAMPLING_RATE,
     }
 )
 
@@ -110,6 +112,8 @@ COLUMNS: tuple[str, ...] = (
     "ContextDroppedMessages",
     "ContextDroppedTokens",
     "ContextWindowUsedPct",
+    "SamplingStratum",
+    "SamplingRate",
     "SpanAttributes",
     "SampleRate",
 )
@@ -210,6 +214,10 @@ def span_to_row(
         _i(span.get(GenAI.CONTEXT_DROPPED_MESSAGES)),
         _i(span.get(GenAI.CONTEXT_DROPPED_TOKENS)),
         _f(span.get(GenAI.CONTEXT_WINDOW_USED_PCT)),
+        # CTO-119: stratum default 'unsampled' matches the DDL — pre-CTO-119 spans land in their
+        # own honestly-labelled bucket on the DQ surface rather than masquerading as 'body'.
+        _s(span.get(GenAI.SAMPLING_STRATUM) or "unsampled"),
+        _f(span.get(GenAI.SAMPLING_RATE) if span.get(GenAI.SAMPLING_RATE) is not None else 1.0),
         extra,
         float(sample_rate),
     )

--- a/infra/gateway/tests/test_mapping_sampling.py
+++ b/infra/gateway/tests/test_mapping_sampling.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-119: gateway mapping for stratified-sampling provenance.
+
+The SDK emits ``gen_ai.sampling.stratum`` and ``gen_ai.sampling.rate``; the gateway promotes
+them onto typed columns (``SamplingStratum`` / ``SamplingRate``). Pre-CTO-119 spans land in the
+``unsampled`` bucket with rate 1.0 so the DQ surface can group them honestly.
+"""
+
+from __future__ import annotations
+
+from gateway.mapping import COLUMNS, span_to_row
+
+
+def _row_dict(row: tuple[object, ...]) -> dict[str, object]:
+    assert len(row) == len(COLUMNS)
+    return dict(zip(COLUMNS, row, strict=True))
+
+
+def test_sampling_attrs_promoted_to_columns() -> None:
+    span = {"gen_ai.sampling.stratum": "tail", "gen_ai.sampling.rate": 1.0}
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    assert row["SamplingStratum"] == "tail"
+    assert row["SamplingRate"] == 1.0
+
+
+def test_sampling_columns_default_when_absent() -> None:
+    """A span without sampling attrs lands in the 'unsampled' bucket at rate 1.0."""
+    row = _row_dict(span_to_row({}, tenant_id="t1", effective_ts_ns=0))
+    assert row["SamplingStratum"] == "unsampled"
+    assert row["SamplingRate"] == 1.0
+
+
+def test_sampling_attrs_not_duplicated_in_span_attributes_map() -> None:
+    span = {"gen_ai.sampling.stratum": "body", "gen_ai.sampling.rate": 0.1}
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    extra = row["SpanAttributes"]
+    assert isinstance(extra, dict)
+    assert "gen_ai.sampling.stratum" not in extra
+    assert "gen_ai.sampling.rate" not in extra

--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -165,6 +165,10 @@ class TallyClient:
                 price_catalog_version=catalog_version,
                 feature_tag=ctx.feature_tag,
                 session_id=ctx.session_id,
+                # CTO-119: stratum + configured keep-rate ride on the kept span so the DQ surface
+                # can compute per-stratum CIs without re-classifying after the fact.
+                sampling_stratum=decision.stratum.value,
+                sampling_rate=decision.sample_rate,
             )
             attrs = build_span_attributes(fields)
             # NB: sample_rate travels at the batch level (wire Sampling, §12.2), not as a span

--- a/sdk/python/src/tally/schema.py
+++ b/sdk/python/src/tally/schema.py
@@ -60,6 +60,13 @@ class GenAI:
     CONTEXT_DROPPED_TOKENS = "gen_ai.context.dropped_tokens"  # int, total tokens trimmed
     CONTEXT_WINDOW_USED_PCT = "gen_ai.context.window_used_pct"  # float, 0..1
 
+    # Stratified-sampling provenance (CTO-119). The stratum the head-time sampler placed this trace
+    # in ("body" | "mid" | "tail") plus the stratum's configured keep rate. Distinct from the
+    # existing per-span `SampleRate` weight used for billing extrapolation — this pair lets the DQ
+    # surface compute per-stratum confidence bands without inferring them from cost histograms.
+    SAMPLING_STRATUM = "gen_ai.sampling.stratum"  # str, "body" | "mid" | "tail"
+    SAMPLING_RATE = "gen_ai.sampling.rate"  # float, 0..1
+
 
 # Known operation names (open set — unknown values are allowed but should be lowercase tokens).
 OPERATIONS = frozenset({"chat", "completion", "embeddings", "tool", "agent", "rerank"})
@@ -81,8 +88,8 @@ _INT_KEYS = frozenset(
         GenAI.CONTEXT_DROPPED_TOKENS,
     }
 )
-# Float keys — currently just the context-window utilization signal (CTO-118).
-_FLOAT_KEYS = frozenset({GenAI.CONTEXT_WINDOW_USED_PCT})
+# Float keys — context-window utilization (CTO-118) and stratum keep-rate (CTO-119).
+_FLOAT_KEYS = frozenset({GenAI.CONTEXT_WINDOW_USED_PCT, GenAI.SAMPLING_RATE})
 _STR_KEYS = frozenset(
     {
         GenAI.SYSTEM,
@@ -100,8 +107,12 @@ _STR_KEYS = frozenset(
         GenAI.TOOL_NAME,
         GenAI.TOOL_CALL_ID,
         GenAI.RESOLVED_CONTEXT_REF,
+        GenAI.SAMPLING_STRATUM,
     }
 )
+# Allowed values for the stratum string. The validator rejects anything else so we don't end up
+# with a long-tail of free-text strata polluting the DQ table.
+_SAMPLING_STRATA = frozenset({"body", "mid", "tail"})
 _ALL_KEYS = _INT_KEYS | _STR_KEYS | _FLOAT_KEYS
 
 _MICRO = Decimal(1_000_000)
@@ -145,6 +156,8 @@ class SpanFields:
     tool_call_id: str | None = None
     tool_cost_micro_usd: int | None = None
     resolved_context_ref: str | None = None
+    sampling_stratum: str | None = None
+    sampling_rate: float | None = None
 
 
 _FIELD_TO_KEY = {
@@ -170,6 +183,8 @@ _FIELD_TO_KEY = {
     "tool_call_id": GenAI.TOOL_CALL_ID,
     "tool_cost_micro_usd": GenAI.TOOL_COST_MICRO_USD,
     "resolved_context_ref": GenAI.RESOLVED_CONTEXT_REF,
+    "sampling_stratum": GenAI.SAMPLING_STRATUM,
+    "sampling_rate": GenAI.SAMPLING_RATE,
 }
 
 
@@ -229,5 +244,11 @@ def validate_span_attributes(attrs: dict[str, object]) -> list[str]:
 
     if GenAI.COST_ESTIMATED_MICRO_USD in attrs and GenAI.COST_CURRENCY not in attrs:
         violations.append("cost present without gen_ai.cost.currency")
+
+    stratum = attrs.get(GenAI.SAMPLING_STRATUM)
+    if isinstance(stratum, str) and stratum not in _SAMPLING_STRATA:
+        violations.append(
+            f"{GenAI.SAMPLING_STRATUM} must be one of {sorted(_SAMPLING_STRATA)}, got {stratum!r}"
+        )
 
     return violations

--- a/sdk/python/tests/test_schema.py
+++ b/sdk/python/tests/test_schema.py
@@ -74,6 +74,23 @@ def test_bad_currency_rejected():
     )
 
 
+def test_sampling_stratum_and_rate_round_trip():
+    fields = SpanFields(sampling_stratum="tail", sampling_rate=1.0)
+    attrs = build_span_attributes(fields)
+    assert attrs[GenAI.SAMPLING_STRATUM] == "tail"
+    assert attrs[GenAI.SAMPLING_RATE] == 1.0
+    assert validate_span_attributes(attrs) == []
+
+
+def test_sampling_stratum_rejects_unknown_value():
+    violations = validate_span_attributes({GenAI.SAMPLING_STRATUM: "outlier"})
+    assert any("stratum" in v for v in violations)
+
+
+def test_sampling_rate_must_be_in_unit_interval():
+    assert validate_span_attributes({GenAI.SAMPLING_RATE: 1.5})
+
+
 @pytest.mark.parametrize(
     "usd,micro",
     [("0.0012", 1200), ("1", 1_000_000), ("0.0000005", 1), ("0.00000049", 0)],

--- a/web/app/data-quality/page.tsx
+++ b/web/app/data-quality/page.tsx
@@ -153,32 +153,55 @@ export default async function DataQualityPage() {
         </table>
       </Card>
 
-      <Card title="Sampling by stratum">
-        <table className="w-full text-sm">
-          <thead className="text-xs uppercase text-muted">
-            <tr>
-              <th className="py-1 text-left font-medium">Stratum</th>
-              <th className="py-1 text-right font-medium">Keep rate</th>
-              <th className="py-1 text-right font-medium">CI on extrapolated cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sampling.map((s) => (
-              <tr key={s.stratum} className="border-t border-edge">
-                <td className="py-2 capitalize">{s.stratum}</td>
-                <td className="py-2 text-right tabular-nums">{Math.round(s.rate * 100)}%</td>
-                <td className="py-2 text-right tabular-nums">
-                  {s.ciHalfWidthPct === 0 ? (
-                    <span className="text-good">exact</span>
-                  ) : (
-                    `±${Math.round(s.ciHalfWidthPct * 100)}%`
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </Card>
+      {/* CTO-119: hide the table entirely when no sampling is configured (effective rate == 100%
+          AND no spans in any stratum) — every span is captured, the CI is degenerate, the table
+          would just be confusing. Inactive tenants (no data) get the same treatment. */}
+      {(() => {
+        const totalSpans = sampling.reduce((s, r) => s + r.spans, 0);
+        if (overall.effectiveSampleRate >= 1.0 && totalSpans === 0) {
+          return (
+            <Card title="Sampling by stratum">
+              <p className="text-sm text-muted" title="no sampling configured — every span captured">
+                Not applicable — every span captured.
+              </p>
+            </Card>
+          );
+        }
+        return (
+          <Card title="Sampling by stratum">
+            <table className="w-full text-sm">
+              <thead className="text-xs uppercase text-muted">
+                <tr>
+                  <th className="py-1 text-left font-medium">Stratum</th>
+                  <th className="py-1 text-right font-medium">Keep rate</th>
+                  <th className="py-1 text-right font-medium">CI on extrapolated cost</th>
+                  <th className="py-1 text-right font-medium">Spans (30d)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sampling.map((s) => (
+                  <tr key={s.stratum} className="border-t border-edge">
+                    <td className="py-2 capitalize">{s.stratum}</td>
+                    <td className="py-2 text-right tabular-nums">{Math.round(s.rate * 100)}%</td>
+                    <td className="py-2 text-right tabular-nums">
+                      {s.ciHalfWidthPct === null ? (
+                        <span className="text-muted" title="needs ≥30 kept spans in 30d">
+                          —
+                        </span>
+                      ) : s.ciHalfWidthPct === 0 ? (
+                        <span className="text-good">exact</span>
+                      ) : (
+                        `±${Math.round(s.ciHalfWidthPct * 100)}%`
+                      )}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">{s.spans.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+        );
+      })()}
     </div>
   );
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -403,8 +403,43 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
       reconciledMicroUsd: micro(r.recon),
     }));
 
-    // No stratified-sampling metadata in otel_spans yet → leave empty (the page renders no rows).
-    const sampling: SampleByStratum[] = [];
+    // CTO-119: per-stratum stats from typed columns. The "ci_half" formula is the standard
+    // coefficient-of-variation half-width: zCrit × stddev(cost) / mean(cost) / sqrt(n), which
+    // assumes cost is approximately log-normal within the stratum. Fine for body (high-volume,
+    // similar costs); heroic for tail (rare, expensive) — flagged in CTO-119 as a follow-up
+    // where a bootstrap estimator may be warranted. n<30 → null (page renders "—") rather than
+    // a meaninglessly wide band.
+    const strata = await rows<{ stratum: string; rate: string; n: string; mean: string; std: string }>(
+      db,
+      `SELECT SamplingStratum AS stratum,
+              avg(SamplingRate) AS rate,
+              count() AS n,
+              avg(EstimatedCost) AS mean,
+              stddevPop(EstimatedCost) AS std
+       FROM otel_spans
+       WHERE TenantId = {tenant:String}
+         AND Timestamp >= now() - INTERVAL 30 DAY
+         AND SamplingStratum IN ('body', 'mid', 'tail')
+       GROUP BY stratum`,
+      tenant,
+    );
+    const Z95 = 1.96;
+    const byStratum = new Map(strata.map((r) => {
+      const n = parseInt(r.n, 10) || 0;
+      const mean = parseFloat(r.mean) || 0;
+      const std = parseFloat(r.std) || 0;
+      const ci = n >= 30 && mean > 0 ? (Z95 * std) / mean / Math.sqrt(n) : null;
+      return [r.stratum, { rate: parseFloat(r.rate) || 0, ci, spans: n }];
+    }));
+    const sampling: SampleByStratum[] = (["tail", "mid", "body"] as const).map((s) => {
+      const row = byStratum.get(s);
+      return {
+        stratum: s,
+        rate: row?.rate ?? 0,
+        ciHalfWidthPct: row?.ci ?? null,
+        spans: row?.spans ?? 0,
+      };
+    });
 
     return {
       overall: {

--- a/web/lib/dq.test.ts
+++ b/web/lib/dq.test.ts
@@ -30,6 +30,6 @@ describe("data-quality", () => {
   it("body has wider CI than mid", () => {
     const body = dq.sampling.find((s) => s.stratum === "body")!;
     const mid = dq.sampling.find((s) => s.stratum === "mid")!;
-    expect(body.ciHalfWidthPct).toBeGreaterThan(mid.ciHalfWidthPct);
+    expect(body.ciHalfWidthPct!).toBeGreaterThan(mid.ciHalfWidthPct!);
   });
 });

--- a/web/lib/dq.ts
+++ b/web/lib/dq.ts
@@ -25,8 +25,15 @@ export interface CalibrationDay {
 
 export interface SampleByStratum {
   stratum: "body" | "mid" | "tail";
-  rate: number; // 0..1
-  ciHalfWidthPct: number; // 0..1 fractional half-width of CI on extrapolated cost
+  rate: number; // 0..1, average configured keep rate seen in this stratum over the window
+  /**
+   * 0..1 fractional half-width of the 95% CI on extrapolated cost. `null` when fewer than 30
+   * kept spans landed in this stratum over the window — Wilson-flavoured estimators get
+   * uselessly wide below that. Render `—`, never a fabricated tight band (CTO-119).
+   */
+  ciHalfWidthPct: number | null;
+  /** kept-span count in this stratum over the window (used to gate the CI). */
+  spans: number;
 }
 
 export interface DataQualityReport {
@@ -75,8 +82,8 @@ export const dq: DataQualityReport = {
     { date: "2026-05-19", estimatedMicroUsd: 1_120_000_000, reconciledMicroUsd: 1_101_000_000 },
   ],
   sampling: [
-    { stratum: "tail", rate: 1.0, ciHalfWidthPct: 0.0 },
-    { stratum: "mid", rate: 0.5, ciHalfWidthPct: 0.04 },
-    { stratum: "body", rate: 0.1, ciHalfWidthPct: 0.18 },
+    { stratum: "tail", rate: 1.0, ciHalfWidthPct: 0.0, spans: 420 },
+    { stratum: "mid", rate: 0.5, ciHalfWidthPct: 0.04, spans: 1840 },
+    { stratum: "body", rate: 0.1, ciHalfWidthPct: 0.18, spans: 12_600 },
   ],
 };


### PR DESCRIPTION
## Summary

Closes [CTO-119](https://linear.app/cto-assist/issue/CTO-119). The \"Sampling by stratum\" table on /data-quality stops being empty — it now reads real per-stratum keep rate + CI on extrapolated cost from `otel_spans`, with the SDK emitting the stratum/rate on every kept span.

## What changed

**SDK** (sdk/python)
- `gen_ai.sampling.stratum` (str: \`body\`|\`mid\`|\`tail\`) + `gen_ai.sampling.rate` (float, 0..1) added to the schema with validation
- `TallyClient.record_llm_call` plumbs the existing `Sampler.decide()` outputs onto every kept span

**Gateway + DDL**
- Additive ALTER on `otel_spans`: `SamplingStratum LowCardinality(String) DEFAULT 'unsampled'`, `SamplingRate Float32 DEFAULT 1.0` — distinct from the existing per-span `SampleRate` billing-extrapolation weight (comment in DDL spells out the difference)
- Gateway promotes the two attrs to typed columns; pre-CTO-119 spans default to the `unsampled` bucket so they don't pollute the body/mid/tail breakdown

**Web**
- `queryDataQualityReport()` computes per-stratum: avg keep rate + coefficient-of-variation 95% CI half-width (`zCrit × std / mean / sqrt(n)`)
- n<30 → `ciHalfWidthPct: null` → page renders \`—\` rather than a fabricated tight band
- New \"Spans (30d)\" column so tenants can see why a CI is suppressed
- When `effectiveSampleRate >= 1.0` AND no stratum data → \"Not applicable — every span captured\" card instead of an empty 0%/—/0 table

## Out of scope (per ticket)

- Adaptive sampling, per-feature stratification, historical backfill, bootstrap CI for the tail (the CV estimator's log-normal assumption is heroic there — comment in the query flags it)

## Test plan

- [x] SDK pytest (837 passing) + ruff clean
- [x] Gateway pytest (245 passing) + ruff clean, 3 new mapping tests
- [x] Web `npx vitest run` — only the pre-existing attribution mock-fallback test fails locally when ClickHouse is up (env-dependent, passes in CI)
- [x] Browser preview: navigated to /data-quality, confirmed the table renders Tail 100%/exact/420 · Mid 50%/±4%/1,840 · Body 10%/±18%/12,600 (mock fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)