### PR TITLE
feat(vector): Vertex AI Vector Search on the Vector cost layer (CTO-151)

### DIFF
--- a/sdk/python/src/tally/pricing.py
+++ b/sdk/python/src/tally/pricing.py
@@ -286,6 +286,23 @@ _VECTOR_SEEDS: list[tuple[str, str, PriceType, str]] = [
     ("pinecone", "upsert", PriceType.VECTOR_CALL, "0.0002"),
     ("weaviate", "query", PriceType.VECTOR_CALL, "0.0003"),
     ("qdrant", "query", PriceType.VECTOR_CALL, "0.00025"),
+    # --- Vertex AI Vector Search (formerly Matching Engine), CTO-151 -------------------------
+    # GCP-native vector provider. Keyed off the operation name (query/upsert) like the other
+    # vector DBs above, so it resolves through the same compute_call_cost_micro_usd path in
+    # record_vector_call (provider="vertex"). Mirrors the CTO-142 span shape — no new wrapper.
+    #
+    # COST SPLIT (important — avoids double-counting):
+    # Vertex Vector Search bills in two parts:
+    #   1. Per-query / serving requests — the online-query request portion. Priced HERE, on the
+    #      Vector cost layer, per call.
+    #   2. Deployed-index node-hours — the compute cost of keeping the index endpoint warm
+    #      (the dominant Vertex Vector Search spend). This is a COMPUTE cost, NOT a per-query
+    #      cost, and is DEFERRED to the GCP Cloud Billing compute connector (CTO-150). It is
+    #      deliberately NOT modeled here so the Vector layer and the future Compute layer do not
+    #      both count node-hours. See CTO-150.
+    # Both rates below are the per-query serving portion only. [unverified at implementation time]
+    ("vertex", "query", PriceType.VECTOR_CALL, "0.0004"),
+    ("vertex", "upsert", PriceType.VECTOR_CALL, "0.0002"),
 ]
 
 

--- a/sdk/python/tests/test_pricing_seeds.py
+++ b/sdk/python/tests/test_pricing_seeds.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import date
 
 from tally.enrichment import enrich_cost
-from tally.pricing import seed_catalog
+from tally.pricing import PriceType, compute_call_cost_micro_usd, seed_catalog
 from tally.schema import GenAI
 
 AT = date(2026, 6, 1)
@@ -109,6 +109,34 @@ def test_gemini_3_flash_priced() -> None:
 
 def test_gemini_flash_cheaper_than_pro() -> None:
     assert _cost("google", "gemini-2.5-flash") < _cost("google", "gemini-2.5-pro")
+
+
+# --- Vertex AI Vector Search (CTO-151) — Vector cost layer, per-call ----
+
+
+def test_vertex_vector_query_priced() -> None:
+    cost, ver = compute_call_cost_micro_usd(
+        seed_catalog(), "vertex", "query", PriceType.VECTOR_CALL
+    )
+    assert cost == 400
+    assert ver
+
+
+def test_vertex_vector_upsert_priced() -> None:
+    cost, ver = compute_call_cost_micro_usd(
+        seed_catalog(), "vertex", "upsert", PriceType.VECTOR_CALL
+    )
+    assert cost == 200
+    assert ver
+
+
+def test_vertex_node_hours_deferred_not_priced() -> None:
+    # Node-hours are a compute cost deferred to CTO-150 — must not be on the Vector layer.
+    cost, ver = compute_call_cost_micro_usd(
+        seed_catalog(), "vertex", "node-hour", PriceType.VECTOR_CALL
+    )
+    assert cost == 0
+    assert ver == ""
 
 
 # --- Family-classifier intuition ----

