### PR TITLE
feat(agents): derive real reconciler last-run instead of a constant (CTO-169)

### DIFF
--- a/web/app/agents/Live.tsx
+++ b/web/app/agents/Live.tsx
@@ -29,7 +29,9 @@ import { useLivePoll } from "@/lib/useLivePoll";
 export interface AgentsPayload {
   agents: AgentSummary[];
   runs: AgentRun[];
-  reconcilerLastRunMinutesAgo: number;
+  // Real reconciler last-run in minutes (CTO-169), or null when the reconciler has never run /
+  // the source is unavailable — rendered as `—` (no freshness badge) rather than a fake number.
+  reconcilerLastRunMinutesAgo: number | null;
 }
 
 export function AgentsLive({

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
-import { agents, RECONCILER_LAST_RUN_MINUTES_AGO, runs } from "@/lib/agents";
-import { queryAgents } from "@/lib/clickhouse";
+import { agents, runs } from "@/lib/agents";
+import { queryAgents, queryReconcilerLastRun } from "@/lib/clickhouse";
 
 // Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
 export const dynamic = "force-dynamic";
@@ -17,10 +17,16 @@ export async function GET(req: Request) {
   const tag = searchParams.get("tag") ?? "";
   const run = searchParams.get("run") ?? "";
   const hasFilter = Boolean(tag || run);
-  const live = await queryAgents({ tag, run });
+  // Read agents telemetry and the reconciler's real last-run in parallel. The freshness signal is
+  // the real reconciliation_runs value (CTO-169) — or null when the reconciler has never run / the
+  // gateway is unavailable, which the page renders as `—` rather than a fabricated constant.
+  const [live, reconcilerLastRunMinutesAgo] = await Promise.all([
+    queryAgents({ tag, run }),
+    queryReconcilerLastRun(),
+  ]);
   return NextResponse.json({
     agents: live && live.agents.length > 0 ? live.agents : hasFilter ? [] : agents,
     runs: live && live.runs.length > 0 ? live.runs : hasFilter ? [] : runs,
-    reconcilerLastRunMinutesAgo: RECONCILER_LAST_RUN_MINUTES_AGO,
+    reconcilerLastRunMinutesAgo,
   });
 }

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -33,13 +33,16 @@ describe("api routes", () => {
     expect(body.dq).toBeDefined();
   });
 
-  it("GET /api/agents returns agents + runs + reconciler freshness", async () => {
-    const body = await json<{ agents: unknown[]; runs: unknown[]; reconcilerLastRunMinutesAgo: number }>(
+  it("GET /api/agents returns agents + runs + real-or-null reconciler freshness (CTO-169)", async () => {
+    const body = await json<{ agents: unknown[]; runs: unknown[]; reconcilerLastRunMinutesAgo: number | null }>(
       await AgentsGET(new Request("http://test/api/agents") as never),
     );
     expect(body.agents.length).toBeGreaterThan(0);
     expect(body.runs.length).toBeGreaterThan(0);
-    expect(body.reconcilerLastRunMinutesAgo).toBeTypeOf("number");
+    // No reconciler gateway runs in CI, so the route applies honest-null (renders `—`) rather than
+    // the old hardcoded constant (23). Real value or null — never a fabricated number.
+    expect(body.reconcilerLastRunMinutesAgo === null || typeof body.reconcilerLastRunMinutesAgo === "number").toBe(true);
+    expect(body.reconcilerLastRunMinutesAgo).not.toBe(23);
   });
 
   it("GET /api/agents/runs/:runId returns the run, 404 on miss", async () => {

--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -9,6 +9,8 @@ vi.mock("@/lib/clickhouse", () => ({
   queryCurrentModel: vi.fn(),
   queryReplayCandidates: vi.fn(),
   queryEvalCandidates: vi.fn(),
+  // CTO-169: reconciler last-run is read from the real source; default to null (honest-null) here.
+  queryReconcilerLastRun: vi.fn().mockResolvedValue(null),
 }));
 
 import { GET as CompareGET } from "./route";

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -4,6 +4,7 @@ import { comparison, deriveRecommendation, deriveWorkload } from "@/lib/compare"
 import {
   queryCurrentModel,
   queryEvalCandidates,
+  queryReconcilerLastRun,
   queryReplayCandidates,
   type EvalCandidateRow,
 } from "@/lib/clickhouse";
@@ -54,6 +55,10 @@ export async function GET(req: Request) {
   // Pull it in parallel so the route doesn't add 30s of latency stacked behind the replay call.
   const evalProj = await queryEvalCandidates(featureTag);
 
+  // CTO-169: the baseline's freshness signal is the real reconciliation_runs last-run, not the
+  // fixture constant — null (→ `—`) when the reconciler has never run / the source is unavailable.
+  const reconcilerLastRunMinutesAgo = await queryReconcilerLastRun();
+
   // The "current model" half is the one we can ground in real traffic today: most-trafficked
   // model over the last 7 days. Quality/latency on `current` stay mocked because we don't yet
   // have an eval harness — flagged honestly via SyntheticPreviewBanner on the page.
@@ -73,6 +78,7 @@ export async function GET(req: Request) {
       ...comparison,
       current: { ...comparison.current, qualityScore: null },
       candidates,
+      diagnostics: { ...comparison.diagnostics, reconcilerLastRunMinutesAgo },
       replay_source: replay ? "replay" : "mock",
     });
   }
@@ -149,6 +155,7 @@ export async function GET(req: Request) {
           (replay.diagnostics.context_fidelity as
             | "resolved-context replay (no live retrieval)"
             | "live retrieval") ?? comparison.diagnostics.contextFidelity,
+        reconcilerLastRunMinutesAgo,
       },
       replay_source: "replay",
     });
@@ -216,6 +223,7 @@ export async function GET(req: Request) {
     },
     candidates,
     recommendation,
+    diagnostics: { ...comparison.diagnostics, reconcilerLastRunMinutesAgo },
     replay_source: "mock",
   });
 }

--- a/web/app/api/estimate/route.test.ts
+++ b/web/app/api/estimate/route.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/clickhouse", () => ({
   queryReplayCandidates: vi.fn(),
   queryReplayEstimate: vi.fn(),
+  // CTO-169: reconciler last-run is read from the real source; default to null (honest-null) here.
+  queryReconcilerLastRun: vi.fn().mockResolvedValue(null),
 }));
 
 import { POST as EstimatePOST } from "./route";

