### PR TITLE
chore(connectors): mark catalog entries without real ingest as "Coming soon"

### DIFF
--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -6,7 +6,9 @@ import { relativeAge } from "@/lib/dataState";
 import {
   type ConnectorCategory,
   type ConnectorStatus,
+  comingSoonCount,
   connectedCount,
+  liveAvailableCount,
 } from "@/lib/connectors";
 import { queryEnabledConnectors } from "@/lib/tenant";
 import { ConnectorToggle } from "./ConnectorToggle";
@@ -30,6 +32,14 @@ function StateBadge({ row }: { row: ConnectorStatus }) {
       <span className="inline-flex items-center gap-1.5 rounded-full border border-good/40 bg-good/10 px-2 py-0.5 text-xs font-medium text-good">
         <span className="h-1.5 w-1.5 rounded-full bg-good" />
         Connected
+      </span>
+    );
+  }
+  if (row.state === "coming_soon") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink/40 px-2 py-0.5 text-xs font-medium text-muted">
+        <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+        Coming soon
       </span>
     );
   }
@@ -84,7 +94,7 @@ function ConnectorTable({
                   {r.lastAt ? relativeAge(r.lastAt) : "—"}
                 </td>
                 <td className="py-2 text-right">
-                  {layer ? (
+                  {layer && r.state !== "coming_soon" ? (
                     <ConnectorToggle layer={layer} initialEnabled={isEnabled} />
                   ) : (
                     <span className="text-xs text-muted">—</span>
@@ -114,8 +124,11 @@ export default async function ConnectorsPage() {
       {SECTIONS.map((s) => {
         const rows = visibleConnectors.filter((c) => c.category === s.category);
         const n = connectedCount(rows);
+        const live = liveAvailableCount(rows);
+        const soon = comingSoonCount(rows);
+        const suffix = soon > 0 ? ` · ${soon} coming soon` : "";
         return (
-          <Card key={s.category} title={`${s.title} — ${n}/${rows.length} connected`}>
+          <Card key={s.category} title={`${s.title} — ${n}/${live} connected${suffix}`}>
             <p className="mb-3 max-w-prose text-xs text-muted">{s.blurb}</p>
             <ConnectorTable rows={rows} enabledLayers={enabledLayers} />
           </Card>
@@ -124,12 +137,16 @@ export default async function ConnectorsPage() {
     </div>
   );
 
+  const totalSoon = comingSoonCount(visibleConnectors);
+  const totalLive = liveAvailableCount(visibleConnectors);
+
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-xl font-semibold">Connectors</h1>
         <span className="text-sm text-muted">
-          {connected} of {visibleConnectors.length} sources connected
+          {connected} of {totalLive} sources connected
+          {totalSoon > 0 ? ` · ${totalSoon} coming soon` : ""}
         </span>
       </div>
 

--- a/web/lib/connectors.test.ts
+++ b/web/lib/connectors.test.ts
@@ -29,7 +29,7 @@ describe("connector catalog", () => {
 });
 
 describe("applyActivity", () => {
-  it("marks sources with records connected and the rest available", () => {
+  it("marks sources with records connected; live-but-empty -> available; coming-soon stays so", () => {
     const rows = applyActivity(CONNECTORS, {
       records: { llm_proxy: 10, stripe: 2 },
       lastAt: { llm_proxy: "2026-05-31T18:00:00Z" },
@@ -38,15 +38,20 @@ describe("applyActivity", () => {
     expect(byId.llm_proxy.state).toBe("connected");
     expect(byId.llm_proxy.records).toBe(10);
     expect(byId.stripe.state).toBe("connected");
-    expect(byId.pinecone.state).toBe("available");
+    // pinecone is in the catalog with availability='coming_soon' (no ingest worker yet) so it
+    // surfaces as 'coming_soon' rather than the previous catch-all 'available'.
+    expect(byId.pinecone.state).toBe("coming_soon");
     expect(byId.pinecone.records).toBe(0);
     expect(byId.pinecone.lastAt).toBeNull();
   });
 
-  it("an empty activity map leaves every source available", () => {
+  it("an empty activity map: nothing connected; live entries -> available, coming-soon -> coming_soon", () => {
     const rows = applyActivity(CONNECTORS, { records: {}, lastAt: {} });
     expect(connectedCount(rows)).toBe(0);
-    expect(rows.every((r) => r.state === "available")).toBe(true);
+    for (const r of rows) {
+      const expected = r.availability === "live" ? "available" : "coming_soon";
+      expect(r.state).toBe(expected);
+    }
   });
 
   it("preserves the full catalog (no source dropped or duplicated)", () => {

--- a/web/lib/connectors.ts
+++ b/web/lib/connectors.ts
@@ -19,6 +19,15 @@ export type LiveKey =
   | { kind: "cost-layer"; layer: Layer }
   | { kind: "revenue-source"; source: string };
 
+/**
+ * Whether the backend ingest path for this connector actually exists today.
+ * - `live`        — a real worker / SDK / webhook ingests data when configured (LLM proxy, Stripe)
+ * - `coming_soon` — catalog entry only; no worker yet, the UI advertises a placeholder so users
+ *                   know it's planned. Re-classify to `live` when the corresponding integration
+ *                   ships (Pinecone, Tavily, AWS Cost Explorer, Vercel via CTO-127 follow-ups).
+ */
+export type Availability = "live" | "coming_soon";
+
 export interface ConnectorDef {
   /** Stable id — matches the backend connector's `name`. */
   id: string;
@@ -28,9 +37,10 @@ export interface ConnectorDef {
   feeds: string;
   description: string;
   liveKey: LiveKey;
+  availability: Availability;
 }
 
-export type ConnectorState = "connected" | "available";
+export type ConnectorState = "connected" | "available" | "coming_soon";
 
 export interface ConnectorStatus extends ConnectorDef {
   state: ConnectorState;
@@ -49,6 +59,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "LLM cost",
     description: "Token usage from the edge proxy or SDK — the primary spend signal.",
     liveKey: { kind: "cost-layer", layer: "llm" },
+    availability: "live",
   },
   {
     id: "pinecone",
@@ -57,6 +68,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Vector DB cost",
     description: "Vector database read/write/storage usage attributed to features.",
     liveKey: { kind: "cost-layer", layer: "vector" },
+    availability: "coming_soon",
   },
   {
     id: "tavily",
@@ -65,6 +77,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Tool-call cost",
     description: "Search / tool API usage billed per call.",
     liveKey: { kind: "cost-layer", layer: "tools" },
+    availability: "coming_soon",
   },
   {
     id: "aws_cost_explorer",
@@ -73,6 +86,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Compute cost",
     description: "Cloud billing line items for compute backing the AI workload.",
     liveKey: { kind: "cost-layer", layer: "compute" },
+    availability: "coming_soon",
   },
   {
     id: "vercel",
@@ -81,6 +95,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Egress cost",
     description: "Edge/serverless and bandwidth usage for the serving tier.",
     liveKey: { kind: "cost-layer", layer: "egress" },
+    availability: "coming_soon",
   },
   {
     id: "segment",
@@ -89,6 +104,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Revenue events",
     description: "CDP track events — the value side of ROI attribution.",
     liveKey: { kind: "revenue-source", source: "segment" },
+    availability: "coming_soon",
   },
   {
     id: "rudderstack",
@@ -97,6 +113,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Revenue events",
     description: "Open-source CDP track events (Segment-compatible payloads).",
     liveKey: { kind: "revenue-source", source: "rudderstack" },
+    availability: "coming_soon",
   },
   {
     id: "stripe",
@@ -105,6 +122,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Monetary events",
     description: "Payments, subscriptions and refunds as monetary business events.",
     liveKey: { kind: "revenue-source", source: "stripe" },
+    availability: "live",
   },
   {
     id: "hubspot",
@@ -113,6 +131,7 @@ export const CONNECTORS: ConnectorDef[] = [
     feeds: "Lifecycle events",
     description: "Deal-stage / lifecycle changes (e.g. closed-won) for attribution.",
     liveKey: { kind: "revenue-source", source: "hubspot" },
+    availability: "coming_soon",
   },
 ];
 
@@ -134,17 +153,29 @@ export function applyActivity(
   return catalog.map((def) => {
     const records = activity.records[def.id] ?? 0;
     const lastAt = activity.lastAt[def.id] ?? null;
-    return {
-      ...def,
-      records,
-      lastAt,
-      state: records > 0 ? "connected" : "available",
-    };
+    let state: ConnectorState;
+    if (records > 0) {
+      state = "connected";
+    } else if (def.availability === "coming_soon") {
+      state = "coming_soon";
+    } else {
+      state = "available";
+    }
+    return { ...def, records, lastAt, state };
   });
 }
 
 export function connectedCount(rows: ConnectorStatus[]): number {
   return rows.filter((r) => r.state === "connected").length;
+}
+
+/** Number of rows that aren't connected today but are claimed to be possible to connect now. */
+export function liveAvailableCount(rows: ConnectorStatus[]): number {
+  return rows.filter((r) => r.availability === "live").length;
+}
+
+export function comingSoonCount(rows: ConnectorStatus[]): number {
+  return rows.filter((r) => r.state === "coming_soon").length;
 }
 
 /**


### PR DESCRIPTION
## Summary

Stacked on top of [#102](https://github.com/jain-aanchal/ai-tally/pull/102). After that PR drops the dead Revenue & CDP + Third-party integrations sections, the Cost sources section still labels Pinecone / Tavily / AWS Cost Explorer / Vercel as **\"Available — Disabled\"** — implying a tenant could flip a switch and start ingesting. That's false; no worker exists for any of them. Today only the LLM proxy and Stripe webhook ingest real data.

Renames the badge for these entries to **\"Coming soon\"** and updates the counts honestly.

## What changed

**\`web/lib/connectors.ts\`**
- Add \`availability: \"live\" | \"coming_soon\"\` to \`ConnectorDef\`
- Mark \`llm_proxy\` and \`stripe\` as \`live\`; everything else \`coming_soon\`
- Extend \`ConnectorState\` with \`coming_soon\`; \`applyActivity\` returns it when a coming-soon connector hasn't observed records (instead of falsely \"available\")
- New helpers \`liveAvailableCount\` and \`comingSoonCount\` for header math

**\`web/app/connectors/page.tsx\`**
- New \"Coming soon\" badge in \`StateBadge\`
- Hide the Enable/Disable toggle on \`coming_soon\` rows (nothing to enable yet)
- Section title and page header split the counts: \"1/1 connected · 4 coming soon\" instead of \"1/5 connected\"

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Rendered page has 4 \"Coming soon\" badges (Pinecone / Tavily / AWS Cost Explorer / Vercel), 1 \"Connected\" (LLM proxy via mock activity), 0 misleading \"Available\"
- [x] Section title reads \"Cost sources — 1/1 connected · 4 coming soon\"

## Re-classify path

When a real Pinecone / Tavily / AWS Cost Explorer / Vercel ingest worker ships (CTO-127 family of follow-ups), flip the entry's \`availability\` to \`\"live\"\` in \`web/lib/connectors.ts\`. The badge, toggle visibility, and counts all rederive from that one field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)