### PR TITLE
docs(readme): refresh for the features shipped this stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,67 +7,58 @@ Cost-and-value observability for AI products. See what your AI actually costs �
 Five workflows on one shared data spine:
 
 1. **Agent loop cost visibility** — why did this run cost 50× median?
-2. **Cross-provider comparison** — are we on the right model?
-3. **End-to-end cost** — what does this feature really cost, all-in?
-4. **Business-outcome attribution** — is this AI feature profitable?
+2. **Cross-provider comparison** — are we on the right model? Real replay, real eval, no marketing benchmarks.
+3. **End-to-end cost** — what does this feature really cost, all-in (LLM + vector + tools + compute + egress)?
+4. **Business-outcome attribution** — is this AI feature profitable? `$/conversion` and margin per provider, joined from real Stripe revenue.
 5. **Pre-deploy estimation** — what will this change cost before we ship?
 
 ## Product principles
 
-- **Honest under uncertainty** — estimated vs. reconciled, confidence shown everywhere.
-- **Tail-aware, not median-aware** — agent cost is a power law; optimize for p99.
-- **Never corrupt customer state** — guardrails degrade gracefully, never hard-kill.
-- **OTel-native** — built on OpenTelemetry `gen_ai.*` conventions; contribute upstream.
-- **Time-to-value < 30 min** — proxy in 5, SDK in 30.
+- **Honest under uncertainty** — render `—` rather than fabricate a number. A quality cell with no eval pass behind it is `—`, not "85%". A p95 latency built from fewer than 50 spans is `—`, not noise. Misleadingly-rosy zeros are worse than empty space.
+- **No bodies in telemetry** — token counts and drop counts, never message text. The PII guard at the gateway suffix-matches keys like `prompt`, `messages`, `completion`, `body` and drops them on the floor. This is the contract, not a flag.
+- **Billing decoupled from sampling** — head-time meter counts every trace before the sampling decision, so invoices are exact regardless of analytics sample rate.
+- **Tail-aware, not median-aware** — agent cost is a power law; stratified sampling keeps the tail at ~100% and samples the cheap body down.
+- **Never corrupt customer state** — guardrails default to OBSERVE (record what would have fired), never hard-kill.
+- **OTel-native** — built on OpenTelemetry `gen_ai.*` conventions; extensions namespaced under the same.
 
 ## Repository layout
 
 ```
-sdk/python/        Python SDK (OTel gen_ai.* + cost/feature/identity extensions)
+sdk/python/        Python SDK (OTel gen_ai.* + cost/feature/identity/sampling/guardrails)
 infra/gateway/     Ingest gateway (FastAPI: auth → enrich cost → ClickHouse)
+                   plus per-tenant control plane (connectors, replay, eval, guardrails, CAC)
 infra/edge-proxy/  Zero-code edge proxy (Go) + BYO-deployment Helm chart
 infra/             docker-compose stack (ClickHouse, Postgres, Redpanda, MinIO) + Makefile
-db/clickhouse/     ClickHouse DDL (telemetry store)
-db/postgres/       Postgres control-plane schema
+db/clickhouse/     ClickHouse DDL — otel_spans, attribution, business_events, replay_samples, eval_runs
+db/postgres/       Postgres control-plane schema — tenants, connectors, stripe, replay,
+                   eval, guardrails, CAC, integration runs
 web/               Next.js dashboard (the five workflows)
+examples/          End-to-end demos: Aider edge-proxy traffic, Vercel AI Chatbot, Stripe
 ```
 
 ## Running it
 
 To bring up the whole stack on a laptop and see ingested telemetry in the dashboard, follow
-**[RUNNING.md](./RUNNING.md)** — a verified end-to-end runbook (send a batch → gateway → ClickHouse
-→ web UI). Short version:
+**[RUNNING.md](./RUNNING.md)** — a verified end-to-end runbook. Short version:
 
 ```bash
 cd infra && make up && make seed && make demo   # stack + tenant + sample telemetry
 cd web && npm install && npm run dev            # dashboard at http://localhost:3000
 ```
 
-Want to see real agent traffic, not just a seeded batch? Run the Aider
-fixture demo — it drives Aider against a small Python repo through the edge
-proxy and pre-filters the dashboard to those traces:
+The runbook covers nine end-to-end steps, including the demos that exercise each workflow.
 
-```bash
-export OPENAI_API_KEY=sk-...
-cd infra && make aider-demo                     # ~3 min, three multi-turn tasks
-```
+### Demos by workflow
 
-See [examples/aider-demo/README.md](examples/aider-demo/README.md) for the
-walkthrough.
+| Workflow | Command | What it does |
+|---|---|---|
+| Agent loop + edge proxy | `make aider-demo` | Drives Aider against a fixture repo through the edge proxy |
+| Business-outcome attribution | `make chatbot-demo` | 50 scripted chat sessions across OpenAI + Anthropic with thumbs-up conversion events |
+| Real revenue via Stripe | RUNNING.md §7 | Verified webhook ingest → `business_events` → `$/conversion` |
+| Replay-backed Compare/Estimate | RUNNING.md §8 | Opt-in 5% sampling, cross-provider replay with daily budget cap |
+| Pairwise LLM-judge quality | RUNNING.md §9 | Pairwise judge with Wilson 95% CIs on win-rate |
 
