### PR TITLE
feat(chatbot-demo): emit tool + embedding spans for all-in cost (CTO-137)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -178,6 +178,15 @@ this exercises the **gateway-POST ingestion path** — distinct from Aider's
 edge-proxy path. After ~2 minutes, the dashboard auto-opens to
 `/attribution?tag=chatbot-demo&outcome=positive_feedback`.
 
+The run also emits **tool** spans (weather-style prompts trigger a `getWeather`
+tool span) and, for ~30% of sessions, a simulated RAG-retrieval **embedding**
+span. So on the **Cost** tab you'll now see LLM dominant with the **Tools** and
+**Embeddings** bars non-zero (instead of $0), matching the seed mock. The tool
+prices are a small fixed table (`getWeather`=$0.001, document tools=$0.005,
+`requestSuggestions`=$0.002) and the embedding cost is computed at
+text-embedding-3-small's $0.02/Mtok — both are demo-seed values, not real
+billing. (Vector/Compute/Egress layers stay $0 — out of scope here.)
+
 Walkthrough, configuration knobs, and the upstream patch list are in
 [examples/vercel-chatbot/README.md](examples/vercel-chatbot/README.md) and
 [examples/vercel-chatbot/PATCHES.md](examples/vercel-chatbot/PATCHES.md).

--- a/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
@@ -49,10 +49,65 @@ import { type PostRequestBody, postRequestBodySchema } from "./schema";
 // this they'd never produce telemetry. resolveProvider() infers the real
 // provider from the picker's "<provider>/<model>" id; falls back to anthropic
 // because that's the local-demo default in lib/ai/providers.ts.
-import { postSpan, sessionUserHash } from "@/lib/tally";
+import { postSpan, postToolSpan, sessionUserHash } from "@/lib/tally";
 
 function resolveRealProvider(modelId: string): "openai" | "anthropic" {
   return modelId.startsWith("openai/") ? "openai" : "anthropic";
+}
+
+// ai-tally (CTO-137): fixed per-tool price table in micro-USD. Tool calls have
+// no provider token cost, so we attach a small flat price per invocation; the
+// gateway buckets these (gen_ai.operation.name='tool') into the Cost tab's
+// Tools layer. Demo-seed pricing — not a real billing model.
+const TOOL_COST_MICRO_USD: Record<string, number> = {
+  getWeather: 1_000,
+  createDocument: 5_000,
+  updateDocument: 5_000,
+  editDocument: 5_000,
+  requestSuggestions: 2_000,
+};
+
+// ai-tally (CTO-137): scan finished assistant message parts for tool
+// invocations and emit one tool span each. The AI SDK encodes tool calls as
+// parts with a `type` like "tool-getWeather" (or a legacy "tool-invocation"
+// / "dynamic-tool" part carrying `toolName`). Best-effort — never throws into
+// the stream.
+function emitToolSpans(
+  messages: { role: string; parts?: unknown[] }[],
+  ctx: { sessionId: string; userHash: string; provider: string; runId: string }
+): void {
+  for (const msg of messages) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.parts)) {
+      continue;
+    }
+    for (const part of msg.parts) {
+      const p = part as { type?: string; toolName?: string };
+      let toolName: string | undefined;
+      if (typeof p.type === "string" && p.type.startsWith("tool-")) {
+        toolName = p.type.slice("tool-".length);
+      } else if (
+        (p.type === "tool-invocation" || p.type === "dynamic-tool") &&
+        typeof p.toolName === "string"
+      ) {
+        toolName = p.toolName;
+      }
+      if (!toolName || toolName === "invocation") {
+        continue;
+      }
+      const costMicroUsd = TOOL_COST_MICRO_USD[toolName];
+      if (costMicroUsd === undefined) {
+        continue;
+      }
+      void postToolSpan({
+        sessionId: ctx.sessionId,
+        userHash: ctx.userHash,
+        provider: ctx.provider,
+        tool: toolName,
+        costMicroUsd,
+        runId: ctx.runId,
+      });
+    }
+  }
 }
 
 // The picker id is "<provider>/<model>"; the gateway's price catalog stores
