### PR TITLE
chatbot demo: fire positive_feedback CDP event on UI upvote

### DIFF
--- a/examples/vercel-chatbot/app/app/(chat)/api/vote/route.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/api/vote/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { auth } from "@/app/(auth)/auth";
 import { getChatById, getVotesByChatId, voteMessage } from "@/lib/db/queries";
 import { ChatbotError } from "@/lib/errors";
+import { postCdpEvent, sessionUserHash } from "@/lib/tally";
 
 const voteSchema = z.object({
   chatId: z.string(),
@@ -79,6 +80,17 @@ export async function PATCH(request: Request) {
     messageId,
     type,
   });
+
+  // ai-tally: surface upvotes as positive_feedback CDP events so /attribution
+  // lights up conversions for the live chat (matches the synthetic driver path
+  // in /api/demo-chat). Same userHash scheme as postSpan so the join works.
+  if (type === "up") {
+    void postCdpEvent({
+      sessionId: chatId,
+      userHash: sessionUserHash(session.user.id ?? chatId),
+      type: "positive_feedback",
+    });
+  }
 
   return new Response("Message voted", { status: 200 });
 }


### PR DESCRIPTION
## Summary

Follow-up to [#93](https://github.com/jain-aanchal/ai-tally/pull/93). That PR wired `postSpan` into the live `/api/chat` route so manual chats produce telemetry; `/attribution` still showed `conversions: 0` for the live sessions because **only spans were emitted** — the synthetic driver fires CDP events via `/api/demo-chat`, but the real UI's vote PATCH route had no equivalent.

## What changed

`examples/vercel-chatbot/app/app/(chat)/api/vote/route.ts`:
- When a user clicks 👍 on an assistant response, POST a `positive_feedback` business_event to the ai-tally gateway
- Keyed on the same `sessionUserHash(session.user.id ?? chatId)` that `postSpan` uses in `/api/chat`, so the attribution join lights up
- Best-effort — `postCdpEvent`'s existing `console.warn` catch keeps it from ever blocking the vote write

## Test plan

- [x] Chat in the UI, upvote a response, observe row land in `business_events WHERE EventName='positive_feedback'` within ~2s
- [x] `curl http://localhost:3000/api/attribution?tag=chatbot-demo&outcome=positive_feedback` returns nonzero `conversions` for the provider that generated the upvoted reply

## Scope notes

- Only `positive_feedback` for v1 — `session_engaged` and `conversion` are still synthetic-driver only. Wiring those needs separate UI affordances (session-length heuristic + a "Subscribe" CTA) that are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)