### PR TITLE
fix(ci): cap ruff <0.16 to keep the Lint step green

### DIFF
--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -26,7 +26,7 @@ s3 = [
 ]
 dev = [
     "pytest>=8.0",
-    "ruff>=0.6",
+    "ruff>=0.6,<0.16",
     "httpx>=0.27",
 ]
 # Optional analytics-mirror sink (CTO-154). Only needed by deployments that turn on the

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "ruff>=0.12",
+    "ruff>=0.12,<0.16",
 ]
 
 [build-system]


### PR DESCRIPTION
CI runs `uv run ruff check .` but `uv.lock` is gitignored, so `ruff>=0.6` resolves to the latest PyPI release. **ruff 0.16.x** shipped new rules the codebase (linted against 0.15.x) violates → the gateway & python-sdk **Lint** step is now red **repo-wide, including main**, with no code change. Capping ruff `<0.16` in both `infra/gateway/pyproject.toml` and `sdk/python/pyproject.toml` pins CI back to 0.15.x. Verified `ruff check .` passes clean in both projects. Unblocks the remaining merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)