### PR TITLE
feat(unit-econ): persist ARPA + gross margin so LTV/payback go live (CTO-145)

### DIFF
--- a/db/postgres/0013_cac_revenue_fields.sql
+++ b/db/postgres/0013_cac_revenue_fields.sql
@@ -1,0 +1,19 @@
+-- Revenue-side inputs on cac_periods so the unit-economics page can compute payback + LTV live
+-- (CTO-145).
+--
+-- WHY HERE: CAC periods already carry the *cost* side (spend + customer counts). Payback and LTV
+-- additionally need the *revenue* side — ARPA (average revenue per account / month) and gross
+-- margin. Option A: finance enters these alongside the spend figures on the same monthly row, so
+-- they live on cac_periods rather than in a separate table. One row per tenant per month still holds.
+--
+-- NULLABLE ON PURPOSE: existing rows (entered before this migration) have no ARPA / margin. Leaving
+-- the columns NULL lets the page render payback/LTV as "—" (honest-null) for those months instead
+-- of fabricating a number. A month is "complete" for payback/LTV only once both are filled.
+--
+-- Money: ARPA is ``micro_usd`` (1/1,000,000 USD), matching the spend columns and the rest of the
+-- wire/store contract. Gross margin is a fraction in [0,1] (0.78 = 78%), constrained by CHECK.
+ALTER TABLE cac_periods
+    ADD COLUMN IF NOT EXISTS arpa_micro_usd   BIGINT
+        CHECK (arpa_micro_usd IS NULL OR arpa_micro_usd >= 0),
+    ADD COLUMN IF NOT EXISTS gross_margin_pct NUMERIC(5, 4)
+        CHECK (gross_margin_pct IS NULL OR (gross_margin_pct >= 0 AND gross_margin_pct <= 1));

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - ../db/postgres/0008_reconciliation_runs.sql:/docker-entrypoint-initdb.d/0008_reconciliation_runs.sql:ro
       - ../db/postgres/0011_tenant_compute_config.sql:/docker-entrypoint-initdb.d/0011_tenant_compute_config.sql:ro
       - ../db/postgres/0012_tenant_egress_config.sql:/docker-entrypoint-initdb.d/0012_tenant_egress_config.sql:ro
+      - ../db/postgres/0013_cac_revenue_fields.sql:/docker-entrypoint-initdb.d/0013_cac_revenue_fields.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/tenant_cac.py
+++ b/infra/gateway/src/gateway/tenant_cac.py
@@ -40,6 +40,10 @@ class CacPeriod:
     new_customers_total: int
     notes: str | None
     closed_at: datetime | None
+    # Revenue-side inputs for payback / LTV (CTO-145). Nullable: a row entered before these fields
+    # existed (or left blank) carries None → the page renders payback/LTV as "—" (honest-null).
+    arpa_micro_usd: int | None = None
+    gross_margin_pct: float | None = None
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -55,6 +59,8 @@ class CacPeriod:
             "notes": self.notes,
             "closed_at": self.closed_at.isoformat() if self.closed_at else None,
             "locked": self.closed_at is not None,
+            "arpa_micro_usd": self.arpa_micro_usd,
+            "gross_margin_pct": self.gross_margin_pct,
         }
 
 
@@ -98,6 +104,9 @@ class CacFormInput:
     new_customers_paid: int
     new_customers_total: int
     notes: str | None
+    # Revenue side (CTO-145). Nullable — finance may fill spend one month and ARPA/margin later.
+    arpa_micro_usd: int | None = None
+    gross_margin_pct: float | None = None
 
     @classmethod
     def from_json(cls, body: dict) -> "CacFormInput":
@@ -115,6 +124,8 @@ class CacFormInput:
             new_customers_paid=_as_count(body.get("new_customers_paid", 0), "new_customers_paid"),
             new_customers_total=_as_count(body.get("new_customers_total", 0), "new_customers_total"),
             notes=_as_notes(body.get("notes")),
