### PR TITLE
fix(chatbot-demo): reinstall deps when node_modules is stale vs lockfile (CTO-174)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -172,6 +172,12 @@ export ANTHROPIC_API_KEY=sk-ant-...
 cd infra && make chatbot-demo
 ```
 
+`run.sh` (re)installs the chatbot's deps whenever `node_modules` is missing **or
+stale** — i.e. `pnpm-lock.yaml` / `package.json` is newer than `node_modules`
+(CTO-174) — so a dependency bump is picked up automatically instead of failing
+the build with `Module not found`. If a run ever trips over a stale install,
+recover manually with `cd examples/vercel-chatbot/app && pnpm install`.
+
 On launch the demo **refreshes the model lineup** (CTO-147): before booting the
 chatbot, `run.sh` force-refreshes the gateway's discovery cache
 (`.tally/models.json`, CTO-109) with `TALLY_MODELS_REFRESH=1` and logs the live

--- a/examples/vercel-chatbot/run.sh
+++ b/examples/vercel-chatbot/run.sh
@@ -91,7 +91,18 @@ if curl -fsS --max-time 2 "${CHATBOT_URL}/api/demo-chat" -X POST \
   echo "✓ Chatbot already up at ${CHATBOT_URL}"
 else
   echo "→ Booting chatbot on ${CHATBOT_URL}…"
-  if [ ! -d "${APP_DIR}/node_modules" ]; then
+  # Install deps when node_modules is missing OR stale relative to the
+  # lockfile/manifest (CTO-174). The old "install only if node_modules is
+  # absent" guard skipped reinstalls after a dependency bump (e.g. @ai-sdk/google
+  # via CTO-164), so a pre-existing node_modules kept a stale install and the
+  # build failed with "Module not found". Reinstall if node_modules is absent,
+  # or if pnpm-lock.yaml / package.json is newer than node_modules.
+  need_install=0
+  if [ ! -d "${APP_DIR}/node_modules" ]; then need_install=1
+  elif [ "${APP_DIR}/pnpm-lock.yaml" -nt "${APP_DIR}/node_modules" ] || \
+       [ "${APP_DIR}/package.json" -nt "${APP_DIR}/node_modules" ]; then need_install=1
+  fi
+  if [ "$need_install" -eq 1 ]; then
     echo "  · installing chatbot deps (pnpm install)…"
     (cd "${APP_DIR}" && pnpm install --silent --prefer-offline) || \
       (cd "${APP_DIR}" && npm install --silent --no-audit --no-fund)


### PR DESCRIPTION
## CTO-174 — Chatbot demo `run.sh` skips dep install when `node_modules` already exists

### Bug
`make chatbot-demo` failed with `Module not found: Can't resolve '@ai-sdk/google'`. The install guard in `examples/vercel-chatbot/run.sh` (~line 94) only ran an install when `node_modules` was **absent**:

```sh
if [ ! -d "${APP_DIR}/node_modules" ]; then
  (cd "${APP_DIR}" && pnpm install --silent --prefer-offline) || \
    (cd "${APP_DIR}" && npm install --silent --no-audit --no-fund)
fi
```

`@ai-sdk/google` was added to `package.json` + `pnpm-lock.yaml` in CTO-164, but a user with a pre-existing `node_modules` kept a stale install — the guard skipped the reinstall, the package was never pulled, and the build failed. Every future dependency change would repeat this.

### Fix — missing-or-stale guard (chosen approach)
Install when `node_modules` is absent **or stale** relative to the lockfile/manifest: reinstall if `node_modules` is missing, OR `pnpm-lock.yaml` is newer than `node_modules`, OR `package.json` is newer than `node_modules`.

```sh
need_install=0
if [ ! -d "${APP_DIR}/node_modules" ]; then need_install=1
elif [ "${APP_DIR}/pnpm-lock.yaml" -nt "${APP_DIR}/node_modules" ] || \
     [ "${APP_DIR}/package.json" -nt "${APP_DIR}/node_modules" ]; then need_install=1
fi
if [ "$need_install" -eq 1 ]; then
  echo "  · installing chatbot deps (pnpm install)…"
  (cd "${APP_DIR}" && pnpm install --silent --prefer-offline) || \
    (cd "${APP_DIR}" && npm install --silent --no-audit --no-fund)
fi
```

I chose the explicit **missing-or-stale** guard (over "always run `pnpm install`") because it keeps the common up-to-date path a true no-op — no pnpm invocation at all — while still catching every manifest/lockfile bump. The lockfile-newer-than-`node_modules` mtime check is the standard, good-enough staleness signal. The existing pnpm→npm fallback and `--silent`/`--prefer-offline` flags are preserved.

### Docs
`RUNNING.md` Step 6 now explains that deps are (re)installed whenever `node_modules` is missing or stale, plus a one-line manual-recovery note: `cd examples/vercel-chatbot/app && pnpm install`.

### Scope
Purely the `run.sh` install guard + a RUNNING.md note. **No changes** to `package.json`, `pnpm-lock.yaml`, `models.ts`, or `providers.ts`.

### Verify
- `bash -n examples/vercel-chatbot/run.sh` — clean.
- `cd infra && make -n chatbot-demo` — parses.
- Logic traced across all four cases (missing → install; lock newer → install; package newer → install; up-to-date → skip), confirmed with a scratch harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)