### PR TITLE
feat(compare): ground the Gemini candidate in real replay + eval (CTO-166)

### DIFF
--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -377,4 +377,130 @@ describe("/api/compare", () => {
     expect(body.candidates[0].qualityScore).toBeNull();
     expect(body.current.qualityScore).toBeNull();
   });
+
+  // --- CTO-166: the Gemini (provider: "google") candidate flows through the SAME live path ----
+
+  it("CTO-166: grounds the google/gemini candidate in real replay + eval (no provider gating)", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 60,
+      per_candidate: [
+        {
+          provider: "google",
+          model: "gemini-3-flash",
+          projected_monthly_cost_micro_usd: 2_400_000,
+          p50_latency_ms: 700,
+          p95_latency_ms: 1400,
+          error_rate: 0.012,
+          samples_replayed: 60, // >= 50-replay floor → real latency/error
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 9_000,
+      },
+    });
+    queryEvalCandidates.mockResolvedValueOnce({
+      samples_available: 40,
+      per_candidate: [
+        {
+          provider: "google",
+          model: "gemini-3-flash",
+          samples_judged: 22, // >= 10-judge floor → real win-rate + CI
+          current_wins: 9,
+          candidate_wins: 10,
+          ties: 3,
+          errors: 0,
+          win_rate: 0.45,
+          win_rate_ci_lo: 0.27,
+          win_rate_ci_hi: 0.64,
+          judge_cost_micro_usd: 40_000,
+        },
+      ],
+      diagnostics: { judge_model: "claude-opus-4-8", rubric_version: "rubric-v1", judge_cost_micro_usd: 40_000 },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    expect(body.replay_source).toBe("replay");
+    const gemini = body.candidates.find((c: { model: string }) => c.model === "gemini-3-flash");
+    expect(gemini).toBeDefined();
+    expect(gemini.provider).toBe("google");
+    // Cost/latency/error come straight from the projection — not a borrowed mock.
+    expect(gemini.monthlyCostMicroUsd).toBe(2_400_000);
+    expect(gemini.latencyP95Ms).toBe(1400);
+    expect(gemini.errorRate).toBeCloseTo(0.012, 6);
+    // Quality is the real pairwise-LLM-judge win-rate + Wilson CI.
+    expect(gemini.qualityScore).toBeCloseTo(0.45);
+    expect(gemini.qualityCi).toEqual({ lo: 0.27, hi: 0.64 });
+  });
+
+  it("CTO-166: honest-nulls the gemini row below the floors (<50 replay, <10 judged)", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 30,
+      per_candidate: [
+        {
+          provider: "google",
+          model: "gemini-3-flash",
+          projected_monthly_cost_micro_usd: 2_400_000,
+          p50_latency_ms: 700,
+          p95_latency_ms: 1400,
+          error_rate: 0.012,
+          samples_replayed: 30, // below the 50-replay floor → null latency/error
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 4_500,
+      },
+    });
+    queryEvalCandidates.mockResolvedValueOnce({
+      samples_available: 8,
+      per_candidate: [
+        {
+          provider: "google",
+          model: "gemini-3-flash",
+          samples_judged: 8, // below the 10-judge floor → null qualityScore, never fabricated
+          current_wins: 3,
+          candidate_wins: 3,
+          ties: 2,
+          errors: 0,
+          win_rate: 0.5,
+          win_rate_ci_lo: 0.2,
+          win_rate_ci_hi: 0.8,
+          judge_cost_micro_usd: 12_000,
+        },
+      ],
+      diagnostics: { judge_model: "claude-opus-4-8", rubric_version: "rubric-v1", judge_cost_micro_usd: 12_000 },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    const gemini = body.candidates.find((c: { model: string }) => c.model === "gemini-3-flash");
+    expect(gemini).toBeDefined();
+    // Below the replay floor → honest null latency/error (page renders "—"); cost still real.
+    expect(gemini.latencyP95Ms).toBeNull();
+    expect(gemini.errorRate).toBeNull();
+    expect(gemini.monthlyCostMicroUsd).toBe(2_400_000);
+    // Below the judge floor → honest null quality; NEVER a fabricated Gemini number.
+    expect(gemini.qualityScore).toBeNull();
+    expect(gemini.qualityCi).toBeUndefined();
+  });
 });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1365,10 +1365,17 @@ const _replayCache = new Map<string, { at: number; data: ReplayProjection | null
 // Default candidate list when the caller doesn't override. Models come from the SDK's expanded
 // catalog (CTO-106) — picked to mirror the existing mock so the dashboard's switcher looks the
 // same when replay is active.
+//
+// CTO-166: Google/Gemini is a first-class priced provider (CTO-149), so the gemini candidate now
+// goes through the SAME /v1/replay + /v1/eval path as anthropic/openai — no provider allowlist.
+// It was previously absent here, which meant the gemini-3-flash row never got real replay/eval
+// data and stayed stuck on the compare.ts mock fallback. Adding it is the whole fix: the route
+// and the gateway clients are already provider-generic.
 const DEFAULT_CANDIDATES = [
   { provider: "anthropic", model: "claude-haiku-4-5" },
   { provider: "openai", model: "gpt-5-mini" },
   { provider: "openai", model: "gpt-4o-mini" },
+  { provider: "google", model: "gemini-3-flash" },
 ];
 
 /**

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -15,6 +15,14 @@
 // honest-null floor (null below 50 replayed responses → "—"). The numeric values on the mock
 // candidates below are used only by the unreachable-gateway rescaled-mock fallback path.
 //
+// CTO-166: the `gemini-3-flash` / `provider: "google"` candidate below is now ALSO grounded in
+// the live path — CTO-149 made Google a first-class priced provider, and gemini was added to the
+// gateway candidate list (DEFAULT_CANDIDATES in clickhouse.ts) so it flows through /v1/replay +
+// /v1/eval exactly like the anthropic/openai rows. The same honest-null floors apply to it:
+// null latency/error below 50 replayed responses, null qualityScore below 10 judged samples —
+// never a fabricated Gemini number. The numeric mock below is now purely the
+// unreachable-gateway fallback, same status as the other mock candidates.
+//
 // CTO-114: `qualityScore` is now `number | null`. Non-null only when a pairwise-LLM-judge
 // eval pass has run and judged >= 10 samples for that candidate; the value is the
 // candidate's win-rate (candidate_wins / non-error judgments) with a Wilson 95% CI in


### PR DESCRIPTION
## What & why

CTO-149 made Google/Gemini a first-class priced provider but left the `/compare` candidate list untouched — the `gemini-3-flash` / `provider: "google"` row was still served from the `compare.ts` mock fixture, never grounded in real replay/eval like the anthropic/openai rows.

**Root cause — there WAS provider gating:** `DEFAULT_CANDIDATES` in `web/lib/clickhouse.ts` (consumed by both `queryReplayCandidates` and `queryEvalCandidates`) listed only anthropic + openai models. The google candidate was therefore never sent to `/v1/replay` or `/v1/eval`, so it always fell through to the mock. The `/api/compare` route and the gateway clients are otherwise fully provider-generic (they map over whatever `per_candidate` the gateway returns) — no allowlist or switch in the route itself.

## Changes

- **`web/lib/clickhouse.ts`** — added `{ provider: "google", model: "gemini-3-flash" }` to `DEFAULT_CANDIDATES`. This is the whole fix: gemini now flows through the same live replay + eval path as the other candidates.
- **`web/lib/compare.ts`** — updated the header comments to document that the live path now grounds the google row too; the numeric mock is now purely the unreachable-gateway fallback (same status as the other mock candidates). No `qualityCi` added to the candidate (the api test enforces no candidate CI on the fallback path).
- **Honest-null confirmed for google** — the existing floors apply identically: `latencyP95Ms`/`errorRate` → `null` below 50 replayed responses; `qualityScore` → `null` below 10 judged samples. No special-casing, never a fabricated Gemini number.
- **`web/app/api/compare/route.test.ts`** — two new CTO-166 tests: (1) a `provider: "google"` candidate flows through real replay + eval (real cost/latency/error + win-rate + Wilson CI); (2) honest-nulls under the `<50`-replay and `<10`-judge floors.

## Verify

`npx tsc --noEmit` clean. `npx vitest run`: all pass except the two known-flaky web tests that are pre-existing and unrelated (they pass in CI, fail only against a live local ClickHouse):
- `app/api/api.test.ts > GET /api/data-quality returns a report`
- `app/api/api.test.ts > GET /api/attribution falls back to mock when ClickHouse is unreachable`

New compare tests (11 total in the file) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)