### PR TITLE
chore(nav): hide Settings tab

### DIFF
--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -10,10 +10,10 @@ const NAV: { label: string; href: string }[] = [
   { label: "Compare", href: "/compare" },
   { label: "Attribution", href: "/attribution" },
   { label: "Connectors", href: "/connectors" },
-  { label: "Settings", href: "/settings" },
-  // Estimate (/estimate) and Data Quality (/data-quality) hidden from the nav — the pages
-  // still render at their URLs but most of their tiles are mock fixtures today. Re-add to NAV
-  // when CTO-128 (estimate body-driven what-if) and the DQ follow-ups land.
+  // Hidden from the nav until they have real signal end-to-end (pages still render at the URL):
+  //   - /settings        — empty shell, no real settings wired
+  //   - /estimate        — mock fixtures (re-add when CTO-128 lands)
+  //   - /data-quality    — placeholder rows (re-add when DQ follow-ups land)
 ];
 
 export function Shell({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

\`/settings\` is an empty shell — no tenant prefs, no API key rotation, no real toggles. Hiding from the nav until we actually build the surface. Page still loads at \`/settings\` for direct links.

Folds Settings into the same comment block that documents Estimate / Data Quality being hidden for the same reason, so future re-adds have one place to update.

## What changed

\`web/components/Shell.tsx\` — drop the Settings entry, update the comment to list all three hidden routes (Settings / Estimate / Data Quality) with the gating tickets.

## Test plan

- [x] \`curl http://localhost:3000/ | grep -cE 'href=\"/settings\"'\` returns 0
- [x] Remaining 7 nav links (Home / Cost / Features / Agents / Compare / Attribution / Connectors) intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)