### PR TITLE
feat(compare): drop retired gpt-4o-mini + validate/derive candidate list (CTO-171)

### DIFF
--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -95,3 +95,47 @@ describe("queryCurrentModel — latency/error suppression (CTO-115)", () => {
     expect(out!.sampleCount).toBe(75);
   });
 });
+
+// CTO-171: guard the Compare candidate list against silently shipping a retired model id.
+//
+// The gateway discovers its live provider lineup at boot but does not expose it over HTTP yet
+// (no `/v1/models` route — that's the follow-up), so DEFAULT_CANDIDATES stays hardcoded. This
+// test is the safety net: it mirrors the current, catalog-priced ids from the SDK's seed_catalog()
+// (sdk/python/src/tally/pricing.py) and asserts every candidate is one of them. A retired id like
+// `gpt-4o-mini` — which is still *priced* in the catalog for backward compat but is NOT a model we
+// want the switcher to surface — must not appear. If seed_catalog() gains/loses a current model,
+// update KNOWN_CURRENT_CANDIDATES here in the same change.
+describe("DEFAULT_CANDIDATES guard (CTO-171)", () => {
+  // Current, non-retired models we're willing to surface in Compare, keyed "provider/model".
+  // Kept in sync by hand with seed_catalog() until discovery is exposed over HTTP.
+  const KNOWN_CURRENT_CANDIDATES = new Set([
+    "anthropic/claude-haiku-4-5",
+    "anthropic/claude-sonnet-4-5",
+    "anthropic/claude-opus-4-8",
+    "openai/gpt-5-mini",
+    "openai/gpt-5",
+    "google/gemini-3-flash",
+    "google/gemini-2.5-flash",
+    "google/gemini-2.5-pro",
+  ]);
+
+  // Priced-but-retired ids that must never leak back into the switcher.
+  const RETIRED_IDS = new Set(["openai/gpt-4o-mini"]);
+
+  it("lists only current, catalog-priced models", async () => {
+    const { DEFAULT_CANDIDATES } = await freshSut();
+    expect(DEFAULT_CANDIDATES.length).toBeGreaterThan(0);
+    for (const c of DEFAULT_CANDIDATES) {
+      const id = `${c.provider}/${c.model}`;
+      expect(KNOWN_CURRENT_CANDIDATES.has(id), `${id} is not a current catalog model`).toBe(true);
+    }
+  });
+
+  it("does not include the retired gpt-4o-mini", async () => {
+    const { DEFAULT_CANDIDATES } = await freshSut();
+    for (const c of DEFAULT_CANDIDATES) {
+      const id = `${c.provider}/${c.model}`;
+      expect(RETIRED_IDS.has(id), `${id} is retired and must not be a candidate`).toBe(false);
+    }
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1371,10 +1371,17 @@ const _replayCache = new Map<string, { at: number; data: ReplayProjection | null
 // It was previously absent here, which meant the gemini-3-flash row never got real replay/eval
 // data and stayed stuck on the compare.ts mock fallback. Adding it is the whole fix: the route
 // and the gateway clients are already provider-generic.
-const DEFAULT_CANDIDATES = [
+//
+// CTO-171: dropped the retired `openai/gpt-4o-mini` — it is no longer a model we want the Compare
+// switcher to surface. Every id below MUST be a current, catalog-priced model (see the SDK's
+// `seed_catalog()` in sdk/python/src/tally/pricing.py). This list is hardcoded rather than derived
+// from live provider discovery: the gateway discovers its lineup at boot (`app.state.models` via
+// `discover_models()`), but it does NOT yet expose that over HTTP — there is no `/v1/models` route.
+// Building one is the follow-up; until then, the guard test in clickhouse.test.ts asserts every id
+// here is present in a current known-good catalog set, so a retired id can't silently return.
+export const DEFAULT_CANDIDATES = [
   { provider: "anthropic", model: "claude-haiku-4-5" },
   { provider: "openai", model: "gpt-5-mini" },
-  { provider: "openai", model: "gpt-4o-mini" },
   { provider: "google", model: "gemini-3-flash" },
 ];
 


### PR DESCRIPTION
## CTO-171 — Dashboard: derive Compare's candidate list from discovery + drop the retired gpt-4o-mini

### What changed
- **Removed** the retired `{ provider: "openai", model: "gpt-4o-mini" }` from `DEFAULT_CANDIDATES` in `web/lib/clickhouse.ts`. The list is now `claude-haiku-4-5`, `gpt-5-mini`, `gemini-3-flash` — all current, catalog-priced models (`seed_catalog()` in `sdk/python/src/tally/pricing.py`).
- `DEFAULT_CANDIDATES` is now `export`ed so it can be guarded by a test.

### Discovery-derived vs. hardcoded + guard test
Went **hardcoded + guard test**. The gateway *discovers* its model lineup at boot (`app.state.models = discover_models()`, CTO-109 `.tally/models.json`) but does **not** expose it over HTTP — there is no `/v1/models` / `/models` route (only `/v1/capabilities`, which advertises protocol/ceilings, not the model lineup). Building a read-only discovery endpoint is more than a small change, and CTO-171 explicitly allows the guard-test path in that case. **Follow-up:** expose discovery over HTTP and build `DEFAULT_CANDIDATES` at request time (fail-soft + brief cache, mirroring the 5-min replay cache).

### Guard test
Added `DEFAULT_CANDIDATES guard (CTO-171)` in `web/lib/clickhouse.test.ts`:
- asserts every candidate id is in `KNOWN_CURRENT_CANDIDATES` (mirrors the current catalog-priced ids from `seed_catalog()`), so a retired id can't silently return;
- asserts the retired `openai/gpt-4o-mini` (still priced for backward compat, but not a model we surface) is absent.

The honest-null + rescaled-mock fallback behavior on `/api/compare` is unchanged; replay/eval machinery untouched.

### Verify
- `npx tsc --noEmit` — clean.
- `npx vitest run` — 180 passed, 2 failed. The 2 failures are the pre-existing, known-flaky ClickHouse-dependent tests (`GET /api/data-quality returns a report`, `GET /api/attribution falls back to mock when ClickHouse is unreachable`) called out in the ticket — not touched here. The 2 new guard tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)