### PR TITLE
feat(deploy): GCP deployment — GKE / Cloud Run + Secret Manager + Workload Identity (CTO-153)

### DIFF
--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,297 @@
+# Deploying ai-tally on GCP (GKE or Cloud Run)
+
+A from-zero runbook for running ai-tally's two application tiers — the **ingest gateway**
+(FastAPI/uvicorn) and the **Next.js dashboard** — on Google Cloud, wired to GCP-managed backing
+stores and GCP-native secrets + identity. This is the cloud counterpart to the local
+[`RUNNING.md`](../../RUNNING.md); the pipeline shape is identical, only the backing services change:
+
+```
+ send_batch / SDK ──POST /v1/batches──▶  gateway (Cloud Run svc or GKE Deployment)
+                                              │  auth → rate-limit → idempotency →
+                                              │  validate → enrich cost → map to row
+                                              ▼
+                                         ClickHouse  (ClickHouse Cloud, or in-cluster StatefulSet)
+                                              ▲
+   browser ──▶ Next.js web ──Route Handler──┘   (queries ClickHouse live + calls the gateway)
+
+ control plane:  Postgres  ──▶  Cloud SQL for Postgres
+ replay blobs:   object store ─▶ GCS bucket (CTO-152)
+ secrets:        provider keys / DB creds ─▶ Secret Manager  (consumed via Workload Identity)
+```
+
+Everything here is **additive** — it does not touch `infra/docker-compose.yml`, the app source, or the
+local dev flow. It reuses the conventions of the existing `infra/edge-proxy` Helm chart.
+
+## What's in this directory
+
+```
+deploy/gcp/
+├── README.md                       this runbook
+├── helm/ai-tally/                  GKE Helm chart (gateway + web + optional ClickHouse StatefulSet)
+│   ├── Chart.yaml
+│   ├── values.yaml                 all knobs, documented
+│   ├── values-gke.example.yaml     a filled-in example override file
+│   └── templates/                  Deployments, Services, ConfigMaps, ServiceAccount (Workload
+│                                   Identity), SecretProviderClass (Secret Manager via CSI), HPAs
+└── cloudrun/                       Cloud Run service YAMLs
+    ├── gateway.service.yaml
+    └── web.service.yaml
+```
+
+The gateway image already ships (`infra/gateway/Dockerfile`). The web image is built from the
+**new** `web/Dockerfile` added by this ticket (multi-stage Next.js standalone build).
+
+## GKE vs Cloud Run — which to pick
+
+| Pick **Cloud Run** when… | Pick **GKE** when… |
+|---|---|
+| You want the least ops: no cluster to manage, scale-to-N, per-request billing. | You already run a GKE cluster / want pods next to other in-cluster services. |
+| Traffic is spiky or low and cold-start latency (~1–2s) is acceptable. | You need an in-cluster ClickHouse StatefulSet, DaemonSets, or fine pod control. |
+| You're fine with the two tiers as independent managed services. | You want one Helm release, HPAs, and k8s-native networking/mesh. |
+
+Both paths use the **same images**, the **same Secret Manager secrets**, and the **same
+Workload-Identity-style** model (a Google Service Account with no exported JSON key). You can start on
+Cloud Run and lift to GKE later without rebuilding anything.
+
+> Backing stores (Cloud SQL, ClickHouse, GCS) are shared by both paths and are provisioned once
+> (steps 3–4). Only the compute deploy (step 7) differs.
+
+---
+
+## 0. Prerequisites
+
+- `gcloud` CLI authenticated (`gcloud auth login`) with a project set (`gcloud config set project PROJECT`).
+- Billing enabled on the project.
+- For GKE: `kubectl` and `helm` (v3).
+- Shell variables used throughout (edit and export):
+
+```bash
+export PROJECT=my-project
+export REGION=us-central1
+export AR_REPO=ai-tally                      # Artifact Registry repo name
+export IMAGE_TAG=1.0.0                        # or a git sha
+export AR=$REGION-docker.pkg.dev/$PROJECT/$AR_REPO
+```
+
+## 1. Enable APIs
+
+```bash
+gcloud services enable \
+  artifactregistry.googleapis.com \
+  run.googleapis.com \
+  container.googleapis.com \
+  sqladmin.googleapis.com \
+  secretmanager.googleapis.com \
+  cloudbuild.googleapis.com \
+  storage.googleapis.com \
+  --project "$PROJECT"
+```
+
+## 2. Artifact Registry — build & push images
+
+Create the repo, then build both images. The gateway build context is the **repo root** (its
+Dockerfile COPYs both the gateway and the SDK it depends on); the web build context is `web/`.
+
+```bash
+gcloud artifacts repositories create "$AR_REPO" \
+  --repository-format=docker --location="$REGION" \
+  --description="ai-tally images"
+
+# Option A — Cloud Build (no local Docker needed):
+gcloud builds submit --tag "$AR/gateway:$IMAGE_TAG" --file infra/gateway/Dockerfile .
+gcloud builds submit --tag "$AR/web:$IMAGE_TAG" web/
+
+# Option B — local Docker:
+gcloud auth configure-docker "$REGION-docker.pkg.dev"
+docker build -t "$AR/gateway:$IMAGE_TAG" -f infra/gateway/Dockerfile .
+docker build -t "$AR/web:$IMAGE_TAG" web/
+docker push "$AR/gateway:$IMAGE_TAG"
+docker push "$AR/web:$IMAGE_TAG"
+```
+
+## 3. Provision Cloud SQL (Postgres control plane)
+
+```bash
+gcloud sql instances create ai-tally-pg \
+  --database-version=POSTGRES_16 --tier=db-custom-1-3840 \
+  --region="$REGION" --storage-size=20GB
+
+gcloud sql databases create tally --instance=ai-tally-pg
+gcloud sql users create tally --instance=ai-tally-pg --password='CHOOSE_A_STRONG_PASSWORD'
+
+# The value you'll store as the postgresDsn secret depends on the compute target:
+#   GKE (Cloud SQL Auth Proxy sidecar, TCP on localhost):
+#     postgresql://tally:PASS@127.0.0.1:5432/tally
+#   Cloud Run (platform-provided unix socket):
+#     postgresql://tally:PASS@/tally?host=/cloudsql/PROJECT:REGION:ai-tally-pg
+export INSTANCE_CONNECTION_NAME="$PROJECT:$REGION:ai-tally-pg"
+```
+
+Apply the control-plane DDL (`db/postgres/*.sql`) once — e.g. connect through the Cloud SQL Auth
+Proxy locally and run the migrations in order, or use `gcloud sql import`.
+
+## 4. Provision ClickHouse + the GCS replay bucket
+
+**ClickHouse** — two supported shapes:
+
+- **ClickHouse Cloud (recommended for production):** create a service, note its HTTPS host and port
+  (usually `:8443`), and the `tally` user's password. The gateway + web talk to it over HTTP(S).
+- **In-cluster StatefulSet (GKE staging only):** set `clickhouse.mode=statefulset` in the chart.
+  Apply the canonical DDL (`db/clickhouse/*.sql`) via an initdb ConfigMap mounted at
+  `/docker-entrypoint-initdb.d` — the same files docker-compose mounts. Single-node, not HA.
+
+**GCS bucket** for replay blobs (CTO-152):
+
+```bash
+gcloud storage buckets create gs://$PROJECT-ai-tally-replay --location="$REGION"
+```
+
+## 5. Secret Manager — create the secrets
+
+Store every secret value here; the manifests reference them **by name** and never contain the value.
+
+```bash
+# Postgres DSN (use the GKE or Cloud Run form from step 3, matching your target).
+printf 'postgresql://tally:PASS@127.0.0.1:5432/tally' | \
+  gcloud secrets create ai-tally-postgres-dsn --data-file=-
+
+printf 'YOUR_CLICKHOUSE_PASSWORD' | \
+  gcloud secrets create ai-tally-clickhouse-password --data-file=-
+
+# Provider keys are OPTIONAL — the gateway boots fail-soft without them (CTO-109). Skip if unused.
+printf 'sk-...'      | gcloud secrets create ai-tally-openai-api-key    --data-file=-
+printf 'sk-ant-...'  | gcloud secrets create ai-tally-anthropic-api-key --data-file=-
+```
+
+> **Not deploy-time secrets:** the **Stripe** webhook signing secret is pasted per-tenant in the
+> dashboard and persisted in Postgres (`db/postgres/0003_tenant_stripe_config.sql`) — protect it by
+> protecting Cloud SQL, not via an env var. Per-tenant **HMAC** user-id keys (CTO-74) live in the
+> gateway's runtime `HmacKeyRegistry`, provisioned per-tenant — also not a deploy secret.
+
+## 6. Identity — Workload Identity (GKE) / runtime SA (Cloud Run)
+
+Create one Google Service Account and grant it exactly what the workload needs. No JSON key is ever
+created or downloaded.
+
+```bash
+gcloud iam service-accounts create ai-tally-workload \
+  --display-name="ai-tally workload"
+export GSA="ai-tally-workload@$PROJECT.iam.gserviceaccount.com"
+
+# Access to each secret (or grant project-wide secretAccessor if you prefer).
+for s in ai-tally-postgres-dsn ai-tally-clickhouse-password ai-tally-openai-api-key ai-tally-anthropic-api-key; do
+  gcloud secrets add-iam-policy-binding "$s" \
+    --member="serviceAccount:$GSA" --role="roles/secretmanager.secretAccessor" 2>/dev/null || true
+done
+
+# Cloud SQL client + GCS on the replay bucket.
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member="serviceAccount:$GSA" --role="roles/cloudsql.client"
+gcloud storage buckets add-iam-policy-binding gs://$PROJECT-ai-tally-replay \
+  --member="serviceAccount:$GSA" --role="roles/storage.objectAdmin"
+```
+
+**GKE only** — create the cluster with Workload Identity, install the Secrets Store CSI driver, and
+bind the KSA the chart creates (`ai-tally` in namespace `ai-tally`) to the GSA:
+
+```bash
+gcloud container clusters create ai-tally \
+  --region="$REGION" --workload-pool="$PROJECT.svc.id.goog" --num-nodes=2
+gcloud container clusters get-credentials ai-tally --region="$REGION"
+
+# Secrets Store CSI driver + GCP provider (installs the DaemonSet + SecretProviderClass CRD):
+helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver \
+  --namespace kube-system --set syncSecret.enabled=true
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/main/deploy/provider-gcp-plugin.yaml
+
+# Bind the KSA (created by the chart on first install) to the GSA:
+kubectl create namespace ai-tally
+gcloud iam service-accounts add-iam-policy-binding "$GSA" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:$PROJECT.svc.id.goog[ai-tally/ai-tally]"
+```
+
+**Cloud Run only** — use a runtime SA (`ai-tally-run@...`) instead; grant it the same
+`secretAccessor` + `cloudsql.client` roles. The service YAMLs already set `serviceAccountName` to it.
+
+## 7. Deploy
+
+### Option A — GKE (Helm)
+
+Copy the example overrides and fill in the CAPS values (project, GSA, image repos, Cloud SQL
+instance, ClickHouse host):
+
+```bash
+cp deploy/gcp/helm/ai-tally/values-gke.example.yaml my-values.yaml
+$EDITOR my-values.yaml
+
+helm upgrade --install ai-tally deploy/gcp/helm/ai-tally \
+  --namespace ai-tally --create-namespace \
+  -f my-values.yaml
+```
+
+The chart renders: a Workload-Identity-annotated ServiceAccount, a SecretProviderClass that syncs the
+Secret Manager secrets into a Kubernetes Secret, gateway + web Deployments/Services (the gateway with
+a Cloud SQL Auth Proxy sidecar), optional HPAs, and — if `clickhouse.mode=statefulset` — an
+in-cluster ClickHouse. See `templates/NOTES.txt` (printed on install) for the smoke-test commands.
+
+### Option B — Cloud Run
+
+Substitute the placeholders in the service YAMLs and apply. Deploy the gateway first, capture its
+URL, then deploy the web service pointed at it:
+
+```bash
+sed -e "s/PROJECT/$PROJECT/g" -e "s/REGION/$REGION/g" -e "s/TAG/$IMAGE_TAG/g" \
+    -e "s#PROJECT:REGION:INSTANCE#$INSTANCE_CONNECTION_NAME#g" \
+    -e "s/REPLACE_CLICKHOUSE_HOST/YOUR_CLICKHOUSE_HOST/g" \
+    deploy/gcp/cloudrun/gateway.service.yaml \
+  | gcloud run services replace - --region "$REGION"
+
+GATEWAY_URL=$(gcloud run services describe ai-tally-gateway --region "$REGION" --format='value(status.url)')
+
+sed -e "s/PROJECT/$PROJECT/g" -e "s/REGION/$REGION/g" -e "s/TAG/$IMAGE_TAG/g" \
+    -e "s#REPLACE_GATEWAY_URL#$GATEWAY_URL#g" \
+    -e "s#REPLACE_CLICKHOUSE_URL#https://YOUR_CLICKHOUSE_HOST:8443#g" \
+    deploy/gcp/cloudrun/web.service.yaml \
+  | gcloud run services replace - --region "$REGION"
+```
+
+Grant invoker access as your access model requires (e.g. `--member=allUsers` for a public dashboard,
+or an IAP/identity-aware setup for internal-only).
+
+## 8. Smoke test
+
+```bash
+# Cloud Run:
+curl -s "$GATEWAY_URL/healthz"                      # {"status":"ok"}
+
+# GKE:
+kubectl -n ai-tally port-forward svc/ai-tally-gateway 8080:8080 &
+curl -s localhost:8080/healthz                      # {"status":"ok"}
+```
+
+Then send a batch (the same payload as `RUNNING.md` step 3, pointed at your gateway URL) and confirm
+rows land in ClickHouse. Finally open the web service URL — the **Cost**, **Features**, **Agents**,
+and **Data Quality** pages should render your ingested `local-dev` spans.
+
+## 9. Point the dashboard at production tenants
+
+The web tier defaults to tenant `local-dev` (matching local dev). For real tenants, set
+`web.config.tenantId` (GKE) or the `TALLY_TENANT_ID` env (Cloud Run), and enable
+`gateway.config.requireApiKey=true` (the cloud default) so ingest requires
+`Authorization: Bearer <key>` — seed keys with the gateway's `seed.py` against Cloud SQL.
+
+---
+
+## Open TODOs (documented, out of scope for CTO-153)
+
+- **Terraform/Pulumi IaC** — this ticket ships Helm + `gcloud` docs for v1; codify the project
+  bootstrap (APIs, Cloud SQL, ClickHouse, Secret Manager, IAM) as IaC in a follow-up.
+- **In-cluster ClickHouse DDL bootstrap** — the StatefulSet path expects you to mount `db/clickhouse`
+  as an initdb ConfigMap; a chart hook to build/apply that ConfigMap automatically is a follow-up.
+- **Ingress/TLS + custom domain** — the chart ships ClusterIP Services (port-forward / your own
+  Ingress). A managed-cert Ingress (GKE) and domain mapping (Cloud Run) are left to the operator.
+- **GCS replay wiring** — the bucket + IAM are provisioned here; binding the gateway's replay blob
+  store to GCS is tracked under CTO-152.
+- **Autoscaling tuning / multi-region HA** — explicitly out of scope (single-region, default HPAs).

