### PR TITLE
feat(unit-economics): render CAC / payback / LTV page from wired libs (CTO-121)

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./onboarding/first-trace/route";
 import { GET as GuardrailsGET, PUT as GuardrailsPUT } from "./guardrails/route";
 import { GET as AttributionGET } from "./attribution/route";
+import { GET as CacGET } from "./cac/route";
 
 async function json<T = unknown>(res: Response): Promise<T> {
   return (await res.json()) as T;
@@ -154,6 +155,24 @@ describe("api routes", () => {
     ]);
     expect(body.filters.tag).toBe("chatbot-demo");
     expect(body.filters.outcome).toBe("positive_feedback");
+  });
+
+  it("GET /api/cac falls back to the labelled mock when the gateway is unreachable", async () => {
+    // CI / fresh-clone: the gateway isn't running, so queryCacPeriods returns [] and the route
+    // serves MOCK_CAC_PERIODS. Real CAC data goes through the live path (isMock=false).
+    const body = await json<{
+      periods: { periodStart: string; locked: boolean }[];
+      economics: Record<string, { arpaMicroUsd: number }>;
+      isMock: boolean;
+    }>(await CacGET());
+    expect(body.isMock).toBe(true);
+    expect(body.periods.length).toBeGreaterThan(0);
+    // Newest-first ordering.
+    expect(body.periods[0].periodStart).toBe("2026-05-01");
+    // A period intentionally omits economics (honest-null payback/LTV demo).
+    expect(body.economics["2026-03-01"]).toBeUndefined();
+    // And at least one period carries economics so the cards render real numbers.
+    expect(body.economics["2026-05-01"].arpaMicroUsd).toBeGreaterThan(0);
   });
 
   it("PUT /api/guardrails echoes a valid rule, rejects an unconstrained one", async () => {

--- a/web/app/api/cac/route.ts
+++ b/web/app/api/cac/route.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from "next/server";
+
+import {
+  MOCK_CAC_PERIODS,
+  MOCK_PERIOD_ECONOMICS,
+  queryCacPeriods,
+  type CacPeriod,
+  type PeriodEconomics,
+} from "@/lib/cac";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export interface CacPayload {
+  periods: CacPeriod[];
+  /** Per-period revenue-side economics, keyed by `periodStart`. Absent ⇒ payback/LTV render "—". */
+  economics: Record<string, PeriodEconomics>;
+  /** True when the gateway was unreachable / empty and we fell back to the labelled mock. */
+  isMock: boolean;
+}
+
+export async function GET(): Promise<NextResponse<CacPayload>> {
+  // queryCacPeriods returns [] when the gateway is unreachable OR has no rows (CI / fresh clone).
+  // Mirror the established fallback (see /api/attribution, /api/cost): serve the clearly-labelled
+  // mock so the page is useful before the CAC backend has data, never fabricate as real.
+  const live = await queryCacPeriods();
+  if (live.length > 0) {
+    // Real gateway data: no economics yet (the CAC backend doesn't store ARPA / gross margin), so
+    // payback / LTV honest-null until a revenue source is wired. Periods + CAC flavors are real.
+    return NextResponse.json({ periods: live, economics: {}, isMock: false });
+  }
+  return NextResponse.json({
+    periods: MOCK_CAC_PERIODS,
+    economics: MOCK_PERIOD_ECONOMICS,
+    isMock: true,
+  });
+}

--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Unit Economics page (CTO-121): renders CAC flavors / payback / LTV from the already-wired libs
+// (web/lib/cac.ts + web/lib/unitEconomics.ts). Read-only. Band colors come from the lib's
+// `ltvCacBand` helper — NO hardcoded thresholds live in this file.
+
+import { Card } from "@/components/Card";
+import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { apiGet } from "@/lib/api";
+import type { CacPayload } from "@/app/api/cac/route";
+import type { CacPeriod, PeriodEconomics } from "@/lib/cac";
+import {
+  blendedCac,
+  fullyLoadedCac,
+  ltv,
+  ltvCacBand,
+  ltvOverCac,
+  marginPerUser,
+  marketingCac,
+  paybackMonths,
+} from "@/lib/unitEconomics";
+import { formatUSD } from "@/lib/types";
+
+const DASH = "—";
+
+/** Monthly contribution margin per account = ARPA × gross margin. Null when economics is missing. */
+function monthlyMargin(econ: PeriodEconomics | undefined): number | null {
+  if (!econ) return null;
+  const value = econ.arpaMicroUsd;
+  const cost = econ.arpaMicroUsd * (1 - econ.grossMarginPct);
+  return marginPerUser(value, cost);
+}
+
+function fmtMoney(v: number | null): string {
+  return v === null ? DASH : formatUSD(v);
+}
+
+function fmtMonths(v: number | null): string {
+  return v === null ? DASH : `${v.toFixed(1)} mo`;
+}
+
+function fmtRatio(v: number | null): string {
+  return v === null ? DASH : `${v.toFixed(2)}×`;
+}
+
+function fmtPct(v: number | null): string {
+  return v === null ? DASH : `${Math.round(v * 100)}%`;
+}
+
+function fmtMonthLabel(periodStart: string): string {
+  // periodStart is "YYYY-MM-01"; render "Mon YYYY" without timezone drift.
+  const [y, m] = periodStart.split("-").map((s) => parseInt(s, 10));
+  const d = new Date(Date.UTC(y, m - 1, 1));
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
+}
+
+/** Tailwind text color for a band from the lib's `ltvCacBand` classifier. */
+function bandText(band: ReturnType<typeof ltvCacBand>): string {
+  return band === "green"
+    ? "text-good"
+    : band === "yellow"
+      ? "text-warn"
+      : band === "red"
+        ? "text-bad"
+        : "text-muted";
+}
+
+export default async function UnitEconomicsPage() {
+  const data = await apiGet<CacPayload>("/api/cac");
+  const { periods, economics, isMock } = data;
+
+  // Headline cards reflect the most recent period for which we have both CAC inputs and economics.
+  // Falling to the latest period regardless keeps the CAC flavors visible even when economics is
+  // missing (payback/LTV then honest-null to "—").
+  const latest: CacPeriod | undefined = periods[0];
+  const latestEcon = latest ? economics[latest.periodStart] : undefined;
+
+  const blended = latest ? blendedCac(latest) : null;
+  const paid = latest ? marketingCac(latest) : null; // "paid CAC" = paid spend / paid customers
+  const loaded = latest ? fullyLoadedCac(latest) : null;
+  const margin = monthlyMargin(latestEcon);
+  const payback = paybackMonths(loaded, margin);
+  const ltvValue = ltv(margin, latestEcon?.retentionMonths ?? 0);
+  const ratio = ltvOverCac(ltvValue, loaded);
+  const band = ltvCacBand(ratio);
+
+  const body = (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <Metric label="Blended CAC" value={fmtMoney(blended)} hint="(paid+sales+content) / new customers" />
+        <Metric label="Paid CAC" value={fmtMoney(paid)} hint="paid spend / new paid customers" />
+        <Metric label="Payback" value={fmtMonths(payback)} hint="fully-loaded CAC / monthly margin" />
+        <Metric label="LTV" value={fmtMoney(ltvValue)} hint="margin × expected retention" />
+        <Metric
+          label="LTV : CAC"
+          value={fmtRatio(ratio)}
+          valueClass={bandText(band)}
+          hint="vs. fully-loaded CAC"
+        />
+      </div>
+
+      <Card title="Monthly history">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-muted">
+              <tr>
+                <th className="py-1 text-left font-medium">Period</th>
+                <th className="py-1 text-right font-medium">Marketing spend</th>
+                <th className="py-1 text-right font-medium">Sales spend</th>
+                <th className="py-1 text-right font-medium">New (total)</th>
+                <th className="py-1 text-right font-medium">New (paid)</th>
+                <th className="py-1 text-right font-medium">ARPA</th>
+                <th className="py-1 text-right font-medium">Gross margin</th>
+                <th className="py-1 text-right font-medium">Blended CAC</th>
+                <th className="py-1 text-right font-medium">Paid CAC</th>
+                <th className="py-1 text-right font-medium">Payback</th>
+                <th className="py-1 text-right font-medium">LTV : CAC</th>
+              </tr>
+            </thead>
+            <tbody>
+              {periods.map((p) => {
+                const econ = economics[p.periodStart];
+                const m = monthlyMargin(econ);
+                const loadedRow = fullyLoadedCac(p);
+                const ltvRow = ltv(m, econ?.retentionMonths ?? 0);
+                const ratioRow = ltvOverCac(ltvRow, loadedRow);
+                const bandRow = ltvCacBand(ratioRow);
+                return (
+                  <tr
+                    key={p.periodStart}
+                    className={`border-t border-edge ${p.locked ? "text-muted" : ""}`}
+                  >
+                    <td className="py-2 font-medium">
+                      <span className={p.locked ? "" : "text-white"}>{fmtMonthLabel(p.periodStart)}</span>
+                      {p.locked && (
+                        <span
+                          className="ml-2 rounded bg-edge px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted"
+                          title={`Closed${p.closedAt ? ` ${p.closedAt.slice(0, 10)}` : ""} — locked, not editable`}
+                        >
+                          Locked
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">{formatUSD(p.paidSpendMicroUsd + p.contentSpendMicroUsd)}</td>
+                    <td className="py-2 text-right tabular-nums">{formatUSD(p.salesSpendMicroUsd)}</td>
+                    <td className="py-2 text-right tabular-nums">{p.newCustomersTotal.toLocaleString()}</td>
+                    <td className="py-2 text-right tabular-nums">{p.newCustomersPaid.toLocaleString()}</td>
+                    <td className="py-2 text-right tabular-nums">{econ ? formatUSD(econ.arpaMicroUsd) : DASH}</td>
+                    <td className="py-2 text-right tabular-nums">{econ ? fmtPct(econ.grossMarginPct) : DASH}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(blendedCac(p))}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(marketingCac(p))}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMonths(paybackMonths(loadedRow, m))}</td>
+                    <td className={`py-2 text-right tabular-nums ${bandText(bandRow)}`}>{fmtRatio(ratioRow)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-xs text-muted">
+          Marketing spend = paid + content. Locked months are prior-month-closed and not editable.
+          Payback / LTV need ARPA and gross margin; periods missing either show {DASH}.
+        </p>
+      </Card>
+
+      {/* CSV upload deferred (CTO-121): the gateway exposes /v1/tenant/cac/csv, but wiring an
+          authenticated file-upload proxy + optimistic UI is its own change. Read-only render first.
+          TODO(CTO-121-followup): add a file-upload button that POSTs to a thin /api/cac proxy. */}
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">Unit Economics</h1>
+          <p className="mt-1 text-sm text-muted">
+            CAC by flavor, payback, and LTV — honest under uncertainty. Undefined metrics render {DASH}.
+          </p>
+        </div>
+      </div>
+
+      {isMock ? (
+        <SyntheticPreviewBanner workflow="Unit Economics">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  hint,
+  valueClass,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+  valueClass?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-edge bg-panel p-5">
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className={`mt-2 text-2xl font-semibold tabular-nums ${valueClass ?? ""}`}>{value}</div>
+      <div className="mt-2 text-xs text-muted">{hint}</div>
+    </div>
+  );
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -9,6 +9,7 @@ const NAV: { label: string; href: string }[] = [
   { label: "Agents", href: "/agents" },
   { label: "Compare", href: "/compare" },
   { label: "Attribution", href: "/attribution" },
+  { label: "Unit Economics", href: "/unit-economics" },
   { label: "Connectors", href: "/connectors" },
   // Hidden from the nav until they have real signal end-to-end (pages still render at the URL):
   //   - /settings        — empty shell, no real settings wired

--- a/web/lib/cac.ts
+++ b/web/lib/cac.ts
@@ -76,6 +76,102 @@ export async function queryCacPeriods(): Promise<CacPeriod[]> {
 }
 
 /**
+ * Page-level economic assumptions that do NOT come from the gateway's cac_periods wire shape.
+ *
+ * CAC periods carry spend + customer counts only. Computing payback and LTV additionally needs the
+ * revenue side — ARPA (average revenue per account / month) and gross margin — which the CAC
+ * backend does not store. Until a revenue source is wired (the Stripe-backed business_events table,
+ * see unitEconomics.ts `valuePerUser`), the page reads these from a per-period companion record.
+ *
+ * Kept deliberately separate from `CacPeriod` so we never imply the gateway returns these: a period
+ * with no economics record renders payback/LTV as "—" (honest-null), never a fabricated number.
+ */
+export interface PeriodEconomics {
+  /** Average revenue per account, per month, in micro-USD. */
+  arpaMicroUsd: number;
+  /** Gross margin as a fraction in [0,1], e.g. 0.78 for 78%. */
+  grossMarginPct: number;
+  /** Expected retention in months — drives LTV. */
+  retentionMonths: number;
+}
+
+/**
+ * Mock CAC periods for local dev / CI / fresh clones, used when the gateway is unreachable.
+ * CLEARLY LABELLED MOCK — not real telemetry. Newest-first, mirroring the gateway's
+ * `queryCacPeriods` ordering. The latest two months are unlocked (still editable); older months are
+ * `locked` (prior-month-closed). One month deliberately omits its economics record so the page's
+ * honest-null path (payback/LTV → "—") is exercised by the demo, and one has zero paid customers so
+ * the marketing-CAC divide-by-zero guard ("—") is exercised too.
+ */
+export const MOCK_CAC_PERIODS: CacPeriod[] = [
+  {
+    periodStart: "2026-05-01",
+    periodEnd: "2026-05-31",
+    currency: "USD",
+    paidSpendMicroUsd: 42_000_000_000,
+    salesSpendMicroUsd: 28_000_000_000,
+    contentSpendMicroUsd: 9_000_000_000,
+    overheadMicroUsd: 31_000_000_000,
+    newCustomersPaid: 38,
+    newCustomersTotal: 61,
+    notes: "Spring campaign tail-off",
+    closedAt: null,
+    locked: false,
+  },
+  {
+    periodStart: "2026-04-01",
+    periodEnd: "2026-04-30",
+    currency: "USD",
+    paidSpendMicroUsd: 39_500_000_000,
+    salesSpendMicroUsd: 26_000_000_000,
+    contentSpendMicroUsd: 8_500_000_000,
+    overheadMicroUsd: 30_000_000_000,
+    newCustomersPaid: 41,
+    newCustomersTotal: 66,
+    notes: null,
+    closedAt: null,
+    locked: false,
+  },
+  {
+    periodStart: "2026-03-01",
+    periodEnd: "2026-03-31",
+    currency: "USD",
+    paidSpendMicroUsd: 44_000_000_000,
+    salesSpendMicroUsd: 24_000_000_000,
+    contentSpendMicroUsd: 8_000_000_000,
+    overheadMicroUsd: 29_000_000_000,
+    newCustomersPaid: 33,
+    newCustomersTotal: 52,
+    // No economics record below for this month → payback/LTV render "—" (honest-null demo).
+    notes: "ARPA reconciliation pending",
+    closedAt: "2026-04-03T00:00:00Z",
+    locked: true,
+  },
+  {
+    periodStart: "2026-02-01",
+    periodEnd: "2026-02-28",
+    currency: "USD",
+    paidSpendMicroUsd: 36_000_000_000,
+    salesSpendMicroUsd: 22_000_000_000,
+    contentSpendMicroUsd: 7_000_000_000,
+    overheadMicroUsd: 28_000_000_000,
+    newCustomersPaid: 0,
+    newCustomersTotal: 44,
+    // Zero paid customers → marketing CAC renders "—" (divide-by-zero guard in the lib).
+    notes: "Paid channels paused mid-month",
+    closedAt: "2026-03-04T00:00:00Z",
+    locked: true,
+  },
+];
+
+/** Per-period economics keyed by `periodStart`. March is intentionally absent (honest-null demo). */
+export const MOCK_PERIOD_ECONOMICS: Record<string, PeriodEconomics> = {
+  "2026-05-01": { arpaMicroUsd: 220_000_000, grossMarginPct: 0.78, retentionMonths: 24 },
+  "2026-04-01": { arpaMicroUsd: 215_000_000, grossMarginPct: 0.77, retentionMonths: 24 },
+  "2026-02-01": { arpaMicroUsd: 205_000_000, grossMarginPct: 0.75, retentionMonths: 22 },
+};
+
+/**
  * Default first month finance should fill — the *next* un-entered month.
  *
  * Finance fills serially, in chronological order; the form should not default to the current


### PR DESCRIPTION
## Summary

CTO-111 shipped the CAC backend and the computation libs (`web/lib/cac.ts`, `web/lib/unitEconomics.ts`), but no page rendered any of it — the libs were dead code from the dashboard's POV. This PR builds the read-only **Unit Economics** page on top of those libs.

## What I rendered

**Top metric cards** (latest period, via the existing lib fns):
- **Blended CAC** — `blendedCac` = (paid + sales + content) / new total customers
- **Paid CAC** — `marketingCac` = paid spend / new paid customers
- **Payback (months)** — `paybackMonths(fullyLoadedCac, monthly margin)`
- **LTV** — `ltv(margin, retentionMonths)`
- **LTV : CAC** — `ltvOverCac(ltv, fullyLoadedCac)`, colored by band

**Monthly history table** (newest-first), columns drawn from what `cac.ts` actually exposes:
- Marketing spend (paid + content), Sales spend
- New customers (total) + New customers (paid)
- ARPA, Gross margin (from the `PeriodEconomics` companion record — see below)
- Per-row Blended CAC, Paid CAC, Payback, LTV:CAC

## Band colors

LTV:CAC band colors come **exclusively** from the lib's `ltvCacBand` helper (`>3 green`, `[1,3] yellow`, `<1 red`, `null` unknown). **No thresholds are hardcoded in the page** — `bandText()` only maps the helper's returned band string to a Tailwind class.

## Honest-null

Any undefined/missing metric renders `—`, never a fabricated number:
- Periods with zero paid customers → Paid CAC `—` (lib divide-by-zero guard).
- Periods missing economics (ARPA / gross margin) → ARPA, gross margin, payback, LTV:CAC all `—`. The mock includes one such month (March) on purpose.
- Locked periods (`locked: true`, prior-month-closed) are visually distinct (muted + "Locked" pill, `closedAt` in the tooltip) and not editable.

## ARPA / gross margin source

`CacPeriod` (the gateway wire shape) carries spend + customer counts only — no revenue side. I did **not** invent fields on it. Instead `cac.ts` gains a clearly-labelled `PeriodEconomics` companion type (ARPA / gross margin / retention) used to compute margin → payback → LTV. Real gateway periods return `economics: {}` until a revenue source is wired, so payback/LTV honest-null on live data; the CAC flavors are real.

## Mock / fallback

`web/app/api/cac/route.ts` fetches periods from the gateway via the existing `queryCacPeriods()` and falls back to `MOCK_CAC_PERIODS` + `MOCK_PERIOD_ECONOMICS` (added to `cac.ts`, clearly labelled) when the gateway is unreachable/empty — mirroring the `/api/cost` and `/api/attribution` fallback pattern. The page wraps mock data in the existing `SyntheticPreviewBanner` ("Sample data").

## Nav

Re-added `{ label: "Unit Economics", href: "/unit-economics" }` to the `NAV` array in `Shell.tsx`, after "Attribution".

## CSV upload

**Deferred.** The read-only render was prioritized for correctness. A clearly-commented `TODO(CTO-121-followup)` is left in the page for a thin file-upload proxy to the gateway's existing `/v1/tenant/cac/csv`.

## Test plan

- `cd web && npx tsc --noEmit` — clean.
- `cd web && npx vitest run` — 170 passing. Added a smoke test for `GET /api/cac` (mock-fallback shape, newest-first ordering, honest-null economics gap).
- Page is a server component reusing the established `apiGet` / `Card` / `DataStateBanner` patterns.

### Known pre-existing flakes (not touched)
`GET /api/data-quality returns a report` and `GET /api/attribution falls back to mock...` fail locally with a local ClickHouse up but pass in CI. Only those two fail here — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)