+            arpa_micro_usd=_as_micro_opt(body.get("arpa_micro_usd"), "arpa_micro_usd"),
+            gross_margin_pct=_as_fraction_opt(body.get("gross_margin_pct"), "gross_margin_pct"),
         )
 
     def sanity_check(self) -> None:
@@ -169,6 +180,33 @@ def _as_notes(v: object) -> str | None:
     if not isinstance(v, str):
         raise CacPeriodError("notes must be a string")
     return v
+
+
+def _as_micro_opt(v: object, field: str) -> int | None:
+    """Nullable micro-USD: absent / None / "" ⇒ None (honest-null), else reuse ``_as_micro``."""
+    if v is None or v == "":
+        return None
+    return _as_micro(v, field)
+
+
+def _as_fraction_opt(v: object, field: str) -> float | None:
+    """Nullable fraction in [0,1] (gross margin). Absent / None / "" ⇒ None."""
+    if v is None or v == "":
+        return None
+    if isinstance(v, bool):
+        raise CacPeriodError(f"{field} must be a number")
+    if isinstance(v, (int, float)):
+        result = float(v)
+    elif isinstance(v, str):
+        try:
+            result = float(v)
+        except ValueError as exc:
+            raise CacPeriodError(f"{field} must be a number, got {v!r}") from exc
+    else:
+        raise CacPeriodError(f"{field} must be a number")
+    if not (0.0 <= result <= 1.0):
+        raise CacPeriodError(f"{field} must be between 0 and 1 (got {result})")
+    return result
 
 
 def parse_csv(body: str) -> list[CacFormInput]:
@@ -235,7 +273,7 @@ class TenantCacStore:
                 SELECT period_start, period_end, currency,
                        paid_spend_micro_usd, sales_spend_micro_usd, content_spend_micro_usd,
                        overhead_micro_usd, new_customers_paid, new_customers_total,
-                       notes, closed_at
+                       notes, closed_at, arpa_micro_usd, gross_margin_pct
                 FROM cac_periods
                 WHERE tenant_id = %s
                 ORDER BY period_start DESC
@@ -263,8 +301,8 @@ class TenantCacStore:
                     tenant_id, period_start, period_end, currency,
                     paid_spend_micro_usd, sales_spend_micro_usd, content_spend_micro_usd,
                     overhead_micro_usd, new_customers_paid, new_customers_total,
-                    notes, updated_at
-                ) VALUES (%s,%s,%s,'USD',%s,%s,%s,%s,%s,%s,%s, now())
+                    notes, arpa_micro_usd, gross_margin_pct, updated_at
+                ) VALUES (%s,%s,%s,'USD',%s,%s,%s,%s,%s,%s,%s,%s,%s, now())
                 ON CONFLICT (tenant_id, period_start) DO UPDATE
                   SET period_end              = EXCLUDED.period_end,
                       paid_spend_micro_usd    = EXCLUDED.paid_spend_micro_usd,
@@ -274,16 +312,19 @@ class TenantCacStore:
                       new_customers_paid      = EXCLUDED.new_customers_paid,
                       new_customers_total     = EXCLUDED.new_customers_total,
                       notes                   = EXCLUDED.notes,
+                      arpa_micro_usd          = EXCLUDED.arpa_micro_usd,
+                      gross_margin_pct        = EXCLUDED.gross_margin_pct,
                       updated_at              = now()
                 RETURNING period_start, period_end, currency,
                           paid_spend_micro_usd, sales_spend_micro_usd, content_spend_micro_usd,
                           overhead_micro_usd, new_customers_paid, new_customers_total,
