### PR TITLE
feat(bedrock): Amazon Bedrock as a priced+discoverable LLM provider (CTO-157)

### DIFF
--- a/infra/gateway/tests/test_enrich_bedrock.py
+++ b/infra/gateway/tests/test_enrich_bedrock.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gateway cost enrichment for Amazon Bedrock spans (CTO-157).
+
+The gateway recomputes cost from the catalog in ``enrich_cost``. A span with
+``gen_ai.system="bedrock"`` and a seeded Bedrock model must price to a non-zero cost with
+no ``catalog_miss`` — proving Bedrock needs no special-casing in the mapping/enrich path
+(provider is just the catalog lookup key), exactly like the CTO-149 Gemini case.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from tally.enrichment import enrich_cost
+from tally.pricing import seed_catalog
+from tally.schema import GenAI
+
+from gateway.mapping import COLUMNS, span_to_row
+
+AT = date(2026, 6, 1)
+
+
+def _span(model: str, input_tokens: int = 1000, output_tokens: int = 250) -> dict[str, object]:
+    return {
+        GenAI.SYSTEM: "bedrock",
+        GenAI.REQUEST_MODEL: model,
+        GenAI.RESPONSE_MODEL: model,
+        GenAI.USAGE_INPUT_TOKENS: input_tokens,
+        GenAI.USAGE_OUTPUT_TOKENS: output_tokens,
+    }
+
+
+def test_enrich_bedrock_claude_no_catalog_miss() -> None:
+    res = enrich_cost(_span("anthropic.claude-sonnet-4-5"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enrich_bedrock_nova_no_catalog_miss() -> None:
+    res = enrich_cost(_span("amazon.nova-pro"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enrich_bedrock_llama_no_catalog_miss() -> None:
+    res = enrich_cost(_span("meta.llama3-3-70b-instruct"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enriched_bedrock_span_maps_to_row_with_cost() -> None:
+    # End-to-end through the mapping: enriched bedrock span -> otel row with a non-zero
+    # EstimatedCost and GenAiSystem="bedrock", no special-casing anywhere.
+    res = enrich_cost(
+        _span("anthropic.claude-sonnet-4-5", 1_000_000, 1_000_000), seed_catalog(), at=AT
+    )
+    row = span_to_row(res.attributes, tenant_id="tn-1", effective_ts_ns=1_700_000_000_000_000_000)
+    by_col = dict(zip(COLUMNS, row, strict=True))
+    assert by_col["GenAiSystem"] == "bedrock"
+    assert by_col["GenAiRequestModel"] == "anthropic.claude-sonnet-4-5"
+    assert by_col["EstimatedCost"] > 0

--- a/sdk/python/src/tally/models.py
+++ b/sdk/python/src/tally/models.py
@@ -49,7 +49,7 @@ DEFAULT_CACHE_PATH = Path(".tally/models.json")
 class ModelInfo:
     """A single model entry as returned by a provider's ``/v1/models`` endpoint."""
 
-    provider: str  # "openai" | "anthropic" | "google"
+    provider: str  # "openai" | "anthropic" | "google" | "bedrock"
     id: str  # canonical id, e.g. "claude-sonnet-4-5" or "gpt-4o-mini"
     family: str  # see classify_family()
     created_at: datetime | None
@@ -240,6 +240,78 @@ def fetch_google_models(api_key: str, *, timeout: float = 5.0) -> list[ModelInfo
     return out
 
 
+def _default_bedrock_client(region: str | None):
+    """Build a boto3 ``bedrock`` (control-plane) client via the AWS default credential chain.
+
+    Imported lazily because ``boto3`` is an OPTIONAL dependency — the SDK is dep-light and must
+    import fine without it. Callers that want Bedrock discovery either install ``boto3`` or inject
+    their own client. Region resolves from the ``region`` arg, then ``AWS_REGION`` /
+    ``AWS_DEFAULT_REGION``. Credentials come from the standard chain (env vars, shared config,
+    SSO, instance/task role) — no raw keys are handled here.
+    """
+    import boto3  # optional dep; ImportError is caught by the discover_models fail-soft path
+
+    region = region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    return boto3.client("bedrock", region_name=region)
+
+
+def fetch_bedrock_models(*, client=None, region: str | None = None) -> list[ModelInfo]:
+    """List Amazon Bedrock foundation models via the Bedrock control-plane (CTO-157).
+
+    Uses the ``bedrock`` client's ``list_foundation_models`` (NOT ``bedrock-runtime`` — the
+    control plane is where the catalog lives). ``client`` is injectable so tests never hit AWS;
+    when omitted, a boto3 client is built via :func:`_default_bedrock_client` using the AWS
+    default credential chain.
+
+    Response shape: ``{"modelSummaries": [{"modelId": "anthropic.claude-...", ...}]}``. The
+    ``modelId`` is used verbatim as the ``ModelInfo.id`` — it matches what a Bedrock caller
+    passes as ``gen_ai.request_model`` and the ``bedrock/`` catalog slugs.
+
+    Only TEXT-output (chat/completion) models are returned: a summary whose ``outputModalities``
+    is present and excludes ``"TEXT"`` (image/embedding-only SKUs) is skipped, mirroring the
+    CTO-172 non-chat guard so a chat family never receives a non-chat model.
+    """
+    if client is None:
+        client = _default_bedrock_client(region)
+    payload = client.list_foundation_models()
+    out: list[ModelInfo] = []
+    for row in payload.get("modelSummaries", []):
+        model_id = row.get("modelId")
+        if not model_id or not isinstance(model_id, str):
+            continue
+        modalities = row.get("outputModalities")
+        if modalities and "TEXT" not in modalities:
+            continue
+        out.append(
+            ModelInfo(
+                provider="bedrock",
+                id=model_id,
+                family=classify_family(model_id),
+                created_at=None,
+                deprecated_at=None,
+            )
+        )
+    return out
+
+
+def _aws_configured() -> bool:
+    """True when the environment carries enough AWS config to attempt Bedrock discovery.
+
+    We can't validate credentials without a call, so this is a cheap gate on the default-chain
+    signals (a region plus some credential source). When false, Bedrock discovery is skipped
+    entirely — exactly like a missing ``GOOGLE_API_KEY`` skips Google.
+    """
+    has_region = bool(os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"))
+    has_creds = bool(
+        os.environ.get("AWS_ACCESS_KEY_ID")
+        or os.environ.get("AWS_PROFILE")
+        or os.environ.get("AWS_ROLE_ARN")
+        or os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+        or os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE")
+    )
+    return has_region and has_creds
+
+
 def save_cache(models: list[ModelInfo], path: Path = DEFAULT_CACHE_PATH) -> None:
     """Persist the discovered list to ``path`` (creating parent dirs)."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -321,6 +393,7 @@ def discover_models(
     openai_api_key: str | None = None,
     anthropic_api_key: str | None = None,
     google_api_key: str | None = None,
+    bedrock_client=None,
     timeout: float = 5.0,
 ) -> list[ModelInfo]:
     """Boot-time discovery entry point. Fail-soft on every error path.
@@ -357,6 +430,7 @@ def discover_models(
     openai_err: Exception | None = None
     anthropic_err: Exception | None = None
     google_err: Exception | None = None
+    bedrock_err: Exception | None = None
 
     if openai_key:
         try:
@@ -390,6 +464,20 @@ def discover_models(
     else:
         logger.info("models: GOOGLE_API_KEY/GEMINI_API_KEY not set — skipping google discovery")
 
+    # Bedrock is behind an injectable client (tests never touch AWS). Attempt it when a client
+    # is injected OR the AWS default credential chain looks configured. Fail-soft on EVERY error
+    # — missing boto3 (ImportError), no/invalid creds, region issues, or a botocore API error must
+    # skip Bedrock, never crash discovery. boto3's exception hierarchy can't be imported when boto3
+    # isn't installed, so this catch is intentionally broad.
+    if bedrock_client is not None or _aws_configured():
+        try:
+            discovered.extend(fetch_bedrock_models(client=bedrock_client))
+        except Exception as exc:  # noqa: BLE001 - optional dep + external SDK; must fail soft
+            bedrock_err = exc
+            logger.warning("models: bedrock fetch failed: %s", exc)
+    else:
+        logger.info("models: AWS creds/region not set — skipping bedrock discovery")
+
     if discovered:
         try:
             save_cache(discovered, cache_path)
@@ -403,21 +491,23 @@ def discover_models(
     stale = _load_unchecked(cache_path)
     if stale is not None:
         logger.warning(
-            "models: live fetch failed (openai=%s anthropic=%s google=%s) — "
+            "models: live fetch failed (openai=%s anthropic=%s google=%s bedrock=%s) — "
             "using stale cache (%d entries)",
             openai_err,
             anthropic_err,
             google_err,
+            bedrock_err,
             len(stale),
         )
         return stale
 
     logger.warning(
-        "models: no live data and no cache (openai=%s anthropic=%s google=%s) — "
+        "models: no live data and no cache (openai=%s anthropic=%s google=%s bedrock=%s) — "
         "booting with empty list",
         openai_err,
         anthropic_err,
         google_err,
+        bedrock_err,
     )
     return []
 
@@ -426,7 +516,14 @@ def _log_summary(models: list[ModelInfo]) -> None:
     openai_ids = sorted(m.id for m in models if m.provider == "openai")
     anth_ids = sorted(m.id for m in models if m.provider == "anthropic")
     google_ids = sorted(m.id for m in models if m.provider == "google")
-    logger.info("models: openai=%s anthropic=%s google=%s", openai_ids, anth_ids, google_ids)
+    bedrock_ids = sorted(m.id for m in models if m.provider == "bedrock")
+    logger.info(
+        "models: openai=%s anthropic=%s google=%s bedrock=%s",
+        openai_ids,
+        anth_ids,
+        google_ids,
+        bedrock_ids,
+    )
 
 
 __all__ = [
@@ -435,6 +532,7 @@ __all__ = [
     "fetch_openai_models",
     "fetch_anthropic_models",
     "fetch_google_models",
+    "fetch_bedrock_models",
     "save_cache",
     "load_cached",
     "latest",

--- a/sdk/python/src/tally/pricing.py
+++ b/sdk/python/src/tally/pricing.py
@@ -307,7 +307,7 @@ _VECTOR_SEEDS: list[tuple[str, str, PriceType, str]] = [
 
 
 def seed_catalog() -> PriceCatalog:
-    """Multi-provider seed catalog (OpenAI + Anthropic + Google Gemini/Vertex).
+    """Multi-provider seed catalog (OpenAI + Anthropic + Google Gemini/Vertex + Amazon Bedrock).
 
     Expanded for CTO-106; previously the gpt-5-mini pinning workaround in
     examples/* was needed because of catalog gaps. The scraper (CTO-53) will
@@ -381,6 +381,49 @@ def seed_catalog() -> PriceCatalog:
         ("google", "gemini-3-flash", PriceType.INPUT, "0.30"),
         ("google", "gemini-3-flash", PriceType.CACHED_INPUT, "0.075"),
         ("google", "gemini-3-flash", PriceType.OUTPUT, "2.50"),
+        # --- Amazon Bedrock (https://aws.amazon.com/bedrock/pricing/) ---------
+        # CTO-157. Bedrock is a *managed* re-seller of third-party + Amazon-first
+        # models, so it gets its own provider dimension ("bedrock") rather than
+        # sharing the vendor-direct keys. The model slot holds Bedrock's native
+        # modelId minus the "-vN:0" version tag (e.g. "anthropic.claude-sonnet-4-5"),
+        # which is exactly what a Bedrock caller passes as gen_ai.request_model and
+        # what list_foundation_models advertises. This deliberately does NOT collide
+        # with the vendor-direct entries above (provider="anthropic",
+        # model="claude-sonnet-4-5") — same model, different surface, different price.
+        #
+        # Bedrock re-prices some models ABOVE the vendor-direct rate (the managed
+        # infra premium): e.g. Bedrock's Claude Sonnet output is listed higher than
+        # Anthropic-direct. These capture Bedrock's OWN published on-demand rates,
+        # not the vendor-direct numbers. Bedrock's prompt-caching read tier maps to
+        # CACHED_INPUT (steady-state read price); the cache-write premium is not
+        # modeled by the current PriceType enum. Usage field mapping mirrors the
+        # Bedrock Converse API: usage.inputTokens -> input,
+        # usage.outputTokens -> output, usage.cacheReadInputTokens -> cached_input.
+        # All rates [unverified at implementation time] — the live Bedrock pricing
+        # page was not reachable from the implementation environment, so values are
+        # taken from training-data values for the published per-MTok on-demand
+        # prices; update once the scraper (CTO-53) lands.
+        #
+        # Anthropic on Bedrock — priced above Anthropic-direct (managed premium).
+        ("bedrock", "anthropic.claude-sonnet-4-5", PriceType.INPUT, "3.30"),
+        ("bedrock", "anthropic.claude-sonnet-4-5", PriceType.CACHED_INPUT, "0.33"),
+        ("bedrock", "anthropic.claude-sonnet-4-5", PriceType.OUTPUT, "16.50"),
+        ("bedrock", "anthropic.claude-haiku-4-5", PriceType.INPUT, "1.10"),
+        ("bedrock", "anthropic.claude-haiku-4-5", PriceType.CACHED_INPUT, "0.11"),
+        ("bedrock", "anthropic.claude-haiku-4-5", PriceType.OUTPUT, "5.50"),
+        # Meta Llama on Bedrock — no cached tier published on-demand.
+        ("bedrock", "meta.llama3-3-70b-instruct", PriceType.INPUT, "0.72"),
+        ("bedrock", "meta.llama3-3-70b-instruct", PriceType.OUTPUT, "0.72"),
+        # Amazon Nova (first-party flagship-ish + micro tiers).
+        ("bedrock", "amazon.nova-pro", PriceType.INPUT, "0.80"),
+        ("bedrock", "amazon.nova-pro", PriceType.CACHED_INPUT, "0.20"),
+        ("bedrock", "amazon.nova-pro", PriceType.OUTPUT, "3.20"),
+        ("bedrock", "amazon.nova-micro", PriceType.INPUT, "0.035"),
+        ("bedrock", "amazon.nova-micro", PriceType.CACHED_INPUT, "0.00875"),
+        ("bedrock", "amazon.nova-micro", PriceType.OUTPUT, "0.14"),
+        # Amazon Titan (legacy first-party text) — no cached tier.
+        ("bedrock", "amazon.titan-text-express", PriceType.INPUT, "0.20"),
+        ("bedrock", "amazon.titan-text-express", PriceType.OUTPUT, "0.60"),
     ]
     for provider, model, pt, rate in seeds:
         cat.add(_mtok(provider, model, pt, rate))

--- a/sdk/python/tests/test_bedrock_provider.py
+++ b/sdk/python/tests/test_bedrock_provider.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Amazon Bedrock as a first-class LLM cost provider (CTO-157).
+
+Mirror of the CTO-149 Gemini coverage. Proves the three things the ticket asks the SDK side
+to demonstrate:
+  1. the seed catalog prices the Bedrock lineup under the ``bedrock/`` provider prefix
+     (non-zero, correct against the seeded rates, no collision with vendor-direct entries);
+  2. ``record_llm_call(provider="bedrock", ...)`` costs from the catalog and stamps
+     ``gen_ai.system="bedrock"`` on a conformant span — no provider allowlist to trip over;
+  3. model discovery lists foundation models via an INJECTED Bedrock control-plane client
+     (never the network), classifies them into families, and fails soft when unavailable.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tally import models as M
+from tally.client import MemoryExporter, TallyClient
+from tally.context import with_trace_context
+from tally.pricing import (
+    PriceType,
+    Usage,
+    compute_cost_micro_usd,
+    seed_catalog,
+)
+from tally.sampling import Sampler, SamplingConfig
+from tally.schema import GenAI, validate_span_attributes
+
+AT = date(2026, 6, 1)
+
+
+# --- Price catalog ------------------------------------------------------------
+
+
+def test_bedrock_claude_sonnet_priced_correctly() -> None:
+    cat = seed_catalog()
+    # 1M input @ $3.30/MTok + 1M output @ $16.50/MTok = $19.80 = 19_800_000 micro-USD.
+    cost, version = compute_cost_micro_usd(
+        cat, "bedrock", "anthropic.claude-sonnet-4-5", Usage(1_000_000, 1_000_000), at=AT
+    )
+    assert cost == 19_800_000
+    assert version  # a real catalog version, not the empty "partial price" sentinel
+
+
+def test_bedrock_nova_micro_priced_correctly() -> None:
+    cat = seed_catalog()
+    # 1M input @ $0.035/MTok + 1M output @ $0.14/MTok = $0.175 = 175_000 micro-USD.
+    cost, version = compute_cost_micro_usd(
+        cat, "bedrock", "amazon.nova-micro", Usage(1_000_000, 1_000_000), at=AT
+    )
+    assert cost == 175_000
+    assert version
+
+
+def test_bedrock_reprices_above_vendor_direct() -> None:
+    # The whole point of a separate provider dimension: Bedrock's managed rate is NOT the
+    # Anthropic-direct rate. Sonnet output is $16.50 on Bedrock vs $15.00 vendor-direct.
+    cat = seed_catalog()
+    bedrock = cat.lookup("bedrock", "anthropic.claude-sonnet-4-5", PriceType.OUTPUT, at=AT)
+    direct = cat.lookup("anthropic", "claude-sonnet-4-5", PriceType.OUTPUT, at=AT)
+    assert bedrock is not None and direct is not None
+    assert bedrock.price_per_unit > direct.price_per_unit
+
+
+def test_bedrock_does_not_collide_with_vendor_direct() -> None:
+    # The vendor-direct Anthropic key must be untouched by the Bedrock entries.
+    cat = seed_catalog()
+    # Bedrock uses the dotted native modelId; vendor-direct uses the bare slug.
+    assert cat.lookup("bedrock", "claude-sonnet-4-5", PriceType.INPUT, at=AT) is None
+    assert cat.lookup("anthropic", "anthropic.claude-sonnet-4-5", PriceType.INPUT, at=AT) is None
+    direct = cat.lookup("anthropic", "claude-sonnet-4-5", PriceType.INPUT, at=AT)
+    assert direct is not None and direct.price_per_unit == Decimal("3.00")
+
+
+def test_bedrock_llama_has_no_cached_tier_but_still_prices() -> None:
+    cat = seed_catalog()
+    assert (
+        cat.lookup("bedrock", "meta.llama3-3-70b-instruct", PriceType.CACHED_INPUT, at=AT) is None
+    )
+    cost, version = compute_cost_micro_usd(
+        cat, "bedrock", "meta.llama3-3-70b-instruct", Usage(1000, 250), at=AT
+    )
+    assert cost > 0
+    assert version
+
+
+def test_bedrock_cached_tier_is_cheaper() -> None:
+    cat = seed_catalog()
+    cached = cat.lookup("bedrock", "amazon.nova-pro", PriceType.CACHED_INPUT, at=AT)
+    standard = cat.lookup("bedrock", "amazon.nova-pro", PriceType.INPUT, at=AT)
+    assert cached is not None and standard is not None
+    assert cached.price_per_unit < standard.price_per_unit
+
+
+def test_bedrock_rates_are_decimal() -> None:
+    cat = seed_catalog()
+    entry = cat.lookup("bedrock", "amazon.titan-text-express", PriceType.OUTPUT, at=AT)
+    assert entry is not None
+    assert isinstance(entry.price_per_unit, Decimal)
+
+
+def test_bedrock_cost_is_nonzero_for_small_usage() -> None:
+    cat = seed_catalog()
+    for model in (
+        "anthropic.claude-sonnet-4-5",
+        "anthropic.claude-haiku-4-5",
+        "meta.llama3-3-70b-instruct",
+        "amazon.nova-pro",
+        "amazon.nova-micro",
+        "amazon.titan-text-express",
+    ):
+        cost, version = compute_cost_micro_usd(cat, "bedrock", model, Usage(1000, 250), at=AT)
+        assert cost > 0, model
+        assert version, model
+
+
+# --- Provider path (record_llm_call) ------------------------------------------
+
+
+def _client(**kw) -> TallyClient:
+    return TallyClient(catalog=seed_catalog(), **kw)
+
+
+def test_record_llm_call_bedrock_costs_from_catalog() -> None:
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t1", feature_tag="compare", session_id="s1"):
+        result = client.record_llm_call(
+            provider="bedrock",
+            model="anthropic.claude-sonnet-4-5",
+            usage=Usage(input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+    assert result.kept is True
+    assert result.cost_micro_usd == 19_800_000
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    assert span[GenAI.SYSTEM] == "bedrock"
+    assert span[GenAI.COST_ESTIMATED_MICRO_USD] == 19_800_000
+
+
+def test_record_llm_call_bedrock_maps_cached_tokens() -> None:
+    # cacheReadInputTokens -> cached_input_tokens; billed at the cheaper cached rate.
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t2"):
+        full = client.record_llm_call(
+            provider="bedrock",
+            model="amazon.nova-pro",
+            usage=Usage(input_tokens=1_000_000, output_tokens=0),
+        )
+        cached = client.record_llm_call(
+            provider="bedrock",
+            model="amazon.nova-pro",
+            usage=Usage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=1_000_000),
+        )
+    assert full.cost_micro_usd is not None and cached.cost_micro_usd is not None
+    assert cached.cost_micro_usd < full.cost_micro_usd
+
+
+# --- Model discovery (injected client — never the network) --------------------
+
+
+class _FakeBedrock:
+    """Stand-in for a boto3 ``bedrock`` control-plane client."""
+
+    def __init__(self, summaries: list[dict]):
+        self._summaries = summaries
+
+    def list_foundation_models(self, **_kw) -> dict:
+        return {"modelSummaries": self._summaries}
+
+
+_SUMMARIES = [
+    {"modelId": "anthropic.claude-sonnet-4-5-20250101-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "anthropic.claude-haiku-4-5-20250101-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "meta.llama3-3-70b-instruct-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "amazon.nova-pro-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "amazon.titan-text-express-v1", "outputModalities": ["TEXT"]},
+    # Non-chat SKUs that must be filtered out by the modality guard:
+    {"modelId": "amazon.titan-embed-text-v2:0", "outputModalities": ["EMBEDDING"]},
+    {"modelId": "amazon.titan-image-generator-v1", "outputModalities": ["IMAGE"]},
+]
+
+
+def test_fetch_bedrock_models_parses_and_classifies() -> None:
+    out = M.fetch_bedrock_models(client=_FakeBedrock(_SUMMARIES))
+    ids = {m.id for m in out}
+    # Text models kept, embedding/image dropped.
+    assert "anthropic.claude-sonnet-4-5-20250101-v1:0" in ids
+    assert "meta.llama3-3-70b-instruct-v1:0" in ids
+    assert "amazon.titan-embed-text-v2:0" not in ids
+    assert "amazon.titan-image-generator-v1" not in ids
+    assert all(m.provider == "bedrock" for m in out)
+    # Families are classified consistently with classify_family.
+    by_id = {m.id: m for m in out}
+    assert by_id["anthropic.claude-sonnet-4-5-20250101-v1:0"].family == "sonnet"
+    assert by_id["anthropic.claude-haiku-4-5-20250101-v1:0"].family == "haiku"
+    # Llama's "instruct" routes to "other" (CTO-172 non-chat-family guard keyword), Titan/Nova too.
+    assert by_id["meta.llama3-3-70b-instruct-v1:0"].family == "other"
+    assert by_id["amazon.titan-text-express-v1"].family == "other"
+    # latest() can resolve a Bedrock family.
+    sonnet = M.latest("bedrock", "sonnet", out)
+    assert sonnet is not None and sonnet.family == "sonnet"
+
+
+def test_classify_bedrock_families() -> None:
+    assert M.classify_family("anthropic.claude-sonnet-4-5-20250101-v1:0") == "sonnet"
+    assert M.classify_family("anthropic.claude-haiku-4-5") == "haiku"
+
+
+def test_discover_includes_bedrock_with_injected_client(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No AWS env needed: injecting a client is itself the enable signal.
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(
+        cache_path=tmp_path / "models.json",
+        bedrock_client=_FakeBedrock(_SUMMARIES),
+    )
+    bedrock_ids = {m.id for m in result if m.provider == "bedrock"}
+    assert "amazon.nova-pro-v1:0" in bedrock_ids
+    # Non-text SKUs never made it into the discovered lineup.
+    assert "amazon.titan-embed-text-v2:0" not in bedrock_ids
+
+
+def test_discover_skips_bedrock_when_unconfigured(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No injected client and no AWS env → Bedrock is skipped, no crash, empty result.
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_PROFILE",
+        "AWS_ROLE_ARN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(cache_path=tmp_path / "absent.json")
+    assert [m for m in result if m.provider == "bedrock"] == []
+
+
+def test_discover_bedrock_fails_soft_on_client_error(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A control-plane error (e.g. AccessDenied / no creds) must skip Bedrock, not crash discovery.
+    class _BoomBedrock:
+        def list_foundation_models(self, **_kw):
+            raise RuntimeError("AccessDeniedException")
+
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(
+        cache_path=tmp_path / "absent.json",
+        bedrock_client=_BoomBedrock(),
+    )
+    assert result == []
+
+
+def test_aws_configured_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_PROFILE",
+        "AWS_ROLE_ARN",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert M._aws_configured() is False
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    assert M._aws_configured() is False  # region alone is not enough
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-fake")
+    assert M._aws_configured() is True

--- a/sdk/python/tests/test_pricing_seeds.py
+++ b/sdk/python/tests/test_pricing_seeds.py
@@ -111,6 +111,30 @@ def test_gemini_flash_cheaper_than_pro() -> None:
     assert _cost("google", "gemini-2.5-flash") < _cost("google", "gemini-2.5-pro")
 
 
+# --- Amazon Bedrock (CTO-157) — managed LLM provider, own price dimension ----
+
+
+def test_bedrock_claude_sonnet_priced() -> None:
+    _cost("bedrock", "anthropic.claude-sonnet-4-5")
+
+
+def test_bedrock_llama_priced() -> None:
+    _cost("bedrock", "meta.llama3-3-70b-instruct")
+
+
+def test_bedrock_nova_pro_priced() -> None:
+    _cost("bedrock", "amazon.nova-pro")
+
+
+def test_bedrock_titan_priced() -> None:
+    _cost("bedrock", "amazon.titan-text-express")
+
+
+def test_bedrock_sonnet_repriced_above_anthropic_direct() -> None:
+    # Same model, different surface: Bedrock's managed rate exceeds the vendor-direct rate.
+    assert _cost("bedrock", "anthropic.claude-sonnet-4-5") > _cost("anthropic", "claude-sonnet-4-5")
+
+
 # --- Vertex AI Vector Search (CTO-151) — Vector cost layer, per-call ----
 
 


### PR DESCRIPTION
## CTO-157 — Amazon Bedrock as an instrumented LLM provider

Mirror of CTO-149 (Gemini). Adds Amazon Bedrock as a priced + discoverable LLM provider under its own `bedrock` provider dimension.

### Pricing (`seed_catalog`)
Bedrock entries keyed by native modelId under the `bedrock/` prefix — `anthropic.claude-sonnet-4-5`, `anthropic.claude-haiku-4-5`, `meta.llama3-3-70b-instruct`, `amazon.nova-pro`, `amazon.nova-micro`, `amazon.titan-text-express` — with input/output/cached tiers. Captures **Bedrock's own** on-demand rates (re-priced above vendor-direct for the managed premium, e.g. Sonnet output $16.50 vs $15.00 direct) and does **not** collide with the vendor-direct `anthropic/*` keys. Every rate marked `# [unverified at implementation time]`.

### Provider path
`record_llm_call(provider="bedrock", ...)` costs from the catalog; the gateway's `enrich_cost` prices `gen_ai.system="bedrock"` with **no special-casing** — proven by a non-zero-cost, no-`catalog_miss` gateway test.

### Discovery
`discover_models()` gains a Bedrock branch: lists foundation models via the `bedrock` control-plane's `list_foundation_models`, behind an **injectable client** so tests never hit AWS. Auth via the AWS default credential chain (no raw keys); fails soft on missing `boto3` / creds / API errors. TEXT models classified consistently with `classify_family`; non-TEXT SKUs (embedding/image) filtered out (mirrors the CTO-172 non-chat guard).

### Tests
- SDK: `test_bedrock_provider.py` (16 — pricing regression, `bedrock/*` cost-compute, mocked injected-client discovery incl. fail-soft) + 5 in `test_pricing_seeds.py`
- Gateway: `test_enrich_bedrock.py` (4 — enrich + span→row)
- **SDK 921 passed, gateway 321 passed, ruff clean on both.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)