### PR TITLE
feat(export): optional BigQuery export sink for spans + attribution (CTO-154)

### DIFF
--- a/db/postgres/0009_tenant_bq_export_config.sql
+++ b/db/postgres/0009_tenant_bq_export_config.sql
@@ -1,0 +1,30 @@
+-- Per-tenant opt-in for the BigQuery export sink (CTO-154).
+--
+-- The export worker mirrors a tenant's telemetry (spans / business_events / attribution / daily
+-- rollups) into the tenant's OWN BigQuery dataset for enterprise analytics. ClickHouse stays the
+-- primary store and the dashboard keeps reading it — this is an additive mirror, never a
+-- replacement.
+--
+-- Opt-in and off by default: `enabled=false`, and a tenant with no row exports nothing. Existing
+-- tenants don't suddenly start mirroring on upgrade.
+--
+-- `project_id` / `dataset` / `table_prefix` name the destination. `credential_ref` is a
+-- *reference*, not a secret: an ADC hint, a Workload-Identity service-account email, or a Secret
+-- Manager resource name. The gateway rejects inline service-account keys here
+-- (`tenant_bq_export._reject_raw_key`) — raw keys never live in this table.
+--
+-- `tenant_id` is plain TEXT (not a UUID FK) because the export worker keys off the same TenantId
+-- string the telemetry path uses end-to-end, exactly like `reconciliation_runs`.
+
+CREATE TABLE IF NOT EXISTS tenant_bq_export_config (
+    tenant_id      TEXT PRIMARY KEY,
+    enabled        BOOLEAN NOT NULL DEFAULT false,
+    project_id     TEXT NOT NULL DEFAULT '',
+    dataset        TEXT NOT NULL DEFAULT 'tally_export',
+    table_prefix   TEXT NOT NULL DEFAULT 'tally_',
+    credential_ref TEXT NOT NULL DEFAULT '',
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- When enabled, a destination is required.
+    CONSTRAINT bq_export_enabled_needs_destination
+        CHECK (enabled = false OR (project_id <> '' AND dataset <> ''))
+);

--- a/db/postgres/0010_bq_export_watermarks.sql
+++ b/db/postgres/0010_bq_export_watermarks.sql
@@ -1,0 +1,21 @@
+-- Incremental export cursor for the BigQuery export sink (CTO-154).
+--
+-- One row per (tenant, source table). `watermark` is the high-water value of that table's
+-- incremental column (spans → Timestamp, business_events → OccurredAt, attribution_records →
+-- AttributedTraceTs, daily_feature_rollup → Day) that has been exported so far. Each export pass
+-- reads rows strictly greater than the stored watermark, upserts them into BigQuery on the same
+-- natural key ClickHouse dedupes on, then advances the watermark to the max value it saw.
+--
+-- A missing row means "never exported" and reads back as NULL — the first pass is a full backfill.
+-- Because the sink upserts on the natural key, a re-run over the same window is idempotent and
+-- never duplicates rows, so it is safe to replay a pass after a crash.
+
+CREATE TABLE IF NOT EXISTS bq_export_watermarks (
+    tenant_id     TEXT NOT NULL,
+    source_table  TEXT NOT NULL,
+    watermark     TIMESTAMPTZ NOT NULL,
+    rows_exported BIGINT NOT NULL DEFAULT 0
+                      CHECK (rows_exported >= 0),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, source_table)
+);

