### PR TITLE
feat(home): add compact Per-provider · conversion card

### DIFF
--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -12,6 +12,7 @@ import {
 import { LiveIndicator } from "@/components/LiveIndicator";
 import { LAYERS, type Layer } from "@/lib/cost";
 import { allZero, asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
+import type { ProviderAttribution } from "@/lib/attribution";
 import type { CostOutlier, FeatureRoi, SpendSummary } from "@/lib/types";
 import { formatUSD } from "@/lib/types";
 import { useLivePoll } from "@/lib/useLivePoll";
@@ -20,6 +21,7 @@ export interface HomePayload {
   spend: SpendSummary;
   outliers: CostOutlier[];
   roi: FeatureRoi[];
+  perProviderConversion: ProviderAttribution[];
 }
 
 export function HomeLive({
@@ -32,7 +34,7 @@ export function HomeLive({
   enabledLayers: readonly Layer[];
 }) {
   const { data, updatedAt } = useLivePoll<HomePayload>(endpoint, initialData);
-  const { spend: s, outliers, roi } = data;
+  const { spend: s, outliers, roi, perProviderConversion } = data;
 
   const hidden = s.byLayer.vector + s.byLayer.tools + s.byLayer.compute + s.byLayer.embeddings + s.byLayer.egress;
   const hiddenPct = s.totalMicroUsd === 0 ? 0 : Math.round((hidden / s.totalMicroUsd) * 100);
@@ -113,6 +115,51 @@ export function HomeLive({
             ))}
           </tbody>
         </table>
+      </Card>
+
+      <Card title="Per-provider · conversion">
+        {perProviderConversion.length === 0 ? (
+          <p className="text-sm text-muted">
+            No sessions yet — drive traffic to populate (link out from{" "}
+            <a className="text-good underline" href="/attribution">
+              Attribution
+            </a>
+            ).
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-muted">
+              <tr>
+                <th className="py-1 text-left font-medium">Provider</th>
+                <th className="py-1 text-right font-medium">Sessions</th>
+                <th className="py-1 text-right font-medium">Conversions</th>
+                <th className="py-1 text-right font-medium">Rate</th>
+                <th className="py-1 text-right font-medium">$/conversion</th>
+              </tr>
+            </thead>
+            <tbody>
+              {perProviderConversion.map((p) => (
+                <tr key={p.provider} className="border-t border-edge">
+                  <td className="py-1.5 font-mono">{p.provider}</td>
+                  <td className="py-1.5 text-right tabular-nums">
+                    {p.sessions.toLocaleString()}
+                  </td>
+                  <td className="py-1.5 text-right tabular-nums">
+                    {p.conversions.toLocaleString()}
+                  </td>
+                  <td className="py-1.5 text-right tabular-nums">
+                    {(p.conversionRate * 100).toFixed(1)}%
+                  </td>
+                  <td className="py-1.5 text-right font-semibold tabular-nums">
+                    {p.costPerConversionMicroUsd === null
+                      ? "—"
+                      : formatUSD(p.costPerConversionMicroUsd)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </Card>
 
     </div>

--- a/web/app/api/home/route.ts
+++ b/web/app/api/home/route.ts
@@ -2,23 +2,34 @@
 import { NextResponse } from "next/server";
 
 import { mockDataQuality, mockOutliers, mockRoi, mockSpend } from "@/lib/mock";
-import { queryDataQuality, queryOutliers, queryRoi, querySpendSummary } from "@/lib/clickhouse";
+import {
+  queryAttribution,
+  queryDataQuality,
+  queryOutliers,
+  queryRoi,
+  querySpendSummary,
+} from "@/lib/clickhouse";
 
 // Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET() {
-  const [spend, outliers, roi, dq] = await Promise.all([
+  // Match the Attribution page's default view so the Home compact table reads
+  // the same numbers a user would see on /attribution with no filters set.
+  const attributionFilters = { tag: null, provider: null, outcome: "conversion" as const };
+  const [spend, outliers, roi, dq, attribution] = await Promise.all([
     querySpendSummary(),
     queryOutliers(),
     queryRoi(),
     queryDataQuality(),
+    queryAttribution(attributionFilters),
   ]);
   return NextResponse.json({
     spend: spend ?? mockSpend,
     outliers: outliers && outliers.length > 0 ? outliers : mockOutliers,
     roi: roi && roi.length > 0 ? roi : mockRoi,
     dq: dq ?? mockDataQuality,
+    perProviderConversion: attribution?.perProvider ?? [],
   });
 }


### PR DESCRIPTION
## Summary

Mirrors the per-provider conversion table from /attribution onto Home, trimmed for density: **Provider / Sessions / Conversions / Rate / \$/conversion**. Drops the Wilson CI text, Value/User, and Margin/User columns — those only have signal on /attribution today and most cells read '—' for the live tenant.

## What changed

**\`web/app/api/home/route.ts\`**
- Add \`queryAttribution\` call with default filters (no tag, no provider, \`outcome='conversion'\`) so the Home numbers match what a user sees on /attribution with no filters set
- Return the \`perProviderConversion\` array on the payload

**\`web/app/Live.tsx\`**
- Add \`perProviderConversion: ProviderAttribution[]\` to \`HomePayload\`
- New \`<Card title=\"Per-provider · conversion\">\` after the ROI snapshot card
- Empty state links to /attribution

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`curl http://localhost:3000/api/home\` returns \`perProviderConversion\` with live shape (openai: 122 sessions / 18 conversions / \$0.0052 per; anthropic: 87 / 17 / \$0.0315 per)
- [x] Card renders on Home with the trimmed 5-column layout
- [x] Empty case: when no sessions match, shows link out to /attribution rather than a blank table

🤖 Generated with [Claude Code](https://claude.com/claude-code)