-Want to exercise the business-outcome attribution workflow? Run the chatbot
-demo — it boots the Vercel AI Chatbot template on `:3001`, drives synthetic
-chat sessions across OpenAI and Anthropic, and lights up the
-`/attribution` view with $/conversion per provider:
-
-```bash
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...
-cd infra && make chatbot-demo                   # ~2 min, 50 scripted sessions
-```
-
-See [examples/vercel-chatbot/README.md](examples/vercel-chatbot/README.md)
-for the walkthrough.
+Demos need provider keys exported: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`.
 
 ## Development
 
@@ -80,58 +71,70 @@ uv run ruff check .
 uv run pytest
 ```
 
+Gateway tests:
+
+```bash
+cd infra/gateway && uv run pytest
+```
+
+Web tests:
+
+```bash
+cd web && npx vitest run
+```
+
 ## Model auto-discovery
 
-On startup the gateway hits `GET /v1/models` on every provider whose API key it
-has (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), classifies each id into a coarse
-family (`haiku` / `sonnet` / `opus` / `mini` / `flagship` / `embedding`), and
-writes the result to `.tally/models.json` with a 24 h TTL. The demos read that
-file via `tally.models.latest_anthropic("sonnet")` (Python) or `resolveLatest()`
-(Node), so when a provider retires a SKU — `claude-3-5-haiku-latest` was the
-case that prompted this — the next boot picks up the replacement automatically.
+On startup the gateway hits `GET /v1/models` on every provider whose API key it has (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), classifies each id into a coarse family (`haiku` / `sonnet` / `opus` / `mini` / `flagship` / `embedding`), and writes the result to `.tally/models.json` with a 24h TTL. The demos read that file via `tally.models.latest_anthropic("sonnet")` (Python) or `resolveLatest()` (Node), so when a provider retires a SKU — `claude-3-5-haiku-latest` was the case that prompted this — the next boot picks up the replacement automatically.
 
 Knobs:
 
-- `TALLY_MODELS_REFRESH=1` — bypass the 24 h TTL and refetch on the next boot.
-- `TALLY_PINNED_MODELS=<path>` — skip discovery entirely, load the lineup from
-  that file (useful for CI runs that must be hermetic).
-- `TALLY_MODELS_CACHE=<path>` — Node-side override for where `resolveLatest()`
-  reads the cache from.
+- `TALLY_MODELS_REFRESH=1` — bypass the 24h TTL and refetch on the next boot.
+- `TALLY_PINNED_MODELS=<path>` — skip discovery entirely, load the lineup from that file (useful for CI runs that must be hermetic).
+- `TALLY_MODELS_CACHE=<path>` — Node-side override for where `resolveLatest()` reads the cache from.
 
-Discovery is fail-soft: if both providers are unreachable and the cache file
-doesn't exist, the gateway boots with an empty list and a warning. The demos
-fall back to their hardcoded defaults.
+Discovery is fail-soft: if both providers are unreachable and the cache file doesn't exist, the gateway boots with an empty list and a warning. The demos fall back to their hardcoded defaults.
 
-## Replay-backed estimation
+## Replay-backed Compare and Estimate
 
-Workflows 2 (Cross-provider compare) and 5 (Pre-deploy estimate) used to be
-mock projections rescaled off the user's real current-model spend. They're now
-backed by **real cross-provider replay** (CTO-113): the gateway captures an
-opt-in 5% sample of spans, scrubs PII (emails, API keys, postal addresses),
-stores the resolved request envelope in object storage, and replays it against
-candidate models on demand.
+Workflows 2 (Compare) and 5 (Estimate) used to be mock projections rescaled off the user's real current-model spend. They're now backed by **real cross-provider replay**: the gateway captures an opt-in 5% sample of spans, scrubs PII (emails, API keys, postal addresses), stores the resolved request envelope in object storage, and replays it against candidate models on demand.
 
-Per-tenant opt-in — default off; nothing is sampled until a tenant flips
-`enabled=true` via `POST /v1/tenant/replay/config`. A daily budget cap
-(default $5/day) hard-stops the replay executor from running away. The
-diagnostics block on `/api/compare` carries the honest fidelity string
-`"resolved-context replay (no live retrieval)"` so the dashboard never claims
-a tier it doesn't have.
+Per-tenant opt-in — default off; nothing is sampled until a tenant flips `enabled=true` via `POST /v1/tenant/replay/config`. A daily budget cap (default `$5/day`) hard-stops the replay executor from running away. The diagnostics block on `/api/compare` carries the honest fidelity string `"resolved-context replay (no live retrieval)"` so the dashboard never claims a tier it doesn't have.
 