@@ -303,6 +358,15 @@ export async function POST(request: Request) {
       },
       generateId: generateUUID,
       onFinish: async ({ messages: finishedMessages }) => {
+        // ai-tally (CTO-137): emit a tool span per tool invocation in the
+        // finished assistant messages so the Cost tab's Tools bar fills on
+        // manual (non-driver) sessions too. Fire-and-forget inside.
+        emitToolSpans(finishedMessages, {
+          sessionId: id,
+          userHash: sessionUserHash(session.user.id ?? id),
+          provider: resolveRealProvider(chatModel),
+          runId: id,
+        });
         if (isToolApprovalFlow) {
           for (const finishedMsg of finishedMessages) {
             const existingMsg = uiMessages.find((m) => m.id === finishedMsg.id);

--- a/examples/vercel-chatbot/app/app/api/demo-chat/route.ts
+++ b/examples/vercel-chatbot/app/app/api/demo-chat/route.ts
@@ -13,8 +13,47 @@ import {
   type FeatureTag,
   postCdpEvent,
   postSpan,
+  postToolSpan,
   sessionUserHash,
 } from "@/lib/tally";
+
+// ai-tally (CTO-137): the synthetic driver hits THIS route (not the upstream
+// (chat) UI route), so to fill the Cost tab's Tools bar on a live
+// `make chatbot-demo` we detect tool-shaped prompts here and emit a matching
+// tool span. Same fixed price table as the UI route. Demo-seed pricing — not a
+// real billing model.
+const TOOL_COST_MICRO_USD: Record<string, number> = {
+  getWeather: 1_000,
+  createDocument: 5_000,
+  updateDocument: 5_000,
+  editDocument: 5_000,
+  requestSuggestions: 2_000,
+};
+
+// Map a prompt to the demo tool it would have triggered, mirroring the upstream
+// route's tool set. Keyword-based and intentionally coarse — this is scripted
+// demo traffic, not a real tool router.
+function inferDemoTool(prompt: string): string | undefined {
+  const t = prompt.toLowerCase();
+  if (
+    t.includes("weather") ||
+    t.includes("forecast") ||
+    t.includes("temperature")
+  ) {
+    return "getWeather";
+  }
+  if (
+    t.includes("draft a doc") ||
+    t.includes("write a document") ||
+    t.includes("create a doc")
+  ) {
+    return "createDocument";
+  }
+  if (t.includes("suggestion") && t.includes("document")) {
+    return "requestSuggestions";
+  }
+  return undefined;
+}
 
 // ai-tally: Next.js 16 cacheComponents rejects route segment config
 // (`runtime`, `dynamic`). POST routes are dynamic by default; Node runtime
@@ -167,6 +206,21 @@ export async function POST(req: NextRequest) {
     featureTagOverride: featureTag,
     runId: body.sessionId,
   });
+
+  // ai-tally (CTO-137): if the prompt is tool-shaped, emit a tool span so the
+  // Cost tab's Tools bar is non-zero on a live demo run. Fire-and-forget.
+  const demoTool = inferDemoTool(body.prompt);
+  if (demoTool) {
+    void postToolSpan({
+      sessionId: body.sessionId,
+      userHash,
+      provider: body.provider,
+      tool: demoTool,
+      costMicroUsd: TOOL_COST_MICRO_USD[demoTool] ?? 1_000,
+      runId: body.sessionId,
+      featureTagOverride: featureTag,
+    });
+  }
 
   // ai-tally: after the 5th message in a session, signal engagement so the
   // attribution dashboard can show $/engaged-session alongside $/conversion.

--- a/examples/vercel-chatbot/app/lib/tally.ts
+++ b/examples/vercel-chatbot/app/lib/tally.ts
@@ -164,6 +164,128 @@ export async function postSpan(input: SpanInput): Promise<void> {
   }
 }
 
+// ai-tally (CTO-137): tool + embedding spans so a live `make chatbot-demo`
+// fills the Cost tab's Tools/Embeddings bars (not just LLM). The gateway/web
+// bucket spans by `gen_ai.operation.name`: 'tool' → Tools, 'embeddings' →
+// Embeddings (the LAYER_CASE expression). These helpers build the same batch
+// shape as postSpan and reuse every structural field (ServiceName, trace/span
+// ids via hexId, timestamp_ns, duration_ns, user_id_hash). Best-effort like
+// the existing helpers — never break the chat completion on a gateway hiccup.
+
+export interface ToolSpanInput {
+  sessionId: string;
+  userHash?: string;
+  /** gen_ai.system — which provider/runtime owns the tool call. */
+  provider: string;
+  /** gen_ai.tool.name — e.g. "getWeather". */
+  tool: string;
+  /** gen_ai.tool.cost_micro_usd — fixed price-table value in micro-USD. */
+  costMicroUsd: number;
+  runId?: string;
+  featureTagOverride?: FeatureTag;
+}
+
+export async function postToolSpan(input: ToolSpanInput): Promise<void> {
+  const userHash = input.userHash ?? sessionUserHash(input.sessionId);
+
+  const span: Record<string, unknown> = {
+    // structural — identical conventions to postSpan
+    ServiceName: "vercel-chatbot",
+    SpanName: "tool.execution",
+    trace_id: hexId(16),
+    span_id: hexId(8),
+    timestamp_ns: Date.now() * 1_000_000,
+    duration_ns: 0,
+    status_code: 1,
+    // gen_ai.* — operation 'tool' buckets into the Cost tab's Tools layer.
+    "gen_ai.system": input.provider,
+    "gen_ai.operation.name": "tool",
+    "gen_ai.tool.name": input.tool,
+    "gen_ai.tool.cost_micro_usd": input.costMicroUsd,
+    "gen_ai.session_id": input.sessionId,
+    "gen_ai.user_id_hash": userHash,
+    "chatbot.run_id": input.runId ?? "ad-hoc",
+  };
+  if (input.featureTagOverride) {
+    span["gen_ai.feature_tag"] = input.featureTagOverride;
+  }
+
+  const batch = {
+    tenant_id: TENANT,
+    sdk_version: "vercel-chatbot/0.1",
+    batch_id: uuidish(),
+    resource_spans: [span],
+  };
+
+  try {
+    await fetch(GATEWAY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(batch),
+    });
+  } catch (err) {
+    console.warn("[tally] postToolSpan failed:", (err as Error).message);
+  }
+}
+
+export interface EmbeddingSpanInput {
+  sessionId: string;
+  userHash?: string;
+  /** gen_ai.system — e.g. "openai". */
+  provider: string;
+  /** gen_ai.request.model — e.g. "text-embedding-3-small". */
+  model: string;
+  /** gen_ai.usage.input_tokens — tokens embedded. */
+  inputTokens: number;
+  /** gen_ai.cost.estimated_micro_usd — computed at the model's $/Mtok rate. */
+  costMicroUsd: number;
+  runId?: string;
+}
+
+export async function postEmbeddingSpan(
+  input: EmbeddingSpanInput,
+): Promise<void> {
+  const userHash = input.userHash ?? sessionUserHash(input.sessionId);
+
+  const span: Record<string, unknown> = {
+    // structural — identical conventions to postSpan
+    ServiceName: "vercel-chatbot",
+    SpanName: "embeddings",
+    trace_id: hexId(16),
+    span_id: hexId(8),
+    timestamp_ns: Date.now() * 1_000_000,
+    duration_ns: 0,
+    status_code: 1,
+    // gen_ai.* — operation 'embeddings' buckets into the Cost tab's
+    // Embeddings layer.
+    "gen_ai.system": input.provider,
+    "gen_ai.operation.name": "embeddings",
+    "gen_ai.request.model": input.model,
+    "gen_ai.usage.input_tokens": input.inputTokens,
+    "gen_ai.cost.estimated_micro_usd": input.costMicroUsd,
+    "gen_ai.session_id": input.sessionId,
+    "gen_ai.user_id_hash": userHash,
+    "chatbot.run_id": input.runId ?? "ad-hoc",
+  };
+
+  const batch = {
+    tenant_id: TENANT,
+    sdk_version: "vercel-chatbot/0.1",
+    batch_id: uuidish(),
+    resource_spans: [span],
+  };
+
+  try {
+    await fetch(GATEWAY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(batch),
+    });
+  } catch (err) {
+    console.warn("[tally] postEmbeddingSpan failed:", (err as Error).message);
+  }
+}
+
 export type CdpEventType =
   | "positive_feedback"
   | "session_engaged"