--- a/deploy/gcp/cloudrun/gateway.service.yaml
+++ b/deploy/gcp/cloudrun/gateway.service.yaml
@@ -1,0 +1,78 @@
+# ai-tally ingest gateway on Cloud Run (fully managed).
+#
+# Placeholders to replace before `gcloud run services replace` (see deploy/gcp/README.md):
+#   PROJECT        GCP project id
+#   REGION         e.g. us-central1
+#   TAG            image tag (e.g. 1.0.0 or a git sha)
+#   PROJECT:REGION:INSTANCE   Cloud SQL INSTANCE_CONNECTION_NAME
+#
+# Secrets are pulled from Secret Manager at deploy/boot via env valueFrom.secretKeyRef — the runtime
+# service account (ai-tally-run@PROJECT.iam.gserviceaccount.com) must hold roles/secretmanager.
+# secretAccessor and roles/cloudsql.client. No JSON key, no secret literal in this file.
+#
+# Deploy:
+#   sed -e 's/PROJECT/my-proj/g' -e 's/REGION/us-central1/g' -e 's/TAG/1.0.0/g' \
+#       -e 's/PROJECT:REGION:INSTANCE/my-proj:us-central1:ai-tally-pg/g' \
+#       deploy/gcp/cloudrun/gateway.service.yaml | gcloud run services replace - --region REGION
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: ai-tally-gateway
+  labels:
+    app.kubernetes.io/part-of: ai-tally
+    app.kubernetes.io/component: gateway
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        # Attach Cloud SQL. On Cloud Run the proxy is provided by the platform; the DSN connects over
+        # the unix socket /cloudsql/PROJECT:REGION:INSTANCE (baked into the postgresDsn secret).
+        run.googleapis.com/cloudsql-instances: PROJECT:REGION:INSTANCE
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "10"
+    spec:
+      # Workload identity on Cloud Run = the runtime service account. No exported key.
+      serviceAccountName: ai-tally-run@PROJECT.iam.gserviceaccount.com
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+        - image: REGION-docker.pkg.dev/PROJECT/ai-tally/gateway:TAG
+          ports:
+            # Cloud Run sets PORT=8080; uvicorn is started on 8080 by the image CMD.
+            - containerPort: 8080
+          env:
+            # --- non-secret config (mirrors infra/gateway/src/gateway/config.py) ---
+            - { name: TALLY_CLICKHOUSE_HOST, value: "REPLACE_CLICKHOUSE_HOST" }
+            - { name: TALLY_CLICKHOUSE_PORT, value: "8123" }
+            - { name: TALLY_CLICKHOUSE_DB,   value: "default" }
+            - { name: TALLY_CLICKHOUSE_USER, value: "tally" }
+            - { name: TALLY_REQUIRE_API_KEY, value: "true" }
+            # --- secrets from Secret Manager ---
+            - name: TALLY_POSTGRES_DSN
+              valueFrom:
+                secretKeyRef: { name: ai-tally-postgres-dsn, key: latest }
+            - name: TALLY_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: ai-tally-clickhouse-password, key: latest }
+            # Provider keys are OPTIONAL — the gateway boots fail-soft without them (CTO-109).
+            # Remove these two blocks if you have not created the secrets.
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef: { name: ai-tally-openai-api-key, key: latest }
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef: { name: ai-tally-anthropic-api-key, key: latest }
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          startupProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            periodSeconds: 15

