### PR TITLE
feat(sdk): record_vector_call + vector cost-layer bucketing (CTO-142)

### DIFF
--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -42,10 +42,23 @@ _TOOL_PRICING: dict[tuple[str, str], int] = {
     ("firecrawl", "scrape"): 20_000,
 }
 
+# Default per-(provider, operation) vector-DB prices in micro-USD (CTO-142). Inline and
+# hand-maintained until a real vector-pricing catalog lands (follow-up, à la CTO-141). When a
+# caller omits an explicit ``cost_micro_usd`` we look the pair up here; an unknown pair defaults to
+# 0 with a one-time WARN.
+_VECTOR_PRICING: dict[tuple[str, str], int] = {
+    ("pinecone", "query"): 400,
+    ("pinecone", "upsert"): 200,
+    ("weaviate", "query"): 300,
+    ("qdrant", "query"): 250,
+}
+
 # Pairs we've already warned about, so the missing-price WARN fires once per (provider, tool).
 _warned_tool_pairs: set[tuple[str, str]] = set()
 # Embedding (provider, model) pairs we've already warned about (CTO-136).
 _warned_embedding_pairs: set[tuple[str, str]] = set()
+# Vector (provider, operation) pairs we've already warned about (CTO-142).
+_warned_vector_pairs: set[tuple[str, str]] = set()
 
 
 class Exporter(Protocol):
@@ -353,6 +366,63 @@ class TallyClient:
         if result is None:  # boundary swallowed an error; return a benign result
             return EmbeddingCallResult(None, None, {})
         return result
+
+    # --- high-level: record a vector-DB call (Vector cost layer, CTO-142) ---
+    def record_vector_call(
+        self,
+        *,
+        provider: str,
+        index: str,
+        operation: str,
+        cost_micro_usd: int | None = None,
+        record_count: int | None = None,
+        latency_ms: int | None = None,
+    ) -> None:
+        """Record a vector-DB call so the span lands in the gateway's ``vector`` cost-layer bucket.
+
+        Bucketing is keyed off ``gen_ai.operation.name == 'vector'``. The call's cost rides on
+        ``gen_ai.tool.cost_micro_usd`` (same carrier as ``record_tool_call`` — the gateway promotes
+        it into the layer's spend). The tool-name slot encodes ``{provider}.{index}.{operation}``.
+        When ``cost_micro_usd`` is omitted we resolve a default from the inline
+        :data:`_VECTOR_PRICING` table keyed by ``(provider, operation)`` (follow-up: promote to a
+        real catalog, à la CTO-141); an unknown pair defaults to 0 with a one-time WARN. Never
+        raises.
+
+        ``record_count`` and ``latency_ms`` are accepted for API symmetry with future span fields
+        but are not yet emitted as schema attributes (no conformant key exists for them).
+        """
+
+        @safe(self.obs, where="TallyClient.record_vector_call")
+        def _do() -> None:
+            ctx = current_context()
+            if ctx.trace_id is None:
+                note_context_drop(self.obs, where="record_vector_call")
+
+            resolved_cost = cost_micro_usd
+            if resolved_cost is None:
+                key = (provider, operation)
+                resolved_cost = _VECTOR_PRICING.get(key)
+                if resolved_cost is None:
+                    if key not in _warned_vector_pairs:
+                        _warned_vector_pairs.add(key)
+                        _log.warning(
+                            "no default vector price for (%s, %s); defaulting cost to 0",
+                            provider,
+                            operation,
+                        )
+                    resolved_cost = 0
+
+            fields = SpanFields(
+                system=provider,
+                operation="vector",
+                tool_name=f"{provider}.{index}.{operation}",
+                tool_cost_micro_usd=resolved_cost,
+                feature_tag=ctx.feature_tag,
+                session_id=ctx.session_id,
+            )
+            self._emit(build_span_attributes(fields))
+
+        _do()
 
     # --- guardrails (may raise, by design — pre-call check) ---
     def guard(self, state: GuardrailState, config: GuardrailConfig) -> Verdict:

--- a/sdk/python/src/tally/schema.py
+++ b/sdk/python/src/tally/schema.py
@@ -69,7 +69,9 @@ class GenAI:
 
 
 # Known operation names (open set — unknown values are allowed but should be lowercase tokens).
-OPERATIONS = frozenset({"chat", "completion", "embeddings", "tool", "agent", "rerank"})
+OPERATIONS = frozenset(
+    {"chat", "completion", "embeddings", "tool", "agent", "rerank", "vector"}
+)
 
 #: Default currency when none supplied.
 DEFAULT_CURRENCY = "USD"

