### PR TITLE
feat(chatbot): resolve model picker from discovery at boot + Google support (CTO-170)

### DIFF
--- a/examples/vercel-chatbot/app/app/(chat)/actions.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/actions.ts
@@ -4,7 +4,8 @@ import { generateText, type UIMessage } from "ai";
 import { cookies } from "next/headers";
 import { auth } from "@/app/(auth)/auth";
 import type { VisibilityType } from "@/components/chat/visibility-selector";
-import { titleModel } from "@/lib/ai/models";
+// CTO-170: resolved (discovery-self-healing) title model; server-only module.
+import { titleModel } from "@/lib/ai/models.server";
 import { titlePrompt } from "@/lib/ai/prompts";
 import { getTitleModel } from "@/lib/ai/providers";
 import {

--- a/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/api/chat/route.ts
@@ -12,12 +12,16 @@ import { after } from "next/server";
 import { createResumableStreamContext } from "resumable-stream";
 import { auth, type UserType } from "@/app/(auth)/auth";
 import { entitlementsByUserType } from "@/lib/ai/entitlements";
+import { getCapabilities } from "@/lib/ai/models";
+// CTO-170: the resolved lineup (ids self-healed from discovery) lives in the
+// server-only module; allowedModelIds/DEFAULT_CHAT_MODEL/chatModels here must be
+// the resolved values so validation, the default, and capability lookups all key
+// off the ids the picker actually offers.
 import {
   allowedModelIds,
   chatModels,
   DEFAULT_CHAT_MODEL,
-  getCapabilities,
-} from "@/lib/ai/models";
+} from "@/lib/ai/models.server";
 import { type RequestHints, systemPrompt } from "@/lib/ai/prompts";
 import { getLanguageModel } from "@/lib/ai/providers";
 import { createDocument } from "@/lib/ai/tools/create-document";
@@ -253,7 +257,7 @@ export async function POST(request: Request) {
     }
 
     const modelConfig = chatModels.find((m) => m.id === chatModel);
-    const modelCapabilities = await getCapabilities();
+    const modelCapabilities = await getCapabilities(chatModels);
     const capabilities = modelCapabilities[chatModel];
     const isReasoningModel = capabilities?.reasoning === true;
     const supportsTools = capabilities?.tools === true;

--- a/examples/vercel-chatbot/app/app/(chat)/api/models/route.ts
+++ b/examples/vercel-chatbot/app/app/(chat)/api/models/route.ts
@@ -1,11 +1,15 @@
 import { getAllGatewayModels, getCapabilities, isDemo } from "@/lib/ai/models";
