### PR TITLE
chore(nav): drop "Get started" tab

### DIFF
--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 const NAV: { label: string; href: string }[] = [
-  { label: "Get started", href: "/onboarding" },
   { label: "Home", href: "/" },
   { label: "Cost", href: "/cost" },
   { label: "Features", href: "/features" },


### PR DESCRIPTION
## Summary

Following [#96](https://github.com/jain-aanchal/ai-tally/pull/96) (hide Estimate + Data Quality), drop the \"Get started\" tab too. Onboarding lives in RUNNING.md; surface it from the empty/zero states inside the real pages when a user needs it, rather than as a top-level nav item competing with the actual product surfaces.

## What changed

\`web/components/Shell.tsx\` — remove the \`{ label: \"Get started\", href: \"/onboarding\" }\` entry from \`NAV\`. Page still renders at \`/onboarding\` for direct links.

## Test plan

- [x] \`curl http://localhost:3000/ | grep -cE 'Get started|/onboarding'\` returns 0
- [x] Remaining 8 nav links (Home/Cost/Features/Agents/Compare/Attribution/Connectors/Settings) intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)