--- a/examples/vercel-chatbot/scripts/drive-traffic.ts
+++ b/examples/vercel-chatbot/scripts/drive-traffic.ts
@@ -10,6 +10,21 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+// ai-tally (CTO-137): import the embedding-span helper directly. The real chat
+// route has no embedding/RAG path today, so rather than fabricate one we have a
+// fraction of synthetic sessions emit a RAG-retrieval embedding span straight
+// to the gateway. This is DEMO SEED TRAFFIC — clearly not a real code path.
+import { postEmbeddingSpan } from "../app/lib/tally";
+
+// Embedding pricing for the simulated RAG retrieval. text-embedding-3-small is
+// $0.02 per 1M input tokens. Demo-seed only — the gateway catalog remains the
+// source of truth for any real numbers.
+const EMBED_MODEL = "text-embedding-3-small";
+const EMBED_USD_PER_MTOK = 0.02;
+
+function embedCostMicroUsd(inputTokens: number): number {
+  return Math.round(((inputTokens * EMBED_USD_PER_MTOK) / 1_000_000) * 1_000_000);
+}
 
 interface Prompt {
   id: string;
@@ -224,6 +239,28 @@ async function runSession(
       errors++;
       console.warn(`[session ${index}] turn ${t} failed: ${(err as Error).message}`);
       break;
+    }
+  }
+
+  // ai-tally (CTO-137): ~30% of sessions ALSO emit a simulated RAG-retrieval
+  // embedding span so the Cost tab's Embeddings bar is non-zero on a live demo.
+  // DEMO SEED TRAFFIC — the real chat route has no embedding path; this stands
+  // in for a retrieval step. Best-effort; never fails the session.
+  if (rng() < 0.3 && errors === 0 && !args.dryRun) {
+    const embedTokens = 200 + Math.floor(rng() * 600); // 200..799
+    try {
+      await postEmbeddingSpan({
+        sessionId,
+        provider: "openai",
+        model: EMBED_MODEL,
+        inputTokens: embedTokens,
+        costMicroUsd: embedCostMicroUsd(embedTokens),
+        runId: sessionId,
+      });
+    } catch (err) {
+      console.warn(
+        `[session ${index}] embedding span failed: ${(err as Error).message}`,
+      );
     }
   }
 

