### PR TITLE
chore(shell): drop misleading top-bar chips (Tenant / Range / Feature / Env)

### DIFF
--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -38,23 +38,8 @@ export function Shell({ children }: { children: ReactNode }) {
       </aside>
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex items-center gap-3 border-b border-edge bg-panel/60 px-6 py-3 text-sm">
-          <TopBarSelect label="Tenant" value="acme-prod" />
-          <TopBarSelect label="Range" value="Last 30 days" />
-          <TopBarSelect label="Feature" value="All features" />
-          <TopBarSelect label="Env" value="production" />
-        </header>
         <main className="min-w-0 flex-1 p-6">{children}</main>
       </div>
-    </div>
-  );
-}
-
-function TopBarSelect({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-center gap-1.5">
-      <span className="text-xs uppercase tracking-wide text-muted">{label}</span>
-      <span className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-200">{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The four header chips (Tenant: acme-prod, Range: Last 30 days, Feature: All features, Env: production) were pure decoration — two \`<span>\`s with no interactivity, hardcoded values that disagreed with what the underlying pages actually showed:

- "Tenant: acme-prod" while real tenant is \`local-dev\`
- "Range: Last 30 days" while \`/cost\` uses 14d, \`current-model\` uses 7d, etc.
- "Feature: All features" never reflected \`?tag=\` from the URL
- "Env: production" while running on local-dev

Same category as the "mock data" badge removed in [#93](https://github.com/jain-aanchal/ai-tally/pull/93) and the Filters card removed in [#95](https://github.com/jain-aanchal/ai-tally/pull/95) — decorative chrome lying about state. Real range/feature/env filters live in the page-level UI + URL params.

## What changed

\`web/components/Shell.tsx\`:
- Drop the four \`<TopBarSelect>\` calls and the whole \`<header>\` row
- Remove the now-unused \`TopBarSelect\` helper

## Test plan

- [x] \`curl http://localhost:3000/ | grep -cE 'acme-prod|Last 30 days'\` returns 0
- [x] Sidebar nav still rendered (Cost / Features / Attribution etc. links intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)