--- a/sdk/python/tests/test_record_vector_call.py
+++ b/sdk/python/tests/test_record_vector_call.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-142 — record_vector_call lands spans in the Vector cost-layer bucket."""
+
+from __future__ import annotations
+
+from tally.client import MemoryExporter, TallyClient
+from tally.context import with_trace_context
+from tally.schema import GenAI, validate_span_attributes
+
+
+def _client(exporter: MemoryExporter | None = None) -> TallyClient:
+    return TallyClient(exporter=exporter or MemoryExporter())
+
+
+def test_explicit_cost_emits_vector_span():
+    exporter = MemoryExporter()
+    client = _client(exporter)
+    with with_trace_context(trace_id="t1", feature_tag="research", session_id="s1"):
+        client.record_vector_call(
+            provider="pinecone", index="docs", operation="query", cost_micro_usd=400
+        )
+
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    assert span[GenAI.OPERATION_NAME] == "vector"
+    assert span[GenAI.TOOL_NAME] == "pinecone.docs.query"
+    assert span[GenAI.TOOL_COST_MICRO_USD] == 400
+    assert span[GenAI.SYSTEM] == "pinecone"
+    assert span[GenAI.FEATURE_TAG] == "research"
+    assert span[GenAI.SESSION_ID] == "s1"
+
+
+def test_default_pricing_lookup_when_cost_omitted():
+    exporter = MemoryExporter()
+    client = _client(exporter)
+    client.record_vector_call(provider="pinecone", index="docs", operation="query")
+    client.record_vector_call(provider="pinecone", index="docs", operation="upsert")
+    client.record_vector_call(provider="weaviate", index="docs", operation="query")
+    client.record_vector_call(provider="qdrant", index="docs", operation="query")
+
+    costs = [s[GenAI.TOOL_COST_MICRO_USD] for s in exporter.spans]
+    assert costs == [400, 200, 300, 250]
+
+
+def test_unknown_pair_defaults_to_zero():
+    exporter = MemoryExporter()
+    client = _client(exporter)
+    client.record_vector_call(provider="acme", index="docs", operation="frobnicate")
+
+    span = exporter.spans[0]
+    assert span[GenAI.TOOL_COST_MICRO_USD] == 0
+    assert span[GenAI.OPERATION_NAME] == "vector"
+
+
+def test_never_raises_when_exporter_throws():
+    class BoomExporter:
+        def export(self, attributes: dict[str, object]) -> None:
+            raise RuntimeError("exporter down")
+
+    client = TallyClient(exporter=BoomExporter())
+    # Must not raise.
+    client.record_vector_call(
+        provider="pinecone", index="docs", operation="query", cost_micro_usd=400
+    )
+    assert client.observability.internal_error_count == 1

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -80,7 +80,7 @@ function zeroLayers(): SpendByLayer {
 
 // Map a gen_ai operation to a cost layer. Only LLM-family spans exist today.
 const LAYER_CASE =
-  "multiIf(GenAiOperation = 'tool', 'tools', GenAiOperation = 'embeddings', 'embeddings', 'llm')";
+  "multiIf(GenAiOperation = 'tool', 'tools', GenAiOperation = 'embeddings', 'embeddings', GenAiOperation = 'vector', 'vector', 'llm')";
 
 async function rows<T>(db: ClickHouseClient, query: string, tenant: string): Promise<T[]> {
   const rs = await db.query({


### PR DESCRIPTION
## CTO-142 — Vector cost layer

**STACKED on #111** (the SDK tool/embedding helpers — `record_tool_call` + `record_embedding_call`, shared `client.py`). Base branch is `feat/cto-135-136-tool-embedding-helpers`; GitHub auto-retargets to `main` once #111 merges. Review only the diff against #111.

The Vector column on `/cost` reads `$0` because no path emits vector-DB spend. This adds the SDK helper and teaches the gateway to bucket it.

### Changes
- **SDK schema** — add `'vector'` to the `OPERATIONS` frozenset so `validate_span_attributes` accepts vector spans.
- **SDK `record_vector_call`** (`client.py`) — mirrors `record_tool_call`. Emits `operation='vector'`, `tool_name=f"{provider}.{index}.{operation}"`, with cost carried on `tool_cost_micro_usd` (the gateway promotes it into the layer's spend, same carrier as tool calls). Reads ambient `feature_tag`/`session` like the sibling helpers. Runs inside the `@safe` boundary — **never raises**.
- **Inline pricing** — `_VECTOR_PRICING` defaults (micro-USD/call): `(pinecone, query)=400`, `(pinecone, upsert)=200`, `(weaviate, query)=300`, `(qdrant, query)=250`. When `cost_micro_usd is None`, looked up by `(provider, operation)`; unknown pair → `0` + one-time WARN. **Stopgap — a real vector pricing catalog is a follow-up (à la CTO-141).**
- **Gateway bucketing** — extend the single `LAYER_CASE` const in `web/lib/clickhouse.ts` to recognize `GenAiOperation = 'vector'` → `'vector'`. No query function touched.

`'vector'` is already a layer in `web/lib/cost.ts` (`LAYERS`/`LAYER_LABEL`/`LAYER_COLORS`), so the column lights up once spans flow.

### Test plan
- `sdk/python/tests/test_record_vector_call.py` (new, 4 tests): explicit cost → `operation == 'vector'`; default-pricing lookup; unknown pair → 0; never raises when the exporter throws.
- **SDK**: `uv run ruff check .` clean (ruff 0.15.18 per `uv.lock`); `uv run pytest` — all pass.
- **web**: `npx tsc --noEmit` 100% clean; `npx vitest run` → **170/172**.

### Known flakes (pre-existing, not touched)
Only these two fail, as documented: `api.test.ts > GET /api/data-quality returns a report` and `> GET /api/attribution falls back to mock when ClickHouse is unreachable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)