### PR TITLE
feat(compare): data-driven recommendation text + workload label (CTO-168)

### DIFF
--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/clickhouse", () => ({
 }));
 
 import { GET as CompareGET } from "./route";
+import { comparison } from "@/lib/compare";
 import * as ch from "@/lib/clickhouse";
 
 const queryCurrentModel = ch.queryCurrentModel as unknown as ReturnType<typeof vi.fn>;
@@ -502,5 +503,189 @@ describe("/api/compare", () => {
     // Below the judge floor → honest null quality; NEVER a fabricated Gemini number.
     expect(gemini.qualityScore).toBeNull();
     expect(gemini.qualityCi).toBeUndefined();
+  });
+
+  // --- CTO-168: data-driven workload label + recommendation prose --------------------------------
+
+  it("CTO-168: workload + verdict + summary are derived from computed data on the live path", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 60,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 3_000_000, // 70% cheaper than current
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 60,
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 12_500,
+      },
+    });
+    queryEvalCandidates.mockResolvedValueOnce({
+      samples_available: 40,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          samples_judged: 30,
+          current_wins: 12,
+          candidate_wins: 16,
+          ties: 2,
+          errors: 0,
+          win_rate: 0.6, // candidate wins the majority of judged pairs → "switch"
+          win_rate_ci_lo: 0.42,
+          win_rate_ci_hi: 0.76,
+          judge_cost_micro_usd: 60_000,
+        },
+      ],
+      diagnostics: { judge_model: "claude-opus-4-8", rubric_version: "rubric-v1", judge_cost_micro_usd: 60_000 },
+    });
+
+    const res = await CompareGET(
+      new Request("http://test/api/compare?tag=chat_assistant") as never,
+    );
+    const body = await res.json();
+
+    // Workload derived from the ?tag= filter + the 7-day current-model window — NOT the fixture
+    // (a distinct tag proves the label tracks the query context rather than the hardcoded string).
+    expect(body.workload).toBe("chat_assistant / production / last 7 days");
+    expect(body.workload).not.toBe(comparison.workload);
+
+    // Verdict + summary reflect the REAL deltas: 70% cheaper + 60% judge win-rate → switch.
+    expect(body.recommendation.verdict).toBe("switch");
+    expect(body.recommendation.summary).toContain("claude-haiku-4-5");
+    expect(body.recommendation.summary).toContain("70%");
+    expect(body.recommendation.summary).toContain("60%");
+    // The old hardcoded fixture prose must never appear on the live path.
+    expect(body.recommendation.summary).not.toContain("$12.2K");
+    expect(body.recommendation.summary).not.toBe(comparison.recommendation.summary);
+    // Savings computed off the cheapest candidate vs live current cost.
+    expect(body.recommendation.projectedSavingsMicroUsd).toBe(7_000_000);
+    expect(body.recommendation.projectedSavingsPct).toBeCloseTo(0.7, 6);
+  });
+
+  it("CTO-168: workload defaults to 'all traffic' when no ?tag= filter is set", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 60,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 3_000_000,
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 60,
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 12_500,
+      },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    expect(body.workload).toBe("all traffic / production / last 7 days");
+    // No eval judged (< floor is moot — none ran) → quality unknown → verdict "mixed".
+    expect(body.recommendation.verdict).toBe("mixed");
+    expect(body.recommendation.summary).toContain("run an eval pass");
+  });
+
+  it("CTO-168: honest 'insufficient data' recommendation when replay samples are thin", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 10_000_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 20,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 3_000_000,
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 20, // total replayed (20) below the recommend floor (50)
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 5_000,
+      },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    // Thin data → say so honestly, never the fixture prose.
+    expect(body.recommendation.summary).toMatch(/insufficient replay data/i);
+    expect(body.recommendation.summary).not.toBe(comparison.recommendation.summary);
+    // Savings are still projected off the (thin) cheapest candidate for the display.
+    expect(body.recommendation.projectedSavingsMicroUsd).toBe(7_000_000);
+  });
+
+  it("CTO-168: rescaled-mock branch (live current, no replay) drops the fixture prose", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 1_310_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 500,
+    });
+    queryReplayCandidates.mockResolvedValueOnce(null); // no cross-provider replay behind this
+
+    const res = await CompareGET(
+      new Request("http://test/api/compare?tag=research_agent") as never,
+    );
+    const body = await res.json();
+    expect(body.replay_source).toBe("mock");
+    // Live current model exists → workload derived, fixture label gone.
+    expect(body.workload).toBe("research_agent / production / last 7 days");
+    // No real replay → honest "insufficient replay data", not the hardcoded "$12.2K" prose.
+    expect(body.recommendation.summary).toMatch(/insufficient replay data/i);
+    expect(body.recommendation.summary).not.toContain("$12.2K");
+  });
+
+  it("CTO-168: the unreachable-gateway fallback KEEPS the fixture workload + recommendation", async () => {
+    queryCurrentModel.mockResolvedValueOnce(null); // gateway/DB unreachable
+    queryReplayCandidates.mockResolvedValueOnce(null);
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    expect(body.replay_source).toBe("mock");
+    // This is the only path that still ships the fixture prose (labeled by SyntheticPreviewBanner).
+    expect(body.workload).toBe(comparison.workload);
+    expect(body.recommendation.summary).toBe(comparison.recommendation.summary);
+    expect(body.recommendation.verdict).toBe(comparison.recommendation.verdict);
   });
 });

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
-import { comparison } from "@/lib/compare";
+import { comparison, deriveRecommendation, deriveWorkload } from "@/lib/compare";
 import {
   queryCurrentModel,
   queryEvalCandidates,
@@ -18,6 +18,10 @@ const MIN_JUDGED_SAMPLES = 10;
 // error rate are shown as real numbers. Below this, both are null and the page renders "—" —
 // the same honest-null rule the `current` row uses for its live otel window (CTO-115).
 const MIN_REPLAYED_SAMPLES = 50;
+
+// CTO-168: the current-model cost window queryCurrentModel reads (last 7 days). Used to derive the
+// `workload` label on the live path instead of shipping the fixture string.
+const WORKLOAD_WINDOW_DAYS = 7;
 
 /** Look up a candidate's eval row; return null when no row exists or sample count too small. */
 function evalQualityFor(
@@ -101,18 +105,26 @@ export async function GET(req: Request) {
           errorRate: enoughReplayed ? c.error_rate : null,
         };
       });