--- a/web/app/api/estimate/route.ts
+++ b/web/app/api/estimate/route.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 import { projection, type WhatIfProjection } from "@/lib/estimate";
-import { queryReplayCandidates, queryReplayEstimate } from "@/lib/clickhouse";
+import {
+  queryReconcilerLastRun,
+  queryReplayCandidates,
+  queryReplayEstimate,
+} from "@/lib/clickhouse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -22,15 +26,19 @@ export async function GET(req: Request) {
   const candidateProvider = url.searchParams.get("candidate_provider") ?? "anthropic";
   const featureTag = url.searchParams.get("tag") ?? undefined;
 
+  // CTO-169: baseline freshness is the real reconciliation_runs last-run, not the fixture constant —
+  // null (→ `—`) when the reconciler has never run / the source is unavailable.
+  const reconcilerLastRunMinutesAgo = await queryReconcilerLastRun();
+
   if (!candidateModel) {
-    return NextResponse.json({ ...projection, replay_source: "mock" });
+    return NextResponse.json({ ...projection, reconcilerLastRunMinutesAgo, replay_source: "mock" });
   }
 
   const replay = await queryReplayCandidates(featureTag, [
     { provider: candidateProvider, model: candidateModel },
   ]);
   if (!replay || replay.per_candidate.length === 0) {
-    return NextResponse.json({ ...projection, replay_source: "mock" });
+    return NextResponse.json({ ...projection, reconcilerLastRunMinutesAgo, replay_source: "mock" });
   }
 
   // GET replays the captured envelope as-is against the candidate model (no prompt rewrite).
