### PR TITLE
feat(gateway): persist candidate response text for honest eval (CTO-125)

### DIFF
--- a/db/clickhouse/replay_samples.sql
+++ b/db/clickhouse/replay_samples.sql
@@ -56,3 +56,18 @@ CREATE TABLE IF NOT EXISTS replay_runs
 ENGINE = ReplacingMergeTree
 PARTITION BY toYYYYMM(RanAt)
 ORDER BY (TenantId, RunId);
+
+
+-- CTO-125 additive migration. Idempotent: `ADD COLUMN IF NOT EXISTS` plus defaults so existing
+-- rows (which predate candidate-response persistence) read back as empty strings and the eval
+-- judge falls back to the envelope re-render path for them. Same style as the otel_spans ALTERs.
+--
+-- PII CARVE-OUT: ResponseText is the verbatim candidate-model response body. The span-side guard
+-- (mapping.py `_is_body_key`) deliberately refuses message bodies in `otel_spans`/business events.
+-- Replay is a *separate, opt-in* path (Postgres `tenant_replay_config`, default OFF) with its own
+-- retention TTL (`retention_days`) and access tier. Persisting the body here lets the pairwise LLM
+-- judge grade the candidate's ACTUAL output instead of a reconstruction. This does NOT relax the
+-- span-side no-bodies invariant; it applies only to this opt-in replay table.
+ALTER TABLE replay_runs
+    ADD COLUMN IF NOT EXISTS ResponseText  String  DEFAULT '' CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS FinishReason  LowCardinality(String) DEFAULT '';

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -1305,11 +1305,23 @@ async def _mock_candidate_client(call: CandidateCall) -> CandidateResponse:
 
     The envelope is expected to carry ``{"input_tokens": int, "output_tokens": int}`` from the
     captured sample. Falls back to small defaults if missing.
