### PR TITLE
feat(cost): GCP Cloud Billing compute connector (CTO-150)

### DIFF
--- a/db/postgres/0015_tenant_compute_config_gcp.sql
+++ b/db/postgres/0015_tenant_compute_config_gcp.sql
@@ -1,0 +1,23 @@
+-- GCP Cloud Billing fields for the compute connector (CTO-150).
+--
+-- CTO-143 shipped tenant_compute_config with the AWS path fully wired (cloud_provider already
+-- accepts 'gcp' via its CHECK). GCP is different in one way: it has no fine-grained REST cost API,
+-- so the source of truth is the Cloud Billing *BigQuery export* table. Two additive columns carry
+-- that GCP-specific config; the AWS path leaves both NULL/default and is unaffected.
+--
+--   * bq_billing_export_table — the fully-qualified export table id (project.dataset.table) the GCP
+--     source queries. NULL for AWS tenants; required (non-empty) for a GCP tenant to fetch anything
+--     (the connector raises on a blank table, recording a 'failed' run and emitting no span).
+--   * label_filter — the GCP label set the export query is scoped to. GCP label keys can't contain
+--     ':' , so the AI workload uses a '-' ({"tally-workload":"ai"}), unlike the AWS tag_filter's
+--     {"tally:workload":"ai"}. Default matches the connector's DEFAULT_GCP_LABEL_FILTER.
+--
+-- Auth stays by REFERENCE only (CTO-143 hard rule): credentials_ref is a Secret Manager pointer, or
+-- the deployment authenticates the BigQuery client via ADC / Workload Identity — never raw keys.
+--
+-- Additive & idempotent: ADD COLUMN IF NOT EXISTS, existing rows keep working (AWS unchanged).
+
+ALTER TABLE tenant_compute_config
+    ADD COLUMN IF NOT EXISTS bq_billing_export_table TEXT
+        CHECK (bq_billing_export_table IS NULL OR length(bq_billing_export_table) < 1024),
+    ADD COLUMN IF NOT EXISTS label_filter JSONB NOT NULL DEFAULT '{"tally-workload": "ai"}'::jsonb;

--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
 gcs = [
     "google-cloud-storage>=2.10",
 ]
