### PR TITLE
fix(models): exclude non-chat OpenAI SKUs from chat families (CTO-172)

### DIFF
--- a/sdk/python/src/tally/models.py
+++ b/sdk/python/src/tally/models.py
@@ -89,6 +89,22 @@ _FAMILY_RULES: list[tuple[re.Pattern[str], str]] = [
     # OpenAI-shaped bucket.
     (re.compile(r"flash", re.I), "flash"),
     (re.compile(r"gemini.*pro|pro.*gemini", re.I), "pro"),
+    # Non-chat OpenAI SKUs. `GET /v1/models` lists audio / realtime / tts / transcribe /
+    # image / moderation / instruct / search / legacy-base models, and many carry a chat
+    # keyword in their id (e.g. "gpt-4o-mini-tts", "gpt-4o-realtime-preview"). Without this
+    # guard they'd fall through to the "mini"/"flagship" buckets below, and resolveLatest
+    # could hand one to the chat-completions path — which 404s with "not a chat model".
+    # Route them to "other" so a chat family only ever contains chat-capable models. This
+    # sits AFTER the embedding rule (embeddings are a real cost family) and BEFORE the
+    # OpenAI chat buckets. o1/o3/o4 reasoning "mini"s are chat-capable, so they're not listed.
+    (
+        re.compile(
+            r"(audio|realtime|transcribe|whisper|tts|moderation|dall-e|image|"
+            r"instruct|search-preview|davinci|babbage|computer-use|codex)",
+            re.I,
+        ),
+        "other",
+    ),
     (re.compile(r"mini", re.I), "mini"),
     (re.compile(r"^gpt-4o(?!-mini)", re.I), "flagship"),
     (re.compile(r"^gpt-5(?!-mini)", re.I), "flagship"),

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -37,9 +37,40 @@ def test_classify_family_truth_table() -> None:
         "gemini-2.5-flash": "flash",
         "gemini-3-flash": "flash",
         "gemini-2.5-pro": "pro",
+        # Non-chat OpenAI SKUs must NOT land in a chat family — they'd 404 on
+        # chat-completions if resolveLatest handed them over.
+        "gpt-4o-mini-tts": "other",
+        "gpt-4o-mini-transcribe": "other",
+        "gpt-4o-mini-realtime-preview": "other",
+        "gpt-4o-audio-preview": "other",
+        "gpt-4o-realtime-preview": "other",
+        "gpt-4o-search-preview": "other",
+        "gpt-3.5-turbo-instruct": "other",
+        "dall-e-3": "other",
+        "whisper-1": "other",
+        "omni-moderation-latest": "other",
+        # o-series reasoning minis are chat-capable — they stay in "mini".
+        "o3-mini": "mini",
     }
     for model_id, expected in cases.items():
         assert M.classify_family(model_id) == expected, model_id
+
+
+def test_latest_openai_mini_skips_non_chat_skus() -> None:
+    # Regression (chatbot demo 404 "not a chat model"): OpenAI's /v1/models returns
+    # non-chat SKUs carrying "mini" (e.g. gpt-4o-mini-tts). Even when one is NEWER than
+    # the real chat mini, latest_openai("mini", …) must return the chat model, because
+    # the non-chat SKUs are classified out of the "mini" family entirely.
+    older = datetime(2024, 7, 18, tzinfo=timezone.utc)
+    newer = datetime(2025, 3, 20, tzinfo=timezone.utc)
+    lineup = [
+        _make("openai", "gpt-4o-mini", created=older),          # real chat mini
+        _make("openai", "gpt-4o-mini-tts", created=newer),      # non-chat, but newer
+        _make("openai", "gpt-4o-mini-realtime-preview", created=newer),
+    ]
+    picked = M.latest_openai("mini", lineup)
+    assert picked is not None
+    assert picked.id == "gpt-4o-mini"
 
 
 def _make(


### PR DESCRIPTION
## Bug

`make chatbot-demo` failed on every session with:

> openai 404: This is not a chat model and thus not supported in the v1/chat/completions endpoint.

## Root cause

`demo-chat/route.ts` resolves its OpenAI model via `resolveLatest("openai", "mini", …)` from the discovery cache. `classify_family()` bucketed ids by keyword with **no chat-capability filter**, so OpenAI's non-chat SKUs that carry a chat keyword (`gpt-4o-mini-tts`, `gpt-4o-mini-realtime-preview`, `gpt-4o-audio-preview`, …) landed in the `mini`/`flagship` families. When the CTO-147 launch refresh pulled a live lineup where such a SKU sorted as the newest in-family model, `latest_openai("mini", …)` handed it to chat-completions → 404. Latent since CTO-109; surfaced now that the demo refreshes against the live account and resolves the picker from discovery (CTO-170).

## Fix

A non-chat guard rule in `_FAMILY_RULES` (after the embedding rule, before the OpenAI chat buckets) routes `audio|realtime|transcribe|whisper|tts|moderation|dall-e|image|instruct|search-preview|davinci|babbage|computer-use|codex` ids to `"other"`, so a chat family only ever holds chat-capable models. `o1/o3/o4` reasoning minis stay in `"mini"` (they're chat-capable). Truth-table rows + a regression test (`latest_openai("mini", …)` skips a newer non-chat mini) added.

## Verify

`cd sdk/python && uv run ruff check . && uv run pytest` — ruff clean, full suite passes.

## Immediate workaround (no deploy needed)

`export TALLY_OPENAI_MODEL=gpt-4o-mini` before `make chatbot-demo` — the demo-chat route honors that env override ahead of discovery.

## Follow-up

`o1/o3/o4` minis are chat-capable but reject some chat params; if a run resolves to one and errors on params, handle reasoning params in the demo's `callOpenAI` (noted on CTO-172).

🤖 Generated with [Claude Code](https://claude.com/claude-code)