-    const cheapest = candidates.reduce(
-      (best, c) => (c.monthlyCostMicroUsd < best.monthlyCostMicroUsd ? c : best),
-      candidates[0] ?? null,
-    );
-    const projectedSavingsMicroUsd = cheapest
-      ? Math.max(0, live.monthlyCostMicroUsd - cheapest.monthlyCostMicroUsd)
-      : 0;
-    const projectedSavingsPct = live.monthlyCostMicroUsd > 0
-      ? projectedSavingsMicroUsd / live.monthlyCostMicroUsd
-      : 0;
+    // CTO-168: verdict + summary + projected savings are all generated from the REAL replayed
+    // deltas here — cost savings %, pairwise-judge quality, latency — never the fixture prose.
+    // Gated on total replayed responses; a thin projection yields an honest "insufficient data"
+    // summary rather than a confident recommendation off noise.
+    const totalReplayed = replay.per_candidate.reduce((s, c) => s + c.samples_replayed, 0);
+    const recommendation = deriveRecommendation({
+      currentModel: live.model,
+      currentCostMicroUsd: live.monthlyCostMicroUsd,
+      candidates: candidates.map((c) => ({
+        model: c.model,
+        monthlyCostMicroUsd: c.monthlyCostMicroUsd,
+        qualityScore: c.qualityScore,
+        latencyP95Ms: c.latencyP95Ms,
+      })),
+      samplesReplayed: totalReplayed,
+    });
     return NextResponse.json({
       ...comparison,
+      // CTO-168: real query context (tag filter + 7-day window), not the fixture label.
+      workload: deriveWorkload(featureTag, WORKLOAD_WINDOW_DAYS),
       current: {
         ...comparison.current,
         model: live.model,
@@ -127,14 +139,10 @@ export async function GET(req: Request) {
         qualityScore: null,
       },
       candidates,
-      recommendation: {
-        ...comparison.recommendation,
-        projectedSavingsMicroUsd,
-        projectedSavingsPct,
-      },
+      recommendation,
       diagnostics: {
         ...comparison.diagnostics,
-        samplesReplayed: replay.per_candidate.reduce((s, c) => s + c.samples_replayed, 0),
+        samplesReplayed: totalReplayed,
         samplesAvailable: replay.samples_available,
         replayCostMicroUsd: replay.diagnostics.replay_cost_micro_usd,
         contextFidelity:
@@ -172,12 +180,29 @@ export async function GET(req: Request) {
         ...(quality ? { qualityCi: quality.qualityCi } : {}),
       };
     });
-  const projectedSavingsMicroUsd = Math.round(
-    comparison.recommendation.projectedSavingsMicroUsd * scale,
-  );
+  // CTO-168: this branch has a LIVE current model but only rescaled-mock candidate costs — there
+  // is no real cross-provider replay behind it. So we do NOT ship the fixture verdict/summary
+  // (that would be the hardcoded "$12.2K/mo … haiku-4.5" prose on live data). Instead we pass
+  // samplesReplayed: 0, which deriveRecommendation surfaces as an honest "insufficient replay data"
+  // recommendation while still projecting savings off the rescaled cheapest candidate.
+  const recommendation = deriveRecommendation({
+    currentModel: live.model,
+    currentCostMicroUsd: live.monthlyCostMicroUsd,
+    candidates: candidates.map((c) => ({
+      model: c.model,
+      monthlyCostMicroUsd: c.monthlyCostMicroUsd,
+      qualityScore: c.qualityScore,
+      // Candidate latency here is still the fixture mock (no replay); deriveRecommendation ignores
+      // it on the insufficient-data path, so no mock latency leaks into the summary.
+      latencyP95Ms: c.latencyP95Ms,
+    })),
+    samplesReplayed: 0,
+  });
 
   return NextResponse.json({
     ...comparison,
+    // CTO-168: real query context (tag filter + 7-day window), not the fixture label.
+    workload: deriveWorkload(featureTag, WORKLOAD_WINDOW_DAYS),
     current: {
       ...comparison.current,
       model: live.model,
@@ -190,10 +215,7 @@ export async function GET(req: Request) {
       qualityScore: null,
     },
     candidates,
-    recommendation: {
-      ...comparison.recommendation,
-      projectedSavingsMicroUsd,
-    },
+    recommendation,
     replay_source: "mock",
   });
 }

--- a/web/lib/compare.test.ts
+++ b/web/lib/compare.test.ts
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from "vitest";
-import { comparison, deltaPct } from "./compare";
+import {
+  comparison,
+  deltaPct,
+  deriveRecommendation,
+  deriveWorkload,
+  MIN_SAMPLES_TO_RECOMMEND,
+  type RecommendationCandidate,
+} from "./compare";
 
 describe("compare", () => {
   it("deltaPct: negative when candidate cheaper than current", () => {
@@ -24,5 +31,98 @@ describe("compare", () => {
   it("diagnostics excludes throttled samples from headline metrics (modeled)", () => {
     expect(comparison.diagnostics.excludedRateLimited).toBeGreaterThan(0);
     expect(comparison.diagnostics.contextFidelity).toMatch(/resolved-context/);
+  });
+});
+
+// CTO-168: pure derivation helpers that ground the workload label + recommendation on live data.
+describe("deriveWorkload", () => {
+  it("uses the feature tag + window when a tag is present", () => {
+    expect(deriveWorkload("research_agent", 7)).toBe(
+      "research_agent / production / last 7 days",
+    );
+  });
+
+  it("falls back to 'all traffic' when the tag is absent or blank", () => {
+    expect(deriveWorkload(undefined, 7)).toBe("all traffic / production / last 7 days");
+    expect(deriveWorkload("   ", 30)).toBe("all traffic / production / last 30 days");
+  });
+});
+
+describe("deriveRecommendation", () => {
+  const cand = (over: Partial<RecommendationCandidate>): RecommendationCandidate => ({
+    model: "claude-haiku-4-5",
+    monthlyCostMicroUsd: 3_000_000,
+    qualityScore: null,
+    latencyP95Ms: 1500,
+    ...over,
+  });
+
+  it("verdict 'switch' when meaningfully cheaper and wins the majority of judged pairs", () => {
+    const r = deriveRecommendation({
+      currentModel: "claude-sonnet-4-5",
+      currentCostMicroUsd: 10_000_000,
+      candidates: [cand({ qualityScore: 0.62 })],
+      samplesReplayed: 60,
+    });
+    expect(r.verdict).toBe("switch");
+    expect(r.summary).toContain("Switch to claude-haiku-4-5");
+    expect(r.projectedSavingsMicroUsd).toBe(7_000_000);
+    expect(r.projectedSavingsPct).toBeCloseTo(0.7, 6);
+  });
+
+  it("verdict 'mixed' (cost win, quality regression) when the candidate wins < 50% of pairs", () => {
+    const r = deriveRecommendation({
+      currentModel: "claude-sonnet-4-5",
+      currentCostMicroUsd: 10_000_000,
+      candidates: [cand({ qualityScore: 0.41 })],
+      samplesReplayed: 60,
+    });
+    expect(r.verdict).toBe("mixed");
+    expect(r.summary).toContain("wins only 41%");
+  });
+
+  it("verdict 'mixed' (quality unknown) when no eval has judged the cheapest candidate", () => {
+    const r = deriveRecommendation({
+      currentModel: "claude-sonnet-4-5",
+      currentCostMicroUsd: 10_000_000,
+      candidates: [cand({ qualityScore: null })],
+      samplesReplayed: 60,
+    });
+    expect(r.verdict).toBe("mixed");
+    expect(r.summary).toContain("run an eval pass");
+  });
+
+  it("verdict 'keep' when the cheapest candidate saves less than 5%", () => {
+    const r = deriveRecommendation({
+      currentModel: "claude-sonnet-4-5",
+      currentCostMicroUsd: 10_000_000,
+      candidates: [cand({ monthlyCostMicroUsd: 9_700_000, qualityScore: 0.7 })],
+      samplesReplayed: 60,
+    });
+    expect(r.verdict).toBe("keep");
+    expect(r.summary).toContain("Keep claude-sonnet-4-5");
+  });
+
+  it("honest 'insufficient data' below the recommend floor — never fabricated prose", () => {
+    const r = deriveRecommendation({
+      currentModel: "claude-sonnet-4-5",
+      currentCostMicroUsd: 10_000_000,
+      candidates: [cand({ qualityScore: 0.9 })],
+      samplesReplayed: MIN_SAMPLES_TO_RECOMMEND - 1,
+    });
+    expect(r.summary).toMatch(/insufficient replay data/i);
+    // Savings still projected for display even when we won't issue a confident verdict.
+    expect(r.projectedSavingsMicroUsd).toBe(7_000_000);
+  });
+
+  it("no candidates → keep current, savings zero", () => {
+    const r = deriveRecommendation({
+      currentModel: "claude-sonnet-4-5",
+      currentCostMicroUsd: 10_000_000,
+      candidates: [],
+      samplesReplayed: 100,
+    });
+    expect(r.projectedSavingsMicroUsd).toBe(0);
+    expect(r.summary).toContain("no alternative candidate");
   });
 });

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -5,6 +5,15 @@
 // /api/compare route when the gateway has no opted-in samples yet (or is unreachable). The
 // CandidateMetrics / Comparison types are the wire shape for both branches.
 //
+// CTO-168: the fixture's `workload` string and `recommendation` prose below are NO LONGER shipped
+// on the live path. When queryCurrentModel returns real traffic, the /api/compare route derives
+// `workload` from the real query context (tag filter + time window — see deriveWorkload) and
+// generates `recommendation.verdict` + `summary` from the REAL computed deltas (cost savings %,
+// pairwise-judge quality, latency — see deriveRecommendation). The fixture verdict/summary/workload
+// survive ONLY on the unreachable-gateway fallback (queryCurrentModel === null), which the page
+// labels via SyntheticPreviewBanner. This stops the old bug where the hardcoded
+// "$12.2K/mo … haiku-4.5" prose and "research_agent / … / last 7 days" label rendered on live data.
+//
 // CTO-115: the `current` row's `latencyP95Ms` and `errorRate` are now derived from live
 // otel_spans over the same 7-day window the cost query uses (see queryCurrentModel in
 // clickhouse.ts). They carry `null` when the live window has fewer than 50 spans, and the
@@ -32,7 +41,7 @@
 // The numeric mocks in `comparison.current` below are the unreachable-gateway fallback (CI /
 // fresh clones); that path keeps showing numbers, not nulls, for backwards compatibility.
 
-import type { MicroUSD } from "./types";
+import { formatUSD, type MicroUSD } from "./types";
 
 export interface CandidateMetrics {
   /** display label, e.g. "claude-haiku-4.5" */
@@ -91,7 +100,12 @@ export function deltaPct(current: number, candidate: number): number {
 
 // Compare fixture for the research_agent workload — the dominant cost driver from cost.ts
 // ($19.1K LLM spend on this workload alone over 30 days, ≈ $4.5K/week).
+//
+// CTO-168: this whole object is the unreachable-gateway fallback ONLY. The `workload` label and
+// the `recommendation` verdict/summary below are fixture prose — on the live path the route
+// replaces them with values derived from real traffic (deriveWorkload / deriveRecommendation).
 export const comparison: Comparison = {
+  // Fixture label — used only in the unreachable-gateway fallback. Live path calls deriveWorkload.
   workload: "research_agent / production / last 7 days",
   current: {
     model: "claude-sonnet-4.5",
@@ -131,6 +145,8 @@ export const comparison: Comparison = {
       errorRate: 0.012,
     },
   ],
+  // Fixture verdict/summary — unreachable-gateway fallback ONLY. The live path never renders this
+  // prose; the route calls deriveRecommendation off the real computed deltas instead (CTO-168).
   recommendation: {
     verdict: "mixed",
     summary:
@@ -147,3 +163,133 @@ export const comparison: Comparison = {
     reconcilerLastRunMinutesAgo: 18,
   },
 };
+
+// --- CTO-168: live-path grounding for the workload label + recommendation prose ------------------
+//
+// These replace the fixture strings whenever the /api/compare route has real traffic to work from.
+// They are pure (no I/O) so they're unit-testable and shared across the route's live branches.
+
+/**
+ * Human-readable label for the workload a comparison was built from, derived from the real query
+ * context: the `?tag=` feature filter (or "all traffic" when unfiltered) and the current-model
+ * cost window (queryCurrentModel reads the last 7 days). Replaces the fixture
+ * "research_agent / production / last 7 days" on the live path.
+ */
+export function deriveWorkload(featureTag: string | undefined, windowDays: number): string {
+  const scope = featureTag && featureTag.trim() ? featureTag.trim() : "all traffic";
+  return `${scope} / production / last ${windowDays} days`;
+}
+
+/**
+ * Minimum replayed-response count across all candidates before we'll issue a switch/keep verdict.
+ * Below this the projection is too thin to recommend anything — we return an honest "insufficient
+ * data" summary instead of the fixture prose. Matches the per-candidate replay floor (CTO-123).
+ */
+export const MIN_SAMPLES_TO_RECOMMEND = 50;
+
+export interface RecommendationCandidate {
+  model: string;
+  monthlyCostMicroUsd: MicroUSD;
+  /** Pairwise-LLM-judge win-rate (0..1) vs current, or null when < 10 judged samples (CTO-114). */
+  qualityScore: number | null;
+  /** p95 latency in ms, or null below the replay floor (CTO-123). */
+  latencyP95Ms: number | null;
+}
+
+export interface DerivedRecommendation {
+  verdict: "switch" | "keep" | "mixed";
+  summary: string;
+  projectedSavingsMicroUsd: MicroUSD;
+  projectedSavingsPct: number;
+}
+
+// Below this fractional cost saving we don't consider a switch worthwhile (noise, not signal).
+const MIN_MEANINGFUL_SAVINGS_PCT = 0.05;
+
+/**
+ * Generate a data-driven recommendation (verdict + templated summary + projected savings) from the
+ * REAL computed deltas of a live comparison. Never emits the fixture prose.
+ *
+ * The savings are always computed off the cheapest candidate vs the live current cost. The verdict:
+ *   - thin data (no candidates, or `samplesReplayed` below the floor) → honest "insufficient data".
+ *   - cheapest saves < 5% → "keep" (current is already near-cheapest).
+ *   - meaningful savings + candidate wins ≥ 50% of judged pairs → "switch".
+ *   - meaningful savings + candidate wins < 50% → "mixed" (cost win, quality regression).
+ *   - meaningful savings + quality not yet judged → "mixed" (run an eval before switching).
+ */
+export function deriveRecommendation(input: {
+  currentModel: string;
+  currentCostMicroUsd: MicroUSD;
+  candidates: RecommendationCandidate[];
+  /** total replayed responses across candidates — the gate for whether we recommend at all. */
+  samplesReplayed: number;
+}): DerivedRecommendation {
+  const { currentModel, currentCostMicroUsd, candidates, samplesReplayed } = input;
+
+  const cheapest = candidates.reduce<RecommendationCandidate | null>(
+    (best, c) => (best === null || c.monthlyCostMicroUsd < best.monthlyCostMicroUsd ? c : best),
+    null,
+  );
+
+  const projectedSavingsMicroUsd = cheapest
+    ? Math.max(0, currentCostMicroUsd - cheapest.monthlyCostMicroUsd)
+    : 0;
+  const projectedSavingsPct =
+    currentCostMicroUsd > 0 ? projectedSavingsMicroUsd / currentCostMicroUsd : 0;
+
+  // Thin / absent data — say so honestly rather than shipping a confident sentence off noise.
+  if (!cheapest || samplesReplayed < MIN_SAMPLES_TO_RECOMMEND) {
+    return {
+      verdict: "mixed",
+      summary: cheapest
+        ? `— insufficient replay data to recommend a switch (only ${samplesReplayed.toLocaleString()} of the needed ${MIN_SAMPLES_TO_RECOMMEND} responses replayed). Run a fuller replay pass.`
+        : `— no alternative candidate cleared replay for this workload yet. Keep ${currentModel} until a candidate has samples.`,
+      projectedSavingsMicroUsd,
+      projectedSavingsPct,
+    };
+  }
+
+  const pct = Math.round(projectedSavingsPct * 100);
+  const dollars = formatUSD(projectedSavingsMicroUsd);
+  const latencyClause =
+    cheapest.latencyP95Ms !== null ? ` Latency p95 ${cheapest.latencyP95Ms}ms.` : "";
+
+  // Current is already at/near the cheapest option — no candidate saves enough to bother switching.
+  if (projectedSavingsPct < MIN_MEANINGFUL_SAVINGS_PCT) {
+    return {
+      verdict: "keep",
+      summary: `Keep ${currentModel}: the cheapest candidate (${cheapest.model}) saves only ${pct}% — below the ${Math.round(
+        MIN_MEANINGFUL_SAVINGS_PCT * 100,
+      )}% threshold worth a switch.`,
+      projectedSavingsMicroUsd,
+      projectedSavingsPct,
+    };
+  }
+
+  // Meaningful savings — the verdict now hinges on quality (the pairwise-judge win-rate vs current).
+  if (cheapest.qualityScore === null) {
+    return {
+      verdict: "mixed",
+      summary: `${cheapest.model} projects ${pct}% cheaper (saves ${dollars}/mo vs ${currentModel}), but no eval has judged its quality yet — run an eval pass before routing production traffic.${latencyClause}`,
+      projectedSavingsMicroUsd,
+      projectedSavingsPct,
+    };
+  }
+
+  const winPct = Math.round(cheapest.qualityScore * 100);
+  if (cheapest.qualityScore >= 0.5) {
+    return {
+      verdict: "switch",
+      summary: `Switch to ${cheapest.model}: ${pct}% cheaper (saves ${dollars}/mo) and wins ${winPct}% of judged pairs against ${currentModel}.${latencyClause}`,
+      projectedSavingsMicroUsd,
+      projectedSavingsPct,
+    };
+  }
+
+  return {
+    verdict: "mixed",
+    summary: `${cheapest.model} is ${pct}% cheaper (saves ${dollars}/mo) but wins only ${winPct}% of judged pairs vs ${currentModel} — route cost-tolerant traffic to it, keep ${currentModel} for quality-critical calls.${latencyClause}`,
+    projectedSavingsMicroUsd,
+    projectedSavingsPct,
+  };
+}


### PR DESCRIPTION
## CTO-168 — Compare: ground the recommendation text + workload label

Stops shipping the `compare.ts` fixture prose on the live `/api/compare` path.

### What changed
- **`workload` label** — now derived from the real query context (`?tag=` feature filter, or `all traffic` when unfiltered, + the 7-day current-model cost window) via `deriveWorkload`, instead of the fixture `"research_agent / production / last 7 days"`.
- **`recommendation.verdict` + `summary`** — generated from the REAL computed deltas (cost savings %, pairwise-LLM-judge win-rate, latency) via `deriveRecommendation`. A templated, data-driven sentence:
  - meaningful savings + candidate wins ≥ 50% of judged pairs → `switch`
  - meaningful savings + wins < 50% → `mixed` (cost win, quality regression)
  - meaningful savings + quality not yet judged → `mixed` (run an eval first)
  - cheapest saves < 5% → `keep`
  - thin projection (below the replay floor) → honest `— insufficient replay data …`, never the hardcoded `$12.2K/mo … haiku-4.5` prose.
- The **rescaled-mock branch** (live current, no cross-provider replay) is treated as insufficient-data, so it no longer emits fixture prose on live data.
- The `comparison` fixture (workload + verdict/summary) now survives **only** on the unreachable-gateway fallback (`queryCurrentModel === null`), labeled by the existing `SyntheticPreviewBanner`. Header + inline comments updated.
- Current-model `qualityScore` stays honest-`null` (no self-eval). No `qualityCi` hardcoded on candidates.

### Tests
- `/api/compare` route tests: workload/verdict/summary reflect computed data on the live path; honest fallback when replay samples are thin; rescaled-mock branch drops fixture prose; unreachable-gateway fallback keeps the fixture.
- Pure unit tests for `deriveWorkload` / `deriveRecommendation` (switch / mixed / keep / insufficient / no-candidates).

### Verify
`cd web && npm install && npx tsc --noEmit && npx vitest run` — tsc clean; **193 passed**, the only 2 failures are the pre-existing known-flaky ClickHouse-reachability tests (`GET /api/data-quality`, `GET /api/attribution falls back to mock when ClickHouse is unreachable`), untouched by this change.

Note: this branch also edits `web/lib/clickhouse.ts`' consumers — CTO-169 stacks on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)