### PR TITLE
feat(estimate): body-driven what-if (candidate model + prompt override) (CTO-128)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -57,6 +57,7 @@ from gateway.stripe_ingest import (
     map_stripe_event,
     verify_stripe_signature,
 )
+from gateway.replay_estimate import apply_system_prompt_override
 from gateway.replay_executor import (
     CandidateCall,
     CandidateResponse,
@@ -1274,6 +1275,159 @@ async def project_replay(
             "context_fidelity": "resolved-context replay (no live retrieval)",
             "replay_cost_micro_usd": total_replay_cost,
         },
+    })
+
+
+@app.post("/v1/replay/estimate")
+async def project_replay_estimate(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Body-driven what-if: project one candidate with an optional prompt override (CTO-128).
+
+    Body::
+
+        {
+          "tenant_id": "...",            # optional — falls back to control-plane resolution
+          "feature_tag": "research",     # optional filter
+          "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+          "system_prompt_override": "...",  # optional — applied to the envelope before pricing
+          "sample_size": 50              # optional, default 50; sized to min(sample_size, available)
+        }
+
+    Reuses the ``/v1/replay`` executor + per-corpus extrapolation. The only new behavior is
+    applying ``system_prompt_override`` to each captured envelope before the candidate call
+    (see :func:`gateway.replay_estimate.apply_system_prompt_override`). Returns the same
+    projection shape as ``/v1/replay`` (a single-element ``per_candidate`` list) plus the v1
+    honesty/diagnostics block. Like ``/v1/replay``, the candidate client is injectable via
+    ``app.state.replay_candidate_client`` (a deterministic mock by default).
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+
+    tenant_id = body.get("tenant_id") or _resolve_tenant_for_control_plane(
+        authorization, x_tenant_id
+    )
+    feature_tag = body.get("feature_tag")
+    candidate = body.get("candidate_model")
+    if not isinstance(candidate, dict) or "provider" not in candidate or "model" not in candidate:
+        raise HTTPException(
+            status_code=422,
+            detail="candidate_model must be a {provider, model} object",
+        )
+    system_prompt_override = body.get("system_prompt_override")
+    if system_prompt_override is not None and not isinstance(system_prompt_override, str):
+        raise HTTPException(status_code=422, detail="system_prompt_override must be a string")
+    sample_size = int(body.get("sample_size") or 50)
+
+    cfg = app.state.tenant_replay.get(tenant_id)
+    index: list = app.state.replay_sample_index
+    matching = [
+        r for r in index
+        if r.tenant_id == tenant_id
+        and (feature_tag is None or r.feature_tag == feature_tag)
+    ]
+    samples_available = len(matching)
+
+    diagnostics = {
+        "context_fidelity": "resolved-context replay (no live retrieval)",
+        "prompt_override_applied": bool(system_prompt_override),
+        # The override length is estimated at 4 chars/token — no real tokenizer in v1.
+        "token_estimate": "4-chars-per-token (no live tokenizer)",
+        "replay_cost_micro_usd": 0,
+    }
+
+    if samples_available == 0:
+        return JSONResponse({
+            "tenant_id": tenant_id,
+            "feature_tag": feature_tag,
+            "samples_available": 0,
+            "per_candidate": [],
+            "diagnostics": diagnostics,
+        })
+
+    # Size to min(sample_size, available); _pick_for_projection already clamps when size>=len.
+    selected = _pick_for_projection(matching, min(sample_size, samples_available))
+
+    client = getattr(app.state, "replay_candidate_client", None) or _mock_candidate_client
+    executor = ReplayExecutor(
+        catalog=app.state.catalog,
+        blob_store=app.state.replay_blob_store,
+        client=client,
+        todays_spend_micro_usd=lambda t: _todays_spend(app.state.replay_runs, t),
+        sink=app.state.replay_runs.append,
+    )
+
+    transform = (
+        (lambda env: apply_system_prompt_override(env, system_prompt_override))
+        if system_prompt_override
+        else None
+    )
+
+    provider = str(candidate["provider"])
+    model = str(candidate["model"])
+    results = []
+    excluded_budget = 0
+    latencies: list[int] = []
+    errors = 0
+    cost_sum = 0
+    for sample in selected:
+        from tally.pricing import Usage as _Usage
+        from tally.pricing import compute_cost_micro_usd as _ccost
+        est_cost, _ = _ccost(
+            app.state.catalog, provider, model,
+            _Usage(input_tokens=sample.input_tokens, output_tokens=sample.input_tokens),
+        )
+        result = await executor.replay_sample(
+            tenant_id=tenant_id,
+            sample_id=sample.sample_id,
+            object_key=sample.s3_object_key,
+            candidate_provider=provider,
+            candidate_model=model,
+            daily_budget_usd=cfg.daily_budget_usd,
+            estimated_call_cost_micro_usd=est_cost,
+            envelope_transform=transform,
+        )
+        results.append(result)
+        if result.excluded_budget:
+            excluded_budget += 1
+            continue
+        if result.row is not None:
+            latencies.append(result.row.latency_ms)
+            cost_sum += result.row.cost_micro_usd
+            if result.row.error_msg:
+                errors += 1
+
+    replayed = len(results) - excluded_budget
+    avg_cost = (cost_sum / replayed) if replayed > 0 else 0
+    projected_monthly_cost = int(round(avg_cost * samples_available))
+    sorted_lat = sorted(latencies)
+    p50 = sorted_lat[len(sorted_lat) // 2] if sorted_lat else 0
+    p95 = sorted_lat[max(0, int(len(sorted_lat) * 0.95) - 1)] if sorted_lat else 0
+    error_rate = (errors / replayed) if replayed > 0 else 0.0
+
+    diagnostics["replay_cost_micro_usd"] = cost_sum
+
+    return JSONResponse({
+        "tenant_id": tenant_id,
+        "feature_tag": feature_tag,
+        "samples_available": samples_available,
+        "per_candidate": [{
+            "provider": provider,
+            "model": model,
+            "projected_monthly_cost_micro_usd": projected_monthly_cost,
+            "p50_latency_ms": p50,
+            "p95_latency_ms": p95,
+            "error_rate": error_rate,
+            "samples_replayed": replayed,
+            "excluded_budget_count": excluded_budget,
+        }],
+        "diagnostics": diagnostics,
     })
 
 

--- a/infra/gateway/src/gateway/replay_estimate.py
+++ b/infra/gateway/src/gateway/replay_estimate.py
@@ -1,0 +1,75 @@
+"""Body-driven what-if estimate helpers (CTO-128).
+
+`/estimate` lets an operator ask "what would last week's workload cost if we swapped to a
+cheaper candidate model *and* tightened the system prompt?" The candidate-model swap was
+already covered by ``/v1/replay`` (CTO-113). The only new behavior here is applying a
+``system_prompt_override`` to the captured envelope *before* the candidate call, so the
+projected cost reflects the new prompt length rather than the captured one.
+
+We do not have a real tokenizer wired in the gateway; the rest of the codebase estimates at
+4 chars/token (see ``app._estimate_judge_cost``), so we stay consistent with that. Applying
+the override:
+
+1. Reads the captured system prompt from the envelope (``system_prompt`` / ``system``).
+2. Computes the token delta between the captured prompt and the override at 4 chars/token.
+3. Rewrites the envelope's ``input_tokens`` by that delta (floored at 1) and swaps the
+   system-prompt field to the override text.
+
+The mock candidate client reads ``input_tokens``/``output_tokens`` straight off the envelope,
+so the rewritten count flows into the executor's pricing unchanged — no new mock path. A real
+provider client would re-tokenize the actual rewritten prompt; the 4-chars/token estimate is
+the honest v1 approximation and is documented as such in the projection diagnostics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CHARS_PER_TOKEN = 4
+
+# Envelope keys that may carry the captured system prompt, in precedence order.
+_SYSTEM_PROMPT_KEYS = ("system_prompt", "system")
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate at 4 chars/token — matches the rest of the gateway's heuristics."""
+    if not text:
+        return 0
+    return len(text) // CHARS_PER_TOKEN
+
+
+def _captured_system_prompt(envelope: dict[str, Any]) -> tuple[str | None, str]:
+    """Return ``(key, text)`` for the captured system prompt, or ``(None, "")`` if absent."""
+    for key in _SYSTEM_PROMPT_KEYS:
+        v = envelope.get(key)
+        if isinstance(v, str):
+            return key, v
+    return None, ""
+
+
+def apply_system_prompt_override(
+    envelope: dict[str, Any], override: str | None
+) -> dict[str, Any]:
+    """Return a copy of ``envelope`` with the system prompt swapped to ``override``.
+
+    The envelope's ``input_tokens`` is adjusted by the (override - captured) token delta so the
+    projected cost reflects the new prompt length. When ``override`` is ``None`` or empty, the
+    envelope is returned unchanged (just shallow-copied so callers never mutate the original).
+    """
+    out = dict(envelope)
+    if not override:
+        return out
+
+    captured_key, captured_text = _captured_system_prompt(envelope)
+    delta = _estimate_tokens(override) - _estimate_tokens(captured_text)
+
+    try:
+        base_input = int(envelope.get("input_tokens") or 0)
+    except (TypeError, ValueError):
+        base_input = 0
+    out["input_tokens"] = max(1, base_input + delta)
+
+    # Swap the system-prompt field to the override; default to `system_prompt` when the captured
+    # envelope had no system prompt at all (so the override is still represented).
+    out[captured_key or "system_prompt"] = override
+    return out

--- a/infra/gateway/src/gateway/replay_executor.py
+++ b/infra/gateway/src/gateway/replay_executor.py
@@ -135,6 +135,10 @@ class ReplayExecutor:
         # budget check. Callers compute this from the sample's known input tokens + an output
         # token estimate (default 1x input tokens, i.e. a 50/50 chat shape).
         estimated_call_cost_micro_usd: int = 0,
+        # Optional transform applied to the loaded envelope before the candidate call — used by
+        # the body-driven what-if estimate (CTO-128) to apply a system_prompt_override. Pure;
+        # must return a (possibly new) envelope dict and never mutate the input.
+        envelope_transform: Callable[[dict[str, object]], dict[str, object]] | None = None,
     ) -> ReplayResult:
         """Replay one sample against one candidate. Honors the daily budget cap and concurrency limit."""
 
@@ -155,6 +159,8 @@ class ReplayExecutor:
         async with self._semaphore(tenant_id):
             envelope_bytes = self.blob_store.get_bytes(object_key)
             envelope = json.loads(envelope_bytes.decode("utf-8"))
+            if envelope_transform is not None:
+                envelope = envelope_transform(envelope)
             call = CandidateCall(
                 provider=candidate_provider, model=candidate_model, envelope=envelope
             )

--- a/infra/gateway/tests/test_app_replay_estimate.py
+++ b/infra/gateway/tests/test_app_replay_estimate.py
@@ -1,0 +1,210 @@
+"""Tests for POST /v1/replay/estimate — body-driven what-if (CTO-128)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.replay_estimate import apply_system_prompt_override
+from gateway.replay_executor import CandidateCall, CandidateResponse
+from gateway.replay_store import (
+    InMemoryReplayBlobStore,
+    ReplaySampleRow,
+    build_replay_object_key,
+)
+from gateway.tenant_replay import ReplayConfig
+
+T = "t-acme"
+
+
+class FakeReplayStore:
+    def __init__(self) -> None:
+        self._cfg: dict[str, ReplayConfig] = {}
+
+    def get(self, tenant_id: str) -> ReplayConfig:
+        return self._cfg.get(
+            tenant_id,
+            ReplayConfig(
+                enabled=False, sample_rate=0.05, retention_days=30,
+                daily_budget_usd=Decimal("50.00"),
+            ),
+        )
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_replay = FakeReplayStore()
+        app.state.replay_blob_store = InMemoryReplayBlobStore()
+        app.state.replay_sample_index = []
+        app.state.replay_runs = []
+        if hasattr(app.state, "replay_candidate_client"):
+            delattr(app.state, "replay_candidate_client")
+        yield c
+
+
+def _seed_samples(n: int = 50, *, feature_tag: str = "chat", system_prompt: str = "short") -> None:
+    blob_store = app.state.replay_blob_store
+    index = app.state.replay_sample_index
+    now = datetime.now(timezone.utc)
+    for i in range(n):
+        sid = uuid4()
+        key = build_replay_object_key(T, sid, now)
+        input_tokens = 100 + i * 5
+        output_tokens = 50 + i * 2
+        body = json.dumps({
+            "prompt": f"sample {i}",
+            "system_prompt": system_prompt,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        }).encode()
+        blob_store.put_bytes(key, body)
+        index.append(ReplaySampleRow(
+            tenant_id=T,
+            sample_id=sid,
+            trace_id=f"trace-{i}",
+            feature_tag=feature_tag,
+            real_provider="anthropic",
+            real_model="claude-sonnet-4.5",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            captured_at=now,
+            s3_object_key=key,
+            pii_scrubbed=True,
+        ))
+
+
+# --- helper unit tests ---------------------------------------------------------------
+
+def test_override_adjusts_input_tokens_up() -> None:
+    env = {"system_prompt": "tiny", "input_tokens": 100, "output_tokens": 50}
+    # 'tiny' ~ 1 token; a 400-char override ~ 100 tokens => +99 delta.
+    out = apply_system_prompt_override(env, "x" * 400)
+    assert out["input_tokens"] == 100 - (len("tiny") // 4) + (400 // 4)
+    assert out["system_prompt"] == "x" * 400
+    # original envelope untouched.
+    assert env["input_tokens"] == 100
+
+
+def test_override_none_is_passthrough() -> None:
+    env = {"system_prompt": "tiny", "input_tokens": 100}
+    out = apply_system_prompt_override(env, None)
+    assert out["input_tokens"] == 100
+    assert out is not env  # shallow copy, never the original
+
+
+def test_override_floors_at_one_token() -> None:
+    env = {"system_prompt": "x" * 4000, "input_tokens": 10}
+    out = apply_system_prompt_override(env, "")  # empty override => passthrough
+    assert out["input_tokens"] == 10
+    out2 = apply_system_prompt_override(env, "a")  # huge captured prompt, tiny override
+    assert out2["input_tokens"] == 1
+
+
+# --- endpoint tests ------------------------------------------------------------------
+
+def test_estimate_empty_tenant(client: TestClient) -> None:
+    r = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={"candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"}},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["samples_available"] == 0
+    assert body["per_candidate"] == []
+    assert body["diagnostics"]["prompt_override_applied"] is False
+
+
+def test_estimate_rejects_missing_candidate(client: TestClient) -> None:
+    r = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={"tenant_id": T, "sample_size": 10},
+    )
+    assert r.status_code == 422
+
+
+def test_estimate_returns_single_candidate_projection(client: TestClient) -> None:
+    _seed_samples(n=50)
+    r = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+            "sample_size": 20,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["samples_available"] == 50
+    assert len(body["per_candidate"]) == 1
+    row = body["per_candidate"][0]
+    assert row["model"] == "claude-haiku-4-5"
+    assert row["samples_replayed"] > 0
+    assert row["projected_monthly_cost_micro_usd"] > 0
+    assert body["diagnostics"]["prompt_override_applied"] is False
+
+
+def test_estimate_prompt_override_raises_projected_cost(client: TestClient) -> None:
+    """A longer system prompt should raise the projected cost vs. no override."""
+    _seed_samples(n=40, system_prompt="hi")  # tiny captured prompt
+    base = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+            "sample_size": 20,
+        },
+    ).json()
+    overridden = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+            "system_prompt_override": "a much longer system prompt " * 200,
+            "sample_size": 20,
+        },
+    ).json()
+    assert overridden["diagnostics"]["prompt_override_applied"] is True
+    assert (
+        overridden["per_candidate"][0]["projected_monthly_cost_micro_usd"]
+        > base["per_candidate"][0]["projected_monthly_cost_micro_usd"]
+    )
+
+
+def test_estimate_uses_injected_candidate_client(client: TestClient) -> None:
+    """The candidate client is injectable just like /v1/replay (no real provider call)."""
+    seen: list[CandidateCall] = []
+
+    async def fake_client(call: CandidateCall) -> CandidateResponse:
+        seen.append(call)
+        return CandidateResponse(input_tokens=call.envelope.get("input_tokens", 100),
+                                 output_tokens=10, status_code=200)
+
+    app.state.replay_candidate_client = fake_client
+    _seed_samples(n=10, system_prompt="hi")
+    r = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+            "system_prompt_override": "x" * 2000,
+            "sample_size": 10,
+        },
+    )
+    assert r.status_code == 200
+    # The override must have reached the injected client's envelope.
+    assert seen
+    assert all(c.envelope.get("system_prompt") == "x" * 2000 for c in seen)

--- a/web/app/api/estimate/route.test.ts
+++ b/web/app/api/estimate/route.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Route tests for /api/estimate POST — body-driven what-if + honest-null floor (CTO-128).
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/clickhouse", () => ({
+  queryReplayCandidates: vi.fn(),
+  queryReplayEstimate: vi.fn(),
+}));
+
+import { POST as EstimatePOST } from "./route";
+import * as ch from "@/lib/clickhouse";
+
+const queryReplayEstimate = ch.queryReplayEstimate as unknown as ReturnType<typeof vi.fn>;
+
+function postReq(body: unknown) {
+  return new Request("http://test/api/estimate", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as never;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("POST /api/estimate", () => {
+  it("400s when candidateModel is missing", async () => {
+    const res = await EstimatePOST(postReq({ systemPromptOverride: "x" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("maps a well-grounded projection into the proposed shape", async () => {
+    queryReplayEstimate.mockResolvedValueOnce({
+      samples_available: 120,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 5_000_000,
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 60,
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 1000,
+      },
+    });
+
+    const res = await EstimatePOST(
+      postReq({ candidateModel: "claude-haiku-4-5", systemPromptOverride: "tighter prompt" }),
+    );
+    const body = await res.json();
+    expect(body.replay_source).toBe("replay");
+    expect(body.proposed.monthlyCostMicroUsd).toBe(5_000_000);
+    expect(body.proposed.p99CostMicroUsd).toBe(Math.round(5_000_000 * 1.4));
+    expect(body.proposed.meanLatencyMs).toBe(800);
+    expect(body.groundedSamples).toBe(60);
+    expect(body.candidate).toEqual({ provider: "anthropic", model: "claude-haiku-4-5" });
+
+    // The override + candidate were forwarded to the gateway helper.
+    expect(queryReplayEstimate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateModel: { provider: "anthropic", model: "claude-haiku-4-5" },
+        systemPromptOverride: "tighter prompt",
+      }),
+    );
+  });
+
+  it("applies the honest-null floor when fewer than 50 samples ground the estimate", async () => {
+    queryReplayEstimate.mockResolvedValueOnce({
+      samples_available: 40,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 5_000_000,
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 40, // below the 50-sample floor
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 1000,
+      },
+    });
+
+    const res = await EstimatePOST(postReq({ candidateModel: "claude-haiku-4-5" }));
+    const body = await res.json();
+    expect(body.replay_source).toBe("mock");
+    expect(body.proposed.monthlyCostMicroUsd).toBeNull();
+    expect(body.proposed.p99CostMicroUsd).toBeNull();
+    expect(body.proposed.meanLatencyMs).toBeNull();
+    expect(body.groundedSamples).toBe(40);
+  });
+
+  it("applies the honest-null floor when the gateway returns null (no corpus / unreachable)", async () => {
+    queryReplayEstimate.mockResolvedValueOnce(null);
+    const res = await EstimatePOST(postReq({ candidateModel: "gpt-5-mini", providerOverride: "openai" }));
+    const body = await res.json();
+    expect(body.proposed.monthlyCostMicroUsd).toBeNull();
+    expect(body.groundedSamples).toBe(0);
+    expect(body.replay_source).toBe("mock");
+  });
+});

--- a/web/app/api/estimate/route.ts
+++ b/web/app/api/estimate/route.ts
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
-import { projection } from "@/lib/estimate";
-import { queryReplayCandidates } from "@/lib/clickhouse";
+import { projection, type WhatIfProjection } from "@/lib/estimate";
+import { queryReplayCandidates, queryReplayEstimate } from "@/lib/clickhouse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+// Honest-null floor: a what-if grounded on too few replayed samples is noise, not a forecast.
+// Below this count the route returns null cost/latency so the page renders "—" instead of a
+// fabricated number (CTO-128).
+const MIN_GROUNDING_SAMPLES = 50;
 
 // CTO-113: /estimate accepts a what-if candidate via `?candidate_model=...&candidate_provider=...`
 // and replays the captured corpus against it. When no candidate is supplied or no replay
@@ -28,11 +33,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ ...projection, replay_source: "mock" });
   }
 
-  // FIXME(CTO-113-estimate): prompt_template_override is not yet wired through. v1 only
-  // replays the captured envelope as-is against the candidate model — no prompt rewrite.
-  // The richer body-driven what-if surface (POST {candidate_model, prompt_template_override,
-  // sample_size}) is a follow-up.
-
+  // GET replays the captured envelope as-is against the candidate model (no prompt rewrite).
+  // The richer body-driven what-if (candidate model + system_prompt_override) lives in POST below.
   const proposed = replay.per_candidate[0];
   return NextResponse.json({
     ...projection,
@@ -49,4 +51,72 @@ export async function GET(req: Request) {
     },
     replay_source: "replay",
   });
+}
+
+// Body-driven what-if (CTO-128): swap a candidate model and optionally tighten the system prompt,
+// then re-project cost off the captured corpus. Returns the Projection shape the page consumes,
+// with the honest-null floor applied to the proposed numbers.
+//
+// Body: { candidateModel: string, providerOverride?: string, systemPromptOverride?: string,
+//         sampleSize?: number, tag?: string }
+export async function POST(req: Request) {
+  let body: {
+    candidateModel?: string;
+    providerOverride?: string;
+    systemPromptOverride?: string;
+    sampleSize?: number;
+    tag?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const candidateModel = (body.candidateModel ?? "").trim();
+  if (!candidateModel) {
+    return NextResponse.json({ error: "candidateModel is required" }, { status: 400 });
+  }
+  const provider = (body.providerOverride ?? "anthropic").trim() || "anthropic";
+  const systemPromptOverride = body.systemPromptOverride?.trim() || undefined;
+  const featureTag = body.tag?.trim() || undefined;
+  const sampleSize =
+    typeof body.sampleSize === "number" && body.sampleSize > 0
+      ? Math.floor(body.sampleSize)
+      : undefined;
+
+  const candidate = { provider, model: candidateModel };
+  const replay = await queryReplayEstimate({
+    candidateModel: candidate,
+    systemPromptOverride,
+    featureTag,
+    sampleSize,
+  });
+
+  const row = replay?.per_candidate[0];
+  const grounded = row?.samples_replayed ?? 0;
+  // Honest-null floor: too few samples grounding the estimate -> null cost, page renders "—".
+  const sufficient = !!row && grounded >= MIN_GROUNDING_SAMPLES;
+
+  const monthly = sufficient ? row!.projected_monthly_cost_micro_usd : null;
+  const result: WhatIfProjection = {
+    ...projection,
+    proposed: {
+      monthlyCostMicroUsd: monthly,
+      // p99 cost not available from per-call replay yet — keep the mock 1.4x multiplier as a
+      // rough proxy until the executor returns the full distribution.
+      p99CostMicroUsd: monthly === null ? null : Math.round(monthly * 1.4),
+      meanLatencyMs: sufficient ? row!.p50_latency_ms : null,
+    },
+    sample: {
+      ...projection.sample,
+      used: grounded,
+    },
+    candidate,
+    systemPromptOverride,
+    groundedSamples: grounded,
+    replay_source: sufficient ? "replay" : "mock",
+  };
+
+  return NextResponse.json(result);
 }

--- a/web/app/estimate/EstimateWhatIf.tsx
+++ b/web/app/estimate/EstimateWhatIf.tsx
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/Card";
+import { pctDelta, type Projection, type WhatIfProjection } from "@/lib/estimate";
+import { formatUSD } from "@/lib/types";
+
+// A small hardcoded candidate list keeps the picker simple (CTO-128 out-of-scope: model catalog).
+const CANDIDATES = [
+  { provider: "anthropic", model: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  { provider: "anthropic", model: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+  { provider: "openai", model: "gpt-5-mini", label: "GPT-5 mini" },
+  { provider: "openai", model: "gpt-4o-mini", label: "GPT-4o mini" },
+];
+
+type Proposed = WhatIfProjection["proposed"];
+
+const EM_DASH = "—";
+
+function fmtCost(v: number | null): string {
+  return v === null ? EM_DASH : formatUSD(v);
+}
+
+export function EstimateWhatIf({ initial }: { initial: Projection }) {
+  const { current } = initial;
+
+  const [model, setModel] = useState(CANDIDATES[0].model);
+  const [systemPromptOverride, setSystemPromptOverride] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Start from the mock projection's proposed numbers (GET); POST replaces them.
+  const [proposed, setProposed] = useState<Proposed>(initial.proposed);
+  const [sampleUsed, setSampleUsed] = useState(initial.sample.used);
+  const [grounded, setGrounded] = useState<number | null>(null);
+
+  async function onEstimate() {
+    setPending(true);
+    setError(null);
+    try {
+      const provider = CANDIDATES.find((c) => c.model === model)?.provider ?? "anthropic";
+      const res = await fetch("/api/estimate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          candidateModel: model,
+          providerOverride: provider,
+          systemPromptOverride: systemPromptOverride.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `request failed (${res.status})`);
+      }
+      const body = (await res.json()) as WhatIfProjection;
+      setProposed(body.proposed);
+      setSampleUsed(body.sample.used);
+      setGrounded(body.groundedSamples);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const costDelta = pctDelta(current.monthlyCostMicroUsd, proposed.monthlyCostMicroUsd);
+  const p99Delta = pctDelta(current.p99CostMicroUsd, proposed.p99CostMicroUsd);
+  const latDelta = pctDelta(current.meanLatencyMs, proposed.meanLatencyMs);
+  const riskSeverity =
+    initial.blowUpRisk >= 0.3 ? "bad" : initial.blowUpRisk >= 0.1 ? "warn" : "good";
+
+  return (
+    <div className="space-y-6">
+      <Card title="What-if">
+        <div className="space-y-3 text-sm">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="space-y-1">
+              <span className="text-xs uppercase tracking-wide text-muted">Candidate model</span>
+              <select
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                className="w-full rounded-lg border border-edge bg-panel px-3 py-2"
+              >
+                {CANDIDATES.map((c) => (
+                  <option key={`${c.provider}/${c.model}`} value={c.model}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <label className="block space-y-1">
+            <span className="text-xs uppercase tracking-wide text-muted">
+              System prompt override (optional)
+            </span>
+            <textarea
+              value={systemPromptOverride}
+              onChange={(e) => setSystemPromptOverride(e.target.value)}
+              rows={4}
+              placeholder="Leave blank to replay the captured prompt as-is."
+              className="w-full rounded-lg border border-edge bg-panel px-3 py-2 font-mono text-xs"
+            />
+          </label>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={onEstimate}
+              disabled={pending}
+              className="rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 font-medium text-accent disabled:opacity-50"
+            >
+              {pending ? "Estimating…" : "Estimate"}
+            </button>
+            {error && <span className="text-bad">{error}</span>}
+            {grounded !== null && !error && (
+              <span className="text-muted">
+                grounded on {grounded} replayed sample{grounded === 1 ? "" : "s"}
+                {proposed.monthlyCostMicroUsd === null && " (too few — showing —)"}
+              </span>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Kpi
+          label="Cost / month"
+          current={formatUSD(current.monthlyCostMicroUsd)}
+          proposed={fmtCost(proposed.monthlyCostMicroUsd)}
+          delta={costDelta}
+          betterWhenNegative
+        />
+        <Kpi
+          label="p99 cost / run"
+          current={formatUSD(current.p99CostMicroUsd)}
+          proposed={fmtCost(proposed.p99CostMicroUsd)}
+          delta={p99Delta}
+          betterWhenNegative
+          headline
+        />
+        <Kpi
+          label="Blow-up risk"
+          current={EM_DASH}
+          proposed={`${Math.round(initial.blowUpRisk * 100)}%`}
+          severity={riskSeverity}
+          hint="P(p99 > 2× current)"
+        />
+        <Kpi
+          label="Mean latency"
+          current={`${current.meanLatencyMs} ms`}
+          proposed={proposed.meanLatencyMs === null ? EM_DASH : `${proposed.meanLatencyMs} ms`}
+          delta={latDelta}
+          betterWhenNegative
+        />
+      </div>
+
+      <Card title="Driver breakdown">
+        <ul className="space-y-2 text-sm">
+          {initial.drivers.map((d) => (
+            <li key={d.reason} className="flex items-baseline justify-between gap-3">
+              <span className="text-gray-300">{d.reason}</span>
+              <span
+                className={`tabular-nums font-medium ${d.delta > 0 ? "text-bad" : "text-good"}`}
+              >
+                {d.delta > 0 ? "+" : ""}
+                {formatUSD(d.delta)}/mo
+              </span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      <Card title="Sample diagnostics">
+        <dl className="grid grid-cols-1 gap-y-1.5 text-sm sm:grid-cols-2">
+          <Diag k="samples used" v={`${sampleUsed}`} />
+          <Diag
+            k="pathological runs included"
+            v={initial.sample.pathologicalIncluded.toString()}
+            good
+          />
+          <Diag
+            k="confidence interval (on p99)"
+            v={`±${Math.round(initial.sample.ciHalfWidthPct * 100)}%`}
+          />
+          <Diag k="sampling strategy" v="tail-weighted (recommended)" good />
+        </dl>
+      </Card>
+    </div>
+  );
+}
+
+function Kpi({
+  label,
+  current,
+  proposed,
+  delta,
+  betterWhenNegative,
+  headline,
+  severity,
+  hint,
+}: {
+  label: string;
+  current: string;
+  proposed: string;
+  delta?: number | null;
+  betterWhenNegative?: boolean;
+  headline?: boolean;
+  severity?: "good" | "warn" | "bad";
+  hint?: string;
+}) {
+  const ring =
+    severity === "bad"
+      ? "border-bad/40"
+      : severity === "warn"
+        ? "border-warn/40"
+        : headline
+          ? "border-accent/40"
+          : "border-edge";
+  const valueClass =
+    severity === "bad" ? "text-bad" : severity === "warn" ? "text-warn" : "";
+  return (
+    <div className={`rounded-xl border ${ring} bg-panel p-5`}>
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className={`mt-2 text-2xl font-semibold tabular-nums ${valueClass}`}>{proposed}</div>
+      <div className="mt-1 text-xs text-muted">from {current}</div>
+      {delta !== undefined && delta !== null && delta !== 0 && (
+        <div
+          className={`mt-2 text-sm tabular-nums ${
+            (betterWhenNegative ? delta < 0 : delta > 0) ? "text-good" : "text-bad"
+          }`}
+        >
+          {delta > 0 ? "+" : ""}
+          {Math.round(delta * 100)}%
+          {Math.abs(delta) >= 0.5 && (betterWhenNegative ? delta > 0 : delta < 0) ? " ⚠" : ""}
+        </div>
+      )}
+      {hint && <div className="mt-2 text-xs text-muted">{hint}</div>}
+    </div>
+  );
+}
+
+function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
+  return (
+    <>
+      <dt className="text-muted">{k}</dt>
+      <dd className={good ? "text-good" : ""}>{v}</dd>
+    </>
+  );
+}

--- a/web/app/estimate/page.tsx
+++ b/web/app/estimate/page.tsx
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Card } from "@/components/Card";
 import {
   PartialDataBanner,
   StaleBadge,
@@ -7,17 +6,12 @@ import {
 } from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
 import { asOfLabel, boundaryFromMinutesAgo, deriveDataState, relativeAge } from "@/lib/dataState";
-import { pctDelta, type Projection } from "@/lib/estimate";
-import { formatUSD } from "@/lib/types";
+import { type Projection } from "@/lib/estimate";
+import { EstimateWhatIf } from "./EstimateWhatIf";
 
 export default async function EstimatePage() {
   const projection = await apiGet<Projection>("/api/estimate");
-  const { workload, pr, current, proposed, blowUpRisk, drivers, sample } = projection;
-  const costDelta = pctDelta(current.monthlyCostMicroUsd, proposed.monthlyCostMicroUsd);
-  const p99Delta = pctDelta(current.p99CostMicroUsd, proposed.p99CostMicroUsd);
-  const latDelta = pctDelta(current.meanLatencyMs, proposed.meanLatencyMs);
-  const riskSeverity =
-    blowUpRisk >= 0.3 ? "bad" : blowUpRisk >= 0.1 ? "warn" : "good";
+  const { workload, pr, current, sample } = projection;
 
   // This projection samples a reconciled historical window — surface that window's freshness so a
   // forecast off a stale baseline is never shown as fresh (CTO-80).
@@ -44,62 +38,7 @@ export default async function EstimatePage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Kpi
-          label="Cost / month"
-          current={formatUSD(current.monthlyCostMicroUsd)}
-          proposed={formatUSD(proposed.monthlyCostMicroUsd)}
-          delta={costDelta}
-          betterWhenNegative
-        />
-        <Kpi
-          label="p99 cost / run"
-          current={formatUSD(current.p99CostMicroUsd)}
-          proposed={formatUSD(proposed.p99CostMicroUsd)}
-          delta={p99Delta}
-          betterWhenNegative
-          headline
-        />
-        <Kpi
-          label="Blow-up risk"
-          current="—"
-          proposed={`${Math.round(blowUpRisk * 100)}%`}
-          severity={riskSeverity}
-          hint="P(p99 > 2× current)"
-        />
-        <Kpi
-          label="Mean latency"
-          current={`${current.meanLatencyMs} ms`}
-          proposed={`${proposed.meanLatencyMs} ms`}
-          delta={latDelta}
-          betterWhenNegative
-        />
-      </div>
-
-      <Card title="Driver breakdown">
-        <ul className="space-y-2 text-sm">
-          {drivers.map((d) => (
-            <li key={d.reason} className="flex items-baseline justify-between gap-3">
-              <span className="text-gray-300">{d.reason}</span>
-              <span
-                className={`tabular-nums font-medium ${d.delta > 0 ? "text-bad" : "text-good"}`}
-              >
-                {d.delta > 0 ? "+" : ""}
-                {formatUSD(d.delta)}/mo
-              </span>
-            </li>
-          ))}
-        </ul>
-      </Card>
-
-      <Card title="Sample diagnostics">
-        <dl className="grid grid-cols-1 gap-y-1.5 text-sm sm:grid-cols-2">
-          <Diag k="samples used" v={`${sample.used} (${sample.tailWeighted} tail-weighted, ${sample.used - sample.tailWeighted} random)`} />
-          <Diag k="pathological runs included" v={sample.pathologicalIncluded.toString()} good />
-          <Diag k="confidence interval (on p99)" v={`±${Math.round(sample.ciHalfWidthPct * 100)}%`} />
-          <Diag k="sampling strategy" v="tail-weighted (recommended)" good />
-        </dl>
-      </Card>
+      <EstimateWhatIf initial={projection} />
     </div>
   );
 
@@ -125,64 +64,5 @@ export default async function EstimatePage() {
         body
       )}
     </div>
-  );
-}
-
-function Kpi({
-  label,
-  current,
-  proposed,
-  delta,
-  betterWhenNegative,
-  headline,
-  severity,
-  hint,
-}: {
-  label: string;
-  current: string;
-  proposed: string;
-  delta?: number;
-  betterWhenNegative?: boolean;
-  headline?: boolean;
-  severity?: "good" | "warn" | "bad";
-  hint?: string;
-}) {
-  const ring =
-    severity === "bad"
-      ? "border-bad/40"
-      : severity === "warn"
-        ? "border-warn/40"
-        : headline
-          ? "border-accent/40"
-          : "border-edge";
-  const valueClass =
-    severity === "bad" ? "text-bad" : severity === "warn" ? "text-warn" : "";
-  return (
-    <div className={`rounded-xl border ${ring} bg-panel p-5`}>
-      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
-      <div className={`mt-2 text-2xl font-semibold tabular-nums ${valueClass}`}>{proposed}</div>
-      <div className="mt-1 text-xs text-muted">from {current}</div>
-      {delta !== undefined && delta !== 0 && (
-        <div
-          className={`mt-2 text-sm tabular-nums ${
-            (betterWhenNegative ? delta < 0 : delta > 0) ? "text-good" : "text-bad"
-          }`}
-        >
-          {delta > 0 ? "+" : ""}
-          {Math.round(delta * 100)}%
-          {Math.abs(delta) >= 0.5 && (betterWhenNegative ? delta > 0 : delta < 0) ? " ⚠" : ""}
-        </div>
-      )}
-      {hint && <div className="mt-2 text-xs text-muted">{hint}</div>}
-    </div>
-  );
-}
-
-function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
-  return (
-    <>
-      <dt className="text-muted">{k}</dt>
-      <dd className={good ? "text-good" : ""}>{v}</dd>
-    </>
   );
 }

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1060,6 +1060,56 @@ export async function queryReplayCandidates(
   }
 }
 
+// --- Body-driven what-if estimate (CTO-128) ---------------------------------------------------
+//
+// /estimate's POST surface lets an operator swap a candidate model AND tighten the system prompt,
+// then re-project cost off the captured corpus. Unlike queryReplayCandidates (which is cached and
+// multi-candidate), this is a single-candidate, override-bearing, uncached call — each what-if is
+// a distinct intent and burns a fresh (cheap, mock-by-default) replay.
+
+export interface ReplayEstimateRequest {
+  candidateModel: { provider: string; model: string };
+  systemPromptOverride?: string;
+  featureTag?: string;
+  sampleSize?: number;
+}
+
+/**
+ * Fetch a single-candidate what-if projection from the gateway's `/v1/replay/estimate` endpoint.
+ *
+ * Returns null when no samples ground the estimate or when the gateway is unreachable, so the
+ * route can apply its honest-null floor rather than fabricate a number.
+ */
+export async function queryReplayEstimate(
+  req: ReplayEstimateRequest,
+): Promise<ReplayProjection | null> {
+  const tenant = TENANT;
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/replay/estimate`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant-id": tenant },
+      body: JSON.stringify({
+        tenant_id: tenant,
+        feature_tag: req.featureTag,
+        candidate_model: req.candidateModel,
+        system_prompt_override: req.systemPromptOverride,
+        sample_size: req.sampleSize ?? 50,
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) {
+      console.warn(`[estimate] /v1/replay/estimate HTTP ${res.status}; returning null`);
+      return null;
+    }
+    const body = (await res.json()) as ReplayProjection;
+    return body.samples_available > 0 ? body : null;
+  } catch (err) {
+    console.warn("[estimate] gateway unreachable, returning null:", (err as Error).message);
+    return null;
+  }
+}
+
 // --- Pairwise LLM-judge eval (CTO-114) --------------------------------------------------------
 //
 // The gateway's /v1/eval runs a frontier judge over the replay outputs and returns per-candidate

--- a/web/lib/estimate.ts
+++ b/web/lib/estimate.ts
@@ -32,7 +32,26 @@ export interface Projection {
   reconcilerLastRunMinutesAgo: number;
 }
 
-export function pctDelta(cur: number, prop: number): number {
+/**
+ * What-if projection returned by `POST /api/estimate` (CTO-128). Same shape as {@link Projection}
+ * except the `proposed` cost/latency fields may be `null`: when fewer than the grounding floor of
+ * samples back the estimate, the route returns `null` rather than fabricate a number, and the page
+ * renders `—`. `groundedSamples` carries how many replayed samples actually grounded it.
+ */
+export interface WhatIfProjection extends Omit<Projection, "proposed"> {
+  proposed: {
+    monthlyCostMicroUsd: MicroUSD | null;
+    p99CostMicroUsd: MicroUSD | null;
+    meanLatencyMs: number | null;
+  };
+  candidate: { provider: string; model: string };
+  systemPromptOverride?: string;
+  groundedSamples: number;
+  replay_source: "replay" | "mock";
+}
+
+export function pctDelta(cur: number, prop: number | null): number | null {
+  if (prop === null) return null;
   if (cur === 0) return 0;
   return (prop - cur) / cur;
 }


### PR DESCRIPTION
## Summary

Implements the body-driven what-if on `/estimate`: swap a candidate model **and** optionally tighten the system prompt, then re-project monthly cost off the captured replay corpus. Closes the `FIXME(CTO-113-estimate)` in `web/app/api/estimate/route.ts`.

Previously `/estimate` could only replay last week's workload **as-is** (GET). Now it can answer "what if we swap to haiku-4.5 and tighten the system prompt" (POST).

## New gateway endpoint

`POST /v1/replay/estimate`

```json
{
  "tenant_id": "...",            // optional
  "feature_tag": "research",     // optional filter
  "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
  "system_prompt_override": "...",  // optional
  "sample_size": 50              // optional, default 50
}
```

Returns the same projection shape as `/v1/replay` — a single-element `per_candidate` list with `projected_monthly_cost_micro_usd`, `p50/p95_latency_ms`, `error_rate`, `samples_replayed`, `excluded_budget_count` — plus `samples_available` and a diagnostics block carrying the v1 honesty string and `prompt_override_applied`.

It reuses the existing replay executor + per-corpus extrapolation; sized to `min(sample_size, available)`.

### Override behavior

The only new behavior is `gateway.replay_estimate.apply_system_prompt_override`: it swaps the captured envelope's `system_prompt`/`system` field to the override and adjusts `input_tokens` by the (override − captured) token delta at the gateway's standard 4-chars/token estimate, then prices the call off the rewritten count. Wired through an **additive optional** `envelope_transform` param on `ReplayExecutor.replay_sample` (no signature break, merge-trivial). A real provider client would re-tokenize the actual rewritten prompt; the 4-chars/token estimate is the documented v1 approximation (surfaced in diagnostics as `token_estimate`).

## Web POST handler

`POST /api/estimate` parses `{candidateModel, providerOverride?, systemPromptOverride?, sampleSize?}`, calls the gateway via `queryReplayEstimate`, and maps to the `Projection` shape the page consumes. GET path unchanged.

### Honest-null floor

When fewer than **50** replayed samples ground the estimate (or the gateway returns null — empty corpus / unreachable), the `proposed` cost/latency fields are returned as `null` so the page renders `—` rather than fabricate a number. `groundedSamples` carries the actual count; `replay_source` flips to `"mock"` below the floor.

## Page

A minimal what-if form on `/estimate`: a hardcoded candidate-model picker + a system-prompt-override textarea + an **Estimate** button that POSTs and re-renders the projection client-side (`EstimateWhatIf.tsx`). First load still renders the mock projection (GET). Nav left untouched (page stays hidden — no `Shell.tsx` change).

## What stays mock

The candidate client is **injectable** via `app.state.replay_candidate_client` (a deterministic mock by default) — exactly the same injection pattern `/v1/replay` uses. No new mock path was invented. Tests inject a fake client to assert the override reaches the envelope.

## Test plan

- **Gateway**: `uv run ruff check .` clean; `uv run pytest` → **256 passed**. New `tests/test_app_replay_estimate.py` (8 tests) covers the override helper (token delta up, passthrough, floor-at-1), the endpoint (empty tenant, missing-candidate 422, single-candidate projection, override raises projected cost, injected candidate client receives the override).
- **Web**: `npx tsc --noEmit` → **clean (exit 0)**; `npx vitest run` → **174 passed**, 2 failed. New `app/api/estimate/route.test.ts` (4 tests, all pass) covers missing-candidate 400, well-grounded mapping, honest-null floor below 50 samples, and honest-null on gateway-null.

### Known pre-existing flakes (not touched)

The only 2 web failures are the documented local-ClickHouse flakes that pass in CI: `app/api/api.test.ts > GET /api/data-quality...` and `> GET /api/attribution falls back to mock...`. No other failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)