### PR TITLE
chore(infra): local demo override to lift rate limit for the backfill

### DIFF
--- a/infra/docker-compose.override.yml
+++ b/infra/docker-compose.override.yml
@@ -1,0 +1,14 @@
+# Local demo override: lift the per-tenant rate limit so the chatbot-demo
+# backfill (~297k spans posted in ~800 batches) lands in a single run instead
+# of tripping the gateway's default 500 rps / 2000 burst cap (a 429 partway
+# through). See infra/gateway/src/gateway/config.py (rate_limit_rps / _burst).
+#
+# CAVEAT: docker compose auto-merges docker-compose.override.yml on every
+# `make up`, so with this file present the per-tenant rate limit is effectively
+# disabled for ALL local dev, not just during a backfill. That is fine for a
+# laptop demo. Do not carry this pattern to any shared or deployed environment.
+services:
+  gateway:
+    environment:
+      TALLY_RATE_LIMIT_RPS: "1000000"
+      TALLY_RATE_LIMIT_BURST: "5000000"


### PR DESCRIPTION
## What

Adds `infra/docker-compose.override.yml` raising the gateway's per-tenant rate limit (`TALLY_RATE_LIMIT_RPS` / `TALLY_RATE_LIMIT_BURST`) for local runs.

## Why

The gateway defaults to `rate_limit_rps=500` / `rate_limit_burst=2000` (`infra/gateway/src/gateway/config.py`). The demo backfill (`make chatbot-demo-backfill`) posts ~297k spans in ~800 batches and hits a `429 RATE_LIMITED` partway through, so it fails after landing only ~1% of the ~$52k story. With this override, the backfill lands in one pass.

## Reviewer note (the tradeoff)

`docker compose` **auto-merges `docker-compose.override.yml` on every `make up`**, so while this file is present the per-tenant rate limit is effectively disabled for **all** local dev, not just during a backfill. That is fine for a laptop demo. It should never reach a shared or deployed environment. The caveat is written into the file's header comment too.

If you'd prefer this not auto-apply, the alternatives are:
- rename to an opt-in file (e.g. `docker-compose.demo.yml`) applied only via `-f`, or
- make the backfill script honor the `retry_after_ms` in the 429 and back off (removes the need for any rate-limit change), or
- raise the default `rate_limit_rps`/`burst` in `config.py`.

Happy to switch to any of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)