### PR TITLE
feat(demos): GCP/Gemini support in chatbot + aider demos, README (CTO-164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cost-and-value observability for AI products. See what your AI actually costs (a
 Four workflows on one shared data spine:
 
 1. **Agent loop cost visibility.** Why did this run cost 50× median?
-2. **Cross-provider comparison.** Are we on the right model? Real replay, real eval, no marketing benchmarks.
+2. **Cross-provider comparison.** Are we on the right model? Real replay, real eval, no marketing benchmarks. Google/Gemini is now a first-class priced provider here (CTO-149), not a mock column — Compare ranks it against OpenAI and Anthropic on real cost.
 3. **End-to-end cost.** What does this feature really cost? LLM tokens land today; vector / tools / compute / egress connectors are placeholders ("Coming soon" on `/connectors`) until their ingest workers ship.
 4. **Business-outcome attribution.** Is this AI feature profitable? `$/conversion` and margin per provider, joined on a hashed user id. The chatbot demo (`make chatbot-demo`) proves it end-to-end with synthetic conversions; production tenants wire their own revenue source via the gateway's Stripe webhook (the dashboard-side connector UI is the next thing on deck).
 
@@ -52,13 +52,15 @@ The runbook covers nine end-to-end steps, including the demos that exercise each
 
 | Workflow | Command | What it does |
 |---|---|---|
-| Agent loop + edge proxy | `make aider-demo` | Drives Aider against a fixture repo through the edge proxy |
+| Agent loop + edge proxy | `make aider-demo` | Drives Aider against a fixture repo through the edge proxy (`PROVIDER=anthropic`/`google` for cross-provider variants; Gemini runs direct, see `examples/aider-demo/README.md`) |
 | Business-outcome attribution | `make chatbot-demo` | 50 scripted chat sessions across OpenAI + Anthropic with thumbs-up conversion events |
 | Real revenue via Stripe | RUNNING.md §7 | Verified webhook ingest → `business_events` → `$/conversion` |
 | Replay-backed Compare | RUNNING.md §8 | Opt-in 5% sampling, cross-provider replay with daily budget cap |
 | Pairwise LLM-judge quality | RUNNING.md §9 | Pairwise judge with Wilson 95% CIs on win-rate |
 
-Demos need provider keys exported: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`.
+Demos need provider keys exported: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`. `GOOGLE_API_KEY` / `GEMINI_API_KEY` is optional — the demos run without it, and enable the Google/Gemini models (chatbot picker + `PROVIDER=google make aider-demo`) when present.
+
+Deploying on GCP? See `deploy/gcp/` (CTO-153).
 
 ## Development
 
@@ -85,7 +87,7 @@ cd web && npx vitest run
 
 ## Model auto-discovery
 
-On startup the gateway hits `GET /v1/models` on every provider whose API key it has (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), classifies each id into a coarse family (`haiku` / `sonnet` / `opus` / `mini` / `flagship` / `embedding`), and writes the result to `.tally/models.json` with a 24h TTL. The demos read that file via `tally.models.latest_anthropic("sonnet")` (Python) or `resolveLatest()` (Node), so when a provider retires a SKU (`claude-3-5-haiku-latest` was the case that prompted this) the next boot picks up the replacement automatically.
+On startup the gateway hits `GET /v1/models` on every provider whose API key it has (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and — since CTO-149 — `GOOGLE_API_KEY` / `GEMINI_API_KEY` for Google's model list), classifies each id into a coarse family (`haiku` / `sonnet` / `opus` / `mini` / `flagship` / `flash` / `embedding`), and writes the result to `.tally/models.json` with a 24h TTL. The demos read that file via `tally.models.latest_anthropic("sonnet")` (Python) or `resolveLatest()` (Node), so when a provider retires a SKU (`claude-3-5-haiku-latest` was the case that prompted this) the next boot picks up the replacement automatically.
 
 Knobs:
 

--- a/examples/aider-demo/README.md
+++ b/examples/aider-demo/README.md
@@ -21,17 +21,29 @@ see real agent traces in under five minutes.
 3. A provider API key in the environment:
    ```
    export OPENAI_API_KEY=sk-...
-   # or, for the cross-provider variant:
+   # or, for the cross-provider variants:
    export ANTHROPIC_API_KEY=sk-ant-...
+   export GEMINI_API_KEY=...        # (or GOOGLE_API_KEY) for PROVIDER=google
    ```
 
 ## Run it
 
 ```
 cd infra && make aider-demo
-# cross-provider variant:
+# cross-provider variants:
 cd infra && PROVIDER=anthropic make aider-demo
+cd infra && PROVIDER=google make aider-demo    # (PROVIDER=gemini also works)
 ```
+
+**Note on the `google` path:** unlike openai/anthropic, Gemini does **not**
+run through the Go edge-proxy. The proxy is a transparent pass-through built
+for the OpenAI/Anthropic request shape and `Authorization: Bearer` auth;
+Gemini's REST surface differs (LiteLLM's `gemini/*` path posts to
+`generativelanguage.googleapis.com` with the key as a `?key=`/`x-goog-api-key`
+credential). So Aider talks to Gemini **directly**, and `run.sh` still POSTs
+the feature-tagged batch to the gateway (the same side-channel every provider
+uses) so the dashboard gets its rows. Cost enrichment relies on CTO-149 having
+priced `gemini-2.5-flash` in the catalog.
 
 ## What you'll see
 
@@ -91,6 +103,7 @@ cd infra && make aider-demo-stop   # kills the proxy via PID file
 | --- | --- |
 | `ERROR: ai-tally gateway not reachable` | `cd infra && make up && make seed` first |
 | `ERROR: OPENAI_API_KEY not set` | `export OPENAI_API_KEY=…` or pass `PROVIDER=anthropic` |
+| `ERROR: GEMINI_API_KEY (or GOOGLE_API_KEY) not set` | `export GEMINI_API_KEY=…` before `PROVIDER=google make aider-demo` |
 | `ERROR: aider not on PATH` | `pip install aider-chat` |
 | Edge-proxy didn't bind | Check `/tmp/ai-tally-aider-edge-proxy.log` |
 | Dashboard shows "Synthetic preview" | The gateway batch failed — check `make logs` |

--- a/examples/aider-demo/run.sh
+++ b/examples/aider-demo/run.sh
@@ -10,6 +10,8 @@ here="$(cd "$(dirname "$0")" && pwd)"
 source "$here/_dashboard-links.sh"
 
 PROVIDER="${PROVIDER:-openai}"
+# CTO-164: accept `gemini` as an alias for `google` so either spelling works.
+[[ "$PROVIDER" == "gemini" ]] && PROVIDER="google"
 FEATURE_TAG="${FEATURE_TAG:-aider-demo}"
 TENANT="${TENANT:-local-dev}"
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
@@ -17,9 +19,19 @@ PROXY_PORT="${PROXY_PORT:-7070}"
 PROXY_PID_FILE="${PROXY_PID_FILE:-/tmp/ai-tally-aider-edge-proxy.pid}"
 
 # 1. Validate the API key for the chosen provider.
+#    google (Gemini) takes a different path than openai/anthropic — see below.
 if [[ "$PROVIDER" == "anthropic" ]]; then
   [[ -n "${ANTHROPIC_API_KEY:-}" ]] || { echo "ERROR: ANTHROPIC_API_KEY not set"; exit 1; }
   upstream="https://api.anthropic.com"
+elif [[ "$PROVIDER" == "google" ]]; then
+  # Accept GEMINI_API_KEY or GOOGLE_API_KEY; LiteLLM (Aider's backend) reads
+  # GEMINI_API_KEY, so normalize to that.
+  if [[ -z "${GEMINI_API_KEY:-}" && -n "${GOOGLE_API_KEY:-}" ]]; then
+    export GEMINI_API_KEY="$GOOGLE_API_KEY"
+  fi
+  [[ -n "${GEMINI_API_KEY:-}" ]] || { echo "ERROR: GEMINI_API_KEY (or GOOGLE_API_KEY) not set"; exit 1; }
+  # Informational only — see step 3/4 for why Gemini runs direct, not via proxy.
+  upstream="https://generativelanguage.googleapis.com"
 else
   [[ -n "${OPENAI_API_KEY:-}" ]] || { echo "ERROR: OPENAI_API_KEY not set (or pass PROVIDER=anthropic)"; exit 1; }
   upstream="https://api.openai.com"
@@ -51,7 +63,19 @@ start_proxy() {
   done
   echo "ERROR: edge-proxy didn't bind on :$PROXY_PORT (see /tmp/ai-tally-aider-edge-proxy.log)"; exit 1
 }
-start_proxy
+# CTO-164: Gemini runs DIRECT (not through the edge-proxy). The Go proxy is a
+# transparent pass-through that assumes the OpenAI/Anthropic request shape and
+# Authorization: Bearer auth; Gemini's REST surface differs (LiteLLM's
+# `gemini/*` path posts to generativelanguage.googleapis.com with the key as a
+# `?key=`/`x-goog-api-key` credential and a different body schema). Bridging
+# that in the proxy is out of scope here, so for google we skip the proxy and
+# still POST the feature-tagged batch to the gateway (step 5) — the same
+# side-channel every provider already uses to populate the dashboard rows.
+if [[ "$PROVIDER" != "google" ]]; then
+  start_proxy
+else
+  echo "▶ google/Gemini: running Aider direct to $upstream (edge-proxy skipped — see CTO-164 note)"
+fi
 
 # 4. Point Aider at the proxy and pick a model that matches the provider.
 #    Aider speaks OpenAI protocol by default; for Anthropic we explicitly select
@@ -90,6 +114,14 @@ if [[ "$PROVIDER" == "anthropic" ]]; then
   AIDER_MODEL="${AIDER_MODEL:-anthropic/${resolved:-claude-sonnet-4-5}}"
   export ANTHROPIC_API_BASE="http://localhost:$PROXY_PORT"
   export ANTHROPIC_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
+elif [[ "$PROVIDER" == "google" ]]; then
+  # LiteLLM's `gemini/<model>` path reads GEMINI_API_KEY from the env and talks
+  # to generativelanguage.googleapis.com directly (no base-URL override, no
+  # proxy). The fallback id must be one CTO-149 prices — gemini-2.5-flash is in
+  # seed_catalog(), so the batch POST below enriches with a real cost.
+  resolved=$(resolve_from_cache google flash)
+  AIDER_MODEL="${AIDER_MODEL:-gemini/${resolved:-gemini-2.5-flash}}"
+  # No *_API_BASE / *_DEFAULT_HEADERS: Aider hits Gemini directly (see step 3).
 else
   resolved=$(resolve_from_cache openai flagship)
   AIDER_MODEL="${AIDER_MODEL:-${resolved:-gpt-4o}}"

--- a/examples/vercel-chatbot/app/lib/ai/models.ts
+++ b/examples/vercel-chatbot/app/lib/ai/models.ts
@@ -76,6 +76,20 @@ export const chatModels: ChatModel[] = [
     provider: "openai",
     description: "OpenAI flagship — needs OPENAI_API_KEY with credit",
   },
+  {
+    id: "google/gemini-3-flash",
+    name: "Gemini 3 Flash",
+    provider: "google",
+    description:
+      "Google fast-and-cheap — needs GOOGLE_API_KEY or GEMINI_API_KEY",
+  },
+  {
+    id: "google/gemini-2.5-pro",
+    name: "Gemini 2.5 Pro",
+    provider: "google",
+    description:
+      "Google flagship — higher quality, pricier; needs GOOGLE_API_KEY or GEMINI_API_KEY",
+  },
 ];
 
 export async function getCapabilities(): Promise<

--- a/examples/vercel-chatbot/app/lib/ai/providers.ts
+++ b/examples/vercel-chatbot/app/lib/ai/providers.ts
@@ -4,6 +4,7 @@
 // real provider model names here. Real provider is preserved on the span
 // for the dashboard via the existing instrumentation patch.
 import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
 import { customProvider } from "ai";
 import { resolveLatest } from "../resolveModel";
@@ -46,9 +47,19 @@ function resolve(modelId: string) {
   if (modelId.startsWith("openai/")) {
     return openai(modelId.slice("openai/".length));
   }
+  // CTO-164: google/<model> ids route to @ai-sdk/google (Gemini). Needs
+  // GOOGLE_API_KEY or GEMINI_API_KEY at runtime; with neither set the Google
+  // SDK errors on the first call, so the demo boots fine on anthropic/openai
+  // and only Google models fail.
+  if (modelId.startsWith("google/")) {
+    return google(modelId.slice("google/".length));
+  }
   // Legacy / unprefixed ids: keyword-match Claude family, else default.
   if (modelId.includes("claude")) {
     return anthropic(FALLBACK_ANTHROPIC);
+  }
+  if (modelId.includes("gemini")) {
+    return google(modelId);
   }
   return DEFAULT_PROVIDER === "openai"
     ? openai(FALLBACK_OPENAI)

--- a/examples/vercel-chatbot/app/package.json
+++ b/examples/vercel-chatbot/app/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.84",
+    "@ai-sdk/google": "^3.0.71",
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/provider": "^3.0.3",
     "@ai-sdk/react": "3.0.118",

--- a/examples/vercel-chatbot/app/pnpm-lock.yaml
+++ b/examples/vercel-chatbot/app/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.84
         version: 3.0.84(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^3.0.71
+        version: 3.0.91(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^3.0.71
         version: 3.0.71(zod@3.25.76)
@@ -276,6 +279,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/google@3.0.91':
+    resolution: {integrity: sha512-d/ho+sDjArFjreE2002t9jE4LXX3wde97dN2HCLCX1l41gaJV3wf/c/19axjUNfIf/4uUq+nJmhBO0lW/dg3yw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.71':
     resolution: {integrity: sha512-j6eBAa5oHFZ4U5CxpIV3T4zXNM/BviodNCZCL1qHkA4aqkwK9iQ18TWYz2DZcXpw4BO5pikKzqpXORxb1EnZGA==}
     engines: {node: '>=18'}
@@ -294,8 +303,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.38':
+    resolution: {integrity: sha512-/HHGmtKllqjg1OLc023v9w9kK3laW7Z6TzfZukYQWCsGBbzB9p60zTvvpXFVcs44NZBVXL3viOa1HRKUbeee8g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.3':
@@ -4116,6 +4135,12 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/google@3.0.91(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.38(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/openai@3.0.71(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -4136,7 +4161,18 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.38(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 

--- a/examples/vercel-chatbot/run.sh
+++ b/examples/vercel-chatbot/run.sh
@@ -25,6 +25,19 @@ err() { echo "✗ $*" >&2; exit 1; }
 [ -n "${OPENAI_API_KEY:-}" ]    || err "OPENAI_API_KEY is required (export it or put it in ${HERE}/.env)"
 [ -n "${ANTHROPIC_API_KEY:-}" ] || err "ANTHROPIC_API_KEY is required (export it or put it in ${HERE}/.env)"
 
+# CTO-164: Google/Gemini is optional. The picker lists google/* models, but the
+# demo boots on anthropic/openai regardless; if no Google key is present those
+# models just fail on send. Accept either GOOGLE_API_KEY or GEMINI_API_KEY, and
+# normalize to GOOGLE_API_KEY (what @ai-sdk/google reads).
+if [ -z "${GOOGLE_API_KEY:-}" ] && [ -n "${GEMINI_API_KEY:-}" ]; then
+  export GOOGLE_API_KEY="${GEMINI_API_KEY}"
+fi
+if [ -n "${GOOGLE_API_KEY:-}" ]; then
+  echo "✓ Google key detected — google/* models (Gemini) enabled in the picker"
+else
+  echo "· No GOOGLE_API_KEY/GEMINI_API_KEY — google/* models will 401 on send (anthropic/openai unaffected)"
+fi
+
 GATEWAY_HEALTH="${GATEWAY_URL%/}/healthz"
 if ! curl -fsS --max-time 3 "${GATEWAY_HEALTH}" >/dev/null; then
   err "ai-tally gateway not reachable at ${GATEWAY_HEALTH}. Run 'make up' from infra/ first."
@@ -65,7 +78,10 @@ if not found:
     sys.exit(0)
 oi = sorted(m.id for m in found if m.provider == "openai")
 an = sorted(m.id for m in found if m.provider == "anthropic")
-print(f"  ✓ lineup refreshed: openai={oi} anthropic={an}")
+# CTO-164: Google discovery only runs when a Google key is present (CTO-149);
+# empty list is expected and fine when GOOGLE_API_KEY/GEMINI_API_KEY is unset.
+go = sorted(m.id for m in found if m.provider == "google")
+print(f"  ✓ lineup refreshed: openai={oi} anthropic={an} google={go}")
 PY
 fi
 


### PR DESCRIPTION
Implements CTO-164: let both demos run against Google/Gemini and document it.

> **Base:** originally stacked on `fix/cto-147-chatbot-model-refresh` (CTO-147, PR #124). That branch merged to main while this was in flight, so this PR targets **main** directly (the intended auto-retarget outcome). main already contains the CTO-147 gpt-5 model swap.

## vercel-chatbot
- **models.ts**: added `google/gemini-3-flash` and `google/gemini-2.5-pro` to `chatModels` (provider `"google"`), with descriptions noting they need `GOOGLE_API_KEY`/`GEMINI_API_KEY`. Existing anthropic/openai entries untouched. **Both ids are priced by CTO-149** (`seed_catalog()` has `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3-flash` under provider `google`).
- **providers.ts**: `resolve()` now routes `google/` ids through `@ai-sdk/google` (`import { google } from "@ai-sdk/google"`, prefix stripped), plus a `gemini` keyword branch for unprefixed ids. `DEFAULT_PROVIDER` (anthropic) unchanged.
- **package.json**: added `@ai-sdk/google` at `^3.0.71` (matches the sibling `@ai-sdk/openai` range; resolves to `3.0.91`). Lockfile updated.
- **run.sh**: recognizes `GOOGLE_API_KEY`/`GEMINI_API_KEY` (normalized to `GOOGLE_API_KEY`), logs Google in the launch-time discovery refresh, fail-soft — no Google key just means `google/*` models fail on send; demo still boots on anthropic/openai. No hard requirement.

## aider-demo
- **run.sh**: `PROVIDER=google` (accepts `google` or `gemini`). **Routing: direct, not via the edge-proxy.** The Go edge-proxy is a transparent pass-through built for the OpenAI/Anthropic request shape + `Authorization: Bearer`; LiteLLM's `gemini/*` path posts to `generativelanguage.googleapis.com` with the key as a `?key=`/`x-goog-api-key` credential and a different body schema — bridging that in the proxy is out of scope. So Aider runs direct against Gemini and `run.sh` still POSTs the feature-tagged batch to the gateway (the same side-channel every provider uses for dashboard rows). Fallback model `gemini-2.5-flash` (priced by CTO-149); `TALLY_MODEL` strips the `gemini/` prefix so the catalog key matches.
- **README.md**: `GEMINI_API_KEY` prereq, `PROVIDER=google make aider-demo` variant, an explicit direct-path note, and a troubleshooting row.

## README.md (root)
- `GOOGLE_API_KEY` / `GEMINI_API_KEY` added as an **optional** demo prereq (demos work without it).
- Model auto-discovery: provider enumeration now includes Google (CTO-149).
- Product principle #2 (Cross-provider comparison): Gemini noted as a real priced provider on Compare, not a mock column.
- One-line pointer: "Deploying on GCP? See \`deploy/gcp/\` (CTO-153)."

## Verification
- `pnpm install` + `pnpm exec tsc --noEmit` in `examples/vercel-chatbot/app`: clean (exit 0). `@ai-sdk/google@3.0.91` resolved.
- `bash -n examples/aider-demo/run.sh` and `bash -n examples/vercel-chatbot/run.sh`: OK.
- `make -n chatbot-demo` and `make -n aider-demo`: parse OK.
- No Python touched.

## Notes
- **Runtime dep on #125 (CTO-149)** for Gemini pricing in `seed_catalog()` / Google discovery. This branch doesn't contain #125's pricing at build time — the TS build doesn't need it; cost enrichment for Gemini rows lands once #125 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)