### PR TITLE
chore(nav): hide Estimate + Data Quality tabs (mostly mock today)

### DIFF
--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -10,10 +10,11 @@ const NAV: { label: string; href: string }[] = [
   { label: "Agents", href: "/agents" },
   { label: "Compare", href: "/compare" },
   { label: "Attribution", href: "/attribution" },
-  { label: "Estimate", href: "/estimate" },
   { label: "Connectors", href: "/connectors" },
   { label: "Settings", href: "/settings" },
-  { label: "Data Quality", href: "/data-quality" },
+  // Estimate (/estimate) and Data Quality (/data-quality) hidden from the nav — the pages
+  // still render at their URLs but most of their tiles are mock fixtures today. Re-add to NAV
+  // when CTO-128 (estimate body-driven what-if) and the DQ follow-ups land.
 ];
 
 export function Shell({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

Both pages are mock-heavy and shouldn't be promoted as production surfaces yet:

- **/estimate** is entirely fictional fixture data — fake PR #1284, fake driver breakdown, fake sample diagnostics. Only \`cost/month\` can go live (and only once replay samples exist); everything else needs [CTO-128](https://linear.app/cto-assist/issue/CTO-128) (body-driven what-if) to be useful.
- **/data-quality** renders four tiles, but most rows are placeholder or honest-zero pending [CTO-122](https://linear.app/cto-assist/issue/CTO-122)/[CTO-124](https://linear.app/cto-assist/issue/CTO-124) follow-ups.

Putting them in the nav implies they're real today. Hiding them until they have signal end-to-end.

## What changed

\`web/components/Shell.tsx\` — drop the two entries from \`NAV\`. Pages still render at their URLs (deep links + engineering use keep working); only the sidebar entries go away. Comment in the code points at the tickets that gate re-adding them.

## Test plan

- [x] \`curl http://localhost:3000/ | grep -oE 'href=\"/(estimate|data-quality|...)\"'\` no longer lists the two URLs; the other 7 nav links are intact
- [x] \`/estimate\` and \`/data-quality\` still load when visited directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)