-                          notes, closed_at
+                          notes, closed_at, arpa_micro_usd, gross_margin_pct
                 """,
                 (tenant_id, form.period_start, period_end,
                  form.paid_spend_micro_usd, form.sales_spend_micro_usd,
                  form.content_spend_micro_usd, form.overhead_micro_usd,
-                 form.new_customers_paid, form.new_customers_total, form.notes),
+                 form.new_customers_paid, form.new_customers_total, form.notes,
+                 form.arpa_micro_usd, form.gross_margin_pct),
             )
             row = cur.fetchone()
             cur.execute(
@@ -311,6 +352,8 @@ def _row_to_period(row: tuple) -> CacPeriod:
         new_customers_total=int(row[8]),
         notes=row[9],
         closed_at=_as_aware(row[10]),
+        arpa_micro_usd=int(row[11]) if row[11] is not None else None,
+        gross_margin_pct=float(row[12]) if row[12] is not None else None,
     )
 
 

--- a/infra/gateway/tests/test_app_tenant_cac.py
+++ b/infra/gateway/tests/test_app_tenant_cac.py
@@ -42,6 +42,8 @@ class FakeCacStore:
             new_customers_total=form.new_customers_total,
             notes=form.notes,
             closed_at=None,
+            arpa_micro_usd=form.arpa_micro_usd,
+            gross_margin_pct=form.gross_margin_pct,
         )
         self._rows[(tenant_id, form.period_start)] = period
         for (t, ps), row in list(self._rows.items()):
@@ -87,6 +89,40 @@ def test_round_trip_form(client: TestClient) -> None:
     listing = client.get("/v1/tenant/cac", headers={"X-Tenant-Id": T}).json()
     assert len(listing["periods"]) == 1
     assert listing["periods"][0]["new_customers_total"] == 120
+
+
+def test_round_trip_revenue_fields(client: TestClient) -> None:
+    """CTO-145: ARPA + gross margin round-trip through POST → GET."""
+    r = client.post(
+        "/v1/tenant/cac",
+        headers={"X-Tenant-Id": T},
+        json=_payload(arpa_micro_usd=220_000_000, gross_margin_pct=0.78),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["period"]["arpa_micro_usd"] == 220_000_000
+    assert r.json()["period"]["gross_margin_pct"] == 0.78
+
+    period = client.get("/v1/tenant/cac", headers={"X-Tenant-Id": T}).json()["periods"][0]
+    assert period["arpa_micro_usd"] == 220_000_000
+    assert period["gross_margin_pct"] == 0.78
+
+
+def test_revenue_fields_default_null_when_omitted(client: TestClient) -> None:
+    """Omitting ARPA / margin leaves them null so the page renders payback/LTV as '—'."""
+    r = client.post("/v1/tenant/cac", headers={"X-Tenant-Id": T}, json=_payload())
+    assert r.status_code == 200, r.text
+    assert r.json()["period"]["arpa_micro_usd"] is None
+    assert r.json()["period"]["gross_margin_pct"] is None
+
+
+def test_rejects_gross_margin_out_of_range(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/cac",
+        headers={"X-Tenant-Id": T},
+        json=_payload(gross_margin_pct=1.5),
+    )
+    assert r.status_code == 422
+    assert "gross_margin_pct" in r.text
 
 
 def test_sanity_guard_rejects_paid_gt_total(client: TestClient) -> None:

--- a/web/app/api/cac/route.ts
+++ b/web/app/api/cac/route.ts
@@ -25,10 +25,15 @@ export async function GET(): Promise<NextResponse<CacPayload>> {
   // Mirror the established fallback (see /api/attribution, /api/cost): serve the clearly-labelled
   // mock so the page is useful before the CAC backend has data, never fabricate as real.
   const live = await queryCacPeriods();
-  if (live.length > 0) {
-    // Real gateway data: no economics yet (the CAC backend doesn't store ARPA / gross margin), so
-    // payback / LTV honest-null until a revenue source is wired. Periods + CAC flavors are real.
-    return NextResponse.json({ periods: live, economics: {}, isMock: false });
+  if (live.periods.length > 0) {
+    // Real gateway data. Economics (ARPA + gross margin) come from the same cac_periods rows
+    // (CTO-145, Option A); months where finance hasn't entered both are simply absent from the
+    // map, so the page renders payback / LTV as "—" (honest-null) for those.
+    return NextResponse.json({
+      periods: live.periods,
+      economics: live.economics,
+      isMock: false,
+    });
   }
   return NextResponse.json({
     periods: MOCK_CAC_PERIODS,

--- a/web/lib/cac.test.ts
+++ b/web/lib/cac.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// CTO-145: the gateway-backed economics mapping — ARPA + gross margin light up payback/LTV, and a
+// period missing either field stays honest-null ("—").
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_RETENTION_MONTHS, queryCacPeriods } from "./cac";
+import { ltv, marginPerUser, paybackMonths } from "./unitEconomics";
+
+function apiPeriod(overrides: Record<string, unknown> = {}) {
+  return {
+    period_start: "2026-05-01",
+    period_end: "2026-05-31",
+    currency: "USD",
+    paid_spend_micro_usd: 42_000_000_000,
+    sales_spend_micro_usd: 28_000_000_000,
+    content_spend_micro_usd: 9_000_000_000,
+    overhead_micro_usd: 31_000_000_000,
+    new_customers_paid: 38,
+    new_customers_total: 61,
+    notes: null,
+    closed_at: null,
+    locked: false,
+    arpa_micro_usd: 220_000_000,
+    gross_margin_pct: 0.78,
+    ...overrides,
+  };
+}
+
+function mockGateway(periods: unknown[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ periods }) }) as unknown as Response),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("queryCacPeriods economics mapping (CTO-145)", () => {
+  it("maps ARPA + gross margin into the economics map and yields non-null payback/LTV", async () => {
+    mockGateway([apiPeriod()]);
+    const { periods, economics } = await queryCacPeriods();
+    expect(periods).toHaveLength(1);
+
+    const econ = economics["2026-05-01"];
+    expect(econ).toBeDefined();
+    expect(econ.arpaMicroUsd).toBe(220_000_000);
+    expect(econ.grossMarginPct).toBe(0.78);
+    expect(econ.retentionMonths).toBe(DEFAULT_RETENTION_MONTHS);
+
+    // A fully-entered month lights up payback + LTV (both non-null).
+    const margin = marginPerUser(econ.arpaMicroUsd, econ.arpaMicroUsd * (1 - econ.grossMarginPct));
+    expect(paybackMonths(1_000_000_000, margin)).not.toBeNull();
+    expect(ltv(margin, econ.retentionMonths)).not.toBeNull();
+    expect(ltv(margin, econ.retentionMonths)).toBeGreaterThan(0);
+  });
+
+  it("omits the economics record when ARPA is missing (stays honest-null)", async () => {
+    mockGateway([apiPeriod({ arpa_micro_usd: null })]);
+    const { economics } = await queryCacPeriods();
+    expect(economics["2026-05-01"]).toBeUndefined();
+  });
+
+  it("omits the economics record when gross margin is missing (stays honest-null)", async () => {
+    mockGateway([apiPeriod({ gross_margin_pct: null })]);
+    const { economics } = await queryCacPeriods();
+    expect(economics["2026-05-01"]).toBeUndefined();
+  });
+});

--- a/web/lib/cac.ts
+++ b/web/lib/cac.ts
@@ -36,6 +36,9 @@ interface CacApiPeriod {
   notes: string | null;
   closed_at: string | null;
   locked: boolean;
+  // Revenue-side inputs (CTO-145). Null until finance enters them → payback/LTV render "—".
+  arpa_micro_usd: number | null;
+  gross_margin_pct: number | null;
 }
 
 function fromApi(p: CacApiPeriod): CacPeriod {
@@ -55,24 +58,60 @@ function fromApi(p: CacApiPeriod): CacPeriod {
   };
 }
 
+export interface CacQueryResult {
+  periods: CacPeriod[];
+  /** Per-period economics keyed by `periodStart` — only months where finance entered BOTH ARPA
+   *  and gross margin. Months missing either are omitted, so the page renders payback/LTV "—". */
+  economics: Record<string, PeriodEconomics>;
+}
+
 /**
- * Fetch all CAC periods for the tenant, newest first. Returns ``[]`` when the gateway is
- * unreachable or has no data — the page falls back to its "Need 3+ months" empty state, which is
- * the right behavior for CI / fresh clones.
+ * Fetch all CAC periods for the tenant, newest first, plus the revenue-side economics map (CTO-145).
+ * Returns empty `periods`/`economics` when the gateway is unreachable or has no data — the caller
+ * falls back to the labelled mock, which is the right behavior for CI / fresh clones.
  */
-export async function queryCacPeriods(): Promise<CacPeriod[]> {
+export async function queryCacPeriods(): Promise<CacQueryResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cac`, {
       headers: { "x-tenant-id": TENANT },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
-    if (!res.ok) return [];
+    if (!res.ok) return { periods: [], economics: {} };
     const body = (await res.json()) as { periods: CacApiPeriod[] };
-    return (body.periods ?? []).map(fromApi);
+    const rows = body.periods ?? [];
+    const periods = rows.map(fromApi);
+    const economics: Record<string, PeriodEconomics> = {};
+    for (const p of rows) {
+      const econ = economicsFromApi(p);
+      if (econ) economics[p.period_start] = econ;
+    }
+    return { periods, economics };
   } catch {
-    return [];
+    return { periods: [], economics: {} };
   }
+}
+
+/**
+ * Expected retention in months used for LTV when the gateway doesn't store it. Retention is not a
+ * finance-entered field in Option A (CTO-145 persists ARPA + gross margin only); tenant-configurable
+ * retention/bands are CTO-126. Until then LTV uses this house default so a fully-entered month
+ * (ARPA + margin) lights up rather than staying blank.
+ */
+export const DEFAULT_RETENTION_MONTHS = 24;
+
+/**
+ * Build a `PeriodEconomics` from a gateway CAC row, or `null` when either revenue field is missing.
+ * A month needs BOTH ARPA and gross margin to compute payback/LTV; if either is null we omit the
+ * record so the page shows "—" (honest-null) rather than a half-computed number.
+ */
+function economicsFromApi(p: CacApiPeriod): PeriodEconomics | null {
+  if (p.arpa_micro_usd === null || p.gross_margin_pct === null) return null;
+  return {
+    arpaMicroUsd: p.arpa_micro_usd,
+    grossMarginPct: p.gross_margin_pct,
+    retentionMonths: DEFAULT_RETENTION_MONTHS,
+  };
 }
 
 /**


### PR DESCRIPTION
## CTO-145 — Unit Economics: persist ARPA + gross margin so LTV/payback light up live

Option A (finance-entered fields): ARPA + gross margin live on the same monthly `cac_periods` row finance already edits. The web `/api/cac` route now maps them into the `economics` map instead of returning the `economics: {}` stub, so payback + LTV compute live. Months missing either field are omitted from the map → the page renders `—` (honest-null).

### Changes
- **Migration** `db/postgres/0013_cac_revenue_fields.sql`: adds nullable `arpa_micro_usd BIGINT` and `gross_margin_pct NUMERIC(5,4)` (CHECK 0..1) to `cac_periods`. Mounted in `infra/docker-compose.yml`. Existing rows stay null → `—`.
- **Gateway**: `/v1/tenant/cac` GET + finance-entry POST read/write the two fields; `TenantCacStore` SELECT/INSERT/UPDATE and `CacPeriod`/`CacFormInput` map them, nullable + validated (`gross_margin_pct` must be in [0,1]).
- **Web**: `queryCacPeriods` now returns `{ periods, economics }`; the `economics: {}` stub + its comment are dropped. `DEFAULT_RETENTION_MONTHS` supplies retention (CTO-126 makes it tenant-configurable). `MOCK_PERIOD_ECONOMICS` remains the gateway-unreachable fallback (`isMock`).
- **Tests**: gateway round-trips the new fields (+ null-default + out-of-range rejection); web `lib/cac.test.ts` verifies a period with ARPA+margin yields non-null payback/LTV and a period missing either stays absent.

### Verification
- `infra/gateway`: `ruff` clean; `pytest` **320 passed**.
- `web`: `tsc --noEmit` clean; `vitest` **183 passed**, 2 failing are the known-flaky ClickHouse tests (`data-quality`, `attribution`), not chased per the ticket.

Out of scope (unchanged): cohort LTV, tenant-configurable bands (CTO-126), CSV upload.

Note: **CTO-126 stacks on this branch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)