### PR TITLE
feat(edge-proxy): native Gemini protocol support (CTO-167)

### DIFF
--- a/examples/aider-demo/README.md
+++ b/examples/aider-demo/README.md
@@ -1,9 +1,10 @@
 # make aider-demo
 
 A one-command live demo of ai-tally: [Aider](https://aider.chat) edits a small
-Python fixture, talking to OpenAI (or Anthropic) **through the ai-tally edge
-proxy** with a per-request `X-Tally-Feature-Tag: aider-demo` header. When all
-three tasks finish, the dashboard auto-opens, pre-filtered to that tag.
+Python fixture, talking to OpenAI (or Anthropic, or Gemini) **through the
+ai-tally edge proxy** with a per-request `X-Tally-Feature-Tag: aider-demo`
+header. When all three tasks finish, the dashboard auto-opens, pre-filtered to
+that tag.
 
 Goal: a stranger who just finished `make demo` can run `make aider-demo` and
 see real agent traces in under five minutes.
@@ -35,15 +36,16 @@ cd infra && PROVIDER=anthropic make aider-demo
 cd infra && PROVIDER=google make aider-demo    # (PROVIDER=gemini also works)
 ```
 
-**Note on the `google` path:** unlike openai/anthropic, Gemini does **not**
-run through the Go edge-proxy. The proxy is a transparent pass-through built
-for the OpenAI/Anthropic request shape and `Authorization: Bearer` auth;
-Gemini's REST surface differs (LiteLLM's `gemini/*` path posts to
-`generativelanguage.googleapis.com` with the key as a `?key=`/`x-goog-api-key`
-credential). So Aider talks to Gemini **directly**, and `run.sh` still POSTs
-the feature-tagged batch to the gateway (the same side-channel every provider
-uses) so the dashboard gets its rows. Cost enrichment relies on CTO-149 having
-priced `gemini-2.5-flash` in the catalog.
+**Note on the `google` path:** as of CTO-167, Gemini routes through the Go
+edge-proxy just like openai/anthropic. The proxy runs in native-Gemini mode
+(`EDGE_PROXY_PROVIDER=gemini`): LiteLLM's `gemini/*` calls are pointed at the
+proxy via `GEMINI_API_BASE`, and the proxy forwards them to
+`generativelanguage.googleapis.com` with the `?key=`/`x-goog-api-key`
+credential preserved untouched — never logged — while reading the model and
+token usage off the response into its metadata-only `TraceRecord`. As with
+every provider, `run.sh` also POSTs the feature-tagged batch to the gateway so
+the dashboard gets its rows; cost enrichment relies on CTO-149 having priced
+`gemini-2.5-flash` in the catalog.
 
 ## What you'll see
 

--- a/examples/aider-demo/run.sh
+++ b/examples/aider-demo/run.sh
@@ -18,8 +18,12 @@ GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
 PROXY_PORT="${PROXY_PORT:-7070}"
 PROXY_PID_FILE="${PROXY_PID_FILE:-/tmp/ai-tally-aider-edge-proxy.pid}"
 
+# proxy_provider selects the edge-proxy's response-metadata protocol (EDGE_PROXY_PROVIDER).
+# Empty keeps the proxy in pure pass-through mode (openai/anthropic today); "gemini" turns on
+# CTO-167 native Gemini parsing so the proxy reads model + token usage off the response.
+proxy_provider=""
+
 # 1. Validate the API key for the chosen provider.
-#    google (Gemini) takes a different path than openai/anthropic — see below.
 if [[ "$PROVIDER" == "anthropic" ]]; then
   [[ -n "${ANTHROPIC_API_KEY:-}" ]] || { echo "ERROR: ANTHROPIC_API_KEY not set"; exit 1; }
   upstream="https://api.anthropic.com"
@@ -30,8 +34,9 @@ elif [[ "$PROVIDER" == "google" ]]; then
     export GEMINI_API_KEY="$GOOGLE_API_KEY"
   fi
   [[ -n "${GEMINI_API_KEY:-}" ]] || { echo "ERROR: GEMINI_API_KEY (or GOOGLE_API_KEY) not set"; exit 1; }
-  # Informational only — see step 3/4 for why Gemini runs direct, not via proxy.
+  # CTO-167: Gemini now routes through the edge-proxy in native-Gemini mode.
   upstream="https://generativelanguage.googleapis.com"
+  proxy_provider="gemini"
 else
   [[ -n "${OPENAI_API_KEY:-}" ]] || { echo "ERROR: OPENAI_API_KEY not set (or pass PROVIDER=anthropic)"; exit 1; }
   upstream="https://api.openai.com"
@@ -49,10 +54,11 @@ start_proxy() {
   if [[ -f "$PROXY_PID_FILE" ]] && kill -0 "$(cat "$PROXY_PID_FILE")" 2>/dev/null; then
     echo "  edge-proxy already running (pid $(cat "$PROXY_PID_FILE"))"; return
   fi
-  echo "▶ starting edge-proxy on :$PROXY_PORT → $upstream"
+  echo "▶ starting edge-proxy on :$PROXY_PORT → $upstream${proxy_provider:+ (provider=$proxy_provider)}"
   ( cd "$here/../../infra/edge-proxy" && \
     EDGE_PROXY_LISTEN=":$PROXY_PORT" \
     EDGE_PROXY_UPSTREAM="$upstream" \
+    EDGE_PROXY_PROVIDER="$proxy_provider" \
     go run ./cmd/edge-proxy >/tmp/ai-tally-aider-edge-proxy.log 2>&1 ) &
   echo $! > "$PROXY_PID_FILE"
   # Wait up to ~5s for it to bind.
@@ -63,19 +69,11 @@ start_proxy() {
   done
   echo "ERROR: edge-proxy didn't bind on :$PROXY_PORT (see /tmp/ai-tally-aider-edge-proxy.log)"; exit 1
 }
-# CTO-164: Gemini runs DIRECT (not through the edge-proxy). The Go proxy is a
-# transparent pass-through that assumes the OpenAI/Anthropic request shape and
-# Authorization: Bearer auth; Gemini's REST surface differs (LiteLLM's
-# `gemini/*` path posts to generativelanguage.googleapis.com with the key as a
-# `?key=`/`x-goog-api-key` credential and a different body schema). Bridging
-# that in the proxy is out of scope here, so for google we skip the proxy and
-# still POST the feature-tagged batch to the gateway (step 5) — the same
-# side-channel every provider already uses to populate the dashboard rows.
-if [[ "$PROVIDER" != "google" ]]; then
-  start_proxy
-else
-  echo "▶ google/Gemini: running Aider direct to $upstream (edge-proxy skipped — see CTO-164 note)"
-fi
+# CTO-167: every provider — including Gemini — now routes through the edge-proxy. For google the
+# proxy runs in native-Gemini mode (EDGE_PROXY_PROVIDER=gemini): it forwards LiteLLM's `gemini/*`
+# calls to generativelanguage.googleapis.com with the `?key=`/`x-goog-api-key` credential untouched
+# and reads model + token usage off the response into its metadata-only TraceRecord.
+start_proxy
 
 # 4. Point Aider at the proxy and pick a model that matches the provider.
 #    Aider speaks OpenAI protocol by default; for Anthropic we explicitly select
@@ -115,13 +113,18 @@ if [[ "$PROVIDER" == "anthropic" ]]; then
   export ANTHROPIC_API_BASE="http://localhost:$PROXY_PORT"
   export ANTHROPIC_DEFAULT_HEADERS="X-Tally-Feature-Tag=$FEATURE_TAG,X-Tenant-Key=$TENANT"
 elif [[ "$PROVIDER" == "google" ]]; then
-  # LiteLLM's `gemini/<model>` path reads GEMINI_API_KEY from the env and talks
-  # to generativelanguage.googleapis.com directly (no base-URL override, no
-  # proxy). The fallback id must be one CTO-149 prices — gemini-2.5-flash is in
-  # seed_catalog(), so the batch POST below enriches with a real cost.
+  # CTO-167: LiteLLM's `gemini/<model>` path reads GEMINI_API_KEY from the env
+  # and honors GEMINI_API_BASE for the origin — so we point it at the edge-proxy,
+  # which forwards to generativelanguage.googleapis.com (key preserved as `?key=`)
+  # and records native-Gemini metadata. The fallback id must be one CTO-149
+  # prices — gemini-2.5-flash is in seed_catalog(), so the batch POST below
+  # enriches with a real cost.
   resolved=$(resolve_from_cache google flash)
   AIDER_MODEL="${AIDER_MODEL:-gemini/${resolved:-gemini-2.5-flash}}"
-  # No *_API_BASE / *_DEFAULT_HEADERS: Aider hits Gemini directly (see step 3).
+  export GEMINI_API_BASE="http://localhost:$PROXY_PORT"
+  # LiteLLM's gemini provider has no per-request custom-header env hook, so the
+  # feature tag / tenant reach the dashboard via the batch side-channel (step 5),
+  # the same channel every provider already relies on.
 else
   resolved=$(resolve_from_cache openai flagship)
   AIDER_MODEL="${AIDER_MODEL:-${resolved:-gpt-4o}}"

--- a/infra/edge-proxy/cmd/edge-proxy/main.go
+++ b/infra/edge-proxy/cmd/edge-proxy/main.go
@@ -53,6 +53,12 @@ func main() {
 		log.Printf("edge-proxy: telemetry -> %s (deployment=%s)", cfg.TelemetryURL, dep)
 	}
 
+	// Provider-protocol mode (CTO-167): the proxy reads scalar model/usage metadata off responses.
+	// Empty is pure pass-through (CTO-39), the byte-identical default.
+	if cfg.Provider != "" {
+		log.Printf("edge-proxy: provider protocol = %s (response metadata extraction on)", cfg.Provider)
+	}
+
 	p := proxy.New(cfg, opts...)
 
 	mux := http.NewServeMux()

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -95,11 +95,11 @@ type Config struct {
 
 // Defaults applied when the corresponding env var is unset.
 const (
-	DefaultListenAddr       = ":8088"
-	DefaultUpstream         = "https://api.openai.com"
+	DefaultListenAddr = ":8088"
+	DefaultUpstream   = "https://api.openai.com"
 	// DefaultGeminiUpstream is the origin used when Provider is gemini and EDGE_PROXY_UPSTREAM is
 	// unset — Google's Generative Language API (CTO-167).
-	DefaultGeminiUpstream = "https://generativelanguage.googleapis.com"
+	DefaultGeminiUpstream   = "https://generativelanguage.googleapis.com"
 	DefaultTenantHeader     = "X-Tenant-Key"
 	DefaultFeatureTagHeader = "X-Tally-Feature-Tag"
 	// DefaultUpstreamTimeout is generous because LLM completions are slow and may stream for

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -28,6 +28,30 @@ const (
 	ModeBroker Mode = "broker"
 )
 
+// Provider names the upstream API protocol so the proxy knows how to read scalar metadata (model,
+// token usage) out of the relayed response (CTO-167). It is orthogonal to Mode: it changes what the
+// proxy *understands* about the traffic, never how the request is forwarded — every provider is
+// still a byte-for-byte pass-through.
+//
+// The empty Provider ("") is the CTO-39 default: pure pass-through with zero response inspection, so
+// the hot path stays byte-identical and pays no parsing overhead. Set a provider only when you want
+// per-request model/usage metadata on the TraceRecord.
+type Provider string
+
+const (
+	// ProviderOpenAI reads the OpenAI chat/completions response shape: top-level "model" and
+	// usage.prompt_tokens / usage.completion_tokens.
+	ProviderOpenAI Provider = "openai"
+	// ProviderAnthropic reads the Anthropic Messages response shape: top-level "model" and
+	// usage.input_tokens / usage.output_tokens.
+	ProviderAnthropic Provider = "anthropic"
+	// ProviderGemini reads Google's Generative Language API: the model comes from the request path
+	// (/v1beta/models/{model}:generateContent), token usage from usageMetadata.promptTokenCount /
+	// usageMetadata.candidatesTokenCount, and auth is a ?key= query param or x-goog-api-key header
+	// rather than Authorization: Bearer.
+	ProviderGemini Provider = "gemini"
+)
+
 // Config is the fully-resolved, validated proxy configuration.
 type Config struct {
 	// ListenAddr is the address the proxy binds (e.g. ":8088").
@@ -52,6 +76,10 @@ type Config struct {
 
 	// Mode selects passthrough (default) or broker key handling.
 	Mode Mode
+	// Provider selects the upstream protocol for response-metadata extraction (CTO-167). Empty means
+	// pure pass-through with no response inspection (the CTO-39 default). When set (openai, anthropic,
+	// gemini) the proxy reads scalar model/usage metadata off each response into the TraceRecord.
+	Provider Provider
 	// BrokerFile is the path to the JSON KMS-export consumed in broker mode (required when Mode is
 	// broker). The file maps ai-tally tenant key -> provider Authorization header value.
 	BrokerFile string
@@ -69,6 +97,9 @@ type Config struct {
 const (
 	DefaultListenAddr       = ":8088"
 	DefaultUpstream         = "https://api.openai.com"
+	// DefaultGeminiUpstream is the origin used when Provider is gemini and EDGE_PROXY_UPSTREAM is
+	// unset — Google's Generative Language API (CTO-167).
+	DefaultGeminiUpstream = "https://generativelanguage.googleapis.com"
 	DefaultTenantHeader     = "X-Tenant-Key"
 	DefaultFeatureTagHeader = "X-Tally-Feature-Tag"
 	// DefaultUpstreamTimeout is generous because LLM completions are slow and may stream for
@@ -93,7 +124,22 @@ func FromEnv(lookup Env) (Config, error) {
 		TelemetryURL:     lookup("EDGE_PROXY_TELEMETRY_URL"),
 	}
 
-	rawUpstream := firstNonEmpty(lookup("EDGE_PROXY_UPSTREAM"), DefaultUpstream)
+	// Provider is orthogonal to upstream selection but changes the default upstream: a gemini proxy
+	// with no explicit EDGE_PROXY_UPSTREAM defaults to Google's origin rather than OpenAI's.
+	if v := lookup("EDGE_PROXY_PROVIDER"); v != "" {
+		switch Provider(v) {
+		case ProviderOpenAI, ProviderAnthropic, ProviderGemini:
+			cfg.Provider = Provider(v)
+		default:
+			return Config{}, fmt.Errorf("invalid EDGE_PROXY_PROVIDER %q (want openai|anthropic|gemini)", v)
+		}
+	}
+
+	defaultUpstream := DefaultUpstream
+	if cfg.Provider == ProviderGemini {
+		defaultUpstream = DefaultGeminiUpstream
+	}
+	rawUpstream := firstNonEmpty(lookup("EDGE_PROXY_UPSTREAM"), defaultUpstream)
 	u, err := url.Parse(rawUpstream)
 	if err != nil {
 		return Config{}, fmt.Errorf("invalid EDGE_PROXY_UPSTREAM %q: %w", rawUpstream, err)

--- a/infra/edge-proxy/internal/config/config_test.go
+++ b/infra/edge-proxy/internal/config/config_test.go
@@ -165,3 +165,41 @@ func TestInvalidMode(t *testing.T) {
 		t.Fatal("expected error for invalid mode")
 	}
 }
+
+// TestProviderSelection covers CTO-167: the provider flag validates its value and switches the
+// default upstream to Google's origin for gemini while leaving an explicit upstream untouched.
+func TestProviderSelection(t *testing.T) {
+	// Default: no provider, pure pass-through, OpenAI default upstream.
+	if cfg, _ := FromEnv(envMap(nil)); cfg.Provider != "" {
+		t.Errorf("default Provider = %q, want empty", cfg.Provider)
+	}
+
+	// gemini with no explicit upstream defaults to Google's Generative Language origin.
+	cfg, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_PROVIDER": "gemini"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Provider != ProviderGemini {
+		t.Errorf("Provider = %q, want gemini", cfg.Provider)
+	}
+	if cfg.Upstream.String() != DefaultGeminiUpstream {
+		t.Errorf("Upstream = %q, want %q", cfg.Upstream, DefaultGeminiUpstream)
+	}
+
+	// An explicit upstream still wins for gemini.
+	cfg, err = FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_PROVIDER": "gemini",
+		"EDGE_PROXY_UPSTREAM": "https://gemini.internal.example",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Upstream.String() != "https://gemini.internal.example" {
+		t.Errorf("Upstream = %q, want explicit override", cfg.Upstream)
+	}
+
+	// An unknown provider is rejected.
+	if _, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_PROVIDER": "bard"})); err == nil {
+		t.Error("expected error for unknown provider")
+	}
+}

--- a/infra/edge-proxy/internal/proxy/provider.go
+++ b/infra/edge-proxy/internal/proxy/provider.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// CTO-167: provider-protocol metadata extraction.
+//
+// When a provider protocol is configured, the proxy reads a handful of scalar fields (model id,
+// prompt/completion token counts) out of the relayed response and hangs them on the TraceRecord.
+// This is metadata only — no prompt, no completion, no key is ever retained. The response still
+// streams to the client byte-for-byte and unbuffered on the wire; we merely tee a bounded copy
+// aside to parse the usage block, then discard it (see metaCapture). In pure pass-through mode
+// (empty Provider) none of this runs and the hot path is byte-identical to CTO-39.
+
+// responseMeta holds the scalar metadata pulled from one response. It never carries content.
+type responseMeta struct {
+	Model            string
+	PromptTokens     int64
+	CompletionTokens int64
+}
+
+// metaCaptureCap bounds how many response bytes we tee aside for parsing. A generateContent /
+// chat.completion / messages JSON body is a few KB, so 1 MiB is comfortable headroom while still
+// capping memory for a pathological (or streaming) response. Past the cap we stop capturing and
+// fall back to whatever metadata we could derive without the body (e.g. Gemini's path-based model).
+const metaCaptureCap = 1 << 20
+
+// extractMeta parses provider metadata from a response body and, for Gemini, the request path.
+// It is a pure function so the CTO-167 test can feed it a recorded response and assert the mapping.
+// Unknown providers and unparseable bodies yield a zero responseMeta rather than an error — metadata
+// is best-effort and must never fail the proxied request.
+func extractMeta(p config.Provider, path string, body []byte) responseMeta {
+	switch p {
+	case config.ProviderOpenAI:
+		return openAIMeta(body)
+	case config.ProviderAnthropic:
+		return anthropicMeta(body)
+	case config.ProviderGemini:
+		return geminiMeta(path, body)
+	default:
+		return responseMeta{}
+	}
+}
+
+func openAIMeta(body []byte) responseMeta {
+	var r struct {
+		Model string `json:"model"`
+		Usage struct {
+			PromptTokens     int64 `json:"prompt_tokens"`
+			CompletionTokens int64 `json:"completion_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return responseMeta{}
+	}
+	return responseMeta{
+		Model:            r.Model,
+		PromptTokens:     r.Usage.PromptTokens,
+		CompletionTokens: r.Usage.CompletionTokens,
+	}
+}
+
+func anthropicMeta(body []byte) responseMeta {
+	var r struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return responseMeta{}
+	}
+	return responseMeta{
+		Model:            r.Model,
+		PromptTokens:     r.Usage.InputTokens,
+		CompletionTokens: r.Usage.OutputTokens,
+	}
+}
+
+func geminiMeta(path string, body []byte) responseMeta {
+	var r struct {
+		ModelVersion  string `json:"modelVersion"`
+		UsageMetadata struct {
+			PromptTokenCount     int64 `json:"promptTokenCount"`
+			CandidatesTokenCount int64 `json:"candidatesTokenCount"`
+		} `json:"usageMetadata"`
+	}
+	// The body may be missing/unparseable (e.g. an error response); still return the path-derived
+	// model so an errored call is at least attributable to a model.
+	_ = json.Unmarshal(body, &r)
+
+	model := geminiModelFromPath(path)
+	if model == "" {
+		model = r.ModelVersion
+	}
+	return responseMeta{
+		Model:            model,
+		PromptTokens:     r.UsageMetadata.PromptTokenCount,
+		CompletionTokens: r.UsageMetadata.CandidatesTokenCount,
+	}
+}
+
+// geminiModelFromPath pulls the model id out of a Generative Language request path of the form
+// /v1beta/models/{model}:generateContent (or :streamGenerateContent). Returns "" if the path
+// doesn't match that shape.
+func geminiModelFromPath(path string) string {
+	const marker = "/models/"
+	i := strings.LastIndex(path, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := path[i+len(marker):]
+	// Drop the ":method" suffix (":generateContent", ":streamGenerateContent", ...).
+	if c := strings.IndexByte(rest, ':'); c >= 0 {
+		rest = rest[:c]
+	}
+	// Guard against a trailing slash or empty segment.
+	if s := strings.IndexByte(rest, '/'); s >= 0 {
+		rest = rest[:s]
+	}
+	return rest
+}
+
+// metaCapture wraps a response body, streaming it through untouched while teeing a bounded copy
+// aside so the usage block can be parsed on Close. It preserves the streaming contract — every Read
+// returns the provider's bytes immediately, adding no buffering latency — and never retains content
+// beyond the transient capture, which is freed as soon as the scalar metadata is extracted. The
+// parsed result lands in *out; the raw bytes are discarded.
+type metaCapture struct {
+	inner    io.ReadCloser
+	provider config.Provider
+	path     string
+	out      *responseMeta
+
+	buf  []byte
+	over bool // capture exceeded the cap; stop teeing and skip body-derived metadata
+}
+
+func (m *metaCapture) Read(p []byte) (int, error) {
+	n, err := m.inner.Read(p)
+	if n > 0 && !m.over {
+		if len(m.buf)+n > metaCaptureCap {
+			// Oversized/streaming response: drop the partial capture rather than grow unbounded.
+			m.over = true
+			m.buf = nil
+		} else {
+			m.buf = append(m.buf, p[:n]...)
+		}
+	}
+	return n, err
+}
+
+func (m *metaCapture) Close() error {
+	if m.out != nil {
+		if m.over {
+			// We never saw the whole body; still try path-based metadata (Gemini model).
+			*m.out = extractMeta(m.provider, m.path, nil)
+		} else {
+			*m.out = extractMeta(m.provider, m.path, m.buf)
+		}
+	}
+	m.buf = nil
+	return m.inner.Close()
+}

--- a/infra/edge-proxy/internal/proxy/provider_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_test.go
@@ -49,7 +49,7 @@ func TestGeminiModelFromPath(t *testing.T) {
 		"/v1beta/models/gemini-2.5-flash:generateContent":       "gemini-2.5-flash",
 		"/v1beta/models/gemini-1.5-pro:streamGenerateContent":   "gemini-1.5-pro",
 		"/v1beta/models/gemini-2.5-flash-002:generateContent":   "gemini-2.5-flash-002",
-		"/v1/chat/completions":                                  "", // not a gemini path
+		"/v1/chat/completions":                                  "",                 // not a gemini path
 		"/v1beta/models/gemini-2.5-flash:generateContent?extra": "gemini-2.5-flash", // ':' precedes '?'
 	}
 	for path, want := range cases {

--- a/infra/edge-proxy/internal/proxy/provider_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_test.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// recordedGeminiResponse is a real-shape generateContent response body (content elided): the parts
+// text is irrelevant to metadata — only usageMetadata and, via the path, the model matter.
+const recordedGeminiResponse = `{
+  "candidates": [
+    {"content": {"parts": [{"text": "ok"}], "role": "model"}, "finishReason": "STOP"}
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 259,
+    "candidatesTokenCount": 73,
+    "totalTokenCount": 332
+  },
+  "modelVersion": "gemini-2.5-flash-002"
+}`
+
+// TestGeminiMetaFromRecordedResponse is the CTO-167 acceptance test: the proxy parses a recorded
+// Gemini response into a correct set of TraceRecord scalars — model (from the request path) plus
+// prompt/candidate token counts (from usageMetadata).
+func TestGeminiMetaFromRecordedResponse(t *testing.T) {
+	path := "/v1beta/models/gemini-2.5-flash:generateContent"
+	meta := extractMeta(config.ProviderGemini, path, []byte(recordedGeminiResponse))
+
+	if meta.Model != "gemini-2.5-flash" {
+		t.Errorf("Model = %q, want gemini-2.5-flash", meta.Model)
+	}
+	if meta.PromptTokens != 259 {
+		t.Errorf("PromptTokens = %d, want 259", meta.PromptTokens)
+	}
+	if meta.CompletionTokens != 73 {
+		t.Errorf("CompletionTokens = %d, want 73", meta.CompletionTokens)
+	}
+}
+
+func TestGeminiModelFromPath(t *testing.T) {
+	cases := map[string]string{
+		"/v1beta/models/gemini-2.5-flash:generateContent":       "gemini-2.5-flash",
+		"/v1beta/models/gemini-1.5-pro:streamGenerateContent":   "gemini-1.5-pro",
+		"/v1beta/models/gemini-2.5-flash-002:generateContent":   "gemini-2.5-flash-002",
+		"/v1/chat/completions":                                  "", // not a gemini path
+		"/v1beta/models/gemini-2.5-flash:generateContent?extra": "gemini-2.5-flash", // ':' precedes '?'
+	}
+	for path, want := range cases {
+		if got := geminiModelFromPath(path); got != want {
+			t.Errorf("geminiModelFromPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// TestGeminiMetaFallsBackToModelVersion: if the path lacks a model (unexpected shape), the body's
+// modelVersion is used so the record is still attributable.
+func TestGeminiMetaFallsBackToModelVersion(t *testing.T) {
+	meta := extractMeta(config.ProviderGemini, "/weird/path", []byte(recordedGeminiResponse))
+	if meta.Model != "gemini-2.5-flash-002" {
+		t.Errorf("Model = %q, want gemini-2.5-flash-002 (modelVersion fallback)", meta.Model)
+	}
+}
+
+func TestOpenAIAndAnthropicMeta(t *testing.T) {
+	openai := extractMeta(config.ProviderOpenAI, "/v1/chat/completions",
+		[]byte(`{"model":"gpt-4o-2024-08-06","usage":{"prompt_tokens":12,"completion_tokens":34}}`))
+	if openai.Model != "gpt-4o-2024-08-06" || openai.PromptTokens != 12 || openai.CompletionTokens != 34 {
+		t.Errorf("openai meta = %+v", openai)
+	}
+
+	anthropic := extractMeta(config.ProviderAnthropic, "/v1/messages",
+		[]byte(`{"model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":200}}`))
+	if anthropic.Model != "claude-sonnet-4-5" || anthropic.PromptTokens != 100 || anthropic.CompletionTokens != 200 {
+		t.Errorf("anthropic meta = %+v", anthropic)
+	}
+}
+
+// newGeminiProxy builds a gemini-protocol proxy in front of the given upstream. Mirrors
+// newTestProxy but sets EDGE_PROXY_PROVIDER=gemini so ModifyResponse metadata capture is active.
+func newGeminiProxy(t *testing.T, upstream http.Handler) (*httptest.Server, *recordingSink) {
+	t.Helper()
+	origin := httptest.NewServer(upstream)
+	t.Cleanup(origin.Close)
+
+	cfg, err := config.FromEnv(func(k string) string {
+		switch k {
+		case "EDGE_PROXY_UPSTREAM":
+			return origin.URL
+		case "EDGE_PROXY_PROVIDER":
+			return "gemini"
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	sink := &recordingSink{}
+	front := httptest.NewServer(New(cfg, WithSink(sink)))
+	t.Cleanup(front.Close)
+	return front, sink
+}
+
+// TestGeminiProxyRecordsMetadataAndHidesKey drives an end-to-end Gemini request through the proxy:
+//   - the recorded response is relayed byte-for-byte to the client,
+//   - the TraceRecord carries the model + token counts + status parsed from it, and
+//   - the ?key= credential is forwarded to the upstream but never lands in the TraceRecord.
+func TestGeminiProxyRecordsMetadataAndHidesKey(t *testing.T) {
+	const secretKey = "AIzaSy-super-secret-key"
+	var gotKeyQuery, gotGoogHeader string
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKeyQuery = r.URL.Query().Get("key")
+		gotGoogHeader = r.Header.Get("x-goog-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, recordedGeminiResponse)
+	})
+	front, sink := newGeminiProxy(t, upstream)
+
+	url := front.URL + "/v1beta/models/gemini-2.5-flash:generateContent?key=" + secretKey
+	req, _ := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"contents":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	// Response relayed unmodified.
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if string(body) != recordedGeminiResponse {
+		t.Errorf("response body altered")
+	}
+	// The ?key= credential rode through to the upstream untouched.
+	if gotKeyQuery != secretKey {
+		t.Errorf("upstream ?key = %q, want it forwarded", gotKeyQuery)
+	}
+	_ = gotGoogHeader
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if rec.Model != "gemini-2.5-flash" {
+		t.Errorf("trace Model = %q", rec.Model)
+	}
+	if rec.PromptTokens != 259 || rec.CompletionTokens != 73 {
+		t.Errorf("trace tokens = %d/%d, want 259/73", rec.PromptTokens, rec.CompletionTokens)
+	}
+	if rec.StatusCode != http.StatusOK {
+		t.Errorf("trace status = %d", rec.StatusCode)
+	}
+	// The key must not leak into the recorded metadata: not in Path, not anywhere in the record.
+	if strings.Contains(rec.Path, secretKey) {
+		t.Errorf("trace Path leaked the key: %q", rec.Path)
+	}
+	if s := fmt.Sprintf("%+v", rec); strings.Contains(s, secretKey) || strings.Contains(s, "AIzaSy") {
+		t.Errorf("trace record leaked the key: %s", s)
+	}
+}
+
+// TestGeminiProxyStreamingModelWithoutUsage: a streamed response whose usage we can't buffer past
+// the cap still yields the path-derived model (best-effort metadata), and never blocks streaming.
+func TestGeminiProxyStreamingModelFromPath(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// No usageMetadata in this chunk — exercises the "model without tokens" path.
+		_, _ = io.WriteString(w, `[{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}]`)
+	})
+	front, sink := newGeminiProxy(t, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost,
+		front.URL+"/v1beta/models/gemini-1.5-pro:streamGenerateContent?key=k", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if rec.Model != "gemini-1.5-pro" {
+		t.Errorf("trace Model = %q, want gemini-1.5-pro", rec.Model)
+	}
+	if rec.PromptTokens != 0 || rec.CompletionTokens != 0 {
+		t.Errorf("expected zero tokens when usage absent, got %d/%d", rec.PromptTokens, rec.CompletionTokens)
+	}
+}

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -6,9 +6,14 @@
 // only thing we keep is a TraceRecord of metadata + byte counts (never content), handed to a Sink.
 //
 // Design invariants:
-//   - Bodies are never mutated, buffered, or persisted. We count bytes as they stream; that's it.
-//   - The customer's provider key (Authorization header) is forwarded as-is and never read into
-//     any field, log line, or stored struct — it lives only in the in-flight request.
+//   - Bodies are never mutated or persisted. In the default pass-through mode they are never even
+//     buffered — we count bytes as they stream; that's it. In the opt-in provider-protocol mode
+//     (CTO-167) a bounded copy of the response is teed aside transiently to parse scalar usage
+//     metadata (model, token counts) and then discarded: content is never logged, stored, or handed
+//     to a Sink, and the bytes still stream to the client unbuffered on the wire.
+//   - The customer's provider key (Authorization header, or Gemini's ?key= / x-goog-api-key) is
+//     forwarded as-is and never read into any field, log line, or stored struct — it lives only in
+//     the in-flight request.
 //   - Stateless: no per-request state survives the response, so instances scale horizontally.
 //   - FlushInterval -1 streams responses immediately, so SSE token streams pass through with no
 //     added buffering latency (token *reconstruction* is CTO-40's job, not the proxy core's).
@@ -99,10 +104,41 @@ func New(cfg config.Config, opts ...Option) *Proxy {
 		ErrorHandler:  errorHandler,
 	}
 
+	// CTO-167: when a provider protocol is configured, tee each response through a bounded scanner
+	// that extracts scalar model/usage metadata. Left nil in pure pass-through mode so the hot path
+	// never inspects a response body.
+	if cfg.Provider != "" {
+		p.rp.ModifyResponse = p.captureMeta
+	}
+
 	for _, opt := range opts {
 		opt(p)
 	}
 	return p
+}
+
+// metaKey is the request-context key under which ServeHTTP stashes the responseMeta holder that
+// captureMeta fills in as the response streams.
+type metaKey struct{}
+
+// captureMeta wraps the upstream response body so scalar metadata (model, token usage) is parsed
+// out as it streams — without buffering it on the wire or retaining any content. It is installed as
+// the ReverseProxy's ModifyResponse only when a provider protocol is configured.
+func (p *Proxy) captureMeta(resp *http.Response) error {
+	if resp.Body == nil || resp.Request == nil {
+		return nil
+	}
+	holder, _ := resp.Request.Context().Value(metaKey{}).(*responseMeta)
+	if holder == nil {
+		return nil
+	}
+	resp.Body = &metaCapture{
+		inner:    resp.Body,
+		provider: p.cfg.Provider,
+		path:     resp.Request.URL.Path,
+		out:      holder,
+	}
+	return nil
 }
 
 // ServeHTTP forwards the request and records a telemetry copy.
@@ -155,19 +191,27 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Mark whether the upstream was reachable so the telemetry copy can distinguish a real 502
 	// from us synthesizing one.
 	ctx := context.WithValue(r.Context(), failedKey{}, &rec.failed)
+	// In provider-protocol mode, hand captureMeta a holder to fill as the response streams (CTO-167).
+	var meta responseMeta
+	if p.cfg.Provider != "" {
+		ctx = context.WithValue(ctx, metaKey{}, &meta)
+	}
 	p.rp.ServeHTTP(rec, r.WithContext(ctx))
 
 	p.sink.Record(TraceRecord{
-		TenantKey:  tenant,
-		FeatureTag: featureTag,
-		Method:     r.Method,
-		Path:       r.URL.Path,
-		StatusCode: rec.status,
-		ReqBytes:   reqBytes,
-		RespBytes:  rec.written,
-		Duration:   p.now().Sub(start),
-		StartedAt:  start,
-		Failed:     rec.failed,
+		TenantKey:        tenant,
+		FeatureTag:       featureTag,
+		Method:           r.Method,
+		Path:             r.URL.Path,
+		Model:            meta.Model,
+		PromptTokens:     meta.PromptTokens,
+		CompletionTokens: meta.CompletionTokens,
+		StatusCode:       rec.status,
+		ReqBytes:         reqBytes,
+		RespBytes:        rec.written,
+		Duration:         p.now().Sub(start),
+		StartedAt:        start,
+		Failed:           rec.failed,
 	})
 }
 

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -20,6 +20,18 @@ type TraceRecord struct {
 	FeatureTag string
 	Method     string
 	Path       string
+	// Model is the model id for the request, extracted from the response (or request path for
+	// Gemini) when a provider protocol is configured (CTO-167). Empty in pure pass-through mode or
+	// when the response carried no recognizable model. It is a short identifier
+	// (e.g. "gemini-2.5-flash"), never request/response content.
+	Model string
+	// PromptTokens / CompletionTokens are the input/output token counts reported by the provider in
+	// the response usage block (OpenAI usage.prompt_tokens/completion_tokens, Anthropic
+	// usage.input_tokens/output_tokens, Gemini usageMetadata.promptTokenCount/candidatesTokenCount).
+	// Zero when unknown (pass-through mode, streaming past the scan cap, or an error response). These
+	// are scalar counts only — extracting them never persists or logs the body they came from.
+	PromptTokens     int64
+	CompletionTokens int64
 	// StatusCode is the upstream response status relayed to the client (0 if the upstream failed
 	// before any status, e.g. connection refused — see Failed).
 	StatusCode int


### PR DESCRIPTION
## CTO-167 — Edge-proxy: native Gemini protocol support

Routes aider-demo's Gemini path through the edge-proxy and teaches the proxy to read Gemini response metadata.

### What changed
- **Gemini upstream mode** (`internal/config`): new `EDGE_PROXY_PROVIDER` flag (`openai|anthropic|gemini`) alongside `EDGE_PROXY_UPSTREAM`. When `gemini` and no explicit upstream is set, the default upstream becomes `https://generativelanguage.googleapis.com`. Empty provider keeps the CTO-39 byte-identical pass-through, so the default hot path and the p99 overhead budget are untouched.
- **Metadata extraction** (`internal/proxy/provider.go`, `proxy.go`): in provider mode the ReverseProxy `ModifyResponse` tees a bounded copy of the response aside to parse scalar usage, streaming to the client unbuffered and discarding the bytes once the scalars are pulled. No bodies logged/persisted; the key never enters the `TraceRecord`.
- **TraceRecord mapping** (`trace.go`): adds `Model`, `PromptTokens`, `CompletionTokens` (scalars only — the no-body structural guard still holds). Gemini: model from the `/v1beta/models/{model}:generateContent` path (falls back to `modelVersion`), tokens from `usageMetadata.promptTokenCount`/`candidatesTokenCount`. OpenAI/Anthropic map to the same fields from their `usage` blocks.
- **Gemini auth**: `?key=` / `x-goog-api-key` forwarded untouched; `TraceRecord.Path` excludes the query, so the key is never recorded or logged.
- **aider-demo** (`run.sh`, `README.md`): `PROVIDER=google` now starts the proxy in `EDGE_PROXY_PROVIDER=gemini` mode and points LiteLLM at it via `GEMINI_API_BASE`; the "runs direct" caveat is dropped.

### Tests
`cd infra/edge-proxy && go build ./... && go test ./...` green (incl. `-race`). New coverage: recorded Gemini response → correct `TraceRecord` (model + token counts + status); `?key=` handled without leaking the key; path-only model on a streamed response; provider config selection + gemini default upstream. `bash -n examples/aider-demo/run.sh` passes.

### Out of scope
Vertex ADC auth (fast-follow), chatbot demo, multimodal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)