### PR TITLE
feat(cost): Vercel compute + egress cost connector (CTO-163)

### DIFF
--- a/db/athena/athena_external_tables.sql
+++ b/db/athena/athena_external_tables.sql
@@ -1,0 +1,127 @@
+-- Athena external tables for the S3 export sink (CTO-160) — GENERATED from the shared
+-- gateway.bq_export specs via gateway.athena_export.all_ddl(). Edit `<bucket>`/`<prefix>` to taste,
+-- or regenerate with:  python -c "from gateway.athena_export import all_ddl; ...".
+--
+-- After a load, register new day partitions:  MSCK REPAIR TABLE <table>;  (or run a Glue crawler).
+
+CREATE EXTERNAL TABLE IF NOT EXISTS `tally_export`.`otel_spans` (
+  `TenantId` string,
+  `Timestamp` timestamp,
+  `TraceId` string,
+  `SpanId` string,
+  `ParentSpanId` string,
+  `ServiceName` string,
+  `SpanName` string,
+  `StatusCode` bigint,
+  `DurationNs` bigint,
+  `FeatureTag` string,
+  `SessionId` string,
+  `UserIdHash` string,
+  `UserIdHashKeyVersion` string,
+  `IdempotencyKey` string,
+  `GenAiSystem` string,
+  `GenAiRequestModel` string,
+  `GenAiResponseModel` string,
+  `GenAiOperation` string,
+  `GenAiToolName` string,
+  `InputTokens` bigint,
+  `OutputTokens` bigint,
+  `CachedInputTokens` bigint,
+  `EstimatedCost` decimal(38, 9),
+  `CostCurrency` string,
+  `CostSource` string,
+  `PriceCatalogVersion` string,
+  `AgentRunId` string,
+  `AgentStepIndex` bigint,
+  `ContextDroppedMessages` bigint,
+  `ContextDroppedTokens` bigint,
+  `ContextWindowUsedPct` double,
+  `SamplingStratum` string,
+  `SamplingRate` double,
+  `SpanAttributes` string,
+  `SampleRate` double
+)
+PARTITIONED BY (`dt` date)
+STORED AS PARQUET
+LOCATION 's3://<bucket>/<prefix>/otel_spans/'
+TBLPROPERTIES ('parquet.compression' = 'SNAPPY');
+
+CREATE EXTERNAL TABLE IF NOT EXISTS `tally_export`.`business_events` (
+  `TenantId` string,
+  `BusinessEventId` string,
+  `EventName` string,
+  `UserIdHash` string,
+  `OccurredAt` timestamp,
+  `IngestedAt` timestamp,
+  `ValueAmountMicro` bigint,
+  `ValueCurrency` string,
+  `ValueType` string,
+  `Source` string,
+  `RawPayload` string
+)
+PARTITIONED BY (`dt` date)
+STORED AS PARQUET
+LOCATION 's3://<bucket>/<prefix>/business_events/'
+TBLPROPERTIES ('parquet.compression' = 'SNAPPY');
+
+CREATE EXTERNAL TABLE IF NOT EXISTS `tally_export`.`attribution_records` (
+  `TenantId` string,
+  `BusinessEventId` string,
+  `FeatureTag` string,
+  `AttributedTraceId` string,
+  `AttributedTraceTs` timestamp,
+  `AttributedTraceCost` decimal(38, 9),
+  `ValueAmountMicro` bigint,
+  `ValueCurrency` string,
+  `AttributionModel` string,
+  `AttributionConfidence` string,
+  `UserIdHashKeyVersion` string,
+  `LookbackWindowDays` bigint,
+  `StitchedAt` timestamp,
+  `StitcherVersion` string
+)
+PARTITIONED BY (`dt` date)
+STORED AS PARQUET
+LOCATION 's3://<bucket>/<prefix>/attribution_records/'
+TBLPROPERTIES ('parquet.compression' = 'SNAPPY');
+
+CREATE EXTERNAL TABLE IF NOT EXISTS `tally_export`.`daily_feature_rollup` (
+  `TenantId` string,
+  `Day` date,
+  `FeatureTag` string,
+  `GenAiResponseModel` string,
+  `InputTokens` bigint,
+  `OutputTokens` bigint,
+  `CachedInputTokens` bigint,
+  `EstimatedCost` decimal(38, 9),
+  `ReconciledCost` decimal(38, 9),
+  `SpanCount` bigint,
+  `TraceCount` bigint,
+  `UserCount` bigint
+)
+PARTITIONED BY (`dt` date)
+STORED AS PARQUET
+LOCATION 's3://<bucket>/<prefix>/daily_feature_rollup/'
+TBLPROPERTIES ('parquet.compression' = 'SNAPPY');
+
+
+-- Optional: load the same Parquet into Redshift (IAM_ROLE is a role ARN reference).
+-- COPY otel_spans
+-- FROM 's3://<bucket>/<prefix>/otel_spans/'
+-- IAM_ROLE 'arn:aws:iam::<acct>:role/tally-redshift'
+-- FORMAT AS PARQUET;
+
+-- COPY business_events
+-- FROM 's3://<bucket>/<prefix>/business_events/'
+-- IAM_ROLE 'arn:aws:iam::<acct>:role/tally-redshift'
+-- FORMAT AS PARQUET;
+
+-- COPY attribution_records
+-- FROM 's3://<bucket>/<prefix>/attribution_records/'
+-- IAM_ROLE 'arn:aws:iam::<acct>:role/tally-redshift'
+-- FORMAT AS PARQUET;
+
+-- COPY daily_feature_rollup
+-- FROM 's3://<bucket>/<prefix>/daily_feature_rollup/'
+-- IAM_ROLE 'arn:aws:iam::<acct>:role/tally-redshift'
+-- FORMAT AS PARQUET;

--- a/db/postgres/0016_tenant_vercel_config.sql
+++ b/db/postgres/0016_tenant_vercel_config.sql
@@ -1,0 +1,52 @@
+-- Per-tenant Vercel compute + egress connector config (CTO-163).
+--
+-- Vercel-hosted AI apps pay Vercel for BOTH Functions compute (invocations + GB-hours) and bandwidth
+-- (egress). CTO-143 built the compute layer (AWS/GCP) and CTO-144 the egress layer (Vercel /
+-- Cloudflare / AWS). This ticket adds Vercel to the COMPUTE layer: the daily connector
+-- (gateway.connectors.vercel) pulls a tenant's Vercel usage/billing and lands the Functions compute
+-- spend as synthetic `compute`-layer spans, so a Vercel app's full infra cost sits next to its LLM
+-- spend on /cost. This table is the per-tenant control-plane row that connector reads.
+--
+-- One row per tenant (a tenant has one Vercel account/team for this integration) -> tenant_id PK,
+-- sibling of 0011_tenant_compute_config.
+--
+-- Secrets by REFERENCE only (same hard rule as 0011/0012): ``access_token_ref`` is a Secret Manager /
+-- KMS reference to the Vercel access token — NEVER the raw token. ``team_id`` / ``project_id`` are the
+-- PUBLIC Vercel identifiers the usage query is scoped to, not secrets.
+--
+-- EGRESS DOUBLE-COUNT RECONCILIATION with CTO-144: CTO-144's egress connector already names Vercel
+-- bandwidth as an egress source. To avoid double-counting the /cost Egress column, this connector
+-- emits Vercel egress ONLY when ``emit_egress = true`` (default FALSE). Default: this connector owns
+-- the compute half and Vercel egress flows solely through CTO-144's tenant_egress_config path. Set
+-- ``emit_egress = true`` ONLY for a tenant that has NO tenant_egress_config row for
+-- egress_provider='vercel', so exactly one path emits. (Defence in depth: when it does emit egress it
+-- reuses CTO-144's connector, producing the IDENTICAL synthetic span id, so the base span_exists
+-- guard collapses any overlap to one row regardless.)
+--
+-- Run status lives on this same row (last_run_at / last_status), mirroring 0011/0012. A failed fetch
+-- stamps 'failed' and emits NO span (honest-under-uncertainty — never a guessed number).
+--
+-- Migration is additive: existing tenants have zero rows, which the connector treats as
+-- "Vercel connector not configured" and skips.
+
+CREATE TABLE IF NOT EXISTS tenant_vercel_config (
+    tenant_id         UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    -- Secret Manager / KMS reference to the Vercel access token — NEVER the raw token. Bounded so a
+    -- fat-fingered raw token (which is long) is more likely to trip the check than land silently.
+    access_token_ref  TEXT NOT NULL CHECK (length(access_token_ref) > 0 AND length(access_token_ref) < 512),
+    -- Public Vercel identifiers the usage query is scoped to. Not secrets.
+    team_id           TEXT,
+    project_id        TEXT,
+    -- Lets a tenant keep the row but pause the connector.
+    enabled           BOOLEAN NOT NULL DEFAULT true,
+    -- CTO-144 reconciliation gate: emit Vercel egress spans from THIS connector only when true.
+    -- Default false — egress is owned by CTO-144's egress connector (see header).
+    emit_egress       BOOLEAN NOT NULL DEFAULT false,
+    last_run_at       TIMESTAMPTZ,
+    last_status       TEXT CHECK (last_status IN ('success', 'partial', 'failed')),
+    connected_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    notes             TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_vercel_config_tenant
+    ON tenant_vercel_config(tenant_id);

--- a/db/postgres/0020_tenant_athena_export.sql
+++ b/db/postgres/0020_tenant_athena_export.sql
@@ -1,0 +1,32 @@
+-- Per-tenant opt-in for the S3 / Athena export sink (CTO-160).
+--
+-- The AWS analog of the BigQuery export (CTO-154, migration 0009). The export worker mirrors a
+-- tenant's telemetry (spans / business_events / attribution / daily rollups) into the tenant's OWN
+-- S3 bucket as partitioned Parquet, queryable via an Athena external table (or Glue catalog) and
+-- loadable into Redshift with a COPY recipe. ClickHouse stays the primary store and the dashboard
+-- keeps reading it — this is an additive mirror, never a replacement.
+--
+-- Opt-in and off by default: `enabled=false`, and a tenant with no row exports nothing. Existing
+-- tenants don't suddenly start mirroring on upgrade.
+--
+-- `bucket` / `prefix` / `database` name the destination (S3 prefix + Athena/Glue database); `region`
+-- is the AWS region. `credential_ref` is a *reference*, not a secret: an IAM role ARN the worker
+-- assumes, or a Secrets Manager / SSM parameter resource name. The gateway rejects inline AWS access
+-- keys / secrets here (`tenant_athena_export._reject_raw_key`) — raw keys never live in this table.
+--
+-- `tenant_id` is plain TEXT (not a UUID FK) because the export worker keys off the same TenantId
+-- string the telemetry path uses end-to-end, exactly like `tenant_bq_export_config`.
+
+CREATE TABLE IF NOT EXISTS tenant_athena_export_config (
+    tenant_id      TEXT PRIMARY KEY,
+    enabled        BOOLEAN NOT NULL DEFAULT false,
+    bucket         TEXT NOT NULL DEFAULT '',
+    prefix         TEXT NOT NULL DEFAULT 'tally/',
+    database       TEXT NOT NULL DEFAULT 'tally_export',
+    region         TEXT NOT NULL DEFAULT '',
+    credential_ref TEXT NOT NULL DEFAULT '',
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- When enabled, a destination is required.
+    CONSTRAINT athena_export_enabled_needs_destination
+        CHECK (enabled = false OR (bucket <> '' AND database <> ''))
+);

--- a/db/postgres/0021_athena_export_watermarks.sql
+++ b/db/postgres/0021_athena_export_watermarks.sql
@@ -1,0 +1,21 @@
+-- Incremental export cursor for the S3 / Athena export sink (CTO-160).
+--
+-- The AWS analog of `bq_export_watermarks` (CTO-154, migration 0010). One row per (tenant, source
+-- table). `watermark` is the high-water value of that table's incremental column (spans → Timestamp,
+-- business_events → OccurredAt, attribution_records → AttributedTraceTs, daily_feature_rollup → Day)
+-- exported so far. Each pass reads rows strictly greater than the stored watermark, writes them to
+-- the matching S3 day partition(s) as Parquet, then advances the watermark to the max value it saw.
+--
+-- A missing row means "never exported" and reads back as NULL — the first pass is a full backfill.
+-- Idempotency is per day partition: a partition write upserts the partition's rows on the same
+-- natural key ClickHouse dedupes on, so replaying a pass after a crash never duplicates rows.
+
+CREATE TABLE IF NOT EXISTS athena_export_watermarks (
+    tenant_id     TEXT NOT NULL,
+    source_table  TEXT NOT NULL,
+    watermark     TIMESTAMPTZ NOT NULL,
+    rows_exported BIGINT NOT NULL DEFAULT 0
+                      CHECK (rows_exported >= 0),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, source_table)
+);