--- a/deploy/gcp/cloudrun/web.service.yaml
+++ b/deploy/gcp/cloudrun/web.service.yaml
@@ -1,0 +1,54 @@
+# ai-tally dashboard (Next.js) on Cloud Run (fully managed).
+#
+# Placeholders to replace before `gcloud run services replace` (see deploy/gcp/README.md):
+#   PROJECT   GCP project id
+#   REGION    e.g. us-central1
+#   TAG       image tag
+#   REPLACE_GATEWAY_URL      the gateway Cloud Run URL (https://ai-tally-gateway-....run.app)
+#   REPLACE_CLICKHOUSE_URL   ClickHouse HTTP endpoint (https://...clickhouse.cloud:8443 or in-VPC)
+#
+# The dashboard queries ClickHouse directly and calls the gateway. Its only secret is the ClickHouse
+# password (pulled from Secret Manager). The runtime SA needs roles/secretmanager.secretAccessor.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: ai-tally-web
+  labels:
+    app.kubernetes.io/part-of: ai-tally
+    app.kubernetes.io/component: web
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "6"
+    spec:
+      serviceAccountName: ai-tally-run@PROJECT.iam.gserviceaccount.com
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+        - image: REGION-docker.pkg.dev/PROJECT/ai-tally/web:TAG
+          ports:
+            # Cloud Run sets PORT=8080; Next's standalone server honours PORT.
+            - containerPort: 8080
+          env:
+            - { name: TALLY_GATEWAY_URL,    value: "REPLACE_GATEWAY_URL" }
+            - { name: TALLY_TENANT_ID,      value: "local-dev" }
+            - { name: TALLY_CLICKHOUSE_URL, value: "REPLACE_CLICKHOUSE_URL" }
+            - { name: TALLY_CLICKHOUSE_DB,  value: "default" }
+            - { name: TALLY_CLICKHOUSE_USER, value: "tally" }
+            - { name: NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS, value: "5000" }
+            - name: TALLY_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: ai-tally-clickhouse-password, key: latest }
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          startupProbe:
+            httpGet: { path: /, port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12

--- a/deploy/gcp/helm/ai-tally/.helmignore
+++ b/deploy/gcp/helm/ai-tally/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+*.tmpl.bak
+*.orig
+*~
+# CI/editor cruft
+.vscode/
+.idea/

--- a/deploy/gcp/helm/ai-tally/Chart.yaml
+++ b/deploy/gcp/helm/ai-tally/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ai-tally
+description: |
+  ai-tally on GKE (CTO-153, epic CTO-148). Deploys the two stateless application tiers — the ingest
+  gateway (FastAPI/uvicorn) and the Next.js dashboard — and wires them to GCP-managed backing stores:
+  Cloud SQL for Postgres (control plane), ClickHouse (in-cluster StatefulSet or an external
+  ClickHouse Cloud endpoint) for telemetry, and GCS for replay blobs (CTO-152).
+
+  Secrets (provider API keys, DB creds) live in Secret Manager and are consumed via Workload
+  Identity + the Secrets Store CSI driver — never as JSON keys on disk or literals in manifests.
+type: application
+# Chart version: bump on any template change. App version tracks the ai-tally release the images
+# were cut from; override per-tier image tags in values.yaml.
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - ai-tally
+  - observability
+  - gke
+  - gcp
+  - clickhouse
+home: https://github.com/jain-aanchal/ai-tally
+sources:
+  - https://github.com/jain-aanchal/ai-tally/tree/main/deploy/gcp

--- a/deploy/gcp/helm/ai-tally/templates/NOTES.txt
+++ b/deploy/gcp/helm/ai-tally/templates/NOTES.txt
@@ -1,0 +1,31 @@
+ai-tally {{ .Chart.AppVersion }} deployed as release "{{ .Release.Name }}" in namespace {{ .Release.Namespace }}.
+
+Tiers:
+{{- if .Values.gateway.enabled }}
+  - gateway  {{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }}  (:{{ .Values.gateway.service.port }})
+{{- end }}
+{{- if .Values.web.enabled }}
+  - web      {{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }}  (:{{ .Values.web.service.port }})
+{{- end }}
+ClickHouse: {{ .Values.clickhouse.mode }} ({{ include "ai-tally.clickhouseHost" . }}:{{ .Values.clickhouse.httpPort }})
+Secrets: {{ .Values.secretManager.mode }}{{ if eq .Values.secretManager.mode "csi" }} (Secret Manager via CSI + Workload Identity){{ end }}
+
+1. Watch the pods come up:
+
+   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }} -w
+
+2. Smoke-test the gateway health endpoint:
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }} {{ .Values.gateway.service.port }}:{{ .Values.gateway.service.port }}
+   curl -s localhost:{{ .Values.gateway.service.port }}/healthz    # {"status":"ok"}
+
+3. Open the dashboard:
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }} {{ .Values.web.service.port }}:{{ .Values.web.service.port }}
+   open http://localhost:{{ .Values.web.service.port }}
+
+{{- if not .Values.gcp.serviceAccount }}
+
+WARNING: gcp.serviceAccount is empty — Workload Identity is not wired and Secret Manager access will
+fail. Set gcp.projectId and gcp.serviceAccount and re-run. See deploy/gcp/README.md.
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/_helpers.tpl
+++ b/deploy/gcp/helm/ai-tally/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/* Chart base name, overridable. */}}
+{{- define "ai-tally.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified release name. */}}
+{{- define "ai-tally.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ai-tally.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common labels. */}}
+{{- define "ai-tally.labels" -}}
+helm.sh/chart: {{ include "ai-tally.chart" . }}
+app.kubernetes.io/part-of: ai-tally
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Per-tier selector labels. Pass a dict {"ctx": ., "tier": "gateway"}. */}}
+{{- define "ai-tally.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ai-tally.name" .ctx }}
+app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+app.kubernetes.io/component: {{ .tier }}
+{{- end -}}
+
+{{/* Tier-suffixed resource name, e.g. "myrel-ai-tally-gateway". */}}
+{{- define "ai-tally.tierName" -}}
+{{- printf "%s-%s" (include "ai-tally.fullname" .ctx) .tier | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* KSA name the pods run as. */}}
+{{- define "ai-tally.serviceAccountName" -}}
+{{- default (include "ai-tally.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{/* Name of the Kubernetes Secret the app tiers read env from: an existing one if provided, else
+     the one the CSI driver syncs (named after the release). */}}
+{{- define "ai-tally.secretName" -}}
+{{- if .Values.secretManager.existingSecretName -}}
+{{- .Values.secretManager.existingSecretName -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "ai-tally.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* SecretProviderClass name (CSI mode). */}}
+{{- define "ai-tally.spcName" -}}
+{{- printf "%s-spc" (include "ai-tally.fullname" .) -}}
+{{- end -}}
+
+{{/* In-cluster ClickHouse Service DNS (statefulset mode). */}}
+{{- define "ai-tally.clickhouseHost" -}}
+{{- if .Values.clickhouse.host -}}
+{{- .Values.clickhouse.host -}}
+{{- else if eq .Values.clickhouse.mode "statefulset" -}}
+{{- printf "%s-clickhouse" (include "ai-tally.fullname" .) -}}
+{{- else -}}
+{{- fail "clickhouse.host is required when clickhouse.mode=external" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Gateway in-cluster URL the web tier calls. */}}
+{{- define "ai-tally.gatewayUrl" -}}
+{{- if .Values.web.config.gatewayUrl -}}
+{{- .Values.web.config.gatewayUrl -}}
+{{- else -}}
+{{- printf "http://%s:%d" (include "ai-tally.tierName" (dict "ctx" . "tier" "gateway")) (int .Values.gateway.service.port) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/gcp/helm/ai-tally/templates/clickhouse-service.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/clickhouse-service.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.clickhouse.mode "statefulset" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-tally.fullname" . }}-clickhouse
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 4 }}
+spec:
+  # Headless: stable per-pod DNS for the StatefulSet. The app tiers connect over the HTTP port.
+  clusterIP: None
+  ports:
+    - { name: http,   port: 8123, targetPort: http }
+    - { name: native, port: 9000, targetPort: native }
+  selector:
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 4 }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/clickhouse-statefulset.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/clickhouse-statefulset.yaml
@@ -1,0 +1,71 @@
+{{- if eq .Values.clickhouse.mode "statefulset" }}
+{{- /*
+Single-node in-cluster ClickHouse for staging / low volume. NOT highly available. For production,
+prefer clickhouse.mode=external pointed at ClickHouse Cloud. The canonical DDL from db/clickhouse
+is applied via an initdb ConfigMap you create out-of-band and reference here (see README) — the
+official image runs /docker-entrypoint-initdb.d/*.sql on first boot, exactly like docker-compose.
+The ClickHouse password is read from the same synced Secret as the app tiers.
+*/ -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ai-tally.fullname" . }}-clickhouse
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 4 }}
+spec:
+  serviceName: {{ include "ai-tally.fullname" . }}-clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: clickhouse
+          image: {{ .Values.clickhouse.image }}
+          ports:
+            - { name: http,   containerPort: 8123 }
+            - { name: native, containerPort: 9000 }
+          env:
+            - name: CLICKHOUSE_USER
+              value: {{ .Values.gateway.config.clickhouseUser | quote }}
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+            {{- if .Values.secretManager.secrets.clickhousePassword }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-tally.secretName" . }}
+                  key: TALLY_CLICKHOUSE_PASSWORD
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+          livenessProbe:
+            httpGet: { path: /ping, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet: { path: /ping, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.clickhouse.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.clickhouse.storageClassName }}
+        storageClassName: {{ .Values.clickhouse.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.clickhouse.storage | quote }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/gateway-configmap.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/gateway-configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "gateway") | nindent 4 }}
+data:
+  # Non-secret gateway config (TALLY_*). Secret values (DB password, provider keys) come from the
+  # synced Kubernetes Secret, NOT from here. Mirrors infra/gateway/src/gateway/config.py.
+  TALLY_CLICKHOUSE_HOST: {{ include "ai-tally.clickhouseHost" . | quote }}
+  TALLY_CLICKHOUSE_PORT: {{ .Values.clickhouse.httpPort | quote }}
+  TALLY_CLICKHOUSE_DB: {{ .Values.gateway.config.clickhouseDb | quote }}
+  TALLY_CLICKHOUSE_USER: {{ .Values.gateway.config.clickhouseUser | quote }}
+  TALLY_REQUIRE_API_KEY: {{ .Values.gateway.config.requireApiKey | quote }}
+  TALLY_INGEST_BUFFERED: {{ .Values.gateway.config.ingestBuffered | quote }}
+  {{- if .Values.gateway.config.evalJudgeModel }}
+  TALLY_EVAL_JUDGE_MODEL: {{ .Values.gateway.config.evalJudgeModel | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.gateway.config.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/gateway-deployment.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/gateway-deployment.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.gateway.enabled }}
+{{- $tier := "gateway" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 4 }}
+spec:
+  {{- if not .Values.gateway.autoscaling.enabled }}
+  replicas: {{ .Values.gateway.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll pods when non-secret config changes so a ConfigMap edit takes effect.
+        checksum/config: {{ include (print $.Template.BasePath "/gateway-configmap.yaml") . | sha256sum }}
+        {{- with .Values.gateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "ai-tally.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: gateway
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+            # DB password + provider keys, synced from Secret Manager (or an existingSecret).
+            - secretRef:
+                name: {{ include "ai-tally.secretName" . }}
+          {{- if eq .Values.secretManager.mode "csi" }}
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+          {{- end }}
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+        {{- if .Values.cloudSql.enabled }}
+        # Cloud SQL Auth Proxy sidecar. Authenticates to Cloud SQL via Workload Identity (no DB
+        # password on the wire, no public IP). The gateway's TALLY_POSTGRES_DSN points at
+        # 127.0.0.1:5432, which this proxy tunnels to the instance below.
+        - name: cloud-sql-proxy
+          image: {{ .Values.cloudSql.proxyImage }}
+          args:
+            - "--structured-logs"
+            - "--port=5432"
+            {{- if not .Values.cloudSql.instanceConnectionName }}
+            {{- fail "cloudSql.instanceConnectionName is required when cloudSql.enabled" }}
+            {{- end }}
+            - {{ .Values.cloudSql.instanceConnectionName | quote }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits:   { cpu: 250m, memory: 128Mi }
+        {{- end }}
+      {{- if eq .Values.secretManager.mode "csi" }}
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "ai-tally.spcName" . }}
+      {{- end }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/gateway-service.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/gateway-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "gateway") | nindent 4 }}
+spec:
+  type: {{ .Values.gateway.service.type }}
+  ports:
+    - port: {{ .Values.gateway.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "gateway") | nindent 4 }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/hpa.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- range $tier := (list "gateway" "web") }}
+{{- $cfg := index $.Values $tier }}
+{{- if and $cfg.enabled $cfg.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" $ "tier" $tier) }}
+  labels:
+    {{- include "ai-tally.labels" $ | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" $ "tier" $tier) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-tally.tierName" (dict "ctx" $ "tier" $tier) }}
+  minReplicas: {{ $cfg.autoscaling.minReplicas }}
+  maxReplicas: {{ $cfg.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/secretproviderclass.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/secretproviderclass.yaml
@@ -1,0 +1,41 @@
+{{- if eq .Values.secretManager.mode "csi" }}
+{{- /*
+Secrets Store CSI driver — GCP provider. Pulls named secrets from Secret Manager and, via
+secretObjects, SYNCS them into a Kubernetes Secret ({{ include "ai-tally.secretName" . }}) that the
+Deployments consume with secretKeyRef. The pod must also mount the CSI volume for the sync to run —
+that mount is declared on each Deployment. Requires:
+  - the Secrets Store CSI driver + GCP provider installed on the cluster (README step 6), and
+  - Workload Identity on the pod's KSA with roles/secretmanager.secretAccessor on each secret.
+No secret value is present here — only Secret Manager resource names from .Values.secretManager.secrets.
+*/ -}}
+{{- $proj := .Values.gcp.projectId -}}
+{{- if not $proj }}{{ fail "gcp.projectId is required in csi secret mode" }}{{- end -}}
+{{- $secrets := .Values.secretManager.secrets -}}
+{{- $mappings := list -}}
+{{- if $secrets.postgresDsn }}{{ $mappings = append $mappings (dict "sm" $secrets.postgresDsn "env" "TALLY_POSTGRES_DSN") }}{{- end -}}
+{{- if $secrets.clickhousePassword }}{{ $mappings = append $mappings (dict "sm" $secrets.clickhousePassword "env" "TALLY_CLICKHOUSE_PASSWORD") }}{{- end -}}
+{{- if $secrets.openaiApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.openaiApiKey "env" "OPENAI_API_KEY") }}{{- end -}}
+{{- if $secrets.anthropicApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.anthropicApiKey "env" "ANTHROPIC_API_KEY") }}{{- end -}}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "ai-tally.spcName" . }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      {{- range $mappings }}
+      - resourceName: "projects/{{ $proj }}/secrets/{{ .sm }}/versions/latest"
+        fileName: "{{ .env }}"
+      {{- end }}
+  secretObjects:
+    - secretName: {{ include "ai-tally.secretName" . }}
+      type: Opaque
+      data:
+        {{- range $mappings }}
+        - objectName: "{{ .env }}"
+          key: "{{ .env }}"
+        {{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/serviceaccount.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceAccount.create -}}
+{{- if not .Values.gcp.serviceAccount -}}
+{{- fail "gcp.serviceAccount is required: the GSA email the KSA federates to via Workload Identity" -}}
+{{- end -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ai-tally.serviceAccountName" . }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+  annotations:
+    # Workload Identity: pods running as this KSA federate to the GSA and inherit its IAM roles
+    # (Secret Manager accessor, Cloud SQL client, GCS object admin) with NO exported JSON key.
+    # The reciprocal IAM policy binding (roles/iam.workloadIdentityUser) is created with gcloud —
+    # see deploy/gcp/README.md step 6.
+    iam.gke.io/gcp-service-account: {{ .Values.gcp.serviceAccount | quote }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/web-configmap.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/web-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "web") | nindent 4 }}
+data:
+  # Non-secret web config. The dashboard queries ClickHouse directly (TALLY_CLICKHOUSE_*) and calls
+  # the gateway (TALLY_GATEWAY_URL). The ClickHouse password comes from the synced Secret.
+  PORT: {{ .Values.web.service.port | quote }}
+  TALLY_GATEWAY_URL: {{ include "ai-tally.gatewayUrl" . | quote }}
+  TALLY_TENANT_ID: {{ .Values.web.config.tenantId | quote }}
+  TALLY_CLICKHOUSE_URL: {{ printf "%s://%s:%d" .Values.clickhouse.scheme (include "ai-tally.clickhouseHost" .) (int .Values.clickhouse.httpPort) | quote }}
+  TALLY_CLICKHOUSE_DB: {{ .Values.web.config.clickhouseDb | quote }}
+  TALLY_CLICKHOUSE_USER: {{ .Values.web.config.clickhouseUser | quote }}
+  NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS: {{ .Values.web.config.dashboardRefreshMs | quote }}
+  {{- range $k, $v := .Values.web.config.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/web-deployment.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/web-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.web.enabled }}
+{{- $tier := "web" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 4 }}
+spec:
+  {{- if not .Values.web.autoscaling.enabled }}
+  replicas: {{ .Values.web.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/web-configmap.yaml") . | sha256sum }}
+        {{- with .Values.web.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "ai-tally.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+          env:
+            # The dashboard only needs the ClickHouse password out of the shared Secret — pull just
+            # that key rather than envFrom the whole Secret (keeps provider keys out of the web pod).
+            {{- if .Values.secretManager.secrets.clickhousePassword }}
+            - name: TALLY_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-tally.secretName" . }}
+                  key: TALLY_CLICKHOUSE_PASSWORD
+            {{- end }}
+          {{- if eq .Values.secretManager.mode "csi" }}
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+          {{- end }}
+          livenessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- if eq .Values.secretManager.mode "csi" }}
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "ai-tally.spcName" . }}
+      {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/templates/web-service.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/web-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "web") | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "web") | nindent 4 }}
+{{- end }}