+# S3 / MinIO replay blob-store backend (CTO-158). Optional so the base install stays slim;
+# imported lazily inside S3ReplayBlobStore so the gateway boots without it when the backend is
+# not `s3`.
+s3 = [
+    "boto3>=1.34",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.6",

--- a/infra/gateway/scripts/backfill_gcp_compute.py
+++ b/infra/gateway/scripts/backfill_gcp_compute.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Backfill the GCP compute cost layer for a tenant (CTO-150).
+
+Pulls the last N days of GCP compute spend from the tenant's Cloud Billing BigQuery *export* table
+(GCP has no fine-grained REST cost API — the export is the source of truth) and lands one synthetic
+``compute`` span per day, so a tenant that just enabled the GCP connector doesn't start with an empty
+Compute column.
+
+    uv run python scripts/backfill_gcp_compute.py --tenant <uuid> --days 30
+
+Idempotent on ``(tenant, period, project)``: the base connector's emitter derives a deterministic
+span id from ``(tenant, provider, operation, day)`` and skips any day that already has a span, so
+re-running the same window never double-counts.
+
+Config (billing-export table, label filter, credential reference) is read from
+``tenant_compute_config``; a tenant without a row — or one whose provider isn't ``gcp`` — is a no-op.
+The export table falls back to ``TALLY_COMPUTE_GCP_DEFAULT_BILLING_EXPORT_TABLE`` when the tenant row
+leaves it blank. A failed fetch records a ``failed`` run and emits NO span (never a guess).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+import sys
+from datetime import date, timedelta
+
+from gateway.config import get_settings
+from gateway.connectors.compute import ComputeCostConnector, GcpCloudBillingClient
+from gateway.connectors.config_store import TenantComputeConfigStore
+from gateway.store import ClickHouseStore
+
+logger = logging.getLogger("backfill_gcp_compute")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill the GCP compute cost layer for a tenant.")
+    parser.add_argument("--tenant", required=True, help="tenant_id (UUID) to backfill")
+    parser.add_argument("--days", type=int, default=30, help="number of days back to backfill")
+    parser.add_argument(
+        "--end-day",
+        default=None,
+        help="last day to backfill (YYYY-MM-DD, inclusive); defaults to yesterday (UTC)",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    if args.days < 1:
+        parser.error("--days must be >= 1")
+
+    end_day = date.fromisoformat(args.end_day) if args.end_day else date.today() - timedelta(days=1)
+    start_day = end_day - timedelta(days=args.days - 1)
+
+    settings = get_settings()
+    config_store = TenantComputeConfigStore(settings)
+    config = config_store.load_config(args.tenant)
+    if config is None:
+        logger.error("tenant %s has no tenant_compute_config row — nothing to backfill", args.tenant)
+        return 2
+    if config.cloud_provider != "gcp":
+        logger.error(
+            "tenant %s is configured for provider=%s, not gcp — use backfill_compute.py",
+            args.tenant,
+            config.cloud_provider,
+        )
+        return 2
+
+    # Fall back to the deployment-wide export table when the tenant row leaves it blank.
+    if not config.bq_billing_export_table and settings.compute_gcp_default_billing_export_table:
+        config = dataclasses.replace(
+            config, bq_billing_export_table=settings.compute_gcp_default_billing_export_table
+        )
+
+    store = ClickHouseStore(settings)
+    try:
+        connector = ComputeCostConnector(
+            store=store,
+            recorder=config_store,
+            billing_client=GcpCloudBillingClient(project=settings.compute_gcp_bq_project or None),
+        )
+        result = connector.run_backfill(config, start_day=start_day, end_day=end_day)
+    finally:
+        store.close()
+
+    logger.info(
+        "backfill %s provider=gcp table=%s %s..%s: status=%s spans_emitted=%d total_micro_usd=%d%s",
+        args.tenant,
+        config.bq_billing_export_table or "<unset>",
+        start_day,
+        end_day,
+        result.status,
+        result.spans_emitted,
+        result.cost_micro_usd,
+        f" error={result.error_message}" if result.error_message else "",
+    )
+    return 0 if result.status == "success" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -73,6 +73,7 @@ from gateway.replay_store import (
     GCSReplayBlobStore,
     InMemoryReplayBlobStore,
     ReplayBlobStore,
+    S3ReplayBlobStore,
     persist_sample,
 )
 from gateway.eval_executor import (
@@ -108,9 +109,10 @@ def _build_replay_blob_store(settings) -> ReplayBlobStore:
     """Select the replay blob-store backend from settings (CTO-152).
 
     ``memory`` (default) -> in-process dict store; ``gcs`` -> Google Cloud Storage via ADC /
-    Workload Identity. The GCS client + its optional ``google-cloud-storage`` dependency are only
-    touched when the backend is actually ``gcs`` (lazy import lives inside the store), so the
-    default install/boot never needs the package.
+    Workload Identity; ``s3`` -> AWS S3 (or S3-compatible, e.g. MinIO) via the AWS default
+    credential chain. Each cloud client + its optional dependency (``google-cloud-storage`` /
+    ``boto3``) is only touched when that backend is actually selected (lazy import lives inside the
+    store), so the default install/boot never needs either package.
     """
     backend = (settings.replay_blob_backend or "memory").lower()
     if backend == "memory":
@@ -121,7 +123,19 @@ def _build_replay_blob_store(settings) -> ReplayBlobStore:
                 "TALLY_REPLAY_GCS_BUCKET must be set when TALLY_REPLAY_BLOB_BACKEND=gcs"
             )
         return GCSReplayBlobStore(bucket=settings.replay_gcs_bucket)
-    raise ValueError(f"unknown TALLY_REPLAY_BLOB_BACKEND: {backend!r} (expected 'memory' or 'gcs')")
+    if backend == "s3":
+        if not settings.replay_s3_bucket:
+            raise ValueError(
+                "TALLY_REPLAY_S3_BUCKET must be set when TALLY_REPLAY_BLOB_BACKEND=s3"
+            )
+        return S3ReplayBlobStore(
+            bucket=settings.replay_s3_bucket,
+            prefix=settings.replay_s3_prefix,
+            region=settings.replay_s3_region or None,
+        )
+    raise ValueError(
+        f"unknown TALLY_REPLAY_BLOB_BACKEND: {backend!r} (expected 'memory', 'gcs', or 's3')"
+    )
 
 
 @asynccontextmanager

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -83,6 +83,20 @@ class Settings(BaseSettings):
     # Max rows pulled from ClickHouse per (tenant, table) export pass.
     bq_export_batch_limit: int = 10_000
 
+    # GCP Cloud Billing compute connector (CTO-150). The compute cost layer's GCP source reads a
+    # tenant's Cloud Billing BigQuery *export* table (GCP has no fine-grained REST cost API — the BQ
+    # export is the source of truth) and lands one synthetic `compute` span/day. A tenant opts in via
+    # a `tenant_compute_config` row with cloud_provider='gcp'; these settings only tune the live BQ
+    # job. Auth is via ADC / Workload Identity / a per-tenant Secret Manager reference — never a raw
+    # service-account key. Requires the optional `[bigquery]` extra (google-cloud-bigquery),
+    # lazy-imported in gateway.connectors.compute so the gateway boots without it.
+    compute_gcp_enabled: bool = False
+    # GCP project that runs the BigQuery billing-export jobs. Empty means "resolve from ADC".
+    compute_gcp_bq_project: str = ""
+    # Fallback export table (`project.dataset.gcp_billing_export_v1_XXXX`) for a tenant whose
+    # tenant_compute_config row leaves bq_billing_export_table blank. Empty means "require per-tenant".
+    compute_gcp_default_billing_export_table: str = ""
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -51,11 +51,19 @@ class Settings(BaseSettings):
     ingest_buffer_drain_batch: int = 2_000
     ingest_buffer_poll_interval_s: float = 0.05
 
-    # Replay blob-store backend (CTO-152). ``memory`` (default) uses the in-process dict store;
-    # ``gcs`` persists scrubbed replay samples to a Google Cloud Storage bucket via ADC / Workload
-    # Identity (no raw key material). ``replay_gcs_bucket`` is required when the backend is ``gcs``.
+    # Replay blob-store backend (CTO-152 / CTO-158). ``memory`` (default) uses the in-process dict
+    # store; ``gcs`` persists scrubbed replay samples to a Google Cloud Storage bucket via ADC /
+    # Workload Identity; ``s3`` persists them to an AWS S3 (or S3-compatible, e.g. MinIO) bucket via
+    # the AWS default credential chain (IAM role / IRSA / instance profile / env) — no raw keys for
+    # either. ``replay_gcs_bucket`` is required when the backend is ``gcs``; ``replay_s3_bucket`` is
+    # required when the backend is ``s3``.
     replay_blob_backend: str = "memory"
     replay_gcs_bucket: str = ""
+    # S3 backend (CTO-158). Bucket is required for ``s3``; prefix/region are optional. Region empty
+    # means "resolve from the AWS default chain" (``AWS_REGION`` / config / instance metadata).
+    replay_s3_bucket: str = ""
+    replay_s3_prefix: str = ""
+    replay_s3_region: str = ""
 
     # BigQuery export sink (CTO-154). OPTIONAL, additive analytics mirror that copies
     # spans / business_events / attribution / daily rollups into a tenant's OWN BigQuery

--- a/infra/gateway/src/gateway/connectors/base.py
+++ b/infra/gateway/src/gateway/connectors/base.py
@@ -55,14 +55,23 @@ class ConnectorConfig:
     """One tenant's cloud-billing connector config — the loaded control-plane row.
 
     ``credentials_ref`` is a Secret Manager / KMS / ARN reference (or ``'aws-default-chain'``),
-    NEVER raw credentials. ``tag_filter`` is the cost-allocation tag set the billing query is scoped
-    to (default ``{'tally:workload': 'ai'}``).
+    NEVER raw credentials. ``tag_filter`` is the cost-allocation tag set the AWS billing query is
+    scoped to (default ``{'tally:workload': 'ai'}``).
+
+    The last two fields are GCP-only (CTO-150) and stay empty for AWS: ``bq_billing_export_table`` is
+    the fully-qualified Cloud Billing BigQuery *export* table (``project.dataset.table``) the GCP
+    source reads — GCP has no fine-grained REST cost API, so the BQ export is the source of truth —
+    and ``label_filter`` is the GCP label set the export query is scoped to (default
+    ``{'tally-workload': 'ai'}``; GCP label keys can't contain ``:`` so they use ``-``, unlike the
+    AWS cost-allocation ``tag_filter``).
     """
 
     tenant_id: str
     cloud_provider: str  # 'aws' | 'gcp'
     credentials_ref: str
     tag_filter: dict[str, str] = field(default_factory=dict)
+    bq_billing_export_table: str = ""
+    label_filter: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/src/gateway/connectors/compute.py
+++ b/infra/gateway/src/gateway/connectors/compute.py
@@ -18,7 +18,8 @@ appear in the DB, in this module, or in logs.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+import re
+from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 
 from tally.schema import usd_to_micro
@@ -30,9 +31,18 @@ from gateway.connectors.base import (
     DailyCost,
 )
 
-# Default cost-allocation tag set when a tenant hasn't overridden tag_filter. Scopes the billing
+# Default cost-allocation tag set when a tenant hasn't overridden tag_filter. Scopes the AWS billing
 # query to the AI workload so unrelated infra spend doesn't leak into the compute layer.
 DEFAULT_TAG_FILTER: dict[str, str] = {"tally:workload": "ai"}
+
+# Default GCP label set when a tenant hasn't overridden label_filter (CTO-150). GCP label keys can't
+# contain ``:``, so the AI workload is tagged with a ``-`` — distinct from the AWS ``tally:workload``.
+DEFAULT_GCP_LABEL_FILTER: dict[str, str] = {"tally-workload": "ai"}
+
+# A fully-qualified BigQuery table id: ``project.dataset.table`` (dots optional for dataset-qualified
+# ids). We interpolate the table into the SQL (BQ can't parameterize identifiers), so we validate it
+# to a safe charset first — everything else in the query is a bound parameter.
+_BQ_TABLE_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 
 
 def _to_micro(amount: object) -> int:
@@ -78,22 +88,39 @@ def parse_aws_cost_response(response: dict[str, object]) -> list[DailyCost]:
     return out
 
 
+def _coerce_day(raw: object) -> date | None:
+    """Coerce a BQ billing-export day value to a :class:`date`, or ``None`` if unparseable.
+
+    The live BigQuery client hands back ``datetime.date`` / ``datetime.datetime`` objects; recorded
+    JSON fixtures hand back ISO strings (possibly a full timestamp — we take the date part).
+    """
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, date):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return date.fromisoformat(raw[:10])
+        except ValueError:
+            return None
+    return None
+
+
 def parse_gcp_billing_rows(rows: list[dict[str, object]]) -> list[DailyCost]:
     """Parse GCP Cloud Billing rows (BigQuery billing-export shape) into per-day totals.
 
     Each row is expected to carry a day key (``usage_start_time`` or ``day``) and a ``cost`` value.
-    ``usage_start_time`` may be a full ISO timestamp — we take the date part. Rows for the same day
-    are summed (the export emits one row per service/SKU), so the connector still lands ONE span
-    per day.
+    The day may be a ``date``/``datetime`` (live BQ) or an ISO string/timestamp (fixtures). Rows for
+    the same day are summed (the export emits one row per service/SKU), so the connector still lands
+    ONE span per day.
     """
     per_day: dict[date, int] = {}
     for row in rows:
         if not isinstance(row, dict):
             continue
-        raw_day = row.get("usage_start_time") or row.get("day")
-        if not isinstance(raw_day, str):
+        day = _coerce_day(row.get("usage_start_time") or row.get("day"))
+        if day is None:
             continue
-        day = date.fromisoformat(raw_day[:10])
         micro = _to_micro(row.get("cost"))
         if micro <= 0:
             continue
@@ -149,43 +176,90 @@ class AwsCostExplorerClient:
         return parse_aws_cost_response(response)
 
 
-class GcpCloudBillingClient:
-    """GCP Cloud Billing fetcher over the BigQuery billing export. Client imported lazily.
+def build_gcp_billing_query(
+    config: ConnectorConfig, start_day: date, end_day: date
+) -> tuple[str, dict[str, object]]:
+    """Build the parameterized Cloud Billing BigQuery-export query for ``config``.
 
-    ``credentials_ref`` is a Secret Manager reference to the service-account/table config the prod
-    wrapper resolves; unit tests inject a fake instead of constructing this.
+    Returns ``(sql, params)`` where ``params`` maps bind-parameter name → value. The day range and
+    every label key/value are BOUND parameters (never string-interpolated), so a tenant-supplied
+    label can't inject SQL. The export table id is the one value that can't be a bind parameter (BQ
+    can't parameterize identifiers), so it's validated against :data:`_BQ_TABLE_RE` and interpolated.
+
+    Standard Cloud Billing export schema: ``usage_start_time`` (TIMESTAMP), ``cost`` (FLOAT64), and
+    ``labels`` (``ARRAY<STRUCT<key STRING, value STRING>>``). We sum ``cost`` per calendar day for
+    rows carrying every configured label, so the connector lands ONE ``compute`` span per day.
+    """
+    table = config.bq_billing_export_table
+    if not table or not _BQ_TABLE_RE.match(table):
+        raise ValueError(f"invalid or missing bq_billing_export_table: {table!r}")
+
+    labels = config.label_filter or DEFAULT_GCP_LABEL_FILTER
+    params: dict[str, object] = {"start_day": start_day, "end_day": end_day}
+    predicates: list[str] = []
+    for i, (key, value) in enumerate(sorted(labels.items())):
+        kp, vp = f"label_key_{i}", f"label_val_{i}"
+        params[kp] = key
+        params[vp] = value
+        predicates.append(
+            f"EXISTS (SELECT 1 FROM UNNEST(labels) l WHERE l.key = @{kp} AND l.value = @{vp})"
+        )
+    label_predicate = " AND ".join(predicates)
+
+    sql = (
+        "SELECT DATE(usage_start_time) AS day, SUM(cost) AS cost "
+        f"FROM `{table}` "
+        "WHERE DATE(usage_start_time) BETWEEN @start_day AND @end_day "
+        f"AND {label_predicate} "
+        "GROUP BY day ORDER BY day"
+    )
+    return sql, params
+
+
+class GcpCloudBillingClient:
+    """GCP Cloud Billing fetcher over the BigQuery billing export. Client imported LAZILY.
+
+    GCP has no fine-grained REST cost API, so the Cloud Billing *BigQuery export* is the source of
+    truth. This client reads the tenant's ``bq_billing_export_table``, filtered to its GCP
+    ``label_filter``, and sums cost per day.
+
+    Two injection seams keep the whole thing off the network in tests:
+
+    * ``query_runner`` — a ``(config, start_day, end_day) -> list[dict]`` callable that returns raw
+      export rows. Unit tests inject one returning a recorded fixture; nothing touches BigQuery.
+    * ``bq_client`` — a pre-built BigQuery-like client (``.query(sql, job_config=...).result()``).
+      Integration harnesses may supply one; unit tests use ``query_runner`` instead.
+
+    With neither injected, the live path lazily imports ``google-cloud-bigquery`` and constructs a
+    ``bigquery.Client`` from ADC / Workload Identity (``project`` optional) — raw credentials never
+    appear here; ``credentials_ref`` is a Secret Manager pointer the deployment resolves out of band.
     """
 
-    def __init__(self, query_runner=None) -> None:
+    def __init__(self, *, query_runner=None, bq_client=None, project: str | None = None) -> None:
         self._query_runner = query_runner
+        self._bq_client = bq_client
+        self._project = project
 
     def get_daily_costs(
         self, config: ConnectorConfig, *, start_day: date, end_day: date
     ) -> list[DailyCost]:
         if self._query_runner is not None:
             rows = self._query_runner(config, start_day, end_day)
-        else:  # pragma: no cover - exercised only against live GCP
-            from google.cloud import bigquery  # lazy import
+        else:  # pragma: no cover - exercised only against live GCP / an injected bq_client
+            from google.cloud import bigquery  # lazy: keep the SDK out of the base install/test path
 
-            client = bigquery.Client()
-            rows = [dict(r) for r in client.query(_gcp_query(config, start_day, end_day)).result()]
+            client = self._bq_client or bigquery.Client(project=self._project or None)
+            sql, params = build_gcp_billing_query(config, start_day, end_day)
+            job_config = bigquery.QueryJobConfig(
+                query_parameters=[
+                    bigquery.ScalarQueryParameter(
+                        name, "DATE" if isinstance(value, date) else "STRING", value
+                    )
+                    for name, value in params.items()
+                ]
+            )
+            rows = [dict(r) for r in client.query(sql, job_config=job_config).result()]
         return parse_gcp_billing_rows(rows)
-
-
-def _gcp_query(config: ConnectorConfig, start_day: date, end_day: date) -> str:  # pragma: no cover
-    """Placeholder BigQuery billing-export query (the export table id is deployment config)."""
-    tags = config.tag_filter or DEFAULT_TAG_FILTER
-    label_predicate = " AND ".join(
-        f"EXISTS (SELECT 1 FROM UNNEST(labels) l WHERE l.key = '{k}' AND l.value = '{v}')"
-        for k, v in sorted(tags.items())
-    )
-    return (
-        "SELECT DATE(usage_start_time) AS usage_start_time, SUM(cost) AS cost "
-        "FROM `billing_export.gcp_billing` "
-        f"WHERE DATE(usage_start_time) BETWEEN '{start_day.isoformat()}' AND '{end_day.isoformat()}' "
-        f"AND {label_predicate} "
-        "GROUP BY usage_start_time ORDER BY usage_start_time"
-    )
 
 
 class ComputeCostConnector(CloudBillingConnector):
@@ -205,10 +279,14 @@ class ComputeCostConnector(CloudBillingConnector):
         return self._client.get_daily_costs(config, start_day=start_day, end_day=end_day)
 
 
-def build_billing_client(provider: str) -> BillingClient:
-    """Factory: the live :class:`BillingClient` for a provider. Used by the cron/backfill entrypoints."""
+def build_billing_client(provider: str, *, gcp_project: str | None = None) -> BillingClient:
+    """Factory: the live :class:`BillingClient` for a provider. Used by the cron/backfill entrypoints.
+
+    ``gcp_project`` (from ``TALLY_COMPUTE_GCP_BQ_PROJECT``) sets the BigQuery job project for the GCP
+    source; ``None`` falls back to the ADC-resolved default project. Ignored for AWS.
+    """
     if provider == "aws":
         return AwsCostExplorerClient()
     if provider == "gcp":
-        return GcpCloudBillingClient()
+        return GcpCloudBillingClient(project=gcp_project or None)
     raise ValueError(f"unsupported cloud_provider {provider!r} (aws|gcp only)")

--- a/infra/gateway/src/gateway/connectors/config_store.py
+++ b/infra/gateway/src/gateway/connectors/config_store.py
@@ -24,6 +24,13 @@ from gateway.connectors.egress import EgressConfig
 _ALLOWED_STATUSES = frozenset({"success", "partial", "failed"})
 
 
+def _as_dict(value: Any) -> dict[str, str]:
+    """Coerce a JSONB column (dict, raw JSON text, or NULL) to a plain ``dict``."""
+    if isinstance(value, str):  # driver returned raw JSON text
+        value = json.loads(value)
+    return dict(value or {})
+
+
 class TenantComputeConfigStore:
     """Tiny Postgres-backed reader/recorder over ``tenant_compute_config``."""
 
@@ -39,7 +46,8 @@ class TenantComputeConfigStore:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT tenant_id, cloud_provider, credentials_ref, tag_filter
+                SELECT tenant_id, cloud_provider, credentials_ref, tag_filter,
+                       bq_billing_export_table, label_filter
                 FROM tenant_compute_config
                 WHERE tenant_id = %s
                 """,
@@ -48,14 +56,13 @@ class TenantComputeConfigStore:
             row = cur.fetchone()
         if row is None:
             return None
-        tag_filter = row[3]
-        if isinstance(tag_filter, str):  # driver returned raw JSON text
-            tag_filter = json.loads(tag_filter)
         return ConnectorConfig(
             tenant_id=str(row[0]),
             cloud_provider=str(row[1]),
             credentials_ref=str(row[2]),
-            tag_filter=dict(tag_filter or {}),
+            tag_filter=_as_dict(row[3]),
+            bq_billing_export_table=str(row[4] or ""),
+            label_filter=_as_dict(row[5]),
         )
 
     def record_run(

--- a/infra/gateway/src/gateway/replay_store.py
+++ b/infra/gateway/src/gateway/replay_store.py
@@ -116,6 +116,103 @@ class GCSReplayBlobStore:
         return self._bucket.blob(key).download_as_bytes()
 
 
+class S3ReplayBlobStore:
+    """AWS S3 (or S3-compatible, e.g. MinIO) backend for replay sample blobs (CTO-158).
+
+    Mirror of :class:`GCSReplayBlobStore` — satisfies the same :class:`ReplayBlobStore` protocol
+    as :class:`InMemoryReplayBlobStore` and the GCS path: objects are keyed with the identical
+    ``tenants/{tenant_id}/replay_samples/{yyyy/mm/dd}/{sample_id}.json`` layout produced by
+    :func:`build_replay_object_key`, so the ClickHouse index rows and the executor read path are
+    unchanged regardless of which backend is wired. An optional ``prefix`` is prepended to every
+    key (e.g. to share a bucket across environments) without touching the stored index key — the
+    prefix is a storage-layout detail applied on the way in/out only.
+
+    **PII scrub** — the pre-storage PII scrub from CTO-113 runs upstream in the sampler /
+    ``persist_sample`` ingest path, before any ``put_bytes`` call. This backend only moves already
+    scrubbed bytes, so it inherits the scrub unchanged; the CTO-125 candidate-response retention
+    carve-out likewise applies identically here.
+
+    **Auth** — no raw key material is passed. The ``boto3`` S3 client is constructed with the AWS
+    default credential chain, so it transparently picks up an IAM role / IRSA (EKS) / EC2 instance
+    profile / ``AWS_*`` environment credentials / a shared credentials file, in boto3's normal
+    resolution order. We never handle an access key or secret here.
+
+    **Retention** — object lifecycle (TTL / expiration) is expected to be enforced by an S3 bucket
+    lifecycle policy provisioned out-of-band (e.g. Terraform), mirroring the replay
+    ``retention_days`` knob. This backend does NOT create or manage lifecycle rules (out of scope
+    for CTO-158).
+
+    The ``boto3`` dependency is OPTIONAL (``[s3]`` extra) and imported lazily at construction —
+    importing this module never requires the package; only instantiating this class does. That
+    keeps the base gateway install slim and lets it boot without boto3 when unused.
+    """
+
+    __slots__ = ("_bucket", "_prefix", "_client")
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        region: str | None = None,
+        client: object | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("bucket must be non-empty")
+        if client is None:
+            # Lazy import: keep boto3 optional. Constructing the client with no explicit
+            # credentials makes it resolve the AWS default credential chain (IAM role / IRSA /
+            # instance profile / env / shared file) automatically — we never handle a raw key here.
+            import boto3  # type: ignore[import-not-found]
+
+            client = boto3.client("s3", region_name=region)
+        self._client = client
+        self._bucket = bucket
+        # Normalise prefix to a bare, slash-terminated segment (or empty) so key joins are clean.
+        self._prefix = prefix.strip("/")
+
+    def _full_key(self, key: str) -> str:
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def put_bytes(self, key: str, body: bytes, content_type: str = "application/json") -> None:
+        self._client.put_object(
+            Bucket=self._bucket,
+            Key=self._full_key(key),
+            Body=body,
+            ContentType=content_type,
+        )
+
+    def get_bytes(self, key: str) -> bytes:
+        resp = self._client.get_object(Bucket=self._bucket, Key=self._full_key(key))
+        return resp["Body"].read()
+
+    def exists(self, key: str) -> bool:
+        """True if an object lives at ``key``. Uses ``head_object``; a 404/NoSuchKey means absent."""
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=self._full_key(key))
+        except Exception as exc:  # noqa: BLE001 — normalise botocore ClientError (404) to False.
+            if _is_s3_not_found(exc):
+                return False
+            raise
+        return True
+
+
+def _is_s3_not_found(exc: BaseException) -> bool:
+    """Return True for a boto3/botocore 'object not found' error (404 / NoSuchKey / NotFound).
+
+    Kept structural (duck-typed on ``response``) so tests can raise a lightweight stand-in and so
+    the module never needs botocore imported to interpret the error."""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error", {})
+        if str(error.get("Code")) in {"404", "NoSuchKey", "NotFound"}:
+            return True
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if status == 404:
+            return True
+    return False
+
+
 # --- ClickHouse-side index rows --------------------------------------------------------------
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/tests/fixtures/compute/gcp_billing_export.json
+++ b/infra/gateway/tests/fixtures/compute/gcp_billing_export.json
@@ -1,0 +1,6 @@
+[
+  {"usage_start_time": "2026-07-01T00:00:00+00:00", "cost": "3.00", "labels": [{"key": "tally-workload", "value": "ai"}]},
+  {"usage_start_time": "2026-07-01T06:00:00+00:00", "cost": "4.50", "labels": [{"key": "tally-workload", "value": "ai"}]},
+  {"usage_start_time": "2026-07-02T00:00:00+00:00", "cost": "8.25", "labels": [{"key": "tally-workload", "value": "ai"}]},
+  {"usage_start_time": "2026-07-03T00:00:00+00:00", "cost": "0", "labels": [{"key": "tally-workload", "value": "ai"}]}
+]

--- a/infra/gateway/tests/test_connectors_compute.py
+++ b/infra/gateway/tests/test_connectors_compute.py
@@ -15,14 +15,17 @@ touches boto3, BigQuery, ClickHouse, or Postgres.
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from gateway.connectors.base import ConnectorConfig, DailyCost, synthetic_span_id
 from gateway.connectors.compute import (
+    DEFAULT_GCP_LABEL_FILTER,
     ComputeCostConnector,
+    GcpCloudBillingClient,
+    build_gcp_billing_query,
     parse_aws_cost_response,
     parse_gcp_billing_rows,
 )
@@ -86,6 +89,18 @@ def _config(provider: str = "aws") -> ConnectorConfig:
         cloud_provider=provider,
         credentials_ref="aws-default-chain",
         tag_filter={"tally:workload": "ai"},
+    )
+
+
+def _gcp_config(
+    *, table: str = "acme-prod.billing.gcp_billing_export_v1_ABC", label_filter=None
+) -> ConnectorConfig:
+    return ConnectorConfig(
+        tenant_id="t-acme",
+        cloud_provider="gcp",
+        credentials_ref="sm://projects/acme/secrets/tally-billing-sa",
+        bq_billing_export_table=table,
+        label_filter=label_filter if label_filter is not None else {},
     )
 
 
@@ -225,3 +240,123 @@ def test_connector_requires_operation_and_client() -> None:
     connector = ComputeCostConnector(store=FakeStore(), recorder=FakeRecorder(), billing_client=None)
     result = connector.run(_config(), day=date(2026, 7, 1))
     assert result.status == "failed"
+
+
+# --- GCP Cloud Billing (BigQuery export) source (CTO-150) --------------------------------------
+
+
+def test_build_gcp_billing_query_binds_days_and_labels() -> None:
+    # Every label + the day range is a BOUND parameter (no interpolation), and the default label
+    # filter is applied when the tenant hasn't set one.
+    sql, params = build_gcp_billing_query(
+        _gcp_config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 30)
+    )
+    assert "`acme-prod.billing.gcp_billing_export_v1_ABC`" in sql
+    assert "BETWEEN @start_day AND @end_day" in sql
+    assert "UNNEST(labels)" in sql and "l.key = @label_key_0 AND l.value = @label_val_0" in sql
+    assert params["start_day"] == date(2026, 7, 1)
+    assert params["end_day"] == date(2026, 7, 30)
+    # DEFAULT_GCP_LABEL_FILTER == {"tally-workload": "ai"} — note the '-' (GCP keys can't hold ':').
+    assert params["label_key_0"] == "tally-workload"
+    assert params["label_val_0"] == "ai"
+    assert DEFAULT_GCP_LABEL_FILTER == {"tally-workload": "ai"}
+
+
+def test_build_gcp_billing_query_rejects_missing_or_unsafe_table() -> None:
+    with pytest.raises(ValueError, match="bq_billing_export_table"):
+        build_gcp_billing_query(
+            _gcp_config(table=""), start_day=date(2026, 7, 1), end_day=date(2026, 7, 2)
+        )
+    with pytest.raises(ValueError, match="bq_billing_export_table"):
+        build_gcp_billing_query(
+            _gcp_config(table="billing`; DROP TABLE x --"),
+            start_day=date(2026, 7, 1),
+            end_day=date(2026, 7, 2),
+        )
+
+
+def test_gcp_client_parses_injected_export_rows() -> None:
+    # The BQ-touching client never needs google-cloud-bigquery: inject a query_runner that returns
+    # the recorded export fixture. Per-SKU rows for the same day are summed into ONE DailyCost.
+    rows = _fixture("gcp_billing_export.json")
+    client = GcpCloudBillingClient(query_runner=lambda config, s, e: rows)
+    costs = client.get_daily_costs(
+        _gcp_config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 3)
+    )
+    assert costs == [
+        DailyCost(day=date(2026, 7, 1), cost_micro_usd=7_500_000),  # 3.00 + 4.50
+        DailyCost(day=date(2026, 7, 2), cost_micro_usd=8_250_000),
+        # 2026-07-03 is $0 → dropped.
+    ]
+
+
+def test_parse_gcp_billing_rows_accepts_date_and_datetime_objects() -> None:
+    # The live BigQuery client hands back date/datetime objects, not ISO strings.
+    costs = parse_gcp_billing_rows(
+        [
+            {"day": date(2026, 7, 1), "cost": 3.0},
+            {"usage_start_time": datetime(2026, 7, 1, 6, tzinfo=timezone.utc), "cost": 4.5},
+            {"day": date(2026, 7, 2), "cost": "8.25"},
+        ]
+    )
+    assert costs == [
+        DailyCost(day=date(2026, 7, 1), cost_micro_usd=7_500_000),
+        DailyCost(day=date(2026, 7, 2), cost_micro_usd=8_250_000),
+    ]
+
+
+def test_gcp_run_emits_one_compute_span_per_day() -> None:
+    store, recorder = FakeStore(), FakeRecorder()
+    rows = _fixture("gcp_billing_export.json")
+    connector = ComputeCostConnector(
+        store=store,
+        recorder=recorder,
+        billing_client=GcpCloudBillingClient(query_runner=lambda config, s, e: rows),
+    )
+
+    result = connector.run_backfill(
+        _gcp_config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 3)
+    )
+
+    assert result.status == "success"
+    assert result.spans_emitted == 2  # two non-zero days
+    assert len(store.rows) == 2
+    assert all(r[_OP] == "compute" and r[_SYSTEM] == "gcp" for r in store.rows)
+    assert float(store.rows[0][_COST]) == pytest.approx(7.50)
+    assert recorder.calls == [("t-acme", "compute", "success", None)]
+
+
+def test_gcp_backfill_is_idempotent() -> None:
+    store = FakeStore()
+    rows = _fixture("gcp_billing_export.json")
+    connector = ComputeCostConnector(
+        store=store,
+        recorder=FakeRecorder(),
+        billing_client=GcpCloudBillingClient(query_runner=lambda config, s, e: rows),
+    )
+    first = connector.run_backfill(_gcp_config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 3))
+    second = connector.run_backfill(_gcp_config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 3))
+    assert first.spans_emitted == 2
+    assert second.spans_emitted == 0  # deterministic span-id guard → no double-count
+    assert len(store.rows) == 2
+
+
+def test_gcp_failed_fetch_records_failed_and_emits_no_span() -> None:
+    store, recorder = FakeStore(), FakeRecorder()
+
+    def _boom(config, s, e):
+        raise RuntimeError("bigquery 403 permission denied")
+
+    connector = ComputeCostConnector(
+        store=store,
+        recorder=recorder,
+        billing_client=GcpCloudBillingClient(query_runner=_boom),
+    )
+
+    result = connector.run(_gcp_config(), day=date(2026, 7, 1))
+
+    assert result.status == "failed"
+    assert result.spans_emitted == 0
+    assert store.rows == []  # honest-under-uncertainty: never a guessed number
+    assert recorder.calls[0][2] == "failed"
+    assert "bigquery 403" in (recorder.calls[0][3] or "")