--- a/docs/bigquery-export.md
+++ b/docs/bigquery-export.md
@@ -1,0 +1,127 @@
+# BigQuery export sink (CTO-154)
+
+An **optional, additive** worker that mirrors a tenant's telemetry into the tenant's *own*
+BigQuery dataset for enterprise analytics. ClickHouse stays ai-tally's primary telemetry store and
+the dashboard keeps reading it — BigQuery is a **mirror, never a replacement**. There is no reverse
+sync and no realtime-streaming SLA; batch / near-real-time passes are the v1 contract.
+
+- Code: `infra/gateway/src/gateway/bq_export.py` (worker) and
+  `infra/gateway/src/gateway/tenant_bq_export.py` (per-tenant config + watermark stores).
+- Optional dependency: the `[bigquery]` extra (`google-cloud-bigquery`), **lazy-imported** inside
+  the worker. The gateway imports and boots without it.
+- Default: **disabled** — at the process level (`TALLY_BQ_EXPORT_ENABLED=false`) and per-tenant
+  (`tenant_bq_export_config.enabled=false`, the state for any tenant with no row).
+
+## What is exported
+
+| BigQuery table (prefix + name) | ClickHouse source     | Incremental column   | Natural key (dedupe)                          |
+| ------------------------------ | --------------------- | -------------------- | --------------------------------------------- |
+| `<prefix>otel_spans`           | `otel_spans`          | `Timestamp`          | `TenantId, TraceId, SpanId`                   |
+| `<prefix>business_events`      | `business_events`     | `OccurredAt`         | `TenantId, BusinessEventId`                   |
+| `<prefix>attribution_records`  | `attribution_records` | `AttributedTraceTs`  | `TenantId, BusinessEventId, FeatureTag`       |
+| `<prefix>daily_feature_rollup` | `daily_feature_rollup`| `Day`                | `TenantId, Day, FeatureTag, GenAiResponseModel` |
+
+Columns are schema-mapped 1:1 with typed BigQuery columns. ClickHouse → BigQuery type mapping:
+`String`/`LowCardinality`/`FixedString`/`Enum8` → `STRING`; `DateTime64` → `TIMESTAMP`;
+`Date` → `DATE`; integer types → `INT64`; `Decimal64(8)` → `NUMERIC`; `Float32` → `FLOAT64`.
+
+The long-tail attribute maps are exported as a single BigQuery `JSON` column:
+`otel_spans.SpanAttributes` → `JSON`, and `business_events.RawPayload` → `JSON`.
+
+For `daily_feature_rollup`, the `AggregateFunction(uniq, …)` HLL states cannot be exported raw: the
+reader `uniqMerge`s them into plain `INT64` counts (`TraceCount`, `UserCount`) and `sum()`s the
+`SummingMergeTree` measures, grouped by the rollup's natural key.
+
+The authoritative BigQuery schema for each table is the `schema` on each `ExportTableSpec` in
+`bq_export.py` (`SPANS_SPEC`, `BUSINESS_EVENTS_SPEC`, `ATTRIBUTION_SPEC`, `DAILY_ROLLUP_SPEC`).
+
+## No message bodies (by construction)
+
+The export preserves ai-tally's "counts only, never bodies" invariant (CTO-118):
+
+1. The exported tables hold no message text to begin with — `otel_spans` already drops body-keyed
+   attributes on ingest (`mapping.span_to_row`).
+2. At import time the worker asserts no exported column is body-keyed (reusing the span-side
+   `mapping._is_body_key` guard) and that no spec reads a replay table.
+3. As a second, independent guard, `SpanAttributes` / `RawPayload` JSON maps are body-stripped
+   again before they leave (`strip_body_keys`).
+
+The replay **candidate-response text** (CTO-125, `replay_runs.ResponseText`) is a **separate,
+opt-in tier** and is explicitly **excluded** here — no export spec sources a replay table.
+
+Covered by `infra/gateway/tests/test_bq_export.py`:
+`test_no_exported_column_is_body_keyed`, `test_no_spec_sources_a_replay_body_table`,
+`test_span_attribute_map_strips_body_keys`, `test_project_row_body_strips_json_column`.
+
+## Idempotency
+
+Each pass reads rows strictly greater than the stored watermark, then **upserts** into BigQuery on
+the same natural key ClickHouse dedupes on (`MERGE ... ON <key>`). Re-running a pass — e.g. after a
+crash — never duplicates rows. The watermark advances only to the max value actually seen. Covered
+by `test_rerun_over_same_window_does_not_duplicate` and `test_watermark_advances_and_second_run_is_incremental`.
+
+## Configuration
+
+Process-level settings (env, `TALLY_`-prefixed — see `gateway/config.py`):
+
+| Setting                              | Default         | Meaning                                        |
+| ------------------------------------ | --------------- | ---------------------------------------------- |
+| `TALLY_BQ_EXPORT_ENABLED`            | `false`         | Master kill-switch for the worker.             |
+| `TALLY_BQ_EXPORT_GCP_PROJECT`        | `""`            | Project owning the datasets (or resolve ADC).  |
+| `TALLY_BQ_EXPORT_DEFAULT_DATASET`    | `tally_export`  | Default dataset for a newly-enabled tenant.    |
+| `TALLY_BQ_EXPORT_DEFAULT_TABLE_PREFIX` | `tally_`      | Default table-name prefix.                     |
+| `TALLY_BQ_EXPORT_BATCH_LIMIT`        | `10000`         | Max rows pulled per (tenant, table) pass.      |
+
+Per-tenant config (`tenant_bq_export_config`, migration `db/postgres/0009_...`): `enabled`,
+`project_id`, `dataset`, `table_prefix`, `credential_ref`. Incremental cursor
+(`bq_export_watermarks`, migration `db/postgres/0010_...`): one row per (tenant, source table).
+
+### Auth — reference only, never a raw key
+
+`credential_ref` is a **reference**, not a secret: an ADC hint, a Workload-Identity
+service-account **email**, or a Secret Manager resource name. The gateway **rejects** anything that
+looks like an inline service-account key (`tenant_bq_export._reject_raw_key`). At runtime the client
+uses its default credential chain (ADC / Workload Identity / a `GOOGLE_APPLICATION_CREDENTIALS`
+Secret Manager mount). Raw keys never live in the database.
+
+## Runbook
+
+1. Install the optional extra on the worker host: `uv sync --extra bigquery`.
+2. Grant the runtime identity (Workload Identity SA) `roles/bigquery.dataEditor` on the tenant's
+   dataset and `roles/bigquery.jobUser` on the project.
+3. Create the dataset (`bq mk --dataset <project>:<dataset>`); tables are created on demand
+   (`ensure_table`, `exists_ok=True`).
+4. Enable for the tenant: set `tenant_bq_export_config.enabled=true` with the destination and a
+   `credential_ref`. `TALLY_BQ_EXPORT_ENABLED=true` at the process level.
+5. Invoke a pass per tenant (from a scheduler / cron):
+
+   ```python
+   from gateway.bq_export import ClickHouseExportReader, load_bigquery_sink, run_export
+   from gateway.config import get_settings
+   from gateway.store import ClickHouseStore
+   from gateway.tenant_bq_export import BQExportWatermarkStore, TenantBQExportStore
+
+   settings = get_settings()
+   cfg = TenantBQExportStore(settings).get(tenant_id)
+   run_export(
+       reader=ClickHouseExportReader(ClickHouseStore(settings).client),
+       sink=load_bigquery_sink(cfg.project_id),
+       watermarks=BQExportWatermarkStore(settings),
+       tenant_id=tenant_id,
+       dataset_ref=cfg.dataset_ref(),
+       enabled=cfg.enabled,
+       batch_limit=settings.bq_export_batch_limit,
+   )
+   ```
+
+The first pass backfills (watermark is `NULL`); subsequent passes are incremental. Re-running a
+pass is safe.
+
+## What's stubbed
+
+`GoogleBigQuerySink` (the real load-into-staging + `MERGE` sink) and `ClickHouseExportReader` are
+implemented but exercised only against live BigQuery / ClickHouse — the unit suite drives the
+in-memory fakes (`InMemoryBigQuerySink`, `FakeReader`) so the incremental + idempotency + no-body
+logic is fully testable with no cloud dependencies. Per-tenant *scheduling* (a running daemon /
+cron wiring) is intentionally out of scope, exactly as in `reconciliation.py`; `run_export` is the
+invocable entry point a scheduler calls.

--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -23,6 +23,12 @@ dev = [
     "ruff>=0.6",
     "httpx>=0.27",
 ]
+# Optional analytics-mirror sink (CTO-154). Only needed by deployments that turn on the
+# per-tenant BigQuery export; `gateway.bq_export` lazy-imports it, so the gateway imports
+# and boots fine without this extra installed.
+bigquery = [
+    "google-cloud-bigquery>=3.20",
+]
 
 [tool.uv.sources]
 # The gateway reuses the SDK's wire/enrichment/timekeeping/pricing logic directly.

