### PR TITLE
feat(gateway): GCS replay blob-store backend (CTO-152)

### DIFF
--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# GCS replay blob-store backend (CTO-152). Optional so the base install stays slim; imported
+# lazily inside GCSReplayBlobStore so the gateway boots without it when the backend is `memory`.
+gcs = [
+    "google-cloud-storage>=2.10",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.6",

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -70,7 +70,9 @@ from gateway.replay_sampler import (
     stratified_sample,
 )
 from gateway.replay_store import (
+    GCSReplayBlobStore,
     InMemoryReplayBlobStore,
+    ReplayBlobStore,
     persist_sample,
 )
 from gateway.eval_executor import (
@@ -102,6 +104,26 @@ from tally.hmac_keys import HmacKeyRegistry
 logger = logging.getLogger("tally.gateway")
 
 
+def _build_replay_blob_store(settings) -> ReplayBlobStore:
+    """Select the replay blob-store backend from settings (CTO-152).
+
+    ``memory`` (default) -> in-process dict store; ``gcs`` -> Google Cloud Storage via ADC /
+    Workload Identity. The GCS client + its optional ``google-cloud-storage`` dependency are only
+    touched when the backend is actually ``gcs`` (lazy import lives inside the store), so the
+    default install/boot never needs the package.
+    """
+    backend = (settings.replay_blob_backend or "memory").lower()
+    if backend == "memory":
+        return InMemoryReplayBlobStore()
+    if backend == "gcs":
+        if not settings.replay_gcs_bucket:
+            raise ValueError(
+                "TALLY_REPLAY_GCS_BUCKET must be set when TALLY_REPLAY_BLOB_BACKEND=gcs"
+            )
+        return GCSReplayBlobStore(bucket=settings.replay_gcs_bucket)
+    raise ValueError(f"unknown TALLY_REPLAY_BLOB_BACKEND: {backend!r} (expected 'memory' or 'gcs')")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     settings = get_settings()
@@ -128,7 +150,7 @@ async def lifespan(app: FastAPI):
     # a deployment shim. Replay runs accumulate in-memory until ClickHouse writeback lands
     # (sink wired to a list for v1 — the projection API reads from it directly).
     app.state.tenant_replay = TenantReplayStore(settings)
-    app.state.replay_blob_store = InMemoryReplayBlobStore()
+    app.state.replay_blob_store = _build_replay_blob_store(settings)
     app.state.replay_sample_index = []  # list[ReplaySampleRow]
     app.state.replay_runs = []  # list[ReplayRunRow]
     # Eval harness (CTO-114): pairwise-LLM-judge over the replay outputs. Opt-in like replay;

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -51,6 +51,12 @@ class Settings(BaseSettings):
     ingest_buffer_drain_batch: int = 2_000
     ingest_buffer_poll_interval_s: float = 0.05
 
+    # Replay blob-store backend (CTO-152). ``memory`` (default) uses the in-process dict store;
+    # ``gcs`` persists scrubbed replay samples to a Google Cloud Storage bucket via ADC / Workload
+    # Identity (no raw key material). ``replay_gcs_bucket`` is required when the backend is ``gcs``.
+    replay_blob_backend: str = "memory"
+    replay_gcs_bucket: str = ""
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/replay_store.py
+++ b/infra/gateway/src/gateway/replay_store.py
@@ -63,6 +63,59 @@ class InMemoryReplayBlobStore:
         return len(self._objects)
 
 
+class GCSReplayBlobStore:
+    """Google Cloud Storage backend for replay sample blobs (CTO-152).
+
+    Satisfies the same :class:`ReplayBlobStore` protocol as :class:`InMemoryReplayBlobStore`
+    (and the S3/MinIO path): objects are keyed with the identical
+    ``tenants/{tenant_id}/replay_samples/{yyyy/mm/dd}/{sample_id}.json`` layout produced by
+    :func:`build_replay_object_key`, so the ClickHouse index rows and the executor read path are
+    unchanged regardless of which backend is wired.
+
+    **PII scrub** — the pre-storage PII scrub from CTO-113 runs upstream in the sampler /
+    ``persist_sample`` ingest path, before any ``put_bytes`` call. This backend only moves already
+    scrubbed bytes, so it inherits the scrub unchanged; the CTO-125 candidate-response retention
+    carve-out likewise applies identically here.
+
+    **Auth** — no raw key material is passed. The ``google-cloud-storage`` client is constructed
+    with Application Default Credentials (ADC), so it transparently picks up Workload Identity in
+    GKE / GCE metadata credentials / a ``GOOGLE_APPLICATION_CREDENTIALS`` file / ``gcloud`` user
+    creds, in that resolution order.
+
+    **Retention** — object lifecycle (TTL / deletion) is expected to be enforced by a GCS bucket
+    lifecycle policy provisioned out-of-band (e.g. Terraform), mirroring the replay
+    ``retention_days`` knob. This backend does NOT create or manage lifecycle rules (out of scope
+    for CTO-152).
+
+    The ``google-cloud-storage`` dependency is OPTIONAL (``[gcs]`` extra) and imported lazily at
+    construction — importing this module never requires the package; only instantiating this class
+    does. That keeps the base gateway install slim and lets it boot without GCS when unused.
+    """
+
+    __slots__ = ("_bucket_name", "_bucket", "_client")
+
+    def __init__(self, bucket: str, *, client: object | None = None) -> None:
+        if not bucket:
+            raise ValueError("bucket must be non-empty")
+        if client is None:
+            # Lazy import: keep google-cloud-storage optional. Constructing the client with no
+            # explicit credentials makes it resolve Application Default Credentials (ADC) /
+            # Workload Identity automatically — we never handle a raw key here.
+            from google.cloud import storage  # type: ignore[import-not-found]
+
+            client = storage.Client()
+        self._client = client
+        self._bucket_name = bucket
+        self._bucket = client.bucket(bucket)
+
+    def put_bytes(self, key: str, body: bytes, content_type: str = "application/json") -> None:
+        blob = self._bucket.blob(key)
+        blob.upload_from_string(body, content_type=content_type)
+
+    def get_bytes(self, key: str) -> bytes:
+        return self._bucket.blob(key).download_as_bytes()
+
+
 # --- ClickHouse-side index rows --------------------------------------------------------------
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/tests/test_replay_store_gcs.py
+++ b/infra/gateway/tests/test_replay_store_gcs.py
@@ -1,0 +1,202 @@
+"""Unit tests for the GCS replay blob-store backend (CTO-152).
+
+These use an in-memory fake that mimics the ``google-cloud-storage`` client surface we touch
+(``client.bucket(name).blob(key).upload_from_string(...)`` / ``.download_as_bytes()``), so no
+network access, real bucket, or credentials are required and ``google-cloud-storage`` need not be
+installed to run the suite.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from gateway.config import Settings
+from gateway.replay_sampler import ReplaySamplePayload
+from gateway.replay_store import (
+    GCSReplayBlobStore,
+    InMemoryReplayBlobStore,
+    build_replay_object_key,
+    persist_sample,
+)
+
+UTC = timezone.utc
+
+
+# --- Fake GCS client -------------------------------------------------------------------------
+
+class _FakeBlob:
+    def __init__(self, store: dict[str, bytes], key: str) -> None:
+        self._store = store
+        self._key = key
+
+    def upload_from_string(self, body: bytes, content_type: str = "application/json") -> None:
+        self._store[self._key] = body
+
+    def download_as_bytes(self) -> bytes:
+        return self._store[self._key]
+
+
+class _FakeBucket:
+    def __init__(self, store: dict[str, bytes], name: str) -> None:
+        self._store = store
+        self.name = name
+
+    def blob(self, key: str) -> _FakeBlob:
+        return _FakeBlob(self._store, key)
+
+
+class _FakeClient:
+    """Stands in for ``google.cloud.storage.Client``. Backed by one dict per client instance."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.buckets_requested: list[str] = []
+
+    def bucket(self, name: str) -> _FakeBucket:
+        self.buckets_requested.append(name)
+        return _FakeBucket(self.objects, name)
+
+
+def _payload() -> ReplaySamplePayload:
+    return ReplaySamplePayload(
+        sample_id=uuid4(),
+        trace_id="trace-abc",
+        feature_tag="checkout",
+        real_provider="openai",
+        real_model="gpt-4o",
+        input_tokens=120,
+        output_tokens=45,
+        scrubbed_json=b'{"messages": [{"role": "user", "content": "hi"}]}',
+        pii_scrubbed=True,
+    )
+
+
+# --- Round-trip ------------------------------------------------------------------------------
+
+def test_persisted_sample_round_trips_through_gcs() -> None:
+    client = _FakeClient()
+    store = GCSReplayBlobStore(bucket="tally-replay", client=client)
+    payload = _payload()
+    captured_at = datetime(2026, 7, 12, 9, 30, tzinfo=UTC)
+
+    row = persist_sample(
+        blob_store=store,
+        tenant_id="tenant-1",
+        payload=payload,
+        captured_at=captured_at,
+    )
+
+    # Keyed identically to the in-memory/S3 path.
+    expected_key = build_replay_object_key("tenant-1", payload.sample_id, captured_at)
+    assert row.s3_object_key == expected_key
+    # Write-then-read returns the same envelope bytes.
+    assert store.get_bytes(expected_key) == payload.scrubbed_json
+
+
+def test_gcs_key_matches_in_memory_backend() -> None:
+    client = _FakeClient()
+    gcs = GCSReplayBlobStore(bucket="b", client=client)
+    mem = InMemoryReplayBlobStore()
+    payload = _payload()
+    captured_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+
+    gcs_row = persist_sample(
+        blob_store=gcs, tenant_id="t", payload=payload, captured_at=captured_at
+    )
+    mem_row = persist_sample(
+        blob_store=mem, tenant_id="t", payload=payload, captured_at=captured_at
+    )
+    assert gcs_row.s3_object_key == mem_row.s3_object_key
+    assert gcs.get_bytes(gcs_row.s3_object_key) == mem.get_bytes(mem_row.s3_object_key)
+
+
+def test_content_type_passed_and_bucket_used() -> None:
+    client = _FakeClient()
+    store = GCSReplayBlobStore(bucket="my-bucket", client=client)
+    store.put_bytes("tenants/t/x.json", b"{}", content_type="application/json")
+    assert client.objects["tenants/t/x.json"] == b"{}"
+    assert "my-bucket" in client.buckets_requested
+
+
+def test_empty_bucket_rejected() -> None:
+    with pytest.raises(ValueError):
+        GCSReplayBlobStore(bucket="", client=_FakeClient())
+
+
+# --- Backend selection via settings ----------------------------------------------------------
+
+def test_backend_selection_defaults_to_memory() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="memory")
+    store = _build_replay_blob_store(settings)
+    assert isinstance(store, InMemoryReplayBlobStore)
+
+
+def test_backend_selection_picks_gcs(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.app import _build_replay_blob_store
+
+    # Avoid needing the real client: swap the class so construction doesn't touch google-cloud.
+    captured: dict[str, str] = {}
+
+    class _StubGCS:
+        def __init__(self, bucket: str) -> None:
+            captured["bucket"] = bucket
+
+    monkeypatch.setattr("gateway.app.GCSReplayBlobStore", _StubGCS)
+    settings = Settings(replay_blob_backend="gcs", replay_gcs_bucket="tally-replay-prod")
+    store = _build_replay_blob_store(settings)
+    assert isinstance(store, _StubGCS)
+    assert captured["bucket"] == "tally-replay-prod"
+
+
+def test_gcs_backend_requires_bucket() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="gcs", replay_gcs_bucket="")
+    with pytest.raises(ValueError):
+        _build_replay_blob_store(settings)
+
+
+def test_unknown_backend_rejected() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="s4")
+    with pytest.raises(ValueError):
+        _build_replay_blob_store(settings)
+
+
+# --- Lazy import -----------------------------------------------------------------------------
+
+def test_replay_store_imports_without_google_cloud_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing replay_store must not require google-cloud-storage; only constructing the store
+    (without an injected client) does. Simulate the package being absent and re-import."""
+    # Block any google.cloud.storage import.
+    for name in list(sys.modules):
+        if name == "google" or name.startswith("google."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = importlib.import_module
+
+    def _blocking_import(name: str, *args, **kwargs):
+        if name == "google.cloud.storage" or name.startswith("google.cloud"):
+            raise ModuleNotFoundError("No module named 'google'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _blocking_import)
+
+    # Module (re)import works fine even with google-cloud-storage unavailable.
+    mod = importlib.reload(importlib.import_module("gateway.replay_store"))
+    assert hasattr(mod, "GCSReplayBlobStore")
+
+    # And an injected client sidesteps the lazy import entirely, so the store is still usable.
+    store = mod.GCSReplayBlobStore(bucket="b", client=_FakeClient())
+    store.put_bytes("k", b"v")
+    assert store.get_bytes("k") == b"v"


### PR DESCRIPTION
## Summary
Adds a Google Cloud Storage backend for replay sample blobs (CTO-113 replay), so GCP tenants keep resolved-request envelopes in GCS. Part of the GCP epic **CTO-148**.

`GCSReplayBlobStore` satisfies the same `ReplayBlobStore` protocol as `InMemoryReplayBlobStore` (and the S3/MinIO path): each sample is stored under the identical deterministic key `tenants/{tenant_id}/replay_samples/{yyyy/mm/dd}/{sample_id}.json`, and the read path mirrors the existing one. ClickHouse index rows and the executor are unchanged regardless of backend.

## Backend + settings
- New settings: `TALLY_REPLAY_BLOB_BACKEND` (`memory` default | `gcs`) and `TALLY_REPLAY_GCS_BUCKET`.
- `_build_replay_blob_store(settings)` selects the backend in the lifespan; `gcs` requires a bucket (raises otherwise). Unknown backends are rejected.

## Optional dep + lazy import
- `google-cloud-storage` is an **optional** `[gcs]` extra in `infra/gateway/pyproject.toml`, keeping the base install slim.
- `from google.cloud import storage` is imported **lazily inside `GCSReplayBlobStore.__init__`** (at construction, not module top-level), so importing `replay_store` and booting the gateway never require the package when the backend is `memory`.

## PII scrub untouched
The CTO-113 pre-storage PII scrub runs **upstream** in the sampler / `persist_sample` ingest path, before any `put_bytes`. This backend only moves already-scrubbed bytes, so it inherits the scrub unchanged — nothing duplicated or moved. The CTO-125 candidate-response retention carve-out applies identically.

## Auth
Application Default Credentials (ADC) / Workload Identity — the `storage.Client()` is constructed with no explicit credentials, so it picks up Workload Identity / metadata creds / `GOOGLE_APPLICATION_CREDENTIALS` automatically. No raw key material is passed or handled.

## Out of scope (per ticket)
No S3→GCS migration; GCS lifecycle-policy automation is documented as a recommendation in a docstring comment, not built.

## Test plan
`infra/gateway/tests/test_replay_store_gcs.py` uses an in-memory fake GCS client (no network/creds, no `google-cloud-storage` install needed):
- persisted sample round-trips (write then read returns the same envelope);
- GCS key matches the in-memory backend for the same inputs;
- backend selection picks GCS when configured, defaults to memory, requires a bucket, rejects unknown backends;
- `replay_store` imports fine without `google-cloud-storage` (only construction needs it).

```
cd infra/gateway && uv run ruff check . && uv run --extra dev pytest
```
Ruff: clean. Pytest: **278 passed** (9 new in `test_replay_store_gcs.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)