### PR TITLE
feat(deploy): AWS deployment path (EKS/ECS + Secrets Manager + IRSA) (CTO-159)

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,372 @@
+# Deploying ai-tally on AWS (ECS-Fargate or EKS)
+
+A from-zero runbook for running ai-tally's two application tiers — the **ingest gateway**
+(FastAPI/uvicorn) and the **Next.js dashboard** — on AWS, wired to AWS-managed backing stores and
+AWS-native secrets + identity. This is the AWS counterpart to the GCP runbook in
+[`deploy/gcp/README.md`](../gcp/README.md) (CTO-153); the pipeline shape is identical, only the
+backing services and the identity/secrets plumbing change:
+
+```
+ send_batch / SDK ──POST /v1/batches──▶  gateway (ECS-Fargate service or EKS Deployment)
+                                              │  auth → rate-limit → idempotency →
+                                              │  validate → enrich cost → map to row
+                                              ▼
+                                         ClickHouse  (ClickHouse Cloud, or in-cluster StatefulSet)
+                                              ▲
+   browser ──▶ Next.js web ──Route Handler──┘   (queries ClickHouse live + calls the gateway)
+
+ control plane:  Postgres  ──▶  RDS for PostgreSQL
+ replay blobs:   object store ─▶ S3 bucket (CTO-152)
+ secrets:        provider keys / DB creds ─▶ AWS Secrets Manager (consumed via IRSA / task roles)
+```
+
+Everything here is **additive** — it does not touch `infra/docker-compose.yml`, the app source, or
+the local dev flow. It reuses the **same images** the GCP path uses: the gateway
+(`infra/gateway/Dockerfile`) and the web tier (`web/Dockerfile`).
+
+## What's in this directory
+
+```
+deploy/aws/
+├── README.md                       this runbook
+├── ecs/                            PRIMARY — ECS-on-Fargate task/service definitions
+│   ├── gateway.taskdef.json        gateway task definition (Secrets Manager injection, task role)
+│   ├── web.taskdef.json            web task definition
+│   ├── gateway.service.json        gateway ECS service (Fargate, ALB target group)
+│   ├── web.service.json            web ECS service
+│   └── iam/
+│       ├── task-role-policy.json          workload identity: S3 replay + Cost Explorer + Bedrock (+Secrets)
+│       ├── execution-role-policy.json     ECS execution role: ECR pull + logs + secret injection
+│       ├── ecs-tasks-trust-policy.json    trust policy for the ECS task/execution roles
+│       └── irsa-trust-policy.json         trust policy for the EKS IRSA role (OIDC)
+└── helm/ai-tally-eks/              SECONDARY — EKS Helm chart (gateway + web + optional ClickHouse)
+    ├── Chart.yaml
+    ├── values.yaml                 all knobs, documented
+    ├── values-eks.example.yaml     a filled-in example override file
+    └── templates/                  Deployments, Services, ConfigMaps, ServiceAccount (IRSA),
+                                    SecretProviderClass (Secrets Manager via CSI), HPAs
+```
+
+## ECS-Fargate vs EKS — which to pick
+
+**ECS-Fargate is the primary/default AWS path** (this ticket's recommendation): it is the closest
+AWS analog of the GCP Cloud Run path — fully managed, no cluster to operate, per-task billing, two
+independent services. Reach for **EKS** only when you already run a cluster or need in-cluster
+workloads (a ClickHouse StatefulSet, DaemonSets, a service mesh).
+
+| Pick **ECS-Fargate** when… | Pick **EKS** when… |
+|---|---|
+| You want the least ops: no cluster/nodes to manage, Fargate runs the tasks. | You already run an EKS cluster / want pods next to other in-cluster services. |
+| You're fine with the two tiers as independent managed services behind an ALB. | You need an in-cluster ClickHouse StatefulSet, DaemonSets, or fine pod control. |
+| You want the simplest secrets story: `secrets[].valueFrom` injects at task start. | You want one Helm release, HPAs, and k8s-native networking/mesh. |
+
+Both paths use the **same images**, the **same Secrets Manager secrets**, and the **same workload
+IAM role** (`ai-tally-workload`) — ECS attaches it as the task role; EKS binds it to the KSA via
+IRSA. You can start on ECS and lift to EKS later without rebuilding anything.
+
+> Backing stores (RDS, ClickHouse, S3) are shared by both paths and are provisioned once (steps
+> 3–4). Only the compute deploy (step 7) differs.
+
+### Mapping to the GCP (CTO-153) path
+
+| Concern | GCP (CTO-153) | AWS (this ticket) |
+|---|---|---|
+| Managed serverless compute | Cloud Run | **ECS-Fargate** (primary) |
+| Cluster compute | GKE + Helm | EKS + Helm (`helm/ai-tally-eks`) |
+| Control-plane DB | Cloud SQL for Postgres | **RDS for PostgreSQL** |
+| Telemetry store | ClickHouse Cloud / in-cluster STS | ClickHouse Cloud / in-cluster STS |
+| Streaming buffer (CTO-37) | Pub/Sub-style | **MSK** or self-hosted **Redpanda** |
+| Replay blobs (CTO-152) | GCS bucket | **S3 bucket** |
+| Secrets | Secret Manager + CSI | **Secrets Manager** + CSI / task injection |
+| Workload identity | Workload Identity (GSA↔KSA) | **IRSA** (EKS) / **task role** (ECS) |
+| DB connectivity | Cloud SQL Auth Proxy sidecar | RDS direct over the VPC (no sidecar) |
+
+---
+
+## 0. Prerequisites
+
+- `aws` CLI v2 authenticated (`aws sts get-caller-identity` succeeds) with a default region.
+- For EKS: `eksctl`, `kubectl`, and `helm` (v3).
+- Shell variables used throughout (edit and export):
+
+```bash
+export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export REGION=us-east-1
+export ECR=$ACCOUNT.dkr.ecr.$REGION.amazonaws.com
+export IMAGE_TAG=1.0.0                         # or a git sha
+```
+
+## 1. ECR — build & push images
+
+The gateway build context is the **repo root** (its Dockerfile COPYs both the gateway and the SDK it
+depends on); the web build context is `web/`.
+
+```bash
+aws ecr create-repository --repository-name ai-tally/gateway --region "$REGION"
+aws ecr create-repository --repository-name ai-tally/web --region "$REGION"
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ECR"
+
+docker build -t "$ECR/ai-tally/gateway:$IMAGE_TAG" -f infra/gateway/Dockerfile .
+docker build -t "$ECR/ai-tally/web:$IMAGE_TAG" web/
+docker push "$ECR/ai-tally/gateway:$IMAGE_TAG"
+docker push "$ECR/ai-tally/web:$IMAGE_TAG"
+```
+
+## 2. Networking (shared)
+
+Both paths run in a VPC with private subnets for the tasks/pods and RDS, and (for public ingress) an
+ALB in public subnets. Use your existing VPC, or `eksctl create cluster` (step 7B) which creates one.
+Ensure the compute security group can reach **RDS:5432** and **ClickHouse:8123/8443**.
+
+## 3. Provision RDS (Postgres control plane)
+
+```bash
+aws rds create-db-instance \
+  --db-instance-identifier ai-tally-pg \
+  --engine postgres --engine-version 16 \
+  --db-instance-class db.t3.medium \
+  --allocated-storage 20 \
+  --master-username tally \
+  --master-user-password 'CHOOSE_A_STRONG_PASSWORD' \
+  --db-name tally \
+  --no-publicly-accessible \
+  --vpc-security-group-ids sg-YOUR_DB_SG
+
+# Endpoint (host) for the DSN:
+aws rds describe-db-instances --db-instance-identifier ai-tally-pg \
+  --query 'DBInstances[0].Endpoint.Address' --output text
+```
+
+The DSN you store as the `postgresDsn` secret (step 5) is:
+`postgresql://tally:PASS@<rds-endpoint>:5432/tally`. Unlike GCP's Cloud SQL, **there is no
+auth-proxy sidecar** — the gateway reaches RDS directly over the VPC. (IAM database authentication is
+an optional hardening step: enable `--enable-iam-database-authentication`, grant `rds-db:connect` on
+the task/IRSA role, and issue a short-lived token instead of a password — left to the operator.)
+
+Apply the control-plane DDL (`db/postgres/*.sql`) once — e.g. connect from a bastion / a one-off task
+in the VPC and run the migrations in order.
+
+## 4. Provision ClickHouse + the S3 replay bucket + (optional) MSK/Redpanda
+
+**ClickHouse** — two supported shapes (identical to GCP):
+
+- **ClickHouse Cloud (recommended for production):** create a service on AWS, note its HTTPS host and
+  port (usually `:8443`), and the `tally` user's password. The gateway + web talk to it over HTTP(S).
+- **In-cluster StatefulSet (EKS staging only):** set `clickhouse.mode=statefulset` in the chart.
+  Apply the canonical DDL (`db/clickhouse/*.sql`) via an initdb ConfigMap mounted at
+  `/docker-entrypoint-initdb.d`. Single-node, not HA. On ECS-Fargate there is no in-cluster option —
+  use ClickHouse Cloud.
+
+**S3 bucket** for replay blobs (CTO-152):
+
+```bash
+aws s3 mb "s3://$ACCOUNT-ai-tally-replay" --region "$REGION"
+```
+
+**Streaming buffer (optional, CTO-37 `TALLY_INGEST_BUFFERED=true`):** the in-process burst buffer has
+no external dependency. For a durable cross-instance buffer, provision **Amazon MSK** (managed Kafka)
+or run **Redpanda** (self-hosted, Kafka-API compatible) in the VPC, and point the gateway's buffer at
+it. Not required for the synchronous default; documented here as the AWS analog of the GCP note.
+
+## 5. Secrets Manager — create the secrets
+
+Store every secret value here; the task defs / manifests reference them **by ARN** and never contain
+the value.
+
+```bash
+aws secretsmanager create-secret --name ai-tally-postgres-dsn \
+  --secret-string "postgresql://tally:PASS@<rds-endpoint>:5432/tally"
+aws secretsmanager create-secret --name ai-tally-clickhouse-password \
+  --secret-string 'YOUR_CLICKHOUSE_PASSWORD'
+
+# Provider keys are OPTIONAL — the gateway boots fail-soft without them (CTO-109). Skip if you use
+# Bedrock (granted via the workload role) or have no outbound provider calls.
+aws secretsmanager create-secret --name ai-tally-openai-api-key    --secret-string 'sk-...'
+aws secretsmanager create-secret --name ai-tally-anthropic-api-key --secret-string 'sk-ant-...'
+```
+
+> **Not deploy-time secrets:** the **Stripe** webhook signing secret is pasted per-tenant in the
+> dashboard and persisted in Postgres (`db/postgres/0003_tenant_stripe_config.sql`) — protect it by
+> protecting RDS, not via an env var. Per-tenant **HMAC** user-id keys (CTO-74) live in the gateway's
+> runtime `HmacKeyRegistry`, provisioned per-tenant — also not a deploy secret.
+
+## 6. Identity — task role (ECS) / IRSA (EKS)
+
+Create **one workload IAM role** and grant it exactly what the app needs. No static access key is
+ever created. The permissions policy is `ecs/iam/task-role-policy.json` (S3 replay + Cost Explorer +
+Bedrock + Secrets Manager read); reuse it verbatim for both paths — only the **trust** differs.
+
+```bash
+# The permissions policy (shared by both paths):
+aws iam create-policy --policy-name ai-tally-workload \
+  --policy-document file://deploy/aws/ecs/iam/task-role-policy.json
+export WORKLOAD_POLICY_ARN=arn:aws:iam::$ACCOUNT:policy/ai-tally-workload
+```
+
+**ECS** — create the task role (trusted by `ecs-tasks.amazonaws.com`) and the execution role:
+
+```bash
+# Task role = the app's own identity (S3 / Cost Explorer / Bedrock).
+aws iam create-role --role-name ai-tally-workload \
+  --assume-role-policy-document file://deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+aws iam attach-role-policy --role-name ai-tally-workload --policy-arn "$WORKLOAD_POLICY_ARN"
+
+# Execution role = what Fargate needs to START a task (ECR pull, logs, secret injection).
+aws iam create-role --role-name ai-tally-ecs-execution \
+  --assume-role-policy-document file://deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+aws iam put-role-policy --role-name ai-tally-ecs-execution --policy-name ai-tally-ecs-execution \
+  --policy-document file://deploy/aws/ecs/iam/execution-role-policy.json
+```
+
+**EKS** — bind the same permissions to the KSA the chart creates (`ai-tally` in namespace
+`ai-tally`) via IRSA. Easiest with `eksctl`, which writes the OIDC trust policy for you:
+
+```bash
+eksctl utils associate-iam-oidc-provider --cluster ai-tally --approve
+eksctl create iamserviceaccount \
+  --cluster ai-tally --namespace ai-tally --name ai-tally \
+  --role-name ai-tally-workload \
+  --attach-policy-arn "$WORKLOAD_POLICY_ARN" \
+  --approve
+# Note the role ARN it prints; pass it as serviceAccount.roleArn (step 7B). Because eksctl already
+# created the KSA, set serviceAccount.create=false, OR let the chart create it and instead apply the
+# trust manually from ecs/iam/irsa-trust-policy.json (replace ACCOUNT/REGION/OIDC_ID).
+```
+
+The IRSA role also needs the Secrets Store CSI driver's AWS provider installed (step 7B).
+
+## 7. Deploy
+
+### Option A — ECS-Fargate (primary)
+
+Create the cluster and the CloudWatch log groups, then register the task defs and create the
+services. Deploy the **gateway first**, wire an ALB target group to it, capture its URL, then deploy
+web pointed at it.
+
+```bash
+aws ecs create-cluster --cluster-name ai-tally
+
+# Substitute placeholders and register the gateway task def:
+sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+    -e "s/REPLACE_CLICKHOUSE_HOST/YOUR_CLICKHOUSE_HOST/g" \
+    deploy/aws/ecs/gateway.taskdef.json > /tmp/gateway.taskdef.json
+aws ecs register-task-definition --cli-input-json file:///tmp/gateway.taskdef.json
+
+# Create the gateway service (edit subnets/SGs/targetGroupArn in the file first):
+aws ecs create-service --cli-input-json file://deploy/aws/ecs/gateway.service.json
+
+# After the gateway is reachable behind its ALB, capture GATEWAY_URL (the ALB DNS/HTTPS URL), then:
+sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+    -e "s#REPLACE_GATEWAY_URL#https://YOUR_GATEWAY_ALB#g" \
+    -e "s#REPLACE_CLICKHOUSE_URL#https://YOUR_CLICKHOUSE_HOST:8443#g" \
+    deploy/aws/ecs/web.taskdef.json > /tmp/web.taskdef.json
+aws ecs register-task-definition --cli-input-json file:///tmp/web.taskdef.json
+aws ecs create-service --cli-input-json file://deploy/aws/ecs/web.service.json
+```
+
+Notes on the task defs:
+- **Secrets** are injected from Secrets Manager by Fargate at task start via `secrets[].valueFrom`
+  (a secret ARN) — the value never appears in the file or in the registered task def. The **execution
+  role** must be able to read them (`execution-role-policy.json`).
+- Provider-key secret entries are optional — delete them from `gateway.taskdef.json` if you did not
+  create those secrets (or if you use Bedrock via the task role instead).
+- Fronting is an **ALB**: create a target group per tier (`ai-tally-gateway` on 8080, `ai-tally-web`
+  on 3000, health-check paths `/healthz` and `/`), an HTTPS listener, and put the target-group ARNs
+  into the `*.service.json` files. For internal-only, use an internal ALB.
+
+### Option B — EKS (Helm)
+
+Create the cluster (with OIDC for IRSA), install the Secrets Store CSI driver + AWS provider, then
+install the chart with your overrides.
+
+```bash
+eksctl create cluster --name ai-tally --region "$REGION" --nodes 2 --with-oidc
+
+# Secrets Store CSI driver + AWS provider (installs the DaemonSet + SecretProviderClass CRD):
+helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver \
+  --namespace kube-system --set syncSecret.enabled=true
+kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
+
+# IRSA (step 6) must be done so the KSA can read Secrets Manager. Then:
+cp deploy/aws/helm/ai-tally-eks/values-eks.example.yaml my-values.yaml
+$EDITOR my-values.yaml     # fill in aws.region/accountId, serviceAccount.roleArn, image repos, CH host
+
+helm upgrade --install ai-tally deploy/aws/helm/ai-tally-eks \
+  --namespace ai-tally --create-namespace \
+  -f my-values.yaml
+```
+
+The chart renders: an IRSA-annotated ServiceAccount, a SecretProviderClass that syncs the Secrets
+Manager secrets into a Kubernetes Secret, gateway + web Deployments/Services, optional HPAs, and —
+if `clickhouse.mode=statefulset` — an in-cluster ClickHouse. See `templates/NOTES.txt` (printed on
+install) for the smoke-test commands. If you created the KSA with `eksctl create iamserviceaccount`,
+set `serviceAccount.create=false` so Helm reuses it.
+
+## 8. Smoke test
+
+```bash
+# ECS (behind the ALB):
+curl -s "https://YOUR_GATEWAY_ALB/healthz"          # {"status":"ok"}
+
+# EKS:
+kubectl -n ai-tally port-forward svc/ai-tally-gateway 8080:8080 &
+curl -s localhost:8080/healthz                      # {"status":"ok"}
+```
+
+Then send a batch (the same payload as `RUNNING.md` step 3, pointed at your gateway URL) and confirm
+rows land in ClickHouse. Finally open the web URL — the **Cost**, **Features**, **Agents**, and
+**Data Quality** pages should render your ingested spans.
+
+## 9. Point the dashboard at production tenants
+
+The web tier defaults to tenant `local-dev`. For real tenants, set `web.config.tenantId` (EKS) or the
+`TALLY_TENANT_ID` env (ECS `web.taskdef.json`), and keep `gateway.config.requireApiKey=true` (the
+cloud default) so ingest requires `Authorization: Bearer <key>` — seed keys with the gateway's
+`seed.py` against RDS.
+
+## 10. Teardown
+
+```bash
+# ECS
+aws ecs update-service --cluster ai-tally --service ai-tally-web --desired-count 0
+aws ecs update-service --cluster ai-tally --service ai-tally-gateway --desired-count 0
+aws ecs delete-service --cluster ai-tally --service ai-tally-web --force
+aws ecs delete-service --cluster ai-tally --service ai-tally-gateway --force
+aws ecs delete-cluster --cluster ai-tally
+
+# EKS
+helm uninstall ai-tally -n ai-tally
+eksctl delete cluster --name ai-tally --region "$REGION"
+
+# Shared backing stores + identity (irreversible — deletes data):
+aws rds delete-db-instance --db-instance-identifier ai-tally-pg --skip-final-snapshot
+aws s3 rb "s3://$ACCOUNT-ai-tally-replay" --force
+for s in ai-tally-postgres-dsn ai-tally-clickhouse-password ai-tally-openai-api-key ai-tally-anthropic-api-key; do
+  aws secretsmanager delete-secret --secret-id "$s" --force-delete-without-recovery
+done
+aws iam delete-role --role-name ai-tally-workload
+aws iam delete-role --role-name ai-tally-ecs-execution
+# (detach/delete the ai-tally-workload policy and any ECR repos / ALB / target groups you created.)
+```
+
+---
+
+## Open TODOs (documented, out of scope for CTO-159)
+
+- **Terraform/CloudFormation IaC** — this ticket ships ECS task defs + a Helm chart + `aws` CLI docs
+  for v1; codify the account bootstrap (VPC, RDS, ClickHouse, Secrets Manager, IAM, ALB) as IaC in a
+  follow-up.
+- **S3 replay wiring** — the bucket + IAM are provisioned here and the gateway exposes
+  `TALLY_REPLAY_BLOB_BACKEND`/`TALLY_REPLAY_S3_BUCKET` knobs, but an S3 replay blob-store backend
+  itself (the AWS analog of the GCS backend added under CTO-152) is a follow-up; today the supported
+  backends are `memory` and `gcs`.
+- **In-cluster ClickHouse DDL bootstrap (EKS)** — the StatefulSet path expects you to mount
+  `db/clickhouse` as an initdb ConfigMap; a chart hook to build/apply it automatically is a follow-up.
+- **ALB Ingress / TLS + custom domain** — the ECS services expect an ALB target group you create; the
+  EKS chart ships ClusterIP Services (port-forward / your own AWS Load Balancer Controller Ingress).
+  A managed-cert ALB Ingress and domain mapping are left to the operator.
+- **MSK/Redpanda streaming buffer** — provisioning notes are here; binding the gateway's CTO-37 burst
+  buffer to a durable Kafka-API broker is a follow-up.
+- **Autoscaling tuning / multi-AZ HA for ClickHouse** — single-region defaults; explicitly out of scope.
+```

--- a/deploy/aws/ecs/gateway.service.json
+++ b/deploy/aws/ecs/gateway.service.json
@@ -1,0 +1,28 @@
+{
+  "cluster": "ai-tally",
+  "serviceName": "ai-tally-gateway",
+  "taskDefinition": "ai-tally-gateway",
+  "desiredCount": 2,
+  "launchType": "FARGATE",
+  "platformVersion": "LATEST",
+  "deploymentConfiguration": {
+    "minimumHealthyPercent": 100,
+    "maximumPercent": 200
+  },
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-PRIVATE_A", "subnet-PRIVATE_B"],
+      "securityGroups": ["sg-AI_TALLY_GATEWAY"],
+      "assignPublicIp": "DISABLED"
+    }
+  },
+  "loadBalancers": [
+    {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/ai-tally-gateway/REPLACE",
+      "containerName": "gateway",
+      "containerPort": 8080
+    }
+  ],
+  "healthCheckGracePeriodSeconds": 30,
+  "enableExecuteCommand": true
+}

--- a/deploy/aws/ecs/gateway.taskdef.json
+++ b/deploy/aws/ecs/gateway.taskdef.json
@@ -1,0 +1,54 @@
+{
+  "family": "ai-tally-gateway",
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "512",
+  "memory": "1024",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-workload",
+  "containerDefinitions": [
+    {
+      "name": "gateway",
+      "image": "ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/gateway:1.0.0",
+      "essential": true,
+      "portMappings": [
+        { "containerPort": 8080, "protocol": "tcp", "name": "http" }
+      ],
+      "environment": [
+        { "name": "TALLY_CLICKHOUSE_HOST", "value": "REPLACE_CLICKHOUSE_HOST" },
+        { "name": "TALLY_CLICKHOUSE_PORT", "value": "8123" },
+        { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
+        { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },
+        { "name": "TALLY_REQUIRE_API_KEY", "value": "true" },
+        { "name": "AWS_REGION", "value": "REGION" },
+        { "name": "TALLY_REPLAY_BLOB_BACKEND", "value": "memory" }
+      ],
+      "secrets": [
+        { "name": "TALLY_POSTGRES_DSN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-postgres-dsn" },
+        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" },
+        { "name": "OPENAI_API_KEY", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-openai-api-key" },
+        { "name": "ANTHROPIC_API_KEY", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-anthropic-api-key" }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/healthz').status==200 else 1)\""],
+        "interval": 15,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 10
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ai-tally-gateway",
+          "awslogs-region": "REGION",
+          "awslogs-stream-prefix": "gateway",
+          "awslogs-create-group": "true"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+++ b/deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "ecs-tasks.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/deploy/aws/ecs/iam/execution-role-policy.json
+++ b/deploy/aws/ecs/iam/execution-role-policy.json
@@ -1,0 +1,37 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrPull",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:log-group:/ecs/ai-tally-*:*"
+    },
+    {
+      "Sid": "SecretsInjection",
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": [
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-postgres-dsn*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-clickhouse-password*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-openai-api-key*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-anthropic-api-key*"
+      ]
+    }
+  ]
+}

--- a/deploy/aws/ecs/iam/irsa-trust-policy.json
+++ b/deploy/aws/ecs/iam/irsa-trust-policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/oidc.eks.REGION.amazonaws.com/id/OIDC_ID"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:sub": "system:serviceaccount:ai-tally:ai-tally",
+          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:aud": "sts.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aws/ecs/iam/task-role-policy.json
+++ b/deploy/aws/ecs/iam/task-role-policy.json
@@ -1,0 +1,51 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReplayBucketS3",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-org-ai-tally-replay",
+        "arn:aws:s3:::my-org-ai-tally-replay/*"
+      ]
+    },
+    {
+      "Sid": "CostExplorerRead",
+      "Effect": "Allow",
+      "Action": [
+        "ce:GetCostAndUsage",
+        "ce:GetCostForecast",
+        "ce:GetDimensionValues",
+        "ce:GetTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "BedrockInvoke",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:ListFoundationModels"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManagerRead",
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": [
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-postgres-dsn*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-clickhouse-password*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-openai-api-key*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-anthropic-api-key*"
+      ]
+    }
+  ]
+}

--- a/deploy/aws/ecs/web.service.json
+++ b/deploy/aws/ecs/web.service.json
@@ -1,0 +1,28 @@
+{
+  "cluster": "ai-tally",
+  "serviceName": "ai-tally-web",
+  "taskDefinition": "ai-tally-web",
+  "desiredCount": 2,
+  "launchType": "FARGATE",
+  "platformVersion": "LATEST",
+  "deploymentConfiguration": {
+    "minimumHealthyPercent": 100,
+    "maximumPercent": 200
+  },
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-PRIVATE_A", "subnet-PRIVATE_B"],
+      "securityGroups": ["sg-AI_TALLY_WEB"],
+      "assignPublicIp": "DISABLED"
+    }
+  },
+  "loadBalancers": [
+    {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/ai-tally-web/REPLACE",
+      "containerName": "web",
+      "containerPort": 3000
+    }
+  ],
+  "healthCheckGracePeriodSeconds": 30,
+  "enableExecuteCommand": true
+}

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -1,0 +1,51 @@
+{
+  "family": "ai-tally-web",
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "512",
+  "memory": "1024",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-workload",
+  "containerDefinitions": [
+    {
+      "name": "web",
+      "image": "ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/web:1.0.0",
+      "essential": true,
+      "portMappings": [
+        { "containerPort": 3000, "protocol": "tcp", "name": "http" }
+      ],
+      "environment": [
+        { "name": "PORT", "value": "3000" },
+        { "name": "TALLY_GATEWAY_URL", "value": "REPLACE_GATEWAY_URL" },
+        { "name": "TALLY_TENANT_ID", "value": "local-dev" },
+        { "name": "TALLY_CLICKHOUSE_URL", "value": "REPLACE_CLICKHOUSE_URL" },
+        { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
+        { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },
+        { "name": "NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS", "value": "5000" }
+      ],
+      "secrets": [
+        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/ || exit 1"],
+        "interval": 15,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 15
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ai-tally-web",
+          "awslogs-region": "REGION",
+          "awslogs-stream-prefix": "web",
+          "awslogs-create-group": "true"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aws/helm/ai-tally-eks/.helmignore
+++ b/deploy/aws/helm/ai-tally-eks/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.swp
+*~

--- a/deploy/aws/helm/ai-tally-eks/Chart.yaml
+++ b/deploy/aws/helm/ai-tally-eks/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: ai-tally
+description: |
+  ai-tally on Amazon EKS (CTO-159, epic CTO-148). Deploys the two stateless application tiers — the
+  ingest gateway (FastAPI/uvicorn) and the Next.js dashboard — and wires them to AWS-managed backing
+  stores: RDS for PostgreSQL (control plane), ClickHouse (in-cluster StatefulSet or an external
+  ClickHouse Cloud endpoint) for telemetry, and S3 for replay blobs (CTO-152).
+
+  Secrets (provider API keys, DB creds) live in AWS Secrets Manager and are consumed via IRSA
+  (IAM Roles for Service Accounts) + the Secrets Store CSI driver (AWS provider) — never as static
+  IAM access keys on disk or literals in manifests.
+
+  This is the EKS counterpart to the GKE chart in deploy/gcp/helm/ai-tally. The ECS-on-Fargate
+  task definitions in deploy/aws/ecs are the PRIMARY AWS path; this chart is the "you already run
+  a cluster" alternative, mirroring the GKE-vs-Cloud-Run split from CTO-153.
+type: application
+# Chart version: bump on any template change. App version tracks the ai-tally release the images
+# were cut from; override per-tier image tags in values.yaml.
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - ai-tally
+  - observability
+  - eks
+  - aws
+  - clickhouse
+home: https://github.com/jain-aanchal/ai-tally
+sources:
+  - https://github.com/jain-aanchal/ai-tally/tree/main/deploy/aws

--- a/deploy/aws/helm/ai-tally-eks/templates/NOTES.txt
+++ b/deploy/aws/helm/ai-tally-eks/templates/NOTES.txt
@@ -1,0 +1,31 @@
+ai-tally {{ .Chart.AppVersion }} deployed as release "{{ .Release.Name }}" in namespace {{ .Release.Namespace }} (EKS).
+
+Tiers:
+{{- if .Values.gateway.enabled }}
+  - gateway  {{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }}  (:{{ .Values.gateway.service.port }})
+{{- end }}
+{{- if .Values.web.enabled }}
+  - web      {{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }}  (:{{ .Values.web.service.port }})
+{{- end }}
+ClickHouse: {{ .Values.clickhouse.mode }} ({{ include "ai-tally.clickhouseHost" . }}:{{ .Values.clickhouse.httpPort }})
+Secrets: {{ .Values.secretsManager.mode }}{{ if eq .Values.secretsManager.mode "csi" }} (Secrets Manager via CSI + IRSA){{ end }}
+
+1. Watch the pods come up:
+
+   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }} -w
+
+2. Smoke-test the gateway health endpoint:
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }} {{ .Values.gateway.service.port }}:{{ .Values.gateway.service.port }}
+   curl -s localhost:{{ .Values.gateway.service.port }}/healthz    # {"status":"ok"}
+
+3. Open the dashboard:
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }} {{ .Values.web.service.port }}:{{ .Values.web.service.port }}
+   open http://localhost:{{ .Values.web.service.port }}
+
+{{- if not .Values.serviceAccount.roleArn }}
+
+WARNING: serviceAccount.roleArn is empty — IRSA is not wired and Secrets Manager access will fail.
+Set serviceAccount.roleArn (and aws.region) and re-run. See deploy/aws/README.md.
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/_helpers.tpl
+++ b/deploy/aws/helm/ai-tally-eks/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/* Chart base name, overridable. */}}
+{{- define "ai-tally.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified release name. */}}
+{{- define "ai-tally.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ai-tally.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common labels. */}}
+{{- define "ai-tally.labels" -}}
+helm.sh/chart: {{ include "ai-tally.chart" . }}
+app.kubernetes.io/part-of: ai-tally
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Per-tier selector labels. Pass a dict {"ctx": ., "tier": "gateway"}. */}}
+{{- define "ai-tally.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ai-tally.name" .ctx }}
+app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+app.kubernetes.io/component: {{ .tier }}
+{{- end -}}
+
+{{/* Tier-suffixed resource name, e.g. "myrel-ai-tally-gateway". */}}
+{{- define "ai-tally.tierName" -}}
+{{- printf "%s-%s" (include "ai-tally.fullname" .ctx) .tier | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* KSA name the pods run as. */}}
+{{- define "ai-tally.serviceAccountName" -}}
+{{- default (include "ai-tally.fullname" .) .Values.serviceAccount.name -}}
+{{- end -}}
+
+{{/* Name of the Kubernetes Secret the app tiers read env from: an existing one if provided, else
+     the one the CSI driver syncs (named after the release). */}}
+{{- define "ai-tally.secretName" -}}
+{{- if .Values.secretsManager.existingSecretName -}}
+{{- .Values.secretsManager.existingSecretName -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "ai-tally.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* SecretProviderClass name (CSI mode). */}}
+{{- define "ai-tally.spcName" -}}
+{{- printf "%s-spc" (include "ai-tally.fullname" .) -}}
+{{- end -}}
+
+{{/* In-cluster ClickHouse Service DNS (statefulset mode). */}}
+{{- define "ai-tally.clickhouseHost" -}}
+{{- if .Values.clickhouse.host -}}
+{{- .Values.clickhouse.host -}}
+{{- else if eq .Values.clickhouse.mode "statefulset" -}}
+{{- printf "%s-clickhouse" (include "ai-tally.fullname" .) -}}
+{{- else -}}
+{{- fail "clickhouse.host is required when clickhouse.mode=external" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Gateway in-cluster URL the web tier calls. */}}
+{{- define "ai-tally.gatewayUrl" -}}
+{{- if .Values.web.config.gatewayUrl -}}
+{{- .Values.web.config.gatewayUrl -}}
+{{- else -}}
+{{- printf "http://%s:%d" (include "ai-tally.tierName" (dict "ctx" . "tier" "gateway")) (int .Values.gateway.service.port) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/aws/helm/ai-tally-eks/templates/clickhouse-service.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/clickhouse-service.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.clickhouse.mode "statefulset" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-tally.fullname" . }}-clickhouse
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 4 }}
+spec:
+  # Headless: stable per-pod DNS for the StatefulSet. The app tiers connect over the HTTP port.
+  clusterIP: None
+  ports:
+    - { name: http,   port: 8123, targetPort: http }
+    - { name: native, port: 9000, targetPort: native }
+  selector:
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 4 }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/clickhouse-statefulset.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/clickhouse-statefulset.yaml
@@ -1,0 +1,72 @@
+{{- if eq .Values.clickhouse.mode "statefulset" }}
+{{- /*
+Single-node in-cluster ClickHouse for staging / low volume. NOT highly available. For production,
+prefer clickhouse.mode=external pointed at ClickHouse Cloud. The canonical DDL from db/clickhouse
+is applied via an initdb ConfigMap you create out-of-band and reference here (see README) — the
+official image runs /docker-entrypoint-initdb.d/*.sql on first boot, exactly like docker-compose.
+The ClickHouse password is read from the same synced Secret as the app tiers. On EKS the volume is
+provisioned by the EBS CSI driver (gp3 by default via the cluster's default StorageClass).
+*/ -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ai-tally.fullname" . }}-clickhouse
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 4 }}
+spec:
+  serviceName: {{ include "ai-tally.fullname" . }}-clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "clickhouse") | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: clickhouse
+          image: {{ .Values.clickhouse.image }}
+          ports:
+            - { name: http,   containerPort: 8123 }
+            - { name: native, containerPort: 9000 }
+          env:
+            - name: CLICKHOUSE_USER
+              value: {{ .Values.gateway.config.clickhouseUser | quote }}
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+            {{- if .Values.secretsManager.secrets.clickhousePassword }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-tally.secretName" . }}
+                  key: TALLY_CLICKHOUSE_PASSWORD
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+          livenessProbe:
+            httpGet: { path: /ping, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet: { path: /ping, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.clickhouse.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.clickhouse.storageClassName }}
+        storageClassName: {{ .Values.clickhouse.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.clickhouse.storage | quote }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/gateway-configmap.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/gateway-configmap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "gateway") | nindent 4 }}
+data:
+  # Non-secret gateway config (TALLY_*). Secret values (DB password, provider keys) come from the
+  # synced Kubernetes Secret, NOT from here. Mirrors infra/gateway/src/gateway/config.py.
+  TALLY_CLICKHOUSE_HOST: {{ include "ai-tally.clickhouseHost" . | quote }}
+  TALLY_CLICKHOUSE_PORT: {{ .Values.clickhouse.httpPort | quote }}
+  TALLY_CLICKHOUSE_DB: {{ .Values.gateway.config.clickhouseDb | quote }}
+  TALLY_CLICKHOUSE_USER: {{ .Values.gateway.config.clickhouseUser | quote }}
+  TALLY_REQUIRE_API_KEY: {{ .Values.gateway.config.requireApiKey | quote }}
+  TALLY_INGEST_BUFFERED: {{ .Values.gateway.config.ingestBuffered | quote }}
+  {{- if .Values.aws.region }}
+  # Consumed by the AWS SDK (boto3) for S3 replay / Cost Explorer / Bedrock via IRSA.
+  AWS_REGION: {{ .Values.aws.region | quote }}
+  AWS_DEFAULT_REGION: {{ .Values.aws.region | quote }}
+  {{- end }}
+  TALLY_REPLAY_BLOB_BACKEND: {{ .Values.gateway.config.replayBlobBackend | quote }}
+  {{- if .Values.gateway.config.replayS3Bucket }}
+  TALLY_REPLAY_S3_BUCKET: {{ .Values.gateway.config.replayS3Bucket | quote }}
+  {{- end }}
+  {{- if .Values.gateway.config.evalJudgeModel }}
+  TALLY_EVAL_JUDGE_MODEL: {{ .Values.gateway.config.evalJudgeModel | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.gateway.config.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/gateway-deployment.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/gateway-deployment.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.gateway.enabled }}
+{{- $tier := "gateway" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 4 }}
+spec:
+  {{- if not .Values.gateway.autoscaling.enabled }}
+  replicas: {{ .Values.gateway.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll pods when non-secret config changes so a ConfigMap edit takes effect.
+        checksum/config: {{ include (print $.Template.BasePath "/gateway-configmap.yaml") . | sha256sum }}
+        {{- with .Values.gateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "ai-tally.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: gateway
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+            # DB password + provider keys, synced from Secrets Manager (or an existingSecret).
+            - secretRef:
+                name: {{ include "ai-tally.secretName" . }}
+          {{- if eq .Values.secretsManager.mode "csi" }}
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+          {{- end }}
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+      # NOTE: unlike the GKE chart there is NO database auth-proxy sidecar — on AWS the gateway
+      # reaches RDS directly over the VPC. Put the nodes and RDS in the same VPC and allow the node
+      # security group to reach RDS:5432. The DSN (endpoint + password) is the postgresDsn secret.
+      {{- if eq .Values.secretsManager.mode "csi" }}
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "ai-tally.spcName" . }}
+      {{- end }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/gateway-service.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/gateway-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "gateway") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "gateway") | nindent 4 }}
+spec:
+  type: {{ .Values.gateway.service.type }}
+  ports:
+    - port: {{ .Values.gateway.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "gateway") | nindent 4 }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/hpa.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- range $tier := (list "gateway" "web") }}
+{{- $cfg := index $.Values $tier }}
+{{- if and $cfg.enabled $cfg.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" $ "tier" $tier) }}
+  labels:
+    {{- include "ai-tally.labels" $ | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" $ "tier" $tier) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-tally.tierName" (dict "ctx" $ "tier" $tier) }}
+  minReplicas: {{ $cfg.autoscaling.minReplicas }}
+  maxReplicas: {{ $cfg.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/secretproviderclass.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/secretproviderclass.yaml
@@ -1,0 +1,46 @@
+{{- if eq .Values.secretsManager.mode "csi" }}
+{{- /*
+Secrets Store CSI driver — AWS provider. Pulls named secrets from AWS Secrets Manager and, via
+secretObjects, SYNCS them into a Kubernetes Secret ({{ include "ai-tally.secretName" . }}) that the
+Deployments consume with secretKeyRef. The pod must also mount the CSI volume for the sync to run —
+that mount is declared on each Deployment. Requires:
+  - the Secrets Store CSI driver + AWS provider installed on the cluster (README), and
+  - IRSA on the pod's KSA with secretsmanager:GetSecretValue on each secret.
+No secret value is present here — only Secrets Manager names/ARNs from .Values.secretsManager.secrets.
+*/ -}}
+{{- $region := .Values.aws.region -}}
+{{- $account := .Values.aws.accountId -}}
+{{- $secrets := .Values.secretsManager.secrets -}}
+{{- $mappings := list -}}
+{{- if $secrets.postgresDsn }}{{ $mappings = append $mappings (dict "sm" $secrets.postgresDsn "env" "TALLY_POSTGRES_DSN") }}{{- end -}}
+{{- if $secrets.clickhousePassword }}{{ $mappings = append $mappings (dict "sm" $secrets.clickhousePassword "env" "TALLY_CLICKHOUSE_PASSWORD") }}{{- end -}}
+{{- if $secrets.openaiApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.openaiApiKey "env" "OPENAI_API_KEY") }}{{- end -}}
+{{- if $secrets.anthropicApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.anthropicApiKey "env" "ANTHROPIC_API_KEY") }}{{- end -}}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "ai-tally.spcName" . }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+spec:
+  provider: aws
+  parameters:
+    # Each object references a Secrets Manager secret by ARN (preferred) or bare name. A bare name is
+    # expanded to a full ARN when aws.region and aws.accountId are both set; otherwise supply the ARN
+    # directly in secretsManager.secrets. objectAlias is the filename the driver mounts and the key
+    # the synced Kubernetes Secret exposes.
+    objects: |
+      {{- range $mappings }}
+      - objectName: {{ if hasPrefix "arn:aws:secretsmanager:" .sm }}{{ .sm | quote }}{{ else if and $region $account }}{{ printf "arn:aws:secretsmanager:%s:%s:secret:%s" $region $account .sm | quote }}{{ else }}{{ fail "provide full secret ARNs in secretsManager.secrets, or set aws.region and aws.accountId to expand bare names" }}{{ end }}
+        objectType: "secretsmanager"
+        objectAlias: {{ .env | quote }}
+      {{- end }}
+  secretObjects:
+    - secretName: {{ include "ai-tally.secretName" . }}
+      type: Opaque
+      data:
+        {{- range $mappings }}
+        - objectName: {{ .env | quote }}
+          key: {{ .env | quote }}
+        {{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/serviceaccount.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceAccount.create -}}
+{{- if not .Values.serviceAccount.roleArn -}}
+{{- fail "serviceAccount.roleArn is required: the IAM role ARN the KSA assumes via IRSA" -}}
+{{- end -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ai-tally.serviceAccountName" . }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+  annotations:
+    # IRSA: pods running as this KSA assume the IAM role below via the cluster's OIDC provider and
+    # inherit its IAM permissions (Secrets Manager GetSecretValue, S3 on the replay bucket, Cost
+    # Explorer, Bedrock) with NO static AWS access key. The reciprocal trust policy on the role
+    # (sts:AssumeRoleWithWebIdentity for this namespace/KSA) is created with eksctl / the AWS CLI —
+    # see deploy/aws/README.md and deploy/aws/ecs/iam/irsa-trust-policy.json.
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.roleArn | quote }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/web-configmap.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/web-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "web") | nindent 4 }}
+data:
+  # Non-secret web config. The dashboard queries ClickHouse directly (TALLY_CLICKHOUSE_*) and calls
+  # the gateway (TALLY_GATEWAY_URL). The ClickHouse password comes from the synced Secret.
+  PORT: {{ .Values.web.service.port | quote }}
+  TALLY_GATEWAY_URL: {{ include "ai-tally.gatewayUrl" . | quote }}
+  TALLY_TENANT_ID: {{ .Values.web.config.tenantId | quote }}
+  TALLY_CLICKHOUSE_URL: {{ printf "%s://%s:%d" .Values.clickhouse.scheme (include "ai-tally.clickhouseHost" .) (int .Values.clickhouse.httpPort) | quote }}
+  TALLY_CLICKHOUSE_DB: {{ .Values.web.config.clickhouseDb | quote }}
+  TALLY_CLICKHOUSE_USER: {{ .Values.web.config.clickhouseUser | quote }}
+  NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS: {{ .Values.web.config.dashboardRefreshMs | quote }}
+  {{- range $k, $v := .Values.web.config.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/web-deployment.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/web-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.web.enabled }}
+{{- $tier := "web" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 4 }}
+spec:
+  {{- if not .Values.web.autoscaling.enabled }}
+  replicas: {{ .Values.web.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/web-configmap.yaml") . | sha256sum }}
+        {{- with .Values.web.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" $tier) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "ai-tally.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" $tier) }}
+          env:
+            # The dashboard only needs the ClickHouse password out of the shared Secret — pull just
+            # that key rather than envFrom the whole Secret (keeps provider keys out of the web pod).
+            {{- if .Values.secretsManager.secrets.clickhousePassword }}
+            - name: TALLY_CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-tally.secretName" . }}
+                  key: TALLY_CLICKHOUSE_PASSWORD
+            {{- end }}
+          {{- if eq .Values.secretsManager.mode "csi" }}
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+          {{- end }}
+          livenessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- if eq .Values.secretsManager.mode "csi" }}
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "ai-tally.spcName" . }}
+      {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/templates/web-service.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/web-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-tally.tierName" (dict "ctx" . "tier" "web") }}
+  labels:
+    {{- include "ai-tally.labels" . | nindent 4 }}
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "web") | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-tally.selectorLabels" (dict "ctx" . "tier" "web") | nindent 4 }}
+{{- end }}

--- a/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
@@ -1,0 +1,56 @@
+# Example overrides for a real EKS install. Copy, fill in the CAPS values, and pass with:
+#   helm upgrade --install ai-tally deploy/aws/helm/ai-tally-eks -n ai-tally -f my-values.yaml
+#
+# This example uses external ClickHouse Cloud + RDS + Secrets Manager via CSI — the recommended
+# production shape. For a self-contained staging cluster, set clickhouse.mode=statefulset instead.
+
+aws:
+  region: us-east-1
+  accountId: "123456789012"
+
+serviceAccount:
+  create: true
+  # The IRSA role the KSA assumes (create with: eksctl create iamserviceaccount ...). Its policy is
+  # deploy/aws/ecs/iam/task-role-policy.json (S3 replay + Cost Explorer + Bedrock) plus Secrets
+  # Manager GetSecretValue on the secrets below.
+  roleArn: arn:aws:iam::123456789012:role/ai-tally-workload
+
+secretsManager:
+  mode: csi
+  # Secrets Manager secret NAMES (expanded to ARNs via aws.region + aws.accountId) or full ARNs.
+  secrets:
+    postgresDsn: ai-tally-postgres-dsn
+    clickhousePassword: ai-tally-clickhouse-password
+    openaiApiKey: ai-tally-openai-api-key
+    anthropicApiKey: ai-tally-anthropic-api-key
+
+rds:
+  endpoint: ai-tally-pg.abcdefghijkl.us-east-1.rds.amazonaws.com   # informational
+
+clickhouse:
+  mode: external
+  host: my-instance.us-east-1.aws.clickhouse.cloud
+  httpPort: 8443
+  scheme: https   # ClickHouse Cloud is TLS-terminated
+
+gateway:
+  replicaCount: 2
+  image:
+    repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/ai-tally/gateway
+    tag: "1.0.0"
+  config:
+    requireApiKey: true
+    replayBlobBackend: s3
+    replayS3Bucket: my-org-ai-tally-replay
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+
+web:
+  replicaCount: 2
+  image:
+    repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/ai-tally/web
+    tag: "1.0.0"
+  config:
+    tenantId: local-dev

--- a/deploy/aws/helm/ai-tally-eks/values.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values.yaml
@@ -1,0 +1,197 @@
+# Default values for the ai-tally EKS chart.
+#
+# The two application tiers (gateway, web) are stateless and 12-factor: everything they read is an
+# env var. This file maps those env vars onto Kubernetes knobs, plus the AWS-native secrets/identity
+# wiring. Backing stores (RDS Postgres, ClickHouse, S3) are managed OUT of this chart by default —
+# RDS and S3 are provisioned with the AWS CLI / eksctl / Terraform (see deploy/aws/README.md);
+# ClickHouse is either an in-cluster StatefulSet (clickhouse.mode=statefulset) or an external
+# endpoint (clickhouse.mode=external).
+
+# -- Global naming -------------------------------------------------------------------------------
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+# =================================================================================================
+# AWS identity + secrets
+# =================================================================================================
+aws:
+  # AWS region the workload runs in. Required — used to construct Secrets Manager ARNs when only a
+  # secret NAME is given, and surfaced to the app tiers (AWS_REGION) for the AWS SDK. No default.
+  region: ""
+  # AWS account id. Optional but recommended: used to expand bare secret names into full ARNs and
+  # to document the IRSA role. Leave blank if you provide full secret ARNs in secretsManager.secrets.
+  accountId: ""
+
+# Kubernetes ServiceAccount the pods run as. Annotated for IRSA so pods assume the IAM role below
+# WITHOUT any static AWS access key. create=false lets you reference a pre-existing KSA.
+serviceAccount:
+  create: true
+  name: ai-tally
+  # The IAM role ARN the KSA assumes via IRSA (the OIDC trust is created out-of-band with eksctl /
+  # the AWS CLI — see deploy/aws/README.md). Example:
+  #   arn:aws:iam::123456789012:role/ai-tally-workload
+  # Grant it: Secrets Manager GetSecretValue on the secrets below, S3 access on the replay bucket,
+  # ce:GetCostAndUsage (Cost Explorer), and bedrock:InvokeModel (see deploy/aws/ecs/iam/*.json).
+  roleArn: ""
+  annotations: {}   # eks.amazonaws.com/role-arn is injected from .Values.serviceAccount.roleArn
+
+# -- Secrets Manager -> pod wiring ----------------------------------------------------------------
+# Secrets are pulled from AWS Secrets Manager by the Secrets Store CSI driver (AWS provider) and
+# synced into a Kubernetes Secret, which the Deployments consume via envFrom/secretKeyRef. No secret
+# value ever appears in this chart or in git. Each entry maps a Secrets Manager secret (NAME or full
+# ARN) to the env var the app expects. Create the secrets with the AWS CLI (README).
+secretsManager:
+  # csi   — pull from Secrets Manager via the Secrets Store CSI driver (recommended on EKS).
+  # existingSecret — you manage a Kubernetes Secret out-of-band (e.g. external-secrets operator);
+  #                  set existingSecretName and the chart references it directly.
+  mode: csi
+  existingSecretName: ""
+  # Secrets Manager secret NAMES or full ARNs (NOT values). "" disables that mapping (the env var is
+  # simply not set, and the app falls back to its documented default or fail-soft path). A bare name
+  # is expanded to arn:aws:secretsmanager:<region>:<accountId>:secret:<name> when both aws.region and
+  # aws.accountId are set; otherwise provide the full ARN here.
+  secrets:
+    # Postgres control-plane DSN, e.g. postgresql://USER:PASS@ai-tally-pg.xxxx.us-east-1.rds.amazonaws.com:5432/tally
+    # RDS is reached directly over the VPC (no auth-proxy sidecar). Consumed as TALLY_POSTGRES_DSN.
+    postgresDsn: ai-tally-postgres-dsn
+    # ClickHouse password. Consumed as TALLY_CLICKHOUSE_PASSWORD by both tiers.
+    clickhousePassword: ai-tally-clickhouse-password
+    # Outbound provider keys for model discovery / replay / eval. Optional — the gateway boots
+    # fail-soft without them (CTO-109). Consumed as OPENAI_API_KEY / ANTHROPIC_API_KEY. If you use
+    # Amazon Bedrock instead of direct provider keys, leave these blank and grant bedrock:InvokeModel
+    # to the IRSA role (the SDK uses the role, not a key).
+    openaiApiKey: ai-tally-openai-api-key
+    anthropicApiKey: ai-tally-anthropic-api-key
+  # NOTE on Stripe + HMAC: the Stripe webhook *signing secret* is NOT a gateway env var — it is
+  # pasted per-tenant in the dashboard and persisted in Postgres (see db/postgres/0003_*.sql), so it
+  # is protected by protecting RDS. Per-tenant HMAC user-id keys (CTO-74) live in the gateway's
+  # HmacKeyRegistry, provisioned per-tenant at runtime — also not a deploy-time secret.
+
+# =================================================================================================
+# Gateway tier (FastAPI ingest gateway — infra/gateway)
+# =================================================================================================
+gateway:
+  enabled: true
+  replicaCount: 2
+  image:
+    # Amazon ECR, e.g. 123456789012.dkr.ecr.us-east-1.amazonaws.com/ai-tally/gateway
+    repository: ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/gateway
+    pullPolicy: IfNotPresent
+    tag: ""   # defaults to .Chart.AppVersion
+  service:
+    type: ClusterIP
+    port: 8080
+  # Non-secret env (TALLY_*). Secret env is injected from secretsManager above. Mirrors the
+  # docker-compose gateway service and infra/gateway/src/gateway/config.py defaults.
+  config:
+    clickhouseDb: default        # the ClickHouse image loads unqualified DDL into `default`
+    clickhouseUser: tally
+    requireApiKey: true          # cloud default: enforce Authorization: Bearer <key>
+    ingestBuffered: false        # flip on to decouple the request edge from ClickHouse (CTO-37)
+    evalJudgeModel: ""           # override TALLY_EVAL_JUDGE_MODEL; "" keeps the app default
+    # S3 replay blob store (CTO-152). Leave replayS3Bucket blank to keep the in-memory backend.
+    replayBlobBackend: memory    # memory | s3
+    replayS3Bucket: ""           # required when replayBlobBackend=s3; the IRSA role needs S3 access
+    # Free-form extra TALLY_* pairs merged verbatim into the ConfigMap (rate limits, quotas, etc.).
+    extraEnv: {}
+  resources:
+    requests: { cpu: 250m, memory: 256Mi }
+    limits:   { cpu: "1",  memory: 512Mi }
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =================================================================================================
+# Web tier (Next.js dashboard — web/)
+# =================================================================================================
+web:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/web
+    pullPolicy: IfNotPresent
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 3000
+  config:
+    # The dashboard queries ClickHouse directly AND calls the gateway. The gateway URL defaults to
+    # the in-cluster Service; leave blank to auto-derive it from the release name.
+    gatewayUrl: ""
+    tenantId: local-dev
+    clickhouseDb: default
+    clickhouseUser: tally
+    dashboardRefreshMs: "5000"   # NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS
+    extraEnv: {}
+  resources:
+    requests: { cpu: 100m, memory: 192Mi }
+    limits:   { cpu: 500m, memory: 384Mi }
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =================================================================================================
+# ClickHouse (telemetry store)
+# =================================================================================================
+# statefulset — run a single-node ClickHouse in-cluster with a PersistentVolume. Fine for staging /
+#               low volume; NOT HA. Applies the same DDL as docker-compose via an initdb ConfigMap
+#               you mount (see README). For production, prefer external ClickHouse Cloud.
+# external    — point the gateway + web at an external ClickHouse HTTP endpoint (e.g. ClickHouse
+#               Cloud). No StatefulSet is rendered.
+clickhouse:
+  mode: external
+  # Used by BOTH modes as the host the app tiers connect to. In statefulset mode this defaults to
+  # the in-cluster Service DNS; in external mode set it to your ClickHouse Cloud host.
+  host: ""
+  httpPort: 8123
+  # URL scheme the web tier uses to reach ClickHouse (TALLY_CLICKHOUSE_URL). Keep "http" for the
+  # in-cluster StatefulSet; set "https" for a TLS endpoint like ClickHouse Cloud (usually port 8443).
+  scheme: http
+  # statefulset-mode knobs (ignored when mode=external).
+  image: clickhouse/clickhouse-server:24.8
+  storage: 50Gi
+  storageClassName: ""   # "" uses the cluster default StorageClass (gp3 on EKS via the EBS CSI driver)
+  resources:
+    requests: { cpu: "1", memory: 4Gi }
+    limits:   { cpu: "2", memory: 8Gi }
+
+# =================================================================================================
+# RDS (Postgres control plane) connectivity
+# =================================================================================================
+# Unlike Cloud SQL on GCP, RDS is reached DIRECTLY over the VPC — no auth-proxy sidecar. Put the EKS
+# nodes and the RDS instance in the same VPC and allow the nodes' security group to reach RDS:5432.
+# The DSN itself (with the app-user password and the RDS endpoint host) is the Secrets Manager
+# `postgresDsn` secret above. IAM database authentication is an optional hardening step documented in
+# the README; the default DSN form uses a password.
+rds:
+  # Informational only (the actual endpoint lives inside the postgresDsn secret). Recorded here so
+  # `helm get values` documents which instance a release points at.
+  endpoint: ""
+
+# =================================================================================================
+# Pod security posture (applied to gateway + web)
+# =================================================================================================
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false   # Next's standalone server writes a cache dir; keep false for web
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION
## CTO-159 — Deploy on AWS (mirror of CTO-153 GCP path)

Strictly additive under `deploy/aws/`; no runtime code touched. Reuses the existing gateway (`infra/gateway/Dockerfile`) and web (`web/Dockerfile`) images.

### What's here
- **Primary — ECS-on-Fargate** (`deploy/aws/ecs/`): gateway + web task definitions and ECS service definitions. Secrets injected from AWS Secrets Manager via `secrets[].valueFrom` (ARNs, never baked in). IAM policy JSON for the workload task role (S3 replay + Cost Explorer + Bedrock), the ECS execution role (ECR/logs/secret injection), plus ECS-tasks and IRSA trust policies.
- **Secondary — EKS Helm chart** (`deploy/aws/helm/ai-tally-eks/`): mirrors the GKE chart from CTO-153, AWS-native — IRSA-annotated ServiceAccount, `SecretProviderClass` (Secrets Store CSI, AWS provider), gateway/web Deployments + Services, optional HPAs, optional in-cluster ClickHouse StatefulSet. RDS is reached directly over the VPC (no auth-proxy sidecar).
- **README** (`deploy/aws/README.md`): prerequisites, ECS-vs-EKS guidance, a GCP→AWS mapping table, ECR/RDS/ClickHouse/S3/MSK provisioning, Secrets Manager wiring, `eksctl`/CLI identity steps, smoke test, and teardown.

### Secrets & identity mapping (GCP → AWS)
- Secret Manager → **Secrets Manager**; consumed by ARN. ECS: injected at task start by the execution role. EKS: synced by the CSI driver into a k8s Secret.
- Workload Identity → **IRSA** (EKS, KSA↔role via OIDC) / **task role** (ECS). Same `ai-tally-workload` permissions policy for both; only the trust differs.
- Cloud SQL Auth Proxy sidecar → dropped; RDS is reached directly over the VPC.

### Backing stores
RDS Postgres (control plane), MSK or self-hosted Redpanda (CTO-37 buffer), S3 (replay, CTO-152), ClickHouse Cloud or in-cluster StatefulSet.

### Verification
- `git diff --name-status origin/main` — all 26 files are additions (A); zero modifications.
- `helm lint` + `helm template` render clean (external, statefulset, and existingSecret modes); rendered YAML parses.
- All ECS/IAM JSON parses and is free of comment keys (valid for `aws ecs register-task-definition` / IAM policy validation).

Out of scope (documented as follow-up TODOs): live provisioning, IaC, CI/CD, an S3 replay backend impl, ALB Ingress/TLS, Azure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)