--- a/infra/gateway/src/gateway/bq_export.py
+++ b/infra/gateway/src/gateway/bq_export.py
@@ -1,0 +1,517 @@
+"""Optional BigQuery export sink for spans + attribution (CTO-154).
+
+An **additive, opt-in mirror** of a tenant's telemetry into their *own* BigQuery dataset for
+enterprise analytics. ClickHouse stays ai-tally's primary store and the dashboard keeps reading
+it; this worker only copies rows out. It is never a replacement and never reads back into the
+product.
+
+What it mirrors, incrementally, per tenant:
+
+* ``otel_spans``            — one BQ row per span (counts/tokens/cost, **never message text**)
+* ``business_events``       — conversion / revenue events
+* ``attribution_records``   — stitched value→feature attributions
+* ``daily_feature_rollup``  — the daily cost/usage rollup (uniq states merged to plain counts)
+
+Design mirrors the repo's existing patterns:
+
+* a :class:`ReplayBlobStore`-style :class:`BigQuerySink` **Protocol** with an in-memory fake for
+  tests and a lazily-constructed real client, so the module imports without the optional dep
+  (exactly like the replay/GCS optional-backend split);
+* a :mod:`gateway.reconciliation`-style pure orchestrator (``run_export``) over injected
+  reader / sink / watermark stores, so the incremental + idempotency logic is unit-testable with
+  no live ClickHouse or BigQuery;
+* the ClickHouse read uses ``client.query(sql).result_rows`` — the same surface
+  :meth:`gateway.store.ClickHouseStore.ping` uses.
+
+**No bodies, by construction (CTO-118 / CTO-125).** The exported tables hold no message bodies:
+we reuse the span-side ``_is_body_key`` guard to (a) assert at import time that no exported column
+is body-keyed and (b) strip any body-keyed entry out of the ``SpanAttributes`` JSON map before it
+leaves. The replay candidate-response text (CTO-125, ``replay_runs.ResponseText``) is a separate
+opt-in tier and is *explicitly excluded* here — none of the export specs read a replay table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any, Protocol
+
+from gateway.mapping import COLUMNS as _SPAN_COLUMNS
+from gateway.mapping import _is_body_key
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Sequence
+
+
+class BigQueryDependencyMissing(RuntimeError):
+    """Raised when export is invoked but the optional ``[bigquery]`` extra isn't installed."""
+
+
+# Replay tables carry candidate response bodies (CTO-125) under their own opt-in tier; the export
+# sink must never source from them. Enforced at import time against every spec below.
+_EXCLUDED_SOURCE_TABLES = frozenset({"replay_runs", "replay_samples"})
+
+
+# --- Schema ------------------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class BQField:
+    """One BigQuery column. ``type`` is a standard-SQL type name (STRING/INT64/NUMERIC/...)."""
+
+    name: str
+    type: str
+    mode: str = "NULLABLE"
+
+
+@dataclass(frozen=True, slots=True)
+class ExportTableSpec:
+    """How one ClickHouse source table maps to one BigQuery table.
+
+    * ``watermark_column`` — the monotonically-advancing column used for incremental reads.
+    * ``key_columns``      — the same natural key ClickHouse dedupes on; the sink upserts on it so
+                             re-runs never duplicate.
+    * ``json_columns``     — columns exported as a BQ ``JSON`` column (the long-tail
+                             ``SpanAttributes`` / ``RawPayload`` maps).
+    * ``source_exprs``     — optional SQL expression overriding a column's source (used for the
+                             rollup's ``uniqMerge``/``sum`` aggregates).
+    * ``group_by``         — non-empty only for aggregate specs (the rollup); drives ``GROUP BY``.
+    """
+
+    name: str
+    source_table: str
+    watermark_column: str
+    key_columns: tuple[str, ...]
+    schema: tuple[BQField, ...]
+    json_columns: tuple[str, ...] = ()
+    source_exprs: dict[str, str] = field(default_factory=dict)
+    group_by: tuple[str, ...] = ()
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        return tuple(f.name for f in self.schema)
+
+    def select_list(self) -> str:
+        """The ``SELECT`` expression list, applying any ``source_exprs`` aliases."""
+        parts = []
+        for col in self.columns:
+            expr = self.source_exprs.get(col)
+            parts.append(f"{expr} AS {col}" if expr else col)
+        return ", ".join(parts)
+
+
+def _s(name: str) -> BQField:
+    return BQField(name, "STRING")
+
+
+# otel_spans: 1:1 typed columns straight from the gateway insert column list, with the long-tail
+# SpanAttributes map exported as a single JSON column. Message text is never in this table.
+_SPAN_TYPES: dict[str, str] = {
+    "Timestamp": "TIMESTAMP",
+    "StatusCode": "INT64",
+    "DurationNs": "INT64",
+    "InputTokens": "INT64",
+    "OutputTokens": "INT64",
+    "CachedInputTokens": "INT64",
+    "EstimatedCost": "NUMERIC",
+    "AgentStepIndex": "INT64",
+    "ContextDroppedMessages": "INT64",
+    "ContextDroppedTokens": "INT64",
+    "ContextWindowUsedPct": "FLOAT64",
+    "SamplingRate": "FLOAT64",
+    "SpanAttributes": "JSON",
+    "SampleRate": "FLOAT64",
+}
+SPANS_SPEC = ExportTableSpec(
+    name="otel_spans",
+    source_table="otel_spans",
+    watermark_column="Timestamp",
+    key_columns=("TenantId", "TraceId", "SpanId"),
+    schema=tuple(BQField(c, _SPAN_TYPES.get(c, "STRING")) for c in _SPAN_COLUMNS),
+    json_columns=("SpanAttributes",),
+)
+
+BUSINESS_EVENTS_SPEC = ExportTableSpec(
+    name="business_events",
+    source_table="business_events",
+    watermark_column="OccurredAt",
+    key_columns=("TenantId", "BusinessEventId"),
+    schema=(
+        _s("TenantId"),
+        _s("BusinessEventId"),
+        _s("EventName"),
+        _s("UserIdHash"),
+        BQField("OccurredAt", "TIMESTAMP"),
+        BQField("IngestedAt", "TIMESTAMP"),
+        BQField("ValueAmountMicro", "INT64"),
+        _s("ValueCurrency"),
+        _s("ValueType"),
+        _s("Source"),
+        BQField("RawPayload", "JSON"),
+    ),
+    json_columns=("RawPayload",),
+)
+
+ATTRIBUTION_SPEC = ExportTableSpec(
+    name="attribution_records",
+    source_table="attribution_records",
+    watermark_column="AttributedTraceTs",
+    key_columns=("TenantId", "BusinessEventId", "FeatureTag"),
+    schema=(
+        _s("TenantId"),
+        _s("BusinessEventId"),
+        _s("FeatureTag"),
+        _s("AttributedTraceId"),
+        BQField("AttributedTraceTs", "TIMESTAMP"),
+        BQField("AttributedTraceCost", "NUMERIC"),
+        BQField("ValueAmountMicro", "INT64"),
+        _s("ValueCurrency"),
+        _s("AttributionModel"),
+        _s("AttributionConfidence"),
+        _s("UserIdHashKeyVersion"),
+        BQField("LookbackWindowDays", "INT64"),
+        BQField("StitchedAt", "TIMESTAMP"),
+        _s("StitcherVersion"),
+    ),
+)
+
+# daily_feature_rollup: the uniq HLL states can't be exported raw — merge them to plain counts,
+# and sum the SummingMergeTree measures across parts, grouped by the rollup's natural key.
+DAILY_ROLLUP_SPEC = ExportTableSpec(
+    name="daily_feature_rollup",
+    source_table="daily_feature_rollup",
+    watermark_column="Day",
+    key_columns=("TenantId", "Day", "FeatureTag", "GenAiResponseModel"),
+    schema=(
+        _s("TenantId"),
+        BQField("Day", "DATE"),
+        _s("FeatureTag"),
+        _s("GenAiResponseModel"),
+        BQField("InputTokens", "INT64"),
+        BQField("OutputTokens", "INT64"),
+        BQField("CachedInputTokens", "INT64"),
+        BQField("EstimatedCost", "NUMERIC"),
+        BQField("ReconciledCost", "NUMERIC"),
+        BQField("SpanCount", "INT64"),
+        BQField("TraceCount", "INT64"),
+        BQField("UserCount", "INT64"),
+    ),
+    source_exprs={
+        "InputTokens": "sum(InputTokens)",
+        "OutputTokens": "sum(OutputTokens)",
+        "CachedInputTokens": "sum(CachedInputTokens)",
+        "EstimatedCost": "sum(EstimatedCost)",
+        "ReconciledCost": "sum(ReconciledCost)",
+        "SpanCount": "sum(SpanCount)",
+        "TraceCount": "uniqMerge(TraceCountState)",
+        "UserCount": "uniqMerge(UserCountState)",
+    },
+    group_by=("TenantId", "Day", "FeatureTag", "GenAiResponseModel"),
+)
+
+ALL_SPECS: tuple[ExportTableSpec, ...] = (
+    SPANS_SPEC,
+    BUSINESS_EVENTS_SPEC,
+    ATTRIBUTION_SPEC,
+    DAILY_ROLLUP_SPEC,
+)
+
+SPECS_BY_TABLE: dict[str, ExportTableSpec] = {s.source_table: s for s in ALL_SPECS}
+
+
+# --- No-bodies invariant, enforced at import ---------------------------------------------------
+
+def _assert_no_body_columns() -> None:
+    """Fail fast if any spec would ever export a body-keyed column or read a replay table."""
+    for spec in ALL_SPECS:
+        if spec.source_table in _EXCLUDED_SOURCE_TABLES:
+            raise AssertionError(
+                f"export spec {spec.name!r} sources an excluded body-bearing table "
+                f"{spec.source_table!r}"
+            )
+        body_cols = [c for c in spec.columns if _is_body_key(c)]
+        if body_cols:
+            raise AssertionError(
+                f"export spec {spec.name!r} would export body-keyed columns {body_cols!r}"
+            )
+        # Belt-and-braces: the replay candidate-response field must never appear as a column.
+        banned = {"responsetext", "response_text"}
+        leaked = [c for c in spec.columns if c.lower() in banned]
+        if leaked:
+            raise AssertionError(f"export spec {spec.name!r} leaks replay body column {leaked!r}")
+
+
+_assert_no_body_columns()
+
+
+def strip_body_keys(attrs: dict[str, Any]) -> dict[str, Any]:
+    """Drop any body-keyed entry from a long-tail attribute map before it is exported.
+
+    ``SpanAttributes`` is already body-filtered on ingest (``mapping.span_to_row``); this is a
+    second, independent guard so a body key can never reach BigQuery even if a raw row is fed in.
+    """
+    return {k: v for k, v in attrs.items() if not _is_body_key(str(k))}
+
+
+def project_row(spec: ExportTableSpec, row: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a raw source row to exactly the exported columns, body-stripping JSON maps."""
+    out: dict[str, Any] = {}
+    for col in spec.columns:
+        value = row.get(col)
+        if col in spec.json_columns and isinstance(value, dict):
+            value = strip_body_keys(value)
+        out[col] = value
+    return out
+
+
+# --- Sink (Protocol + in-memory fake + lazy real client) ---------------------------------------
+
+class BigQuerySink(Protocol):
+    """Minimal put-only contract the exporter needs; keeps the worker BQ-client-agnostic."""
+
+    def ensure_table(self, table_id: str, schema: Sequence[BQField]) -> None: ...
+
+    def upsert_rows(
+        self, table_id: str, key_columns: Sequence[str], rows: Sequence[dict[str, Any]]
+    ) -> int: ...
+
+
+class InMemoryBigQuerySink:
+    """Dict-backed sink used by tests and local dev.
+
+    Idempotent by the same natural key ClickHouse dedupes on: ``upsert_rows`` overwrites any row
+    with a matching key tuple, so re-running an export never grows the table.
+    """
+
+    def __init__(self) -> None:
+        self._tables: dict[str, dict[tuple[Any, ...], dict[str, Any]]] = {}
+        self._schemas: dict[str, tuple[BQField, ...]] = {}
+
+    def ensure_table(self, table_id: str, schema: Sequence[BQField]) -> None:
+        self._tables.setdefault(table_id, {})
+        self._schemas[table_id] = tuple(schema)
+
+    def upsert_rows(
+        self, table_id: str, key_columns: Sequence[str], rows: Sequence[dict[str, Any]]
+    ) -> int:
+        table = self._tables.setdefault(table_id, {})
+        for row in rows:
+            key = tuple(row.get(k) for k in key_columns)
+            table[key] = dict(row)
+        return len(rows)
+
+    def rows(self, table_id: str) -> list[dict[str, Any]]:
+        return list(self._tables.get(table_id, {}).values())
+
+    def __len__(self) -> int:
+        return sum(len(t) for t in self._tables.values())
+
+
+class GoogleBigQuerySink:
+    """Real sink over ``google-cloud-bigquery``. Constructed by :func:`load_bigquery_sink` only.
+
+    Idempotency uses a load-into-staging + ``MERGE`` on the natural key, so a re-export upserts
+    rather than appends. The BQ client is injected (already lazily imported) to keep this class
+    importable for typing even when the extra is absent.
+
+    NB: exercised only against a live BigQuery project — the unit suite drives
+    :class:`InMemoryBigQuerySink`. See docs/bigquery-export.md for the runbook.
+    """
+
+    def __init__(self, client: Any) -> None:  # pragma: no cover - needs live BQ
+        self._client = client
+
+    def ensure_table(self, table_id: str, schema: Sequence[BQField]) -> None:  # pragma: no cover
+        from google.cloud import bigquery  # lazy: optional dep
+
+        fields = [bigquery.SchemaField(f.name, f.type, mode=f.mode) for f in schema]
+        table = bigquery.Table(table_id, schema=fields)
+        self._client.create_table(table, exists_ok=True)
+
+    def upsert_rows(  # pragma: no cover - needs live BQ
+        self, table_id: str, key_columns: Sequence[str], rows: Sequence[dict[str, Any]]
+    ) -> int:
+        from google.cloud import bigquery  # lazy: optional dep
+
+        if not rows:
+            return 0
+        staging_id = f"{table_id}__staging"
+        self._client.load_table_from_json(
+            list(rows),
+            staging_id,
+            job_config=bigquery.LoadJobConfig(
+                write_disposition="WRITE_TRUNCATE",
+                schema_update_options=[bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION],
+            ),
+        ).result()
+        on = " AND ".join(f"T.{k}=S.{k}" for k in key_columns)
+        cols = list(rows[0].keys())
+        set_clause = ", ".join(f"{c}=S.{c}" for c in cols)
+        insert_cols = ", ".join(cols)
+        insert_vals = ", ".join(f"S.{c}" for c in cols)
+        self._client.query(
+            f"MERGE `{table_id}` T USING `{staging_id}` S ON {on} "
+            f"WHEN MATCHED THEN UPDATE SET {set_clause} "
+            f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
+        ).result()
+        return len(rows)
+
+
+def load_bigquery_sink(project_id: str | None = None) -> BigQuerySink:
+    """Lazily construct the real BigQuery sink; raises if the ``[bigquery]`` extra is absent.
+
+    Auth is left to the client's default credential chain (ADC / Workload Identity / a
+    ``GOOGLE_APPLICATION_CREDENTIALS`` Secret Manager mount) — this function never takes a raw key.
+    """
+    try:
+        from google.cloud import bigquery  # noqa: PLC0415 - lazy optional import by design
+    except ImportError as exc:  # pragma: no cover - depends on env
+        raise BigQueryDependencyMissing(
+            "BigQuery export requires the optional 'bigquery' extra: "
+            "`uv sync --extra bigquery` (installs google-cloud-bigquery)."
+        ) from exc
+    return GoogleBigQuerySink(bigquery.Client(project=project_id or None))
+
+
+# --- ClickHouse read source --------------------------------------------------------------------
+
+class ExportReader(Protocol):
+    """Reads incremental source rows since a watermark. Injected so the worker is CH-agnostic."""
+
+    def fetch_since(
+        self, spec: ExportTableSpec, tenant_id: str, watermark: datetime | date | None, limit: int
+    ) -> list[dict[str, Any]]: ...
+
+
+class ClickHouseExportReader:
+    """Reads incremental rows via ``client.query(sql).result_rows`` (same surface as ``ping``)."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def fetch_since(  # pragma: no cover - needs live ClickHouse
+        self, spec: ExportTableSpec, tenant_id: str, watermark: datetime | date | None, limit: int
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"tenant_id": tenant_id, "limit": int(limit)}
+        sql = f"SELECT {spec.select_list()} FROM {spec.source_table} WHERE TenantId = %(tenant_id)s"
+        if watermark is not None:
+            params["watermark"] = watermark
+            sql += f" AND {spec.watermark_column} > %(watermark)s"
+        if spec.group_by:
+            sql += " GROUP BY " + ", ".join(spec.group_by)
+        sql += f" ORDER BY {spec.watermark_column} ASC LIMIT %(limit)s"
+        result = self._client.query(sql, parameters=params)
+        cols = list(result.column_names)
+        return [dict(zip(cols, r, strict=False)) for r in result.result_rows]
+
+
+# --- Watermark store (Postgres-backed; Protocol + in-memory fake) ------------------------------
+
+class WatermarkStore(Protocol):
+    """Persists the last-exported watermark per (tenant, source table)."""
+
+    def get(self, tenant_id: str, source_table: str) -> datetime | date | None: ...
+
+    def advance(
+        self, tenant_id: str, source_table: str, watermark: datetime | date, rows: int
+    ) -> None: ...
+
+
+class InMemoryWatermarkStore:
+    """Dict-backed watermark store for tests / local dev."""
+
+    def __init__(self) -> None:
+        self._marks: dict[tuple[str, str], datetime | date] = {}
+
+    def get(self, tenant_id: str, source_table: str) -> datetime | date | None:
+        return self._marks.get((tenant_id, source_table))
+
+    def advance(
+        self, tenant_id: str, source_table: str, watermark: datetime | date, rows: int
+    ) -> None:
+        self._marks[(tenant_id, source_table)] = watermark
+
+
+# --- Orchestrator ------------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class ExportResult:
+    source_table: str
+    rows_exported: int
+    previous_watermark: datetime | date | None
+    new_watermark: datetime | date | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "source_table": self.source_table,
+            "rows_exported": self.rows_exported,
+            "previous_watermark": _iso(self.previous_watermark),
+            "new_watermark": _iso(self.new_watermark),
+        }
+
+
+def _iso(value: datetime | date | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def export_table(
+    *,
+    spec: ExportTableSpec,
+    reader: ExportReader,
+    sink: BigQuerySink,
+    watermarks: WatermarkStore,
+    tenant_id: str,
+    dataset_ref: str,
+    enabled: bool,
+    batch_limit: int = 10_000,
+) -> ExportResult:
+    """Export one table for one tenant. A no-op returning zero rows when export is disabled.
+
+    ``dataset_ref`` is the fully-qualified ``project.dataset.prefix`` a table name appends to.
+    """
+    previous = watermarks.get(tenant_id, spec.source_table)
+    if not enabled:
+        return ExportResult(spec.source_table, 0, previous, previous)
+
+    table_id = f"{dataset_ref}{spec.name}"
+    sink.ensure_table(table_id, spec.schema)
+
+    rows = reader.fetch_since(spec, tenant_id, previous, batch_limit)
+    projected = [project_row(spec, r) for r in rows]
+    written = sink.upsert_rows(table_id, spec.key_columns, projected)
+
+    new_watermark = previous
+    for raw in rows:
+        ts = raw.get(spec.watermark_column)
+        if ts is not None and (new_watermark is None or ts > new_watermark):
+            new_watermark = ts
+    if new_watermark is not None and new_watermark != previous:
+        watermarks.advance(tenant_id, spec.source_table, new_watermark, written)
+
+    return ExportResult(spec.source_table, written, previous, new_watermark)
+
+
+def run_export(
+    *,
+    reader: ExportReader,
+    sink: BigQuerySink,
+    watermarks: WatermarkStore,
+    tenant_id: str,
+    dataset_ref: str,
+    enabled: bool,
+    batch_limit: int = 10_000,
+    specs: Sequence[ExportTableSpec] = ALL_SPECS,
+) -> list[ExportResult]:
+    """Run every export table for one tenant, advancing each table's watermark independently."""
+    return [
+        export_table(
+            spec=spec,
+            reader=reader,
+            sink=sink,
+            watermarks=watermarks,
+            tenant_id=tenant_id,
+            dataset_ref=dataset_ref,
+            enabled=enabled,
+            batch_limit=batch_limit,
+        )
+        for spec in specs
+    ]

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -57,6 +57,24 @@ class Settings(BaseSettings):
     replay_blob_backend: str = "memory"
     replay_gcs_bucket: str = ""
 
+    # BigQuery export sink (CTO-154). OPTIONAL, additive analytics mirror that copies
+    # spans / business_events / attribution / daily rollups into a tenant's OWN BigQuery
+    # dataset. ClickHouse stays the primary store and the dashboard keeps reading it — this
+    # is a mirror, never a replacement. DISABLED by default at both the process level (this
+    # flag) and per-tenant (``tenant_bq_export_config.enabled``, also default false), so no
+    # existing deployment starts exporting on upgrade. Auth is via ADC / Workload Identity /
+    # a Secret Manager reference stored per-tenant — never a raw service-account key.
+    # Requires the optional ``[bigquery]`` extra (``google-cloud-bigquery``), lazy-imported
+    # in :mod:`gateway.bq_export` so the gateway boots without it.
+    bq_export_enabled: bool = False
+    # GCP project that owns the export datasets. Empty means "resolve from ADC / per-tenant".
+    bq_export_gcp_project: str = ""
+    # Defaults for a tenant that enables export without overriding dataset/prefix.
+    bq_export_default_dataset: str = "tally_export"
+    bq_export_default_table_prefix: str = "tally_"
+    # Max rows pulled from ClickHouse per (tenant, table) export pass.
+    bq_export_batch_limit: int = 10_000
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/tenant_bq_export.py
+++ b/infra/gateway/src/gateway/tenant_bq_export.py
@@ -1,0 +1,201 @@
+"""Per-tenant config + watermark stores for the BigQuery export sink (CTO-154).
+
+Exporting a tenant's telemetry into their own BigQuery dataset is opt-in and off by default: a
+tenant with no row returns :data:`DEFAULT_CONFIG` (``enabled=False``), so no existing deployment
+starts mirroring on upgrade. When enabled, the tenant supplies their destination
+(``project_id`` / ``dataset`` / ``table_prefix``) and a **credential reference** — an ADC hint,
+a Workload-Identity service-account email, or a Secret Manager resource name. We deliberately
+reject anything that looks like an inline service-account key: raw keys never live in this table.
+
+``BQExportWatermarkStore`` is the append-per-pass incremental cursor, one row per
+(tenant, source table), mirroring the ``reconciliation_runs`` run-log pattern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+
+import psycopg
+
+from gateway.config import Settings
+
+
+class RawKeyRejected(ValueError):
+    """Raised when a credential ref looks like an inline key rather than a reference."""
+
+
+# Substrings that betray an inline/raw service-account key being pasted where only a *reference*
+# belongs. Auth must flow through ADC / Workload Identity / Secret Manager, never a raw key.
+_RAW_KEY_MARKERS = ("private_key", "-----begin", "\"type\": \"service_account\"", "'type':")
+
+
+def _reject_raw_key(credential_ref: str) -> None:
+    lowered = credential_ref.lower()
+    if any(marker in lowered for marker in _RAW_KEY_MARKERS):
+        raise RawKeyRejected(
+            "credential_ref must be a reference (ADC hint, Workload-Identity SA email, or "
+            "Secret Manager resource name) — never an inline service-account key."
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BQExportConfig:
+    enabled: bool
+    project_id: str
+    dataset: str
+    table_prefix: str
+    # ADC hint / Workload-Identity SA email / Secret Manager resource name. Never a raw key.
+    credential_ref: str
+
+    def dataset_ref(self) -> str:
+        """Fully-qualified ``project.dataset.prefix`` a table name appends to."""
+        return f"{self.project_id}.{self.dataset}.{self.table_prefix}"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "enabled": self.enabled,
+            "project_id": self.project_id,
+            "dataset": self.dataset,
+            "table_prefix": self.table_prefix,
+            "credential_ref": self.credential_ref,
+        }
+
+
+def default_config(settings: Settings) -> BQExportConfig:
+    return BQExportConfig(
+        enabled=False,
+        project_id=settings.bq_export_gcp_project,
+        dataset=settings.bq_export_default_dataset,
+        table_prefix=settings.bq_export_default_table_prefix,
+        credential_ref="",
+    )
+
+
+# Module-level default with no Settings (off, empty destination). Convenience for callers/tests.
+DEFAULT_CONFIG = BQExportConfig(
+    enabled=False, project_id="", dataset="tally_export", table_prefix="tally_", credential_ref=""
+)
+
+
+class TenantBQExportStore:
+    """Tiny Postgres surface over ``tenant_bq_export_config`` (mirrors ``TenantReplayStore``)."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+        self._defaults = default_config(settings)
+
+    def get(self, tenant_id: str) -> BQExportConfig:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT enabled, project_id, dataset, table_prefix, credential_ref
+                FROM tenant_bq_export_config
+                WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return self._defaults
+            return BQExportConfig(
+                enabled=bool(row[0]),
+                project_id=str(row[1]),
+                dataset=str(row[2]),
+                table_prefix=str(row[3]),
+                credential_ref=str(row[4]),
+            )
+
+    def upsert(
+        self,
+        tenant_id: str,
+        *,
+        enabled: bool | None = None,
+        project_id: str | None = None,
+        dataset: str | None = None,
+        table_prefix: str | None = None,
+        credential_ref: str | None = None,
+    ) -> BQExportConfig:
+        current = self.get(tenant_id)
+        new = BQExportConfig(
+            enabled=current.enabled if enabled is None else bool(enabled),
+            project_id=current.project_id if project_id is None else str(project_id),
+            dataset=current.dataset if dataset is None else str(dataset),
+            table_prefix=current.table_prefix if table_prefix is None else str(table_prefix),
+            credential_ref=current.credential_ref
+            if credential_ref is None
+            else str(credential_ref),
+        )
+        if new.credential_ref:
+            _reject_raw_key(new.credential_ref)
+        if new.enabled and not (new.project_id and new.dataset):
+            raise ValueError("project_id and dataset are required when export is enabled")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO tenant_bq_export_config
+                    (tenant_id, enabled, project_id, dataset, table_prefix, credential_ref,
+                     updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s, now())
+                ON CONFLICT (tenant_id) DO UPDATE
+                  SET enabled        = EXCLUDED.enabled,
+                      project_id     = EXCLUDED.project_id,
+                      dataset        = EXCLUDED.dataset,
+                      table_prefix   = EXCLUDED.table_prefix,
+                      credential_ref = EXCLUDED.credential_ref,
+                      updated_at     = now()
+                """,
+                (
+                    tenant_id,
+                    new.enabled,
+                    new.project_id,
+                    new.dataset,
+                    new.table_prefix,
+                    new.credential_ref,
+                ),
+            )
+            conn.commit()
+        return new
+
+
+class BQExportWatermarkStore:
+    """Postgres-backed incremental cursor: one row per (tenant, source table).
+
+    Implements the :class:`gateway.bq_export.WatermarkStore` protocol so it drops straight into
+    ``run_export``. A missing row means "never exported" and reads back as ``None`` — a full
+    initial backfill on first run.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str, source_table: str) -> datetime | date | None:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT watermark
+                FROM bq_export_watermarks
+                WHERE tenant_id = %s AND source_table = %s
+                """,
+                (tenant_id, source_table),
+            )
+            row = cur.fetchone()
+            return row[0] if row is not None else None
+
+    def advance(
+        self, tenant_id: str, source_table: str, watermark: datetime | date, rows: int
+    ) -> None:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO bq_export_watermarks
+                    (tenant_id, source_table, watermark, rows_exported, updated_at)
+                VALUES (%s, %s, %s, %s, now())
+                ON CONFLICT (tenant_id, source_table) DO UPDATE
+                  SET watermark     = EXCLUDED.watermark,
+                      rows_exported = bq_export_watermarks.rows_exported + EXCLUDED.rows_exported,
+                      updated_at    = now()
+                """,
+                (tenant_id, source_table, watermark, rows),
+            )
+            conn.commit()

