### PR TITLE
fix(unit-economics): separate colliding numeric columns in Monthly history

### DIFF
--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -104,16 +104,16 @@ export default async function UnitEconomicsPage() {
             <thead className="text-xs uppercase text-muted">
               <tr>
                 <th className="py-1 text-left font-medium">Period</th>
-                <th className="py-1 text-right font-medium">Marketing spend</th>
-                <th className="py-1 text-right font-medium">Sales spend</th>
-                <th className="py-1 text-right font-medium">New (total)</th>
-                <th className="py-1 text-right font-medium">New (paid)</th>
-                <th className="py-1 text-right font-medium">ARPA</th>
-                <th className="py-1 text-right font-medium">Gross margin</th>
-                <th className="py-1 text-right font-medium">Blended CAC</th>
-                <th className="py-1 text-right font-medium">Paid CAC</th>
-                <th className="py-1 text-right font-medium">Payback</th>
-                <th className="py-1 text-right font-medium">LTV : CAC</th>
+                <th className="py-1 pl-3 text-right font-medium">Marketing spend</th>
+                <th className="py-1 pl-3 text-right font-medium">Sales spend</th>
+                <th className="py-1 pl-3 text-right font-medium">New (total)</th>
+                <th className="py-1 pl-3 text-right font-medium">New (paid)</th>
+                <th className="py-1 pl-3 text-right font-medium">ARPA</th>
+                <th className="py-1 pl-3 text-right font-medium">Gross margin</th>
+                <th className="py-1 pl-3 text-right font-medium">Blended CAC</th>
+                <th className="py-1 pl-3 text-right font-medium">Paid CAC</th>
+                <th className="py-1 pl-3 text-right font-medium">Payback</th>
+                <th className="py-1 pl-3 text-right font-medium">LTV : CAC</th>
               </tr>
             </thead>
             <tbody>
@@ -140,16 +140,16 @@ export default async function UnitEconomicsPage() {
                         </span>
                       )}
                     </td>
-                    <td className="py-2 text-right tabular-nums">{formatUSD(p.paidSpendMicroUsd + p.contentSpendMicroUsd)}</td>
-                    <td className="py-2 text-right tabular-nums">{formatUSD(p.salesSpendMicroUsd)}</td>
-                    <td className="py-2 text-right tabular-nums">{p.newCustomersTotal.toLocaleString()}</td>
-                    <td className="py-2 text-right tabular-nums">{p.newCustomersPaid.toLocaleString()}</td>
-                    <td className="py-2 text-right tabular-nums">{econ ? formatUSD(econ.arpaMicroUsd) : DASH}</td>
-                    <td className="py-2 text-right tabular-nums">{econ ? fmtPct(econ.grossMarginPct) : DASH}</td>
-                    <td className="py-2 text-right tabular-nums">{fmtMoney(blendedCac(p))}</td>
-                    <td className="py-2 text-right tabular-nums">{fmtMoney(marketingCac(p))}</td>
-                    <td className="py-2 text-right tabular-nums">{fmtMonths(paybackMonths(loadedRow, m))}</td>
-                    <td className={`py-2 text-right tabular-nums ${bandText(bandRow)}`}>{fmtRatio(ratioRow)}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{formatUSD(p.paidSpendMicroUsd + p.contentSpendMicroUsd)}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{formatUSD(p.salesSpendMicroUsd)}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{p.newCustomersTotal.toLocaleString()}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{p.newCustomersPaid.toLocaleString()}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{econ ? formatUSD(econ.arpaMicroUsd) : DASH}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{econ ? fmtPct(econ.grossMarginPct) : DASH}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{fmtMoney(blendedCac(p))}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{fmtMoney(marketingCac(p))}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums">{fmtMonths(paybackMonths(loadedRow, m))}</td>
+                    <td className={`py-2 pl-3 text-right tabular-nums ${bandText(bandRow)}`}>{fmtRatio(ratioRow)}</td>
                   </tr>
                 );
               })}


### PR DESCRIPTION
## Bug

On **Unit Economics**, the *Monthly history* table looked like data was cut off — adjacent right-aligned numeric columns collided into each other:

- `$51,000.00 $28,000.00` (Marketing / Sales spend)
- `$1,295.08 $1,105.26` (Blended / Paid CAC)
- `$1,461.54 $1,333.33`

The cells had only vertical padding (`py-*`) and no horizontal padding, so neighboring values butted together and read as one merged/truncated number.

## Fix

Add `pl-3` to every right-aligned header + numeric cell (`th`/`td`) — matching the column-spacing convention the other dashboard tables already use. Each value now sits in a distinct, readable column.

## Verification

Reloaded `/unit-economics` in the browser after the change: all 11 columns render with clear separation, the rightmost `LTV : CAC` values (`2.28×`, `2.52×`, `—`, `1.60×`) are fully visible, no console errors, `tsc` clean. Before/after confirmed against the running dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)