--- a/sdk/python/tests/test_vertex_vector.py
+++ b/sdk/python/tests/test_vertex_vector.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-151 — Vertex AI Vector Search on the Vector cost layer.
+
+Vertex AI Vector Search (formerly Matching Engine) is a GCP-native vector provider. It rides the
+same ``record_vector_call`` path as the CTO-142 vector DBs (Pinecone/Weaviate/Qdrant): a query or
+upsert emits an ``operation='vector'`` span whose per-query cost resolves from the versioned price
+catalog (CTO-141) under ``PriceType.VECTOR_CALL`` keyed by ``(provider="vertex", operation)``.
+
+Only the per-query / serving portion is priced here. Deployed-index node-hours (a compute cost)
+are deferred to the GCP Cloud Billing compute connector (CTO-150), so they must NOT show up on the
+Vector layer — see the cost-split comment in pricing.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tally.client import MemoryExporter, TallyClient
+from tally.context import with_trace_context
+from tally.pricing import (
+    PriceType,
+    compute_call_cost_micro_usd,
+    seed_catalog,
+)
+from tally.schema import GenAI, validate_span_attributes
+
+
+def _client(exporter: MemoryExporter | None = None) -> TallyClient:
+    return TallyClient(exporter=exporter or MemoryExporter(), catalog=seed_catalog())
+
+
+def test_vertex_query_emits_vector_span_priced_from_catalog() -> None:
+    exporter = MemoryExporter()
+    client = _client(exporter)
+    with with_trace_context(trace_id="t1", feature_tag="rag", session_id="s1"):
+        client.record_vector_call(provider="vertex", index="products", operation="query")
+
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    # Lands in the gateway's Vector bucket (LAYER_CASE: GenAiOperation='vector' -> 'vector').
+    assert span[GenAI.OPERATION_NAME] == "vector"
+    assert span[GenAI.SYSTEM] == "vertex"
+    assert span[GenAI.TOOL_NAME] == "vertex.products.query"
+    # Non-zero cost, resolved from the catalog (no catalog miss) -> version stamped.
+    assert span[GenAI.TOOL_COST_MICRO_USD] == 400
+    assert span[GenAI.COST_PRICE_CATALOG_VERSION]
+    assert span[GenAI.FEATURE_TAG] == "rag"
+    assert span[GenAI.SESSION_ID] == "s1"
+
+
+def test_vertex_upsert_priced() -> None:
+    exporter = MemoryExporter()
+    client = _client(exporter)
+    client.record_vector_call(provider="vertex", index="products", operation="upsert")
+    span = exporter.spans[0]
+    assert span[GenAI.TOOL_COST_MICRO_USD] == 200
+    assert span[GenAI.COST_PRICE_CATALOG_VERSION]
+
+
+def test_vertex_unknown_index_tier_defaults_to_zero_and_warns(caplog) -> None:
+    # An unseeded Vertex operation / index tier must fail soft: 0 cost + one-time WARN, still a
+    # well-formed vector span (never raises, never a partial-data crash).
+    exporter = MemoryExporter()
+    client = _client(exporter)
+    with caplog.at_level(logging.WARNING, logger="tally"):
+        client.record_vector_call(
+            provider="vertex", index="products", operation="brute-force-tier"
+        )
+
+    span = exporter.spans[0]
+    assert span[GenAI.TOOL_COST_MICRO_USD] == 0
+    assert span[GenAI.OPERATION_NAME] == "vector"
+    assert GenAI.COST_PRICE_CATALOG_VERSION not in span
+    assert any("no catalog vector price" in r.message for r in caplog.records)
+
+
+def test_real_seed_catalog_prices_vertex_query_and_upsert() -> None:
+    # Pricing regression against the real seed_catalog(): both seeded Vertex ops price > 0.
+    cat = seed_catalog()
+    q_cost, q_ver = compute_call_cost_micro_usd(cat, "vertex", "query", PriceType.VECTOR_CALL)
+    u_cost, u_ver = compute_call_cost_micro_usd(cat, "vertex", "upsert", PriceType.VECTOR_CALL)
+    assert q_cost == 400
+    assert u_cost == 200
+    assert q_ver and u_ver
+
+
+def test_node_hours_not_priced_on_vector_layer() -> None:
+    # Node-hour / deployed-index compute is deferred to CTO-150. There must be no VECTOR_CALL
+    # entry for a node-hour-style key, so it never double-counts on the Vector layer.
+    cat = seed_catalog()
+    cost, ver = compute_call_cost_micro_usd(cat, "vertex", "node-hour", PriceType.VECTOR_CALL)
+    assert cost == 0
+    assert ver == ""


### PR DESCRIPTION
## CTO-151 — Vertex AI Vector Search on the Vector cost layer

**Stacked on #125 (CTO-149).** Base is `feat/cto-149-gemini-vertex-provider`; GitHub will auto-retarget to `main` when #125 merges.

Adds **Vertex AI Vector Search** (formerly Matching Engine) as a supported vector provider so GCP-native vector spend lands on the Vector cost layer (CTO-142). Queries/upserts ride the existing `record_vector_call` path with `provider="vertex"` — no new wrapper, no span-shape reinvention. Cost resolves from the versioned catalog (CTO-141) under `PriceType.VECTOR_CALL` keyed by `(provider, operation)`, exactly like Pinecone/Weaviate/Qdrant.

### Catalog entries added (per-query serving portion only)
| provider | operation | PriceType | USD/call |
|----------|-----------|-----------|----------|
| vertex | query | VECTOR_CALL | 0.0004 |
| vertex | upsert | VECTOR_CALL | 0.0002 |

All rates `# [unverified at implementation time]` pending the CTO-53 scraper (consistent with how CTO-149 marked Gemini rates).

### Per-query vs. node-hour split (no double-count with CTO-150)
Vertex Vector Search bills in two parts:
1. **Per-query / serving requests** — priced HERE, on the Vector layer, per call.
2. **Deployed-index node-hours** — the compute cost of keeping the index endpoint warm (the dominant Vertex Vector Search spend). This is a **compute** cost, not a per-query cost, and is **deferred to the GCP Cloud Billing compute connector (CTO-150)**. It is deliberately NOT seeded here, so the Vector layer and the future Compute layer never both count node-hours. Documented in a code comment in `pricing.py` and covered by a regression test asserting a node-hour-style key stays unpriced (0).

### Tests
- Wrapped Vertex query/upsert emit `operation='vector'` spans priced from the catalog (non-zero, `price_catalog_version` stamped, no catalog miss).
- Unknown index tier → 0 + one-time WARN, still a well-formed vector span.
- Pricing regression against the real `seed_catalog()`.
- Node-hour key stays unpriced (deferral guard).

### Verification
- SDK: `ruff` clean, **885 passed**.
- Gateway: `ruff` clean, **272 passed**.

Nothing stubbed. The gateway needs no change — it buckets by `GenAiOperation='vector'` (web `LAYER_CASE`) and the cost rides on the SDK-emitted `tool_cost_micro_usd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)