-When a tenant has no opted-in samples (or the gateway is unreachable), the
-`/api/compare` and `/api/estimate` routes fall back to the rescaled-mock path
-they had before — `replay_source` in each response distinguishes the two
-branches.
+When a tenant has no opted-in samples (or the gateway is unreachable), the `/api/compare` and `/api/estimate` routes fall back to the rescaled-mock path they had before — `replay_source` in each response distinguishes the two branches.
+
+## Pairwise LLM-judge eval
+
+The Quality column on `/compare` is grounded in a real eval pass — pairwise LLM-judge over replay outputs, with A/B order randomized per sample to mitigate position bias, win-rate scored as a Wilson 95% CI. Opt-in separately from replay (judge calls run a frontier model and are pricier than candidate replays); default daily budget `$10/day`, default judge `claude-opus-4-8`, rubric tagged `rubric-v1` so a future tightening stays interpretable.
+
+Below the 10-judged-samples floor, the cell renders `—` with the hint *"needs ≥10 judged samples — run eval pass"*. There is **no fallback to mock here, by design** — a fake quality number is worse than no quality number.
+
+## Stripe → real revenue
+
+Connect Stripe via the `/connectors` UI (paste a signing secret) or `stripe listen` for local dev, and the gateway's verified webhook handler maps Stripe events to `business_events` rows — `checkout.session.completed` → conversion, `invoice.paid` → renewal, `charge.refunded` → negative revenue. Stripe customer emails are HMAC-hashed into the same `UserIdHash` space the SDK uses, so the attribution join lights up the moment events land.
+
+Two new columns appear on `/attribution` once a tenant wires Stripe: **Value/user** and **Margin/user** (with margin %). Cells stay `—` until enough events arrive — we never fabricate numbers from absent data.
+
+## Per-tenant control plane
+
+Stored in Postgres (`db/postgres/000{1..7}_*.sql`), accessed only through the gateway (the web app never talks to Postgres directly):
+
+- **Tenants + API keys + HMAC key versions** for per-tenant user-id hashing
+- **Cost-layer connector declarations** (which of LLM / vector / tools / compute / egress this tenant streams in)
+- **Stripe config**, **replay config**, **eval config**, **guardrail rules** + audit log
+- **CAC periods** for the unit-economics workflow (one row per finance-entered month)
+- **Integration run status** for third-party connectors (light up the connector card with real `last_run_at` and 24h/7d event counts)
+
+Every control-plane write is audited with an idempotent `change_id` (UUID), and `INSERT … ON CONFLICT DO NOTHING` makes a UI double-click safe.
 
 ## Status
 
-Early development. Decisions and the full system spec live in the project tracker.
-Tickets follow a Context / Acceptance criteria / Out-of-scope format and are picked up one PR at a time.
+The five workflows are wired end-to-end on a laptop with `make chatbot-demo`. Each `—` you see on a dashboard tile is honest — a placeholder for a metric we haven't grounded yet. The remaining backlog turns those `—`s into real numbers (per-feature attribution, candidate-response replay for honest eval grading, real workers for the "Coming soon" connectors).
+
+Decisions and the full system spec live in the project tracker. Tickets follow a Context / Acceptance criteria / Out-of-scope format and are picked up one PR at a time.
 
 ## License
 
-ai-tally is licensed under the [Apache License, Version 2.0](LICENSE). Required
-attribution notices for the project and any third-party dependencies live in
-[NOTICE](NOTICE).
+ai-tally is licensed under the [Apache License, Version 2.0](LICENSE). Required attribution notices for the project and any third-party dependencies live in [NOTICE](NOTICE).
 
 We follow the [Contributor Covenant](CODE_OF_CONDUCT.md) Code of Conduct.


### PR DESCRIPTION
## Summary

Brings README in line with what's actually wired today after the recent feature + cleanup wave: Stripe revenue ([CTO-110](https://linear.app/cto-assist/issue/CTO-110)), replay ([CTO-113](https://linear.app/cto-assist/issue/CTO-113)), eval ([CTO-114](https://linear.app/cto-assist/issue/CTO-114)), guardrails control plane ([CTO-116](https://linear.app/cto-assist/issue/CTO-116)), integration runs ([CTO-117](https://linear.app/cto-assist/issue/CTO-117)), context drops ([CTO-118](https://linear.app/cto-assist/issue/CTO-118)), stratified sampling ([CTO-119](https://linear.app/cto-assist/issue/CTO-119)), plus the UI honesty cleanup (#93–#103).

## What changed

- **Product principles** lead with \"honest under uncertainty\" and \"no bodies in telemetry\" with concrete examples
- **Demos-by-workflow table** maps each of the 5 workflows to its RUNNING.md step (Aider / chatbot / Stripe / replay / eval)
- **New sections** for the pairwise LLM-judge eval, Stripe revenue path, and the per-tenant Postgres control plane
- **Repo layout** reflects the actual \`db/\` schemas (\`eval_runs\`, \`replay_samples\`, \`business_events\`) and Postgres migrations 0001–0007
- **Status section** drops the \"early development\" framing — describes the remaining honest \`—\` cells as the backlog rather than gaps

Net: +80/−77 lines, similar overall size.

## Test plan

- [x] Markdown renders cleanly (no broken anchors, no orphan links)
- [x] Every code/command block matches the actual targets in \`infra/Makefile\` and RUNNING.md
- [x] No claims about unshipped functionality — all sections describe features actually wired on \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)