### PR TITLE
feat(cost): real hidden-cost detection, drop canned alerts on live path (CTO-122)

### DIFF
--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -2,7 +2,11 @@
 import { NextResponse } from "next/server";
 
 import { costSeries, featureRows, hiddenCostAlerts } from "@/lib/cost";
-import { queryCostSeries, queryFeatureCostRows } from "@/lib/clickhouse";
+import {
+  queryCostSeries,
+  queryFeatureCostRows,
+  queryHiddenCostAlerts,
+} from "@/lib/clickhouse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -14,15 +18,19 @@ export async function GET(req: Request) {
   // Use the standard URL API rather than NextRequest.nextUrl so unit tests can pass plain Request.
   const tag = new URL(req.url).searchParams.get("tag") ?? "";
   const hasFilter = Boolean(tag);
-  const [series, rows] = await Promise.all([
+  const [series, rows, alerts] = await Promise.all([
     queryCostSeries({ tag }),
     queryFeatureCostRows({ tag }),
+    queryHiddenCostAlerts({ tag }),
   ]);
   return NextResponse.json({
     series: series ?? costSeries,
     featureRows: rows && rows.length > 0 ? rows : hasFilter ? [] : featureRows,
-    // Hidden-cost alerts are derived from cross-source comparison (not wired live yet); only show
-    // the canned alert when we're serving mock data.
-    alerts: rows && rows.length > 0 ? [] : hasFilter ? [] : hiddenCostAlerts,
+    // Hidden-cost alerts now come from real detection over otel_spans (CTO-122). On the LIVE path
+    // we serve queryHiddenCostAlerts' result verbatim — including `[]` (honest-empty: nothing
+    // fired). The canned `hiddenCostAlerts` is served ONLY as the ClickHouse-unreachable fallback
+    // (query returns null → CI / fresh-clone still renders something), and never under a ?tag=
+    // filter (the canned set isn't tag-scoped, so it would misrepresent a filtered view).
+    alerts: alerts ?? (hasFilter ? [] : hiddenCostAlerts),
   });
 }

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -22,7 +22,7 @@ import type {
   SpendByLayer,
   SpendSummary,
 } from "./types";
-import type { CostDayPoint, CostSeries, FeatureCostRow } from "./cost";
+import type { CostDayPoint, CostSeries, FeatureCostRow, HiddenCostAlert } from "./cost";
 import { LAYERS, type Layer } from "./cost";
 import type { AttributionDiagnostics, FeatureEconomics } from "./features";
 import type {
@@ -287,6 +287,133 @@ export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<F
       (a, b) =>
         LAYERS.reduce((s, l) => s + b.byLayer[l], 0) - LAYERS.reduce((s, l) => s + a.byLayer[l], 0),
     );
+  });
+}
+
+// --- Hidden-cost alerts (CTO-122) ---------------------------------------------------------------
+//
+// Real detection over the telemetry we actually have (otel_spans), replacing the canned
+// lib/cost.ts `hiddenCostAlerts` on the live path. Two rules fire today; both run per-tenant over
+// the last 30 days and only emit above a sane threshold (no fabricated alerts — returns [] when
+// nothing qualifies).
+//
+//   1. Uncosted tool/agent activity — `GenAiOperation = 'tool'` spans with `EstimatedCost = 0`,
+//      i.e. tools running without a cost attached. Emitted only above UNCOSTED_TOOL_THRESHOLD.
+//   2. High LLM-calls-per-session ratio — features whose avg LLM spans per SessionId exceeds
+//      LLM_PER_SESSION_THRESHOLD, a classic retry-loop / fan-out cost smell.
+//
+// DEFERRED: the "vendor-billed vs estimated" reconciliation rule (alert when a connector's billed
+// spend diverges from our estimate) has NO source today — the billing connectors aren't built yet
+// (CTO-143/144). It is intentionally omitted rather than faked.
+//
+// Alerts are ranked by impact = (share of total spend attributable to the offending feature) ×
+// (rule confidence) and capped at the top 5.
+
+// >50 uncosted tool spans before we bother the user (below this is noise).
+export const UNCOSTED_TOOL_THRESHOLD = 50;
+// avg LLM spans per session above this reads as a retry/fan-out smell worth surfacing.
+export const LLM_PER_SESSION_THRESHOLD = 8;
+// Keep the alert list short and high-signal.
+const MAX_HIDDEN_COST_ALERTS = 5;
+
+interface RankedAlert {
+  alert: HiddenCostAlert;
+  impact: number;
+}
+
+/**
+ * Detect hidden-cost alerts from `otel_spans` for the current tenant over the last 30 days.
+ *
+ * Returns the top {@link MAX_HIDDEN_COST_ALERTS} alerts ranked by impact, or `[]` when nothing
+ * qualifies (honest-empty — we never fabricate). Returns `null` (via tryLive) when ClickHouse is
+ * unreachable so the route can fall back to the canned mock for CI / fresh-clone rendering.
+ */
+export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<HiddenCostAlert[] | null> {
+  return tryLive(async (db, tenant) => {
+    const tag = filter?.tag ?? "";
+    const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
+
+    // Total tenant spend over the window — the denominator for the impact ranking.
+    const totalRows = await rowsP<{ total: string }>(
+      db,
+      `SELECT sum(EstimatedCost) AS total
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}`,
+      { tenant, tag },
+    );
+    const totalSpend = micro(totalRows[0]?.total ?? "0");
+
+    // Rule 1: uncosted tool/agent activity. Count tool spans with EstimatedCost = 0 per feature,
+    // alongside that feature's total spend (for the impact ranking).
+    const uncostedRows = await rowsP<{ feature: string; uncosted: string; featureCost: string }>(
+      db,
+      `SELECT
+         if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
+         countIf(GenAiOperation = 'tool' AND EstimatedCost = 0) AS uncosted,
+         sum(EstimatedCost) AS featureCost
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}
+       GROUP BY feature
+       HAVING uncosted > {threshold:UInt32}
+       ORDER BY uncosted DESC`,
+      { tenant, tag, threshold: UNCOSTED_TOOL_THRESHOLD },
+    );
+
+    // Rule 2: high LLM-calls-per-session ratio. Average LLM spans per SessionId, per feature.
+    const ratioRows = await rowsP<{ feature: string; callsPerSession: string; featureCost: string }>(
+      db,
+      `SELECT
+         if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
+         countIf(${LAYER_CASE} = 'llm') / nullIf(uniqExact(SessionId), 0) AS callsPerSession,
+         sum(EstimatedCost) AS featureCost
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
+         AND SessionId != '' ${tagClause}
+       GROUP BY feature
+       HAVING callsPerSession > {threshold:Float64}
+       ORDER BY callsPerSession DESC`,
+      { tenant, tag, threshold: LLM_PER_SESSION_THRESHOLD },
+    );
+
+    const ranked: RankedAlert[] = [];
+
+    for (const r of uncostedRows) {
+      const feature = r.feature || "untagged";
+      const uncosted = parseInt(r.uncosted, 10) || 0;
+      if (uncosted <= UNCOSTED_TOOL_THRESHOLD) continue;
+      const share = totalSpend > 0 ? micro(r.featureCost) / totalSpend : 0;
+      // Confidence is high — a zero-cost tool span is an unambiguous instrumentation gap.
+      const confidence = 0.9;
+      ranked.push({
+        impact: share * confidence,
+        alert: {
+          severity: "warn",
+          message:
+            `${feature} ran ${uncosted.toLocaleString()} tool calls with no cost attached over the last 30 days. ` +
+            `Those calls are uncosted — the all-in spend for this feature is understated.`,
+        },
+      });
+    }
+
+    for (const r of ratioRows) {
+      const feature = r.feature || "untagged";
+      const ratio = parseFloat(r.callsPerSession);
+      if (!Number.isFinite(ratio) || ratio <= LLM_PER_SESSION_THRESHOLD) continue;
+      const share = totalSpend > 0 ? micro(r.featureCost) / totalSpend : 0;
+      const confidence = 0.7;
+      ranked.push({
+        impact: share * confidence,
+        alert: {
+          severity: "warn",
+          message:
+            `${feature} averaged ${ratio.toFixed(1)} LLM calls per session over the last 30 days ` +
+            `(threshold ${LLM_PER_SESSION_THRESHOLD}). Worth checking for a retry loop or unbounded fan-out.`,
+        },
+      });
+    }
+
+    ranked.sort((a, b) => b.impact - a.impact);
+    return ranked.slice(0, MAX_HIDDEN_COST_ALERTS).map((r) => r.alert);
   });
 }
 


