### PR TITLE
feat(guardrails): wire /guardrails UI to the control plane (CTO-120)

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -16,7 +16,7 @@ import {
   GET as FirstTraceGET,
   POST as FirstTracePOST,
 } from "./onboarding/first-trace/route";
-import { GET as GuardrailsGET, PUT as GuardrailsPUT } from "./guardrails/route";
+import { GET as GuardrailsGET, POST as GuardrailsPOST } from "./guardrails/route";
 import { GET as AttributionGET } from "./attribution/route";
 import { GET as CacGET } from "./cac/route";
 
@@ -130,7 +130,7 @@ describe("api routes", () => {
 
   it("GET /api/guardrails returns rules + refresh window", async () => {
     const body = await json<{ rules: unknown[]; configRefreshSeconds: number }>(
-      await GuardrailsGET(),
+      await GuardrailsGET(new Request("http://test/api/guardrails")),
     );
     expect(body.rules.length).toBeGreaterThan(0);
     expect(body.configRefreshSeconds).toBeGreaterThan(0);
@@ -175,18 +175,22 @@ describe("api routes", () => {
     expect(body.economics["2026-05-01"].arpaMicroUsd).toBeGreaterThan(0);
   });
 
-  it("PUT /api/guardrails echoes a valid rule, rejects an unconstrained one", async () => {
-    const ok = await GuardrailsPUT(
+  it("POST /api/guardrails echoes a valid rule (gateway unreachable), rejects an unconstrained one", async () => {
+    // Gateway isn't running in CI / fresh clone, so POST validates and echoes the rule back with a
+    // client-supplied change_id rather than blocking on the control plane.
+    const ok = await GuardrailsPOST(
       new Request("http://test/x", {
-        method: "PUT",
+        method: "POST",
         body: JSON.stringify({ id: "gr_x", scope: "a", mode: "warn", maxSteps: 10 }),
       }),
     );
     expect(ok.status).toBe(200);
+    const okBody = await json<{ changeId: string }>(ok);
+    expect(okBody.changeId).toBeTypeOf("string");
 
-    const bad = await GuardrailsPUT(
+    const bad = await GuardrailsPOST(
       new Request("http://test/x", {
-        method: "PUT",
+        method: "POST",
         body: JSON.stringify({ id: "gr_x", scope: "a", mode: "warn" }),
       }),
     );

--- a/web/app/api/guardrails/route.ts
+++ b/web/app/api/guardrails/route.ts
@@ -3,26 +3,69 @@ import { NextResponse } from "next/server";
 
 import {
   CONFIG_REFRESH_SECONDS,
+  type GuardrailMode,
   type GuardrailRule,
   guardrailRules,
 } from "@/lib/guardrails";
+import { queryGuardrailRules } from "@/lib/clickhouse";
 
-// Guardrail config lives in the control plane (Postgres, CTO-27), not ClickHouse. No live reader is
-// wired here yet, so we serve the typed mock directly — `npm run dev/build/test` never need infra.
+// Guardrail config lives in the control plane (Postgres, CTO-27/116), reached via the gateway. The
+// reader (queryGuardrailRules) falls back to the typed mock when the gateway is unreachable, so
+// `npm run dev/build/test` never depend on infra.
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
-  return NextResponse.json({
-    rules: guardrailRules,
-    configRefreshSeconds: CONFIG_REFRESH_SECONDS,
-  });
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+
+// Map the web mode back onto the control-plane state for the upsert. Only `enabled` actually alters
+// the agent; observe maps to `shadow` (recording-only). The precise mode is preserved in params.mode
+// so the reader round-trips it.
+function stateForMode(mode: GuardrailMode): "enabled" | "shadow" | "disabled" {
+  return mode === "observe" ? "shadow" : "enabled";
 }
 
-// Persisting an edited rule. With no control plane wired in the prototype this validates the shape
-// and echoes the rule back (the client treats the echo as the saved state). The SDK would pick the
-// change up on its next config refresh.
-export async function PUT(req: Request) {
+// Map a web rule's caps onto a control-plane kind: cost_cap when a cost cap is set, else loop_limit
+// for a step cap. (pii_gate / model_deprecation are managed elsewhere — out of scope for CTO-120.)
+function kindForRule(
+  rule: Pick<GuardrailRule, "maxCostMicroUsd" | "maxSteps">,
+): "cost_cap" | "loop_limit" {
+  return rule.maxCostMicroUsd != null ? "cost_cap" : "loop_limit";
+}
+
+// GET /api/guardrails           -> rules (live via gateway, falling back to the mock) + refresh window
+// GET /api/guardrails?audit=1   -> recent guardrail rule changes for the tenant (optionally ?rule_id=)
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  if (url.searchParams.get("audit") === "1") {
+    const ruleId = url.searchParams.get("rule_id") ?? undefined;
+    try {
+      const qs = ruleId ? `?rule_id=${encodeURIComponent(ruleId)}` : "";
+      const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails/audit${qs}`, {
+        headers: { "x-tenant-id": TENANT },
+        cache: "no-store",
+        signal: AbortSignal.timeout(2000),
+      });
+      if (!res.ok) {
+        return NextResponse.json({ changes: [], unavailable: true });
+      }
+      const body = (await res.json()) as { changes?: unknown[] };
+      return NextResponse.json({ changes: Array.isArray(body.changes) ? body.changes : [] });
+    } catch {
+      // Gateway unreachable (CI / fresh clone): empty audit, flagged so the UI can say "unavailable".
+      return NextResponse.json({ changes: [], unavailable: true });
+    }
+  }
+
+  const rules = (await queryGuardrailRules()) ?? guardrailRules;
+  return NextResponse.json({ rules, configRefreshSeconds: CONFIG_REFRESH_SECONDS });
+}
+
+// POST /api/guardrails — persist an edited rule. Validates the shape, then forwards to the gateway's
+// idempotent upsert with a client-supplied change_id (UUID). When the gateway is unreachable we still
+// validate and echo the rule back (the client treats the echo as the saved state) so the prototype
+// works without infra; the SDK picks the change up on its next config-refresh window.
+export async function POST(req: Request) {
   let rule: Partial<GuardrailRule>;
   try {
     rule = (await req.json()) as Partial<GuardrailRule>;
@@ -38,5 +81,54 @@ export async function PUT(req: Request) {
       { status: 422 },
     );
   }
-  return NextResponse.json({ rule, configRefreshSeconds: CONFIG_REFRESH_SECONDS });
+
+  const changeId = crypto.randomUUID();
+  const maxCostMicroUsd = rule.maxCostMicroUsd ?? null;
+  const maxSteps = rule.maxSteps ?? null;
+  const payload = {
+    rule_id: rule.id,
+    kind: kindForRule({ maxCostMicroUsd, maxSteps }),
+    state: stateForMode(rule.mode),
+    change_id: changeId,
+    params: {
+      mode: rule.mode,
+      scope: rule.scope,
+      scope_kind: rule.scopeKind ?? "agent",
+      max_cost_micro_usd: maxCostMicroUsd,
+      max_steps: maxSteps,
+    },
+  };
+
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { rule?: unknown };
+      return NextResponse.json({
+        rule,
+        gatewayRule: body.rule ?? null,
+        changeId,
+        configRefreshSeconds: CONFIG_REFRESH_SECONDS,
+      });
+    }
+    // Gateway rejected the upsert (e.g. validation) — surface 422 so the client knows it didn't persist.
+    if (res.status >= 400 && res.status < 500) {
+      const detail = await res.text();
+      return NextResponse.json({ error: `gateway rejected upsert: ${detail}` }, { status: 422 });
+    }
+    return NextResponse.json({ error: `gateway error ${res.status}` }, { status: 502 });
+  } catch {
+    // Gateway unreachable (CI / fresh clone): echo the validated rule so the prototype still works.
+    return NextResponse.json({
+      rule,
+      changeId,
+      persisted: false,
+      configRefreshSeconds: CONFIG_REFRESH_SECONDS,
+    });
+  }
 }

--- a/web/app/guardrails/GuardrailRow.tsx
+++ b/web/app/guardrails/GuardrailRow.tsx
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// One interactive guardrail rule row (CTO-120). Three affordances, all POSTing through
+// /api/guardrails (which forwards an idempotent change_id to the gateway):
+//   - Mode select  — flip enforcement mode; POSTs immediately (optimistic, rolls back on error).
+//   - Edit caps    — change the cost / step cap; shows a confirm dialog BEFORE POSTing, because a
+//                    cap change alters what trips for live traffic.
+//   - Audit        — expand the per-rule change log, read lazily from /api/guardrails?audit=1.
+
+import { useState, useTransition } from "react";
+
+import {
+  type GuardrailMode,
+  type GuardrailRule,
+  GUARDRAIL_MODES,
+  GRADUATION_LABEL,
+  fireRate,
+  graduationSignal,
+  modeMeta,
+} from "@/lib/guardrails";
+import { formatUSD } from "@/lib/types";
+
+const DASH = "—";
+
+interface AuditChange {
+  change_id: string;
+  rule_id: string;
+  actor: string | null;
+  changed_at: string;
+  before: { state?: string } | null;
+  after: { state?: string } | null;
+}
+
+function capLabel(rule: GuardrailRule): string {
+  const parts: string[] = [];
+  if (rule.maxCostMicroUsd != null) parts.push(`${formatUSD(rule.maxCostMicroUsd)}/run`);
+  if (rule.maxSteps != null) parts.push(`${rule.maxSteps} steps`);
+  return parts.length ? parts.join(" · ") : DASH;
+}
+
+async function postRule(rule: GuardrailRule): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch("/api/guardrails", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(rule),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      return { ok: false, error: body.error ?? `save failed (${res.status})` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
+  const [rule, setRule] = useState(initialRule);
+  const [status, setStatus] = useState<{ tone: "ok" | "err"; text: string } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // Cap-edit dialog state.
+  const [editing, setEditing] = useState(false);
+  const [costInput, setCostInput] = useState("");
+  const [stepsInput, setStepsInput] = useState("");
+
+  // Audit-log state (lazy).
+  const [auditOpen, setAuditOpen] = useState(false);
+  const [auditRows, setAuditRows] = useState<AuditChange[] | null>(null);
+  const [auditLoading, setAuditLoading] = useState(false);
+
+  const save = (next: GuardrailRule, okText: string) => {
+    const prev = rule;
+    setRule(next); // optimistic
+    setStatus(null);
+    startTransition(async () => {
+      const res = await postRule(next);
+      if (res.ok) {
+        setStatus({ tone: "ok", text: okText });
+      } else {
+        setRule(prev); // rollback
+        setStatus({ tone: "err", text: res.error ?? "Save failed." });
+      }
+    });
+  };
+
+  const onModeChange = (mode: GuardrailMode) => {
+    if (mode === rule.mode) return;
+    save({ ...rule, mode }, `Mode → ${modeMeta(mode).label}. Live within the refresh window.`);
+  };
+
+  const openEdit = () => {
+    setCostInput(rule.maxCostMicroUsd != null ? (rule.maxCostMicroUsd / 1_000_000).toString() : "");
+    setStepsInput(rule.maxSteps != null ? rule.maxSteps.toString() : "");
+    setEditing(true);
+  };
+
+  const confirmEdit = () => {
+    const costUsd = costInput.trim() === "" ? null : Number(costInput);
+    const steps = stepsInput.trim() === "" ? null : Number(stepsInput);
+    const maxCostMicroUsd =
+      costUsd != null && Number.isFinite(costUsd) && costUsd >= 0
+        ? Math.round(costUsd * 1_000_000)
+        : null;
+    const maxSteps =
+      steps != null && Number.isFinite(steps) && steps >= 0 ? Math.round(steps) : null;
+    if (maxCostMicroUsd == null && maxSteps == null) {
+      setStatus({ tone: "err", text: "A rule must set a cost cap or a step cap." });
+      return;
+    }
+    setEditing(false);
+    save({ ...rule, maxCostMicroUsd, maxSteps }, "Caps updated. Live within the refresh window.");
+  };
+
+  const toggleAudit = async () => {
+    const next = !auditOpen;
+    setAuditOpen(next);
+    if (next && auditRows === null && !auditLoading) {
+      setAuditLoading(true);
+      try {
+        const res = await fetch(`/api/guardrails?audit=1&rule_id=${encodeURIComponent(rule.id)}`);
+        const body = (await res.json()) as { changes?: AuditChange[] };
+        setAuditRows(Array.isArray(body.changes) ? body.changes : []);
+      } catch {
+        setAuditRows([]);
+      } finally {
+        setAuditLoading(false);
+      }
+    }
+  };
+
+  const meta = modeMeta(rule.mode);
+  const signal = graduationSignal(rule);
+  const ratePct = Math.round(fireRate(rule) * 100);
+
+  return (
+    <>
+      <tr className="border-b border-edge/60 align-top">
+        <td className="py-3 pr-3">
+          <div className="font-medium">{rule.scope}</div>
+          <div className="text-xs text-muted">{rule.scopeKind}</div>
+        </td>
+        <td className="py-3 pr-3">
+          <div className="flex items-center gap-2">
+            <span>{capLabel(rule)}</span>
+            <button
+              type="button"
+              onClick={openEdit}
+              disabled={pending}
+              className="rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:bg-edge hover:text-white"
+            >
+              Edit
+            </button>
+          </div>
+        </td>
+        <td className="py-3 pr-3">
+          {rule.runsThisWeek > 0 ? (
+            <span>
+              {rule.wouldHaveFiredThisWeek.toLocaleString()} / {rule.runsThisWeek.toLocaleString()}{" "}
+              <span className="text-muted">({ratePct}%)</span>
+            </span>
+          ) : (
+            <span className="text-muted">{DASH}</span>
+          )}
+        </td>
+        <td className="py-3 pr-3">
+          {meta.enforcing ? (
+            <span className="text-xs text-muted">enforcing</span>
+          ) : (
+            <span
+              className={`text-xs ${signal === "ready" ? "text-accent" : "text-muted"}`}
+              title={GRADUATION_LABEL[signal]}
+            >
+              {GRADUATION_LABEL[signal]}
+            </span>
+          )}
+        </td>
+        <td className="py-3 pr-3">
+          <select
+            value={rule.mode}
+            disabled={pending}
+            onChange={(e) => onModeChange(e.target.value as GuardrailMode)}
+            aria-label={`Mode for ${rule.scope}`}
+            className="rounded border border-edge bg-ink/40 px-2 py-1 text-xs text-white disabled:opacity-50"
+          >
+            {GUARDRAIL_MODES.map((m) => (
+              <option key={m.mode} value={m.mode}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+          {status && (
+            <div className={`mt-1 text-[11px] ${status.tone === "ok" ? "text-good" : "text-warn"}`}>
+              {status.text}
+            </div>
+          )}
+        </td>
+        <td className="py-3 text-right">
+          <button
+            type="button"
+            onClick={toggleAudit}
+            aria-expanded={auditOpen}
+            className="rounded border border-edge px-2 py-1 text-xs text-muted hover:bg-edge hover:text-white"
+          >
+            {auditOpen ? "Hide" : "Audit"}
+          </button>
+        </td>
+      </tr>
+
+      {editing && (
+        <tr className="border-b border-edge/60 bg-ink/30">
+          <td colSpan={6} className="px-2 py-3">
+            <div className="flex flex-wrap items-end gap-3">
+              <label className="flex flex-col text-xs text-muted">
+                Cost cap (USD / run)
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={costInput}
+                  onChange={(e) => setCostInput(e.target.value)}
+                  placeholder="none"
+                  className="mt-1 w-32 rounded border border-edge bg-ink/40 px-2 py-1 text-sm text-white"
+                />
+              </label>
+              <label className="flex flex-col text-xs text-muted">
+                Step cap
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={stepsInput}
+                  onChange={(e) => setStepsInput(e.target.value)}
+                  placeholder="none"
+                  className="mt-1 w-32 rounded border border-edge bg-ink/40 px-2 py-1 text-sm text-white"
+                />
+              </label>
+              <div className="ml-auto flex items-center gap-2">
+                <span className="text-[11px] text-warn">
+                  Confirm: this changes what trips for live traffic.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setEditing(false)}
+                  className="rounded border border-edge px-2.5 py-1 text-xs text-muted hover:bg-edge hover:text-white"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmEdit}
+                  className="rounded border border-accent/50 bg-accent/15 px-2.5 py-1 text-xs font-medium text-accent hover:bg-accent/25"
+                >
+                  Confirm &amp; save
+                </button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+
+      {auditOpen && (
+        <tr className="border-b border-edge/60 bg-ink/20">
+          <td colSpan={6} className="px-2 py-3">
+            {auditLoading ? (
+              <span className="text-xs text-muted">Loading audit log…</span>
+            ) : auditRows && auditRows.length > 0 ? (
+              <ul className="space-y-1 text-xs">
+                {auditRows.map((c) => (
+                  <li key={c.change_id} className="flex flex-wrap gap-2 text-muted">
+                    <span className="text-white">{c.changed_at || "—"}</span>
+                    <span>
+                      {(c.before?.state ?? "∅")} → {(c.after?.state ?? "∅")}
+                    </span>
+                    {c.actor && <span>by {c.actor}</span>}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <span className="text-xs text-muted">
+                No audit entries (the control plane may be unreachable in this environment).
+              </span>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/web/app/guardrails/page.tsx
+++ b/web/app/guardrails/page.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Guardrails page (CTO-120): renders the tenant's guardrail rules from the control plane (gateway
+// GET /v1/tenant/guardrails, via /api/guardrails — falling back to the typed mock when the gateway
+// is unreachable). Each rule is interactive: flip its enforcement mode, edit its caps (behind a
+// confirm dialog), and inspect its audit log. Edits POST through /api/guardrails, which forwards an
+// idempotent change_id to the gateway; the SDK picks the change up on its next config-refresh window.
+
+import { Card } from "@/components/Card";
+import { apiGet } from "@/lib/api";
+import {
+  type GuardrailRule,
+  GUARDRAIL_MODES,
+  summarize,
+} from "@/lib/guardrails";
+import { GuardrailRow } from "./GuardrailRow";
+
+interface GuardrailsPayload {
+  rules: GuardrailRule[];
+  configRefreshSeconds: number;
+}
+
+export default async function GuardrailsPage() {
+  const { rules, configRefreshSeconds } = await apiGet<GuardrailsPayload>("/api/guardrails");
+  const summary = summarize(rules);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Guardrails</h1>
+        <p className="mt-1 text-sm text-muted">
+          Per-tenant cost / step caps. Rules start in observe-only and graduate to enforcement with
+          confidence. Mode changes take effect on the SDK within the {configRefreshSeconds}s
+          config-refresh window.
+        </p>
+      </div>
+
+      <Card title="Summary">
+        <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted">Rules</dt>
+            <dd className="mt-0.5 text-2xl font-semibold">{summary.total}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted">Enforcing</dt>
+            <dd className="mt-0.5 text-2xl font-semibold">{summary.enforcing}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted">Observing</dt>
+            <dd className="mt-0.5 text-2xl font-semibold">{summary.observing}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted">Ready to enforce</dt>
+            <dd className="mt-0.5 text-2xl font-semibold text-accent">{summary.readyToGraduate}</dd>
+          </div>
+        </dl>
+      </Card>
+
+      <Card title="Rules">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-edge text-left text-xs uppercase tracking-wide text-muted">
+                <th className="pb-2 pr-3 font-medium">Scope</th>
+                <th className="pb-2 pr-3 font-medium">Caps</th>
+                <th className="pb-2 pr-3 font-medium">Would-fire / wk</th>
+                <th className="pb-2 pr-3 font-medium">Graduation</th>
+                <th className="pb-2 pr-3 font-medium">Mode</th>
+                <th className="pb-2 font-medium text-right">Audit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rules.map((rule) => (
+                <GuardrailRow key={rule.id} initialRule={rule} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-xs text-muted">
+          Modes (weakest → strongest):{" "}
+          {GUARDRAIL_MODES.map((m) => m.label).join(" · ")}. Only{" "}
+          {GUARDRAIL_MODES.filter((m) => m.enforcing).length} of {GUARDRAIL_MODES.length} alter the
+          agent; observe-only never does.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -11,6 +11,7 @@ const NAV: { label: string; href: string }[] = [
   { label: "Attribution", href: "/attribution" },
   { label: "Unit Economics", href: "/unit-economics" },
   { label: "Connectors", href: "/connectors" },
+  { label: "Guardrails", href: "/guardrails" },
   // Hidden from the nav until they have real signal end-to-end (pages still render at the URL):
   //   - /settings        — empty shell, no real settings wired
   //   - /estimate        — mock fixtures (re-add when CTO-128 lands)

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -40,6 +40,7 @@ import {
   buildProviderRow,
   emptyReport,
 } from "./attribution";
+import type { GuardrailMode, GuardrailRule, GuardrailScopeKind } from "./guardrails";
 
 const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
@@ -677,6 +678,87 @@ export async function queryIntegrationStatus(): Promise<IntegrationStatusRow[] |
     return Array.isArray(body.integrations) ? body.integrations : [];
   } catch (err) {
     console.warn("[integrations] gateway unreachable:", (err as Error).message);
+    return null;
+  }
+}
+
+// --- Tenant guardrails (CTO-120 / control-plane CTO-116) ----------------------------------------
+//
+// The /guardrails page used to serve the typed mock from lib/guardrails.ts. The real source is the
+// gateway's tenant_guardrails table, exposed via GET /v1/tenant/guardrails. We map the control-plane
+// rule shape (rule_id / kind / params / state) onto the web's GuardrailRule and fall back to null on
+// any error so the route can paint the page with the static mock (same pattern as every other
+// gateway-facing helper here).
+//
+// Shape mapping (gateway -> web):
+//   rule_id                       -> id
+//   params.scope_kind ("feature") -> scopeKind (default "agent")
+//   params.scope / rule_id        -> scope
+//   params.mode OR state          -> mode  (params.mode wins; else shadow/disabled->observe,
+//                                            enabled->warn as a safe enforcing default)
+//   params.max_cost_micro_usd     -> maxCostMicroUsd
+//   params.max_steps              -> maxSteps
+// The control plane does not carry fire counts, so wouldHaveFiredThisWeek / runsThisWeek default to
+// 0 (those are observability tallies the SDK emits, not config) — honest rather than fabricated.
+
+interface GatewayGuardrailRule {
+  rule_id: string;
+  kind: string;
+  params?: Record<string, unknown> | null;
+  state: string;
+}
+
+function guardrailIntOrNull(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : parseInt(String(v), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function mapGuardrailRule(r: GatewayGuardrailRule): GuardrailRule {
+  const params = r.params ?? {};
+  const rawMode = params["mode"];
+  const mode: GuardrailMode =
+    rawMode === "observe" || rawMode === "warn" || rawMode === "graceful" || rawMode === "hard_stop"
+      ? rawMode
+      : r.state === "enabled"
+        ? "warn"
+        : "observe"; // shadow / disabled / unknown -> observe (never alters the agent)
+  const scopeKind: GuardrailScopeKind = params["scope_kind"] === "feature" ? "feature" : "agent";
+  const scope =
+    typeof params["scope"] === "string" && params["scope"] ? (params["scope"] as string) : r.rule_id;
+  return {
+    id: r.rule_id,
+    scopeKind,
+    scope,
+    mode,
+    maxCostMicroUsd: guardrailIntOrNull(params["max_cost_micro_usd"]),
+    maxSteps: guardrailIntOrNull(params["max_steps"]),
+    // Control plane carries config, not telemetry — fire counts come from the SDK, default 0.
+    wouldHaveFiredThisWeek: guardrailIntOrNull(params["would_have_fired_this_week"]) ?? 0,
+    runsThisWeek: guardrailIntOrNull(params["runs_this_week"]) ?? 0,
+  };
+}
+
+/**
+ * Fetch the caller's per-tenant guardrail rules from the gateway and map them onto the web's
+ * GuardrailRule shape. Returns null on any error (gateway unreachable, non-2xx, parse failure) so
+ * the route can fall back to the static mock (`?? guardrailRules`) rather than blanking the page.
+ */
+export async function queryGuardrailRules(): Promise<GuardrailRule[] | null> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) {
+      console.warn(`[guardrails] /v1/tenant/guardrails HTTP ${res.status}; falling back to mock`);
+      return null;
+    }
+    const body = (await res.json()) as { rules?: GatewayGuardrailRule[] };
+    return Array.isArray(body.rules) ? body.rules.map(mapGuardrailRule) : [];
+  } catch (err) {
+    console.warn("[guardrails] gateway unreachable, falling back to mock:", (err as Error).message);
     return null;
   }
 }


### PR DESCRIPTION
**Stacked on #112** (Unit Economics) — both touch `web/components/Shell.tsx` NAV. When #112 merges to main, GitHub auto-retargets this PR.

## CTO-120 — Guardrails web UI: wire `/guardrails` to the control plane

The guardrails backend shipped in CTO-116 (Postgres `tenant_guardrails`, gateway `GET/POST /v1/tenant/guardrails` + `/audit`, SDK refresh). The web UI still served the typed mock and did nothing on toggle. This wires it through.

### What changed
- **`queryGuardrailRules()`** (`web/lib/clickhouse.ts`) — calls `GET /v1/tenant/guardrails`, maps the control-plane rule shape (`rule_id` / `kind` / `params` / `state`) onto the typed `GuardrailRule`, and returns `null` on gateway-unreachable so the route falls back to the mock (the established `?? mock` pattern, reusing the same `GATEWAY_URL` / `x-tenant-id` / `AbortSignal.timeout` fetch pattern as `queryIntegrationStatus` / `queryReplayCandidates`). **Only this one function was added to `clickhouse.ts`** — no other function in that file was touched.
- **`/api/guardrails` route**
  - `GET` → `queryGuardrailRules() ?? guardrailRules`; removed the "no live reader is wired here yet" note.
  - `GET ?audit=1` → forwards to `GET /v1/tenant/guardrails/audit` (optional `?rule_id=`); graceful `{ changes: [], unavailable: true }` when the gateway is down.
  - `POST` → forwards to `POST /v1/tenant/guardrails` with a client-supplied `change_id` (`crypto.randomUUID()`) for idempotency; validates + echoes the rule when the gateway is unreachable. (The prototype `PUT` became `POST`.)
- **`/guardrails` page** (`page.tsx` server + `GuardrailRow.tsx` client) — summary cards + a rules table. Mode select POSTs through `/api/guardrails` (optimistic, rolls back on error); cap edits open a **confirm dialog** before POSTing; per-rule **audit** affordance reads `?audit=1`. The mock `guardrailRules` stays in `guardrails.ts` as the unreachable-gateway fallback shape.
- **Nav** — appended `{ label: "Guardrails", href: "/guardrails" }` to the `NAV` array in `Shell.tsx`.

### Gateway endpoints (confirmed present, CTO-116)
`infra/gateway/src/gateway/app.py`: `GET /v1/tenant/guardrails` (L645), `POST /v1/tenant/guardrails` (L665, validates `change_id`/`kind`/`state`), `GET /v1/tenant/guardrails/audit` (L719). Allowed kinds `pii_gate/cost_cap/loop_limit/model_deprecation`, states `enabled/shadow/disabled`.

### Still mocked / honest gaps
- `wouldHaveFiredThisWeek` / `runsThisWeek` default to `0` from a live read — the control plane carries config, not telemetry (those tallies are SDK-emitted). The mock keeps non-zero values for the fallback story.
- Out of scope (unchanged): custom rule kinds, per-feature-tag scoping, rule-trip rate graphs, any backend change.

## Test plan
- `cd web && npx tsc --noEmit` → **clean**.
- `npx vitest run` → **171 / 173 passing**. The only 2 failures are the documented pre-existing flakes: `GET /api/data-quality...` and `GET /api/attribution falls back to mock...` (both assume an unreachable ClickHouse/gateway; a local stack is up in this env). New guardrails GET + POST route tests pass.
- `npx next build` → compiles `/guardrails` and `/api/guardrails`.
- Worktree dev server: nav link renders, page shows the rules, `GET /api/guardrails` returns rules, `?audit=1` returns the graceful `{ unavailable: true }` fallback, `POST` validates (422 on unconstrained) and forwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)