### PR TITLE
chore(attribution): drop read-only Filters card

### DIFF
--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -84,14 +84,6 @@ export function AttributionLive({
           wide bands, by design. Two providers &ldquo;tie&rdquo; when their bands overlap.
         </p>
       </Card>
-
-      <Card title="Filters">
-        <dl className="grid grid-cols-2 gap-y-1 text-sm sm:grid-cols-3">
-          <Filter k="tag" v={tag ?? "(all)"} />
-          <Filter k="provider" v={provider ?? "(all)"} />
-          <Filter k="outcome" v={outcome} />
-        </dl>
-      </Card>
     </div>
   );
 
@@ -192,11 +184,3 @@ function ProviderRow({
   );
 }
 
-function Filter({ k, v }: { k: string; v: string }) {
-  return (
-    <>
-      <dt className="text-muted">{k}</dt>
-      <dd className="font-mono">{v}</dd>
-    </>
-  );
-}


### PR DESCRIPTION
## Summary

The Filters card on `/attribution` was a read-only echo of the URL query state (`?tag=…&provider=…&outcome=…`) — purely a debug breadcrumb with no way to change anything from the UI. Confusing layout, no user value.

## What changed

`web/app/attribution/Live.tsx`:
- Remove the \`<Card title=\"Filters\">\` block
- Remove the now-unused \`Filter\` helper component

The filter values still drive the page through \`searchParams\`; anyone who needs to change them edits the URL (same as before).

## Test plan

- [x] \`curl http://localhost:3000/attribution | grep -c 'FILTERS'\` returns 0
- [x] Rest of page still renders (\"per provider\" section + Wilson 95% footnote intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)