### PR DESCRIPTION
## Summary

Replaces the canned `hiddenCostAlerts` mock on the live `/api/cost` path with honest, real detection over `otel_spans`. The Cost page promised "vector + tools + compute" hidden-cost detection but served hardcoded alerts; this ships the rules that can actually run on the telemetry we have today.

## Detection rules

Implemented in the new `queryHiddenCostAlerts(filter?)` in `web/lib/clickhouse.ts` (the **only** addition to that file — no existing functions/consts touched). Both run per-tenant over the last ~30 days and only emit above a sane threshold:

1. **Uncosted tool/agent activity** — `GenAiOperation = 'tool'` spans with `EstimatedCost = 0` (tools running without a cost attached). Fires only above `UNCOSTED_TOOL_THRESHOLD` (>50 spans). Confidence 0.9.
2. **High LLM-calls-per-session ratio** — features whose avg LLM spans per `SessionId` exceed `LLM_PER_SESSION_THRESHOLD` (>8/session), a classic retry-loop / fan-out smell. Confidence 0.7.

Alerts are ranked by impact = (feature's share of total spend) × (rule confidence) and capped at the top 5.

### Deferred (out of scope)

- **Vendor-billed vs estimated** reconciliation — NO source today; the billing connectors aren't built yet (**CTO-143/144**). Documented in a code comment, intentionally omitted rather than faked.
- Slack/email alerting; auto-resolution.

## Honest-empty behavior

On the LIVE path the route serves `queryHiddenCostAlerts`' result verbatim — **including `[]`** when nothing fires. No fabricated alerts.

## Preserved mock fallback

The canned `hiddenCostAlerts` is kept **only** as the ClickHouse-unreachable fallback (query returns `null` → CI / fresh-clone still renders something), matching the existing `tryLive` pattern across the file. It is never served under a `?tag=` filter. Response shape (`{ series, featureRows, alerts }`) is unchanged.

## Test plan

```
cd web && npx tsc --noEmit && npx vitest run
```

- **tsc:** 100% clean.
- **vitest:** 170/172 passing. The only 2 failures are the documented pre-existing flakes in `app/api/api.test.ts` (data-quality and attribution cases) — in files this PR does not touch. The `/api/cost` route test passes (still returns canned alerts on the mock-fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)