### PR TITLE
feat(sdk): Gemini / Vertex AI as a first-class LLM cost provider (CTO-149)

### DIFF
--- a/infra/gateway/tests/test_enrich_gemini.py
+++ b/infra/gateway/tests/test_enrich_gemini.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gateway cost enrichment for Google Gemini spans (CTO-149).
+
+The gateway recomputes cost from the catalog in ``enrich_cost``. A span with
+``gen_ai.system="google"`` and a seeded gemini model must price to a non-zero cost with
+no ``catalog_miss`` — proving Google needs no special-casing in the mapping/enrich path
+(provider is just the catalog lookup key).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from tally.enrichment import enrich_cost
+from tally.pricing import seed_catalog
+from tally.schema import GenAI
+
+from gateway.mapping import span_to_row
+
+AT = date(2026, 6, 1)
+
+
+def _span(model: str, input_tokens: int = 1000, output_tokens: int = 250) -> dict[str, object]:
+    return {
+        GenAI.SYSTEM: "google",
+        GenAI.REQUEST_MODEL: model,
+        GenAI.RESPONSE_MODEL: model,
+        GenAI.USAGE_INPUT_TOKENS: input_tokens,
+        GenAI.USAGE_OUTPUT_TOKENS: output_tokens,
+    }
+
+
+def test_enrich_gemini_3_flash_no_catalog_miss() -> None:
+    res = enrich_cost(_span("gemini-3-flash"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enrich_gemini_2_5_pro_no_catalog_miss() -> None:
+    res = enrich_cost(_span("gemini-2.5-pro"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enriched_gemini_span_maps_to_row_with_cost() -> None:
+    # End-to-end through the mapping: enriched google span -> otel row with a non-zero
+    # EstimatedCost and GenAiSystem="google".
+    res = enrich_cost(_span("gemini-3-flash", 1_000_000, 1_000_000), seed_catalog(), at=AT)
+    row = span_to_row(res.attributes, tenant_id="tn-1", effective_ts_ns=1_700_000_000_000_000_000)
+    from gateway.mapping import COLUMNS
+
+    by_col = dict(zip(COLUMNS, row, strict=True))
+    assert by_col["GenAiSystem"] == "google"
+    assert by_col["GenAiRequestModel"] == "gemini-3-flash"
+    assert by_col["EstimatedCost"] > 0

--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -155,6 +155,13 @@ class TallyClient:
     ) -> LlmCallResult:
         """Record an LLM call end-to-end. Never raises.
 
+        ``provider`` is a free-form string used verbatim as ``gen_ai.system`` and as the
+        catalog lookup key — there is no provider allowlist, so any provider the catalog
+        prices (``"openai"``, ``"anthropic"``, ``"google"``, ...) works. Gemini / Vertex AI
+        callers pass ``provider="google"`` and map the Google usage fields onto ``Usage``:
+        ``promptTokenCount`` -> ``input_tokens``, ``candidatesTokenCount`` -> ``output_tokens``,
+        ``cachedContentTokenCount`` -> ``cached_input_tokens`` (CTO-149).
+
         Steps (all inside the safety boundary):
           1. read trace context (note a drop if no active trace),
           2. count the trace for billing at HEAD (before sampling),

--- a/sdk/python/src/tally/models.py
+++ b/sdk/python/src/tally/models.py
@@ -15,7 +15,8 @@ Discovery flow (see :func:`discover_models`):
 The SDK is dep-light (no ``httpx``/``requests``), so this module uses ``urllib.request``
 just like ``examples/aider-demo/_emit_batch.py``.
 
-API keys come from ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``. They are never logged.
+API keys come from ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` / ``GOOGLE_API_KEY`` (or
+``GEMINI_API_KEY``). They are never logged.
 
 Env overrides:
     ``TALLY_MODELS_REFRESH=1``      — bypass the cache TTL, always fetch live.
@@ -48,7 +49,7 @@ DEFAULT_CACHE_PATH = Path(".tally/models.json")
 class ModelInfo:
     """A single model entry as returned by a provider's ``/v1/models`` endpoint."""
 
-    provider: str  # "openai" | "anthropic"
+    provider: str  # "openai" | "anthropic" | "google"
     id: str  # canonical id, e.g. "claude-sonnet-4-5" or "gpt-4o-mini"
     family: str  # see classify_family()
     created_at: datetime | None
@@ -83,6 +84,11 @@ _FAMILY_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"sonnet", re.I), "sonnet"),
     (re.compile(r"opus", re.I), "opus"),
     (re.compile(r"(text-embedding|embedding)", re.I), "embedding"),
+    # Google Gemini families (CTO-149). "flash" is the cheap/fast tier, "pro" the
+    # flagship. These sit ahead of "mini"/flagship so a Gemini id never lands in an
+    # OpenAI-shaped bucket.
+    (re.compile(r"flash", re.I), "flash"),
+    (re.compile(r"gemini.*pro|pro.*gemini", re.I), "pro"),
     (re.compile(r"mini", re.I), "mini"),
     (re.compile(r"^gpt-4o(?!-mini)", re.I), "flagship"),
     (re.compile(r"^gpt-5(?!-mini)", re.I), "flagship"),
@@ -180,6 +186,44 @@ def fetch_anthropic_models(api_key: str, *, timeout: float = 5.0) -> list[ModelI
     return out
 
 
+def fetch_google_models(api_key: str, *, timeout: float = 5.0) -> list[ModelInfo]:
+    """Hit Google's Gemini ``GET /v1beta/models`` and return the parsed lineup.
+
+    The Gemini API returns ``{"models": [{"name": "models/gemini-2.5-flash", ...}]}`` — the
+    id lives under ``name`` with a ``models/`` prefix that we strip to the bare id (so it
+    matches the catalog + Compare ``gemini-*`` slugs). The key is passed as the ``?key=``
+    query param (Gemini's convention), not a bearer header. There's no per-model created/
+    deprecated timestamp in the list response, so both are left ``None``.
+
+    Parsing is deliberately tolerant: the Vertex/Gemini list shape has shifted across API
+    versions, so anything without a usable id is skipped rather than raising.
+    """
+    payload = _http_get_json(
+        f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
+        headers={},
+        timeout=timeout,
+    )
+    out: list[ModelInfo] = []
+    for row in payload.get("models", []):
+        raw_id = row.get("name") or row.get("id")
+        if not raw_id or not isinstance(raw_id, str):
+            continue
+        # "models/gemini-2.5-flash" -> "gemini-2.5-flash"
+        model_id = raw_id.split("/", 1)[-1] if raw_id.startswith("models/") else raw_id
+        if not model_id:
+            continue
+        out.append(
+            ModelInfo(
+                provider="google",
+                id=model_id,
+                family=classify_family(model_id),
+                created_at=None,
+                deprecated_at=None,
+            )
+        )
+    return out
+
+
 def save_cache(models: list[ModelInfo], path: Path = DEFAULT_CACHE_PATH) -> None:
     """Persist the discovered list to ``path`` (creating parent dirs)."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -260,6 +304,7 @@ def discover_models(
     cache_path: Path = DEFAULT_CACHE_PATH,
     openai_api_key: str | None = None,
     anthropic_api_key: str | None = None,
+    google_api_key: str | None = None,
     timeout: float = 5.0,
 ) -> list[ModelInfo]:
     """Boot-time discovery entry point. Fail-soft on every error path.
@@ -288,10 +333,14 @@ def discover_models(
 
     openai_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
     anthropic_key = anthropic_api_key or os.environ.get("ANTHROPIC_API_KEY")
+    google_key = (
+        google_api_key or os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+    )
 
     discovered: list[ModelInfo] = []
     openai_err: Exception | None = None
     anthropic_err: Exception | None = None
+    google_err: Exception | None = None
 
     if openai_key:
         try:
@@ -311,6 +360,20 @@ def discover_models(
     else:
         logger.info("models: ANTHROPIC_API_KEY not set — skipping anthropic discovery")
 
+    if google_key:
+        try:
+            discovered.extend(fetch_google_models(google_key, timeout=timeout))
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+            google_err = exc
+            logger.warning("models: google fetch failed: %s", exc)
+        except (KeyError, TypeError, ValueError) as exc:
+            # Defensive: the Gemini/Vertex list shape has drifted across versions.
+            # A malformed body should skip Google, not crash discovery.
+            google_err = exc
+            logger.warning("models: google parse failed: %s", exc)
+    else:
+        logger.info("models: GOOGLE_API_KEY/GEMINI_API_KEY not set — skipping google discovery")
+
     if discovered:
         try:
             save_cache(discovered, cache_path)
@@ -324,17 +387,21 @@ def discover_models(
     stale = _load_unchecked(cache_path)
     if stale is not None:
         logger.warning(
-            "models: live fetch failed (openai=%s anthropic=%s) — using stale cache (%d entries)",
+            "models: live fetch failed (openai=%s anthropic=%s google=%s) — "
+            "using stale cache (%d entries)",
             openai_err,
             anthropic_err,
+            google_err,
             len(stale),
         )
         return stale
 
     logger.warning(
-        "models: no live data and no cache (openai=%s anthropic=%s) — booting with empty list",
+        "models: no live data and no cache (openai=%s anthropic=%s google=%s) — "
+        "booting with empty list",
         openai_err,
         anthropic_err,
+        google_err,
     )
     return []
 
@@ -342,7 +409,8 @@ def discover_models(
 def _log_summary(models: list[ModelInfo]) -> None:
     openai_ids = sorted(m.id for m in models if m.provider == "openai")
     anth_ids = sorted(m.id for m in models if m.provider == "anthropic")
-    logger.info("models: openai=%s anthropic=%s", openai_ids, anth_ids)
+    google_ids = sorted(m.id for m in models if m.provider == "google")
+    logger.info("models: openai=%s anthropic=%s google=%s", openai_ids, anth_ids, google_ids)
 
 
 __all__ = [
@@ -350,6 +418,7 @@ __all__ = [
     "classify_family",
     "fetch_openai_models",
     "fetch_anthropic_models",
+    "fetch_google_models",
     "save_cache",
     "load_cached",
     "latest",

--- a/sdk/python/src/tally/pricing.py
+++ b/sdk/python/src/tally/pricing.py
@@ -290,7 +290,7 @@ _VECTOR_SEEDS: list[tuple[str, str, PriceType, str]] = [
 
 
 def seed_catalog() -> PriceCatalog:
-    """Multi-provider seed catalog (OpenAI + Anthropic).
+    """Multi-provider seed catalog (OpenAI + Anthropic + Google Gemini/Vertex).
 
     Expanded for CTO-106; previously the gpt-5-mini pinning workaround in
     examples/* was needed because of catalog gaps. The scraper (CTO-53) will
@@ -340,6 +340,30 @@ def seed_catalog() -> PriceCatalog:
         ("anthropic", "claude-opus-4-8", PriceType.INPUT, "15.00"),
         ("anthropic", "claude-opus-4-8", PriceType.CACHED_INPUT, "1.50"),
         ("anthropic", "claude-opus-4-8", PriceType.OUTPUT, "75.00"),
+        # --- Google Gemini / Vertex AI (https://ai.google.dev/pricing) --------
+        # CTO-149. Provider string "google" matches gen_ai.system and the Compare
+        # mock's provider: "google". Gemini exposes both the Gemini API and Vertex
+        # AI; per-token rates are the same across both surfaces (Vertex bills the
+        # identical published rate), so one catalog entry covers both. Gemini's
+        # "context cache" read tier maps to CACHED_INPUT (the steady-state read
+        # price for repeated prompts); the one-shot cache-storage fee is not
+        # modeled by the current PriceType enum. Text tokens only for v1
+        # (multimodal token accounting is out of scope). Usage field mapping:
+        # promptTokenCount -> input, candidatesTokenCount -> output,
+        # cachedContentTokenCount -> cached_input. All rates
+        # [unverified at implementation time] — taken from training-data values
+        # for the published per-MTok prices; update once the scraper (CTO-53) lands.
+        ("google", "gemini-2.5-flash", PriceType.INPUT, "0.30"),
+        ("google", "gemini-2.5-flash", PriceType.CACHED_INPUT, "0.075"),
+        ("google", "gemini-2.5-flash", PriceType.OUTPUT, "2.50"),
+        ("google", "gemini-2.5-pro", PriceType.INPUT, "1.25"),
+        ("google", "gemini-2.5-pro", PriceType.CACHED_INPUT, "0.31"),
+        ("google", "gemini-2.5-pro", PriceType.OUTPUT, "10.00"),
+        # gemini-3-flash — the id the /compare mock lists. Priced in line with the
+        # 2.5-flash tier pending a verified published rate. [unverified at implementation time]
+        ("google", "gemini-3-flash", PriceType.INPUT, "0.30"),
+        ("google", "gemini-3-flash", PriceType.CACHED_INPUT, "0.075"),
+        ("google", "gemini-3-flash", PriceType.OUTPUT, "2.50"),
     ]
     for provider, model, pt, rate in seeds:
         cat.add(_mtok(provider, model, pt, rate))

--- a/sdk/python/tests/fixtures/google_models.json
+++ b/sdk/python/tests/fixtures/google_models.json
@@ -1,0 +1,24 @@
+{
+  "models": [
+    {
+      "name": "models/gemini-2.5-flash",
+      "displayName": "Gemini 2.5 Flash",
+      "supportedGenerationMethods": ["generateContent"]
+    },
+    {
+      "name": "models/gemini-2.5-pro",
+      "displayName": "Gemini 2.5 Pro",
+      "supportedGenerationMethods": ["generateContent"]
+    },
+    {
+      "name": "models/gemini-3-flash",
+      "displayName": "Gemini 3 Flash",
+      "supportedGenerationMethods": ["generateContent"]
+    },
+    {
+      "name": "models/embedding-001",
+      "displayName": "Embedding 001",
+      "supportedGenerationMethods": ["embedContent"]
+    }
+  ]
+}

--- a/sdk/python/tests/test_gemini_provider.py
+++ b/sdk/python/tests/test_gemini_provider.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Google Gemini / Vertex AI as a first-class LLM cost provider (CTO-149).
+
+Covers the three things the ticket asks the SDK side to prove:
+  1. the seed catalog prices the Gemini lineup (non-zero, correct against the seeded rates);
+  2. ``record_llm_call(provider="google", ...)`` costs from the catalog and stamps
+     ``gen_ai.system="google"`` on a conformant span — no provider allowlist to trip over;
+  3. model discovery classifies a mocked Google model list into flash/pro and fails soft.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from tally import models as M
+from tally.client import MemoryExporter, TallyClient
+from tally.context import with_trace_context
+from tally.pricing import (
+    PriceType,
+    Usage,
+    compute_cost_micro_usd,
+    seed_catalog,
+)
+from tally.sampling import Sampler, SamplingConfig
+from tally.schema import GenAI, validate_span_attributes
+
+FIXTURES = Path(__file__).parent / "fixtures"
+AT = date(2026, 6, 1)
+
+
+# --- Price catalog ------------------------------------------------------------
+
+
+def test_gemini_3_flash_priced_correctly() -> None:
+    cat = seed_catalog()
+    # 1M input @ $0.30/MTok + 1M output @ $2.50/MTok = $2.80 = 2_800_000 micro-USD.
+    cost, version = compute_cost_micro_usd(
+        cat, "google", "gemini-3-flash", Usage(1_000_000, 1_000_000), at=AT
+    )
+    assert cost == 2_800_000
+    assert version  # a real catalog version, not the empty "partial price" sentinel
+
+
+def test_gemini_2_5_pro_priced_correctly() -> None:
+    cat = seed_catalog()
+    # 1M input @ $1.25/MTok + 1M output @ $10.00/MTok = $11.25 = 11_250_000 micro-USD.
+    cost, version = compute_cost_micro_usd(
+        cat, "google", "gemini-2.5-pro", Usage(1_000_000, 1_000_000), at=AT
+    )
+    assert cost == 11_250_000
+    assert version
+
+
+def test_gemini_2_5_flash_has_cached_tier() -> None:
+    cat = seed_catalog()
+    cached = cat.lookup("google", "gemini-2.5-flash", PriceType.CACHED_INPUT, at=AT)
+    standard = cat.lookup("google", "gemini-2.5-flash", PriceType.INPUT, at=AT)
+    assert cached is not None and standard is not None
+    # cached read tier must be cheaper than the standard input tier
+    assert cached.price_per_unit < standard.price_per_unit
+
+
+def test_gemini_cost_is_nonzero_for_small_usage() -> None:
+    cat = seed_catalog()
+    for model in ("gemini-2.5-flash", "gemini-2.5-pro", "gemini-3-flash"):
+        cost, version = compute_cost_micro_usd(cat, "google", model, Usage(1000, 250), at=AT)
+        assert cost > 0, model
+        assert version, model
+
+
+def test_gemini_rates_are_decimal() -> None:
+    # Money is Decimal, never float (guards against a stray float rate slipping into the seed).
+    cat = seed_catalog()
+    entry = cat.lookup("google", "gemini-3-flash", PriceType.OUTPUT, at=AT)
+    assert entry is not None
+    assert isinstance(entry.price_per_unit, Decimal)
+
+
+# --- Provider path (record_llm_call) ------------------------------------------
+
+
+def _client(**kw) -> TallyClient:
+    return TallyClient(catalog=seed_catalog(), **kw)
+
+
+def test_record_llm_call_google_costs_from_catalog() -> None:
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t1", feature_tag="compare", session_id="s1"):
+        result = client.record_llm_call(
+            provider="google",
+            model="gemini-3-flash",
+            usage=Usage(input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+    assert result.kept is True
+    assert result.cost_micro_usd == 2_800_000
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    assert span[GenAI.SYSTEM] == "google"
+    assert span[GenAI.COST_ESTIMATED_MICRO_USD] == 2_800_000
+
+
+def test_record_llm_call_google_maps_cached_tokens() -> None:
+    # cachedContentTokenCount -> cached_input_tokens; billed at the cheaper cached rate.
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t2"):
+        full = client.record_llm_call(
+            provider="google",
+            model="gemini-2.5-flash",
+            usage=Usage(input_tokens=1_000_000, output_tokens=0),
+        )
+        cached = client.record_llm_call(
+            provider="google",
+            model="gemini-2.5-flash",
+            usage=Usage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=1_000_000),
+        )
+    assert full.cost_micro_usd is not None and cached.cost_micro_usd is not None
+    # A fully-cached prompt costs strictly less than the same prompt uncached.
+    assert cached.cost_micro_usd < full.cost_micro_usd
+
+
+# --- Model discovery ----------------------------------------------------------
+
+
+def _fake_urlopen_factory(payloads_by_url: dict[str, dict]):
+    class _Resp:
+        def __init__(self, body: bytes):
+            self._buf = io.BytesIO(body)
+
+        def read(self) -> bytes:
+            return self._buf.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for prefix, payload in payloads_by_url.items():
+            if url.startswith(prefix):
+                return _Resp(json.dumps(payload).encode("utf-8"))
+        raise AssertionError(f"unexpected URL {url}")
+
+    return fake_urlopen
+
+
+def test_classify_gemini_families() -> None:
+    assert M.classify_family("gemini-2.5-flash") == "flash"
+    assert M.classify_family("gemini-3-flash") == "flash"
+    assert M.classify_family("gemini-2.5-pro") == "pro"
+
+
+def test_fetch_google_parses_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.loads((FIXTURES / "google_models.json").read_text())
+    monkeypatch.setattr(
+        M.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory(
+            {"https://generativelanguage.googleapis.com/v1beta/models": payload}
+        ),
+    )
+    out = M.fetch_google_models("fake-key")
+    ids = {m.id for m in out}
+    # "models/" prefix stripped to the bare catalog/Compare slug.
+    assert "gemini-2.5-flash" in ids
+    assert "gemini-2.5-pro" in ids
+    assert "gemini-3-flash" in ids
+    assert all(m.provider == "google" for m in out)
+    # Families are classified so latest("google", ...) can resolve them.
+    flash = M.latest("google", "flash", out)
+    pro = M.latest("google", "pro", out)
+    assert flash is not None and flash.family == "flash"
+    assert pro is not None and pro.id == "gemini-2.5-pro"
+
+
+def test_discover_includes_google_when_key_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = json.loads((FIXTURES / "google_models.json").read_text())
+    monkeypatch.setattr(
+        M.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory(
+            {"https://generativelanguage.googleapis.com/v1beta/models": payload}
+        ),
+    )
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(cache_path=tmp_path / "models.json")
+    google_ids = {m.id for m in result if m.provider == "google"}
+    assert "gemini-3-flash" in google_ids
+
+
+def test_discover_uses_gemini_api_key_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = json.loads((FIXTURES / "google_models.json").read_text())
+    monkeypatch.setattr(
+        M.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory(
+            {"https://generativelanguage.googleapis.com/v1beta/models": payload}
+        ),
+    )
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(cache_path=tmp_path / "models.json")
+    assert any(m.provider == "google" for m in result)
+
+
+def test_discover_google_fails_soft_on_network_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Google unreachable + no cache → empty list, no crash (fail-soft, like the others).
+    def boom(req, timeout=None):  # noqa: ARG001
+        raise TimeoutError("gemini is down")
+
+    monkeypatch.setattr(M.urllib.request, "urlopen", boom)
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(cache_path=tmp_path / "absent.json")
+    assert result == []
+
+
+def test_discover_google_fails_soft_on_malformed_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A body missing the "models" key must not crash — tolerant parsing skips Google.
+    monkeypatch.setattr(
+        M.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory(
+            {"https://generativelanguage.googleapis.com/v1beta/models": {"unexpected": []}}
+        ),
+    )
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(cache_path=tmp_path / "absent.json")
+    # No google models, but no crash either.
+    assert [m for m in result if m.provider == "google"] == []

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -34,6 +34,9 @@ def test_classify_family_truth_table() -> None:
         "text-embedding-3-large": "embedding",
         "gpt-5": "flagship",
         "ft:gpt-3.5-turbo:acme": "other",
+        "gemini-2.5-flash": "flash",
+        "gemini-3-flash": "flash",
+        "gemini-2.5-pro": "pro",
     }
     for model_id, expected in cases.items():
         assert M.classify_family(model_id) == expected, model_id

--- a/sdk/python/tests/test_pricing_seeds.py
+++ b/sdk/python/tests/test_pricing_seeds.py
@@ -91,6 +91,26 @@ def test_claude_opus_4_8_priced() -> None:
     _cost("anthropic", "claude-opus-4-8")
 
 
+# --- Google Gemini / Vertex AI (CTO-149) ----
+
+
+def test_gemini_2_5_flash_priced() -> None:
+    _cost("google", "gemini-2.5-flash")
+
+
+def test_gemini_2_5_pro_priced() -> None:
+    _cost("google", "gemini-2.5-pro")
+
+
+def test_gemini_3_flash_priced() -> None:
+    # The id the /compare mock lists — must not be a catalog miss.
+    _cost("google", "gemini-3-flash")
+
+
+def test_gemini_flash_cheaper_than_pro() -> None:
+    assert _cost("google", "gemini-2.5-flash") < _cost("google", "gemini-2.5-pro")
+
+
 # --- Family-classifier intuition ----
 
 


### PR DESCRIPTION
## Summary

Makes Google Gemini (Gemini API + Vertex AI) a real, priced, discoverable LLM cost provider so Gemini spend costs correctly like any other LLM call. Provider string is `"google"`, consistent with `gen_ai.system` and the `/compare` mock's `provider: "google"`. Part of epic **CTO-148**.

The provider path is fully catalog-driven — `record_llm_call` has **no provider allowlist**, so `record_llm_call(provider="google", ...)` prices from the catalog and the gateway's `enrich_cost` costs it with **no special-casing**.

## Seeded Gemini models + rates (USD per MTok)

All rates `# [unverified at implementation time]` — taken from training-data values for the published prices; the scraper (CTO-53) will own these.

| model | input | cached_input | output |
|---|---|---|---|
| `gemini-2.5-flash` | 0.30 | 0.075 | 2.50 |
| `gemini-2.5-pro` | 1.25 | 0.31 | 10.00 |
| `gemini-3-flash` | 0.30 | 0.075 | 2.50 |

`gemini-3-flash` is the id the Compare mock lists; priced in line with the 2.5-flash tier pending a verified rate. Gemini's context-cache read tier maps to `CACHED_INPUT`; the one-shot cache-storage fee is not modeled by the current `PriceType` enum. Text tokens only for v1 (multimodal accounting out of scope).

## Discovery extension

`fetch_google_models()` hits the Gemini `GET /v1beta/models` list endpoint (key via the `?key=` query param, Gemini's convention), strips the `models/` prefix to the bare slug, and classifies ids into new **`flash`** / **`pro`** families. Keyed off `GOOGLE_API_KEY` or `GEMINI_API_KEY`. Wired into `discover_models()` with the same fail-soft behavior as OpenAI/Anthropic — unreachable, no key, or a malformed body → skip Google, no crash. Parsing is deliberately tolerant since the Vertex/Gemini list shape has drifted across API versions.

## Provider path

`record_llm_call(provider="google", model="gemini-3-flash", usage=Usage(...))` produces a conformant span carrying `gen_ai.system="google"` and a non-zero `EstimatedCost` from the catalog. A docstring note on `record_llm_call` documents the Gemini/Vertex usage field mapping: `promptTokenCount`→input, `candidatesTokenCount`→output, `cachedContentTokenCount`→cached_input (the caller maps onto `Usage`).

## Test plan

- `sdk/python/tests/test_gemini_provider.py` — cost calc for `gemini-3-flash` (2.8M micro) / `gemini-2.5-pro` (11.25M micro) against seeded rates; `record_llm_call(provider="google")` span carries `gen_ai.system="google"` + non-zero cost; cached-token discount; discovery classifies a mocked Google list into flash/pro; fail-soft on network error, `GEMINI_API_KEY` alias, and malformed body.
- `infra/gateway/tests/test_enrich_gemini.py` — `gen_ai.system="google"` + a seeded gemini model → non-zero cost, no `catalog_miss`, and maps to an `otel_spans` row with `GenAiSystem="google"` and `EstimatedCost > 0`.
- Extended `test_pricing_seeds.py` and `test_models.py` (classifier truth table).

```
sdk/python:    877 passed, ruff clean
infra/gateway: 272 passed, ruff clean
```

## Still stubbed

- Rates are `[unverified at implementation time]` pending the scraper (CTO-53).
- Vertex Vector Search (CTO-151) and multimodal token accounting are out of scope.
- `/compare` candidate list untouched (kept `provider: "google"` consistent only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)