--- a/docs/athena-export.md
+++ b/docs/athena-export.md
@@ -1,0 +1,196 @@
+# S3 / Athena export sink (CTO-160)
+
+An **optional, additive** worker that mirrors a tenant's telemetry into the tenant's *own* S3 bucket
+as partitioned Parquet, queryable through **Athena** (an external table / Glue catalog entry) and
+loadable into **Redshift** with a `COPY` recipe. It is the AWS analog of the BigQuery export
+([`docs/bigquery-export.md`](./bigquery-export.md), CTO-154). ClickHouse stays ai-tally's primary
+telemetry store and the dashboard keeps reading it — S3/Athena is a **mirror, never a replacement**.
+There is no reverse sync and no realtime-streaming SLA; batch / near-real-time passes are the v1
+contract.
+
+- Code: `infra/gateway/src/gateway/athena_export.py` (worker) and
+  `infra/gateway/src/gateway/tenant_athena_export.py` (per-tenant config + watermark stores).
+- **Shared with CTO-154 so both sinks emit identical facts:** the export specs
+  (`gateway.bq_export.ALL_SPECS`), the `ClickHouseExportReader`, the `project_row` / `strip_body_keys`
+  body-stripping, and the `WatermarkStore` protocol are all reused verbatim. Only the *sink* differs
+  (Parquet-to-S3 instead of a BigQuery `MERGE`).
+- Optional dependency: the `[athena]` extra (`pyarrow` + `boto3`), **lazy-imported** inside the real
+  sink. The gateway imports and boots without it.
+- Default: **disabled** — at the process level (`TALLY_ATHENA_EXPORT_ENABLED=false`) and per-tenant
+  (`tenant_athena_export_config.enabled=false`, the state for any tenant with no row).
+
+## What is exported
+
+The same reconciled cost/attribution facts as the BigQuery export (identical columns, natural keys,
+and incremental watermark columns — they are the *same* `ExportTableSpec` objects):
+
+| S3 prefix / Athena table | ClickHouse source     | Incremental column   | Natural key (dedupe)                            |
+| ------------------------ | --------------------- | -------------------- | ----------------------------------------------- |
+| `otel_spans`             | `otel_spans`          | `Timestamp`          | `TenantId, TraceId, SpanId`                     |
+| `business_events`        | `business_events`     | `OccurredAt`         | `TenantId, BusinessEventId`                     |
+| `attribution_records`    | `attribution_records` | `AttributedTraceTs`  | `TenantId, BusinessEventId, FeatureTag`         |
+| `daily_feature_rollup`   | `daily_feature_rollup`| `Day`                | `TenantId, Day, FeatureTag, GenAiResponseModel` |
+
+### S3 layout + partitioning
+
+Each table is written under `s3://<bucket>/<prefix>/<table>/`, Hive-partitioned by a day column `dt`
+derived from the table's incremental watermark column:
+
+```
+s3://<bucket>/<prefix>/otel_spans/dt=2026-07-12/data.parquet
+s3://<bucket>/<prefix>/daily_feature_rollup/dt=2026-07-12/data.parquet
+```
+
+`dt` is a **partition** column (declared with `PARTITIONED BY`), not a stored data column. Register
+new partitions with `MSCK REPAIR TABLE <table>` (or a Glue crawler) after a pass.
+
+### Type mapping
+
+The Athena/Redshift schema is generated from the **same** `BQField` schema the BigQuery sink uses —
+one schema, two dialects:
+
+| BigQuery type | Athena / Parquet type |
+| ------------- | --------------------- |
+| `STRING`      | `string`              |
+| `INT64`       | `bigint`              |
+| `NUMERIC`     | `decimal(38, 9)`      |
+| `FLOAT64`     | `double`              |
+| `TIMESTAMP`   | `timestamp`           |
+| `DATE`        | `date`                |
+| `JSON`        | `string` (JSON map serialized as a JSON string) |
+
+The long-tail attribute maps (`otel_spans.SpanAttributes`, `business_events.RawPayload`) are stored
+as a JSON string column.
+
+### Athena DDL / Redshift COPY
+
+The DDL is generated programmatically from the shared specs:
+
+```python
+from gateway.athena_export import all_ddl, redshift_copy_sql, ALL_SPECS
+
+ddl = all_ddl(database="tally_export", bucket="my-bucket", prefix="tally")
+print(ddl["otel_spans"])
+```
+
+produces, e.g.:
+
+```sql
+CREATE EXTERNAL TABLE IF NOT EXISTS `tally_export`.`otel_spans` (
+  `TenantId` string,
+  ...
+  `EstimatedCost` decimal(38, 9),
+  `SpanAttributes` string
+)
+PARTITIONED BY (`dt` date)
+STORED AS PARQUET
+LOCATION 's3://my-bucket/tally/otel_spans/'
+TBLPROPERTIES ('parquet.compression' = 'SNAPPY');
+```
+
+The optional Redshift `COPY` recipe loads the same Parquet:
+
+```sql
+COPY otel_spans
+FROM 's3://my-bucket/tally/otel_spans/'
+IAM_ROLE 'arn:aws:iam::<acct>:role/tally-redshift'
+FORMAT AS PARQUET;
+```
+
+A ready-to-edit static copy of the four `CREATE EXTERNAL TABLE` statements lives in
+[`db/athena/athena_external_tables.sql`](../db/athena/athena_external_tables.sql).
+
+## No message bodies (by construction)
+
+The export preserves ai-tally's "counts only, never bodies" invariant (CTO-118). Because the specs
+are shared with CTO-154, the same guards apply:
+
+1. The exported tables hold no message text to begin with — `otel_spans` already drops body-keyed
+   attributes on ingest (`mapping.span_to_row`).
+2. At import time the worker re-asserts no exported column is body-keyed (reusing the span-side
+   `mapping._is_body_key` guard) and that no spec reads a replay table.
+3. As a second, independent guard, `SpanAttributes` / `RawPayload` JSON maps are body-stripped again
+   before they leave (`strip_body_keys`).
+
+The replay **candidate-response text** (CTO-125, `replay_runs.ResponseText`) is a **separate, opt-in
+tier** and is explicitly **excluded** here — no export spec sources a replay table. Covered by
+`infra/gateway/tests/test_athena_export.py`: `test_no_exported_column_is_body_keyed`,
+`test_no_spec_sources_a_replay_body_table`, `test_span_attribute_map_strips_body_keys_before_write`.
+
+## Idempotency
+
+Each pass reads rows strictly greater than the stored watermark, groups them by day partition, and
+**upserts** each partition on the same natural key ClickHouse dedupes on (read-merge-write of the
+partition's Parquet object). Re-running a pass — e.g. after a crash — never duplicates rows, and a
+later pass that adds more rows to a day already partially exported keeps the earlier rows. The
+watermark advances only to the max value actually seen. Covered by
+`test_rerun_over_same_window_does_not_duplicate`,
+`test_intraday_incremental_pass_keeps_earlier_rows_of_partition`, and
+`test_watermark_advances_and_second_run_is_incremental`.
+
+## Configuration
+
+Process-level settings (env, `TALLY_`-prefixed — see `gateway/config.py`):
+
+| Setting                                | Default        | Meaning                                        |
+| -------------------------------------- | -------------- | ---------------------------------------------- |
+| `TALLY_ATHENA_EXPORT_ENABLED`          | `false`        | Master kill-switch for the worker.             |
+| `TALLY_ATHENA_EXPORT_S3_BUCKET`        | `""`           | Bucket owning the export prefixes.             |
+| `TALLY_ATHENA_EXPORT_DEFAULT_PREFIX`   | `tally/`       | Default S3 key prefix for a newly-enabled tenant. |
+| `TALLY_ATHENA_EXPORT_DEFAULT_DATABASE` | `tally_export` | Default Athena/Glue database.                  |
+| `TALLY_ATHENA_EXPORT_AWS_REGION`       | `""`           | AWS region (else resolved from the environment). |
+| `TALLY_ATHENA_EXPORT_BATCH_LIMIT`      | `10000`        | Max rows pulled per (tenant, table) pass.      |
+
+Per-tenant config (`tenant_athena_export_config`, migration `db/postgres/0020_...`): `enabled`,
+`bucket`, `prefix`, `database`, `region`, `credential_ref`. Incremental cursor
+(`athena_export_watermarks`, migration `db/postgres/0021_...`): one row per (tenant, source table).
+
+### Auth — reference only, never a raw key
+
+`credential_ref` is a **reference**, not a secret: an IAM **role ARN** the worker assumes, or a
+Secrets Manager / SSM parameter resource name. The gateway **rejects** anything that looks like an
+inline AWS access key / secret (`tenant_athena_export._reject_raw_key`). At runtime the client uses
+its default AWS credential chain (instance/role profile, IRSA, or an assumed role). Raw keys never
+live in the database.
+
+## Runbook
+
+1. Install the optional extra on the worker host: `uv sync --extra athena`.
+2. Create the bucket/prefix and grant the runtime identity (an assumed IAM role) `s3:GetObject` /
+   `s3:PutObject` / `s3:ListBucket` on `s3://<bucket>/<prefix>/*`, plus Athena/Glue read as needed.
+3. Enable for the tenant: set `tenant_athena_export_config.enabled=true` with the destination and a
+   `credential_ref`. Set `TALLY_ATHENA_EXPORT_ENABLED=true` at the process level.
+4. Invoke a pass per tenant (from a scheduler / cron):
+
+   ```python
+   from gateway.athena_export import ClickHouseExportReader, load_s3_parquet_sink, run_export
+   from gateway.config import get_settings
+   from gateway.store import ClickHouseStore
+   from gateway.tenant_athena_export import AthenaExportWatermarkStore, TenantAthenaExportStore
+
+   settings = get_settings()
+   cfg = TenantAthenaExportStore(settings).get(tenant_id)
+   run_export(
+       reader=ClickHouseExportReader(ClickHouseStore(settings).client),
+       sink=load_s3_parquet_sink(cfg.bucket, region=cfg.region),
+       watermarks=AthenaExportWatermarkStore(settings),
+       tenant_id=tenant_id,
+       dataset_ref=cfg.dataset_ref(),
+       enabled=cfg.enabled,
+       batch_limit=settings.athena_export_batch_limit,
+   )
+   ```
+
+5. Register partitions in Athena: `MSCK REPAIR TABLE <table>` (or run a Glue crawler).
+
+The first pass backfills (watermark is `NULL`); subsequent passes are incremental. Re-running a pass
+is safe.
+
+## What's stubbed
+
+`Boto3S3ParquetSink` (the real `pyarrow`-encode + `boto3` put, read-merge-write per partition) and
+`ClickHouseExportReader` (shared with CTO-154) are implemented but exercised only against live S3 /
+ClickHouse — the unit suite drives the in-memory fakes (`InMemoryS3ParquetSink`, `FakeReader`) so
+the partitioning + incremental + idempotency + no-body logic is fully testable with no cloud
+dependencies. Per-tenant *scheduling* (a running daemon / cron wiring) is intentionally out of scope;
+`run_export` is the invocable entry point a scheduler calls.

--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -35,6 +35,13 @@ dev = [
 bigquery = [
     "google-cloud-bigquery>=3.20",
 ]
+# Optional AWS analytics-mirror sink (CTO-160). Only needed by deployments that turn on the
+# per-tenant S3/Athena export; `gateway.athena_export` lazy-imports pyarrow + boto3, so the gateway
+# imports and boots fine without this extra installed.
+athena = [
+    "pyarrow>=16.0",
+    "boto3>=1.34",
+]
 
 [tool.uv.sources]
 # The gateway reuses the SDK's wire/enrichment/timekeeping/pricing logic directly.

--- a/infra/gateway/src/gateway/athena_export.py
+++ b/infra/gateway/src/gateway/athena_export.py
@@ -1,0 +1,461 @@
+"""Optional S3 / Athena (+ Redshift) analytics export sink (CTO-160).
+
+The AWS analog of the BigQuery export (CTO-154). An **additive, opt-in mirror** of a tenant's
+telemetry into their *own* S3 bucket as partitioned Parquet, queryable through an Athena external
+table (or a Glue catalog entry) and loadable into Redshift with a ``COPY`` recipe. ClickHouse stays
+ai-tally's primary store and the dashboard keeps reading it; this worker only copies rows out. It is
+never a replacement and never reads back into the product.
+
+By design this module **reuses CTO-154's machinery so both sinks emit identical facts**:
+
+* the same :class:`~gateway.bq_export.ExportTableSpec` set (:data:`~gateway.bq_export.ALL_SPECS`) —
+  spans / business_events / attribution / daily rollups, the same columns, the same natural keys and
+  the same incremental watermark columns;
+* the same :class:`~gateway.bq_export.ClickHouseExportReader` (``client.query(sql).result_rows``),
+  the same :func:`~gateway.bq_export.project_row` / :func:`~gateway.bq_export.strip_body_keys`
+  body-stripping, and the same :class:`~gateway.bq_export.WatermarkStore` protocol;
+* the same no-bodies invariant, re-asserted at import time here against the shared specs.
+
+What differs is only the **sink**: instead of an upsert-by-key ``MERGE`` into BigQuery, rows are
+written to ``s3://<bucket>/<prefix>/<table>/dt=YYYY-MM-DD/data.parquet`` as Parquet, one object per
+day partition. Idempotency is **per day partition**: a partition write upserts the partition's rows
+on the same natural key ClickHouse dedupes on (read-merge-write), so replaying a pass — or picking up
+more rows for a day already partially exported — never duplicates and never drops earlier rows.
+
+**Optional, lazy-imported deps.** ``pyarrow`` (Parquet encode) and ``boto3`` (S3 put) live behind the
+``[athena]`` extra and are imported *inside* the real sink only, so this module imports and the
+gateway boots without them (exactly like ``bq_export``'s ``[bigquery]`` extra).
+
+**No bodies, by construction (CTO-118 / CTO-125).** Because the specs are shared with CTO-154, the
+same guards apply: no exported column is body-keyed, no spec sources a replay table, and the
+long-tail ``SpanAttributes`` / ``RawPayload`` JSON maps are body-stripped again before they leave.
+The replay candidate-response text (CTO-125) is a separate opt-in tier and is excluded here too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any, Protocol
+
+# Reuse CTO-154's schema + reader + body-strip so both sinks emit identical facts.
+from gateway.bq_export import (
+    ALL_SPECS,
+    SPECS_BY_TABLE,
+    BQField,
+    ClickHouseExportReader,  # noqa: F401 - re-exported for the runbook wiring
+    ExportReader,  # noqa: F401 - re-exported: the reader protocol is shared
+    ExportTableSpec,
+    WatermarkStore,  # noqa: F401 - re-exported: the watermark protocol is shared
+    _EXCLUDED_SOURCE_TABLES,
+    _is_body_key,
+    project_row,
+    strip_body_keys,  # noqa: F401 - re-exported for callers/tests
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Sequence
+
+
+class AthenaDependencyMissing(RuntimeError):
+    """Raised when export is invoked but the optional ``[athena]`` extra isn't installed."""
+
+
+# --- No-bodies invariant, re-asserted at import against the shared specs ------------------------
+
+def _assert_no_body_columns() -> None:
+    """Fail fast if any shared spec would export a body-keyed column or read a replay table."""
+    for spec in ALL_SPECS:
+        if spec.source_table in _EXCLUDED_SOURCE_TABLES:
+            raise AssertionError(
+                f"export spec {spec.name!r} sources an excluded body-bearing table "
+                f"{spec.source_table!r}"
+            )
+        body_cols = [c for c in spec.columns if _is_body_key(c)]
+        if body_cols:
+            raise AssertionError(
+                f"export spec {spec.name!r} would export body-keyed columns {body_cols!r}"
+            )
+        banned = {"responsetext", "response_text"}
+        leaked = [c for c in spec.columns if c.lower() in banned]
+        if leaked:
+            raise AssertionError(f"export spec {spec.name!r} leaks replay body column {leaked!r}")
+
+
+_assert_no_body_columns()
+
+
+# --- Partitioning ------------------------------------------------------------------------------
+
+# Hive-style day partition column laid over every table's S3 prefix, derived from that table's
+# incremental watermark column. Athena reads it as a partition; Redshift Spectrum / COPY ignore it.
+PARTITION_COLUMN = "dt"
+
+
+def partition_key(spec: ExportTableSpec, row: dict[str, Any]) -> date:
+    """The day partition a row lands in, from its watermark column (``date`` or ``datetime``)."""
+    value = row.get(spec.watermark_column)
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    raise ValueError(
+        f"row for {spec.source_table!r} has no usable {spec.watermark_column!r} to partition on"
+    )
+
+
+def partition_prefix(dataset_ref: str, spec: ExportTableSpec, day: date) -> str:
+    """The S3 key prefix for one table's one-day partition: ``<prefix><table>/dt=YYYY-MM-DD/``."""
+    return f"{dataset_ref}{spec.name}/{PARTITION_COLUMN}={day.isoformat()}/"
+
+
+# --- Athena / Redshift DDL ---------------------------------------------------------------------
+
+# BigQuery standard-SQL type -> Athena (Hive/Presto) type. Kept as a pure mapping so the DDL is
+# generated from the *same* BQField schema the BigQuery sink uses — one schema, two dialects.
+_ATHENA_TYPES: dict[str, str] = {
+    "STRING": "string",
+    "INT64": "bigint",
+    "NUMERIC": "decimal(38, 9)",
+    "FLOAT64": "double",
+    "TIMESTAMP": "timestamp",
+    "DATE": "date",
+    # Athena has no native JSON storage type for a Parquet column; the map is stored as a JSON string.
+    "JSON": "string",
+}
+
+
+def athena_type(field: BQField) -> str:
+    """Map one shared :class:`BQField` to its Athena column type."""
+    try:
+        return _ATHENA_TYPES[field.type]
+    except KeyError as exc:  # pragma: no cover - guards a future unmapped type
+        raise ValueError(f"no Athena type mapping for BigQuery type {field.type!r}") from exc
+
+
+def athena_create_table_ddl(spec: ExportTableSpec, *, database: str, s3_location: str) -> str:
+    """``CREATE EXTERNAL TABLE`` over the partitioned Parquet prefix for one export table.
+
+    ``s3_location`` is the table root (``s3://bucket/prefix/<table>/``); the day partition column
+    ``dt`` is declared with ``PARTITIONED BY`` and is *not* repeated in the column list. After a
+    load, new partitions are registered with ``MSCK REPAIR TABLE`` (or a Glue crawler).
+    """
+    cols = ",\n".join(f"  `{f.name}` {athena_type(f)}" for f in spec.schema)
+    location = s3_location if s3_location.endswith("/") else s3_location + "/"
+    return (
+        f"CREATE EXTERNAL TABLE IF NOT EXISTS `{database}`.`{spec.name}` (\n"
+        f"{cols}\n"
+        f")\n"
+        f"PARTITIONED BY (`{PARTITION_COLUMN}` date)\n"
+        f"STORED AS PARQUET\n"
+        f"LOCATION '{location}'\n"
+        f"TBLPROPERTIES ('parquet.compression' = 'SNAPPY');"
+    )
+
+
+def redshift_copy_sql(spec: ExportTableSpec, *, s3_location: str, iam_role: str) -> str:
+    """A Redshift ``COPY`` recipe loading the same Parquet into a Redshift table.
+
+    ``iam_role`` is an IAM **role ARN reference** (never a raw key); Redshift assumes it to read S3.
+    """
+    location = s3_location if s3_location.endswith("/") else s3_location + "/"
+    return (
+        f"COPY {spec.name}\n"
+        f"FROM '{location}'\n"
+        f"IAM_ROLE '{iam_role}'\n"
+        f"FORMAT AS PARQUET;"
+    )
+
+
+def all_ddl(*, database: str, bucket: str, prefix: str) -> dict[str, str]:
+    """The ``CREATE EXTERNAL TABLE`` DDL for every shared spec, keyed by table name."""
+    prefix = prefix if prefix.endswith("/") else prefix + "/"
+    return {
+        spec.name: athena_create_table_ddl(
+            spec, database=database, s3_location=f"s3://{bucket}/{prefix}{spec.name}/"
+        )
+        for spec in ALL_SPECS
+    }
+
+
+# --- Sink (Protocol + in-memory fake + lazy real client) ---------------------------------------
+
+class S3ParquetSink(Protocol):
+    """Minimal put-only contract: write one day partition's rows as Parquet, idempotently."""
+
+    def write_partition(
+        self,
+        *,
+        table: str,
+        prefix: str,
+        schema: Sequence[BQField],
+        key_columns: Sequence[str],
+        rows: Sequence[dict[str, Any]],
+    ) -> int: ...
+
+
+class InMemoryS3ParquetSink:
+    """Dict-backed sink used by tests and local dev.
+
+    Idempotent **per day partition** and by the same natural key ClickHouse dedupes on:
+    ``write_partition`` merges rows into the partition keyed by the key tuple, so replaying a pass —
+    or exporting more rows for a day already partially written — never duplicates and never drops
+    earlier rows of that partition.
+    """
+
+    def __init__(self) -> None:
+        # prefix -> {key tuple -> row}
+        self._partitions: dict[str, dict[tuple[Any, ...], dict[str, Any]]] = {}
+        self._writes = 0
+
+    def write_partition(
+        self,
+        *,
+        table: str,
+        prefix: str,
+        schema: Sequence[BQField],
+        key_columns: Sequence[str],
+        rows: Sequence[dict[str, Any]],
+    ) -> int:
+        partition = self._partitions.setdefault(prefix, {})
+        for row in rows:
+            key = tuple(row.get(k) for k in key_columns)
+            partition[key] = dict(row)
+        self._writes += 1
+        return len(rows)
+
+    def rows(self, prefix: str) -> list[dict[str, Any]]:
+        return list(self._partitions.get(prefix, {}).values())
+
+    def table_rows(self, table_prefix: str) -> list[dict[str, Any]]:
+        """All rows across every partition of one table (prefix ``<dataset_ref><table>/``)."""
+        out: list[dict[str, Any]] = []
+        for prefix, part in self._partitions.items():
+            if prefix.startswith(table_prefix):
+                out.extend(part.values())
+        return out
+
+    @property
+    def partitions(self) -> list[str]:
+        return list(self._partitions)
+
+    @property
+    def write_count(self) -> int:
+        return self._writes
+
+    def __len__(self) -> int:
+        return sum(len(p) for p in self._partitions.values())
+
+
+class Boto3S3ParquetSink:
+    """Real sink writing Parquet to S3 via ``pyarrow`` + ``boto3``. Built by :func:`load_s3_parquet_sink`.
+
+    Idempotency is per day partition: the existing partition object (if any) is read back, merged with
+    the incoming rows on the natural key, and re-uploaded as a single Parquet object. This mirrors the
+    BigQuery sink's staging + ``MERGE`` upsert, at partition granularity, so a replayed pass is safe.
+
+    NB: exercised only against live S3 — the unit suite drives :class:`InMemoryS3ParquetSink`. See
+    docs/athena-export.md for the runbook.
+    """
+
+    _OBJECT_NAME = "data.parquet"
+
+    def __init__(self, bucket: str, *, region: str | None = None) -> None:  # pragma: no cover
+        import boto3  # lazy: optional [athena] dep
+
+        self._bucket = bucket
+        self._client = boto3.client("s3", region_name=region or None)
+
+    def write_partition(  # pragma: no cover - needs live S3
+        self,
+        *,
+        table: str,
+        prefix: str,
+        schema: Sequence[BQField],
+        key_columns: Sequence[str],
+        rows: Sequence[dict[str, Any]],
+    ) -> int:
+        import io
+
+        import pyarrow as pa  # lazy: optional [athena] dep
+        import pyarrow.parquet as pq  # lazy: optional [athena] dep
+
+        if not rows:
+            return 0
+        key = f"{prefix}{self._OBJECT_NAME}"
+
+        # Read-merge-write: fold in any rows already in this partition, upserting on the natural key.
+        merged: dict[tuple[Any, ...], dict[str, Any]] = {}
+        existing = self._get_object(key)
+        if existing is not None:
+            table_in = pq.read_table(io.BytesIO(existing))
+            for rec in table_in.to_pylist():
+                merged[tuple(rec.get(k) for k in key_columns)] = rec
+        for row in rows:
+            merged[tuple(row.get(k) for k in key_columns)] = dict(row)
+
+        columns = [f.name for f in schema]
+        records = list(merged.values())
+        arrow_table = pa.Table.from_pylist([_normalize(r, columns) for r in records])
+        buf = io.BytesIO()
+        pq.write_table(arrow_table, buf, compression="snappy")
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=buf.getvalue())
+        return len(rows)
+
+    def _get_object(self, key: str) -> bytes | None:  # pragma: no cover - needs live S3
+        try:
+            resp = self._client.get_object(Bucket=self._bucket, Key=key)
+        except self._client.exceptions.NoSuchKey:
+            return None
+        return resp["Body"].read()
+
+
+def _normalize(row: dict[str, Any], columns: Sequence[str]) -> dict[str, Any]:  # pragma: no cover
+    """Coerce a projected row to the declared column set (JSON maps -> JSON string for Parquet)."""
+    import json
+
+    out: dict[str, Any] = {}
+    for col in columns:
+        value = row.get(col)
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, separators=(",", ":"), sort_keys=True)
+        out[col] = value
+    return out
+
+
+def load_s3_parquet_sink(bucket: str, *, region: str | None = None) -> S3ParquetSink:
+    """Lazily construct the real S3 sink; raises if the ``[athena]`` extra is absent.
+
+    Auth is left to the default AWS credential chain (instance/role profile, IRSA, or an assumed
+    role referenced per-tenant) — this function never takes a raw secret key.
+    """
+    try:
+        import boto3  # noqa: F401, PLC0415 - lazy optional import by design
+        import pyarrow  # noqa: F401, PLC0415 - lazy optional import by design
+    except ImportError as exc:  # pragma: no cover - depends on env
+        raise AthenaDependencyMissing(
+            "S3/Athena export requires the optional 'athena' extra: "
+            "`uv sync --extra athena` (installs pyarrow + boto3)."
+        ) from exc
+    return Boto3S3ParquetSink(bucket, region=region)
+
+
+# --- Orchestrator ------------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class ExportResult:
+    source_table: str
+    rows_exported: int
+    partitions_written: int
+    previous_watermark: datetime | date | None
+    new_watermark: datetime | date | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "source_table": self.source_table,
+            "rows_exported": self.rows_exported,
+            "partitions_written": self.partitions_written,
+            "previous_watermark": _iso(self.previous_watermark),
+            "new_watermark": _iso(self.new_watermark),
+        }
+
+
+def _iso(value: datetime | date | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def export_table(
+    *,
+    spec: ExportTableSpec,
+    reader: ExportReader,
+    sink: S3ParquetSink,
+    watermarks: WatermarkStore,
+    tenant_id: str,
+    dataset_ref: str,
+    enabled: bool,
+    batch_limit: int = 10_000,
+) -> ExportResult:
+    """Export one table for one tenant to partitioned Parquet. A no-op when export is disabled.
+
+    ``dataset_ref`` is the S3 key prefix a table name appends to (``<prefix>``, e.g. ``tally/``).
+    """
+    previous = watermarks.get(tenant_id, spec.source_table)
+    if not enabled:
+        return ExportResult(spec.source_table, 0, 0, previous, previous)
+
+    rows = reader.fetch_since(spec, tenant_id, previous, batch_limit)
+    projected = [project_row(spec, r) for r in rows]
+
+    # Group by day partition; write each partition idempotently (upsert on the natural key).
+    by_partition: dict[date, list[dict[str, Any]]] = {}
+    for raw, row in zip(rows, projected, strict=True):
+        by_partition.setdefault(partition_key(spec, raw), []).append(row)
+
+    written = 0
+    for day, part_rows in sorted(by_partition.items()):
+        written += sink.write_partition(
+            table=spec.name,
+            prefix=partition_prefix(dataset_ref, spec, day),
+            schema=spec.schema,
+            key_columns=spec.key_columns,
+            rows=part_rows,
+        )
+
+    new_watermark = previous
+    for raw in rows:
+        ts = raw.get(spec.watermark_column)
+        if ts is not None and (new_watermark is None or ts > new_watermark):
+            new_watermark = ts
+    if new_watermark is not None and new_watermark != previous:
+        watermarks.advance(tenant_id, spec.source_table, new_watermark, written)
+
+    return ExportResult(spec.source_table, written, len(by_partition), previous, new_watermark)
+
+
+def run_export(
+    *,
+    reader: ExportReader,
+    sink: S3ParquetSink,
+    watermarks: WatermarkStore,
+    tenant_id: str,
+    dataset_ref: str,
+    enabled: bool,
+    batch_limit: int = 10_000,
+    specs: Sequence[ExportTableSpec] = ALL_SPECS,
+) -> list[ExportResult]:
+    """Run every export table for one tenant, advancing each table's watermark independently."""
+    return [
+        export_table(
+            spec=spec,
+            reader=reader,
+            sink=sink,
+            watermarks=watermarks,
+            tenant_id=tenant_id,
+            dataset_ref=dataset_ref,
+            enabled=enabled,
+            batch_limit=batch_limit,
+        )
+        for spec in specs
+    ]
+
+
+# Convenience re-export so callers can look specs up by source table (shared with CTO-154).
+__all__ = [
+    "ALL_SPECS",
+    "SPECS_BY_TABLE",
+    "AthenaDependencyMissing",
+    "Boto3S3ParquetSink",
+    "ClickHouseExportReader",
+    "ExportResult",
+    "ExportTableSpec",
+    "InMemoryS3ParquetSink",
+    "S3ParquetSink",
+    "all_ddl",
+    "athena_create_table_ddl",
+    "export_table",
+    "load_s3_parquet_sink",
+    "partition_key",
+    "partition_prefix",
+    "redshift_copy_sql",
+    "run_export",
+]

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -96,6 +96,22 @@ class Settings(BaseSettings):
     # Fallback export table (`project.dataset.gcp_billing_export_v1_XXXX`) for a tenant whose
     # tenant_compute_config row leaves bq_billing_export_table blank. Empty means "require per-tenant".
     compute_gcp_default_billing_export_table: str = ""
+    # Vercel compute + egress cost connector (CTO-163). Pulls a tenant's Vercel usage/billing
+    # (Functions compute + bandwidth) into the compute + egress cost layers. DISABLED by default at
+    # both the process level (this flag) and per-tenant (``tenant_vercel_config.enabled``), so no
+    # existing deployment starts pulling on upgrade. Auth is via a Vercel access token stored BY
+    # REFERENCE per-tenant (``tenant_vercel_config.access_token_ref``, a Secret Manager pointer) —
+    # never a raw token in config, the DB, or logs. Requires the optional ``requests`` dep, imported
+    # lazily in :mod:`gateway.connectors.vercel` so the gateway boots without it.
+    vercel_connector_enabled: bool = False
+    # Vercel API base (override for a proxy / test double). No credentials in the URL.
+    vercel_api_base: str = "https://api.vercel.com"
+    # Egress double-count reconciliation with CTO-144 (default off): when false, Vercel egress flows
+    # solely through the CTO-144 egress connector and this connector emits ONLY compute spans. A
+    # per-tenant ``tenant_vercel_config.emit_egress`` flag can opt a tenant into egress here instead —
+    # set it ONLY when the tenant has no CTO-144 Vercel egress row. This process flag is the default
+    # for tenants that leave the column NULL.
+    vercel_emit_egress: bool = False
 
 
 _settings: Settings | None = None

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -112,6 +112,26 @@ class Settings(BaseSettings):
     # set it ONLY when the tenant has no CTO-144 Vercel egress row. This process flag is the default
     # for tenants that leave the column NULL.
     vercel_emit_egress: bool = False
+    # S3 / Athena (+ Redshift) export sink (CTO-160). The AWS analog of the BigQuery export above:
+    # an OPTIONAL, additive analytics mirror that copies the SAME reconciled facts (spans /
+    # business_events / attribution / daily rollups, via the shared ExportTableSpec set) into a
+    # tenant's OWN S3 bucket as partitioned Parquet, queryable through Athena / Glue and loadable
+    # into Redshift. ClickHouse stays the primary store and the dashboard keeps reading it — this
+    # is a mirror, never a replacement. DISABLED by default at both the process level (this flag)
+    # and per-tenant (``tenant_athena_export_config.enabled``, also default false), so no existing
+    # deployment starts exporting on upgrade. Auth is via an assumed IAM role / instance profile /
+    # IRSA referenced per-tenant — never a raw AWS access key. Requires the optional ``[athena]``
+    # extra (``pyarrow`` + ``boto3``), lazy-imported in :mod:`gateway.athena_export` so the gateway
+    # boots without it.
+    athena_export_enabled: bool = False
+    # S3 bucket owning the export prefixes. Empty means "resolve per-tenant".
+    athena_export_s3_bucket: str = ""
+    # Defaults for a tenant that enables export without overriding prefix/database/region.
+    athena_export_default_prefix: str = "tally/"
+    athena_export_default_database: str = "tally_export"
+    athena_export_aws_region: str = ""
+    # Max rows pulled from ClickHouse per (tenant, table) export pass.
+    athena_export_batch_limit: int = 10_000
 
 
 _settings: Settings | None = None

--- a/infra/gateway/src/gateway/connectors/config_store.py
+++ b/infra/gateway/src/gateway/connectors/config_store.py
@@ -20,6 +20,7 @@ import psycopg
 from gateway.config import Settings
 from gateway.connectors.base import ConnectorConfig
 from gateway.connectors.egress import EgressConfig
+from gateway.connectors.vercel import VercelConfig
 
 _ALLOWED_STATUSES = frozenset({"success", "partial", "failed"})
 
@@ -169,6 +170,74 @@ class TenantEgressConfigStore:
                 UPDATE tenant_egress_config
                 SET last_run_at = now(), last_status = %s
                 WHERE tenant_id = %s AND egress_provider = %s
+                """,
+                params,
+            )
+            conn.commit()
+
+
+class TenantVercelConfigStore:
+    """Postgres reader/recorder over ``tenant_vercel_config`` (CTO-163).
+
+    One row per tenant (like compute's 0011, unlike egress's composite key). :meth:`load_config`
+    returns a :class:`gateway.connectors.vercel.VercelConfig` with ``cloud_provider`` pinned to
+    ``'vercel'`` so the reused compute/egress connectors key their spans on the right provider.
+    ``emit_egress`` carries the CTO-144 reconciliation gate straight off the row.
+
+    ``record_run`` matches the ``RunRecorder`` protocol the reused connectors call through; the
+    Vercel connector runs both a compute and (gated) an egress sub-run, and both stamp this single
+    row — ``connector_id`` is ignored (only ``last_run_at`` / ``last_status`` are persisted for v1).
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def load_config(self, tenant_id: str) -> VercelConfig | None:
+        """Return the tenant's Vercel connector config, or ``None`` if not configured.
+
+        ``None`` means "Vercel connector not enabled for this tenant" — the connector skips it,
+        keeping the migration additive (existing tenants have zero rows).
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT tenant_id, access_token_ref, team_id, project_id, enabled, emit_egress
+                FROM tenant_vercel_config
+                WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return VercelConfig(
+            tenant_id=str(row[0]),
+            cloud_provider="vercel",
+            credentials_ref=str(row[1]),
+            team_id=str(row[2] or ""),
+            project_id=str(row[3] or ""),
+            enabled=bool(row[4]),
+            emit_egress=bool(row[5]),
+        )
+
+    def record_run(
+        self,
+        tenant_id: str,
+        connector_id: str,  # noqa: ARG002 - 'compute'|'egress' from the reused connectors; not stored
+        status: str,
+        *,
+        error_message: str | None = None,  # noqa: ARG002 - not persisted on the config row (v1)
+    ) -> None:
+        """Stamp ``last_run_at`` / ``last_status`` on the tenant's ``tenant_vercel_config`` row."""
+        if status not in _ALLOWED_STATUSES:
+            raise ValueError(f"unknown status '{status}'")
+        params: tuple[Any, ...] = (status, tenant_id)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE tenant_vercel_config
+                SET last_run_at = now(), last_status = %s
+                WHERE tenant_id = %s
                 """,
                 params,
             )

--- a/infra/gateway/src/gateway/connectors/vercel.py
+++ b/infra/gateway/src/gateway/connectors/vercel.py
@@ -1,0 +1,279 @@
+"""Vercel compute + egress cost connector (CTO-163).
+
+Vercel-hosted AI apps pay Vercel for BOTH Functions compute (invocations + GB-hours) and bandwidth
+(egress). CTO-143 built the compute layer (AWS/GCP) and CTO-144 built the egress layer (Vercel /
+Cloudflare / AWS). This ticket adds Vercel to the COMPUTE layer and reconciles the egress overlap
+with CTO-144 so a Vercel app's full infra cost sits next to its LLM spend on /cost.
+
+Both layers are pulled from the SAME Vercel usage/billing API payload (``items[]``), split by line
+item ``type``:
+
+  * **compute** — ``function_invocations`` + ``function_duration`` (GB-hours) line items, summed to
+    ONE ``compute`` span/day via the reused :class:`gateway.connectors.compute.ComputeCostConnector`
+    (``operation='compute'``, ``GenAiSystem='vercel'``).
+  * **egress**  — ``bandwidth`` line items, ONE ``egress`` span/day. This is the SAME data CTO-144's
+    :class:`gateway.connectors.egress.VercelBandwidthClient` already ingests.
+
+Egress double-count reconciliation with CTO-144
+-----------------------------------------------
+CTO-144's egress connector already names Vercel bandwidth as an egress source. Emitting a second
+Vercel egress span here would double-count on the /cost Egress column. Two safeguards:
+
+  1. **Gate (primary).** :class:`VercelCostConnector` emits egress ONLY when ``emit_egress=True``
+     (``tenant_vercel_config.emit_egress``, default ``false``). Default behaviour: this connector
+     owns the compute half; Vercel egress flows solely through CTO-144's ``EgressCostConnector``.
+     Set the flag only for a tenant that has NO CTO-144 ``tenant_egress_config`` row for
+     ``egress_provider='vercel'`` (so exactly one path emits).
+  2. **Same span id (defence in depth).** When it does emit egress, this connector routes through the
+     CTO-144 ``EgressCostConnector`` + ``VercelBandwidthClient`` verbatim, so the synthetic span id is
+     ``synthetic_span_id(tenant, 'vercel', 'egress', day)`` — IDENTICAL to the id CTO-144 would
+     produce. Even if both paths ran for the same day, the base ``span_exists`` guard collapses them
+     to one row: no double-count is structurally possible.
+
+Everything else reuses the CTO-143 base verbatim (emitter, idempotency guard, run contract, run
+recorder). Structure mirrors the sibling connectors: a PURE parse function unit-tested against a
+recorded fixture, and thin fetch-then-parse clients with the HTTP dep imported LAZILY so the gateway
+and the whole test suite import without ``requests``. Tests inject a fake fetcher — no network.
+
+Credentials by reference only: ``access_token_ref`` is a Secret Manager reference the prod wrapper
+resolves; the raw Vercel token never appears in the DB, this module, or logs. Honest-under-uncertainty:
+a failed fetch records a ``failed`` run and emits NO span.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+from gateway.connectors.base import (
+    BillingClient,
+    ConnectorConfig,
+    DailyCost,
+    RunResult,
+)
+from gateway.connectors.compute import ComputeCostConnector, _to_micro
+from gateway.connectors.egress import (
+    EgressConfig,
+    EgressCostConnector,
+    VercelBandwidthClient,
+)
+
+#: Fixed provider label for Vercel synthetic spans (``GenAiSystem``). Matches CTO-144's egress
+#: provider so the egress span id lines up exactly (see module docstring, safeguard 2).
+VERCEL_PROVIDER = "vercel"
+
+#: Vercel usage line-item ``type`` values that belong to the COMPUTE layer: Function invocations and
+#: Function duration (GB-hours). ``'compute'`` is accepted as a generic fallback (some payloads label
+#: the Serverless Functions line item simply ``compute``). ``bandwidth`` is DELIBERATELY excluded — it
+#: is egress and must never leak into the compute total (that would double-count across layers).
+_COMPUTE_TYPES = frozenset({"function_invocations", "function_duration", "compute"})
+
+
+@dataclass(frozen=True, slots=True)
+class VercelConfig(ConnectorConfig):
+    """One tenant's Vercel connector config — the loaded ``tenant_vercel_config`` row.
+
+    Extends :class:`ConnectorConfig`: ``cloud_provider`` is pinned to ``'vercel'`` so the reused
+    compute/egress connectors key their synthetic spans on the right provider, and ``credentials_ref``
+    carries the Secret Manager reference to the Vercel access token (NEVER the raw token).
+
+    ``team_id`` / ``project_id`` are the PUBLIC Vercel identifiers the usage query is scoped to (not
+    secrets). ``enabled`` lets a tenant keep the row but pause the connector. ``emit_egress`` is the
+    CTO-144 reconciliation gate (default ``False`` — egress via CTO-144's egress connector).
+    """
+
+    team_id: str = ""
+    project_id: str = ""
+    enabled: bool = True
+    emit_egress: bool = False
+    # tag_filter is inherited but unused for Vercel (the API is already team/project-scoped); keep the
+    # default so the ConnectorConfig contract holds.
+    tag_filter: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class VercelRunResult:
+    """Combined outcome of one Vercel connector cycle: the compute run, plus egress if the gate is on.
+
+    ``egress`` is ``None`` when ``emit_egress`` is ``False`` (the default — Vercel egress is owned by
+    CTO-144's egress connector, so this connector does not touch it).
+    """
+
+    compute: RunResult
+    egress: RunResult | None = None
+
+
+# --- pure response parser -----------------------------------------------------------------------
+
+
+def parse_vercel_compute(response: dict[str, object]) -> list[DailyCost]:
+    """Parse a Vercel usage/billing response into per-day COMPUTE totals (micro-USD).
+
+    Expects ``items[]`` each with a ``date`` (``YYYY-MM-DD``), an ``amount`` (decimal USD string) and
+    a ``type``. Only ``type in _COMPUTE_TYPES`` (Function invocations + GB-hours) items are summed —
+    ``bandwidth`` items are IGNORED so compute never double-counts the egress layer. Same-day items
+    (invocations + duration, possibly several rows) collapse to ONE total; ``$0`` days are dropped.
+
+    Mirrors :func:`gateway.connectors.egress.parse_vercel_usage`, which does the reciprocal split
+    (bandwidth only) on the very same payload.
+    """
+    per_day: dict[date, int] = {}
+    items = response.get("items") if isinstance(response, dict) else None
+    if not isinstance(items, list):
+        return []
+    for item in items:
+        if not isinstance(item, dict) or item.get("type") not in _COMPUTE_TYPES:
+            continue
+        raw_day = item.get("date")
+        if not isinstance(raw_day, str):
+            continue
+        micro = _to_micro(item.get("amount"))
+        if micro <= 0:
+            continue
+        day = date.fromisoformat(raw_day[:10])
+        per_day[day] = per_day.get(day, 0) + micro
+    return [DailyCost(day=d, cost_micro_usd=m) for d, m in sorted(per_day.items())]
+
+
+# --- fetch-then-parse clients (HTTP dep imported lazily) ----------------------------------------
+
+
+class VercelUsageClient:
+    """Fetches the raw Vercel usage/billing payload for a team/project window. Injectable for tests.
+
+    ``http_getter`` is the seam tests use to supply a recorded payload; when absent (prod), ``requests``
+    is imported LAZILY and the Vercel access token is resolved from ``config.credentials_ref`` by the
+    deployment's Secret Manager wiring (out of scope here — the token never lands in this module).
+    """
+
+    def __init__(self, http_getter=None, *, api_base: str = "https://api.vercel.com") -> None:
+        self._http_getter = http_getter
+        self._api_base = api_base
+
+    def fetch(self, config: ConnectorConfig, start_day: date, end_day: date) -> dict[str, object]:
+        if self._http_getter is not None:
+            return self._http_getter(config, start_day, end_day)
+        # pragma: no cover - exercised only against the live Vercel API
+        import requests  # lazy: keep requests off the base install / test path
+
+        team = getattr(config, "team_id", "")
+        project = getattr(config, "project_id", "")
+        params = {"from": start_day.isoformat(), "to": end_day.isoformat()}
+        if team:
+            params["teamId"] = team
+        if project:
+            params["projectId"] = project
+        resp = requests.get(
+            f"{self._api_base}/v1/usage",
+            params=params,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+class VercelComputeClient:
+    """:class:`BillingClient` for the COMPUTE layer: fetch the Vercel payload, keep only compute.
+
+    Wraps a :class:`VercelUsageClient` so the same fetched payload shape feeds both layers; this side
+    parses the Functions compute line items. Range-filters defensively (the base already asks for the
+    window, but the payload may carry neighbours).
+    """
+
+    def __init__(self, usage_client: VercelUsageClient) -> None:
+        self._usage = usage_client
+
+    def get_daily_costs(
+        self, config: ConnectorConfig, *, start_day: date, end_day: date
+    ) -> list[DailyCost]:
+        response = self._usage.fetch(config, start_day, end_day)
+        costs = parse_vercel_compute(response)
+        return [c for c in costs if start_day <= c.day <= end_day]
+
+
+# --- orchestrator -------------------------------------------------------------------------------
+
+
+class VercelCostConnector:
+    """Runs the Vercel compute connector (always) and the egress connector (gated) for one tenant.
+
+    Compute always flows through the reused :class:`ComputeCostConnector` with a Vercel client. Egress
+    is emitted ONLY when ``config.emit_egress`` is set, routed through CTO-144's
+    :class:`EgressCostConnector` + :class:`VercelBandwidthClient` so the span id matches CTO-144's
+    exactly (see module docstring). Both connectors share the ONE injected store, so idempotency holds
+    across layers and across the CTO-144 egress path.
+
+    ``recorder`` (a :class:`gateway.connectors.base.RunRecorder`) is stamped by both sub-runs; the
+    ``tenant_vercel_config`` recorder ignores the ``connector_id`` and stamps the single tenant row.
+    """
+
+    def __init__(
+        self,
+        *,
+        store,
+        usage_client: VercelUsageClient,
+        recorder=None,
+    ) -> None:
+        self._store = store
+        self._usage = usage_client
+        self._recorder = recorder
+
+    def _compute_connector(self) -> ComputeCostConnector:
+        return ComputeCostConnector(
+            store=self._store,
+            recorder=self._recorder,
+            billing_client=VercelComputeClient(self._usage),
+        )
+
+    def _egress_connector(self) -> EgressCostConnector:
+        # Reuse CTO-144's egress connector + Vercel bandwidth client VERBATIM. The bandwidth client's
+        # http_getter is this connector's usage fetch, so egress parses the same payload via CTO-144's
+        # parse_vercel_usage — identical rows AND identical synthetic span id to the CTO-144 path.
+        return EgressCostConnector(
+            store=self._store,
+            recorder=self._recorder,
+            billing_client=VercelBandwidthClient(http_getter=self._usage.fetch),
+        )
+
+    @staticmethod
+    def _egress_config(config: VercelConfig) -> EgressConfig:
+        """Project the Vercel config onto the CTO-144 egress config shape (provider='vercel')."""
+        return EgressConfig(
+            tenant_id=config.tenant_id,
+            cloud_provider=VERCEL_PROVIDER,
+            credentials_ref=config.credentials_ref,
+            resource_id=config.team_id,
+        )
+
+    def run(self, config: VercelConfig, *, day: date) -> VercelRunResult:
+        """Daily entry point: emit the compute span, and the egress span iff the gate is on."""
+        return self._run_range(config, start_day=day, end_day=day)
+
+    def run_backfill(
+        self, config: VercelConfig, *, start_day: date, end_day: date
+    ) -> VercelRunResult:
+        """Backfill ``[start_day, end_day]``. Idempotent via the base ``span_exists`` guard."""
+        return self._run_range(config, start_day=start_day, end_day=end_day)
+
+    def _run_range(
+        self, config: VercelConfig, *, start_day: date, end_day: date
+    ) -> VercelRunResult:
+        compute = self._compute_connector()._run_range(
+            config, start_day=start_day, end_day=end_day
+        )
+        egress: RunResult | None = None
+        if config.emit_egress:
+            egress = self._egress_connector()._run_range(
+                self._egress_config(config), start_day=start_day, end_day=end_day
+            )
+        return VercelRunResult(compute=compute, egress=egress)
+
+
+def build_vercel_usage_client(api_base: str = "https://api.vercel.com") -> VercelUsageClient:
+    """Factory: the live usage client for the cron/backfill entrypoints."""
+    return VercelUsageClient(api_base=api_base)
+
+
+def build_vercel_compute_client(usage_client: VercelUsageClient) -> BillingClient:
+    """Factory: a compute-layer :class:`BillingClient` backed by ``usage_client``."""
+    return VercelComputeClient(usage_client)

--- a/infra/gateway/src/gateway/tenant_athena_export.py
+++ b/infra/gateway/src/gateway/tenant_athena_export.py
@@ -1,0 +1,224 @@
+"""Per-tenant config + watermark stores for the S3 / Athena export sink (CTO-160).
+
+The AWS analog of ``tenant_bq_export`` (CTO-154). Exporting a tenant's telemetry to their own S3
+bucket as partitioned Parquet is opt-in and off by default: a tenant with no row returns
+:data:`DEFAULT_CONFIG` (``enabled=False``), so no existing deployment starts mirroring on upgrade.
+When enabled, the tenant supplies their destination (``bucket`` / ``prefix`` / ``database`` + AWS
+``region``) and a **credential reference** — an IAM **role ARN** the worker assumes, or a Secrets
+Manager / SSM parameter resource name. We deliberately reject anything that looks like an inline AWS
+access key / secret: raw keys never live in this table.
+
+``AthenaExportWatermarkStore`` is the incremental cursor, one row per (tenant, source table),
+mirroring the ``bq_export_watermarks`` / ``reconciliation_runs`` pattern, and implements the shared
+:class:`gateway.bq_export.WatermarkStore` protocol so it drops straight into ``run_export``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+
+import psycopg
+
+from gateway.config import Settings
+
+
+class RawKeyRejected(ValueError):
+    """Raised when a credential ref looks like an inline AWS key rather than a reference."""
+
+
+# Substrings that betray an inline/raw AWS access key or secret being pasted where only a *reference*
+# (an IAM role ARN or a Secrets Manager / SSM resource name) belongs. Auth must flow through an
+# assumed role / instance profile / IRSA, never a raw key.
+_RAW_KEY_MARKERS = (
+    "aws_secret_access_key",
+    "aws_access_key_id",
+    "aws_session_token",
+    "-----begin",
+    "akia",  # long-lived AWS access key id prefix
+    "asia",  # temporary AWS access key id prefix
+)
+
+
+def _reject_raw_key(credential_ref: str) -> None:
+    lowered = credential_ref.lower()
+    if any(marker in lowered for marker in _RAW_KEY_MARKERS):
+        raise RawKeyRejected(
+            "credential_ref must be a reference (an IAM role ARN, or a Secrets Manager / SSM "
+            "resource name) — never an inline AWS access key or secret."
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AthenaExportConfig:
+    enabled: bool
+    bucket: str
+    prefix: str
+    database: str
+    region: str
+    # IAM role ARN to assume, or a Secrets Manager / SSM resource name. Never a raw key.
+    credential_ref: str
+
+    def dataset_ref(self) -> str:
+        """The S3 key prefix a table name appends to — always trailing-slash-terminated."""
+        return self.prefix if self.prefix.endswith("/") else self.prefix + "/"
+
+    def s3_uri(self, table: str) -> str:
+        """The ``s3://`` root for one table's partitioned Parquet."""
+        return f"s3://{self.bucket}/{self.dataset_ref()}{table}/"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "enabled": self.enabled,
+            "bucket": self.bucket,
+            "prefix": self.prefix,
+            "database": self.database,
+            "region": self.region,
+            "credential_ref": self.credential_ref,
+        }
+
+
+def default_config(settings: Settings) -> AthenaExportConfig:
+    return AthenaExportConfig(
+        enabled=False,
+        bucket=settings.athena_export_s3_bucket,
+        prefix=settings.athena_export_default_prefix,
+        database=settings.athena_export_default_database,
+        region=settings.athena_export_aws_region,
+        credential_ref="",
+    )
+
+
+# Module-level default with no Settings (off, empty destination). Convenience for callers/tests.
+DEFAULT_CONFIG = AthenaExportConfig(
+    enabled=False, bucket="", prefix="tally/", database="tally_export", region="", credential_ref=""
+)
+
+
+class TenantAthenaExportStore:
+    """Postgres surface over ``tenant_athena_export_config`` (mirrors ``TenantBQExportStore``)."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+        self._defaults = default_config(settings)
+
+    def get(self, tenant_id: str) -> AthenaExportConfig:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT enabled, bucket, prefix, database, region, credential_ref
+                FROM tenant_athena_export_config
+                WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return self._defaults
+            return AthenaExportConfig(
+                enabled=bool(row[0]),
+                bucket=str(row[1]),
+                prefix=str(row[2]),
+                database=str(row[3]),
+                region=str(row[4]),
+                credential_ref=str(row[5]),
+            )
+
+    def upsert(
+        self,
+        tenant_id: str,
+        *,
+        enabled: bool | None = None,
+        bucket: str | None = None,
+        prefix: str | None = None,
+        database: str | None = None,
+        region: str | None = None,
+        credential_ref: str | None = None,
+    ) -> AthenaExportConfig:
+        current = self.get(tenant_id)
+        new = AthenaExportConfig(
+            enabled=current.enabled if enabled is None else bool(enabled),
+            bucket=current.bucket if bucket is None else str(bucket),
+            prefix=current.prefix if prefix is None else str(prefix),
+            database=current.database if database is None else str(database),
+            region=current.region if region is None else str(region),
+            credential_ref=current.credential_ref
+            if credential_ref is None
+            else str(credential_ref),
+        )
+        if new.credential_ref:
+            _reject_raw_key(new.credential_ref)
+        if new.enabled and not (new.bucket and new.database):
+            raise ValueError("bucket and database are required when export is enabled")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO tenant_athena_export_config
+                    (tenant_id, enabled, bucket, prefix, database, region, credential_ref,
+                     updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, now())
+                ON CONFLICT (tenant_id) DO UPDATE
+                  SET enabled        = EXCLUDED.enabled,
+                      bucket         = EXCLUDED.bucket,
+                      prefix         = EXCLUDED.prefix,
+                      database       = EXCLUDED.database,
+                      region         = EXCLUDED.region,
+                      credential_ref = EXCLUDED.credential_ref,
+                      updated_at     = now()
+                """,
+                (
+                    tenant_id,
+                    new.enabled,
+                    new.bucket,
+                    new.prefix,
+                    new.database,
+                    new.region,
+                    new.credential_ref,
+                ),
+            )
+            conn.commit()
+        return new
+
+
+class AthenaExportWatermarkStore:
+    """Postgres-backed incremental cursor: one row per (tenant, source table).
+
+    Implements the :class:`gateway.bq_export.WatermarkStore` protocol so it drops straight into
+    ``run_export``. A missing row means "never exported" and reads back as ``None`` — a full
+    initial backfill on first run.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str, source_table: str) -> datetime | date | None:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT watermark
+                FROM athena_export_watermarks
+                WHERE tenant_id = %s AND source_table = %s
+                """,
+                (tenant_id, source_table),
+            )
+            row = cur.fetchone()
+            return row[0] if row is not None else None
+
+    def advance(
+        self, tenant_id: str, source_table: str, watermark: datetime | date, rows: int
+    ) -> None:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO athena_export_watermarks
+                    (tenant_id, source_table, watermark, rows_exported, updated_at)
+                VALUES (%s, %s, %s, %s, now())
+                ON CONFLICT (tenant_id, source_table) DO UPDATE
+                  SET watermark     = EXCLUDED.watermark,
+                      rows_exported = athena_export_watermarks.rows_exported
+                                        + EXCLUDED.rows_exported,
+                      updated_at    = now()
+                """,
+                (tenant_id, source_table, watermark, rows),
+            )
+            conn.commit()

--- a/infra/gateway/tests/fixtures/vercel/usage.json
+++ b/infra/gateway/tests/fixtures/vercel/usage.json
@@ -1,0 +1,10 @@
+{
+  "items": [
+    {"name": "Function Invocations", "type": "function_invocations", "date": "2026-07-01", "amount": "2.00", "unit": "USD"},
+    {"name": "Function Duration (GB-Hours)", "type": "function_duration", "date": "2026-07-01", "amount": "3.50", "unit": "USD"},
+    {"name": "Function Duration (GB-Hours)", "type": "function_duration", "date": "2026-07-02", "amount": "4.00", "unit": "USD"},
+    {"name": "Bandwidth", "type": "bandwidth", "date": "2026-07-01", "amount": "1.25", "unit": "USD"},
+    {"name": "Bandwidth", "type": "bandwidth", "date": "2026-07-02", "amount": "6.25", "unit": "USD"},
+    {"name": "Function Invocations", "type": "function_invocations", "date": "2026-07-03", "amount": "0", "unit": "USD"}
+  ]
+}

--- a/infra/gateway/tests/test_athena_export.py
+++ b/infra/gateway/tests/test_athena_export.py
@@ -1,0 +1,406 @@
+"""S3 / Athena export sink (CTO-160).
+
+Pins the AWS export worker's guarantees with a faked reader + in-memory S3 sink (no live ClickHouse
+or S3): the shared CTO-154 specs are exported to day-partitioned Parquet, the incremental watermark
+advances, a re-run doesn't duplicate (idempotency, per day partition), no body-keyed field is ever
+exported, export is disabled by default, the Athena/Redshift DDL maps the shared schema, and the
+optional dependency is lazy-imported (the module imports without pyarrow / boto3).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import date, datetime, timezone
+
+import pytest
+
+from gateway import athena_export
+from gateway.athena_export import (
+    ALL_SPECS,
+    AthenaDependencyMissing,
+    ExportTableSpec,
+    InMemoryS3ParquetSink,
+    all_ddl,
+    athena_create_table_ddl,
+    load_s3_parquet_sink,
+    partition_prefix,
+    redshift_copy_sql,
+    run_export,
+)
+from gateway.bq_export import (
+    DAILY_ROLLUP_SPEC,
+    SPANS_SPEC,
+    strip_body_keys,
+)
+from gateway.tenant_athena_export import (
+    DEFAULT_CONFIG,
+    AthenaExportConfig,
+    RawKeyRejected,
+    _reject_raw_key,
+)
+
+UTC = timezone.utc
+TENANT = "t-acme"
+# S3 key prefix a table name appends to (mirrors dataset_ref in the BigQuery suite).
+DATASET_REF = "tally/"
+
+
+class FakeReader:
+    """In-memory ExportReader: returns canned rows, honouring the watermark + limit like CH would."""
+
+    def __init__(self, rows_by_table: dict[str, list[dict[str, object]]]) -> None:
+        self._rows = rows_by_table
+
+    def fetch_since(
+        self,
+        spec: ExportTableSpec,
+        tenant_id: str,
+        watermark: datetime | date | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        rows = [r for r in self._rows.get(spec.source_table, []) if r["TenantId"] == tenant_id]
+        if watermark is not None:
+            rows = [r for r in rows if r[spec.watermark_column] > watermark]
+        rows.sort(key=lambda r: r[spec.watermark_column])
+        return rows[:limit]
+
+
+class InMemoryWatermarkStore:
+    """Dict-backed watermark store for tests (same protocol the Postgres store implements)."""
+
+    def __init__(self) -> None:
+        self._marks: dict[tuple[str, str], datetime | date] = {}
+
+    def get(self, tenant_id: str, source_table: str) -> datetime | date | None:
+        return self._marks.get((tenant_id, source_table))
+
+    def advance(
+        self, tenant_id: str, source_table: str, watermark: datetime | date, rows: int
+    ) -> None:
+        self._marks[(tenant_id, source_table)] = watermark
+
+
+def _span_row(trace: str, span: str, ts: datetime, **extra: object) -> dict[str, object]:
+    row: dict[str, object] = {c: "" for c in SPANS_SPEC.columns}
+    row.update(
+        TenantId=TENANT,
+        TraceId=trace,
+        SpanId=span,
+        Timestamp=ts,
+        InputTokens=10,
+        OutputTokens=20,
+        SpanAttributes={"gen_ai.request.temperature": "0.7"},
+    )
+    row.update(extra)
+    return row
+
+
+def _spans_reader(rows: list[dict[str, object]]) -> FakeReader:
+    return FakeReader({"otel_spans": rows})
+
+
+# --- disabled by default ------------------------------------------------------------------------
+
+def test_export_disabled_by_default_is_a_noop() -> None:
+    reader = _spans_reader([_span_row("tr1", "sp1", datetime(2026, 7, 1, tzinfo=UTC))])
+    sink = InMemoryS3ParquetSink()
+    marks = InMemoryWatermarkStore()
+
+    results = run_export(
+        reader=reader,
+        sink=sink,
+        watermarks=marks,
+        tenant_id=TENANT,
+        dataset_ref=DATASET_REF,
+        enabled=False,
+        specs=(SPANS_SPEC,),
+    )
+
+    assert results[0].rows_exported == 0
+    assert results[0].partitions_written == 0
+    assert len(sink) == 0
+    assert marks.get(TENANT, "otel_spans") is None
+
+
+def test_tenant_config_default_is_disabled() -> None:
+    assert DEFAULT_CONFIG.enabled is False
+    assert DEFAULT_CONFIG.bucket == ""
+
+
+# --- partitioning + incremental watermark -------------------------------------------------------
+
+def test_rows_land_in_day_partitions_by_watermark() -> None:
+    d1 = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
+    d2 = datetime(2026, 7, 2, 9, 0, tzinfo=UTC)
+    reader = _spans_reader([_span_row("tr1", "sp1", d1), _span_row("tr2", "sp2", d2)])
+    sink = InMemoryS3ParquetSink()
+    marks = InMemoryWatermarkStore()
+
+    result = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+
+    assert result.rows_exported == 2
+    assert result.partitions_written == 2
+    assert partition_prefix(DATASET_REF, SPANS_SPEC, date(2026, 7, 1)) in sink.partitions
+    assert partition_prefix(DATASET_REF, SPANS_SPEC, date(2026, 7, 2)) in sink.partitions
+
+
+def test_watermark_advances_and_second_run_is_incremental() -> None:
+    t0 = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    t1 = datetime(2026, 7, 1, 13, 0, tzinfo=UTC)
+    reader = _spans_reader([_span_row("tr1", "sp1", t0), _span_row("tr2", "sp2", t1)])
+    sink = InMemoryS3ParquetSink()
+    marks = InMemoryWatermarkStore()
+
+    first = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+    assert first.rows_exported == 2
+    assert first.previous_watermark is None
+    assert marks.get(TENANT, "otel_spans") == t1
+
+    # Nothing new -> second pass exports zero and leaves the watermark put.
+    second = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+    assert second.rows_exported == 0
+    assert marks.get(TENANT, "otel_spans") == t1
+
+    # A newer row -> only that one is picked up, watermark advances again.
+    t2 = datetime(2026, 7, 3, 14, 0, tzinfo=UTC)
+    reader._rows["otel_spans"].append(_span_row("tr3", "sp3", t2))
+    third = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )[0]
+    assert third.rows_exported == 1
+    assert marks.get(TENANT, "otel_spans") == t2
+    # Three spans total across the table's partitions.
+    assert len(sink.table_rows(f"{DATASET_REF}{SPANS_SPEC.name}/")) == 3
+
+
+# --- idempotency (per day partition) ------------------------------------------------------------
+
+def test_rerun_over_same_window_does_not_duplicate() -> None:
+    t0 = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    rows = [_span_row("tr1", "sp1", t0), _span_row("tr2", "sp2", t0)]
+    reader = _spans_reader(rows)
+    sink = InMemoryS3ParquetSink()
+
+    # Re-run the SAME window twice by resetting the watermark each time (simulates a replayed pass
+    # after a crash). The partition upserts on (TenantId, TraceId, SpanId), so it stays stable.
+    for _ in range(3):
+        run_export(
+            reader=reader, sink=sink, watermarks=InMemoryWatermarkStore(), tenant_id=TENANT,
+            dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+        )
+
+    prefix = partition_prefix(DATASET_REF, SPANS_SPEC, date(2026, 7, 1))
+    assert len(sink.rows(prefix)) == 2
+    assert sink.write_count == 3  # three passes, but the partition never grew
+
+
+def test_intraday_incremental_pass_keeps_earlier_rows_of_partition() -> None:
+    # Two rows for the same day arriving across two passes must both survive (partition upsert,
+    # not overwrite) — the failure mode a naive "overwrite the day file" sink would have.
+    t_early = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
+    t_late = datetime(2026, 7, 1, 18, 0, tzinfo=UTC)
+    reader = _spans_reader([_span_row("tr1", "sp1", t_early)])
+    sink = InMemoryS3ParquetSink()
+    marks = InMemoryWatermarkStore()
+
+    run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )
+    reader._rows["otel_spans"].append(_span_row("tr2", "sp2", t_late))
+    run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )
+
+    prefix = partition_prefix(DATASET_REF, SPANS_SPEC, date(2026, 7, 1))
+    assert len(sink.rows(prefix)) == 2
+
+
+def test_partition_write_is_keyed_not_appended() -> None:
+    sink = InMemoryS3ParquetSink()
+    prefix = partition_prefix(DATASET_REF, SPANS_SPEC, date(2026, 7, 1))
+    row = {"TenantId": TENANT, "TraceId": "tr1", "SpanId": "sp1", "InputTokens": 1}
+    sink.write_partition(
+        table=SPANS_SPEC.name, prefix=prefix, schema=SPANS_SPEC.schema,
+        key_columns=SPANS_SPEC.key_columns, rows=[row],
+    )
+    sink.write_partition(
+        table=SPANS_SPEC.name, prefix=prefix, schema=SPANS_SPEC.schema,
+        key_columns=SPANS_SPEC.key_columns, rows=[{**row, "InputTokens": 99}],
+    )
+    stored = sink.rows(prefix)
+    assert len(stored) == 1
+    assert stored[0]["InputTokens"] == 99
+
+
+# --- no bodies ----------------------------------------------------------------------------------
+
+def test_no_exported_column_is_body_keyed() -> None:
+    for spec in ALL_SPECS:
+        for col in spec.columns:
+            assert not athena_export._is_body_key(col), f"{spec.name}.{col} is body-keyed"
+
+
+def test_no_spec_sources_a_replay_body_table() -> None:
+    banned = {"replay_runs", "replay_samples"}
+    for spec in ALL_SPECS:
+        assert spec.source_table not in banned
+        assert not any(c.lower() in {"responsetext", "response_text"} for c in spec.columns)
+
+
+def test_span_attribute_map_strips_body_keys_before_write() -> None:
+    t0 = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    row = _span_row(
+        "tr1", "sp1", t0,
+        SpanAttributes={"model_kwargs": "x", "prompt": "LEAK", "body": "LEAK"},
+    )
+    sink = InMemoryS3ParquetSink()
+    run_export(
+        reader=_spans_reader([row]), sink=sink, watermarks=InMemoryWatermarkStore(),
+        tenant_id=TENANT, dataset_ref=DATASET_REF, enabled=True, specs=(SPANS_SPEC,),
+    )
+    prefix = partition_prefix(DATASET_REF, SPANS_SPEC, date(2026, 7, 1))
+    stored = sink.rows(prefix)[0]
+    assert stored["SpanAttributes"] == {"model_kwargs": "x"}
+
+
+def test_strip_body_keys_reused_from_shared_module() -> None:
+    cleaned = strip_body_keys({"region": "us-east1", "prompt": "SECRET", "content": "SECRET"})
+    assert cleaned == {"region": "us-east1"}
+
+
+# --- Athena / Redshift DDL ----------------------------------------------------------------------
+
+def test_athena_ddl_maps_shared_schema_and_partitions_by_day() -> None:
+    ddl = athena_create_table_ddl(
+        SPANS_SPEC, database="tally_export", s3_location="s3://bkt/tally/otel_spans/"
+    )
+    assert "CREATE EXTERNAL TABLE IF NOT EXISTS `tally_export`.`otel_spans`" in ddl
+    assert "PARTITIONED BY (`dt` date)" in ddl
+    assert "STORED AS PARQUET" in ddl
+    assert "LOCATION 's3://bkt/tally/otel_spans/'" in ddl
+    # Type mapping from the shared BQField schema.
+    assert "`TenantId` string" in ddl
+    assert "`InputTokens` bigint" in ddl
+    assert "`EstimatedCost` decimal(38, 9)" in ddl
+    assert "`Timestamp` timestamp" in ddl
+    assert "`SpanAttributes` string" in ddl  # JSON map stored as a JSON string
+    # The partition column must NOT also be a data column.
+    assert "`dt` " not in ddl.split("PARTITIONED BY")[0]
+
+
+def test_daily_rollup_ddl_has_date_partition_and_date_column() -> None:
+    ddl = athena_create_table_ddl(
+        DAILY_ROLLUP_SPEC, database="db", s3_location="s3://bkt/tally/daily_feature_rollup/"
+    )
+    assert "`Day` date" in ddl
+    assert "PARTITIONED BY (`dt` date)" in ddl
+
+
+def test_all_ddl_covers_every_spec() -> None:
+    ddl = all_ddl(database="tally_export", bucket="bkt", prefix="tally")
+    assert set(ddl) == {s.name for s in ALL_SPECS}
+    for spec in ALL_SPECS:
+        assert f"s3://bkt/tally/{spec.name}/" in ddl[spec.name]
+
+
+def test_redshift_copy_recipe_references_role_not_key() -> None:
+    sql = redshift_copy_sql(
+        SPANS_SPEC, s3_location="s3://bkt/tally/otel_spans/",
+        iam_role="arn:aws:iam::123456789012:role/tally-redshift",
+    )
+    assert "COPY otel_spans" in sql
+    assert "FORMAT AS PARQUET" in sql
+    assert "IAM_ROLE 'arn:aws:iam::123456789012:role/tally-redshift'" in sql
+
+
+# --- rollup shape (shared spec) -----------------------------------------------------------------
+
+def test_rollup_exports_and_partitions_by_day() -> None:
+    day = date(2026, 7, 1)
+    reader = FakeReader({
+        "daily_feature_rollup": [{
+            "TenantId": TENANT, "Day": day, "FeatureTag": "chat",
+            "GenAiResponseModel": "gpt-4o", "InputTokens": 100, "OutputTokens": 50,
+            "CachedInputTokens": 0, "EstimatedCost": 1, "ReconciledCost": 1,
+            "SpanCount": 3, "TraceCount": 2, "UserCount": 1,
+        }]
+    })
+    sink = InMemoryS3ParquetSink()
+    marks = InMemoryWatermarkStore()
+    result = run_export(
+        reader=reader, sink=sink, watermarks=marks, tenant_id=TENANT,
+        dataset_ref=DATASET_REF, enabled=True, specs=(DAILY_ROLLUP_SPEC,),
+    )[0]
+    assert result.rows_exported == 1
+    assert result.partitions_written == 1
+    assert marks.get(TENANT, "daily_feature_rollup") == day
+    assert partition_prefix(DATASET_REF, DAILY_ROLLUP_SPEC, day) in sink.partitions
+
+
+# --- credential-ref guard (reference only, never a raw key) -------------------------------------
+
+def test_reject_inline_aws_key() -> None:
+    with pytest.raises(RawKeyRejected):
+        _reject_raw_key("aws_secret_access_key=wJalrXUtnFEMI/K7MDENG")
+    with pytest.raises(RawKeyRejected):
+        _reject_raw_key("AKIAIOSFODNN7EXAMPLE")
+
+
+def test_accept_role_arn_reference() -> None:
+    # An IAM role ARN is a reference, not a raw key — must be accepted.
+    _reject_raw_key("arn:aws:iam::123456789012:role/tally-export")
+
+
+def test_config_s3_uri_and_dataset_ref() -> None:
+    cfg = AthenaExportConfig(
+        enabled=True, bucket="bkt", prefix="tally", database="db", region="us-east-1",
+        credential_ref="arn:aws:iam::1:role/r",
+    )
+    assert cfg.dataset_ref() == "tally/"
+    assert cfg.s3_uri("otel_spans") == "s3://bkt/tally/otel_spans/"
+
+
+# --- lazy optional import -----------------------------------------------------------------------
+
+def test_module_imports_without_athena_dependency() -> None:
+    # The module imported at the top of this file (and is usable) without the optional extra,
+    # which proves pyarrow / boto3 are never imported at module load. A fresh import via the loader
+    # must likewise not pull them in eagerly.
+    module = importlib.import_module("gateway.athena_export")
+    assert hasattr(module, "run_export")
+    assert "pyarrow" not in sys.modules
+    assert "boto3" not in sys.modules
+
+
+def test_load_s3_parquet_sink_guards_missing_dependency() -> None:
+    try:
+        import boto3  # noqa: F401
+        import pyarrow  # noqa: F401
+    except ImportError:
+        with pytest.raises(AthenaDependencyMissing):
+            load_s3_parquet_sink("bkt")
+    else:  # pragma: no cover - extra installed in this env
+        pytest.skip("pyarrow/boto3 installed; lazy-import guard not exercisable")
+
+
+def test_shared_specs_are_the_same_objects_as_bigquery() -> None:
+    # Both sinks emit identical facts: athena_export re-exports the very same spec objects.
+    from gateway import bq_export
+
+    assert athena_export.ALL_SPECS is bq_export.ALL_SPECS
+    for spec in ALL_SPECS:
+        for key in spec.key_columns:
+            assert key in spec.columns, f"{spec.name} key {key} not in columns"

