### PR TITLE
fix(cost): align cost windows to 30 days, drop epoch reconciled date, keep infra layers out of provider/outlier panels

### DIFF
--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -61,7 +61,9 @@ export function HomeLive({
         <div className="text-3xl font-semibold">{formatUSD(s.totalMicroUsd)}</div>
         <div className="mt-2 text-sm text-muted">
           estimated {formatUSD(s.estimatedMicroUsd)} · reconciled {formatUSD(s.reconciledMicroUsd)}
-          <span className="ml-1 text-xs">(through {s.reconciledThrough})</span>
+          {s.reconciledThrough > "1970-01-01" ? (
+            <span className="ml-1 text-xs">(through {s.reconciledThrough})</span>
+          ) : null}
         </div>
         <div className="mt-3 text-sm text-warn">
           Hidden cost: {formatUSD(hidden)} ({hiddenPct}%) — vector + tools + compute

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -69,11 +69,12 @@ export function CostLive({
 
   const body = (
     <div className="space-y-6">
-      <Card title="Cost by layer — last 14 days">
+      <Card title="Cost by layer — last 30 days">
         <div className="mb-2 flex items-baseline gap-3 text-sm">
           <span className="text-2xl font-semibold">{formatUSD(total)}</span>
           <span className="text-muted">
-            reconciled {formatUSD(reconciled)} (through {costSeries.reconciledThrough}) · estimated {formatUSD(estimated)}
+            reconciled {formatUSD(reconciled)}
+            {costSeries.reconciledThrough > "1970-01-01" ? ` (through ${costSeries.reconciledThrough})` : ""} · estimated {formatUSD(estimated)}
           </span>
         </div>
         <StackedBarChart series={costSeries} />

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -130,14 +130,14 @@ export async function querySpendSummary(): Promise<SpendSummary | null> {
          sumIf(EstimatedCost, CostSource = 'reconciled') AS reconciled,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY`,
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY`,
       tenant,
     );
     const byLayerRows = await rows<{ layer: Layer; cost: string }>(
       db,
       `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY
        GROUP BY layer`,
       tenant,
     );
@@ -166,6 +166,7 @@ export async function queryOutliers(): Promise<CostOutlier[] | null> {
          FROM otel_spans
          WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
            AND ServiceName != '' AND ServiceName != 'unknown'
+           AND GenAiOperation NOT IN ('compute', 'egress')
          GROUP BY TraceId
        )
        SELECT runId, agent, cost,
@@ -239,14 +240,14 @@ export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSe
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY ${tagClause}
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY ${tagClause}
        GROUP BY day, layer
        ORDER BY day`,
       { tenant, tag },
     );
     // Pivot into one CostDayPoint per calendar day (fill gaps with zero layers).
     const byDay = new Map<string, CostDayPoint>();
-    for (let i = 13; i >= 0; i--) {
+    for (let i = 29; i >= 0; i--) {
       const d = new Date();
       d.setUTCDate(d.getUTCDate() - i);
       const iso = d.toISOString().slice(0, 10);
@@ -273,7 +274,7 @@ export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<F
       db,
       `SELECT FeatureTag AS feature, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != '' ${tagClause}
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY AND FeatureTag != '' ${tagClause}
        GROUP BY feature, layer`,
       { tenant, tag },
     );
@@ -1286,6 +1287,7 @@ export async function queryAttribution(
        FROM otel_spans s
        WHERE s.TenantId = {tenant:String}
          AND s.Timestamp >= now() - INTERVAL 30 DAY
+         AND s.GenAiOperation NOT IN ('compute', 'egress')
          ${tagSql}
          ${providerSql}
        GROUP BY provider`,
@@ -1304,6 +1306,7 @@ export async function queryAttribution(
        WHERE b.TenantId = {tenant:String}
          AND b.EventName = {outcome:String}
          AND b.OccurredAt >= now() - INTERVAL 30 DAY
+         AND s.GenAiOperation NOT IN ('compute', 'egress')
          ${tagSql}
          ${providerSql}
        GROUP BY provider`,

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -899,6 +899,7 @@ export async function queryAgents(filter?: { tag?: string; run?: string }): Prom
          AND Timestamp >= now() - INTERVAL 30 DAY
          AND ServiceName != ''
          AND ServiceName != 'unknown'
+         AND GenAiOperation NOT IN ('compute', 'egress')
          ${tagClause}
          ${runClause}
        GROUP BY TraceId`,


### PR DESCRIPTION
## What changed

Three fixes to the dashboard's cost surfaces, all query/display-only (no schema or data-model changes).

### 1. One consistent 30-day total across Home and Cost
The Cost page headline chart used a rolling **14-day** window while the Home headline and the by-feature table used a rolling **30-day** window, so the same tenant showed three different "total spend" numbers — and because the window was `now() - INTERVAL 30 DAY`, they also drifted by the second and the chart clipped its oldest partial day.

Switched Home total, Home by-layer, the cost series, and the by-feature table to a calendar-aligned `toDate(now()) - INTERVAL 29 DAY` window (exactly the 30 whole days the chart renders) and grew the series fill to 30 buckets. All three now agree to the penny and stay stable regardless of when the query runs.

### 2. No more `(through 1970-01-01)`
When nothing has been reconciled yet, `reconciledThrough` is the `1970-01-01` sentinel. The Home and Cost headlines were printing it verbatim as "(through 1970-01-01)". They now render the through-date clause only when there's a real reconciliation date — consistent with the honest-under-uncertainty posture (render nothing rather than a fabricated date).

### 3. Compute/egress no longer leak into provider-scoped panels
The `compute` and `egress` cost layers were surfacing synthetic `aws`/`vercel` rows in two panels that answer model-provider questions: pathological-run outliers and per-provider attribution. Added `GenAiOperation NOT IN ('compute','egress')` to `queryOutliers` and the attribution sessions/conversions joins, so those panels reflect real agent runs and openai/anthropic only.

## Why
Prep for a product demo surfaced the inconsistencies: the same spend reading three ways, an epoch date in the headline, and infra-cost rows masquerading as LLM providers.

## Reviewer notes
- Files: `web/lib/clickhouse.ts`, `web/app/Live.tsx`, `web/app/cost/Live.tsx`.
- `npm run typecheck` passes; `npm run lint` clean on touched files.
- `npm run test`: the only 2 failing tests (`api.test.ts` attribution/data-quality "falls back to mock when ClickHouse is unreachable") fail identically on clean `main` in this local env because a live ClickHouse is reachable here — they pass on CI where it isn't. This PR adds no new failures.
- The per-provider attribution panel still uses a rolling 30-day window (only the Cost/Home totals were calendar-aligned); its session counts drift by a handful over time, but rate and \$/conversion are unaffected. Can align it too if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)