--- a/deploy/gcp/helm/ai-tally/values-gke.example.yaml
+++ b/deploy/gcp/helm/ai-tally/values-gke.example.yaml
@@ -1,0 +1,48 @@
+# Example overrides for a real GKE install. Copy, fill in the CAPS values, and pass with:
+#   helm upgrade --install ai-tally deploy/gcp/helm/ai-tally -n ai-tally -f my-values.yaml
+#
+# This example uses external ClickHouse Cloud + Cloud SQL + Secret Manager via CSI — the recommended
+# production shape. For a self-contained staging cluster, set clickhouse.mode=statefulset instead.
+
+gcp:
+  projectId: MY_PROJECT
+  serviceAccount: ai-tally-workload@MY_PROJECT.iam.gserviceaccount.com
+
+secretManager:
+  mode: csi
+  # These are Secret Manager secret NAMES (create the secrets with gcloud — README step 5).
+  secrets:
+    postgresDsn: ai-tally-postgres-dsn
+    clickhousePassword: ai-tally-clickhouse-password
+    openaiApiKey: ai-tally-openai-api-key
+    anthropicApiKey: ai-tally-anthropic-api-key
+
+cloudSql:
+  enabled: true
+  instanceConnectionName: MY_PROJECT:us-central1:ai-tally-pg
+
+clickhouse:
+  mode: external
+  host: my-instance.us-central1.gcp.clickhouse.cloud
+  httpPort: 8443
+  scheme: https   # ClickHouse Cloud is TLS-terminated
+
+gateway:
+  replicaCount: 2
+  image:
+    repository: us-central1-docker.pkg.dev/MY_PROJECT/ai-tally/gateway
+    tag: "1.0.0"
+  config:
+    requireApiKey: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+
+web:
+  replicaCount: 2
+  image:
+    repository: us-central1-docker.pkg.dev/MY_PROJECT/ai-tally/web
+    tag: "1.0.0"
+  config:
+    tenantId: local-dev

