### PR TITLE
feat(unit-econ): tenant-configurable LTV/CAC band thresholds (CTO-126)

### DIFF
--- a/db/postgres/0019_tenant_unit_economics_config.sql
+++ b/db/postgres/0019_tenant_unit_economics_config.sql
@@ -1,0 +1,53 @@
+-- Per-tenant LTV/CAC band thresholds for the unit-economics view (CTO-126).
+--
+-- web/lib/unitEconomics.ts classifies the LTV:CAC ratio and payback months into green/yellow/red
+-- bands. Those cutoffs were hardcoded B2B-SaaS defaults ("tenant-configurable in v2"). This table
+-- IS v2: one row per tenant overrides some or all of the four cutoffs; a tenant with no row keeps
+-- the hardcoded defaults. The defaults remain the fallback everywhere — the row only shifts the
+-- boundaries a given tenant wants.
+--
+-- Semantics (mirrors the lib's classify helpers):
+--   * ltv_cac_green_threshold  — ratio strictly ABOVE this is green (default 3.0)
+--   * ltv_cac_yellow_threshold — ratio at/above this (but not green) is yellow (default 1.0); below is red
+--   * payback_months_green     — payback at/below this many months is green (default 12)
+--   * payback_months_yellow    — payback at/below this (but not green) is yellow (default 18); above is red
+--
+-- Higher LTV:CAC is better, so green_threshold >= yellow_threshold. Lower payback is better, so
+-- payback_green <= payback_yellow. The CHECK constraints encode both so a fat-fingered inversion is
+-- rejected at the DB rather than silently mis-coloring the dashboard.
+--
+-- Reads/writes go through GET/POST /v1/tenant/unit-economics/config — the web app never touches
+-- Postgres directly (same rule as tenant_guardrails / cac_periods). Companion table
+-- tenant_unit_economics_config_changes is the audit trail: every upsert appends one row keyed by a
+-- client-supplied change_id UUID, so a retried request is idempotent (both the config write and the
+-- audit row are no-ops on replay).
+--
+-- Migration is additive: existing tenants have zero rows, which the reader treats as "use defaults".
+
+CREATE TABLE IF NOT EXISTS tenant_unit_economics_config (
+    tenant_id                 UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    ltv_cac_green_threshold   NUMERIC(12, 4) NOT NULL,
+    ltv_cac_yellow_threshold  NUMERIC(12, 4) NOT NULL,
+    payback_months_green      NUMERIC(12, 4) NOT NULL,
+    payback_months_yellow     NUMERIC(12, 4) NOT NULL,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by                TEXT,
+    -- Higher LTV:CAC is healthier; lower payback is healthier. Reject inverted bands.
+    CHECK (ltv_cac_green_threshold >= ltv_cac_yellow_threshold),
+    CHECK (payback_months_green <= payback_months_yellow),
+    CHECK (ltv_cac_yellow_threshold >= 0 AND payback_months_green >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS tenant_unit_economics_config_changes (
+    change_id   UUID NOT NULL,
+    tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    actor       TEXT,
+    before      JSONB,
+    after       JSONB,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, change_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_unit_economics_config_changes_tenant
+    ON tenant_unit_economics_config_changes(tenant_id, changed_at DESC);

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - ../db/postgres/0011_tenant_compute_config.sql:/docker-entrypoint-initdb.d/0011_tenant_compute_config.sql:ro
       - ../db/postgres/0012_tenant_egress_config.sql:/docker-entrypoint-initdb.d/0012_tenant_egress_config.sql:ro
       - ../db/postgres/0013_cac_revenue_fields.sql:/docker-entrypoint-initdb.d/0013_cac_revenue_fields.sql:ro
+      - ../db/postgres/0019_tenant_unit_economics_config.sql:/docker-entrypoint-initdb.d/0019_tenant_unit_economics_config.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -98,6 +98,11 @@ from gateway.tenant_guardrails import (
 from gateway.tenant_integrations import TenantIntegrationStore
 from gateway.tenant_replay import TenantReplayStore
 from gateway.tenant_stripe import TenantStripeStore
+from gateway.tenant_unit_economics import (
+    TenantUnitEconomicsStore,
+    UnitEconomicsConfigError,
+    UnitEconomicsConfigInput,
+)
 from gateway.validation import SpanValidator, span_item_id
 
 from tally.hmac_keys import HmacKeyRegistry
@@ -159,6 +164,9 @@ async def lifespan(app: FastAPI):
     app.state.reconciliation = ReconciliationStore(settings)
     # Per-tenant monthly CAC inputs (CTO-111): finance fills serially, locked when next month opens.
     app.state.tenant_cac = TenantCacStore(settings)
+    # Per-tenant LTV/CAC band thresholds (CTO-126): overrides the hardcoded B2B-SaaS defaults the
+    # dashboard's ltvCacBand/paybackBand classifiers use. A tenant with no row keeps the defaults.
+    app.state.tenant_unit_economics = TenantUnitEconomicsStore(settings)
     # Replay infra (CTO-113): per-tenant opt-in sampling + cross-provider projection.
     # The blob store is in-memory by default — swappable for MinIO/S3 via app.state override in
     # a deployment shim. Replay runs accumulate in-memory until ClickHouse writeback lands
@@ -1075,6 +1083,62 @@ def download_tenant_cac_template(
         csv_template(),
         media_type="text/csv",
         headers={"Content-Disposition": 'attachment; filename="cac_template.csv"'},
+    )
+
+
+@app.get("/v1/tenant/unit-economics/config")
+def get_tenant_unit_economics_config(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """LTV/CAC band thresholds for the caller's tenant (CTO-126).
+
+    Returns ``config: null`` when the tenant has no row — the web classify helpers then fall back to
+    the hardcoded B2B-SaaS defaults. Same per-tenant auth as the CAC route.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantUnitEconomicsStore = app.state.tenant_unit_economics
+    config = store.get(tenant_id)
+    return JSONResponse(
+        {"tenant_id": tenant_id, "config": config.as_dict() if config else None},
+        status_code=200,
+    )
+
+
+@app.post("/v1/tenant/unit-economics/config")
+async def upsert_tenant_unit_economics_config(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Upsert the tenant's LTV/CAC band thresholds. Idempotent on ``change_id`` (CTO-126).
+
+    Body: ``{ltv_cac_green_threshold, ltv_cac_yellow_threshold, payback_months_green,
+    payback_months_yellow, change_id, updated_by?}``. Replaying the same change_id is a no-op
+    (returns the existing config unchanged). Rejects inverted bands (422).
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    change_id = body.get("change_id")
+    if not isinstance(change_id, str) or not change_id:
+        raise HTTPException(status_code=422, detail="change_id required (uuid)")
+    try:
+        config_input = UnitEconomicsConfigInput.from_json(body)
+        config = app.state.tenant_unit_economics.upsert(
+            tenant_id,
+            config_input,
+            change_id=change_id,
+            actor=body.get("updated_by"),
+        )
+    except UnitEconomicsConfigError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(
+        {"tenant_id": tenant_id, "config": config.as_dict()}, status_code=200
     )
 
 

--- a/infra/gateway/src/gateway/tenant_unit_economics.py
+++ b/infra/gateway/src/gateway/tenant_unit_economics.py
@@ -1,0 +1,267 @@
+"""Per-tenant LTV/CAC band thresholds for the unit-economics view (CTO-126).
+
+The dashboard's ``ltvCacBand`` / ``paybackBand`` classifiers colored the LTV:CAC ratio and payback
+months green/yellow/red using hardcoded B2B-SaaS defaults ("tenant-configurable in v2"). This module
+is v2: one row per tenant in ``tenant_unit_economics_config`` overrides the four cutoffs. A tenant
+with no row keeps the hardcoded defaults — the web classify helpers apply the tenant's overrides ON
+TOP of the defaults, so the defaults are always the fallback.
+
+Reads/writes go through ``GET/POST /v1/tenant/unit-economics/config`` — the web app never touches
+Postgres directly (same rule as :mod:`gateway.tenant_guardrails` and :mod:`gateway.tenant_cac`).
+Every upsert appends a row to ``tenant_unit_economics_config_changes`` keyed by a client-supplied
+``change_id`` UUID, so a retried request is idempotent: both the config write and the audit row are
+no-ops on replay.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg
+from psycopg.types.json import Json
+
+from gateway.config import Settings
+
+
+class UnitEconomicsConfigError(ValueError):
+    """Caller-facing validation error — surfaces as HTTP 422 in the gateway."""
+
+
+@dataclass(frozen=True, slots=True)
+class UnitEconomicsConfig:
+    """One (tenant) row of band thresholds."""
+
+    ltv_cac_green_threshold: float
+    ltv_cac_yellow_threshold: float
+    payback_months_green: float
+    payback_months_yellow: float
+    created_at: datetime | None
+    updated_at: datetime | None
+    updated_by: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ltv_cac_green_threshold": self.ltv_cac_green_threshold,
+            "ltv_cac_yellow_threshold": self.ltv_cac_yellow_threshold,
+            "payback_months_green": self.payback_months_green,
+            "payback_months_yellow": self.payback_months_yellow,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "updated_by": self.updated_by,
+        }
+
+
+def _as_number(v: object, field: str) -> float:
+    if isinstance(v, bool):
+        raise UnitEconomicsConfigError(f"{field} must be a number")
+    if isinstance(v, (int, float)):
+        result = float(v)
+    elif isinstance(v, str):
+        try:
+            result = float(v)
+        except ValueError as exc:
+            raise UnitEconomicsConfigError(f"{field} must be a number, got {v!r}") from exc
+    else:
+        raise UnitEconomicsConfigError(f"{field} must be a number")
+    if result < 0:
+        raise UnitEconomicsConfigError(f"{field} must be >= 0")
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class UnitEconomicsConfigInput:
+    ltv_cac_green_threshold: float
+    ltv_cac_yellow_threshold: float
+    payback_months_green: float
+    payback_months_yellow: float
+    updated_by: str | None
+
+    @classmethod
+    def from_json(cls, body: object) -> "UnitEconomicsConfigInput":
+        if not isinstance(body, dict):
+            raise UnitEconomicsConfigError("body must be a JSON object")
+        updated_by = body.get("updated_by")
+        if updated_by is not None and not isinstance(updated_by, str):
+            raise UnitEconomicsConfigError("updated_by must be a string when provided")
+        inst = cls(
+            ltv_cac_green_threshold=_as_number(
+                body.get("ltv_cac_green_threshold"), "ltv_cac_green_threshold"
+            ),
+            ltv_cac_yellow_threshold=_as_number(
+                body.get("ltv_cac_yellow_threshold"), "ltv_cac_yellow_threshold"
+            ),
+            payback_months_green=_as_number(
+                body.get("payback_months_green"), "payback_months_green"
+            ),
+            payback_months_yellow=_as_number(
+                body.get("payback_months_yellow"), "payback_months_yellow"
+            ),
+            updated_by=updated_by,
+        )
+        inst.sanity_check()
+        return inst
+
+    def sanity_check(self) -> None:
+        # Higher LTV:CAC is healthier; lower payback is healthier. Reject inverted bands so the
+        # dashboard can never be told green is a worse ratio than yellow.
+        if self.ltv_cac_green_threshold < self.ltv_cac_yellow_threshold:
+            raise UnitEconomicsConfigError(
+                "ltv_cac_green_threshold must be >= ltv_cac_yellow_threshold "
+                f"(got green={self.ltv_cac_green_threshold}, "
+                f"yellow={self.ltv_cac_yellow_threshold})"
+            )
+        if self.payback_months_green > self.payback_months_yellow:
+            raise UnitEconomicsConfigError(
+                "payback_months_green must be <= payback_months_yellow "
+                f"(got green={self.payback_months_green}, "
+                f"yellow={self.payback_months_yellow})"
+            )
+
+
+def _row_to_config(row: tuple) -> UnitEconomicsConfig:
+    return UnitEconomicsConfig(
+        ltv_cac_green_threshold=float(row[0]),
+        ltv_cac_yellow_threshold=float(row[1]),
+        payback_months_green=float(row[2]),
+        payback_months_yellow=float(row[3]),
+        created_at=row[4],
+        updated_at=row[5],
+        updated_by=row[6],
+    )
+
+
+class TenantUnitEconomicsStore:
+    """Postgres surface over ``tenant_unit_economics_config`` + its audit log.
+
+    ``get`` returns ``None`` for a tenant with no row (the web classify helpers then fall back to
+    the hardcoded defaults). ``upsert`` is idempotent on the client-supplied ``change_id``.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str) -> UnitEconomicsConfig | None:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT ltv_cac_green_threshold, ltv_cac_yellow_threshold,
+                       payback_months_green, payback_months_yellow,
+                       created_at, updated_at, updated_by
+                FROM tenant_unit_economics_config
+                WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            row = cur.fetchone()
+            return _row_to_config(row) if row else None
+
+    def upsert(
+        self,
+        tenant_id: str,
+        config: UnitEconomicsConfigInput,
+        *,
+        change_id: str,
+        actor: str | None = None,
+    ) -> UnitEconomicsConfig:
+        """Upsert the tenant's thresholds. Idempotent on ``change_id``.
+
+        On a new change_id: capture the current row as ``before`` (NULL if absent), apply the
+        upsert, append an audit row with both before/after JSON. On a replayed change_id: no config
+        write — return the existing row unchanged.
+        """
+        config.sanity_check()
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT ltv_cac_green_threshold, ltv_cac_yellow_threshold,
+                       payback_months_green, payback_months_yellow,
+                       created_at, updated_at, updated_by
+                FROM tenant_unit_economics_config
+                WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            existing_row = cur.fetchone()
+            before = _row_to_config(existing_row) if existing_row else None
+
+            cur.execute(
+                """
+                INSERT INTO tenant_unit_economics_config_changes
+                    (change_id, tenant_id, actor, before, after)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, change_id) DO NOTHING
+                RETURNING change_id
+                """,
+                (
+                    change_id,
+                    tenant_id,
+                    actor or config.updated_by,
+                    Json(before.as_dict()) if before is not None else None,
+                    None,
+                ),
+            )
+            reserved = cur.fetchone()
+            if reserved is None:
+                # change_id already applied — replay is a no-op. Return the current row.
+                conn.commit()
+                current = before
+                if current is None:
+                    cur.execute(
+                        """
+                        SELECT ltv_cac_green_threshold, ltv_cac_yellow_threshold,
+                               payback_months_green, payback_months_yellow,
+                               created_at, updated_at, updated_by
+                        FROM tenant_unit_economics_config
+                        WHERE tenant_id = %s
+                        """,
+                        (tenant_id,),
+                    )
+                    row = cur.fetchone()
+                    if row is None:
+                        raise RuntimeError(
+                            "change_id reserved but config absent — out-of-band delete?"
+                        )
+                    return _row_to_config(row)
+                return current
+
+            cur.execute(
+                """
+                INSERT INTO tenant_unit_economics_config
+                    (tenant_id, ltv_cac_green_threshold, ltv_cac_yellow_threshold,
+                     payback_months_green, payback_months_yellow, updated_by)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id) DO UPDATE
+                  SET ltv_cac_green_threshold  = EXCLUDED.ltv_cac_green_threshold,
+                      ltv_cac_yellow_threshold = EXCLUDED.ltv_cac_yellow_threshold,
+                      payback_months_green     = EXCLUDED.payback_months_green,
+                      payback_months_yellow    = EXCLUDED.payback_months_yellow,
+                      updated_by               = EXCLUDED.updated_by,
+                      updated_at               = now()
+                RETURNING ltv_cac_green_threshold, ltv_cac_yellow_threshold,
+                          payback_months_green, payback_months_yellow,
+                          created_at, updated_at, updated_by
+                """,
+                (
+                    tenant_id,
+                    config.ltv_cac_green_threshold,
+                    config.ltv_cac_yellow_threshold,
+                    config.payback_months_green,
+                    config.payback_months_yellow,
+                    config.updated_by,
+                ),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            after = _row_to_config(row)
+
+            cur.execute(
+                """
+                UPDATE tenant_unit_economics_config_changes
+                SET after = %s
+                WHERE tenant_id = %s AND change_id = %s
+                """,
+                (Json(after.as_dict()), tenant_id, change_id),
+            )
+            conn.commit()
+            return after

--- a/infra/gateway/tests/test_app_tenant_unit_economics.py
+++ b/infra/gateway/tests/test_app_tenant_unit_economics.py
@@ -1,0 +1,176 @@
+"""/v1/tenant/unit-economics/config — round-trip + idempotency + validation (CTO-126)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_unit_economics import (
+    UnitEconomicsConfig,
+    UnitEconomicsConfigError,
+    UnitEconomicsConfigInput,
+)
+
+T = "t-acme"
+
+
+class FakeUnitEconomicsStore:
+    """In-memory stand-in mirroring TenantUnitEconomicsStore's idempotent-on-change_id contract."""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, UnitEconomicsConfig] = {}
+        self._changes: set[tuple[str, str]] = set()
+
+    def get(self, tenant_id: str) -> UnitEconomicsConfig | None:
+        return self._rows.get(tenant_id)
+
+    def upsert(
+        self,
+        tenant_id: str,
+        config: UnitEconomicsConfigInput,
+        *,
+        change_id: str,
+        actor: str | None = None,
+    ) -> UnitEconomicsConfig:
+        config.sanity_check()
+        key = (tenant_id, change_id)
+        if key in self._changes:
+            # Replay: no write, return current row unchanged.
+            return self._rows[tenant_id]
+        self._changes.add(key)
+        row = UnitEconomicsConfig(
+            ltv_cac_green_threshold=config.ltv_cac_green_threshold,
+            ltv_cac_yellow_threshold=config.ltv_cac_yellow_threshold,
+            payback_months_green=config.payback_months_green,
+            payback_months_yellow=config.payback_months_yellow,
+            created_at=None,
+            updated_at=None,
+            updated_by=config.updated_by,
+        )
+        self._rows[tenant_id] = row
+        return row
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_unit_economics = FakeUnitEconomicsStore()
+        yield c
+
+
+def _payload(change_id="chg-1", **overrides):
+    base = {
+        "ltv_cac_green_threshold": 4.0,
+        "ltv_cac_yellow_threshold": 1.5,
+        "payback_months_green": 10,
+        "payback_months_yellow": 20,
+        "change_id": change_id,
+        "updated_by": "finance@acme.test",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_get_absent_returns_null_config(client: TestClient) -> None:
+    r = client.get("/v1/tenant/unit-economics/config", headers={"X-Tenant-Id": T})
+    assert r.status_code == 200, r.text
+    assert r.json()["config"] is None
+
+
+def test_round_trip(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/unit-economics/config", headers={"X-Tenant-Id": T}, json=_payload()
+    )
+    assert r.status_code == 200, r.text
+    cfg = r.json()["config"]
+    assert cfg["ltv_cac_green_threshold"] == 4.0
+    assert cfg["payback_months_yellow"] == 20
+    assert cfg["updated_by"] == "finance@acme.test"
+
+    got = client.get("/v1/tenant/unit-economics/config", headers={"X-Tenant-Id": T}).json()
+    assert got["config"]["ltv_cac_yellow_threshold"] == 1.5
+    assert got["config"]["payback_months_green"] == 10
+
+
+def test_idempotent_on_change_id(client: TestClient) -> None:
+    # First write sets 4.0 green.
+    client.post("/v1/tenant/unit-economics/config", headers={"X-Tenant-Id": T}, json=_payload())
+    # Replay of the SAME change_id with a different green value is a no-op.
+    replay = client.post(
+        "/v1/tenant/unit-economics/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(ltv_cac_green_threshold=9.0),
+    )
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["config"]["ltv_cac_green_threshold"] == 4.0
+
+    # A NEW change_id does apply the change.
+    applied = client.post(
+        "/v1/tenant/unit-economics/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(change_id="chg-2", ltv_cac_green_threshold=5.0),
+    )
+    assert applied.json()["config"]["ltv_cac_green_threshold"] == 5.0
+
+
+def test_rejects_inverted_ltv_cac_bands(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/unit-economics/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(ltv_cac_green_threshold=1.0, ltv_cac_yellow_threshold=3.0),
+    )
+    assert r.status_code == 422
+    assert "ltv_cac_green_threshold" in r.text
+
+
+def test_rejects_inverted_payback_bands(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/unit-economics/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(payback_months_green=24, payback_months_yellow=12),
+    )
+    assert r.status_code == 422
+    assert "payback_months_green" in r.text
+
+
+def test_requires_change_id(client: TestClient) -> None:
+    body = _payload()
+    del body["change_id"]
+    r = client.post("/v1/tenant/unit-economics/config", headers={"X-Tenant-Id": T}, json=body)
+    assert r.status_code == 422
+    assert "change_id" in r.text
+
+
+def test_rejects_non_numeric_threshold(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/unit-economics/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(ltv_cac_green_threshold="abc"),
+    )
+    assert r.status_code == 422
+
+
+def test_cross_tenant_isolation(client: TestClient) -> None:
+    client.post(
+        "/v1/tenant/unit-economics/config",
+        headers={"X-Tenant-Id": "t-a"},
+        json=_payload(change_id="a-1", ltv_cac_green_threshold=4.0),
+    )
+    b = client.get("/v1/tenant/unit-economics/config", headers={"X-Tenant-Id": "t-b"}).json()
+    assert b["config"] is None
+
+
+def test_requires_tenant_when_auth_disabled(client: TestClient) -> None:
+    assert client.get("/v1/tenant/unit-economics/config").status_code == 422
+    assert (
+        client.post("/v1/tenant/unit-economics/config", json=_payload()).status_code == 422
+    )
+
+
+def test_input_from_json_direct() -> None:
+    # Guard the parser directly so validation isn't only exercised through HTTP.
+    with pytest.raises(UnitEconomicsConfigError):
+        UnitEconomicsConfigInput.from_json({"ltv_cac_green_threshold": 3.0})

--- a/web/app/api/unit-economics/config/route.ts
+++ b/web/app/api/unit-economics/config/route.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from "next/server";
+
+import {
+  DEFAULT_THRESHOLDS,
+  resolveThresholds,
+  type UnitEconomicsThresholds,
+} from "@/lib/unitEconomics";
+import { queryUnitEconomicsConfig } from "@/lib/unitEconomicsConfig";
+
+// Per-tenant LTV/CAC band thresholds live in the control plane (Postgres, CTO-126), reached via the
+// gateway. The reader falls back to `null` (→ hardcoded defaults) when the gateway is unreachable, so
+// `npm run dev/build/test` never depend on infra.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+
+export interface ThresholdConfigPayload {
+  /** The tenant's resolved thresholds (overrides layered on defaults, or defaults when no row). */
+  thresholds: UnitEconomicsThresholds;
+  /** The hardcoded defaults — the settings panel's reset target. */
+  defaults: UnitEconomicsThresholds;
+  /** True when the tenant has a stored override row (vs. running on pure defaults). */
+  hasOverride: boolean;
+}
+
+// GET /api/unit-economics/config — the tenant's resolved thresholds + defaults for the settings panel.
+export async function GET(): Promise<NextResponse<ThresholdConfigPayload>> {
+  const overrides = await queryUnitEconomicsConfig();
+  return NextResponse.json({
+    thresholds: resolveThresholds(overrides),
+    defaults: DEFAULT_THRESHOLDS,
+    hasOverride: overrides !== null,
+  });
+}
+
+// POST /api/unit-economics/config — persist edited thresholds. Validates the shape, then forwards to
+// the gateway's idempotent upsert with a client-supplied change_id (UUID). When the gateway is
+// unreachable we validate and echo the values back (persisted:false) so the prototype works without
+// infra.
+export async function POST(req: Request) {
+  let body: Partial<UnitEconomicsThresholds> & { updatedBy?: string };
+  try {
+    body = (await req.json()) as Partial<UnitEconomicsThresholds> & { updatedBy?: string };
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const fields: (keyof UnitEconomicsThresholds)[] = [
+    "ltvCacGreen",
+    "ltvCacYellow",
+    "paybackGreen",
+    "paybackYellow",
+  ];
+  for (const f of fields) {
+    const v = body[f];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) {
+      return NextResponse.json({ error: `${f} must be a number >= 0` }, { status: 422 });
+    }
+  }
+  const t = body as UnitEconomicsThresholds;
+  if (t.ltvCacGreen < t.ltvCacYellow) {
+    return NextResponse.json(
+      { error: "ltvCacGreen must be >= ltvCacYellow" },
+      { status: 422 },
+    );
+  }
+  if (t.paybackGreen > t.paybackYellow) {
+    return NextResponse.json(
+      { error: "paybackGreen must be <= paybackYellow" },
+      { status: 422 },
+    );
+  }
+
+  const changeId = crypto.randomUUID();
+  const payload = {
+    ltv_cac_green_threshold: t.ltvCacGreen,
+    ltv_cac_yellow_threshold: t.ltvCacYellow,
+    payback_months_green: t.paybackGreen,
+    payback_months_yellow: t.paybackYellow,
+    change_id: changeId,
+    updated_by: body.updatedBy ?? null,
+  };
+
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/unit-economics/config`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (res.ok) {
+      return NextResponse.json({ thresholds: t, changeId, persisted: true });
+    }
+    if (res.status >= 400 && res.status < 500) {
+      const detail = await res.text();
+      return NextResponse.json(
+        { error: `gateway rejected upsert: ${detail}` },
+        { status: 422 },
+      );
+    }
+    return NextResponse.json({ error: `gateway error ${res.status}` }, { status: 502 });
+  } catch {
+    // Gateway unreachable (CI / fresh clone): echo the validated thresholds so the prototype works.
+    return NextResponse.json({ thresholds: t, changeId, persisted: false });
+  }
+}

--- a/web/app/unit-economics/ThresholdSettings.tsx
+++ b/web/app/unit-economics/ThresholdSettings.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useState } from "react";
+
+import type { UnitEconomicsThresholds } from "@/lib/unitEconomics";
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+const FIELDS: {
+  key: keyof UnitEconomicsThresholds;
+  label: string;
+  hint: string;
+  step: string;
+}[] = [
+  { key: "ltvCacGreen", label: "LTV:CAC green above", hint: "ratio strictly above → green", step: "0.1" },
+  { key: "ltvCacYellow", label: "LTV:CAC yellow at/above", hint: "at/above → yellow, below → red", step: "0.1" },
+  { key: "paybackGreen", label: "Payback green ≤ (mo)", hint: "months at/below → green", step: "1" },
+  { key: "paybackYellow", label: "Payback yellow ≤ (mo)", hint: "at/below → yellow, above → red", step: "1" },
+];
+
+function invalid(t: UnitEconomicsThresholds): string | null {
+  for (const { key, label } of FIELDS) {
+    const v = t[key];
+    if (!Number.isFinite(v) || v < 0) return `${label} must be a number ≥ 0`;
+  }
+  if (t.ltvCacGreen < t.ltvCacYellow) return "LTV:CAC green cutoff must be ≥ the yellow cutoff";
+  if (t.paybackGreen > t.paybackYellow) return "Payback green cutoff must be ≤ the yellow cutoff";
+  return null;
+}
+
+/**
+ * Settings panel to edit the tenant's LTV/CAC band thresholds (CTO-126). Seeded with the tenant's
+ * resolved thresholds; "Reset to defaults" restores the hardcoded B2B-SaaS values (and saving them
+ * makes the fallback explicit). Persists via POST /api/unit-economics/config (idempotent upsert).
+ */
+export function ThresholdSettings({
+  initial,
+  defaults,
+  hasOverride,
+}: {
+  initial: UnitEconomicsThresholds;
+  defaults: UnitEconomicsThresholds;
+  hasOverride: boolean;
+}) {
+  const [form, setForm] = useState<UnitEconomicsThresholds>(initial);
+  const [state, setState] = useState<SaveState>("idle");
+  const [overridden, setOverridden] = useState(hasOverride);
+  const err = invalid(form);
+  const isDefault =
+    form.ltvCacGreen === defaults.ltvCacGreen &&
+    form.ltvCacYellow === defaults.ltvCacYellow &&
+    form.paybackGreen === defaults.paybackGreen &&
+    form.paybackYellow === defaults.paybackYellow;
+
+  function patch(key: keyof UnitEconomicsThresholds, raw: string) {
+    const n = raw.trim() === "" ? NaN : Number(raw);
+    setForm((f) => ({ ...f, [key]: n }));
+    setState("idle");
+  }
+
+  function resetToDefaults() {
+    setForm(defaults);
+    setState("idle");
+  }
+
+  async function save() {
+    if (err) return;
+    setState("saving");
+    try {
+      const res = await fetch("/api/unit-economics/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setState("saved");
+        setOverridden(true);
+      } else {
+        setState("error");
+      }
+    } catch {
+      setState("error");
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-edge bg-panel p-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-semibold">Band thresholds</h2>
+          <p className="mt-1 text-xs text-muted">
+            Cutoffs that color the LTV:CAC ratio and payback. {overridden && !isDefault
+              ? "Tenant override active."
+              : "Using defaults."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={resetToDefaults}
+          disabled={isDefault}
+          className="rounded-md border border-edge px-3 py-1.5 text-sm text-muted hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Reset to defaults
+        </button>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {FIELDS.map(({ key, label, hint, step }) => (
+          <label key={key} className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-muted">{label}</span>
+            <input
+              aria-label={label}
+              type="number"
+              step={step}
+              min="0"
+              value={Number.isFinite(form[key]) ? form[key] : ""}
+              onChange={(e) => patch(key, e.target.value)}
+              className="w-full rounded-md border border-edge bg-ink px-2 py-1 text-sm tabular-nums"
+            />
+            <span className="text-[11px] text-muted">{hint}</span>
+          </label>
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={save}
+          disabled={!!err || state === "saving"}
+          className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-ink disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Save thresholds
+        </button>
+        {err && <span className="text-xs text-bad">{err}</span>}
+        {!err && state === "saving" && <span className="text-xs text-muted">saving…</span>}
+        {!err && state === "saved" && <span className="text-xs text-good">saved ✓</span>}
+        {!err && state === "error" && <span className="text-xs text-bad">save failed</span>}
+      </div>
+    </section>
+  );
+}

--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Unit Economics page (CTO-121): renders CAC flavors / payback / LTV from the already-wired libs
-// (web/lib/cac.ts + web/lib/unitEconomics.ts). Read-only. Band colors come from the lib's
-// `ltvCacBand` helper — NO hardcoded thresholds live in this file.
+// (web/lib/cac.ts + web/lib/unitEconomics.ts). Band colors come from the lib's `ltvCacBand` /
+// `paybackBand` classifiers — NO hardcoded thresholds live in this file. The cutoffs are per-tenant
+// configurable (CTO-126): resolved thresholds come from /api/unit-economics/config and thread into
+// every classify call; a tenant with no override falls back to the hardcoded defaults.
 
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
 import type { CacPayload } from "@/app/api/cac/route";
+import type { ThresholdConfigPayload } from "@/app/api/unit-economics/config/route";
 import type { CacPeriod, PeriodEconomics } from "@/lib/cac";
 import {
   blendedCac,
@@ -16,9 +19,13 @@ import {
   ltvOverCac,
   marginPerUser,
   marketingCac,
+  paybackBand,
   paybackMonths,
+  type Band,
+  type UnitEconomicsThresholds,
 } from "@/lib/unitEconomics";
 import { formatUSD } from "@/lib/types";
+import { ThresholdSettings } from "./ThresholdSettings";
 
 const DASH = "—";
 
@@ -53,8 +60,8 @@ function fmtMonthLabel(periodStart: string): string {
   return d.toLocaleDateString("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
 }
 
-/** Tailwind text color for a band from the lib's `ltvCacBand` classifier. */
-function bandText(band: ReturnType<typeof ltvCacBand>): string {
+/** Tailwind text color for a band from the lib's `ltvCacBand` / `paybackBand` classifiers. */
+function bandText(band: Band): string {
   return band === "green"
     ? "text-good"
     : band === "yellow"
@@ -65,8 +72,14 @@ function bandText(band: ReturnType<typeof ltvCacBand>): string {
 }
 
 export default async function UnitEconomicsPage() {
-  const data = await apiGet<CacPayload>("/api/cac");
+  // Fetch CAC periods + the tenant's band thresholds in parallel. The thresholds default to the
+  // hardcoded values when the tenant has no override (CTO-126); they thread into every band call.
+  const [data, cfg] = await Promise.all([
+    apiGet<CacPayload>("/api/cac"),
+    apiGet<ThresholdConfigPayload>("/api/unit-economics/config"),
+  ]);
   const { periods, economics, isMock } = data;
+  const thresholds: UnitEconomicsThresholds = cfg.thresholds;
 
   // Headline cards reflect the most recent period for which we have both CAC inputs and economics.
   // Falling to the latest period regardless keeps the CAC flavors visible even when economics is
@@ -81,14 +94,19 @@ export default async function UnitEconomicsPage() {
   const payback = paybackMonths(loaded, margin);
   const ltvValue = ltv(margin, latestEcon?.retentionMonths ?? 0);
   const ratio = ltvOverCac(ltvValue, loaded);
-  const band = ltvCacBand(ratio);
+  const band = ltvCacBand(ratio, thresholds);
 
   const body = (
     <div className="space-y-6">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         <Metric label="Blended CAC" value={fmtMoney(blended)} hint="(paid+sales+content) / new customers" />
         <Metric label="Paid CAC" value={fmtMoney(paid)} hint="paid spend / new paid customers" />
-        <Metric label="Payback" value={fmtMonths(payback)} hint="fully-loaded CAC / monthly margin" />
+        <Metric
+          label="Payback"
+          value={fmtMonths(payback)}
+          valueClass={bandText(paybackBand(payback, thresholds))}
+          hint="fully-loaded CAC / monthly margin"
+        />
         <Metric label="LTV" value={fmtMoney(ltvValue)} hint="margin × expected retention" />
         <Metric
           label="LTV : CAC"
@@ -97,6 +115,12 @@ export default async function UnitEconomicsPage() {
           hint="vs. fully-loaded CAC"
         />
       </div>
+
+      <ThresholdSettings
+        initial={thresholds}
+        defaults={cfg.defaults}
+        hasOverride={cfg.hasOverride}
+      />
 
       <Card title="Monthly history">
         <div className="overflow-x-auto">
@@ -123,7 +147,7 @@ export default async function UnitEconomicsPage() {
                 const loadedRow = fullyLoadedCac(p);
                 const ltvRow = ltv(m, econ?.retentionMonths ?? 0);
                 const ratioRow = ltvOverCac(ltvRow, loadedRow);
-                const bandRow = ltvCacBand(ratioRow);
+                const bandRow = ltvCacBand(ratioRow, thresholds);
                 return (
                   <tr
                     key={p.periodStart}
@@ -148,7 +172,7 @@ export default async function UnitEconomicsPage() {
                     <td className="py-2 pl-3 text-right tabular-nums">{econ ? fmtPct(econ.grossMarginPct) : DASH}</td>
                     <td className="py-2 pl-3 text-right tabular-nums">{fmtMoney(blendedCac(p))}</td>
                     <td className="py-2 pl-3 text-right tabular-nums">{fmtMoney(marketingCac(p))}</td>
-                    <td className="py-2 pl-3 text-right tabular-nums">{fmtMonths(paybackMonths(loadedRow, m))}</td>
+                    <td className={`py-2 pl-3 text-right tabular-nums ${bandText(paybackBand(paybackMonths(loadedRow, m), thresholds))}`}>{fmtMonths(paybackMonths(loadedRow, m))}</td>
                     <td className={`py-2 pl-3 text-right tabular-nums ${bandText(bandRow)}`}>{fmtRatio(ratioRow)}</td>
                   </tr>
                 );

--- a/web/lib/unitEconomics.test.ts
+++ b/web/lib/unitEconomics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CacPeriod } from "./cac";
 import {
+  DEFAULT_THRESHOLDS,
   blendedCac,
   costPerUser,
   fullyLoadedCac,
@@ -12,7 +13,9 @@ import {
   marginPct,
   marginPerUser,
   marketingCac,
+  paybackBand,
   paybackMonths,
+  resolveThresholds,
   valuePerUser,
 } from "./unitEconomics";
 
@@ -131,5 +134,52 @@ describe("LTV / CAC", () => {
     expect(ltvCacBand(1.0)).toBe("yellow");
     expect(ltvCacBand(0.5)).toBe("red");
     expect(ltvCacBand(null)).toBe("unknown");
+  });
+});
+
+describe("configurable band thresholds (CTO-126)", () => {
+  it("resolveThresholds falls back to defaults when no override row", () => {
+    expect(resolveThresholds(null)).toEqual(DEFAULT_THRESHOLDS);
+    expect(resolveThresholds(undefined)).toEqual(DEFAULT_THRESHOLDS);
+  });
+
+  it("resolveThresholds layers partial overrides ON TOP of defaults", () => {
+    const resolved = resolveThresholds({ ltvCacGreen: 5.0 });
+    expect(resolved.ltvCacGreen).toBe(5.0); // overridden
+    expect(resolved.ltvCacYellow).toBe(DEFAULT_THRESHOLDS.ltvCacYellow); // default fallback
+    expect(resolved.paybackGreen).toBe(DEFAULT_THRESHOLDS.paybackGreen);
+    expect(resolved.paybackYellow).toBe(DEFAULT_THRESHOLDS.paybackYellow);
+  });
+
+  it("null fields in an override fall back to the default", () => {
+    const resolved = resolveThresholds({ ltvCacGreen: null, paybackGreen: 6 });
+    expect(resolved.ltvCacGreen).toBe(DEFAULT_THRESHOLDS.ltvCacGreen);
+    expect(resolved.paybackGreen).toBe(6);
+  });
+
+  it("ltvCacBand applies a tenant override (green now needs >5)", () => {
+    const t = resolveThresholds({ ltvCacGreen: 5.0, ltvCacYellow: 2.0 });
+    // 3.5 was green under defaults; with the override it's only yellow.
+    expect(ltvCacBand(3.5, t)).toBe("yellow");
+    expect(ltvCacBand(3.5)).toBe("green"); // default arg unchanged (fallback)
+    expect(ltvCacBand(6.0, t)).toBe("green");
+    expect(ltvCacBand(1.5, t)).toBe("red"); // below the 2.0 yellow cutoff
+  });
+
+  it("paybackBand: lower is healthier; defaults are 12/18", () => {
+    expect(paybackBand(10)).toBe("green");
+    expect(paybackBand(12)).toBe("green");
+    expect(paybackBand(15)).toBe("yellow");
+    expect(paybackBand(18)).toBe("yellow");
+    expect(paybackBand(24)).toBe("red");
+    expect(paybackBand(null)).toBe("unknown");
+  });
+
+  it("paybackBand applies a tenant override and defaults remain the fallback", () => {
+    const t = resolveThresholds({ paybackGreen: 6, paybackYellow: 10 });
+    expect(paybackBand(8, t)).toBe("yellow"); // was green under defaults
+    expect(paybackBand(8)).toBe("green"); // default arg fallback
+    expect(paybackBand(5, t)).toBe("green");
+    expect(paybackBand(12, t)).toBe("red");
   });
 });

--- a/web/lib/unitEconomics.ts
+++ b/web/lib/unitEconomics.ts
@@ -100,10 +100,86 @@ export function ltvOverCac(ltvValue: number | null, cac: number | null): number 
   return ltvValue / cac;
 }
 
-/** Color band for LTV/CAC. B2B SaaS defaults — tenant-configurable in v2. */
-export function ltvCacBand(ratio: number | null): "green" | "yellow" | "red" | "unknown" {
+export type Band = "green" | "yellow" | "red" | "unknown";
+
+/**
+ * Band cutoffs for the LTV:CAC ratio and payback months (CTO-126).
+ *
+ * These were hardcoded B2B-SaaS defaults inline in `ltvCacBand` ("tenant-configurable in v2"). They
+ * are now per-tenant configurable: the gateway stores a partial or full override per tenant, and
+ * `resolveThresholds` layers those overrides ON TOP of `DEFAULT_THRESHOLDS`. A tenant with no row (or
+ * a field left unset) keeps the default — the defaults are always the fallback.
+ *
+ * Semantics: higher LTV:CAC is healthier (green is the high end); lower payback is healthier (green
+ * is the low end).
+ */
+export interface UnitEconomicsThresholds {
+  /** LTV:CAC strictly ABOVE this is green. */
+  ltvCacGreen: number;
+  /** LTV:CAC at/above this (but not green) is yellow; below is red. */
+  ltvCacYellow: number;
+  /** Payback at/below this many months is green. */
+  paybackGreen: number;
+  /** Payback at/below this (but not green) is yellow; above is red. */
+  paybackYellow: number;
+}
+
+/** The historical hardcoded B2B-SaaS cutoffs — the fallback for any tenant without an override. */
+export const DEFAULT_THRESHOLDS: UnitEconomicsThresholds = {
+  ltvCacGreen: 3.0,
+  ltvCacYellow: 1.0,
+  paybackGreen: 12,
+  paybackYellow: 18,
+};
+
+/** A per-tenant override read from the gateway. Any field omitted/null falls back to the default. */
+export interface UnitEconomicsThresholdOverrides {
+  ltvCacGreen?: number | null;
+  ltvCacYellow?: number | null;
+  paybackGreen?: number | null;
+  paybackYellow?: number | null;
+}
+
+/**
+ * Layer a tenant's (possibly partial) overrides on top of `DEFAULT_THRESHOLDS`. Passing
+ * `null`/`undefined` (no tenant row) returns the defaults unchanged — the defaults are the fallback.
+ */
+export function resolveThresholds(
+  overrides?: UnitEconomicsThresholdOverrides | null,
+): UnitEconomicsThresholds {
+  if (!overrides) return DEFAULT_THRESHOLDS;
+  return {
+    ltvCacGreen: overrides.ltvCacGreen ?? DEFAULT_THRESHOLDS.ltvCacGreen,
+    ltvCacYellow: overrides.ltvCacYellow ?? DEFAULT_THRESHOLDS.ltvCacYellow,
+    paybackGreen: overrides.paybackGreen ?? DEFAULT_THRESHOLDS.paybackGreen,
+    paybackYellow: overrides.paybackYellow ?? DEFAULT_THRESHOLDS.paybackYellow,
+  };
+}
+
+/**
+ * Color band for LTV/CAC. Cutoffs default to the hardcoded B2B-SaaS values; pass a tenant's resolved
+ * thresholds to apply their overrides (CTO-126).
+ */
+export function ltvCacBand(
+  ratio: number | null,
+  thresholds: UnitEconomicsThresholds = DEFAULT_THRESHOLDS,
+): Band {
   if (ratio === null) return "unknown";
-  if (ratio > 3.0) return "green";
-  if (ratio >= 1.0) return "yellow";
+  if (ratio > thresholds.ltvCacGreen) return "green";
+  if (ratio >= thresholds.ltvCacYellow) return "yellow";
+  return "red";
+}
+
+/**
+ * Color band for payback months — lower is healthier. Null (undefined payback) → "unknown". Cutoffs
+ * default to the hardcoded values; pass a tenant's resolved thresholds to apply their overrides.
+ */
+export function paybackBand(
+  months: number | null,
+  thresholds: UnitEconomicsThresholds = DEFAULT_THRESHOLDS,
+): Band {
+  if (months === null) return "unknown";
+  if (months <= thresholds.paybackGreen) return "green";
+  if (months <= thresholds.paybackYellow) return "yellow";
   return "red";
 }

--- a/web/lib/unitEconomicsConfig.test.ts
+++ b/web/lib/unitEconomicsConfig.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import { resolveThresholds, DEFAULT_THRESHOLDS } from "./unitEconomics";
+import { overridesFromApi } from "./unitEconomicsConfig";
+
+describe("overridesFromApi (CTO-126 wire mapping)", () => {
+  it("maps the gateway snake_case config to camelCase overrides", () => {
+    const overrides = overridesFromApi({
+      ltv_cac_green_threshold: 4.0,
+      ltv_cac_yellow_threshold: 1.5,
+      payback_months_green: 8,
+      payback_months_yellow: 16,
+      created_at: null,
+      updated_at: null,
+      updated_by: "finance@acme.test",
+    });
+    expect(overrides).toEqual({
+      ltvCacGreen: 4.0,
+      ltvCacYellow: 1.5,
+      paybackGreen: 8,
+      paybackYellow: 16,
+    });
+  });
+
+  it("returns null when the tenant has no config row → resolveThresholds uses defaults", () => {
+    const overrides = overridesFromApi(null);
+    expect(overrides).toBeNull();
+    expect(resolveThresholds(overrides)).toEqual(DEFAULT_THRESHOLDS);
+  });
+
+  it("a mapped override resolves ON TOP of defaults", () => {
+    const overrides = overridesFromApi({
+      ltv_cac_green_threshold: 5.0,
+      ltv_cac_yellow_threshold: 2.0,
+      payback_months_green: 6,
+      payback_months_yellow: 12,
+      created_at: null,
+      updated_at: null,
+      updated_by: null,
+    });
+    expect(resolveThresholds(overrides)).toEqual({
+      ltvCacGreen: 5.0,
+      ltvCacYellow: 2.0,
+      paybackGreen: 6,
+      paybackYellow: 12,
+    });
+  });
+});

--- a/web/lib/unitEconomicsConfig.ts
+++ b/web/lib/unitEconomicsConfig.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Per-tenant LTV/CAC band threshold overrides, read via the gateway (CTO-126).
+//
+// The band cutoffs used to be hardcoded B2B-SaaS defaults inline in unitEconomics.ts. They are now
+// tenant-configurable: the gateway persists a per-tenant row (GET/POST /v1/tenant/unit-economics/
+// config). This module is the server-only reader — the web app never touches Postgres directly, same
+// rule as web/lib/cac.ts and web/lib/tenant.ts. A tenant with no row (or an unreachable gateway on
+// CI / fresh clones) yields `null`, which the classify helpers treat as "use the defaults".
+
+import type { UnitEconomicsThresholdOverrides } from "./unitEconomics";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+
+/** Wire shape of the gateway's config object (snake_case, matching the Postgres columns). */
+export interface UnitEconomicsConfigApi {
+  ltv_cac_green_threshold: number;
+  ltv_cac_yellow_threshold: number;
+  payback_months_green: number;
+  payback_months_yellow: number;
+  created_at: string | null;
+  updated_at: string | null;
+  updated_by: string | null;
+}
+
+/** Map the gateway's snake_case config to the lib's camelCase override shape. */
+export function overridesFromApi(
+  cfg: UnitEconomicsConfigApi | null,
+): UnitEconomicsThresholdOverrides | null {
+  if (!cfg) return null;
+  return {
+    ltvCacGreen: cfg.ltv_cac_green_threshold,
+    ltvCacYellow: cfg.ltv_cac_yellow_threshold,
+    paybackGreen: cfg.payback_months_green,
+    paybackYellow: cfg.payback_months_yellow,
+  };
+}
+
+/**
+ * Fetch the tenant's threshold overrides. Returns `null` when the tenant has no row OR the gateway
+ * is unreachable — callers pass that straight to `resolveThresholds`, which falls back to defaults.
+ */
+export async function queryUnitEconomicsConfig(): Promise<UnitEconomicsThresholdOverrides | null> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/unit-economics/config`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { config: UnitEconomicsConfigApi | null };
+    return overridesFromApi(body.config ?? null);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## CTO-126 — Tenant-configurable LTV/CAC band thresholds

Replaces the hardcoded B2B-SaaS band cutoffs in `web/lib/unitEconomics.ts` (`"tenant-configurable in v2"`) with per-tenant configurable thresholds. The hardcoded values remain the fallback for any tenant without an override.

**Stacked on #147** (base `feat/cto-145-unit-econ-arpa-margin`, which wired ARPA/margin into `/unit-economics`). Auto-retargets to `main` when #147 merges. Does not regress CTO-145.

### Changes
- **Postgres** — `db/postgres/0019_tenant_unit_economics_config.sql`: `tenant_unit_economics_config` (`tenant_id` PK, the four cutoffs, `created_at`/`updated_at`/`updated_by`) + companion `tenant_unit_economics_config_changes` audit table. CHECK constraints reject inverted bands. Mounted in `infra/docker-compose.yml`.
- **Gateway** — `GET/POST /v1/tenant/unit-economics/config` with the same per-tenant auth as the CAC route (`_resolve_tenant_for_control_plane`). Audited idempotent upsert keyed on a client-supplied `change_id` UUID with `ON CONFLICT`, mirroring `tenant_guardrails`. New `gateway.tenant_unit_economics` store.
- **Web** — `queryUnitEconomicsConfig()` reads via the gateway (returns `null` → defaults on no-row/unreachable). `ltvCacBand` + new `paybackBand` accept resolved thresholds; `resolveThresholds()` layers tenant overrides **on top of** `DEFAULT_THRESHOLDS`. Settings panel on `/unit-economics` edits the four cutoffs with reset-to-defaults, persisting via a thin `/api/unit-economics/config` proxy.
- **Tests** — gateway: round-trip, `change_id` idempotency, inverted-band + missing-`change_id` rejection, cross-tenant isolation (10 tests). Web: override application + default fallback + wire mapping (added to `unitEconomics.test.ts`, new `unitEconomicsConfig.test.ts`).

### Verification
- `infra/gateway`: `ruff check` clean; `pytest` 330 passed.
- `web`: `tsc --noEmit` clean; `vitest run` passes except the two known-flaky ClickHouse tests (`data-quality`, `attribution`), which are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)