### PR TITLE
fix: chatbot demo — live-UI fixes (PG migrations, guest auth, latency, mock-data badge)

### DIFF
--- a/examples/vercel-chatbot/app/app/(auth)/auth.ts
+++ b/examples/vercel-chatbot/app/app/(auth)/auth.ts
@@ -73,8 +73,14 @@ export const {
       id: "guest",
       credentials: {},
       async authorize() {
-        const [guestUser] = await createGuestUser();
-        return { ...guestUser, type: "guest" };
+        // Pin every guest session to the deterministic demo user seeded by run.sh so the
+        // JWT-issued userId always references an existing row (saveChat / message FKs).
+        // Avoids stale-cookie + empty-User-table failure modes during local dev.
+        return {
+          id: "00000000-0000-0000-0000-000000000001",
+          email: "demo@local",
+          type: "guest",
+        };
       },
     }),
   ],

--- a/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
@@ -205,6 +205,7 @@ export async function POST(request: Request) {
 
     const modelMessages = await convertToModelMessages(uiMessages);
 
+    const turnStartMs = Date.now();
     const stream = createUIMessageStream({
       originalMessages: isToolApprovalFlow ? uiMessages : undefined,
       execute: async ({ writer: dataStream }) => {
@@ -280,6 +281,7 @@ export async function POST(request: Request) {
               promptText,
               inputTokens: usage?.inputTokens ?? 0,
               outputTokens: usage?.outputTokens ?? 0,
+              durationMs: Date.now() - turnStartMs,
               runId: id,
             });
           },

--- a/examples/vercel-chatbot/app/lib/tally.ts
+++ b/examples/vercel-chatbot/app/lib/tally.ts
@@ -109,6 +109,8 @@ export interface SpanInput {
   promptText: string;
   inputTokens: number;
   outputTokens: number;
+  /** End-to-end completion duration in ms (drives the p95 latency column on /compare). */
+  durationMs?: number;
   featureTagOverride?: FeatureTag;
   runId?: string;
 }
@@ -125,7 +127,7 @@ export async function postSpan(input: SpanInput): Promise<void> {
     trace_id: hexId(16),
     span_id: hexId(8),
     timestamp_ns: Date.now() * 1_000_000,
-    duration_ns: 0,
+    duration_ns: Math.max(0, Math.round((input.durationMs ?? 0) * 1_000_000)),
     status_code: 1,
     // gen_ai.* — real provider/model since CTO-106 expanded the seed catalog
     // to cover them. The gateway's enrich_cost computes authoritative cost

--- a/examples/vercel-chatbot/run.sh
+++ b/examples/vercel-chatbot/run.sh
@@ -56,6 +56,14 @@ else
     (cd "${APP_DIR}" && pnpm --silent exec drizzle-kit push >>"${LOG_FILE}" 2>&1) || \
       err "drizzle-kit push failed — see ${LOG_FILE}"
   fi
+  # Seed the deterministic demo user that the auth flow pins every guest session to
+  # (see app/(auth)/auth.ts). Without this row, saveChat 400s on a foreign-key violation
+  # because the JWT-issued userId would have nothing to reference. Idempotent.
+  PGPASSWORD=tally psql -h localhost -U tally -d chatbot_demo >/dev/null <<'SQL'
+INSERT INTO "User" (id, email, "isAnonymous", "emailVerified")
+VALUES ('00000000-0000-0000-0000-000000000001', 'demo@local', true, false)
+ON CONFLICT (id) DO NOTHING;
+SQL
   TALLY_GATEWAY_URL="${TALLY_GATEWAY_URL:-${GATEWAY_URL}/v1/batches}" \
   TALLY_TENANT="${TALLY_TENANT:-local-dev}" \
     nohup pnpm --dir "${APP_DIR}" exec next dev --turbo --port 3001 \

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -60,6 +60,12 @@ services:
       - postgres-data:/var/lib/postgresql/data
       - ../db/postgres/0001_control_plane.sql:/docker-entrypoint-initdb.d/0001_control_plane.sql:ro
       - ../db/postgres/0002_tenant_connectors.sql:/docker-entrypoint-initdb.d/0002_tenant_connectors.sql:ro
+      - ../db/postgres/0003_tenant_stripe_config.sql:/docker-entrypoint-initdb.d/0003_tenant_stripe_config.sql:ro
+      - ../db/postgres/0004_tenant_replay_config.sql:/docker-entrypoint-initdb.d/0004_tenant_replay_config.sql:ro
+      - ../db/postgres/0005_cac_periods.sql:/docker-entrypoint-initdb.d/0005_cac_periods.sql:ro
+      - ../db/postgres/0005_tenant_eval_config.sql:/docker-entrypoint-initdb.d/0005a_tenant_eval_config.sql:ro
+      - ../db/postgres/0006_tenant_guardrails.sql:/docker-entrypoint-initdb.d/0006_tenant_guardrails.sql:ro
+      - ../db/postgres/0007_tenant_integration_runs.sql:/docker-entrypoint-initdb.d/0007_tenant_integration_runs.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -42,9 +42,6 @@ export function Shell({ children }: { children: ReactNode }) {
           <TopBarSelect label="Range" value="Last 30 days" />
           <TopBarSelect label="Feature" value="All features" />
           <TopBarSelect label="Env" value="production" />
-          <span className="ml-auto rounded-full bg-edge px-2 py-0.5 text-xs text-muted">
-            mock data
-          </span>
         </header>
         <main className="min-w-0 flex-1 p-6">{children}</main>
       </div>


### PR DESCRIPTION
## Summary

Fixes a chain of bugs that surfaced while running the chatbot UI live (not just the synthetic driver):

1. **Postgres migrations 0003–0007 weren't being applied** on a fresh `make up` (compose only mounted 0001 + 0002) → `make seed` failed with `relation "tenant_connectors" does not exist`
2. **`/api/chat` 400 on every chat submit** — saveChat foreign-key violation because no `User` row existed for the JWT-issued userId
3. **`/compare` latency p95 stuck at `—`** even after 750+ chatbot spans landed — `postSpan` was always emitting `duration_ns=0`, so CTO-115's `DurationNs > 0` filter dropped every row
4. **Misleading "mock data" badge** in the page header on every screen regardless of data source

## What changed

- **infra/docker-compose.yml** — mount all 7 PG migrations into `/docker-entrypoint-initdb.d/`; rename the duplicate-`0005` eval-config target to `0005a` so both run
- **examples/vercel-chatbot/run.sh** — idempotent SQL after `drizzle-kit push` that seeds a deterministic demo user (`00000000-…-001`) into `chatbot_demo` Postgres
- **examples/vercel-chatbot/app/app/(auth)/auth.ts** — pin the guest `authorize()` callback to that demo user UUID so every session JWT references a row that exists
- **examples/vercel-chatbot/app/lib/tally.ts** + **app/(chat)/api/chat/route.ts** — capture `Date.now()` at stream start, pass `durationMs` through to `postSpan` so `DurationNs` lands as a real value
- **web/components/Shell.tsx** — drop the hardcoded `"mock data"` chip; real data-state banners on the relevant pages already do this job correctly

## Test plan

- [x] `make nuke && make up && make seed` runs clean end-to-end with all migrations applied
- [x] Chatbot UI on `:3001` accepts live chat submissions without 400; new spans land in ClickHouse continuously
- [x] After re-chatting with the fix loaded, `quantile(0.95)(DurationNs) > 0` on `otel_spans WHERE ServiceName='vercel-chatbot'`
- [x] `curl http://localhost:3000/ | grep -c 'mock data'` returns 0

## Scope notes

- Excludes the unrelated Next 15→16 / vitest 2→4 bump that's sitting in the working tree on `cto-119-stratified-sampling`; that deserves its own PR
- The diagnostic `console.error` lines added during debugging have been reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)