### PR TITLE
feat(guardrails): real rule-trip counts from verdict spans (CTO-146)

### DIFF
--- a/sdk/python/src/tally/guardrails.py
+++ b/sdk/python/src/tally/guardrails.py
@@ -180,6 +180,23 @@ class RuleVerdict:
         }
 
 
+def verdict_span_attributes(verdicts: list[RuleVerdict]) -> dict[str, str]:
+    """Merge a batch of per-rule verdicts into a single span-attribute dict.
+
+    This is what the enforcement path attaches to the active span after
+    :meth:`GuardrailEngine.apply_rules` — one ``gen_ai.guardrail.{rule_id}.verdict``
+    (plus ``.kind``) key per rule evaluated. The dashboard (CTO-146) counts these over
+    the trailing 7d to source ``runsThisWeek`` (every verdict) and
+    ``wouldHaveFiredThisWeek`` (verdict ∈ {enforced, shadow_observed}).
+
+    PII bar: verdict/kind only — never the request/response body or any rule input.
+    """
+    attrs: dict[str, str] = {}
+    for v in verdicts:
+        attrs.update(v.attrs())
+    return attrs
+
+
 @dataclass(slots=True)
 class GuardrailEngine:
     """Evaluates guardrails against per-trace state. Holds the OBSERVE-mode would-fire tally.

--- a/sdk/python/tests/test_guardrails_refresh.py
+++ b/sdk/python/tests/test_guardrails_refresh.py
@@ -17,6 +17,8 @@ from tally.guardrails import (
     GuardrailEngine,
     RuleKind,
     RuleState,
+    RuleVerdict,
+    verdict_span_attributes,
 )
 
 
@@ -178,6 +180,61 @@ def test_disabled_rule_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = GuardrailEngine.from_gateway("http://gw.local", "t-acme", start=False)
     verdicts = engine.apply_rules({"cost_micro_usd": 999_999})
     assert verdicts == []
+
+
+def test_verdict_span_attributes_merges_batch_counts_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A trace that evaluates two rules: one enforced, one shadow-observed, one passed.
+    rules = [
+        {
+            "rule_id": "gr_cost",
+            "kind": "cost_cap",
+            "state": "enabled",
+            "params": {"max_cost_micro_usd": 1000},
+        },
+        {
+            "rule_id": "gr_loop",
+            "kind": "loop_limit",
+            "state": "shadow",
+            "params": {"max_steps": 3},
+        },
+        {
+            "rule_id": "gr_pii",
+            "kind": "pii_gate",
+            "state": "enabled",
+            "params": {},
+        },
+    ]
+    monkeypatch.setattr("tally.guardrails.urllib.request.urlopen", _ok_response(rules))
+    engine = GuardrailEngine.from_gateway("http://gw.local", "t-acme", start=False)
+
+    verdicts = engine.apply_rules(
+        {"cost_micro_usd": 5000, "step_count": 9, "contains_pii": False, "body": "secret"}
+    )
+    attrs = verdict_span_attributes(verdicts)
+
+    # One verdict + kind key per evaluated rule — this is exactly what the 7d dashboard counts.
+    assert attrs["gen_ai.guardrail.gr_cost.verdict"] == "enforced"
+    assert attrs["gen_ai.guardrail.gr_loop.verdict"] == "shadow_observed"
+    assert attrs["gen_ai.guardrail.gr_pii.verdict"] == "passed"
+    assert attrs["gen_ai.guardrail.gr_cost.kind"] == "cost_cap"
+    # PII bar: only verdict/kind keys leak — never the call body or rule inputs.
+    assert all(k.startswith("gen_ai.guardrail.") for k in attrs)
+    assert all(k.endswith(".verdict") or k.endswith(".kind") for k in attrs)
+    assert not any("secret" in v for v in attrs.values())
+
+
+def test_verdict_span_attributes_empty_batch_is_empty() -> None:
+    assert verdict_span_attributes([]) == {}
+
+
+def test_verdict_span_attributes_typed_verdict_roundtrips() -> None:
+    v = RuleVerdict(rule_id="gr_x", kind=RuleKind.MODEL_DEPRECATION, verdict="enforced")
+    assert verdict_span_attributes([v]) == {
+        "gen_ai.guardrail.gr_x.verdict": "enforced",
+        "gen_ai.guardrail.gr_x.kind": "model_deprecation",
+    }
 
 
 def test_refresh_loop_interval(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -30,6 +30,12 @@ function respond(row: RowShape | null) {
   });
 }
 
+function respondRows(rowsData: RowShape[]) {
+  queryMock.mockResolvedValueOnce({
+    json: async () => rowsData,
+  });
+}
+
 beforeEach(() => {
   queryMock.mockReset();
 });
@@ -105,6 +111,67 @@ describe("queryCurrentModel — latency/error suppression (CTO-115)", () => {
 // `gpt-4o-mini` — which is still *priced* in the catalog for backward compat but is NOT a model we
 // want the switcher to surface — must not appear. If seed_catalog() gains/loses a current model,
 // update KNOWN_CURRENT_CANDIDATES here in the same change.
+// CTO-146: per-rule trip counts sourced from guardrail-verdict spans.
+//
+// queryGuardrailActivity aggregates SpanAttributes['gen_ai.guardrail.{rule_id}.verdict'] over 7d:
+//   runsThisWeek           = every verdict row for the rule (it was evaluated)
+//   wouldHaveFiredThisWeek = verdict ∈ {enforced, shadow_observed}
+// We stub the ClickHouse rows the ARRAY JOIN would produce and assert the mapping.
+describe("queryGuardrailActivity — verdict-span trip counts (CTO-146)", () => {
+  it("maps verdict rows to runs/wouldFire counts per rule", async () => {
+    const { queryGuardrailActivity } = await freshSut();
+    respondRows([
+      { ruleId: "gr_research_cost", runs: "8680", wouldFire: "312" },
+      { ruleId: "gr_support_steps", runs: "58100", wouldFire: "1240" },
+    ]);
+    const activity = await queryGuardrailActivity();
+    expect(activity).not.toBeNull();
+    expect(activity!.get("gr_research_cost")).toEqual({
+      runsThisWeek: 8680,
+      wouldHaveFiredThisWeek: 312,
+    });
+    expect(activity!.get("gr_support_steps")).toEqual({
+      runsThisWeek: 58100,
+      wouldHaveFiredThisWeek: 1240,
+    });
+  });
+
+  it("counts a shadow rule's would-fires without counting them as enforcement", async () => {
+    // A rule fully in shadow: every fire is shadow_observed, so wouldFire tracks would-have-fired,
+    // and it never enforces. The query does not distinguish enforced vs shadow in wouldFire — both
+    // count toward 'would have fired' — which is exactly the graduation signal.
+    const { queryGuardrailActivity } = await freshSut();
+    respondRows([{ ruleId: "gr_shadow", runs: "1000", wouldFire: "47" }]);
+    const activity = await queryGuardrailActivity();
+    const a = activity!.get("gr_shadow")!;
+    expect(a.runsThisWeek).toBe(1000);
+    expect(a.wouldHaveFiredThisWeek).toBe(47);
+    expect(a.wouldHaveFiredThisWeek).toBeLessThan(a.runsThisWeek);
+  });
+
+  it("is honest about a rule with no telemetry — absent from the map (renders as —)", async () => {
+    const { queryGuardrailActivity } = await freshSut();
+    respondRows([{ ruleId: "gr_active", runs: "500", wouldFire: "5" }]);
+    const activity = await queryGuardrailActivity();
+    // A rule the query never saw is simply not in the map — the caller leaves its counts at 0,
+    // which the UI renders as `—`, never a fabricated number.
+    expect(activity!.has("gr_never_ran")).toBe(false);
+    expect(activity!.get("gr_active")).toEqual({ runsThisWeek: 500, wouldHaveFiredThisWeek: 5 });
+  });
+
+  it("drops rows with an empty extracted rule id", async () => {
+    const { queryGuardrailActivity } = await freshSut();
+    respondRows([
+      { ruleId: "", runs: "10", wouldFire: "1" },
+      { ruleId: "gr_ok", runs: "20", wouldFire: "2" },
+    ]);
+    const activity = await queryGuardrailActivity();
+    expect(activity!.has("")).toBe(false);
+    expect(activity!.size).toBe(1);
+    expect(activity!.get("gr_ok")).toEqual({ runsThisWeek: 20, wouldHaveFiredThisWeek: 2 });
+  });
+});
+
 describe("DEFAULT_CANDIDATES guard (CTO-171)", () => {
   // Current, non-retired models we're willing to surface in Compare, keyed "provider/model".
   // Kept in sync by hand with seed_catalog() until discovery is exposed over HTTP.

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1016,10 +1016,56 @@ function mapGuardrailRule(r: GatewayGuardrailRule): GuardrailRule {
   };
 }
 
+// Per-rule trip telemetry (CTO-146). The control plane stores config, not counts — the real
+// runsThisWeek / wouldHaveFiredThisWeek come from guardrail-verdict spans the SDK emits. When a
+// rule is evaluated on a trace the SDK sets one map attribute per rule:
+//   SpanAttributes['gen_ai.guardrail.{rule_id}.verdict'] ∈ {enforced, shadow_observed, passed}
+// We count those over the trailing 7d:
+//   runsThisWeek           = every verdict present (the rule was evaluated)
+//   wouldHaveFiredThisWeek = verdict ∈ {enforced, shadow_observed} (it fired / would have)
+// The key is dynamic per rule_id, so we ARRAY JOIN the attribute map and extract the rule_id from
+// keys matching `gen_ai.guardrail.%.verdict` — no need to enumerate rule ids in SQL.
+export interface GuardrailActivity {
+  runsThisWeek: number;
+  wouldHaveFiredThisWeek: number;
+}
+
+export async function queryGuardrailActivity(): Promise<Map<string, GuardrailActivity> | null> {
+  return tryLive(async (db, tenant) => {
+    const out = await rows<{ ruleId: string; runs: string; wouldFire: string }>(
+      db,
+      `SELECT
+         extract(key, '^gen_ai\\\\.guardrail\\\\.(.+)\\\\.verdict$') AS ruleId,
+         count() AS runs,
+         countIf(val IN ('enforced', 'shadow_observed')) AS wouldFire
+       FROM otel_spans
+       ARRAY JOIN mapKeys(SpanAttributes) AS key, mapValues(SpanAttributes) AS val
+       WHERE TenantId = {tenant:String}
+         AND Timestamp >= now() - INTERVAL 7 DAY
+         AND key LIKE 'gen_ai.guardrail.%.verdict'
+       GROUP BY ruleId`,
+      tenant,
+    );
+    const activity = new Map<string, GuardrailActivity>();
+    for (const r of out) {
+      if (!r.ruleId) continue;
+      activity.set(r.ruleId, {
+        runsThisWeek: parseInt(r.runs, 10) || 0,
+        wouldHaveFiredThisWeek: parseInt(r.wouldFire, 10) || 0,
+      });
+    }
+    return activity;
+  });
+}
+
 /**
  * Fetch the caller's per-tenant guardrail rules from the gateway and map them onto the web's
  * GuardrailRule shape. Returns null on any error (gateway unreachable, non-2xx, parse failure) so
  * the route can fall back to the static mock (`?? guardrailRules`) rather than blanking the page.
+ *
+ * The gateway carries config only, so trip counts are merged in from verdict-span telemetry
+ * (queryGuardrailActivity). A rule with no verdict spans keeps runsThisWeek = 0, which the UI
+ * renders as `—` (honest null) rather than a fabricated count.
  */
 export async function queryGuardrailRules(): Promise<GuardrailRule[] | null> {
   try {
@@ -1033,7 +1079,20 @@ export async function queryGuardrailRules(): Promise<GuardrailRule[] | null> {
       return null;
     }
     const body = (await res.json()) as { rules?: GatewayGuardrailRule[] };
-    return Array.isArray(body.rules) ? body.rules.map(mapGuardrailRule) : [];
+    const rules = Array.isArray(body.rules) ? body.rules.map(mapGuardrailRule) : [];
+    // Overlay live trip counts from verdict spans. If telemetry is unavailable (null), leave the
+    // config-default 0s — never fabricate a count.
+    const activity = await queryGuardrailActivity();
+    if (activity) {
+      for (const rule of rules) {
+        const a = activity.get(rule.id);
+        if (a) {
+          rule.runsThisWeek = a.runsThisWeek;
+          rule.wouldHaveFiredThisWeek = a.wouldHaveFiredThisWeek;
+        }
+      }
+    }
+    return rules;
   } catch (err) {
     console.warn("[guardrails] gateway unreachable, falling back to mock:", (err as Error).message);
     return null;


### PR DESCRIPTION
## CTO-146 — Guardrails: surface real rule-trip counts from verdict spans

CTO-120 wired `/guardrails` config to the live control plane, but per-rule `wouldHaveFiredThisWeek` / `runsThisWeek` still read 0 — the control plane stores config, not telemetry. This sources them from guardrail-verdict spans.

### SDK
The enforcement path (`GuardrailEngine.apply_rules`) already emits the verdict as a span attribute via `RuleVerdict.attrs()` → `gen_ai.guardrail.{rule_id}.verdict` ∈ `{enforced, shadow_observed, passed}`. Added `verdict_span_attributes()` to merge a batch of per-rule verdicts into the single span-attr dict an emitter attaches, holding the PII bar (verdict/kind only, never the body). Added 3 SDK tests.

### Web
Added `queryGuardrailActivity()`: `ARRAY JOIN`s `otel_spans.SpanAttributes` over the trailing 7d, extracts `rule_id` from `gen_ai.guardrail.%.verdict` keys, and counts `runsThisWeek` (every verdict) and `wouldHaveFiredThisWeek` (verdict ∈ `{enforced, shadow_observed}`). `queryGuardrailRules()` overlays these onto the config rows.

### Honest-null
Rules with no verdict spans keep `runsThisWeek = 0`; the existing UI renders that as `—` rather than a fabricated count. Added 4 web tests (verdict→counts mapping, shadow would-fire vs enforcement, no-activity honesty, empty-ruleId drop).

### Verification
- SDK: `ruff check` + full `pytest` green.
- Web: `tsc --noEmit` clean; `vitest run` green except the two pre-existing known-flaky ClickHouse tests (`GET /api/data-quality`, `GET /api/attribution falls back to mock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)