+
+    CTO-125: the mock also surfaces a ``response_text`` so the replay run persists candidate body
+    text (real provider clients return the model's actual completion). We prefer an explicit
+    ``candidate_response`` on the envelope, else the captured current ``response``.
     """
     env = call.envelope or {}
+    response_text = ""
+    for key in ("candidate_response", "response", "response_text", "completion"):
+        v = env.get(key)
+        if isinstance(v, str) and v:
+            response_text = v
+            break
     return CandidateResponse(
         input_tokens=int(env.get("input_tokens") or 100),
         output_tokens=int(env.get("output_tokens") or 50),
+        response_text=response_text,
+        finish_reason="stop",
         status_code=200,
     )
 
@@ -1485,12 +1497,14 @@ async def project_eval(
             envelope = _load_envelope(blob_store, sample_row.s3_object_key)
             instruction = _extract_instruction(envelope)
             current_response = _extract_response(envelope)
-            # Candidate response: we don't currently persist the candidate's response text in
-            # replay_runs (CTO-113 only wrote tokens/cost/latency). The mock-judge path uses a
-            # synthetic candidate_response derived from the envelope; the production path will
-            # need replay_runs to grow a response-text column.
-            # FIXME(CTO-114-followup): persist candidate response text on replay_runs.
-            candidate_response = envelope.get("candidate_response") or current_response
+            # Candidate response (CTO-125): the replay executor now persists the candidate model's
+            # actual response body on the run row, so the judge grades what the candidate truly
+            # produced rather than an envelope re-render. KEEP a fallback for legacy rows written
+            # before this column existed (response_text absent → reconstruct from the envelope) so
+            # historical eval results keep working.
+            candidate_response = getattr(run, "response_text", "") or (
+                envelope.get("candidate_response") or current_response
+            )
             est_cost = _estimate_judge_cost(app.state.catalog, cfg.judge_model, instruction,
                                              current_response, candidate_response)
             result = await executor.judge_pair(

--- a/infra/gateway/src/gateway/replay_executor.py
+++ b/infra/gateway/src/gateway/replay_executor.py
@@ -67,6 +67,7 @@ class CandidateResponse:
     input_tokens: int
     output_tokens: int
     response_text: str = ""
+    finish_reason: str = ""
     status_code: int = 200
     error_msg: str = ""
 
@@ -181,6 +182,12 @@ class ReplayExecutor:
             latency_ms=latency_ms,
             error_msg=response.error_msg,
             ran_at=datetime.now(UTC),
+            # CTO-125: persist the candidate's actual response body so the LLM judge grades what
+            # the candidate model really produced, not an envelope re-render. See the PII
+            # carve-out note on ReplayRunRow — this is an opt-in replay-only path, distinct from
+            # the span-side "no bodies in telemetry" guard.
+            response_text=response.response_text,
+            finish_reason=response.finish_reason,
         )
         self.sink(row)
         return ReplayResult(

--- a/infra/gateway/src/gateway/replay_store.py
+++ b/infra/gateway/src/gateway/replay_store.py
@@ -106,7 +106,7 @@ REPLAY_SAMPLE_COLS = (
 REPLAY_RUN_COLS = (
     "TenantId", "RunId", "SampleId", "CandidateProvider", "CandidateModel",
     "InputTokens", "OutputTokens", "CostMicroUsd", "LatencyMs", "ErrorMsg",
-    "RanAt", "ContextFidelity",
+    "RanAt", "ContextFidelity", "ResponseText", "FinishReason",
 )
 
 
@@ -124,6 +124,17 @@ class ReplayRunRow:
     error_msg: str
     ran_at: datetime
     context_fidelity: str = "resolved-context"
+    # --- Candidate response body (CTO-125) ---------------------------------------------------
+    # PII CARVE-OUT: ``response_text`` is the verbatim text the candidate model produced. This is
+    # a message body — exactly the kind of payload the span-side PII guard (mapping.py
+    # ``_is_body_key``) refuses to persist into telemetry. Replay is a *separate, opt-in* path:
+    # a tenant must explicitly enable ``tenant_replay_config`` (default OFF), the body lives in
+    # the replay store under its own retention TTL (``retention_days``) and access tier, and it is
+    # never written to spans/business_events. We persist it here so the pairwise LLM judge grades
+    # the candidate's ACTUAL output rather than an envelope re-render. The span-side "counts only,
+    # never bodies" invariant is untouched by this field.
+    response_text: str = ""
+    finish_reason: str = ""
 
     def as_clickhouse_row(self) -> tuple[object, ...]:
         return (
@@ -139,6 +150,9 @@ class ReplayRunRow:
             self.error_msg,
             self.ran_at,
             self.context_fidelity,
+            # Candidate response body — see PII carve-out note on the dataclass above.
+            self.response_text,
+            self.finish_reason,
         )
 
 

--- a/infra/gateway/src/gateway/tenant_replay.py
+++ b/infra/gateway/src/gateway/tenant_replay.py
@@ -19,6 +19,18 @@ import psycopg
 from gateway.config import Settings
 
 
+# Consent disclosure (CTO-125). When a tenant opts into replay, captured samples AND the candidate
+# models' response bodies are retained (under `retention_days`) so the eval harness can grade the
+# real candidate output. Surfaced in the config response so the opt-in is informed; wiring it into
+# the dashboard UI is out of scope here.
+CANDIDATE_RESPONSE_RETENTION_CONSENT = (
+    "When replay is enabled, candidate models are re-run against your scrubbed samples and their "
+    "response text is retained alongside the sample for the configured retention period, so quality "
+    "evaluation can judge the candidate's actual output. Retention follows retention_days; replay "
+    "is opt-in and off by default."
+)
+
+
 @dataclass(frozen=True, slots=True)
 class ReplayConfig:
     enabled: bool
@@ -32,6 +44,7 @@ class ReplayConfig:
             "sample_rate": self.sample_rate,
             "retention_days": self.retention_days,
             "daily_budget_usd": float(self.daily_budget_usd),
+            "candidate_response_retention_consent": CANDIDATE_RESPONSE_RETENTION_CONSENT,
         }
 
 

--- a/infra/gateway/tests/test_app_eval.py
+++ b/infra/gateway/tests/test_app_eval.py
@@ -229,3 +229,92 @@ def test_eval_candidate_wins_aggregate(client: TestClient) -> None:
     assert cand["current_wins"] > 5
     assert cand["candidate_wins"] + cand["current_wins"] == 40
     assert cand["ties"] == 0
+
+
+# --- CTO-125: judge reads persisted candidate response text ----------------------
+
+def _seed_with_persisted_response(
+    *, persisted_text: str, envelope_candidate: str, feature_tag: str = "chat",
+) -> None:
+    """One sample whose envelope carries a *different* candidate_response than the persisted
+    replay_run.response_text, so a test can tell which one the judge actually graded."""
+    blob_store = app.state.replay_blob_store
+    sample_index = app.state.replay_sample_index
+    replay_runs = app.state.replay_runs
+    now = datetime.now(timezone.utc)
+    sid = uuid4()
+    key = build_replay_object_key(T, sid, now)
+    body = json.dumps({
+        "prompt": "What is 2 + 2?",
+        "response": "4",
+        "candidate_response": envelope_candidate,
+        "input_tokens": 50,
+        "output_tokens": 20,
+    }).encode()
+    blob_store.put_bytes(key, body)
+    sample_index.append(ReplaySampleRow(
+        tenant_id=T, sample_id=sid, trace_id="trace-x", feature_tag=feature_tag,
+        real_provider="anthropic", real_model="claude-sonnet-4-5",
+        input_tokens=50, output_tokens=20,
+        captured_at=now, s3_object_key=key, pii_scrubbed=True,
+    ))
+    replay_runs.append(ReplayRunRow(
+        tenant_id=T, run_id=uuid4(), sample_id=sid,
+        candidate_provider="anthropic", candidate_model="claude-haiku-4-5",
+        input_tokens=50, output_tokens=20,
+        cost_micro_usd=1234, latency_ms=42, error_msg="", ran_at=now,
+        response_text=persisted_text, finish_reason="stop",
+    ))
+
+
+def test_eval_judges_persisted_response_not_envelope(client: TestClient) -> None:
+    """The judge must grade the persisted replay_run.response_text, NOT the envelope re-render."""
+    _seed_with_persisted_response(
+        persisted_text="PERSISTED candidate answer",
+        envelope_candidate="ENVELOPE reconstructed answer",
+    )
+    seen_prompts: list[str] = []
+
+    async def capturing_judge(call: JudgeCall) -> JudgeResponse:
+        seen_prompts.append(call.prompt)
+        return JudgeResponse(text="TIE", input_tokens=100, output_tokens=2)
+    app.state.eval_judge_client = capturing_judge
+
+    r = client.post(
+        "/v1/eval",
+        headers={"X-Tenant-Id": T},
+        json={"tenant_id": T,
+              "candidate_models": [{"provider": "anthropic", "model": "claude-haiku-4-5"}],
+              "sample_size": 1},
+    )
+    assert r.status_code == 200
+    assert len(seen_prompts) == 1
+    prompt = seen_prompts[0]
+    assert "PERSISTED candidate answer" in prompt
+    assert "ENVELOPE reconstructed answer" not in prompt
+
+
+def test_eval_legacy_row_falls_back_to_envelope(client: TestClient) -> None:
+    """Legacy replay_runs predating CTO-125 have empty response_text → judge falls back to the
+    envelope reconstruct path so historical eval results keep working."""
+    _seed_with_persisted_response(
+        persisted_text="",  # legacy row: column absent / empty
+        envelope_candidate="ENVELOPE reconstructed answer",
+    )
+    seen_prompts: list[str] = []
+
+    async def capturing_judge(call: JudgeCall) -> JudgeResponse:
+        seen_prompts.append(call.prompt)
+        return JudgeResponse(text="TIE", input_tokens=100, output_tokens=2)
+    app.state.eval_judge_client = capturing_judge
+
+    r = client.post(
+        "/v1/eval",
+        headers={"X-Tenant-Id": T},
+        json={"tenant_id": T,
+              "candidate_models": [{"provider": "anthropic", "model": "claude-haiku-4-5"}],
+              "sample_size": 1},
+    )
+    assert r.status_code == 200
+    assert len(seen_prompts) == 1
+    assert "ENVELOPE reconstructed answer" in seen_prompts[0]

--- a/infra/gateway/tests/test_app_replay.py
+++ b/infra/gateway/tests/test_app_replay.py
@@ -78,6 +78,9 @@ def test_config_defaults_off(client: TestClient) -> None:
     assert r.status_code == 200
     assert r.json()["config"]["enabled"] is False
     assert r.json()["config"]["sample_rate"] == 0.05
+    # CTO-125: the opt-in config surfaces a candidate-response retention consent disclosure.
+    consent = r.json()["config"]["candidate_response_retention_consent"]
+    assert "response text is retained" in consent
 
 
 def test_config_round_trip(client: TestClient) -> None:

--- a/infra/gateway/tests/test_replay_executor.py
+++ b/infra/gateway/tests/test_replay_executor.py
@@ -88,6 +88,35 @@ def test_replay_writes_run_row() -> None:
     assert row.cost_micro_usd > 0
 
 
+def test_replay_persists_candidate_response_text() -> None:
+    """CTO-125: the replay run row carries the candidate model's actual response body."""
+
+    async def text_client(call: CandidateCall) -> CandidateResponse:
+        return CandidateResponse(
+            input_tokens=100, output_tokens=50,
+            response_text="The candidate's actual answer is 42.",
+            finish_reason="stop",
+            status_code=200,
+        )
+
+    exec_, rows = _make_executor(client=text_client)
+    sid = uuid4()
+    key = _seed_blob(exec_.blob_store, "t1", sid)
+    result = asyncio.run(exec_.replay_sample(
+        tenant_id="t1", sample_id=sid, object_key=key,
+        candidate_provider="anthropic", candidate_model="claude-haiku-4-5",
+        daily_budget_usd=Decimal("5.00"),
+    ))
+    assert result.succeeded
+    row: ReplayRunRow = rows[0]
+    assert row.response_text == "The candidate's actual answer is 42."
+    assert row.finish_reason == "stop"
+    # And it survives the ClickHouse-row serialization (last two columns).
+    ch = row.as_clickhouse_row()
+    assert ch[-2] == "The candidate's actual answer is 42."
+    assert ch[-1] == "stop"
+
+
 # --- Budget cap ---------------------------------------------------------------
 
 def test_replay_skips_when_budget_exceeded() -> None:


### PR DESCRIPTION
## Summary

The mock-judge eval path carried a `FIXME(CTO-114-followup)`: because `replay_runs` never persisted the candidate-response body, the pairwise LLM judge graded an envelope *re-render* rather than the text the candidate model actually produced. This makes the candidate-response side of judging honest by persisting the real response body on the replay run and reading it directly in the judge.

## Schema fields added (additive, defaulted)

- **In-memory** `ReplayRunRow` (`replay_store.py`): `response_text: str = ""`, `finish_reason: str = ""`; `REPLAY_RUN_COLS` and `as_clickhouse_row()` extended with `ResponseText`, `FinishReason`.
- **DDL** (`db/clickhouse/replay_samples.sql`): idempotent `ALTER TABLE replay_runs ADD COLUMN IF NOT EXISTS ResponseText String DEFAULT ''` and `FinishReason LowCardinality(String) DEFAULT ''`, matching the additive/defaulted `otel_spans.sql` style.
- `CandidateResponse` grows `finish_reason`; `ReplayExecutor.execute`/`replay_sample` writes both onto the run row.

## PII carve-out rationale

Candidate response text **is** a message body. The span-side "no bodies in telemetry" invariant (`mapping.py` `_is_body_key`) is **unchanged** — spans/business_events still reject bodies. Replay is a *separate, opt-in* path: a tenant must enable `tenant_replay_config` (default OFF), and the body lives in the replay store under its own retention TTL (`retention_days`) and access tier. The carve-out is documented at each write site (dataclass, executor, DDL).

## Legacy-row fallback

The judge reads `run.response_text` directly. Rows that predate this schema (empty `response_text`) fall back to the previous envelope reconstruct path, so historical eval results keep working. The `FIXME(CTO-114-followup)` is removed.

## Consent string

`tenant_replay.CANDIDATE_RESPONSE_RETENTION_CONSENT` is surfaced in the replay config response (`candidate_response_retention_consent`). UI wiring is out of scope.

## Test plan

- `test_replay_persists_candidate_response_text` — run row + ClickHouse tuple carry the body.
- `test_eval_judges_persisted_response_not_envelope` — judge prompt contains the persisted text, not the envelope re-render.
- `test_eval_legacy_row_falls_back_to_envelope` — empty `response_text` → envelope fallback.
- `test_config_defaults_off` — consent disclosure present.

Results: gateway **251 passed**, SDK **840 passed**, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)