--- a/infra/gateway/tests/test_connectors_vercel.py
+++ b/infra/gateway/tests/test_connectors_vercel.py
@@ -1,0 +1,279 @@
+"""Vercel compute + egress cost connector (CTO-163) — offline tests, NO live cloud calls.
+
+Pins the contract the /cost Compute + Egress columns depend on for a Vercel-hosted app:
+
+  * The SAME Vercel usage payload splits into compute (Function invocations + GB-hours) and egress
+    (bandwidth) with NO cross-layer double-count — compute ignores bandwidth, egress ignores compute.
+  * The connector lands ONE synthetic ``compute`` span/day (GenAiSystem='vercel') with the day's
+    compute total as EstimatedCost (cost set directly — no catalog enrichment).
+  * Egress double-count reconciliation with CTO-144: by default (``emit_egress=False``) the connector
+    emits NO egress span — CTO-144's egress connector owns it. With the gate on it DOES emit egress,
+    and the span id is IDENTICAL to CTO-144's, so the base span_exists guard collapses any overlap.
+  * Backfill is idempotent; a failed fetch records 'failed' and emits NO span.
+
+Reuses the CTO-143 base + CTO-144 egress connector verbatim: everything Vercel-specific is behind an
+injected fake usage fetcher / fake store — no test touches requests, ClickHouse, or Postgres.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from gateway.connectors.base import synthetic_span_id
+from gateway.connectors.egress import (
+    EgressCostConnector,
+    VercelBandwidthClient,
+    parse_vercel_usage,
+)
+from gateway.connectors.vercel import (
+    VercelComputeClient,
+    VercelConfig,
+    VercelCostConnector,
+    VercelUsageClient,
+    parse_vercel_compute,
+)
+from gateway.mapping import COLUMNS
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "vercel"
+
+_OP = COLUMNS.index("GenAiOperation")
+_COST = COLUMNS.index("EstimatedCost")
+_SYSTEM = COLUMNS.index("GenAiSystem")
+_SOURCE = COLUMNS.index("CostSource")
+_SPAN_ID = COLUMNS.index("SpanId")
+_TENANT = COLUMNS.index("TenantId")
+
+
+def _fixture(name: str) -> object:
+    return json.loads((_FIXTURES / name).read_text())
+
+
+# --- fake infra -------------------------------------------------------------------------------
+
+
+class FakeStore:
+    """In-memory stand-in for ClickHouseStore — records inserted rows, answers span_exists."""
+
+    def __init__(self) -> None:
+        self.rows: list[tuple[object, ...]] = []
+
+    def span_exists(self, tenant_id: str, span_id: str) -> bool:
+        return any(r[_TENANT] == tenant_id and r[_SPAN_ID] == span_id for r in self.rows)
+
+    def insert_spans(self, rows: list[tuple[object, ...]]) -> int:
+        self.rows.extend(rows)
+        return len(rows)
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str, str | None]] = []
+
+    def record_run(self, tenant_id, connector_id, status, *, error_message=None) -> None:
+        self.calls.append((tenant_id, connector_id, status, error_message))
+
+
+def _usage_client(payload: object | None = None, *, raises: Exception | None = None):
+    """A VercelUsageClient whose fetch returns the fixture (or raises), never hitting the network."""
+
+    def _getter(config, start_day, end_day):
+        if raises is not None:
+            raise raises
+        return payload if payload is not None else _fixture("usage.json")
+
+    return VercelUsageClient(http_getter=_getter)
+
+
+def _config(*, emit_egress: bool = False) -> VercelConfig:
+    return VercelConfig(
+        tenant_id="t-acme",
+        cloud_provider="vercel",
+        credentials_ref="secret://vercel-token",
+        team_id="team_123",
+        project_id="prj_456",
+        emit_egress=emit_egress,
+    )
+
+
+# --- pure parsers: the compute/egress split, no double-count -----------------------------------
+
+
+def test_parse_vercel_compute_sums_only_function_compute() -> None:
+    costs = parse_vercel_compute(_fixture("usage.json"))
+    # 2026-07-01: invocations 2.00 + GB-hours 3.50 = 5.50; 07-02: 4.00; the $99-equivalent bandwidth
+    # lines are IGNORED (no double-count with egress); the $0 day is dropped.
+    assert costs == [
+        _dc(date(2026, 7, 1), 5_500_000),
+        _dc(date(2026, 7, 2), 4_000_000),
+    ]
+
+
+def test_compute_and_egress_split_the_same_payload_disjointly() -> None:
+    """Compute keeps function_* lines; egress keeps bandwidth lines — no item counts twice."""
+    payload = _fixture("usage.json")
+    compute = parse_vercel_compute(payload)
+    egress = parse_vercel_usage(payload)  # CTO-144's reciprocal parser
+    assert [(c.day, c.cost_micro_usd) for c in compute] == [
+        (date(2026, 7, 1), 5_500_000),
+        (date(2026, 7, 2), 4_000_000),
+    ]
+    assert [(c.day, c.cost_micro_usd) for c in egress] == [
+        (date(2026, 7, 1), 1_250_000),
+        (date(2026, 7, 2), 6_250_000),
+    ]
+
+
+def test_compute_client_range_filters() -> None:
+    client = VercelComputeClient(_usage_client())
+    costs = client.get_daily_costs(_config(), start_day=date(2026, 7, 2), end_day=date(2026, 7, 2))
+    assert costs == [_dc(date(2026, 7, 2), 4_000_000)]
+
+
+# --- synthetic span emission (compute) --------------------------------------------------------
+
+
+def test_run_emits_one_compute_span_with_direct_cost() -> None:
+    store, recorder = FakeStore(), FakeRecorder()
+    connector = VercelCostConnector(store=store, usage_client=_usage_client(), recorder=recorder)
+
+    result = connector.run(_config(), day=date(2026, 7, 1))
+
+    assert result.compute.status == "success"
+    assert result.compute.spans_emitted == 1
+    assert result.egress is None  # gate off by default
+    assert len(store.rows) == 1
+    row = store.rows[0]
+    assert row[_OP] == "compute"
+    assert row[_SYSTEM] == "vercel"
+    assert row[_SOURCE] == "estimated"
+    assert float(row[_COST]) == pytest.approx(5.50)
+
+
+def test_default_gate_emits_no_egress_span() -> None:
+    """emit_egress=False → CTO-144 owns Vercel egress; this connector emits ONLY the compute span."""
+    store = FakeStore()
+    connector = VercelCostConnector(store=store, usage_client=_usage_client())
+    connector.run(_config(emit_egress=False), day=date(2026, 7, 1))
+    ops = {r[_OP] for r in store.rows}
+    assert ops == {"compute"}
+
+
+# --- egress reconciliation with CTO-144 -------------------------------------------------------
+
+
+def test_gated_egress_emits_compute_and_egress_one_each() -> None:
+    store = FakeStore()
+    connector = VercelCostConnector(store=store, usage_client=_usage_client())
+    result = connector.run(_config(emit_egress=True), day=date(2026, 7, 1))
+
+    assert result.compute.spans_emitted == 1
+    assert result.egress is not None and result.egress.spans_emitted == 1
+    by_op = {r[_OP]: r for r in store.rows}
+    assert set(by_op) == {"compute", "egress"}
+    assert float(by_op["compute"][_COST]) == pytest.approx(5.50)
+    assert float(by_op["egress"][_COST]) == pytest.approx(1.25)
+
+
+def test_gated_egress_span_id_matches_cto144_path() -> None:
+    """The gated egress span is byte-identical in id to CTO-144's egress connector for the same day,
+    so if BOTH ever ran the base span_exists guard collapses them — no double-count is possible."""
+    day = date(2026, 7, 1)
+    store = FakeStore()
+
+    # This connector, gate on.
+    VercelCostConnector(store=store, usage_client=_usage_client()).run(
+        _config(emit_egress=True), day=day
+    )
+    egress_row = next(r for r in store.rows if r[_OP] == "egress")
+    ours = egress_row[_SPAN_ID]
+
+    # Independently, CTO-144's egress connector with the same Vercel payload.
+    store2 = FakeStore()
+    EgressCostConnector(
+        store=store2,
+        recorder=FakeRecorder(),
+        billing_client=VercelBandwidthClient(http_getter=_usage_client()._http_getter),
+    ).run(VercelCostConnector._egress_config(_config()), day=day)
+    theirs = next(r for r in store2.rows if r[_OP] == "egress")[_SPAN_ID]
+
+    assert ours == theirs == synthetic_span_id("t-acme", "vercel", "egress", day)[1]
+
+
+def test_both_paths_same_store_do_not_double_count_egress() -> None:
+    """Belt-and-braces: run CTO-144's egress AND this connector's gated egress on one store; the
+    second insert is skipped by span_exists — one egress row total."""
+    day = date(2026, 7, 1)
+    store = FakeStore()
+    EgressCostConnector(
+        store=store,
+        recorder=FakeRecorder(),
+        billing_client=VercelBandwidthClient(http_getter=_usage_client()._http_getter),
+    ).run(VercelCostConnector._egress_config(_config()), day=day)
+    VercelCostConnector(store=store, usage_client=_usage_client()).run(
+        _config(emit_egress=True), day=day
+    )
+    egress_rows = [r for r in store.rows if r[_OP] == "egress"]
+    assert len(egress_rows) == 1
+
+
+def test_compute_and_egress_span_ids_distinct_same_day() -> None:
+    compute = synthetic_span_id("t", "vercel", "compute", date(2026, 7, 1))
+    egress = synthetic_span_id("t", "vercel", "egress", date(2026, 7, 1))
+    assert compute != egress
+
+
+# --- idempotency & backfill -------------------------------------------------------------------
+
+
+def test_backfill_is_idempotent() -> None:
+    store = FakeStore()
+    connector = VercelCostConnector(store=store, usage_client=_usage_client())
+    first = connector.run_backfill(
+        _config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 2)
+    )
+    second = connector.run_backfill(
+        _config(), start_day=date(2026, 7, 1), end_day=date(2026, 7, 2)
+    )
+    assert first.compute.spans_emitted == 2
+    assert second.compute.spans_emitted == 0
+    assert len([r for r in store.rows if r[_OP] == "compute"]) == 2
+
+
+# --- run-status recording ---------------------------------------------------------------------
+
+
+def test_run_records_success_status() -> None:
+    recorder = FakeRecorder()
+    connector = VercelCostConnector(
+        store=FakeStore(), usage_client=_usage_client(), recorder=recorder
+    )
+    connector.run(_config(), day=date(2026, 7, 1))
+    assert recorder.calls == [("t-acme", "compute", "success", None)]
+
+
+def test_failed_fetch_records_failed_and_emits_no_span() -> None:
+    store, recorder = FakeStore(), FakeRecorder()
+    connector = VercelCostConnector(
+        store=store,
+        usage_client=_usage_client(raises=RuntimeError("vercel 503")),
+        recorder=recorder,
+    )
+    result = connector.run(_config(), day=date(2026, 7, 1))
+    assert result.compute.status == "failed"
+    assert result.compute.spans_emitted == 0
+    assert store.rows == []
+    assert recorder.calls[0][2] == "failed"
+    assert "vercel 503" in (recorder.calls[0][3] or "")
+
+
+# --- helpers ----------------------------------------------------------------------------------
+
+
+def _dc(day, micro):
+    from gateway.connectors.base import DailyCost
+
+    return DailyCost(day=day, cost_micro_usd=micro)


### PR DESCRIPTION
Implements CTO-163. Adds a daily Vercel connector (`gateway.connectors.vercel`) that pulls a tenant's Vercel usage/billing and lands **Functions compute** (invocations + GB-hours) as synthetic `compute`-layer spans via the reused CTO-143 base, so a Vercel-hosted AI app's full infra cost sits next to its LLM spend on `/cost`.

## Compute + egress mapping
The same Vercel usage payload (`items[]`) is split disjointly by line-item `type`:
- **compute** — `function_invocations` + `function_duration` (GB-hours) → one `compute` span/day (`GenAiSystem='vercel'`), cost set directly (no catalog enrichment).
- **egress** — `bandwidth` → one `egress` span/day (see reconciliation).

`bandwidth` never enters the compute total and `function_*` never enters egress, so no item is counted twice across layers.

## Egress double-count reconciliation with CTO-144
CTO-144's egress connector already ingests Vercel bandwidth. Two safeguards prevent double-counting the `/cost` Egress column:
1. **Gate (primary).** This connector emits egress **only** when `tenant_vercel_config.emit_egress = true` (default **false**). Default behaviour: this ticket owns the compute half; Vercel egress flows solely through CTO-144's `EgressCostConnector`. Set the flag only for a tenant with **no** CTO-144 `tenant_egress_config` row for `egress_provider='vercel'`.
2. **Same span id (defence in depth).** When the gate is on, egress is routed through CTO-144's `EgressCostConnector` + `VercelBandwidthClient` verbatim, so the synthetic span id equals `synthetic_span_id(tenant, 'vercel', 'egress', day)` — **identical** to CTO-144's. Even if both paths ran for a day, the base `span_exists` guard collapses them to one row. A test asserts this id equality and the single-row outcome on a shared store.

## Migration
New `db/postgres/0016_tenant_vercel_config.sql` (0013–0016 free on origin/main). One row per tenant, PK `tenant_id`. Token by **reference only** (`access_token_ref`, Secret Manager pointer, bounded-length check); `team_id`/`project_id` public; `enabled` + `emit_egress` flags. Additive — existing tenants have zero rows and are skipped.

## config.py
Additive `TALLY_`-prefixed settings only (`vercel_connector_enabled`, `vercel_api_base`, `vercel_emit_egress`), appended after the CTO-154 BigQuery block — no logic changes, no edits to existing settings, so it unions cleanly with CTO-150/158/160 if they touch the same file. Not yet rebased (no conflict on push).

## Behaviour
Idempotent per day (base `synthetic_span_id`); fail-soft (a failed fetch records `failed` and emits **no** span — honest-null). Injectable usage client; no network in tests.

## Tests
12 new offline tests in `test_connectors_vercel.py` (payload → compute + egress rows, disjoint split, default gate emits no egress, gated egress + same-id reconciliation, idempotent backfill, failure emits no span). Full suite: **329 passed**, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)