--- a/infra/gateway/tests/test_bq_export.py
+++ b/infra/gateway/tests/test_bq_export.py
@@ -1,0 +1,261 @@
+"""BigQuery export sink (CTO-154).
+
+Pins the export worker's guarantees with a faked reader + in-memory sink (no live ClickHouse or
+BigQuery): the incremental watermark advances, a re-run doesn't duplicate (idempotency), no
+body-keyed field is ever exported, export is disabled by default, and the optional dependency is
+lazy-imported (the module imports without ``google-cloud-bigquery``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import date, datetime, timezone
+
+import pytest
+
+from gateway import bq_export
+from gateway.bq_export import (
+    ALL_SPECS,
+    DAILY_ROLLUP_SPEC,
+    SPANS_SPEC,
+    BigQueryDependencyMissing,
+    ExportTableSpec,
+    InMemoryBigQuerySink,
+    InMemoryWatermarkStore,
+    load_bigquery_sink,
+    project_row,
+    run_export,
+    strip_body_keys,
+)
+
+UTC = timezone.utc
+TENANT = "t-acme"
+DATASET_REF = "proj.tally_export.tally_"
+
+
+class FakeReader:
+    """In-memory ExportReader: returns canned rows, honouring the watermark + limit like CH would."""
+
+    def __init__(self, rows_by_table: dict[str, list[dict[str, object]]]) -> None:
+        self._rows = rows_by_table
+
+    def fetch_since(
+        self,
+        spec: ExportTableSpec,
+        tenant_id: str,
+        watermark: datetime | date | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        rows = [r for r in self._rows.get(spec.source_table, []) if r["TenantId"] == tenant_id]
+        if watermark is not None:
+            rows = [r for r in rows if r[spec.watermark_column] > watermark]
+        rows.sort(key=lambda r: r[spec.watermark_column])
+        return rows[:limit]
+
+
+def _span_row(trace: str, span: str, ts: datetime, **extra: object) -> dict[str, object]:
+    row: dict[str, object] = {c: "" for c in SPANS_SPEC.columns}
+    row.update(
+        TenantId=TENANT,
+        TraceId=trace,
+        SpanId=span,
+        Timestamp=ts,
+        InputTokens=10,
+        OutputTokens=20,
+        SpanAttributes={"gen_ai.request.temperature": "0.7"},
+    )
+    row.update(extra)
+    return row
+
+
+def _spans_reader(rows: list[dict[str, object]]) -> FakeReader:
+    return FakeReader({"otel_spans": rows})
+
+
+# --- disabled by default ------------------------------------------------------------------------
+
+def test_export_disabled_by_default_is_a_noop() -> None:
+    reader = _spans_reader([_span_row("tr1", "sp1", datetime(2026, 7, 1, tzinfo=UTC))])
+    sink = InMemoryBigQuerySink()
+    marks = InMemoryWatermarkStore()
+
+    results = run_export(
+        reader=reader,
+        sink=sink,
+        watermarks=marks,
+        tenant_id=TENANT,
+        dataset_ref=DATASET_REF,
+        enabled=False,
+        specs=(SPANS_SPEC,),
+    )
+
+    assert results[0].rows_exported == 0
+    assert len(sink) == 0
+    assert marks.get(TENANT, "otel_spans") is None
+
+
+# --- incremental watermark ----------------------------------------------------------------------
+
+def test_watermark_advances_and_second_run_is_incremental() -> None:
+    t0 = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    t1 = datetime(2026, 7, 1, 13, 0, tzinfo=UTC)
+    reader = _spans_reader([_span_row("tr1", "sp1", t0), _span_row("tr2", "sp2", t1)])
+    sink = InMemoryBigQuerySink()
+    marks = InMemoryWatermarkStore()
+
+    first = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+    assert first.rows_exported == 2
+    assert first.previous_watermark is None
+    assert marks.get(TENANT, "otel_spans") == t1
+
+    # Nothing new -> second pass exports zero and leaves the watermark put.
+    second = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+    assert second.rows_exported == 0
+    assert marks.get(TENANT, "otel_spans") == t1
+
+    # A newer row -> only that one is picked up, watermark advances again.
+    t2 = datetime(2026, 7, 1, 14, 0, tzinfo=UTC)
+    reader._rows["otel_spans"].append(_span_row("tr3", "sp3", t2))
+    third = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+    assert third.rows_exported == 1
+    assert marks.get(TENANT, "otel_spans") == t2
+    assert len(sink.rows(f"{DATASET_REF}otel_spans")) == 3
+
+
+# --- idempotency --------------------------------------------------------------------------------
+
+def test_rerun_over_same_window_does_not_duplicate() -> None:
+    t0 = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    rows = [_span_row("tr1", "sp1", t0), _span_row("tr2", "sp2", t0)]
+    reader = _spans_reader(rows)
+    sink = InMemoryBigQuerySink()
+
+    # Re-run the SAME window twice by resetting the watermark each time (simulates a replayed pass
+    # after a crash). The sink upserts on (TenantId, TraceId, SpanId), so the table size is stable.
+    for _ in range(3):
+        run_export(
+            reader=reader, sink=sink, watermarks=InMemoryWatermarkStore(), tenant_id=TENANT,
+            dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+        )
+
+    assert len(sink.rows(f"{DATASET_REF}otel_spans")) == 2
+
+
+def test_sink_upsert_is_keyed_not_appended() -> None:
+    sink = InMemoryBigQuerySink()
+    sink.ensure_table("tbl", SPANS_SPEC.schema)
+    row = {"TenantId": TENANT, "TraceId": "tr1", "SpanId": "sp1", "InputTokens": 1}
+    sink.upsert_rows("tbl", SPANS_SPEC.key_columns, [row])
+    sink.upsert_rows("tbl", SPANS_SPEC.key_columns, [{**row, "InputTokens": 99}])
+    stored = sink.rows("tbl")
+    assert len(stored) == 1
+    assert stored[0]["InputTokens"] == 99
+
+
+# --- no bodies ----------------------------------------------------------------------------------
+
+def test_no_exported_column_is_body_keyed() -> None:
+    for spec in ALL_SPECS:
+        for col in spec.columns:
+            assert not bq_export._is_body_key(col), f"{spec.name}.{col} is body-keyed"
+
+
+def test_no_spec_sources_a_replay_body_table() -> None:
+    banned = {"replay_runs", "replay_samples"}
+    for spec in ALL_SPECS:
+        assert spec.source_table not in banned
+        # The CTO-125 candidate response field must never surface as a column either.
+        assert not any(c.lower() in {"responsetext", "response_text"} for c in spec.columns)
+
+
+def test_span_attribute_map_strips_body_keys() -> None:
+    attrs = {
+        "gen_ai.request.temperature": "0.7",
+        "gen_ai.prompt": "SECRET USER PROMPT",
+        "content": "SECRET BODY",
+        "messages": "[...]",
+        "region": "us-east1",
+    }
+    cleaned = strip_body_keys(attrs)
+    assert cleaned == {"gen_ai.request.temperature": "0.7", "region": "us-east1"}
+
+
+def test_project_row_body_strips_json_column() -> None:
+    row = _span_row(
+        "tr1", "sp1", datetime(2026, 7, 1, tzinfo=UTC),
+        SpanAttributes={"model_kwargs": "x", "prompt": "LEAK", "body": "LEAK"},
+    )
+    projected = project_row(SPANS_SPEC, row)
+    assert projected["SpanAttributes"] == {"model_kwargs": "x"}
+
+
+# --- rollup shape -------------------------------------------------------------------------------
+
+def test_rollup_merges_uniq_states_and_groups() -> None:
+    # The uniq HLL states can't be exported raw; the SELECT must uniqMerge them, grouped by key.
+    sql = DAILY_ROLLUP_SPEC.select_list()
+    assert "uniqMerge(TraceCountState) AS TraceCount" in sql
+    assert "uniqMerge(UserCountState) AS UserCount" in sql
+    assert "sum(InputTokens) AS InputTokens" in sql
+    assert DAILY_ROLLUP_SPEC.group_by == (
+        "TenantId", "Day", "FeatureTag", "GenAiResponseModel"
+    )
+
+    day = date(2026, 7, 1)
+    reader = FakeReader({
+        "daily_feature_rollup": [{
+            "TenantId": TENANT, "Day": day, "FeatureTag": "chat",
+            "GenAiResponseModel": "gpt-4o", "InputTokens": 100, "OutputTokens": 50,
+            "CachedInputTokens": 0, "EstimatedCost": 1, "ReconciledCost": 1,
+            "SpanCount": 3, "TraceCount": 2, "UserCount": 1,
+        }]
+    })
+    sink = InMemoryBigQuerySink()
+    marks = InMemoryWatermarkStore()
+    result = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(DAILY_ROLLUP_SPEC,),
+    )[0]
+    assert result.rows_exported == 1
+    assert marks.get(TENANT, "daily_feature_rollup") == day
+
+
+# --- lazy optional import -----------------------------------------------------------------------
+
+def test_module_imports_without_bigquery_dependency() -> None:
+    # The module imported at the top of this file (and is usable) without the optional extra,
+    # which proves google-cloud-bigquery is never imported at module load. A fresh import via the
+    # loader must likewise not pull it in eagerly.
+    module = importlib.import_module("gateway.bq_export")
+    assert hasattr(module, "run_export")
+    assert "google.cloud.bigquery" not in sys.modules
+
+
+def test_load_bigquery_sink_guards_missing_dependency() -> None:
+    try:
+        import google.cloud.bigquery  # noqa: F401
+    except ImportError:
+        with pytest.raises(BigQueryDependencyMissing):
+            load_bigquery_sink("proj")
+    else:  # pragma: no cover - extra installed in this env
+        pytest.skip("google-cloud-bigquery is installed; lazy-import guard not exercisable")
+
+
+def test_all_specs_have_consistent_schema_and_keys() -> None:
+    for spec in ALL_SPECS:
+        # Every key column must be an exported column.
+        for key in spec.key_columns:
+            assert key in spec.columns, f"{spec.name} key {key} not in columns"
+        # Every JSON column must be declared as BQ JSON in the schema.
+        json_fields = {f.name for f in spec.schema if f.type == "JSON"}
+        assert set(spec.json_columns) <= json_fields


### PR DESCRIPTION
## Summary

Adds an **optional, additive** export worker that mirrors a tenant's telemetry into the tenant's *own* BigQuery dataset for enterprise analytics. ClickHouse stays ai-tally's primary telemetry store and the dashboard keeps reading it — BigQuery is a **mirror, never a replacement**. No reverse sync, no realtime SLA (batch/near-real-time for v1). Default **disabled**.

Mirrors the repo's existing patterns: a `ReplayBlobStore`-style sink Protocol + in-memory fake + lazily-imported real client, and a `reconciliation.py`-style pure orchestrator (`run_export`) over injected reader/sink/watermark stores, so the incremental + idempotency logic is unit-testable with no live ClickHouse or BigQuery.

## Tables exported

| BigQuery table | ClickHouse source | Watermark | Natural key |
| --- | --- | --- | --- |
| `<prefix>otel_spans` | `otel_spans` | `Timestamp` | `TenantId, TraceId, SpanId` |
| `<prefix>business_events` | `business_events` | `OccurredAt` | `TenantId, BusinessEventId` |
| `<prefix>attribution_records` | `attribution_records` | `AttributedTraceTs` | `TenantId, BusinessEventId, FeatureTag` |
| `<prefix>daily_feature_rollup` | `daily_feature_rollup` | `Day` | `TenantId, Day, FeatureTag, GenAiResponseModel` |

Columns are schema-mapped 1:1 with typed BQ columns. The long-tail `SpanAttributes` map → a BQ **`JSON`** column (and `business_events.RawPayload` → `JSON`). The rollup's `AggregateFunction(uniq,…)` states are `uniqMerge`d to plain `INT64` counts, grouped by the rollup key.

## Settings added (`TALLY_`-prefixed, `gateway/config.py`)

`bq_export_enabled` (default `false`), `bq_export_gcp_project`, `bq_export_default_dataset` (`tally_export`), `bq_export_default_table_prefix` (`tally_`), `bq_export_batch_limit` (`10000`). Per-tenant config lives in Postgres `tenant_bq_export_config` (migration 0009): `enabled` (default false), `project_id`, `dataset`, `table_prefix`, `credential_ref`. Incremental cursor in `bq_export_watermarks` (migration 0010).

## No message bodies (by construction, + how tested)

- Exported tables hold no message text (`otel_spans` drops body-keyed attrs on ingest).
- Import-time assertion (reusing span-side `mapping._is_body_key`) that no exported column is body-keyed and no spec reads a replay table.
- Second independent guard strips body keys out of the `SpanAttributes`/`RawPayload` JSON maps before export (`strip_body_keys`).
- Replay **candidate-response text** (CTO-125, `replay_runs.ResponseText`) is a separate opt-in tier and **explicitly excluded** — no spec sources a replay table.

Tested by `test_no_exported_column_is_body_keyed`, `test_no_spec_sources_a_replay_body_table`, `test_span_attribute_map_strips_body_keys`, `test_project_row_body_strips_json_column`.

## Idempotency

Each pass reads rows strictly `>` the stored watermark, then **upserts** into BQ on the same natural key ClickHouse dedupes on (`MERGE ... ON <key>`), so replaying a pass never duplicates. Tested by `test_rerun_over_same_window_does_not_duplicate` and `test_watermark_advances_and_second_run_is_incremental`.

## Optional extra + lazy import

`[bigquery]` extra (`google-cloud-bigquery`), **lazy-imported** inside the worker — the module imports and the gateway boots without it. `load_bigquery_sink` raises `BigQueryDependencyMissing` when the extra is absent. Auth via ADC / Workload Identity / Secret Manager reference — `tenant_bq_export._reject_raw_key` refuses inline service-account keys.

## Stubbed

`GoogleBigQuerySink` (load-into-staging + `MERGE`) and `ClickHouseExportReader` are implemented but exercised only against live cloud services; the unit suite drives the in-memory fakes. Per-tenant scheduling (a running daemon) is intentionally out of scope, as in `reconciliation.py`; `run_export` is the invocable entry point.

## Verification

`uv run ruff check .` clean; `uv run --extra dev pytest` → **281 passed** (12 new in `test_bq_export.py`). Docs/runbook + schema in `docs/bigquery-export.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)