### PR TITLE
feat(vercel): AI Gateway instrumentation with true-upstream attribution (CTO-161)

### DIFF
--- a/infra/gateway/tests/test_enrich_bedrock.py
+++ b/infra/gateway/tests/test_enrich_bedrock.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gateway cost enrichment for Amazon Bedrock spans (CTO-157).
+
+The gateway recomputes cost from the catalog in ``enrich_cost``. A span with
+``gen_ai.system="bedrock"`` and a seeded Bedrock model must price to a non-zero cost with
+no ``catalog_miss`` — proving Bedrock needs no special-casing in the mapping/enrich path
+(provider is just the catalog lookup key), exactly like the CTO-149 Gemini case.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from tally.enrichment import enrich_cost
+from tally.pricing import seed_catalog
+from tally.schema import GenAI
+
+from gateway.mapping import COLUMNS, span_to_row
+
+AT = date(2026, 6, 1)
+
+
+def _span(model: str, input_tokens: int = 1000, output_tokens: int = 250) -> dict[str, object]:
+    return {
+        GenAI.SYSTEM: "bedrock",
+        GenAI.REQUEST_MODEL: model,
+        GenAI.RESPONSE_MODEL: model,
+        GenAI.USAGE_INPUT_TOKENS: input_tokens,
+        GenAI.USAGE_OUTPUT_TOKENS: output_tokens,
+    }
+
+
+def test_enrich_bedrock_claude_no_catalog_miss() -> None:
+    res = enrich_cost(_span("anthropic.claude-sonnet-4-5"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enrich_bedrock_nova_no_catalog_miss() -> None:
+    res = enrich_cost(_span("amazon.nova-pro"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enrich_bedrock_llama_no_catalog_miss() -> None:
+    res = enrich_cost(_span("meta.llama3-3-70b-instruct"), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enriched_bedrock_span_maps_to_row_with_cost() -> None:
+    # End-to-end through the mapping: enriched bedrock span -> otel row with a non-zero
+    # EstimatedCost and GenAiSystem="bedrock", no special-casing anywhere.
+    res = enrich_cost(
+        _span("anthropic.claude-sonnet-4-5", 1_000_000, 1_000_000), seed_catalog(), at=AT
+    )
+    row = span_to_row(res.attributes, tenant_id="tn-1", effective_ts_ns=1_700_000_000_000_000_000)
+    by_col = dict(zip(COLUMNS, row, strict=True))
+    assert by_col["GenAiSystem"] == "bedrock"
+    assert by_col["GenAiRequestModel"] == "anthropic.claude-sonnet-4-5"
+    assert by_col["EstimatedCost"] > 0

--- a/infra/gateway/tests/test_enrich_vercel_gateway.py
+++ b/infra/gateway/tests/test_enrich_vercel_gateway.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gateway cost enrichment for Vercel-AI-Gateway-proxied spans (CTO-161).
+
+A call routed through the Vercel AI Gateway is resolved SDK-side to its TRUE upstream
+``(provider, model)`` (see :mod:`tally.vercel_gateway`), so by the time the span reaches the
+gateway it carries ``gen_ai.system="openai"`` / ``gen_ai.request.model="gpt-4o-mini"`` — and
+``enrich_cost`` prices it straight from the catalog with no special-casing, exactly like a
+direct SDK call (the CTO-149 / CTO-157 pattern). An unresolved upstream carries
+``gen_ai.system="unknown"``, which the catalog can't price → ``catalog_miss`` → cost null.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from tally.enrichment import enrich_cost
+from tally.pricing import seed_catalog
+from tally.schema import GenAI
+from tally.vercel_gateway import resolve_upstream
+
+from gateway.mapping import COLUMNS, span_to_row
+
+AT = date(2026, 6, 1)
+
+# The same captured Vercel-AI-Gateway response the SDK test uses, minus bodies.
+_GATEWAY_OPENAI_RESPONSE = {
+    "model": "openai/gpt-4o-mini",
+    "usage": {
+        "prompt_tokens": 1_000_000,
+        "completion_tokens": 1_000_000,
+        "prompt_tokens_details": {"cached_tokens": 0},
+    },
+}
+
+
+def _span_from_gateway(md: dict[str, object]) -> dict[str, object]:
+    """Build the span the SDK would emit for a gateway-proxied call from its response metadata."""
+    att = resolve_upstream(md)
+    return {
+        GenAI.SYSTEM: att.provider,
+        GenAI.REQUEST_MODEL: att.model,
+        GenAI.RESPONSE_MODEL: att.model,
+        GenAI.USAGE_INPUT_TOKENS: att.usage.input_tokens,
+        GenAI.USAGE_OUTPUT_TOKENS: att.usage.output_tokens,
+        GenAI.USAGE_CACHED_INPUT_TOKENS: att.usage.cached_input_tokens,
+    }
+
+
+def test_enrich_gateway_openai_prices_true_upstream() -> None:
+    res = enrich_cost(_span_from_gateway(_GATEWAY_OPENAI_RESPONSE), seed_catalog(), at=AT)
+    assert res.catalog_miss is False
+    assert res.server_cost_micro_usd is not None
+    assert res.server_cost_micro_usd > 0
+
+
+def test_enrich_gateway_matches_direct_openai_cost() -> None:
+    # The gateway hop must not change the price: enriching the resolved span equals enriching a
+    # direct openai/gpt-4o-mini span with the same usage.
+    gateway = enrich_cost(_span_from_gateway(_GATEWAY_OPENAI_RESPONSE), seed_catalog(), at=AT)
+    direct_span = {
+        GenAI.SYSTEM: "openai",
+        GenAI.REQUEST_MODEL: "gpt-4o-mini",
+        GenAI.RESPONSE_MODEL: "gpt-4o-mini",
+        GenAI.USAGE_INPUT_TOKENS: 1_000_000,
+        GenAI.USAGE_OUTPUT_TOKENS: 1_000_000,
+    }
+    direct = enrich_cost(direct_span, seed_catalog(), at=AT)
+    assert gateway.server_cost_micro_usd == direct.server_cost_micro_usd
+
+
+def test_enriched_gateway_span_maps_to_row_with_true_upstream() -> None:
+    res = enrich_cost(_span_from_gateway(_GATEWAY_OPENAI_RESPONSE), seed_catalog(), at=AT)
+    row = span_to_row(res.attributes, tenant_id="tn-1", effective_ts_ns=1_700_000_000_000_000_000)
+    by_col = dict(zip(COLUMNS, row, strict=True))
+    # True upstream lands in the typed columns — NOT "vercel".
+    assert by_col["GenAiSystem"] == "openai"
+    assert by_col["GenAiRequestModel"] == "gpt-4o-mini"
+    assert by_col["EstimatedCost"] > 0
+
+
+def test_enrich_gateway_unknown_upstream_is_catalog_miss() -> None:
+    # Gateway metadata with no nameable model -> resolved to "unknown" -> the catalog can't price
+    # it, so the cost is dropped (dashboard "—"), never fabricated.
+    span = _span_from_gateway({"usage": {"prompt_tokens": 1000, "completion_tokens": 250}})
+    assert span[GenAI.SYSTEM] == "unknown"
+    res = enrich_cost(span, seed_catalog(), at=AT)
+    assert res.catalog_miss is True
+    assert res.server_cost_micro_usd is None
+    assert GenAI.COST_ESTIMATED_MICRO_USD not in res.attributes

--- a/sdk/python/src/tally/models.py
+++ b/sdk/python/src/tally/models.py
@@ -49,7 +49,7 @@ DEFAULT_CACHE_PATH = Path(".tally/models.json")
 class ModelInfo:
     """A single model entry as returned by a provider's ``/v1/models`` endpoint."""
 
-    provider: str  # "openai" | "anthropic" | "google"
+    provider: str  # "openai" | "anthropic" | "google" | "bedrock"
     id: str  # canonical id, e.g. "claude-sonnet-4-5" or "gpt-4o-mini"
     family: str  # see classify_family()
     created_at: datetime | None
@@ -240,6 +240,78 @@ def fetch_google_models(api_key: str, *, timeout: float = 5.0) -> list[ModelInfo
     return out
 
 
+def _default_bedrock_client(region: str | None):
+    """Build a boto3 ``bedrock`` (control-plane) client via the AWS default credential chain.
+
+    Imported lazily because ``boto3`` is an OPTIONAL dependency — the SDK is dep-light and must
+    import fine without it. Callers that want Bedrock discovery either install ``boto3`` or inject
+    their own client. Region resolves from the ``region`` arg, then ``AWS_REGION`` /
+    ``AWS_DEFAULT_REGION``. Credentials come from the standard chain (env vars, shared config,
+    SSO, instance/task role) — no raw keys are handled here.
+    """
+    import boto3  # optional dep; ImportError is caught by the discover_models fail-soft path
+
+    region = region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    return boto3.client("bedrock", region_name=region)
+
+
+def fetch_bedrock_models(*, client=None, region: str | None = None) -> list[ModelInfo]:
+    """List Amazon Bedrock foundation models via the Bedrock control-plane (CTO-157).
+
+    Uses the ``bedrock`` client's ``list_foundation_models`` (NOT ``bedrock-runtime`` — the
+    control plane is where the catalog lives). ``client`` is injectable so tests never hit AWS;
+    when omitted, a boto3 client is built via :func:`_default_bedrock_client` using the AWS
+    default credential chain.
+
+    Response shape: ``{"modelSummaries": [{"modelId": "anthropic.claude-...", ...}]}``. The
+    ``modelId`` is used verbatim as the ``ModelInfo.id`` — it matches what a Bedrock caller
+    passes as ``gen_ai.request_model`` and the ``bedrock/`` catalog slugs.
+
+    Only TEXT-output (chat/completion) models are returned: a summary whose ``outputModalities``
+    is present and excludes ``"TEXT"`` (image/embedding-only SKUs) is skipped, mirroring the
+    CTO-172 non-chat guard so a chat family never receives a non-chat model.
+    """
+    if client is None:
+        client = _default_bedrock_client(region)
+    payload = client.list_foundation_models()
+    out: list[ModelInfo] = []
+    for row in payload.get("modelSummaries", []):
+        model_id = row.get("modelId")
+        if not model_id or not isinstance(model_id, str):
+            continue
+        modalities = row.get("outputModalities")
+        if modalities and "TEXT" not in modalities:
+            continue
+        out.append(
+            ModelInfo(
+                provider="bedrock",
+                id=model_id,
+                family=classify_family(model_id),
+                created_at=None,
+                deprecated_at=None,
+            )
+        )
+    return out
+
+
+def _aws_configured() -> bool:
+    """True when the environment carries enough AWS config to attempt Bedrock discovery.
+
+    We can't validate credentials without a call, so this is a cheap gate on the default-chain
+    signals (a region plus some credential source). When false, Bedrock discovery is skipped
+    entirely — exactly like a missing ``GOOGLE_API_KEY`` skips Google.
+    """
+    has_region = bool(os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"))
+    has_creds = bool(
+        os.environ.get("AWS_ACCESS_KEY_ID")
+        or os.environ.get("AWS_PROFILE")
+        or os.environ.get("AWS_ROLE_ARN")
+        or os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+        or os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE")
+    )
+    return has_region and has_creds
+
+
 def save_cache(models: list[ModelInfo], path: Path = DEFAULT_CACHE_PATH) -> None:
     """Persist the discovered list to ``path`` (creating parent dirs)."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -321,6 +393,7 @@ def discover_models(
     openai_api_key: str | None = None,
     anthropic_api_key: str | None = None,
     google_api_key: str | None = None,
+    bedrock_client=None,
     timeout: float = 5.0,
 ) -> list[ModelInfo]:
     """Boot-time discovery entry point. Fail-soft on every error path.
@@ -357,6 +430,7 @@ def discover_models(
     openai_err: Exception | None = None
     anthropic_err: Exception | None = None
     google_err: Exception | None = None
+    bedrock_err: Exception | None = None
 
     if openai_key:
         try:
@@ -390,6 +464,20 @@ def discover_models(
     else:
         logger.info("models: GOOGLE_API_KEY/GEMINI_API_KEY not set — skipping google discovery")
 
+    # Bedrock is behind an injectable client (tests never touch AWS). Attempt it when a client
+    # is injected OR the AWS default credential chain looks configured. Fail-soft on EVERY error
+    # — missing boto3 (ImportError), no/invalid creds, region issues, or a botocore API error must
+    # skip Bedrock, never crash discovery. boto3's exception hierarchy can't be imported when boto3
+    # isn't installed, so this catch is intentionally broad.
+    if bedrock_client is not None or _aws_configured():
+        try:
+            discovered.extend(fetch_bedrock_models(client=bedrock_client))
+        except Exception as exc:  # noqa: BLE001 - optional dep + external SDK; must fail soft
+            bedrock_err = exc
+            logger.warning("models: bedrock fetch failed: %s", exc)
+    else:
+        logger.info("models: AWS creds/region not set — skipping bedrock discovery")
+
     if discovered:
         try:
             save_cache(discovered, cache_path)
@@ -403,21 +491,23 @@ def discover_models(
     stale = _load_unchecked(cache_path)
     if stale is not None:
         logger.warning(
-            "models: live fetch failed (openai=%s anthropic=%s google=%s) — "
+            "models: live fetch failed (openai=%s anthropic=%s google=%s bedrock=%s) — "
             "using stale cache (%d entries)",
             openai_err,
             anthropic_err,
             google_err,
+            bedrock_err,
             len(stale),
         )
         return stale
 
     logger.warning(
-        "models: no live data and no cache (openai=%s anthropic=%s google=%s) — "
+        "models: no live data and no cache (openai=%s anthropic=%s google=%s bedrock=%s) — "
         "booting with empty list",
         openai_err,
         anthropic_err,
         google_err,
+        bedrock_err,
     )
     return []
 
@@ -426,7 +516,14 @@ def _log_summary(models: list[ModelInfo]) -> None:
     openai_ids = sorted(m.id for m in models if m.provider == "openai")
     anth_ids = sorted(m.id for m in models if m.provider == "anthropic")
     google_ids = sorted(m.id for m in models if m.provider == "google")
-    logger.info("models: openai=%s anthropic=%s google=%s", openai_ids, anth_ids, google_ids)
+    bedrock_ids = sorted(m.id for m in models if m.provider == "bedrock")
+    logger.info(
+        "models: openai=%s anthropic=%s google=%s bedrock=%s",
+        openai_ids,
+        anth_ids,
+        google_ids,
+        bedrock_ids,
+    )
 
 
 __all__ = [
@@ -435,6 +532,7 @@ __all__ = [
     "fetch_openai_models",
     "fetch_anthropic_models",
     "fetch_google_models",
+    "fetch_bedrock_models",
     "save_cache",
     "load_cached",
     "latest",

--- a/sdk/python/src/tally/pricing.py
+++ b/sdk/python/src/tally/pricing.py
@@ -307,7 +307,7 @@ _VECTOR_SEEDS: list[tuple[str, str, PriceType, str]] = [
 
 
 def seed_catalog() -> PriceCatalog:
-    """Multi-provider seed catalog (OpenAI + Anthropic + Google Gemini/Vertex).
+    """Multi-provider seed catalog (OpenAI + Anthropic + Google Gemini/Vertex + Amazon Bedrock).
 
     Expanded for CTO-106; previously the gpt-5-mini pinning workaround in
     examples/* was needed because of catalog gaps. The scraper (CTO-53) will
@@ -381,6 +381,49 @@ def seed_catalog() -> PriceCatalog:
         ("google", "gemini-3-flash", PriceType.INPUT, "0.30"),
         ("google", "gemini-3-flash", PriceType.CACHED_INPUT, "0.075"),
         ("google", "gemini-3-flash", PriceType.OUTPUT, "2.50"),
+        # --- Amazon Bedrock (https://aws.amazon.com/bedrock/pricing/) ---------
+        # CTO-157. Bedrock is a *managed* re-seller of third-party + Amazon-first
+        # models, so it gets its own provider dimension ("bedrock") rather than
+        # sharing the vendor-direct keys. The model slot holds Bedrock's native
+        # modelId minus the "-vN:0" version tag (e.g. "anthropic.claude-sonnet-4-5"),
+        # which is exactly what a Bedrock caller passes as gen_ai.request_model and
+        # what list_foundation_models advertises. This deliberately does NOT collide
+        # with the vendor-direct entries above (provider="anthropic",
+        # model="claude-sonnet-4-5") — same model, different surface, different price.
+        #
+        # Bedrock re-prices some models ABOVE the vendor-direct rate (the managed
+        # infra premium): e.g. Bedrock's Claude Sonnet output is listed higher than
+        # Anthropic-direct. These capture Bedrock's OWN published on-demand rates,
+        # not the vendor-direct numbers. Bedrock's prompt-caching read tier maps to
+        # CACHED_INPUT (steady-state read price); the cache-write premium is not
+        # modeled by the current PriceType enum. Usage field mapping mirrors the
+        # Bedrock Converse API: usage.inputTokens -> input,
+        # usage.outputTokens -> output, usage.cacheReadInputTokens -> cached_input.
+        # All rates [unverified at implementation time] — the live Bedrock pricing
+        # page was not reachable from the implementation environment, so values are
+        # taken from training-data values for the published per-MTok on-demand
+        # prices; update once the scraper (CTO-53) lands.
+        #
+        # Anthropic on Bedrock — priced above Anthropic-direct (managed premium).
+        ("bedrock", "anthropic.claude-sonnet-4-5", PriceType.INPUT, "3.30"),
+        ("bedrock", "anthropic.claude-sonnet-4-5", PriceType.CACHED_INPUT, "0.33"),
+        ("bedrock", "anthropic.claude-sonnet-4-5", PriceType.OUTPUT, "16.50"),
+        ("bedrock", "anthropic.claude-haiku-4-5", PriceType.INPUT, "1.10"),
+        ("bedrock", "anthropic.claude-haiku-4-5", PriceType.CACHED_INPUT, "0.11"),
+        ("bedrock", "anthropic.claude-haiku-4-5", PriceType.OUTPUT, "5.50"),
+        # Meta Llama on Bedrock — no cached tier published on-demand.
+        ("bedrock", "meta.llama3-3-70b-instruct", PriceType.INPUT, "0.72"),
+        ("bedrock", "meta.llama3-3-70b-instruct", PriceType.OUTPUT, "0.72"),
+        # Amazon Nova (first-party flagship-ish + micro tiers).
+        ("bedrock", "amazon.nova-pro", PriceType.INPUT, "0.80"),
+        ("bedrock", "amazon.nova-pro", PriceType.CACHED_INPUT, "0.20"),
+        ("bedrock", "amazon.nova-pro", PriceType.OUTPUT, "3.20"),
+        ("bedrock", "amazon.nova-micro", PriceType.INPUT, "0.035"),
+        ("bedrock", "amazon.nova-micro", PriceType.CACHED_INPUT, "0.00875"),
+        ("bedrock", "amazon.nova-micro", PriceType.OUTPUT, "0.14"),
+        # Amazon Titan (legacy first-party text) — no cached tier.
+        ("bedrock", "amazon.titan-text-express", PriceType.INPUT, "0.20"),
+        ("bedrock", "amazon.titan-text-express", PriceType.OUTPUT, "0.60"),
     ]
     for provider, model, pt, rate in seeds:
         cat.add(_mtok(provider, model, pt, rate))

--- a/sdk/python/src/tally/vercel_gateway.py
+++ b/sdk/python/src/tally/vercel_gateway.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vercel AI Gateway instrumentation (CTO-161).
+
+An app can route its model calls through the **Vercel AI Gateway**, which proxies OpenAI /
+Anthropic / Google / Bedrock / ... behind a single OpenAI-compatible endpoint. If ai-tally
+recorded such a call naively it would either lose the spend behind the gateway hop or mislabel
+it generically ``"vercel"`` — neither of which prices correctly against the catalog.
+
+This module maps the **gateway response metadata** back onto the TRUE upstream provider + model,
+so a call proxied through the gateway records a span whose ``gen_ai.system`` /
+``gen_ai.request.model`` resolve to (e.g.) ``openai`` / ``gpt-4o-mini``. The gateway does no
+special-casing downstream: :func:`tally.enrichment.enrich_cost` prices the span straight from the
+catalog exactly as it does for a direct SDK call (same as the CTO-149 / CTO-157 provider paths).
+
+Resolution (see :func:`resolve_upstream`):
+
+* **provider** — from an explicit provider slug in the metadata, else the prefix of the
+  namespaced model id (Vercel model ids are ``"<creator>/<model>"``, e.g. ``"openai/gpt-4o-mini"``).
+  Creator slugs are normalised to the catalog's provider keys via :data:`_PROVIDER_ALIASES`.
+* **model** — the bare model id (the part after ``"<creator>/"``), or an explicit model field.
+* **usage** — the gateway's own token counts are PREFERRED (OpenAI-compatible
+  ``prompt_tokens`` / ``completion_tokens`` / ``prompt_tokens_details.cached_tokens`` and the
+  AI-SDK ``inputTokens`` / ``outputTokens`` / ``cachedInputTokens`` shapes are both accepted). If
+  the gateway omits usage, an optional caller-supplied ``fallback_usage`` (token-counted at the
+  call site — never a message body) is used instead.
+
+**Unknown-safe:** if the upstream provider/model can't be resolved from the metadata, the call is
+attributed to :data:`UNKNOWN` (``"unknown"``). The catalog has no ``unknown`` price, so
+``enrich_cost`` reports ``catalog_miss`` and the cost lands null — the dashboard renders ``—``.
+We NEVER guess a provider or fabricate a model id.
+
+Counts only, never bodies: this helper reads token counts and model ids from response metadata; it
+never touches prompt/completion text.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from tally.pricing import Usage
+
+#: Attribution used when the upstream provider/model can't be resolved. The catalog prices nothing
+#: under this key, so cost enriches to null (dashboard ``—``) rather than a fabricated number.
+UNKNOWN = "unknown"
+
+# Vercel AI Gateway creator slug -> ai-tally catalog provider key. The gateway namespaces model ids
+# by the model's *creator* (e.g. "openai/gpt-4o-mini"); the catalog keys spend by provider. For the
+# vendor-direct creators the slug already matches the catalog key. The Amazon/Vertex aliases map the
+# managed-runtime creators onto the provider dimension the catalog prices them under.
+_PROVIDER_ALIASES: dict[str, str] = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "google": "google",
+    "google-vertex": "google",
+    "vertex": "google",
+    "amazon": "bedrock",
+    "aws": "bedrock",
+    "bedrock": "bedrock",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class UpstreamAttribution:
+    """Resolved true-upstream attribution for a gateway-proxied call.
+
+    ``resolved`` is False when the provider/model couldn't be determined from the metadata; in that
+    case ``provider`` is :data:`UNKNOWN` and callers get a null cost rather than a guessed one.
+    """
+
+    provider: str
+    model: str
+    usage: Usage
+    resolved: bool
+
+
+def _as_mapping(v: object) -> Mapping[str, Any] | None:
+    return v if isinstance(v, Mapping) else None
+
+
+def _first_str(md: Mapping[str, Any], *keys: str) -> str | None:
+    """First non-empty string value among ``keys`` (top level only)."""
+    for k in keys:
+        v = md.get(k)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+def _int_or_none(v: object) -> int | None:
+    return v if isinstance(v, int) and not isinstance(v, bool) else None
+
+
+def _gateway_meta(md: Mapping[str, Any]) -> Mapping[str, Any]:
+    """The nested ``providerMetadata.gateway`` block, if present, else an empty mapping.
+
+    The AI SDK surfaces gateway routing/usage info under ``providerMetadata.gateway`` (snake_case
+    ``provider_metadata`` also accepted). Falls back to any top-level ``gateway`` block.
+    """
+    pm = _as_mapping(md.get("providerMetadata")) or _as_mapping(md.get("provider_metadata"))
+    if pm is not None:
+        gw = _as_mapping(pm.get("gateway"))
+        if gw is not None:
+            return gw
+    return _as_mapping(md.get("gateway")) or {}
+
+
+def _resolve_provider_model(md: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """Return ``(provider, model)`` resolved from the metadata; either may be None if absent.
+
+    Precedence for the model id: explicit ``model`` / ``modelId`` at the top level, else the
+    gateway block's ``model`` / ``modelId``. A namespaced ``"<creator>/<model>"`` id splits into a
+    creator slug (mapped to a catalog provider) and the bare model. An explicit provider slug
+    (top-level or gateway ``provider``) overrides the creator prefix.
+    """
+    gw = _gateway_meta(md)
+    model_id = _first_str(md, "model", "modelId") or _first_str(gw, "model", "modelId")
+    explicit_provider = _first_str(md, "provider") or _first_str(gw, "provider")
+
+    creator: str | None = None
+    model: str | None = None
+    if model_id is not None:
+        if "/" in model_id:
+            creator, _, model = model_id.partition("/")
+            creator = creator or None
+            model = model or None
+        else:
+            model = model_id
+
+    slug = explicit_provider or creator
+    provider = _PROVIDER_ALIASES.get(slug.lower()) if slug is not None else None
+    # An unknown slug is still a real provider signal we shouldn't discard silently — but we won't
+    # invent a catalog key for it. Pass it through verbatim; the catalog decides if it prices.
+    if provider is None and slug is not None:
+        provider = slug.lower()
+    return provider, model
+
+
+def _parse_usage(md: Mapping[str, Any]) -> Usage | None:
+    """Extract the gateway's own usage numbers, or None if it reported none.
+
+    Accepts both the OpenAI-compatible shape (``prompt_tokens`` / ``completion_tokens`` /
+    ``prompt_tokens_details.cached_tokens``) and the AI-SDK shape (``inputTokens`` /
+    ``outputTokens`` / ``cachedInputTokens``). Usage may sit at the top level or inside a nested
+    ``usage`` block (also checked under the gateway block).
+    """
+    gw = _gateway_meta(md)
+    for source in (
+        md,
+        _as_mapping(md.get("usage")) or {},
+        gw,
+        _as_mapping(gw.get("usage")) or {},
+    ):
+        inp = _int_or_none(source.get("prompt_tokens"))
+        if inp is None:
+            inp = _int_or_none(source.get("inputTokens"))
+        out = _int_or_none(source.get("completion_tokens"))
+        if out is None:
+            out = _int_or_none(source.get("outputTokens"))
+        if inp is None and out is None:
+            continue
+        cached = _int_or_none(source.get("cachedInputTokens"))
+        if cached is None:
+            details = _as_mapping(source.get("prompt_tokens_details")) or {}
+            cached = _int_or_none(details.get("cached_tokens"))
+        return Usage(
+            input_tokens=inp or 0,
+            output_tokens=out or 0,
+            cached_input_tokens=cached or 0,
+        )
+    return None
+
+
+def resolve_upstream(
+    metadata: Mapping[str, Any],
+    *,
+    fallback_usage: Usage | None = None,
+) -> UpstreamAttribution:
+    """Map Vercel AI Gateway response metadata onto true-upstream ``(provider, model, usage)``.
+
+    Prefers the gateway's own usage numbers; if it reports none, uses ``fallback_usage`` (which the
+    caller may have token-counted locally — never a message body), else zero usage. When the
+    provider or model can't be resolved, attributes to :data:`UNKNOWN` with ``resolved=False`` so
+    the cost enriches to null rather than a guess.
+    """
+    provider, model = _resolve_provider_model(metadata)
+    usage = _parse_usage(metadata) or fallback_usage or Usage(0, 0, 0)
+
+    if not provider or not model:
+        # Can't price what we can't name — attribute to unknown, never guess.
+        return UpstreamAttribution(
+            provider=provider or UNKNOWN,
+            model=model or UNKNOWN,
+            usage=usage,
+            resolved=False,
+        )
+    return UpstreamAttribution(provider=provider, model=model, usage=usage, resolved=True)
+
+
+def record_gateway_llm_call(
+    client: Any,
+    metadata: Mapping[str, Any],
+    *,
+    fallback_usage: Usage | None = None,
+    signals: Any = None,
+    at: Any = None,
+) -> Any:
+    """Resolve true-upstream attribution from ``metadata`` and record it via ``client``.
+
+    Thin convenience over :func:`resolve_upstream` + ``TallyClient.record_llm_call`` so a
+    gateway-proxied call is a one-liner. Returns the ``LlmCallResult``. Unknown upstreams flow
+    through as ``provider="unknown"`` (cost null) — the call is still recorded, never dropped.
+    """
+    att = resolve_upstream(metadata, fallback_usage=fallback_usage)
+    return client.record_llm_call(
+        provider=att.provider,
+        model=att.model,
+        usage=att.usage,
+        signals=signals,
+        at=at,
+    )

--- a/sdk/python/tests/test_bedrock_provider.py
+++ b/sdk/python/tests/test_bedrock_provider.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Amazon Bedrock as a first-class LLM cost provider (CTO-157).
+
+Mirror of the CTO-149 Gemini coverage. Proves the three things the ticket asks the SDK side
+to demonstrate:
+  1. the seed catalog prices the Bedrock lineup under the ``bedrock/`` provider prefix
+     (non-zero, correct against the seeded rates, no collision with vendor-direct entries);
+  2. ``record_llm_call(provider="bedrock", ...)`` costs from the catalog and stamps
+     ``gen_ai.system="bedrock"`` on a conformant span — no provider allowlist to trip over;
+  3. model discovery lists foundation models via an INJECTED Bedrock control-plane client
+     (never the network), classifies them into families, and fails soft when unavailable.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from tally import models as M
+from tally.client import MemoryExporter, TallyClient
+from tally.context import with_trace_context
+from tally.pricing import (
+    PriceType,
+    Usage,
+    compute_cost_micro_usd,
+    seed_catalog,
+)
+from tally.sampling import Sampler, SamplingConfig
+from tally.schema import GenAI, validate_span_attributes
+
+AT = date(2026, 6, 1)
+
+
+# --- Price catalog ------------------------------------------------------------
+
+
+def test_bedrock_claude_sonnet_priced_correctly() -> None:
+    cat = seed_catalog()
+    # 1M input @ $3.30/MTok + 1M output @ $16.50/MTok = $19.80 = 19_800_000 micro-USD.
+    cost, version = compute_cost_micro_usd(
+        cat, "bedrock", "anthropic.claude-sonnet-4-5", Usage(1_000_000, 1_000_000), at=AT
+    )
+    assert cost == 19_800_000
+    assert version  # a real catalog version, not the empty "partial price" sentinel
+
+
+def test_bedrock_nova_micro_priced_correctly() -> None:
+    cat = seed_catalog()
+    # 1M input @ $0.035/MTok + 1M output @ $0.14/MTok = $0.175 = 175_000 micro-USD.
+    cost, version = compute_cost_micro_usd(
+        cat, "bedrock", "amazon.nova-micro", Usage(1_000_000, 1_000_000), at=AT
+    )
+    assert cost == 175_000
+    assert version
+
+
+def test_bedrock_reprices_above_vendor_direct() -> None:
+    # The whole point of a separate provider dimension: Bedrock's managed rate is NOT the
+    # Anthropic-direct rate. Sonnet output is $16.50 on Bedrock vs $15.00 vendor-direct.
+    cat = seed_catalog()
+    bedrock = cat.lookup("bedrock", "anthropic.claude-sonnet-4-5", PriceType.OUTPUT, at=AT)
+    direct = cat.lookup("anthropic", "claude-sonnet-4-5", PriceType.OUTPUT, at=AT)
+    assert bedrock is not None and direct is not None
+    assert bedrock.price_per_unit > direct.price_per_unit
+
+
+def test_bedrock_does_not_collide_with_vendor_direct() -> None:
+    # The vendor-direct Anthropic key must be untouched by the Bedrock entries.
+    cat = seed_catalog()
+    # Bedrock uses the dotted native modelId; vendor-direct uses the bare slug.
+    assert cat.lookup("bedrock", "claude-sonnet-4-5", PriceType.INPUT, at=AT) is None
+    assert cat.lookup("anthropic", "anthropic.claude-sonnet-4-5", PriceType.INPUT, at=AT) is None
+    direct = cat.lookup("anthropic", "claude-sonnet-4-5", PriceType.INPUT, at=AT)
+    assert direct is not None and direct.price_per_unit == Decimal("3.00")
+
+
+def test_bedrock_llama_has_no_cached_tier_but_still_prices() -> None:
+    cat = seed_catalog()
+    assert (
+        cat.lookup("bedrock", "meta.llama3-3-70b-instruct", PriceType.CACHED_INPUT, at=AT) is None
+    )
+    cost, version = compute_cost_micro_usd(
+        cat, "bedrock", "meta.llama3-3-70b-instruct", Usage(1000, 250), at=AT
+    )
+    assert cost > 0
+    assert version
+
+
+def test_bedrock_cached_tier_is_cheaper() -> None:
+    cat = seed_catalog()
+    cached = cat.lookup("bedrock", "amazon.nova-pro", PriceType.CACHED_INPUT, at=AT)
+    standard = cat.lookup("bedrock", "amazon.nova-pro", PriceType.INPUT, at=AT)
+    assert cached is not None and standard is not None
+    assert cached.price_per_unit < standard.price_per_unit
+
+
+def test_bedrock_rates_are_decimal() -> None:
+    cat = seed_catalog()
+    entry = cat.lookup("bedrock", "amazon.titan-text-express", PriceType.OUTPUT, at=AT)
+    assert entry is not None
+    assert isinstance(entry.price_per_unit, Decimal)
+
+
+def test_bedrock_cost_is_nonzero_for_small_usage() -> None:
+    cat = seed_catalog()
+    for model in (
+        "anthropic.claude-sonnet-4-5",
+        "anthropic.claude-haiku-4-5",
+        "meta.llama3-3-70b-instruct",
+        "amazon.nova-pro",
+        "amazon.nova-micro",
+        "amazon.titan-text-express",
+    ):
+        cost, version = compute_cost_micro_usd(cat, "bedrock", model, Usage(1000, 250), at=AT)
+        assert cost > 0, model
+        assert version, model
+
+
+# --- Provider path (record_llm_call) ------------------------------------------
+
+
+def _client(**kw) -> TallyClient:
+    return TallyClient(catalog=seed_catalog(), **kw)
+
+
+def test_record_llm_call_bedrock_costs_from_catalog() -> None:
+    exporter = MemoryExporter()
+    client = _client(exporter=exporter, sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t1", feature_tag="compare", session_id="s1"):
+        result = client.record_llm_call(
+            provider="bedrock",
+            model="anthropic.claude-sonnet-4-5",
+            usage=Usage(input_tokens=1_000_000, output_tokens=1_000_000),
+        )
+    assert result.kept is True
+    assert result.cost_micro_usd == 19_800_000
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    assert validate_span_attributes(span) == []
+    assert span[GenAI.SYSTEM] == "bedrock"
+    assert span[GenAI.COST_ESTIMATED_MICRO_USD] == 19_800_000
+
+
+def test_record_llm_call_bedrock_maps_cached_tokens() -> None:
+    # cacheReadInputTokens -> cached_input_tokens; billed at the cheaper cached rate.
+    client = _client(sampler=Sampler(SamplingConfig(body_rate=1.0)))
+    with with_trace_context(trace_id="t2"):
+        full = client.record_llm_call(
+            provider="bedrock",
+            model="amazon.nova-pro",
+            usage=Usage(input_tokens=1_000_000, output_tokens=0),
+        )
+        cached = client.record_llm_call(
+            provider="bedrock",
+            model="amazon.nova-pro",
+            usage=Usage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=1_000_000),
+        )
+    assert full.cost_micro_usd is not None and cached.cost_micro_usd is not None
+    assert cached.cost_micro_usd < full.cost_micro_usd
+
+
+# --- Model discovery (injected client — never the network) --------------------
+
+
+class _FakeBedrock:
+    """Stand-in for a boto3 ``bedrock`` control-plane client."""
+
+    def __init__(self, summaries: list[dict]):
+        self._summaries = summaries
+
+    def list_foundation_models(self, **_kw) -> dict:
+        return {"modelSummaries": self._summaries}
+
+
+_SUMMARIES = [
+    {"modelId": "anthropic.claude-sonnet-4-5-20250101-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "anthropic.claude-haiku-4-5-20250101-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "meta.llama3-3-70b-instruct-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "amazon.nova-pro-v1:0", "outputModalities": ["TEXT"]},
+    {"modelId": "amazon.titan-text-express-v1", "outputModalities": ["TEXT"]},
+    # Non-chat SKUs that must be filtered out by the modality guard:
+    {"modelId": "amazon.titan-embed-text-v2:0", "outputModalities": ["EMBEDDING"]},
+    {"modelId": "amazon.titan-image-generator-v1", "outputModalities": ["IMAGE"]},
+]
+
+
+def test_fetch_bedrock_models_parses_and_classifies() -> None:
+    out = M.fetch_bedrock_models(client=_FakeBedrock(_SUMMARIES))
+    ids = {m.id for m in out}
+    # Text models kept, embedding/image dropped.
+    assert "anthropic.claude-sonnet-4-5-20250101-v1:0" in ids
+    assert "meta.llama3-3-70b-instruct-v1:0" in ids
+    assert "amazon.titan-embed-text-v2:0" not in ids
+    assert "amazon.titan-image-generator-v1" not in ids
+    assert all(m.provider == "bedrock" for m in out)
+    # Families are classified consistently with classify_family.
+    by_id = {m.id: m for m in out}
+    assert by_id["anthropic.claude-sonnet-4-5-20250101-v1:0"].family == "sonnet"
+    assert by_id["anthropic.claude-haiku-4-5-20250101-v1:0"].family == "haiku"
+    # Llama's "instruct" routes to "other" (CTO-172 non-chat-family guard keyword), Titan/Nova too.
+    assert by_id["meta.llama3-3-70b-instruct-v1:0"].family == "other"
+    assert by_id["amazon.titan-text-express-v1"].family == "other"
+    # latest() can resolve a Bedrock family.
+    sonnet = M.latest("bedrock", "sonnet", out)
+    assert sonnet is not None and sonnet.family == "sonnet"
+
+
+def test_classify_bedrock_families() -> None:
+    assert M.classify_family("anthropic.claude-sonnet-4-5-20250101-v1:0") == "sonnet"
+    assert M.classify_family("anthropic.claude-haiku-4-5") == "haiku"
+
+
+def test_discover_includes_bedrock_with_injected_client(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No AWS env needed: injecting a client is itself the enable signal.
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(
+        cache_path=tmp_path / "models.json",
+        bedrock_client=_FakeBedrock(_SUMMARIES),
+    )
+    bedrock_ids = {m.id for m in result if m.provider == "bedrock"}
+    assert "amazon.nova-pro-v1:0" in bedrock_ids
+    # Non-text SKUs never made it into the discovered lineup.
+    assert "amazon.titan-embed-text-v2:0" not in bedrock_ids
+
+
+def test_discover_skips_bedrock_when_unconfigured(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No injected client and no AWS env → Bedrock is skipped, no crash, empty result.
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_PROFILE",
+        "AWS_ROLE_ARN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(cache_path=tmp_path / "absent.json")
+    assert [m for m in result if m.provider == "bedrock"] == []
+
+
+def test_discover_bedrock_fails_soft_on_client_error(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A control-plane error (e.g. AccessDenied / no creds) must skip Bedrock, not crash discovery.
+    class _BoomBedrock:
+        def list_foundation_models(self, **_kw):
+            raise RuntimeError("AccessDeniedException")
+
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("TALLY_PINNED_MODELS", raising=False)
+    monkeypatch.setenv("TALLY_MODELS_REFRESH", "1")
+
+    result = M.discover_models(
+        cache_path=tmp_path / "absent.json",
+        bedrock_client=_BoomBedrock(),
+    )
+    assert result == []
+
+
+def test_aws_configured_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_PROFILE",
+        "AWS_ROLE_ARN",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert M._aws_configured() is False
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    assert M._aws_configured() is False  # region alone is not enough
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-fake")
+    assert M._aws_configured() is True

--- a/sdk/python/tests/test_pricing_seeds.py
+++ b/sdk/python/tests/test_pricing_seeds.py
@@ -111,6 +111,30 @@ def test_gemini_flash_cheaper_than_pro() -> None:
     assert _cost("google", "gemini-2.5-flash") < _cost("google", "gemini-2.5-pro")
 
 
+# --- Amazon Bedrock (CTO-157) — managed LLM provider, own price dimension ----
+
+
+def test_bedrock_claude_sonnet_priced() -> None:
+    _cost("bedrock", "anthropic.claude-sonnet-4-5")
+
+
+def test_bedrock_llama_priced() -> None:
+    _cost("bedrock", "meta.llama3-3-70b-instruct")
+
+
+def test_bedrock_nova_pro_priced() -> None:
+    _cost("bedrock", "amazon.nova-pro")
+
+
+def test_bedrock_titan_priced() -> None:
+    _cost("bedrock", "amazon.titan-text-express")
+
+
+def test_bedrock_sonnet_repriced_above_anthropic_direct() -> None:
+    # Same model, different surface: Bedrock's managed rate exceeds the vendor-direct rate.
+    assert _cost("bedrock", "anthropic.claude-sonnet-4-5") > _cost("anthropic", "claude-sonnet-4-5")
+
+
 # --- Vertex AI Vector Search (CTO-151) — Vector cost layer, per-call ----
 
 

--- a/sdk/python/tests/test_vercel_gateway.py
+++ b/sdk/python/tests/test_vercel_gateway.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vercel AI Gateway true-upstream attribution (CTO-161).
+
+Proves the two things the ticket asks the SDK side to demonstrate:
+  1. a captured Vercel-AI-Gateway response shape resolves to the TRUE upstream
+     ``(provider, model, usage)`` so ``record_llm_call`` prices it from the catalog to the
+     right non-zero cost — the gateway hop never launders the spend into a generic "vercel";
+  2. an unresolvable upstream attributes to ``unknown`` with a null cost — never a guess.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from tally.client import MemoryExporter, TallyClient
+from tally.context import with_trace_context
+from tally.pricing import Usage, compute_cost_micro_usd, seed_catalog
+from tally.sampling import Sampler, SamplingConfig
+from tally.schema import GenAI, validate_span_attributes
+from tally.vercel_gateway import (
+    UNKNOWN,
+    record_gateway_llm_call,
+    resolve_upstream,
+)
+
+AT = date(2026, 6, 1)
+
+
+# A captured Vercel AI Gateway chat-completion response (OpenAI-compatible shape). The gateway
+# namespaces the model id by creator ("openai/gpt-4o-mini") and returns its own token counts,
+# including a cached-input tier under prompt_tokens_details. Bodies elided (counts only).
+_GATEWAY_OPENAI_RESPONSE = {
+    "id": "chatcmpl-abc123",
+    "object": "chat.completion",
+    "model": "openai/gpt-4o-mini",
+    "usage": {
+        "prompt_tokens": 1000,
+        "completion_tokens": 250,
+        "total_tokens": 1250,
+        "prompt_tokens_details": {"cached_tokens": 200},
+    },
+    "providerMetadata": {
+        "gateway": {
+            "provider": "openai",
+            "routing": {"originalModelId": "openai/gpt-4o-mini"},
+        }
+    },
+}
+
+# The AI-SDK result shape: namespaced modelId + camelCase usage under a top-level usage block.
+_GATEWAY_ANTHROPIC_AISDK = {
+    "modelId": "anthropic/claude-sonnet-4-5",
+    "usage": {"inputTokens": 2000, "outputTokens": 500, "cachedInputTokens": 100},
+}
+
+
+# --- resolution ---------------------------------------------------------------
+
+
+def test_resolve_openai_from_namespaced_model_id() -> None:
+    att = resolve_upstream(_GATEWAY_OPENAI_RESPONSE)
+    assert att.resolved is True
+    assert att.provider == "openai"
+    assert att.model == "gpt-4o-mini"
+    # Gateway's own usage numbers are preferred, including the cached tier.
+    assert att.usage == Usage(input_tokens=1000, output_tokens=250, cached_input_tokens=200)
+
+
+def test_resolve_anthropic_from_aisdk_shape() -> None:
+    att = resolve_upstream(_GATEWAY_ANTHROPIC_AISDK)
+    assert att.resolved is True
+    assert att.provider == "anthropic"
+    assert att.model == "claude-sonnet-4-5"
+    assert att.usage == Usage(input_tokens=2000, output_tokens=500, cached_input_tokens=100)
+
+
+def test_resolve_prefers_gateway_usage_over_fallback() -> None:
+    att = resolve_upstream(
+        _GATEWAY_OPENAI_RESPONSE,
+        fallback_usage=Usage(9999, 9999, 9999),
+    )
+    # The gateway reported usage, so the locally-counted fallback is ignored.
+    assert att.usage == Usage(1000, 250, 200)
+
+
+def test_resolve_falls_back_to_token_count_when_gateway_omits_usage() -> None:
+    md = {"model": "openai/gpt-4o-mini"}  # no usage block
+    att = resolve_upstream(md, fallback_usage=Usage(500, 120, 0))
+    assert att.resolved is True
+    assert att.usage == Usage(500, 120, 0)
+
+
+def test_amazon_creator_slug_maps_to_bedrock_provider() -> None:
+    att = resolve_upstream({"model": "amazon/nova-pro", "usage": {"prompt_tokens": 10}})
+    assert att.resolved is True
+    assert att.provider == "bedrock"
+    assert att.model == "nova-pro"
+
+
+# --- catalog pricing (true upstream, not "vercel") ----------------------------
+
+
+def test_captured_gateway_response_prices_from_catalog() -> None:
+    att = resolve_upstream(_GATEWAY_OPENAI_RESPONSE)
+    cat = seed_catalog()
+    # gpt-4o-mini: 800 uncached input @ $0.15/MTok + 200 cached @ $0.075/MTok + 250 output
+    # @ $0.60/MTok. Prove it resolves to the SAME cost as a direct openai/gpt-4o-mini call.
+    via_gateway, v1 = compute_cost_micro_usd(cat, att.provider, att.model, att.usage, at=AT)
+    direct, v2 = compute_cost_micro_usd(
+        cat, "openai", "gpt-4o-mini", Usage(1000, 250, 200), at=AT
+    )
+    assert via_gateway == direct
+    assert via_gateway is not None and via_gateway > 0
+    assert v1 and v1 == v2
+
+
+def test_record_gateway_llm_call_lands_true_upstream_span() -> None:
+    exporter = MemoryExporter()
+    client = TallyClient(
+        exporter=exporter,
+        catalog=seed_catalog(),
+        sampler=Sampler(SamplingConfig(body_rate=1.0)),
+    )
+    with with_trace_context(trace_id="trace-vercel-1"):
+        result = record_gateway_llm_call(client, _GATEWAY_OPENAI_RESPONSE, at=AT)
+
+    assert result.cost_micro_usd is not None and result.cost_micro_usd > 0
+    assert len(exporter.spans) == 1
+    span = exporter.spans[0]
+    # True upstream on the span — NOT "vercel".
+    assert span[GenAI.SYSTEM] == "openai"
+    assert span[GenAI.REQUEST_MODEL] == "gpt-4o-mini"
+    assert span[GenAI.USAGE_INPUT_TOKENS] == 1000
+    assert span[GenAI.USAGE_OUTPUT_TOKENS] == 250
+    assert validate_span_attributes(span) == []
+
+
+# --- unknown-safe -------------------------------------------------------------
+
+
+def test_unresolvable_upstream_attributes_to_unknown_null_cost() -> None:
+    # Gateway returned usage but no model id we can name (e.g. a routing failure / redacted meta).
+    md = {"usage": {"prompt_tokens": 1000, "completion_tokens": 250}}
+    att = resolve_upstream(md)
+    assert att.resolved is False
+    assert att.provider == UNKNOWN
+    assert att.model == UNKNOWN
+    # Usage is still captured — we just can't price it.
+    assert att.usage == Usage(1000, 250, 0)
+
+    cost, version = compute_cost_micro_usd(
+        seed_catalog(), att.provider, att.model, att.usage, at=AT
+    )
+    assert cost is None or cost == 0
+    assert not version  # catalog miss -> dashboard renders "—", no fabricated number
+
+
+def test_record_unknown_upstream_emits_span_with_no_cost() -> None:
+    exporter = MemoryExporter()
+    client = TallyClient(
+        exporter=exporter,
+        catalog=seed_catalog(),
+        sampler=Sampler(SamplingConfig(body_rate=1.0)),
+    )
+    with with_trace_context(trace_id="trace-vercel-unknown"):
+        result = record_gateway_llm_call(
+            client, {"usage": {"prompt_tokens": 42, "completion_tokens": 7}}, at=AT
+        )
+    # Recorded, never dropped — but priced null, attributed honestly to unknown.
+    assert result.cost_micro_usd is None or result.cost_micro_usd == 0
+    assert len(exporter.spans) == 1
+    assert exporter.spans[0][GenAI.SYSTEM] == UNKNOWN


### PR DESCRIPTION
## CTO-161 — Vercel AI Gateway instrumentation (LLM cost)

Stacked on #144 (base `feat/cto-157-bedrock-provider`; auto-retargets to `main` when #144 merges). Do not merge before the base.

When an app routes model calls through the **Vercel AI Gateway** (an OpenAI-compatible proxy over OpenAI/Anthropic/Google/Bedrock/...), ai-tally now attributes the spend to the **true upstream** provider/model instead of losing it behind the gateway hop or labelling it generically `vercel`.

### How it works
New SDK helper `tally.vercel_gateway` maps the gateway response metadata onto `gen_ai.system` + `gen_ai.request.model`, so the existing catalog path (`enrich_cost`) prices it with **no special-casing** — the same pattern as CTO-149 (Gemini) and CTO-157 (Bedrock).

- **provider** — explicit provider slug if present, else the creator prefix of the namespaced model id (`openai/gpt-4o-mini` → `openai` / `gpt-4o-mini`); creator slugs normalised to catalog keys (`amazon`/`aws` → `bedrock`, `vertex` → `google`).
- **model** — the bare model id after the creator prefix.
- **usage** — the gateway's own token counts are **preferred** (OpenAI-compatible `prompt_tokens`/`completion_tokens`/`prompt_tokens_details.cached_tokens` and AI-SDK `inputTokens`/`outputTokens`/`cachedInputTokens` both accepted); falls back to a caller-supplied token count when the gateway omits usage.
- `record_gateway_llm_call()` — one-liner convenience over `resolve_upstream` + `TallyClient.record_llm_call`.

### Unknown-safe
An unresolvable upstream is attributed to `unknown` (never guessed) → `enrich_cost` reports `catalog_miss` → cost lands null → dashboard renders `—`.

### No bodies
The helper reads token counts and model ids from response metadata only; it never touches prompt/completion text.

### Tests
- **SDK** `test_vercel_gateway.py` (10): resolution from captured gateway response shapes (OpenAI-compatible + AI-SDK), gateway-usage-preferred + token-count fallback, catalog cost equal to the direct-provider cost, and the unknown-safe null-cost path.
- **Gateway** `test_enrich_vercel_gateway.py` (4): a resolved span enriches to the same non-zero cost as a direct `openai/gpt-4o-mini` span and maps to an otel row with `GenAiSystem="openai"` (not `vercel`); an unknown upstream is a `catalog_miss` with no cost.
- SDK **930 passed**, gateway **325 passed**, ruff clean.

### Scope
Chatbot demo toggle (optional item 3) left for the CTO-147 lineup; the default direct-SDK demo is unchanged (no TS touched). Out of scope: Vercel compute/egress billing (CTO-163); non-Vercel gateways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)