### PR TITLE
feat(replay): S3 replay blob-store backend alongside GCS/MinIO (CTO-158)

### DIFF
--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
 gcs = [
     "google-cloud-storage>=2.10",
 ]
+# S3 / MinIO replay blob-store backend (CTO-158). Optional so the base install stays slim;
+# imported lazily inside S3ReplayBlobStore so the gateway boots without it when the backend is
+# not `s3`.
+s3 = [
+    "boto3>=1.34",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.6",

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -73,6 +73,7 @@ from gateway.replay_store import (
     GCSReplayBlobStore,
     InMemoryReplayBlobStore,
     ReplayBlobStore,
+    S3ReplayBlobStore,
     persist_sample,
 )
 from gateway.eval_executor import (
@@ -108,9 +109,10 @@ def _build_replay_blob_store(settings) -> ReplayBlobStore:
     """Select the replay blob-store backend from settings (CTO-152).
 
     ``memory`` (default) -> in-process dict store; ``gcs`` -> Google Cloud Storage via ADC /
-    Workload Identity. The GCS client + its optional ``google-cloud-storage`` dependency are only
-    touched when the backend is actually ``gcs`` (lazy import lives inside the store), so the
-    default install/boot never needs the package.
+    Workload Identity; ``s3`` -> AWS S3 (or S3-compatible, e.g. MinIO) via the AWS default
+    credential chain. Each cloud client + its optional dependency (``google-cloud-storage`` /
+    ``boto3``) is only touched when that backend is actually selected (lazy import lives inside the
+    store), so the default install/boot never needs either package.
     """
     backend = (settings.replay_blob_backend or "memory").lower()
     if backend == "memory":
@@ -121,7 +123,19 @@ def _build_replay_blob_store(settings) -> ReplayBlobStore:
                 "TALLY_REPLAY_GCS_BUCKET must be set when TALLY_REPLAY_BLOB_BACKEND=gcs"
             )
         return GCSReplayBlobStore(bucket=settings.replay_gcs_bucket)
-    raise ValueError(f"unknown TALLY_REPLAY_BLOB_BACKEND: {backend!r} (expected 'memory' or 'gcs')")
+    if backend == "s3":
+        if not settings.replay_s3_bucket:
+            raise ValueError(
+                "TALLY_REPLAY_S3_BUCKET must be set when TALLY_REPLAY_BLOB_BACKEND=s3"
+            )
+        return S3ReplayBlobStore(
+            bucket=settings.replay_s3_bucket,
+            prefix=settings.replay_s3_prefix,
+            region=settings.replay_s3_region or None,
+        )
+    raise ValueError(
+        f"unknown TALLY_REPLAY_BLOB_BACKEND: {backend!r} (expected 'memory', 'gcs', or 's3')"
+    )
 
 
 @asynccontextmanager

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -51,11 +51,19 @@ class Settings(BaseSettings):
     ingest_buffer_drain_batch: int = 2_000
     ingest_buffer_poll_interval_s: float = 0.05
 
-    # Replay blob-store backend (CTO-152). ``memory`` (default) uses the in-process dict store;
-    # ``gcs`` persists scrubbed replay samples to a Google Cloud Storage bucket via ADC / Workload
-    # Identity (no raw key material). ``replay_gcs_bucket`` is required when the backend is ``gcs``.
+    # Replay blob-store backend (CTO-152 / CTO-158). ``memory`` (default) uses the in-process dict
+    # store; ``gcs`` persists scrubbed replay samples to a Google Cloud Storage bucket via ADC /
+    # Workload Identity; ``s3`` persists them to an AWS S3 (or S3-compatible, e.g. MinIO) bucket via
+    # the AWS default credential chain (IAM role / IRSA / instance profile / env) — no raw keys for
+    # either. ``replay_gcs_bucket`` is required when the backend is ``gcs``; ``replay_s3_bucket`` is
+    # required when the backend is ``s3``.
     replay_blob_backend: str = "memory"
     replay_gcs_bucket: str = ""
+    # S3 backend (CTO-158). Bucket is required for ``s3``; prefix/region are optional. Region empty
+    # means "resolve from the AWS default chain" (``AWS_REGION`` / config / instance metadata).
+    replay_s3_bucket: str = ""
+    replay_s3_prefix: str = ""
+    replay_s3_region: str = ""
 
     # BigQuery export sink (CTO-154). OPTIONAL, additive analytics mirror that copies
     # spans / business_events / attribution / daily rollups into a tenant's OWN BigQuery

--- a/infra/gateway/src/gateway/replay_store.py
+++ b/infra/gateway/src/gateway/replay_store.py
@@ -116,6 +116,103 @@ class GCSReplayBlobStore:
         return self._bucket.blob(key).download_as_bytes()
 
 
+class S3ReplayBlobStore:
+    """AWS S3 (or S3-compatible, e.g. MinIO) backend for replay sample blobs (CTO-158).
+
+    Mirror of :class:`GCSReplayBlobStore` — satisfies the same :class:`ReplayBlobStore` protocol
+    as :class:`InMemoryReplayBlobStore` and the GCS path: objects are keyed with the identical
+    ``tenants/{tenant_id}/replay_samples/{yyyy/mm/dd}/{sample_id}.json`` layout produced by
+    :func:`build_replay_object_key`, so the ClickHouse index rows and the executor read path are
+    unchanged regardless of which backend is wired. An optional ``prefix`` is prepended to every
+    key (e.g. to share a bucket across environments) without touching the stored index key — the
+    prefix is a storage-layout detail applied on the way in/out only.
+
+    **PII scrub** — the pre-storage PII scrub from CTO-113 runs upstream in the sampler /
+    ``persist_sample`` ingest path, before any ``put_bytes`` call. This backend only moves already
+    scrubbed bytes, so it inherits the scrub unchanged; the CTO-125 candidate-response retention
+    carve-out likewise applies identically here.
+
+    **Auth** — no raw key material is passed. The ``boto3`` S3 client is constructed with the AWS
+    default credential chain, so it transparently picks up an IAM role / IRSA (EKS) / EC2 instance
+    profile / ``AWS_*`` environment credentials / a shared credentials file, in boto3's normal
+    resolution order. We never handle an access key or secret here.
+
+    **Retention** — object lifecycle (TTL / expiration) is expected to be enforced by an S3 bucket
+    lifecycle policy provisioned out-of-band (e.g. Terraform), mirroring the replay
+    ``retention_days`` knob. This backend does NOT create or manage lifecycle rules (out of scope
+    for CTO-158).
+
+    The ``boto3`` dependency is OPTIONAL (``[s3]`` extra) and imported lazily at construction —
+    importing this module never requires the package; only instantiating this class does. That
+    keeps the base gateway install slim and lets it boot without boto3 when unused.
+    """
+
+    __slots__ = ("_bucket", "_prefix", "_client")
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        region: str | None = None,
+        client: object | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("bucket must be non-empty")
+        if client is None:
+            # Lazy import: keep boto3 optional. Constructing the client with no explicit
+            # credentials makes it resolve the AWS default credential chain (IAM role / IRSA /
+            # instance profile / env / shared file) automatically — we never handle a raw key here.
+            import boto3  # type: ignore[import-not-found]
+
+            client = boto3.client("s3", region_name=region)
+        self._client = client
+        self._bucket = bucket
+        # Normalise prefix to a bare, slash-terminated segment (or empty) so key joins are clean.
+        self._prefix = prefix.strip("/")
+
+    def _full_key(self, key: str) -> str:
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def put_bytes(self, key: str, body: bytes, content_type: str = "application/json") -> None:
+        self._client.put_object(
+            Bucket=self._bucket,
+            Key=self._full_key(key),
+            Body=body,
+            ContentType=content_type,
+        )
+
+    def get_bytes(self, key: str) -> bytes:
+        resp = self._client.get_object(Bucket=self._bucket, Key=self._full_key(key))
+        return resp["Body"].read()
+
+    def exists(self, key: str) -> bool:
+        """True if an object lives at ``key``. Uses ``head_object``; a 404/NoSuchKey means absent."""
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=self._full_key(key))
+        except Exception as exc:  # noqa: BLE001 — normalise botocore ClientError (404) to False.
+            if _is_s3_not_found(exc):
+                return False
+            raise
+        return True
+
+
+def _is_s3_not_found(exc: BaseException) -> bool:
+    """Return True for a boto3/botocore 'object not found' error (404 / NoSuchKey / NotFound).
+
+    Kept structural (duck-typed on ``response``) so tests can raise a lightweight stand-in and so
+    the module never needs botocore imported to interpret the error."""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error", {})
+        if str(error.get("Code")) in {"404", "NoSuchKey", "NotFound"}:
+            return True
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if status == 404:
+            return True
+    return False
+
+
 # --- ClickHouse-side index rows --------------------------------------------------------------
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/tests/test_replay_store_s3.py
+++ b/infra/gateway/tests/test_replay_store_s3.py
@@ -1,0 +1,264 @@
+"""Unit tests for the S3 replay blob-store backend (CTO-158).
+
+These use an in-memory fake that mimics the ``boto3`` S3 client surface we touch
+(``client.put_object`` / ``client.get_object`` / ``client.head_object``), so no network access,
+real bucket, or credentials are required and ``boto3`` need not be installed to run the suite.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from gateway.config import Settings
+from gateway.replay_sampler import ReplaySamplePayload
+from gateway.replay_store import (
+    InMemoryReplayBlobStore,
+    S3ReplayBlobStore,
+    build_replay_object_key,
+    persist_sample,
+)
+
+UTC = timezone.utc
+
+
+# --- Fake boto3 S3 client --------------------------------------------------------------------
+
+class _FakeClientError(Exception):
+    """Stand-in for ``botocore.exceptions.ClientError`` — carries a ``response`` dict."""
+
+    def __init__(self, code: str, status: int = 404) -> None:
+        super().__init__(code)
+        self.response = {
+            "Error": {"Code": code},
+            "ResponseMetadata": {"HTTPStatusCode": status},
+        }
+
+
+class _FakeS3Client:
+    """Backed by one dict per client instance. Records puts/heads for assertions."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.content_types: dict[str, str] = {}
+        self.buckets_used: list[str] = []
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str) -> None:
+        self.buckets_used.append(Bucket)
+        self.objects[Key] = Body
+        self.content_types[Key] = ContentType
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        self.buckets_used.append(Bucket)
+        if Key not in self.objects:
+            raise _FakeClientError("NoSuchKey")
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        self.buckets_used.append(Bucket)
+        if Key not in self.objects:
+            raise _FakeClientError("404")
+        return {"ContentLength": len(self.objects[Key])}
+
+
+def _payload() -> ReplaySamplePayload:
+    return ReplaySamplePayload(
+        sample_id=uuid4(),
+        trace_id="trace-abc",
+        feature_tag="checkout",
+        real_provider="openai",
+        real_model="gpt-4o",
+        input_tokens=120,
+        output_tokens=45,
+        scrubbed_json=b'{"messages": [{"role": "user", "content": "hi"}]}',
+        pii_scrubbed=True,
+    )
+
+
+# --- Round-trip ------------------------------------------------------------------------------
+
+def test_persisted_sample_round_trips_through_s3() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="tally-replay", client=client)
+    payload = _payload()
+    captured_at = datetime(2026, 7, 12, 9, 30, tzinfo=UTC)
+
+    row = persist_sample(
+        blob_store=store,
+        tenant_id="tenant-1",
+        payload=payload,
+        captured_at=captured_at,
+    )
+
+    # Keyed identically to the in-memory/GCS path.
+    expected_key = build_replay_object_key("tenant-1", payload.sample_id, captured_at)
+    assert row.s3_object_key == expected_key
+    # Write-then-read returns the same envelope bytes.
+    assert store.get_bytes(expected_key) == payload.scrubbed_json
+
+
+def test_s3_key_matches_in_memory_backend() -> None:
+    client = _FakeS3Client()
+    s3 = S3ReplayBlobStore(bucket="b", client=client)
+    mem = InMemoryReplayBlobStore()
+    payload = _payload()
+    captured_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+
+    s3_row = persist_sample(blob_store=s3, tenant_id="t", payload=payload, captured_at=captured_at)
+    mem_row = persist_sample(
+        blob_store=mem, tenant_id="t", payload=payload, captured_at=captured_at
+    )
+    assert s3_row.s3_object_key == mem_row.s3_object_key
+    assert s3.get_bytes(s3_row.s3_object_key) == mem.get_bytes(mem_row.s3_object_key)
+
+
+def test_content_type_passed_and_bucket_used() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="my-bucket", client=client)
+    store.put_bytes("tenants/t/x.json", b"{}", content_type="application/json")
+    assert client.objects["tenants/t/x.json"] == b"{}"
+    assert client.content_types["tenants/t/x.json"] == "application/json"
+    assert "my-bucket" in client.buckets_used
+
+
+# --- exists() --------------------------------------------------------------------------------
+
+def test_exists_true_after_put_and_false_when_absent() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="b", client=client)
+    assert store.exists("tenants/t/missing.json") is False
+    store.put_bytes("tenants/t/present.json", b"{}")
+    assert store.exists("tenants/t/present.json") is True
+
+
+def test_exists_reraises_non_404_errors() -> None:
+    class _BoomClient(_FakeS3Client):
+        def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            raise _FakeClientError("AccessDenied", status=403)
+
+    store = S3ReplayBlobStore(bucket="b", client=_BoomClient())
+    with pytest.raises(_FakeClientError):
+        store.exists("tenants/t/x.json")
+
+
+# --- Prefix ----------------------------------------------------------------------------------
+
+def test_prefix_is_applied_to_stored_key_but_not_index_key() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="b", prefix="env/staging/", client=client)
+    store.put_bytes("tenants/t/x.json", b"{}")
+    # Prefix is prepended (normalised, no leading/trailing slash duplication) on the way to S3.
+    assert "env/staging/tenants/t/x.json" in client.objects
+    assert "tenants/t/x.json" not in client.objects
+    # Round-trip through the same prefixed store still resolves.
+    assert store.get_bytes("tenants/t/x.json") == b"{}"
+    assert store.exists("tenants/t/x.json") is True
+
+
+def test_empty_bucket_rejected() -> None:
+    with pytest.raises(ValueError):
+        S3ReplayBlobStore(bucket="", client=_FakeS3Client())
+
+
+# --- Backend selection via settings ----------------------------------------------------------
+
+def test_backend_selection_defaults_to_memory() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="memory")
+    store = _build_replay_blob_store(settings)
+    assert isinstance(store, InMemoryReplayBlobStore)
+
+
+def test_backend_selection_picks_s3(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.app import _build_replay_blob_store
+
+    # Avoid needing the real client: swap the class so construction doesn't touch boto3.
+    captured: dict[str, object] = {}
+
+    class _StubS3:
+        def __init__(self, bucket: str, *, prefix: str = "", region: str | None = None) -> None:
+            captured["bucket"] = bucket
+            captured["prefix"] = prefix
+            captured["region"] = region
+
+    monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)
+    settings = Settings(
+        replay_blob_backend="s3",
+        replay_s3_bucket="tally-replay-prod",
+        replay_s3_prefix="env/prod",
+        replay_s3_region="us-east-1",
+    )
+    store = _build_replay_blob_store(settings)
+    assert isinstance(store, _StubS3)
+    assert captured == {
+        "bucket": "tally-replay-prod",
+        "prefix": "env/prod",
+        "region": "us-east-1",
+    }
+
+
+def test_s3_empty_region_resolves_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.app import _build_replay_blob_store
+
+    captured: dict[str, object] = {}
+
+    class _StubS3:
+        def __init__(self, bucket: str, *, prefix: str = "", region: str | None = None) -> None:
+            captured["region"] = region
+
+    monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)
+    settings = Settings(replay_blob_backend="s3", replay_s3_bucket="b")
+    _build_replay_blob_store(settings)
+    # Empty string region -> None so boto3 resolves from the AWS default chain.
+    assert captured["region"] is None
+
+
+def test_s3_backend_requires_bucket() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="s3", replay_s3_bucket="")
+    with pytest.raises(ValueError):
+        _build_replay_blob_store(settings)
+
+
+def test_unknown_backend_rejected() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="s4")
+    with pytest.raises(ValueError):
+        _build_replay_blob_store(settings)
+
+
+# --- Lazy import -----------------------------------------------------------------------------
+
+def test_replay_store_imports_without_boto3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing replay_store must not require boto3; only constructing the store (without an
+    injected client) does. Simulate the package being absent and re-import."""
+    # Block any boto3 import.
+    for name in list(sys.modules):
+        if name == "boto3" or name.startswith("boto3."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = importlib.import_module
+
+    def _blocking_import(name: str, *args, **kwargs):
+        if name == "boto3" or name.startswith("boto3."):
+            raise ModuleNotFoundError("No module named 'boto3'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _blocking_import)
+
+    # Module (re)import works fine even with boto3 unavailable.
+    mod = importlib.reload(importlib.import_module("gateway.replay_store"))
+    assert hasattr(mod, "S3ReplayBlobStore")
+
+    # And an injected client sidesteps the lazy import entirely, so the store is still usable.
+    store = mod.S3ReplayBlobStore(bucket="b", client=_FakeS3Client())
+    store.put_bytes("k", b"v")
+    assert store.get_bytes("k") == b"v"


### PR DESCRIPTION
## CTO-158 — S3 replay blob-store backend (mirror of CTO-152 GCS)

Adds an AWS S3 (S3-compatible / MinIO) backend for replay sample blobs, mirroring the merged CTO-152 GCS backend exactly.

### What changed
- **`S3ReplayBlobStore`** in `replay_store.py` — satisfies the same `ReplayBlobStore` protocol (`put_bytes`/`get_bytes`) plus an `exists()` helper, using the identical `tenants/{tenant_id}/replay_samples/{yyyy/mm/dd}/{sample_id}.json` key layout. Optional `prefix` is prepended to stored keys without touching the ClickHouse index key. `boto3` is **lazy-imported inside `__init__`** — the module imports and the gateway boots without boto3.
- **Auth** via the AWS default credential chain (IAM role / IRSA / instance profile / `AWS_*` env) — no raw access keys handled here.
- **Settings**: `TALLY_REPLAY_S3_BUCKET` (required for `s3`), optional `TALLY_REPLAY_S3_PREFIX` / `TALLY_REPLAY_S3_REGION`. Backend selection now supports `memory` (default) | `gcs` | `s3`; `s3` requires a bucket, unknown values raise.
- **`pyproject.toml`**: optional `[s3]` extra (`boto3>=1.34`).
- PII scrub stays upstream, untouched (same as CTO-152).

### Out of scope
Migrating existing blobs; S3 lifecycle/TTL policy (expected out-of-band via Terraform, documented in the class docstring).

### Tests
13 new tests in `test_replay_store_s3.py` with a fake boto3 client: put/get/exists round-trip, prefix handling, backend selection (incl. empty-region → None), bucket-required + unknown-backend guards, and the lazy-import guard. Full suite: **330 passed**, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)