### PR TITLE
feat(compare): per-candidate latency + error from real replay (CTO-123)

### DIFF
--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -135,6 +135,65 @@ describe("/api/compare", () => {
     expect(body.diagnostics.contextFidelity).toBe(
       "resolved-context replay (no live retrieval)",
     );
+    // CTO-123: per-candidate p95 latency + error rate come straight from the projection
+    // (both candidates have >= 50 replayed responses), not a borrowed mock.
+    expect(haiku.latencyP95Ms).toBe(1500);
+    expect(haiku.errorRate).toBeCloseTo(0.01, 6);
+  });
+
+  // CTO-123: a candidate with fewer than 50 replayed responses gets null latency/error —
+  // the same honest-null floor the `current` row uses (CTO-115) — so the page renders "—"
+  // rather than a noisy number or a borrowed mock.
+  it("CTO-123: nulls per-candidate latency/error below the 50-replay floor", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 49,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 3_000_000,
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 49, // below the 50-replay floor
+          excluded_budget_count: 0,
+        },
+        {
+          provider: "openai",
+          model: "gpt-5-mini",
+          projected_monthly_cost_micro_usd: 4_000_000,
+          p50_latency_ms: 900,
+          p95_latency_ms: 1700,
+          error_rate: 0.02,
+          samples_replayed: 50, // exactly at the floor — keeps real numbers
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 12_500,
+      },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    const haiku = body.candidates.find((c: { model: string }) => c.model === "claude-haiku-4-5");
+    const mini = body.candidates.find((c: { model: string }) => c.model === "gpt-5-mini");
+    // Below the floor → honest null (page renders "—"). Cost is still real (separate rule).
+    expect(haiku.latencyP95Ms).toBeNull();
+    expect(haiku.errorRate).toBeNull();
+    expect(haiku.monthlyCostMicroUsd).toBe(3_000_000);
+    // At the floor → real numbers pass through.
+    expect(mini.latencyP95Ms).toBe(1700);
+    expect(mini.errorRate).toBeCloseTo(0.02, 6);
   });
 
   it("drops the current model from replay candidates to avoid model-vs-itself comparisons", async () => {

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -14,6 +14,11 @@ import {
 // mathematically defined, is not informative.
 const MIN_JUDGED_SAMPLES = 10;
 
+// CTO-123: minimum replayed-response count before a candidate's per-candidate p95 latency /
+// error rate are shown as real numbers. Below this, both are null and the page renders "—" —
+// the same honest-null rule the `current` row uses for its live otel window (CTO-115).
+const MIN_REPLAYED_SAMPLES = 50;
+
 /** Look up a candidate's eval row; return null when no row exists or sample count too small. */
 function evalQualityFor(
   evalRows: EvalCandidateRow[] | undefined,
@@ -81,14 +86,19 @@ export async function GET(req: Request) {
         // fall back to a mock number; that would have been the previous workaround and the
         // whole point of this ticket is to stop doing that.
         const quality = evalQualityFor(evalProj?.per_candidate, c.provider, c.model);
+        // CTO-123: real per-candidate p95 latency + error rate from the replay projection.
+        // Honest-null below the floor — same rule the `current` row uses (CTO-115): a p95 / error
+        // rate computed from fewer than 50 replayed responses is too noisy to present, so we emit
+        // null and the page renders "—" rather than a number or a borrowed mock.
+        const enoughReplayed = c.samples_replayed >= MIN_REPLAYED_SAMPLES;
         return {
           model: c.model,
           provider: c.provider,
           monthlyCostMicroUsd: c.projected_monthly_cost_micro_usd,
           qualityScore: quality?.qualityScore ?? null,
           ...(quality ? { qualityCi: quality.qualityCi } : {}),
-          latencyP95Ms: c.p95_latency_ms || comparison.candidates[0]?.latencyP95Ms || 0,
-          errorRate: c.error_rate,
+          latencyP95Ms: enoughReplayed ? c.p95_latency_ms : null,
+          errorRate: enoughReplayed ? c.error_rate : null,
         };
       });
     const cheapest = candidates.reduce(

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -8,8 +8,12 @@
 // CTO-115: the `current` row's `latencyP95Ms` and `errorRate` are now derived from live
 // otel_spans over the same 7-day window the cost query uses (see queryCurrentModel in
 // clickhouse.ts). They carry `null` when the live window has fewer than 50 spans, and the
-// page renders "—" in that case. The candidate rows keep numeric mocks until per-candidate
-// CTO-113-extension lands.
+// page renders "—" in that case.
+//
+// CTO-123: candidate rows' `latencyP95Ms` / `errorRate` are now also grounded in real
+// per-candidate replay (p95 latency + error rate over the replayed responses), with the same
+// honest-null floor (null below 50 replayed responses → "—"). The numeric values on the mock
+// candidates below are used only by the unreachable-gateway rescaled-mock fallback path.
 //
 // CTO-114: `qualityScore` is now `number | null`. Non-null only when a pairwise-LLM-judge
 // eval pass has run and judged >= 10 samples for that candidate; the value is the
@@ -39,8 +43,8 @@ export interface CandidateMetrics {
   qualityCi?: { lo: number; hi: number };
   /**
    * p95 latency in milliseconds. `null` on the `current` row when the live 7-day window has
-   * fewer than 50 spans (rendered as "—" — CTO-115). Candidate rows keep numeric mocks until
-   * per-candidate replay latency lands.
+   * fewer than 50 spans, and on candidate rows when fewer than 50 responses were replayed
+   * (rendered as "—" — CTO-115 / CTO-123).
    */
   latencyP95Ms: number | null;
   /** 0..1. `null` on the `current` row under the same low-sample suppression rule (CTO-115). */


### PR DESCRIPTION
**STACKED on #115** (Estimate what-if) — base is `feat/cto-128-estimate-whatif`. Both touch the gateway replay path; this PR keeps its diff web-only to avoid conflicts. GitHub auto-retargets to `main` when #115 merges.

## What
`/compare` candidate rows still carried numeric **mocks** for latency/error (`web/lib/compare.ts`: "candidate rows keep numeric mocks until per-candidate CTO-113-extension lands"). This grounds them on real replay data.

## Gateway: no change needed
The `/v1/replay` per-candidate projection **already** emits `p95_latency_ms`, `error_rate`, and `samples_replayed` (computed from the replayed `CandidateResponse`s — p95 over `latency_ms`, error_rate = errored/total). `web/lib/clickhouse.ts`'s `ReplayCandidateRow` already types all three. So this is a **web-only** change.

## Web
- `web/app/api/compare/route.ts` (replay path): dropped the `|| comparison.candidates[0]?.latencyP95Ms || 0` mock fallback. Now uses the real per-candidate `p95_latency_ms` / `error_rate`, or **`null` when the candidate has fewer than 50 replayed responses** — honest-null floor, the same rule the `current` row uses for its live otel window (CTO-115). Page renders `—` in that case.
- `web/lib/compare.ts`: removed the "CTO-113-extension" follow-up comments; documented that the candidates' numeric values now serve **only** the gateway-unreachable rescaled-mock fallback.
- The rescaled-mock fallback path (gateway unreachable, CI/fresh clone) keeps its numeric candidate mocks — that is now the **only** place candidate mocks remain.

## Honest-null floor
`MIN_REPLAYED_SAMPLES = 50`. Below it, both `latencyP95Ms` and `errorRate` are `null` (cost stays real — separate rule).

## Test plan
- `infra/gateway`: `uv run ruff check .` clean; `uv run pytest` → **256 passed**.
- `web`: `npx tsc --noEmit` → clean (exit 0); `npx vitest run` → **175 passed, 2 failed**.
  - The 2 failures are the known pre-existing flakes in `api.test.ts` (data-quality report + attribution mock-fallback) — unrelated to this change.
  - `app/api/compare/route.test.ts` → **9 passed**, incl. a new CTO-123 case: real per-candidate latency/error pass through at/above the floor, `null` below it, cost real either way.

## Out of scope
Per-candidate quality (CTO-114, shipped) and routing-rule export — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)