--- a/examples/vercel-chatbot/scripts/prompts.json
+++ b/examples/vercel-chatbot/scripts/prompts.json
@@ -108,6 +108,30 @@
     ]
   },
   {
+    "id": "brainstorm-weather-trip",
+    "tag": "chatbot.brainstorm",
+    "opener": "What's the weather like in San Francisco this weekend? I'm trying to plan a trip.",
+    "followups": [
+      "How about the forecast for Lake Tahoe instead?",
+      "Will the temperature drop much overnight?",
+      "What should I pack given that weather?",
+      "Any chance of rain on Sunday?",
+      "Thanks — what's the weather looking like the following week?"
+    ]
+  },
+  {
+    "id": "support-weather-widget",
+    "tag": "chatbot.support",
+    "opener": "The weather widget on my dashboard shows the wrong temperature — can you check the forecast for my city?",
+    "followups": [
+      "My city is Denver.",
+      "It's showing 90 degrees but it feels much colder.",
+      "Is the forecast data cached?",
+      "How often does the weather refresh?",
+      "Got it, the temperature looks right now."
+    ]
+  },
+  {
     "id": "code-perf",
     "tag": "chatbot.code",
     "opener": "How can I optimize this Python function — it's slow on inputs over 100k items: def f(xs): return [x for x in xs if x in seen]",


### PR DESCRIPTION
## Summary

`make chatbot-demo` only emitted LLM spans, so the Cost tab's **Tools** and **Embeddings** bars stayed $0 on a live demo while the seed mock showed them filled. This makes the chatbot emit operation-typed spans so the gateway/web `LAYER_CASE` expression buckets them: `gen_ai.operation.name='tool'` → Tools, `='embeddings'` → Embeddings.

## Two new Node helpers (`examples/vercel-chatbot/app/lib/tally.ts`)

- **`postToolSpan({ sessionId, userHash?, provider, tool, costMicroUsd, runId?, featureTagOverride? })`** — sets `gen_ai.operation.name='tool'`, `gen_ai.tool.name`, `gen_ai.tool.cost_micro_usd`, `gen_ai.system`.
- **`postEmbeddingSpan({ sessionId, userHash?, provider, model, inputTokens, costMicroUsd, runId? })`** — sets `gen_ai.operation.name='embeddings'`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.cost.estimated_micro_usd`, `gen_ai.system`.

Both reuse the exact structural fields from `postSpan` (`ServiceName`, `trace_id`/`span_id` via `hexId`, `timestamp_ns`, `duration_ns`, `gen_ai.user_id_hash`, `chatbot.run_id`) and the same `/v1/batches` shape. Best-effort (swallow errors, `console.warn`) like the existing helpers.

## Chat-route tool emission + price table

- **`app/(chat)/api/chat/route.ts`** (real UI path): in the outer `onFinish`, `emitToolSpans` scans finished assistant message parts for tool invocations (`type: "tool-<name>"` / `"tool-invocation"` / `"dynamic-tool"`) and `void postToolSpan(...)` per call.
- **`app/api/demo-chat/route.ts`** (the path the synthetic driver actually hits): detects tool-shaped prompts (`inferDemoTool`) and emits a matching `getWeather`/document tool span, so the Tools bar fills on a real `make chatbot-demo` run.

Fixed demo-seed price table (micro-USD), identical in both routes:

| tool | cost |
|---|---|
| `getWeather` | 1,000 |
| `createDocument` | 5,000 |
| `updateDocument` | 5,000 |
| `editDocument` | 5,000 |
| `requestSuggestions` | 2,000 |

## Embeddings — **driver-simulated**, not a real path

The real chat route has no embedding/RAG path today, so (per the ticket) we did **not** fabricate one. Instead `scripts/drive-traffic.ts` has ~30% of sessions emit a simulated RAG-retrieval embedding span directly: `provider='openai'`, `model='text-embedding-3-small'`, `inputTokens` 200–799, cost computed at $0.02/Mtok. Clearly commented as demo-seed traffic.

## Driver — fill the Tools bar

`scripts/prompts.json` gains weather-flavored prompts (`brainstorm-weather-trip`, `support-weather-widget`) so the driver triggers `getWeather` and the Tools bar is non-zero on a demo run.

## RUNNING.md

Step 6 now notes the Cost bar shows LLM dominant with Tools/Embeddings non-zero (instead of $0), matching the seed mock; Vector/Compute/Egress stay $0 (out of scope).

## Demo-seed vs real

- **Real:** tool-span emission on the actual `(chat)/api/chat` route from genuine tool invocations.
- **Demo-seed:** the flat tool price table, the demo-chat prompt→tool heuristic, the weather prompts, and the entire embedding path (driver-simulated).

## Verification

- `tsc --noEmit` clean on the app (route.ts, demo-chat, tally.ts) using the example's installed deps.
- `tsc` clean on `scripts/drive-traffic.ts` standalone (with node types).
- Did **not** touch `web/` or the Python SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)