--- a/infra/gateway/tests/test_replay_store_s3.py
+++ b/infra/gateway/tests/test_replay_store_s3.py
@@ -1,0 +1,264 @@
+"""Unit tests for the S3 replay blob-store backend (CTO-158).
+
+These use an in-memory fake that mimics the ``boto3`` S3 client surface we touch
+(``client.put_object`` / ``client.get_object`` / ``client.head_object``), so no network access,
+real bucket, or credentials are required and ``boto3`` need not be installed to run the suite.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from gateway.config import Settings
+from gateway.replay_sampler import ReplaySamplePayload
+from gateway.replay_store import (
+    InMemoryReplayBlobStore,
+    S3ReplayBlobStore,
+    build_replay_object_key,
+    persist_sample,
+)
+
+UTC = timezone.utc
+
+
+# --- Fake boto3 S3 client --------------------------------------------------------------------
+
+class _FakeClientError(Exception):
+    """Stand-in for ``botocore.exceptions.ClientError`` — carries a ``response`` dict."""
+
+    def __init__(self, code: str, status: int = 404) -> None:
+        super().__init__(code)
+        self.response = {
+            "Error": {"Code": code},
+            "ResponseMetadata": {"HTTPStatusCode": status},
+        }
+
+
+class _FakeS3Client:
+    """Backed by one dict per client instance. Records puts/heads for assertions."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.content_types: dict[str, str] = {}
+        self.buckets_used: list[str] = []
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str) -> None:
+        self.buckets_used.append(Bucket)
+        self.objects[Key] = Body
+        self.content_types[Key] = ContentType
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        self.buckets_used.append(Bucket)
+        if Key not in self.objects:
+            raise _FakeClientError("NoSuchKey")
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        self.buckets_used.append(Bucket)
+        if Key not in self.objects:
+            raise _FakeClientError("404")
+        return {"ContentLength": len(self.objects[Key])}
+
+
+def _payload() -> ReplaySamplePayload:
+    return ReplaySamplePayload(
+        sample_id=uuid4(),
+        trace_id="trace-abc",
+        feature_tag="checkout",
+        real_provider="openai",
+        real_model="gpt-4o",
+        input_tokens=120,
+        output_tokens=45,
+        scrubbed_json=b'{"messages": [{"role": "user", "content": "hi"}]}',
+        pii_scrubbed=True,
+    )
+
+
+# --- Round-trip ------------------------------------------------------------------------------
+
+def test_persisted_sample_round_trips_through_s3() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="tally-replay", client=client)
+    payload = _payload()
+    captured_at = datetime(2026, 7, 12, 9, 30, tzinfo=UTC)
+
+    row = persist_sample(
+        blob_store=store,
+        tenant_id="tenant-1",
+        payload=payload,
+        captured_at=captured_at,
+    )
+
+    # Keyed identically to the in-memory/GCS path.
+    expected_key = build_replay_object_key("tenant-1", payload.sample_id, captured_at)
+    assert row.s3_object_key == expected_key
+    # Write-then-read returns the same envelope bytes.
+    assert store.get_bytes(expected_key) == payload.scrubbed_json
+
+
+def test_s3_key_matches_in_memory_backend() -> None:
+    client = _FakeS3Client()
+    s3 = S3ReplayBlobStore(bucket="b", client=client)
+    mem = InMemoryReplayBlobStore()
+    payload = _payload()
+    captured_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+
+    s3_row = persist_sample(blob_store=s3, tenant_id="t", payload=payload, captured_at=captured_at)
+    mem_row = persist_sample(
+        blob_store=mem, tenant_id="t", payload=payload, captured_at=captured_at
+    )
+    assert s3_row.s3_object_key == mem_row.s3_object_key
+    assert s3.get_bytes(s3_row.s3_object_key) == mem.get_bytes(mem_row.s3_object_key)
+
+
+def test_content_type_passed_and_bucket_used() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="my-bucket", client=client)
+    store.put_bytes("tenants/t/x.json", b"{}", content_type="application/json")
+    assert client.objects["tenants/t/x.json"] == b"{}"
+    assert client.content_types["tenants/t/x.json"] == "application/json"
+    assert "my-bucket" in client.buckets_used
+
+
+# --- exists() --------------------------------------------------------------------------------
+
+def test_exists_true_after_put_and_false_when_absent() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="b", client=client)
+    assert store.exists("tenants/t/missing.json") is False
+    store.put_bytes("tenants/t/present.json", b"{}")
+    assert store.exists("tenants/t/present.json") is True
+
+
+def test_exists_reraises_non_404_errors() -> None:
+    class _BoomClient(_FakeS3Client):
+        def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            raise _FakeClientError("AccessDenied", status=403)
+
+    store = S3ReplayBlobStore(bucket="b", client=_BoomClient())
+    with pytest.raises(_FakeClientError):
+        store.exists("tenants/t/x.json")
+
+
+# --- Prefix ----------------------------------------------------------------------------------
+
+def test_prefix_is_applied_to_stored_key_but_not_index_key() -> None:
+    client = _FakeS3Client()
+    store = S3ReplayBlobStore(bucket="b", prefix="env/staging/", client=client)
+    store.put_bytes("tenants/t/x.json", b"{}")
+    # Prefix is prepended (normalised, no leading/trailing slash duplication) on the way to S3.
+    assert "env/staging/tenants/t/x.json" in client.objects
+    assert "tenants/t/x.json" not in client.objects
+    # Round-trip through the same prefixed store still resolves.
+    assert store.get_bytes("tenants/t/x.json") == b"{}"
+    assert store.exists("tenants/t/x.json") is True
+
+
+def test_empty_bucket_rejected() -> None:
+    with pytest.raises(ValueError):
+        S3ReplayBlobStore(bucket="", client=_FakeS3Client())
+
+
+# --- Backend selection via settings ----------------------------------------------------------
+
+def test_backend_selection_defaults_to_memory() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="memory")
+    store = _build_replay_blob_store(settings)
+    assert isinstance(store, InMemoryReplayBlobStore)
+
+
+def test_backend_selection_picks_s3(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.app import _build_replay_blob_store
+
+    # Avoid needing the real client: swap the class so construction doesn't touch boto3.
+    captured: dict[str, object] = {}
+
+    class _StubS3:
+        def __init__(self, bucket: str, *, prefix: str = "", region: str | None = None) -> None:
+            captured["bucket"] = bucket
+            captured["prefix"] = prefix
+            captured["region"] = region
+
+    monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)
+    settings = Settings(
+        replay_blob_backend="s3",
+        replay_s3_bucket="tally-replay-prod",
+        replay_s3_prefix="env/prod",
+        replay_s3_region="us-east-1",
+    )
+    store = _build_replay_blob_store(settings)
+    assert isinstance(store, _StubS3)
+    assert captured == {
+        "bucket": "tally-replay-prod",
+        "prefix": "env/prod",
+        "region": "us-east-1",
+    }
+
+
+def test_s3_empty_region_resolves_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.app import _build_replay_blob_store
+
+    captured: dict[str, object] = {}
+
+    class _StubS3:
+        def __init__(self, bucket: str, *, prefix: str = "", region: str | None = None) -> None:
+            captured["region"] = region
+
+    monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)
+    settings = Settings(replay_blob_backend="s3", replay_s3_bucket="b")
+    _build_replay_blob_store(settings)
+    # Empty string region -> None so boto3 resolves from the AWS default chain.
+    assert captured["region"] is None
+
+
+def test_s3_backend_requires_bucket() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="s3", replay_s3_bucket="")
+    with pytest.raises(ValueError):
+        _build_replay_blob_store(settings)
+
+
+def test_unknown_backend_rejected() -> None:
+    from gateway.app import _build_replay_blob_store
+
+    settings = Settings(replay_blob_backend="s4")
+    with pytest.raises(ValueError):
+        _build_replay_blob_store(settings)
+
+
+# --- Lazy import -----------------------------------------------------------------------------
+
+def test_replay_store_imports_without_boto3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing replay_store must not require boto3; only constructing the store (without an
+    injected client) does. Simulate the package being absent and re-import."""
+    # Block any boto3 import.
+    for name in list(sys.modules):
+        if name == "boto3" or name.startswith("boto3."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = importlib.import_module
+
+    def _blocking_import(name: str, *args, **kwargs):
+        if name == "boto3" or name.startswith("boto3."):
+            raise ModuleNotFoundError("No module named 'boto3'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _blocking_import)
+
+    # Module (re)import works fine even with boto3 unavailable.
+    mod = importlib.reload(importlib.import_module("gateway.replay_store"))
+    assert hasattr(mod, "S3ReplayBlobStore")
+
+    # And an injected client sidesteps the lazy import entirely, so the store is still usable.
+    store = mod.S3ReplayBlobStore(bucket="b", client=_FakeS3Client())
+    store.put_bytes("k", b"v")
+    assert store.get_bytes("k") == b"v"


### PR DESCRIPTION
## CTO-150 — GCP Cloud Billing connector for the Compute cost layer

Makes GCP a first-class compute source, reusing the CTO-143 `CloudBillingConnector` base (same `'compute'` layer, same deterministic `synthetic_span_id` idempotency, same `emit_cost_span`).

### Approach
GCP has **no fine-grained REST cost API**, so the Cloud Billing **BigQuery export** is the source of truth. The GCP path reads a tenant-configured export table, filtered to a GCP label set (default `tally-workload=ai` — GCP label keys can't hold `:`, unlike the AWS `tally:workload` tag), and aggregates by day into **one synthetic `compute` span/day**.

- `google-cloud-bigquery` is **lazy-imported** behind an injectable client (`query_runner` / `bq_client`), so the gateway boots — and the whole test suite runs — with no SDK and **no network**.
- `build_gcp_billing_query` is a pure, **parameterized** builder: the day range and every label key/value are bound params; the export table (the one identifier BQ can't bind) is validated against a safe charset before interpolation.
- Auth is by **reference only** — ADC / Workload Identity / Secret Manager pointer. No raw credentials in the DB, the code, or logs.

### Migration
`db/postgres/0015_tenant_compute_config_gcp.sql` — additive `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for `bq_billing_export_table` + `label_filter` (default `{"tally-workload":"ai"}`). AWS rows unaffected. (0015 was free on `origin/main`; no rebase needed.)

### config.py
Added `TALLY_COMPUTE_GCP_*` settings (`compute_gcp_enabled`, `compute_gcp_bq_project`, `compute_gcp_default_billing_export_table`) as a new additive block after the CTO-154 `bq_export_*` block — no logic changes, no conflict with the run's other `config.py` edits.

### Backfill
`scripts/backfill_gcp_compute.py --days 30 --tenant <id>` — idempotent on `(tenant, period, project)` via the base span-id guard.

### Tests (no network)
7 new tests: fixture BQ export → correct daily totals, query builder binds days+labels and rejects unsafe/missing tables, live-shape date/datetime parsing, one-span-per-day emission, idempotent backfill, and a failed fetch that records `failed` + emits no span. Suite: **324 passed**, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)