### PR TITLE
fix(chatbot-demo): use max_completion_tokens for the OpenAI call (CTO-175)

### DIFF
--- a/examples/vercel-chatbot/app/app/api/demo-chat/route.ts
+++ b/examples/vercel-chatbot/app/app/api/demo-chat/route.ts
@@ -99,7 +99,10 @@ async function callOpenAI(prompt: string, model: string): Promise<ProviderResult
     body: JSON.stringify({
       model,
       messages: [{ role: "user", content: prompt }],
-      max_tokens: 256,
+      // GPT-5 / o-series reject `max_tokens` and require `max_completion_tokens`;
+      // the newer param is accepted by all current OpenAI chat models (incl. gpt-4o-mini),
+      // so use it unconditionally. (Anthropic's API below still uses `max_tokens`.)
+      max_completion_tokens: 256,
     }),
   });
   if (!res.ok) throw new Error(`openai ${res.status}: ${await res.text()}`);


### PR DESCRIPTION
## Bug

With model discovery now correctly resolving a current chat mini (e.g. `gpt-5.4-mini`, post-CTO-172), the chatbot demo fails:

> openai 400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.

## Root cause

`demo-chat/route.ts` `callOpenAI()` sent `max_tokens: 256`. The GPT-5 family and o-series reject `max_tokens` on `/v1/chat/completions`. (This was the exact follow-up flagged on CTO-172.)

## Fix

Use `max_completion_tokens: 256` for the OpenAI call — accepted by all current OpenAI chat models including `gpt-4o-mini`. The Anthropic call in the same file keeps `max_tokens` (correct for the Anthropic Messages API). One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)