@@ -38,6 +46,7 @@ export async function GET(req: Request) {
   const proposed = replay.per_candidate[0];
   return NextResponse.json({
     ...projection,
+    reconcilerLastRunMinutesAgo,
     proposed: {
       monthlyCostMicroUsd: proposed.projected_monthly_cost_micro_usd,
       // p99 cost not available from per-call replay yet — keep the mock p99 multiplier as a
@@ -86,12 +95,16 @@ export async function POST(req: Request) {
       : undefined;
 
   const candidate = { provider, model: candidateModel };
-  const replay = await queryReplayEstimate({
-    candidateModel: candidate,
-    systemPromptOverride,
-    featureTag,
-    sampleSize,
-  });
+  const [replay, reconcilerLastRunMinutesAgo] = await Promise.all([
+    queryReplayEstimate({
+      candidateModel: candidate,
+      systemPromptOverride,
+      featureTag,
+      sampleSize,
+    }),
+    // CTO-169: real reconciler last-run (or null → `—`), not the fixture constant.
+    queryReconcilerLastRun(),
+  ]);
 
   const row = replay?.per_candidate[0];
   const grounded = row?.samples_replayed ?? 0;
@@ -101,6 +114,7 @@ export async function POST(req: Request) {
   const monthly = sufficient ? row!.projected_monthly_cost_micro_usd : null;
   const result: WhatIfProjection = {
     ...projection,
+    reconcilerLastRunMinutesAgo,
     proposed: {
       monthlyCostMicroUsd: monthly,
       // p99 cost not available from per-call replay yet — keep the mock 1.4x multiplier as a

--- a/web/lib/agents.ts
+++ b/web/lib/agents.ts
@@ -17,12 +17,11 @@ export function p99Ratio(a: AgentSummary): number {
   return a.p50MicroUsd === 0 ? 0 : a.p99MicroUsd / a.p50MicroUsd;
 }
 
-/**
- * Minutes since the reconciler last trued-up these per-agent cost numbers. Agents presents
- * reconciled cost (cost/day, p50/p99), so it carries the same freshness signal as Cost/Features
- * and must surface staleness the same way (CTO-80, "never show stale as fresh").
- */
-export const RECONCILER_LAST_RUN_MINUTES_AGO = 23;
+// Agents presents reconciled cost (cost/day, p50/p99), so it carries the same "reconciler last
+// trued-up N min ago" freshness signal as Cost/Features and must surface staleness the same way
+// (CTO-80, "never show stale as fresh"). That value is NO LONGER a hardcoded constant here: the
+// /api/agents route derives it from the real reconciliation_runs source via
+// queryReconcilerLastRun() (CTO-169), rendering `—` when the reconciler has never run.
 
 export interface RunSpan {
   spanId: string;

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -5,7 +5,7 @@
 // the function under test is the small adapter that converts rows into the typed return value
 // (and applies the n < 50 suppression rule), so we don't need a real ClickHouse to test it.
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type RowShape = Record<string, unknown>;
 
@@ -204,5 +204,50 @@ describe("DEFAULT_CANDIDATES guard (CTO-171)", () => {
       const id = `${c.provider}/${c.model}`;
       expect(RETIRED_IDS.has(id), `${id} is retired and must not be a candidate`).toBe(false);
     }
+  });
+});
+
+// CTO-169: reconciler "last run" freshness is derived from the real reconciliation_runs source
+// (gateway GET /v1/tenant/reconciliation/status), not a hardcoded constant. Honest-null when the
+// reconciler has never run or the gateway is unavailable — the caller renders `—`.
+describe("queryReconcilerLastRun (CTO-169)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function stubFetch(impl: () => Promise<Response>) {
+    globalThis.fetch = vi.fn(impl) as unknown as typeof fetch;
+  }
+
+  it("derives minutes-ago from the latest run's finished_at", async () => {
+    const finished = new Date(Date.now() - 12 * 60_000).toISOString(); // 12 minutes ago
+    stubFetch(async () => new Response(
+      JSON.stringify({ run: { events_late: 3, lag_seconds_median: 120, finished_at: finished } }),
+      { status: 200 },
+    ));
+    const { queryReconcilerLastRun } = await freshSut();
+    const out = await queryReconcilerLastRun();
+    expect(out).toBe(12);
+  });
+
+  it("returns null (honest-null → `—`) when no reconciler run exists yet", async () => {
+    stubFetch(async () => new Response(JSON.stringify({ run: null }), { status: 200 }));
+    const { queryReconcilerLastRun } = await freshSut();
+    expect(await queryReconcilerLastRun()).toBeNull();
+  });
+
+  it("returns null when the gateway is unreachable", async () => {
+    stubFetch(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const { queryReconcilerLastRun } = await freshSut();
+    expect(await queryReconcilerLastRun()).toBeNull();
+  });
+
+  it("returns null on a non-2xx gateway response", async () => {
+    stubFetch(async () => new Response("nope", { status: 503 }));
+    const { queryReconcilerLastRun } = await freshSut();
+    expect(await queryReconcilerLastRun()).toBeNull();
   });
 });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -565,16 +565,23 @@ export async function queryFeatureEconomics(): Promise<FeatureEconomics[] | null
   });
 }
 
+interface ReconciliationRun {
+  events_late: number;
+  lag_seconds_median: number;
+  finished_at: string;
+}
+
 /**
- * Late-arrival diagnostics for the /features attribution card (CTO-139), read from the gateway's
- * reconciler run log via GET /v1/tenant/reconciliation/status. The gateway returns the latest
- * reconciliation run (event-late count + lag distribution in seconds + finished_at); we convert to
- * the page's units (hours / minutes-ago).
+ * The single real source for the reconciler's "last run" freshness (CTO-80): the latest
+ * reconciliation_runs row (CTO-139) for this tenant, read from the gateway's reconciler run log via
+ * GET /v1/tenant/reconciliation/status. Every surface that carries "reconciler last trued-up N min
+ * ago" — Features diagnostics, Agents, Compare, Estimate — derives it from THIS function so they all
+ * reflect one truth instead of independent hardcoded constants.
  *
- * Honest-null: when no reconciler run exists yet (`run` is null) — or the gateway is unreachable /
- * non-2xx — we return null so the /api/features route falls back to its mock via `?? diagnostics`.
+ * Returns null when no reconciler run exists yet (`run` is null) — or the gateway is unreachable /
+ * non-2xx — so callers can apply honest-null (`—`) rather than fabricate a value.
  */
-export async function queryAttributionDiagnostics(): Promise<AttributionDiagnostics | null> {
+async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/reconciliation/status`, {
       headers: { "x-tenant-id": TENANT },
@@ -585,26 +592,47 @@ export async function queryAttributionDiagnostics(): Promise<AttributionDiagnost
       console.warn(`[reconciliation] /v1/tenant/reconciliation/status HTTP ${res.status}; falling back`);
       return null;
     }
-    const body = (await res.json()) as {
-      run?: {
-        events_late: number;
-        lag_seconds_median: number;
-        finished_at: string;
-      } | null;
-    };
-    const run = body.run;
-    // No reconciler run yet → null so the route falls back to the mock (honest "no data" state).
-    if (!run) return null;
-    const minutesAgo = Math.max(0, Math.round((Date.now() - Date.parse(run.finished_at)) / 60000));
-    return {
-      lateArrivalEvents7d: run.events_late,
-      lateArrivalMedianHours: Math.round((run.lag_seconds_median / 3600) * 10) / 10,
-      reconcilerLastRunMinutesAgo: minutesAgo,
-    };
+    const body = (await res.json()) as { run?: ReconciliationRun | null };
+    // No reconciler run yet → null so callers render the honest "no data" state.
+    return body.run ?? null;
   } catch (err) {
     console.warn("[reconciliation] gateway unreachable:", (err as Error).message);
     return null;
   }
+}
+
+function minutesSince(finishedAt: string): number {
+  return Math.max(0, Math.round((Date.now() - Date.parse(finishedAt)) / 60000));
+}
+
+/**
+ * Minutes since the reconciler last finished a pass for the current tenant, from the real
+ * reconciliation_runs source (see {@link fetchLatestReconciliationRun}). Returns null when the
+ * reconciler has never run or the gateway is unavailable — the caller renders `—` (honest-null),
+ * NEVER a fabricated constant (CTO-169 / the CTO-80 staleness guard).
+ */
+export async function queryReconcilerLastRun(): Promise<number | null> {
+  const run = await fetchLatestReconciliationRun();
+  return run ? minutesSince(run.finished_at) : null;
+}
+
+/**
+ * Late-arrival diagnostics for the /features attribution card (CTO-139). The gateway returns the
+ * latest reconciliation run (event-late count + lag distribution in seconds + finished_at); we
+ * convert to the page's units (hours / minutes-ago). Reads the same real source as
+ * {@link queryReconcilerLastRun} so the freshness signal agrees across surfaces.
+ *
+ * Honest-null: when no reconciler run exists yet — or the gateway is unreachable / non-2xx — we
+ * return null so the /api/features route falls back to its mock via `?? diagnostics`.
+ */
+export async function queryAttributionDiagnostics(): Promise<AttributionDiagnostics | null> {
+  const run = await fetchLatestReconciliationRun();
+  if (!run) return null;
+  return {
+    lateArrivalEvents7d: run.events_late,
+    lateArrivalMedianHours: Math.round((run.lag_seconds_median / 3600) * 10) / 10,
+    reconcilerLastRunMinutesAgo: minutesSince(run.finished_at),
+  };
 }
 
 // --- Data Quality (dedicated report) ------------------------------------------------------------

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -87,9 +87,11 @@ export interface Comparison {
     contextFidelity: "resolved-context replay (no live retrieval)" | "live retrieval";
     /**
      * Minutes since the reconciler last trued-up the baseline traffic this comparison is built
-     * from. A projection off a stale baseline must not be presented as fresh (CTO-80).
+     * from. A projection off a stale baseline must not be presented as fresh (CTO-80). Sourced from
+     * the real reconciliation_runs log on the live path (CTO-169); `null` when the reconciler has
+     * never run / the source is unavailable, rendered as `—` rather than the fixture constant.
      */
-    reconcilerLastRunMinutesAgo: number;
+    reconcilerLastRunMinutesAgo: number | null;
   };
 }
 

--- a/web/lib/dataState.test.ts
+++ b/web/lib/dataState.test.ts
@@ -31,6 +31,12 @@ describe("boundaryFromMinutesAgo", () => {
     const boundary = boundaryFromMinutesAgo(180, NOW);
     expect(deriveDataState({ isEmpty: false, isPartial: true, reconciledThrough: boundary, now: NOW })).toBe("stale");
   });
+  it("maps null (unknown reconciler last-run, CTO-169) to the epoch sentinel — no as-of, no stale badge", () => {
+    const boundary = boundaryFromMinutesAgo(null, NOW);
+    expect(isSentinelBoundary(boundary)).toBe(true);
+    expect(asOfLabel(boundary)).toBeNull();
+    expect(isStale(boundary, NOW)).toBe(false);
+  });
 });
 
 describe("isSentinelBoundary", () => {

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -28,8 +28,13 @@ export function ageMs(reconciledThrough: string, now: number = Date.now()): numb
  * Build a reconciliation-boundary ISO timestamp from "minutes since the reconciler last ran".
  * Surfaces that don't carry an explicit boundary date (Agents, Compare, Estimate) report freshness
  * as a minutes-ago number instead; this converts it so they share the same stale/fresh logic.
+ *
+ * `null` means the reconciler last-run is unknown (never ran / source unavailable, CTO-169). We map
+ * it to the epoch sentinel so downstream logic reads it as pre-data — no "as of" label, no stale
+ * badge — rather than inventing a boundary. The surface shows an honest `—` instead of a claim.
  */
-export function boundaryFromMinutesAgo(minutesAgo: number, now: number = Date.now()): string {
+export function boundaryFromMinutesAgo(minutesAgo: number | null, now: number = Date.now()): string {
+  if (minutesAgo === null) return new Date(0).toISOString();
   return new Date(now - minutesAgo * 60_000).toISOString();
 }
 

--- a/web/lib/estimate.ts
+++ b/web/lib/estimate.ts
@@ -27,9 +27,11 @@ export interface Projection {
   };
   /**
    * Minutes since the reconciler last trued-up the historical window this projection samples.
-   * An estimate built on a stale baseline must not be presented as fresh (CTO-80).
+   * An estimate built on a stale baseline must not be presented as fresh (CTO-80). Sourced from the
+   * real reconciliation_runs log on the live path (CTO-169); `null` when the reconciler has never
+   * run / the source is unavailable, rendered as `—` rather than the fixture constant.
    */
-  reconcilerLastRunMinutesAgo: number;
+  reconcilerLastRunMinutesAgo: number | null;
 }
 
 /**


### PR DESCRIPTION
## CTO-169 — Agents: derive reconciler "last run" freshness instead of a hardcoded constant

**Stacked on #145** (CTO-168). Base auto-retargets to `main` when #145 merges.

`web/app/api/agents/route.ts` set `reconcilerLastRunMinutesAgo` from the hardcoded `RECONCILER_LAST_RUN_MINUTES_AGO` constant (`web/lib/agents.ts`) for **every** response — live or mock — so the CTO-80 "reconciler last trued-up N min ago" staleness signal was never real on the Agents page.

### What changed
- **Real source + query helper** — `web/lib/clickhouse.ts` gains `queryReconcilerLastRun(): Promise<number | null>` plus a shared `fetchLatestReconciliationRun()` that reads the real `reconciliation_runs` log (CTO-80/139) via the gateway's `GET /v1/tenant/reconciliation/status`. `queryAttributionDiagnostics` now reads that same helper, so Features / Agents / Compare / Estimate all reflect **one** truth instead of independent constants.
- **Agents route** derives the real minutes-ago (or `null`); the constant is removed from `lib/agents.ts` (the live path).
- **Honest-null** — `boundaryFromMinutesAgo(null)` maps to the epoch sentinel, so the surface renders `—` / no freshness badge rather than a fabricated value when the reconciler has never run or the gateway is unavailable.
- **Compare + Estimate** carried the same hardcoded `reconcilerLastRunMinutesAgo: 18`; both routes now source it from `queryReconcilerLastRun()` too. CTO-168's compare workload/recommendation logic is untouched.

### Tests
- `/api/agents` returns real-or-`null`, never the old constant (23).
- `queryReconcilerLastRun` — minutes-ago from `finished_at`; honest-null on no-run / unreachable / non-2xx.
- `boundaryFromMinutesAgo(null)` → epoch sentinel (no as-of, no stale badge).

`npx tsc --noEmit` clean; `npx vitest run` green except the two known-flaky ClickHouse tests (`GET /api/data-quality`, `GET /api/attribution falls back to mock`), which are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)