--- a/deploy/gcp/helm/ai-tally/values.yaml
+++ b/deploy/gcp/helm/ai-tally/values.yaml
@@ -1,0 +1,185 @@
+# Default values for the ai-tally GKE chart.
+#
+# The two application tiers (gateway, web) are stateless and 12-factor: everything they read is an
+# env var. This file maps those env vars onto Kubernetes knobs, plus the GCP-native secrets/identity
+# wiring. Backing stores (Postgres, ClickHouse, GCS) are managed OUT of this chart by default —
+# Cloud SQL and GCS are provisioned with gcloud (see deploy/gcp/README.md); ClickHouse is either an
+# in-cluster StatefulSet (clickhouse.mode=statefulset) or an external endpoint (clickhouse.mode=external).
+
+# -- Global naming -------------------------------------------------------------------------------
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+# =================================================================================================
+# GCP identity + secrets
+# =================================================================================================
+gcp:
+  # Your GCP project id. Required — used to construct Secret Manager resource names and the
+  # Workload Identity binding. There is no sane default; deploys fail loudly if left blank.
+  projectId: ""
+  # The Google Service Account (GSA) email that owns access to Secret Manager, Cloud SQL and GCS.
+  # A single KSA (created by this chart) is bound to it via Workload Identity. Example:
+  #   ai-tally-workload@PROJECT.iam.gserviceaccount.com
+  # Grant it: roles/secretmanager.secretAccessor, roles/cloudsql.client, roles/storage.objectAdmin
+  # (on the replay bucket). See README.md step 6.
+  serviceAccount: ""
+
+# Kubernetes ServiceAccount the pods run as. Annotated for Workload Identity so pods federate to the
+# GSA above WITHOUT any exported JSON key. create=false lets you reference a pre-existing KSA.
+serviceAccount:
+  create: true
+  name: ai-tally
+  annotations: {}   # iam.gke.io/gcp-service-account is injected from .Values.gcp.serviceAccount
+
+# -- Secret Manager -> pod wiring -----------------------------------------------------------------
+# Secrets are pulled from Secret Manager by the Secrets Store CSI driver (GCP provider) and synced
+# into a Kubernetes Secret, which the Deployments consume via envFrom/secretKeyRef. No secret value
+# ever appears in this chart or in git. Each entry maps a Secret Manager secret name to the env var
+# the app expects. Provide the secret NAMES here; create the secrets with gcloud (README step 5).
+secretManager:
+  # csi   — pull from Secret Manager via the Secrets Store CSI driver (recommended on GKE).
+  # existingSecret — you manage a Kubernetes Secret out-of-band (e.g. external-secrets operator);
+  #                  set existingSecretName and the chart references it directly.
+  mode: csi
+  existingSecretName: ""
+  # Secret Manager secret names (NOT values). "" disables that mapping (the env var is simply not
+  # set, and the app falls back to its documented default or fail-soft path).
+  secrets:
+    # Postgres control-plane DSN, e.g. postgresql://USER:PASS@127.0.0.1:5432/tally through the
+    # Cloud SQL Auth Proxy sidecar (host 127.0.0.1). Consumed as TALLY_POSTGRES_DSN.
+    postgresDsn: ai-tally-postgres-dsn
+    # ClickHouse password. Consumed as TALLY_CLICKHOUSE_PASSWORD (gateway) and
+    # TALLY_CLICKHOUSE_PASSWORD (web).
+    clickhousePassword: ai-tally-clickhouse-password
+    # Outbound provider keys for model discovery / replay / eval. Optional — the gateway boots
+    # fail-soft without them (CTO-109). Consumed as OPENAI_API_KEY / ANTHROPIC_API_KEY.
+    openaiApiKey: ai-tally-openai-api-key
+    anthropicApiKey: ai-tally-anthropic-api-key
+  # NOTE on Stripe + HMAC: the Stripe webhook *signing secret* is NOT a gateway env var — it is
+  # pasted per-tenant in the dashboard and persisted in Postgres (see db/postgres/0003_*.sql), so
+  # it is protected by protecting Cloud SQL. Per-tenant HMAC user-id keys (CTO-74) live in the
+  # gateway's HmacKeyRegistry, provisioned per-tenant at runtime — also not a deploy-time secret.
+
+# =================================================================================================
+# Gateway tier (FastAPI ingest gateway — infra/gateway)
+# =================================================================================================
+gateway:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: REGION-docker.pkg.dev/PROJECT/ai-tally/gateway
+    pullPolicy: IfNotPresent
+    tag: ""   # defaults to .Chart.AppVersion
+  service:
+    type: ClusterIP
+    port: 8080
+  # Non-secret env (TALLY_*). Secret env is injected from secretManager above. Mirrors the
+  # docker-compose gateway service and infra/gateway/src/gateway/config.py defaults.
+  config:
+    clickhouseDb: default        # the ClickHouse image loads unqualified DDL into `default`
+    clickhouseUser: tally
+    requireApiKey: true          # cloud default: enforce Authorization: Bearer <key>
+    ingestBuffered: false        # flip on to decouple the request edge from ClickHouse (CTO-37)
+    evalJudgeModel: ""           # override TALLY_EVAL_JUDGE_MODEL; "" keeps the app default
+    # Free-form extra TALLY_* pairs merged verbatim into the ConfigMap (rate limits, quotas, etc.).
+    extraEnv: {}
+  resources:
+    requests: { cpu: 250m, memory: 256Mi }
+    limits:   { cpu: "1",  memory: 512Mi }
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =================================================================================================
+# Web tier (Next.js dashboard — web/)
+# =================================================================================================
+web:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: REGION-docker.pkg.dev/PROJECT/ai-tally/web
+    pullPolicy: IfNotPresent
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 3000
+  config:
+    # The dashboard queries ClickHouse directly AND calls the gateway. The gateway URL defaults to
+    # the in-cluster Service; leave blank to auto-derive it from the release name.
+    gatewayUrl: ""
+    tenantId: local-dev
+    clickhouseDb: default
+    clickhouseUser: tally
+    dashboardRefreshMs: "5000"   # NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS
+    extraEnv: {}
+  resources:
+    requests: { cpu: 100m, memory: 192Mi }
+    limits:   { cpu: 500m, memory: 384Mi }
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =================================================================================================
+# ClickHouse (telemetry store)
+# =================================================================================================
+# statefulset — run a single-node ClickHouse in-cluster with a PersistentVolume. Fine for staging /
+#               low volume; NOT HA. Applies the same DDL as docker-compose via an initdb ConfigMap
+#               you mount (see README). For production, prefer external ClickHouse Cloud.
+# external    — point the gateway + web at an external ClickHouse HTTP endpoint (e.g. ClickHouse
+#               Cloud). No StatefulSet is rendered.
+clickhouse:
+  mode: external
+  # Used by BOTH modes as the host the app tiers connect to. In statefulset mode this defaults to
+  # the in-cluster Service DNS; in external mode set it to your ClickHouse Cloud host.
+  host: ""
+  httpPort: 8123
+  # URL scheme the web tier uses to reach ClickHouse (TALLY_CLICKHOUSE_URL). Keep "http" for the
+  # in-cluster StatefulSet; set "https" for a TLS endpoint like ClickHouse Cloud (usually port 8443).
+  scheme: http
+  # statefulset-mode knobs (ignored when mode=external).
+  image: clickhouse/clickhouse-server:24.8
+  storage: 50Gi
+  storageClassName: ""   # "" uses the cluster default StorageClass (pd-balanced on GKE)
+  resources:
+    requests: { cpu: "1", memory: 4Gi }
+    limits:   { cpu: "2", memory: 8Gi }
+
+# =================================================================================================
+# Cloud SQL (Postgres control plane) connectivity
+# =================================================================================================
+# The gateway reaches Postgres over the Cloud SQL Auth Proxy running as a sidecar (127.0.0.1:5432),
+# which authenticates via Workload Identity — no DB password on the wire, no public IP required.
+# The DSN itself (with the app-user password) is the Secret Manager `postgresDsn` secret above.
+cloudSql:
+  enabled: true
+  # INSTANCE_CONNECTION_NAME, i.e. PROJECT:REGION:INSTANCE. Required when enabled.
+  instanceConnectionName: ""
+  proxyImage: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4
+
+# =================================================================================================
+# Pod security posture (applied to gateway + web)
+# =================================================================================================
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false   # Next's standalone server writes a cache dir; keep false for web
+  capabilities:
+    drop:
+      - ALL

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the Docker build context small and reproducible. node_modules is reinstalled from the
+# lockfile inside the image; .next is rebuilt. Never ship local env files into the image.
+node_modules
+.next
+.git
+.gitignore
+Dockerfile
+.dockerignore
+npm-debug.log*
+.env
+.env.*
+*.local
+tsconfig.tsbuildinfo

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,54 @@
+# ai-tally dashboard (Next.js 15 / React 19) — production image.
+#
+# Build context is the `web/` directory:
+#   docker build -t REGION-docker.pkg.dev/PROJECT/ai-tally/web:TAG web/
+#
+# Multi-stage:
+#   deps    — install node_modules from the lockfile (cache-friendly layer).
+#   builder — `next build` in standalone mode, emitting a self-contained server.
+#   runner  — a slim runtime carrying only the standalone server + static assets.
+#
+# Standalone output: the repo's web/next.config.mjs is intentionally NOT modified by this ticket
+# (additive-only), so instead of setting `output: "standalone"` in the config we force it at build
+# time with NEXT_PRIVATE_STANDALONE=true. Next.js reads that env and emits `.next/standalone`
+# exactly as the config flag would. If the web team later adds `output: "standalone"` to
+# next.config.mjs, this env becomes a redundant no-op — leave it or drop it, either works.
+
+# ---- deps ---------------------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS deps
+WORKDIR /app
+# Only the manifests, so this layer is reused whenever source (but not deps) changes.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ---- builder ------------------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PRIVATE_STANDALONE=true
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# ---- runner -------------------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    # Next's standalone server honours PORT/HOSTNAME. Cloud Run overrides PORT (8080); GKE sets it
+    # via the chart. 0.0.0.0 so the container is reachable from outside the pod/instance.
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Run as an unprivileged, numeric non-root user (matches the edge-proxy chart's posture).
+RUN groupadd --system --gid 1001 nodejs \
+ && useradd  --system --uid 1001 --gid nodejs nextjs
+
+# The standalone build bundles a minimal node_modules and a server.js. Static assets are served
+# from .next/static and must be copied alongside it (standalone does not inline them).
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

First-class, documented GCP deployment path for ai-tally's two stateless application tiers — the **ingest gateway** (FastAPI/uvicorn) and the **Next.js dashboard** — using GCP-native secrets + identity instead of raw env keys. Fully **additive**: no changes to `infra/docker-compose.yml`, app source, or the local dev flow. Reuses the conventions of the existing `infra/edge-proxy` Helm chart. Part of epic **CTO-148**.

## What's in `deploy/gcp/`

- **`helm/ai-tally/`** — GKE Helm chart: gateway + web Deployments/Services/ConfigMaps, a Workload-Identity-annotated ServiceAccount, a `SecretProviderClass` (Secret Manager via the Secrets Store CSI driver), per-tier HPAs, and an optional in-cluster ClickHouse StatefulSet. Image tags, replicas, resources, and ClickHouse mode are parameterized. Ships `values.yaml` (documented) + `values-gke.example.yaml`.
- **`cloudrun/`** — Knative service YAMLs for gateway + web with Cloud SQL attachment and Secret Manager env refs.
- **`README.md`** — from-zero runbook: enable APIs → Artifact Registry build/push → provision Cloud SQL + ClickHouse + GCS → Secret Manager entries → Workload Identity → deploy (GKE **or** Cloud Run) → healthz smoke → point the dashboard. Mirrors `RUNNING.md`'s step-by-step clarity.

## Dockerfiles

- **Gateway** — already existed (`infra/gateway/Dockerfile`); **not modified**.
- **Web** — **added** `web/Dockerfile` (multi-stage Next.js standalone) + `web/.dockerignore`. `web/next.config.mjs` has no `output: "standalone"` and this ticket is additive, so the build forces standalone via `NEXT_PRIVATE_STANDALONE=true` rather than editing the config (documented in the Dockerfile; a redundant no-op if the config flag is added later).

## Secrets / identity model

Provider API keys and DB creds live in **Secret Manager**, referenced by name only — no JSON keys on disk, no secret literals in manifests. GKE: the Secrets Store CSI driver syncs them into a K8s Secret consumed via `secretRef`/`secretKeyRef`; the pod KSA federates to a GSA via **Workload Identity**. Cloud Run: env `valueFrom.secretKeyRef` against a runtime SA. The gateway reaches Cloud SQL through the Auth Proxy sidecar (GKE) / platform socket (Cloud Run). Notably, the **Stripe** signing secret is per-tenant in Postgres (not a deploy secret) and **HMAC** user-id keys are runtime per-tenant — both documented as such.

## GKE vs Cloud Run

The README includes a decision table: **Cloud Run** for least-ops / spiky-low traffic / scale-to-N; **GKE** for an existing cluster, in-cluster ClickHouse, or k8s-native control. Same images and secrets both ways.

## How I verified

- `helm lint` — passes (only the cosmetic "icon recommended" info).
- `helm template` in both ClickHouse modes (external + statefulset) and with autoscaling on — renders cleanly; output parses as valid multi-doc YAML; spot-checked KSA annotation, SecretProviderClass mappings, Cloud SQL sidecar, and gateway/web env wiring.
- Cloud Run YAMLs validated with `yaml.safe_load_all`.
- `git diff --name-status origin/main` — **all additions**; the pre-existing gateway Dockerfile is untouched.
- Did not run web/gateway test suites (no source touched).

## Documented TODOs (out of scope for CTO-153)

Terraform/Pulumi IaC; automatic ClickHouse initdb ConfigMap for the StatefulSet path; Ingress/TLS + custom domain; binding the gateway replay blob store to the provisioned GCS bucket (CTO-152); autoscaling tuning / multi-region HA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)