### PR TITLE
fix(chatbot-demo): refresh + fix retired model IDs (gpt-4o→gpt-5) (CTO-147)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -172,6 +172,18 @@ export ANTHROPIC_API_KEY=sk-ant-...
 cd infra && make chatbot-demo
 ```
 
+On launch the demo **refreshes the model lineup** (CTO-147): before booting the
+chatbot, `run.sh` force-refreshes the gateway's discovery cache
+(`.tally/models.json`, CTO-109) with `TALLY_MODELS_REFRESH=1` and logs the live
+OpenAI/Anthropic lineup. This keeps the picker's IDs (`app/lib/ai/models.ts`,
+which now pin `gpt-5` / `gpt-5-mini` — the retired `gpt-4o` / `gpt-4o-mini` SKUs
+are gone) and `providers.ts`'s `resolveLatest()` fallbacks from rotting. The
+refresh is **fail-soft**: offline / no API key just warns and proceeds on the
+pinned IDs. For an offline or hermetic run, either set `TALLY_SKIP_MODEL_REFRESH=1`
+to skip it, or point `TALLY_PINNED_MODELS=<path>` at a saved lineup (discovery
+loads it verbatim and skips the network). The picker list itself is still
+hardcoded; reading the cache dynamically in the model picker is a CTO-147 follow-up.
+
 The chatbot boots on `:3001` (avoiding the dashboard on `:3000`). The driver
 posts spans straight to the gateway from the chatbot's `/api/chat` route, so
 this exercises the **gateway-POST ingestion path** — distinct from Aider's

--- a/examples/vercel-chatbot/app/lib/ai/models.ts
+++ b/examples/vercel-chatbot/app/lib/ai/models.ts
@@ -3,8 +3,20 @@
 // (deepseek/, moonshotai/, openai/gpt-oss-*, xai/) all became unreachable —
 // the picker would happily select them and every send would 404. Listing the
 // real OpenAI + Anthropic models we route through @ai-sdk/* keeps the UI
-// honest. CTO-109 will replace this with a runtime fetch of the live model
-// list per provider.
+// honest.
+//
+// CTO-147: the OpenAI entries used to pin `gpt-4o` / `gpt-4o-mini`, which the
+// provider has since retired — `make chatbot-demo` 404'd on every OpenAI send.
+// They're now `gpt-5` / `gpt-5-mini` (both priced in tally.pricing.seed_catalog,
+// so dashboard cost stays non-zero). run.sh refreshes .tally/models.json on each
+// launch (TALLY_MODELS_REFRESH=1) so operators see the live lineup logged and
+// providers.ts's resolveLatest() fallbacks track the current cheapest in-family
+// id. This picker list is still hardcoded (the source of truth for the UI);
+// wiring it to read the cache dynamically without rearchitecting the Vercel
+// template's model picker is the CTO-147 follow-up. Every id below MUST exist in
+// seed_catalog() or its cost silently drops to $0.
+//
+// CTO-109 owns the gateway/SDK discovery that writes the cache.
 export const DEFAULT_CHAT_MODEL = "anthropic/claude-sonnet-4-5";
 
 export const titleModel = {
@@ -53,16 +65,16 @@ export const chatModels: ChatModel[] = [
     description: "Anthropic's most capable model — slower, pricier",
   },
   {
-    id: "openai/gpt-4o-mini",
-    name: "GPT-4o mini",
+    id: "openai/gpt-5-mini",
+    name: "GPT-5 mini",
     provider: "openai",
     description: "OpenAI cheap-and-fast — needs OPENAI_API_KEY with credit",
   },
   {
-    id: "openai/gpt-4o",
-    name: "GPT-4o",
+    id: "openai/gpt-5",
+    name: "GPT-5",
     provider: "openai",
-    description: "OpenAI flagship multimodal — needs OPENAI_API_KEY with credit",
+    description: "OpenAI flagship — needs OPENAI_API_KEY with credit",
   },
 ];
 

--- a/examples/vercel-chatbot/app/lib/ai/providers.ts
+++ b/examples/vercel-chatbot/app/lib/ai/providers.ts
@@ -31,7 +31,10 @@ const DEFAULT_PROVIDER = process.env.TALLY_DEMO_PROVIDER ?? "anthropic";
 // CTO-109: prefer the gateway's auto-discovered cache so a provider retiring
 // a SKU doesn't break this route. The literal ids are last-resort fallbacks.
 const FALLBACK_ANTHROPIC = resolveLatest("anthropic", "sonnet", "claude-sonnet-4-5");
-const FALLBACK_OPENAI = resolveLatest("openai", "mini", "gpt-4o-mini");
+// CTO-147: last-resort literal bumped gpt-4o-mini → gpt-5-mini (the 4o SKUs were
+// retired). resolveLatest() still prefers the live cache when .tally/models.json
+// is present; this literal only bites when discovery has never run.
+const FALLBACK_OPENAI = resolveLatest("openai", "mini", "gpt-5-mini");
 const FALLBACK_ANTHROPIC_TITLE = resolveLatest("anthropic", "haiku", "claude-haiku-4-5");
 
 function resolve(modelId: string) {

--- a/examples/vercel-chatbot/run.sh
+++ b/examples/vercel-chatbot/run.sh
@@ -30,6 +30,45 @@ if ! curl -fsS --max-time 3 "${GATEWAY_HEALTH}" >/dev/null; then
   err "ai-tally gateway not reachable at ${GATEWAY_HEALTH}. Run 'make up' from infra/ first."
 fi
 
+# CTO-147: refresh the model lineup before launch so the picker's pinned IDs
+# (lib/ai/models.ts) and providers.ts's resolveLatest() fallbacks track what the
+# providers currently advertise — this is what stops the gpt-4o/gpt-4o-mini class
+# of "provider retired the SKU, every send 404s" breakage from silently returning.
+# We force-refresh the gateway's discovery cache (.tally/models.json, CTO-109) by
+# calling tally.models.discover_models with TALLY_MODELS_REFRESH=1 (bypasses the
+# 24h TTL) and log the resulting lineup so operators see the live list.
+#
+# Fail-soft (mirrors CTO-109): offline / no API key / SDK import error just warns
+# and proceeds with the corrected pinned IDs. Set TALLY_PINNED_MODELS=<path> for
+# hermetic/offline runs — discover_models loads it verbatim and skips the network.
+# Skip entirely with TALLY_SKIP_MODEL_REFRESH=1.
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+MODELS_CACHE="${TALLY_MODELS_CACHE:-${REPO_ROOT}/.tally/models.json}"
+if [ "${TALLY_SKIP_MODEL_REFRESH:-0}" = "1" ]; then
+  echo "→ Skipping model-lineup refresh (TALLY_SKIP_MODEL_REFRESH=1); using pinned IDs."
+else
+  echo "→ Refreshing model lineup (.tally/models.json)…"
+  TALLY_SDK_SRC="${REPO_ROOT}/sdk/python/src" TALLY_MODELS_CACHE="${MODELS_CACHE}" \
+    TALLY_MODELS_REFRESH=1 python3 - <<'PY' || echo "  ⚠ model refresh failed — continuing with pinned IDs (see lib/ai/models.ts)" >&2
+import os, sys
+from pathlib import Path
+sys.path.insert(0, os.environ["TALLY_SDK_SRC"])
+try:
+    from tally import models as M
+except Exception as exc:  # SDK not importable — fail soft.
+    print(f"  ⚠ could not import tally.models ({exc}) — using pinned IDs", file=sys.stderr)
+    sys.exit(0)
+cache = Path(os.environ["TALLY_MODELS_CACHE"])
+found = M.discover_models(cache_path=cache)  # honors TALLY_MODELS_REFRESH / TALLY_PINNED_MODELS
+if not found:
+    print("  ⚠ discovery returned no models (offline / no key?) — using pinned IDs", file=sys.stderr)
+    sys.exit(0)
+oi = sorted(m.id for m in found if m.provider == "openai")
+an = sorted(m.id for m in found if m.provider == "anthropic")
+print(f"  ✓ lineup refreshed: openai={oi} anthropic={an}")
+PY
+fi
+
 if curl -fsS --max-time 2 "${CHATBOT_URL}/api/demo-chat" -X POST \
     -H 'content-type: application/json' -d '{"sessionId":"probe","prompt":"hi","provider":"openai","dryRun":true}' \
     >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
`make chatbot-demo` was 404'ing on **gpt-4o** and **gpt-4o-mini** — the chatbot's own picker (`examples/vercel-chatbot/app/lib/ai/models.ts`) hardcoded model IDs the provider has retired. This fixes the immediate breakage and adds a pre-launch refresh so the lineup doesn't rot again.

## The ID swaps + catalog cross-check
In `models.ts` `chatModels`:
- `openai/gpt-4o-mini` → `openai/gpt-5-mini`
- `openai/gpt-4o` → `openai/gpt-5`

`providers.ts` last-resort fallback literal `resolveLatest("openai","mini", …)` bumped `gpt-4o-mini` → `gpt-5-mini`. Anthropic entries (`claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-8`) and `DEFAULT_CHAT_MODEL` were already current.

**Every selectable id is priced in `seed_catalog()`** — cross-checked at build time via `PriceCatalog.lookup()`:

| id (stripped) | seed_catalog |
|---|---|
| claude-sonnet-4-5 | ✅ |
| claude-haiku-4-5 | ✅ |
| claude-opus-4-8 | ✅ |
| gpt-5-mini | ✅ |
| gpt-5 | ✅ |

No new catalog entries needed (both gpt-5 SKUs were already seeded for CTO-106).

## Pre-launch refresh step
`run.sh` (which the Makefile `chatbot-demo` target invokes) now force-refreshes the gateway's CTO-109 discovery cache **before booting the chatbot**: it calls `tally.models.discover_models` with `TALLY_MODELS_REFRESH=1` (bypasses the 24h TTL), regenerates `.tally/models.json`, and logs the live `openai=[…] anthropic=[…]` lineup so operators see the current list each run.

## Fail-soft
Mirrors CTO-109: offline / no API key / SDK-import error just prints a warning and proceeds on the corrected pinned IDs — never blocks the demo. Escape hatches: `TALLY_PINNED_MODELS=<path>` (hermetic — loads a saved lineup, skips the network) and `TALLY_SKIP_MODEL_REFRESH=1`. Both the pinned and fail-soft paths were exercised locally.

## Docs
RUNNING.md Step 6 updated: the demo refreshes the lineup on launch, and how to pin for offline/hermetic runs.

## Dynamic resolution: deferred
The picker list stays hardcoded (the UI's source of truth). Wiring it to read `.tally/models.json` dynamically would rearchitect the Vercel template's model picker (out of scope) — corrected IDs + refresh + doc for v1, follow-up noted in a code comment.

## Verify
- `bash -n run.sh` ✅, `make -n chatbot-demo` ✅
- Every `chatModels` id resolves in `seed_catalog()` ✅
- Refresh snippet: pinned path logs lineup, bad-import path exits 0 ✅
- `tsc --noEmit` skipped (app `node_modules` absent per ticket); TS changes are string-literal swaps + comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)