+// CTO-170: serve the discovery-RESOLVED curated lineup (server-only module) so
+// the client picker self-heals to the current SKUs. Falls back to the pinned
+// literals offline. Capabilities are keyed to these resolved ids.
+import { chatModels } from "@/lib/ai/models.server";
 
 export async function GET() {
   const headers = {
     "Cache-Control": "public, max-age=86400, s-maxage=86400",
   };
 
-  const curatedCapabilities = await getCapabilities();
+  const curatedCapabilities = await getCapabilities(chatModels);
 
   if (isDemo) {
     const models = await getAllGatewayModels();
@@ -16,5 +20,11 @@ export async function GET() {
     return Response.json({ capabilities, models }, { headers });
   }
 
-  return Response.json(curatedCapabilities, { headers });
+  // Return the resolved curated lineup alongside capabilities so the picker
+  // renders self-healed ids. The client tolerates both this `{capabilities,
+  // models}` shape and a bare capabilities map (see multimodal-input.tsx).
+  return Response.json(
+    { capabilities: curatedCapabilities, models: chatModels },
+    { headers }
+  );
 }

--- a/examples/vercel-chatbot/app/lib/ai/models.server.ts
+++ b/examples/vercel-chatbot/app/lib/ai/models.server.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// CTO-170: server-only resolution of the chatbot model picker.
+//
+// resolveModel.ts reads .tally/models.json via node:fs, so this module — and
+// anything that imports it — must stay on the server. The `server-only` import
+// makes that a hard build error if a "use client" component ever pulls it in.
+// The client imports the plain pinned data shape from ./models directly; the chat
+// route, /api/models, and server actions import the discovery-RESOLVED shape here.
+//
+// Resolution is fail-soft at every step: resolveLatest() returns the pinned
+// fallback when .tally/models.json is missing/stale, and the catalog guard below
+// rejects any resolved id that isn't priced in the SDK seed catalog. So offline
+// (or with TALLY_SKIP_MODEL_REFRESH=1 / TALLY_PINNED_MODELS, which gate run.sh's
+// cache refresh) the lineup collapses back to today's literals — never a 404 or an
+// unpriced ($0) model. When a provider retires a SKU, the next launch's refreshed
+// cache makes resolveLatest() pick the replacement with no code change here.
+import "server-only";
+
+import { resolveLatest } from "../resolveModel";
+import {
+  catalogPricedIds,
+  type ChatModel,
+  chatModels as pinnedChatModels,
+  chatModelSlots,
+  DEFAULT_CHAT_MODEL as PINNED_DEFAULT_CHAT_MODEL,
+  defaultChatModelSlot,
+  type ModelSlot,
+  titleModel as pinnedTitleModel,
+  titleModelSlot,
+} from "./models";
+
+// Resolve one (provider, family) slot against the discovery cache, returning a
+// prefixed `<provider>/<id>`. Falls back to the pinned prefixed id when discovery
+// has nothing (resolveLatest's own fallback) OR when the resolved id isn't
+// catalog-priced — offering an unpriced model would show $0 on the dashboard
+// (catalog_miss), which is worse than pinning a slightly-older priced SKU.
+function resolveSlot(slot: ModelSlot, pinnedPrefixedId: string): string {
+  const slash = pinnedPrefixedId.indexOf("/");
+  const pinnedBare =
+    slash >= 0 ? pinnedPrefixedId.slice(slash + 1) : pinnedPrefixedId;
+
+  const resolvedBare = resolveLatest(slot.provider, slot.family, pinnedBare);
+  const resolvedPrefixed = `${slot.provider}/${resolvedBare}`;
+
+  if (resolvedPrefixed === pinnedPrefixedId) return pinnedPrefixedId;
+
+  if (!catalogPricedIds.has(resolvedPrefixed)) {
+    console.warn(
+      `[models.server] discovery resolved ${slot.provider}/${slot.family} to ` +
+        `"${resolvedPrefixed}", which is not in the SDK seed catalog; falling back ` +
+        `to pinned "${pinnedPrefixedId}" to avoid an unpriced (catalog_miss $0) model.`
+    );
+    return pinnedPrefixedId;
+  }
+  return resolvedPrefixed;
+}
+
+// The picker lineup with each `id` resolved from discovery; display labels,
+// provider, and description are preserved from the pinned entry.
+export const chatModels: ChatModel[] = pinnedChatModels.map((model, i) => {
+  const slot = chatModelSlots[i];
+  if (!slot) return model; // defensive: slot list drifted out of sync with chatModels
+  const id = resolveSlot(slot, model.id);
+  return id === model.id ? model : { ...model, id };
+});
+
+export const DEFAULT_CHAT_MODEL = resolveSlot(
+  defaultChatModelSlot,
+  PINNED_DEFAULT_CHAT_MODEL
+);
+
+export const titleModel = (() => {
+  const id = resolveSlot(titleModelSlot, pinnedTitleModel.id);
+  return id === pinnedTitleModel.id
+    ? pinnedTitleModel
+    : { ...pinnedTitleModel, id };
+})();
+
+// Accept a client-sent model id if it's in the resolved lineup OR still a pinned
+// literal. The union matters: the client's first render (and any offline client)
+// uses the pinned ids from ./models before /api/models delivers the resolved list,
+// so both must validate to avoid a spurious fallback-to-DEFAULT on send.
+export const allowedModelIds = new Set<string>([
+  ...chatModels.map((m) => m.id),
+  ...pinnedChatModels.map((m) => m.id),
+]);

--- a/examples/vercel-chatbot/app/lib/ai/models.ts
+++ b/examples/vercel-chatbot/app/lib/ai/models.ts
@@ -17,6 +17,13 @@
 // seed_catalog() or its cost silently drops to $0.
 //
 // CTO-109 owns the gateway/SDK discovery that writes the cache.
+//
+// CTO-170: this module is now the CLIENT-SAFE, plain-data half. The literals below
+// are the pinned fail-soft fallbacks (and what the picker renders offline / before
+// /api/models loads). The discovery-RESOLVED lineup is built server-side in
+// ./models.server.ts (it imports resolveModel.ts, which uses node:fs — so it must
+// never reach the browser bundle). Client components import from HERE; the chat
+// route, /api/models, and actions import the resolved shape from ./models.server.
 export const DEFAULT_CHAT_MODEL = "anthropic/claude-sonnet-4-5";
 
 export const titleModel = {
@@ -92,11 +99,75 @@ export const chatModels: ChatModel[] = [
   },
 ];
 
-export async function getCapabilities(): Promise<
-  Record<string, ModelCapabilities>
-> {
+// CTO-170: discovery-slot metadata. Each entry maps a picker slot to the
+// (provider, family) that the CTO-109 gateway discovery classifies it under, so
+// ./models.server.ts can resolve the newest non-deprecated id per slot from
+// .tally/models.json. `provider`/`family` strings MUST match
+// tally.models.classify_family (sdk/python/src/tally/models.py) — that's what's
+// written into the cache. Kept as plain data (parallel arrays / consts) here so
+// the client bundle never needs the fs-backed discovery machinery.
+export type DiscoveryProvider = "openai" | "anthropic" | "google";
+export type DiscoveryFamily =
+  | "haiku"
+  | "sonnet"
+  | "opus"
+  | "mini"
+  | "flagship"
+  | "flash"
+  | "pro";
+export type ModelSlot = {
+  provider: DiscoveryProvider;
+  family: DiscoveryFamily;
+};
+
+// Parallel to `chatModels` (same order). Zipped with it in ./models.server.ts.
+export const chatModelSlots: ModelSlot[] = [
+  { provider: "anthropic", family: "sonnet" }, // anthropic/claude-sonnet-4-5
+  { provider: "anthropic", family: "haiku" }, // anthropic/claude-haiku-4-5
+  { provider: "anthropic", family: "opus" }, // anthropic/claude-opus-4-8
+  { provider: "openai", family: "mini" }, // openai/gpt-5-mini
+  { provider: "openai", family: "flagship" }, // openai/gpt-5
+  { provider: "google", family: "flash" }, // google/gemini-3-flash
+  { provider: "google", family: "pro" }, // google/gemini-2.5-pro
+];
+
+export const titleModelSlot: ModelSlot = {
+  provider: "anthropic",
+  family: "haiku",
+};
+export const defaultChatModelSlot: ModelSlot = {
+  provider: "anthropic",
+  family: "sonnet",
+};
+
+// CTO-170 catalog guard allowlist. Every id the picker offers MUST be priced in
+// tally.pricing.seed_catalog() (sdk/python/src/tally/pricing.py) or its dashboard
+// cost silently drops to $0 (a "catalog_miss"). A discovery-resolved id that isn't
+// in this set is rejected in favor of the pinned literal (see models.server.ts).
+// There's no build-time export of the Python catalog into JS, so this small set is
+// maintained by hand — keep it in sync with seed_catalog()'s chat SKUs.
+export const catalogPricedIds: ReadonlySet<string> = new Set<string>([
+  "anthropic/claude-sonnet-4-5",
+  "anthropic/claude-haiku-4-5",
+  "anthropic/claude-opus-4-8",
+  "openai/gpt-5",
+  "openai/gpt-5-mini",
+  "openai/gpt-4o",
+  "openai/gpt-4o-mini",
+  "openai/gpt-4-turbo",
+  "google/gemini-3-flash",
+  "google/gemini-2.5-flash",
+  "google/gemini-2.5-pro",
+]);
+
+export async function getCapabilities(
+  // CTO-170: defaults to the pinned list, but the server routes pass the
+  // discovery-resolved lineup so capabilities are keyed by the ids the picker
+  // actually offers.
+  models: ChatModel[] = chatModels
+): Promise<Record<string, ModelCapabilities>> {
   const results = await Promise.all(
-    chatModels.map(async (model) => {
+    models.map(async (model) => {
       try {
         const res = await fetch(
           `https://ai-gateway.vercel.sh/v1/models/${model.id}/endpoints`,

--- a/examples/vercel-chatbot/app/lib/ai/providers.ts
+++ b/examples/vercel-chatbot/app/lib/ai/providers.ts
@@ -37,6 +37,9 @@ const FALLBACK_ANTHROPIC = resolveLatest("anthropic", "sonnet", "claude-sonnet-4
 // is present; this literal only bites when discovery has never run.
 const FALLBACK_OPENAI = resolveLatest("openai", "mini", "gpt-5-mini");
 const FALLBACK_ANTHROPIC_TITLE = resolveLatest("anthropic", "haiku", "claude-haiku-4-5");
+// CTO-170: google fallback for legacy/unprefixed gemini ids, resolved from the
+// discovery cache like the openai/anthropic ones above.
+const FALLBACK_GOOGLE = resolveLatest("google", "flash", "gemini-3-flash");
 
 function resolve(modelId: string) {
   // Honor an explicit anthropic/<model> id — strip the prefix; pass the rest
@@ -59,7 +62,7 @@ function resolve(modelId: string) {
     return anthropic(FALLBACK_ANTHROPIC);
   }
   if (modelId.includes("gemini")) {
-    return google(modelId);
+    return google(FALLBACK_GOOGLE);
   }
   return DEFAULT_PROVIDER === "openai"
     ? openai(FALLBACK_OPENAI)

--- a/examples/vercel-chatbot/app/lib/resolveModel.ts
+++ b/examples/vercel-chatbot/app/lib/resolveModel.ts
@@ -7,8 +7,22 @@
 import fs from "node:fs";
 import path from "node:path";
 
-type Provider = "openai" | "anthropic";
-type Family = "haiku" | "sonnet" | "opus" | "mini" | "flagship" | "embedding" | "other";
+// CTO-170: added "google" so the chatbot picker's Gemini slots (CTO-164) self-heal
+// from discovery like the OpenAI/Anthropic slots already do. The family union gains
+// "flash"/"pro" — the exact strings tally.models.classify_family() writes for Gemini
+// ids (see _FAMILY_RULES in sdk/python/src/tally/models.py: `flash` is the cheap
+// tier, `pro` the flagship). Keep these in lockstep with that classifier.
+export type Provider = "openai" | "anthropic" | "google";
+export type Family =
+  | "haiku"
+  | "sonnet"
+  | "opus"
+  | "mini"
+  | "flagship"
+  | "flash"
+  | "pro"
+  | "embedding"
+  | "other";
 
 interface CachedModel {
   provider: Provider;


### PR DESCRIPTION
## CTO-170 — resolve the chatbot model picker from discovery at boot + add Google to resolveModel

Finishes the dynamic-resolution half CTO-147 deferred. The picker's model ids now self-heal from the CTO-109 discovery cache (`.tally/models.json`) instead of rotting when a provider retires a SKU.

### What changed
- **Google in `resolveModel.ts`**: `Provider` gains `"google"`; `Family` gains `"flash"`/`"pro"` — the exact strings `tally.models.classify_family()` writes for Gemini ids (`sdk/python/src/tally/models.py`). `resolveLatest("google","flash","gemini-3-flash")` now returns the newest non-deprecated Gemini flash id, else the pinned fallback.
- **Server/client split (fs stays server-only)**: `lib/ai/models.ts` becomes the client-safe plain-data module — pinned literals + new slot metadata (`chatModelSlots`, `titleModelSlot`, `defaultChatModelSlot`) + the catalog allowlist. A new server-only `lib/ai/models.server.ts` (guarded by `import "server-only"`) resolves each `(provider, family)` **slot** through `resolveLatest()`, using today's literal as the fail-soft fallback and preserving every display label/description/provider — only `id` becomes discovery-resolved. `resolveModel.ts`'s `node:fs` never reaches the browser bundle; the two `"use client"` components keep importing the pinned shape from `./models`.
- **Catalog guard**: a resolved id absent from the SDK seed-catalog allowlist (mirrors `tally.pricing.seed_catalog()`) is rejected in favor of the pinned id, with a warning — so the picker never offers an unpriced (`catalog_miss` → $0) model.
- **Consumers**: the chat route, `/api/models`, and the title action now consume the resolved lineup; `/api/models` serves it so the client picker self-heals. `allowedModelIds` is the **union** of resolved + pinned ids, so the initial client render / offline client still validates on send. `providers.ts` gains a `google` fallback consistent with the existing openai/anthropic ones.

### How a retired SKU self-heals
`run.sh` refreshes `.tally/models.json` on launch. Next boot, `resolveLatest()` picks the newest non-deprecated id in each slot's family and `/api/models` serves it to the picker — **no code change**. If the replacement isn't catalog-priced yet, the guard pins back to the last priced id.

### Offline / pinned
When the cache is missing/stale (or `TALLY_SKIP_MODEL_REFRESH=1` / `TALLY_PINNED_MODELS` gate `run.sh`'s refresh), every slot collapses to today's literal — never a 404 or a $0 model.

### Verification
- `pnpm install` + `pnpm exec tsc --noEmit` → clean (exit 0).
- Grepped all `"use client"` components: none import `models.server` / `resolveModel` / `node:fs`.
- Runtime-checked `resolveLatest` against a synthetic cache: newest-wins for google flash/pro, and missing-cache falls back to the pinned id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)