### PR TITLE
feat(connectors): connect cloud cost sources from the dashboard

### DIFF
--- a/docs/connector-aws-cost-explorer.md
+++ b/docs/connector-aws-cost-explorer.md
@@ -1,0 +1,113 @@
+# AWS Cost Explorer connector (CTO-143 compute, CTO-144 egress)
+
+Pulls a tenant's daily AWS spend and lands it on `/cost` as synthetic spans, so the Compute and
+Egress columns stop reading `$0`. AWS is the only provider that feeds both layers through the same
+API (`ce:GetCostAndUsage`), with a different filter per layer.
+
+- Compute: `infra/gateway/src/gateway/connectors/compute.py` (`AwsCostExplorerClient`,
+  `parse_aws_cost_response`).
+- Egress: `infra/gateway/src/gateway/connectors/egress.py` (`AwsEgressCostExplorerClient`), which
+  reuses compute's response parser verbatim.
+- Shared base: `connectors/base.py` (`CloudBillingConnector`) owns the emitter, the idempotency
+  guard, the run contract, and the run recorder. Only the fetch differs per provider.
+- Control plane: `tenant_compute_config` (`db/postgres/0011`, `0015`) and `tenant_egress_config`
+  (`db/postgres/0012`).
+- `boto3` is imported lazily inside the client. The gateway and the whole test suite import this
+  module without it installed.
+
+## Problem
+
+Every live deployment shows `$0` in the Compute and Egress columns because no cloud billing data
+ever reaches `otel_spans`. LLM spend is the only layer that arrives on its own, through the proxy.
+Infrastructure spend has to be pulled.
+
+## Data source
+
+One call per run, `get_cost_and_usage` at `DAILY` granularity over `UnblendedCost`:
+
+| Layer   | Filter                                                     | Config source                      |
+| ------- | ---------------------------------------------------------- | ---------------------------------- |
+| compute | Cost-allocation tags, default `{"tally:workload": "ai"}`    | `tenant_compute_config.tag_filter` |
+| egress  | Usage type `DataTransfer-Out-Bytes`                        | fixed in code                      |
+
+The tag filter is what keeps unrelated infrastructure out of the AI cost picture. A tenant that
+doesn't tag its workload gets whatever the default matches, which is usually nothing, and that is
+the honest answer rather than sweeping in the whole account.
+
+Two details the parser handles that are easy to get wrong. Cost Explorer's `End` is exclusive, so
+the client adds a day to include `end_day`. Days with zero or absent cost are dropped rather than
+emitted as `$0` spans.
+
+## Normalization
+
+`parse_aws_cost_response` is a pure function over the raw response, unit-tested against recorded
+fixtures. It reads `ResultsByTime[].TimePeriod.Start` and `ResultsByTime[].Total.UnblendedCost.Amount`
+and returns `DailyCost(day, cost_micro_usd)`.
+
+Money is integer micro-USD everywhere. Rate math uses `Decimal`, never float dollars.
+
+## Emission
+
+One synthetic span per day per layer, written through `gateway.mapping.span_to_row` with
+`gen_ai.cost.estimated_micro_usd` set directly. There is no model to price, so the catalog
+enrichment path is skipped. `GenAiSystem` lands as `aws`, `GenAiOperation` as `compute` or `egress`.
+
+`CostSource` is `estimated`, which is correct: Cost Explorer numbers are un-invoiced. Reconciling
+them against an authoritative invoice is the reconciler's job, not this connector's.
+
+Idempotency matters because `otel_spans` is a plain `MergeTree` with no dedupe. Each span id is
+derived deterministically from `(tenant_id, provider, operation, day)` via `synthetic_span_id`, and
+the emitter checks `span_exists` before inserting. Re-running a day is safe.
+
+## Auth
+
+`credentials_ref` is a Secret Manager, KMS, or ARN pointer. Raw keys never appear in the database,
+in this module, or in logs. The column is length-bounded so a fat-fingered raw key is more likely to
+trip the check than land silently.
+
+The literal value `aws-default-chain` means "use the ambient AWS credential chain" (instance role,
+env, SSO). Any other value is treated as an assumable role ARN and passed through for the
+deployment's STS wiring to resolve.
+
+## Failure behavior
+
+A failed fetch records a `failed` run on the config row and emits no span. The connector never
+writes a guessed number. A tenant with no config row is a no-op, not an error.
+
+## Operations
+
+Backfill after enabling the connector, so a new tenant doesn't start with an empty column:
+
+```bash
+uv run python scripts/backfill_compute.py --tenant <uuid> --days 30
+uv run python scripts/backfill_egress.py --tenant <uuid> --days 30
+```
+
+Both are idempotent on `(tenant_id, provider, day)`.
+
+## Tests
+
+`infra/gateway/tests/test_connectors_compute.py` and `test_connectors_egress.py`. Tests inject a
+fake `BillingClient` and never touch the network.
+
+## Open questions and gaps
+
+Three things are missing before this is a product rather than a library.
+
+**Nothing schedules it.** The connector classes and the backfill scripts exist, but no worker runs
+them daily. Someone has to run the script by hand. The other ingest workers (Segment, HubSpot,
+Pendo) share a cycle pattern in `gateway/integration_workers.py`, which is the obvious model to
+follow, but the cloud billing connectors are not wired into it.
+
+**Config is now writable from the dashboard (CTO-176).** `/connectors` has a Connect form per
+source, backed by `GET/POST /v1/tenant/cost-connectors` and
+`DELETE /v1/tenant/cost-connectors/{connector}` in `gateway.connectors.config_admin`. The form takes
+a credential reference and rejects anything shaped like a raw key before it reaches Postgres.
+
+One thing the schema forces and the UI now says out loud: `tenant_compute_config` is keyed on
+`tenant_id` alone, so AWS and GCP compute are mutually exclusive per tenant. Connecting one replaces
+the other, and the API returns which provider was replaced so the operator is not surprised.
+
+**Cost Explorer costs money to query.** `GetCostAndUsage` is billed per request. A daily run per
+tenant is cheap, but a backfill loop that calls per day rather than per range is not. The current
+client fetches a range in one call, which is right. Any future scheduler should keep that shape.

--- a/docs/connector-cloudflare.md
+++ b/docs/connector-cloudflare.md
@@ -1,0 +1,98 @@
+# Cloudflare connector (CTO-144)
+
+Pulls a tenant's daily bandwidth-out from Cloudflare and lands it as synthetic `egress` spans.
+Cloudflare is the one egress source that reports bytes instead of dollars, so it is the only
+connector that needs a tenant-supplied price to produce a cost at all. That single difference drives
+most of the design below.
+
+- Code: `infra/gateway/src/gateway/connectors/egress.py` (`CloudflareAnalyticsClient`,
+  `parse_cloudflare_bytes`, `_bytes_to_micro`).
+- Control plane: `tenant_egress_config` (`db/postgres/0012`) with `egress_provider = 'cloudflare'`.
+- Shared base: `connectors/base.py` (`CloudBillingConnector`), reused verbatim. Only the fetch
+  differs.
+- The HTTP client is imported lazily.
+
+## Data source
+
+Cloudflare's GraphQL analytics API at `https://api.cloudflare.com/client/v4/graphql`, using the
+`httpRequests1dGroups` aggregate scoped to the configured zone:
+
+```
+data.viewer.zones[].httpRequests1dGroups[] -> { dimensions { date }, sum { bytes } }
+```
+
+`resource_id` on the config row is the Cloudflare zone id. It is a public identifier, not a secret.
+
+Multiple zones or groups on the same day sum, so a tenant running several zones still gets one
+egress span per day rather than one per zone.
+
+## Pricing bytes
+
+This is the part that separates Cloudflare from Vercel and AWS. The analytics API returns bytes, not
+money. `usd_per_gb` on the config row converts them, and `_bytes_to_micro` does the arithmetic in
+`Decimal`.
+
+`usd_per_gb` is `NULL` for Vercel and AWS, which report USD directly, and required for Cloudflare. A
+Cloudflare row without it fails soft: the run records `failed` and emits no span. We will not invent
+a price for bytes. An operator has to state the rate their Cloudflare plan actually charges, because
+we cannot derive it from the analytics response.
+
+Days with zero bytes are dropped rather than emitted as `$0`.
+
+## Emission and idempotency
+
+One synthetic span per day, `GenAiSystem = cloudflare`, `GenAiOperation = egress`, cost set directly
+as `gen_ai.cost.estimated_micro_usd`, `CostSource = estimated`.
+
+Span ids come from `synthetic_span_id(tenant, 'cloudflare', 'egress', day)`, checked against
+`span_exists` before insert, so re-runs never double-count.
+
+A tenant can run Cloudflare alongside Vercel and AWS egress at once. Each provider is its own
+control-plane row and its own run, keyed on a distinct provider, so the three sum cleanly on the
+Egress column with each counted once.
+
+## Auth
+
+`credentials_ref` is a Secret Manager, KMS, or ARN pointer to the Cloudflare API token. Never a raw
+token. The column is length-bounded to catch a pasted credential.
+
+## Failure behavior
+
+Two ways this connector declines to produce a number, both recording `failed` and emitting no span:
+the fetch itself fails, or `usd_per_gb` is missing. A tenant with no config row is skipped.
+
+## Operations
+
+```bash
+uv run python scripts/backfill_egress.py --tenant <uuid> --days 30
+```
+
+The script covers all three egress providers, Cloudflare included, and is idempotent on
+`(tenant_id, provider, day)`.
+
+## Tests
+
+`infra/gateway/tests/test_connectors_egress.py`. `parse_cloudflare_bytes` is a pure function tested
+against a recorded fixture. The GraphQL runner is injected in tests.
+
+## Open questions and gaps
+
+**The GraphQL query is a placeholder.** `_cloudflare_query` is marked `pragma: no cover` and builds
+the query by string interpolation of the zone id and dates. It has never run against live
+Cloudflare. Two things to settle before it does: whether `httpRequests1dGroups` is the right
+aggregate for billable bandwidth (Cloudflare bills on more than HTTP request bytes for some plans),
+and whether the zone id should be parameterized rather than interpolated. The interpolation is not
+an injection risk today because the zone id comes from our own config row and not user input, but it
+is the kind of thing that stops being true later.
+
+**`usd_per_gb` is a flat rate.** Cloudflare pricing tiers by plan and by region. A single rate per
+tenant will be wrong at the margins for anyone on a metered plan. Whether that matters depends on
+how large the Egress column is relative to the rest of the bill, and on this demo data it is small.
+
+**Config is now writable from the dashboard (CTO-176).** `/connectors` writes the Cloudflare row
+through `POST /v1/tenant/cost-connectors`. The form requires a zone id and a `usd_per_gb` rate, and
+the gateway refuses the row without them rather than letting a priceless Cloudflare connector sit
+there failing every run.
+
+**Nothing schedules it.** Same gap as the AWS and Vercel connectors. See
+`docs/connector-aws-cost-explorer.md`.

--- a/docs/connector-vercel.md
+++ b/docs/connector-vercel.md
@@ -1,0 +1,85 @@
+# Vercel connector (CTO-163 compute, CTO-144 egress)
+
+Vercel-hosted AI apps pay Vercel for both Functions compute and bandwidth. This connector pulls both
+from the same usage payload and lands them next to the app's LLM spend on `/cost`. It is the only
+connector that feeds two cost layers from one fetch, which is why the double-count rule below
+exists.
+
+- Compute: `infra/gateway/src/gateway/connectors/vercel.py` (`VercelCostConnector`,
+  `VercelUsageClient`, `parse_vercel_compute`).
+- Egress: `infra/gateway/src/gateway/connectors/egress.py` (`VercelBandwidthClient`,
+  `parse_vercel_usage`).
+- Control plane: `tenant_vercel_config` (`db/postgres/0016`) for compute,
+  `tenant_egress_config` for egress.
+- The HTTP dependency is imported lazily, so the gateway boots without it.
+
+## Data source
+
+One payload, `api.vercel.com` usage/billing, scoped by `team_id` and `project_id`. The response is
+an `items[]` array where each entry carries a `date` (`YYYY-MM-DD`), an `amount` (decimal USD
+string), and a `type`. The split is by line item type:
+
+| Layer   | Line item types                              | Emits                                     |
+| ------- | -------------------------------------------- | ----------------------------------------- |
+| compute | `function_invocations`, `function_duration`   | one `compute` span/day, `GenAiSystem=vercel` |
+| egress  | `bandwidth`                                  | one `egress` span/day, `GenAiSystem=vercel`  |
+
+Amounts arrive as dollars, so no rate conversion is needed. Same-day items sum to one total per
+layer. Each parser ignores the other layer's line items, so neither can absorb the other's spend.
+
+## The double-count rule
+
+CTO-144's egress connector already names Vercel bandwidth as an egress source. If this connector
+also emitted egress, the Egress column would count Vercel twice. Two safeguards, in order:
+
+The gate is primary. `VercelCostConnector` emits egress only when `emit_egress = true`
+(`tenant_vercel_config.emit_egress`, default `false`). By default this connector owns the compute
+half and Vercel egress flows solely through `tenant_egress_config`. Set the flag only for a tenant
+that has no `tenant_egress_config` row for `egress_provider = 'vercel'`, so exactly one path emits.
+
+Matching span ids are the backstop. When it does emit egress, it routes through CTO-144's
+`EgressCostConnector` and `VercelBandwidthClient` verbatim, producing
+`synthetic_span_id(tenant, 'vercel', 'egress', day)`. That is byte-identical to what CTO-144 would
+produce, so even if both paths ran for the same day the base `span_exists` guard collapses them to
+one row. A double-count is structurally impossible, not just unlikely.
+
+## Auth
+
+`access_token_ref` is a Secret Manager or KMS reference to the Vercel access token, never the raw
+token, and the column is length-bounded to catch a pasted token. `team_id` and `project_id` are
+public Vercel identifiers that scope the query, not secrets.
+
+`enabled` (default `true`) lets a tenant keep the row but pause the connector.
+
+## Emission and idempotency
+
+Same as every cloud billing connector: one synthetic span per layer per day, cost set directly as
+`gen_ai.cost.estimated_micro_usd`, `CostSource = estimated`, deterministic span id checked against
+`span_exists` before insert. Re-running a day is safe.
+
+## Failure behavior
+
+A failed fetch stamps `failed` on the config row and emits no span. A tenant with no row is skipped.
+
+## Tests
+
+`infra/gateway/tests/test_connectors_vercel.py`, plus the Vercel egress cases in
+`test_connectors_egress.py`. `parse_vercel_compute` and `parse_vercel_usage` are pure functions
+tested against recorded fixtures; the clients are injected in tests and never hit the network.
+
+## Open questions and gaps
+
+**No backfill script.** `scripts/` has `backfill_compute.py`, `backfill_egress.py`, and
+`backfill_gcp_compute.py`, but nothing for Vercel compute. A tenant enabling the Vercel connector
+starts with an empty Compute column and no supported way to fill it. `VercelCostConnector` already
+exposes `run_backfill`, so this is a thin script, not new plumbing.
+
+**Nothing schedules it.** Same gap as the AWS connector. No daily worker calls `run()`.
+
+**Config is now writable from the dashboard (CTO-176).** `/connectors` writes
+`tenant_vercel_config` through `POST /v1/tenant/cost-connectors`, including the `emit_egress` flag.
+
+**`emit_egress` is now checked across tables.** It used to be enforced by convention only: nothing
+stopped an operator from setting `emit_egress = true` while a `tenant_egress_config` row for Vercel
+also existed. `config_admin._upsert_vercel` now rejects that combination, so the config cannot claim
+two owners for Vercel egress. The span id guard remains as defence in depth.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       - ../db/postgres/0013_cac_revenue_fields.sql:/docker-entrypoint-initdb.d/0013_cac_revenue_fields.sql:ro
       - ../db/postgres/0019_tenant_unit_economics_config.sql:/docker-entrypoint-initdb.d/0019_tenant_unit_economics_config.sql:ro
       - ../db/postgres/0014_tenant_feature_value_events.sql:/docker-entrypoint-initdb.d/0014_tenant_feature_value_events.sql:ro
+      - ../db/postgres/0015_tenant_compute_config_gcp.sql:/docker-entrypoint-initdb.d/0015_tenant_compute_config_gcp.sql:ro
+      - ../db/postgres/0016_tenant_vercel_config.sql:/docker-entrypoint-initdb.d/0016_tenant_vercel_config.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -88,6 +88,11 @@ from gateway.tenant_cac import (
     csv_template,
     parse_csv,
 )
+from gateway.connectors.config_admin import (
+    ALL_CONNECTORS,
+    ConfigError,
+    CostConnectorAdmin,
+)
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
@@ -151,6 +156,9 @@ async def lifespan(app: FastAPI):
     app.state.store = ClickHouseStore(settings)
     app.state.auth = ApiKeyAuth(settings)
     app.state.tenant_connectors = TenantConnectorStore(settings)
+    # CTO-176: write path for the cloud cost-connector config rows (compute / egress /
+    # vercel). Until now those rows could only be inserted straight into Postgres.
+    app.state.cost_connector_admin = CostConnectorAdmin(settings)
     # Per-tenant guardrail registry (CTO-116) — the SDK polls /v1/tenant/guardrails on its
     # config-refresh window and enforces matching rules in-process. Shadow rules emit span
     # attrs but never alter the call; enabled rules do.
@@ -694,6 +702,79 @@ async def set_tenant_connector(
     store: TenantConnectorStore = app.state.tenant_connectors
     row = store.set(tenant_id, layer, enabled=enabled, notes=notes)
     return JSONResponse({"tenant_id": tenant_id, "connector": row.as_dict()}, status_code=200)
+
+
+@app.get("/v1/tenant/cost-connectors")
+def list_cost_connectors(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Configured cloud cost connectors for the caller's tenant (CTO-176).
+
+    Safe view only: every ``*_ref`` returned is a secret-manager REFERENCE, which is all the column
+    ever holds. No raw credential exists to leak here.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    admin: CostConnectorAdmin = app.state.cost_connector_admin
+    try:
+        rows = admin.list_configs(tenant_id)
+    except Exception as exc:  # noqa: BLE001 - control plane read, degrade rather than 500 the page
+        logger.warning("cost connector list failed: %s", type(exc).__name__)
+        raise HTTPException(status_code=503, detail="control plane unavailable") from exc
+    return JSONResponse(
+        {"tenant_id": tenant_id, "configs": [r.as_dict() for r in rows]}, status_code=200
+    )
+
+
+@app.post("/v1/tenant/cost-connectors")
+async def upsert_cost_connector(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Create or replace one cloud cost connector's config.
+
+    Body: ``{"connector": "aws_cost_explorer", "credentials_ref": "arn:...", ...}``. Per-connector
+    required fields are enforced in :mod:`gateway.connectors.config_admin`, which also rejects
+    anything shaped like a raw credential before it can reach Postgres.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    connector = body.get("connector")
+    if not isinstance(connector, str) or connector not in ALL_CONNECTORS:
+        raise HTTPException(
+            status_code=422, detail=f"connector must be one of {sorted(ALL_CONNECTORS)}"
+        )
+    admin: CostConnectorAdmin = app.state.cost_connector_admin
+    try:
+        result = admin.upsert(tenant_id, connector, body)
+    except ConfigError as exc:
+        # Validation messages are authored for the operator and carry no secret material.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse({"tenant_id": tenant_id, **result}, status_code=200)
+
+
+@app.delete("/v1/tenant/cost-connectors/{connector}")
+def delete_cost_connector(
+    connector: str,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Disconnect one cloud cost connector. Idempotent: deleting an absent row is a 200."""
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    admin: CostConnectorAdmin = app.state.cost_connector_admin
+    try:
+        deleted = admin.delete(tenant_id, connector)
+    except ConfigError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(
+        {"tenant_id": tenant_id, "connector": connector, "deleted": deleted}, status_code=200
+    )
 
 
 @app.get("/v1/tenant/guardrails")

--- a/infra/gateway/src/gateway/connectors/config_admin.py
+++ b/infra/gateway/src/gateway/connectors/config_admin.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Write side of the cost-connector control plane (CTO-176).
+
+The connector modules (compute / egress / vercel) READ their per-tenant config rows through
+:mod:`gateway.connectors.config_store`. Nothing could ever WRITE those rows: a tenant had to insert
+into Postgres by hand, so the /connectors page could only ever say "configured in the backend
+runner". This module is the missing write path, kept deliberately separate from the read stores so
+the connector hot path stays a narrow reader.
+
+One dashboard-facing connector id maps onto one storage row:
+
+  ============================  ===============================  ================================
+  connector id                  table                            discriminator
+  ============================  ===============================  ================================
+  ``aws_cost_explorer``         ``tenant_compute_config``        ``cloud_provider='aws'``
+  ``gcp_billing``               ``tenant_compute_config``        ``cloud_provider='gcp'``
+  ``vercel``                    ``tenant_vercel_config``         (compute; egress via emit_egress)
+  ``cloudflare``                ``tenant_egress_config``         ``egress_provider='cloudflare'``
+  ``aws_egress``                ``tenant_egress_config``         ``egress_provider='aws'``
+  ``vercel_egress``             ``tenant_egress_config``         ``egress_provider='vercel'``
+  ============================  ===============================  ================================
+
+``tenant_compute_config`` is keyed on ``tenant_id`` alone, so **AWS and GCP compute are mutually
+exclusive per tenant**: connecting one replaces the other. That is a property of the 0011 schema,
+not a limitation invented here, and :meth:`CostConnectorAdmin.upsert` surfaces it by returning the
+provider that now owns the row so the UI can say so plainly.
+
+Credentials by REFERENCE only (the 0011 / 0012 / 0016 hard rule): every ``*_ref`` field is a Secret
+Manager / KMS / ARN pointer, or the literal ``aws-default-chain``. This module rejects anything that
+looks like a raw key before it can reach the database, so a pasted credential fails loudly at the
+edge instead of landing in a column.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import psycopg
+
+from gateway.config import Settings
+
+# Dashboard connector ids this module can configure.
+COMPUTE_CONNECTORS = {"aws_cost_explorer": "aws", "gcp_billing": "gcp"}
+EGRESS_CONNECTORS = {"cloudflare": "cloudflare", "aws_egress": "aws", "vercel_egress": "vercel"}
+VERCEL_CONNECTOR = "vercel"
+ALL_CONNECTORS = frozenset({*COMPUTE_CONNECTORS, *EGRESS_CONNECTORS, VERCEL_CONNECTOR})
+
+# The one non-reference value the schema blesses: the ambient AWS credential chain.
+AMBIENT_AWS = "aws-default-chain"
+
+# Shapes that are almost certainly a RAW credential rather than a reference. Checked before write so
+# a pasted key never lands in a column (the schema's length bound is the backstop, not the guard).
+_RAW_KEY_PATTERNS = (
+    re.compile(r"^AKIA[0-9A-Z]{12,}$"),           # AWS access key id
+    re.compile(r"^ASIA[0-9A-Z]{12,}$"),           # AWS temporary access key id
+    re.compile(r"^sk-[A-Za-z0-9_-]{16,}$"),       # OpenAI-style secret
+    re.compile(r"^whsec_[A-Za-z0-9_-]{16,}$"),    # Stripe webhook secret
+    re.compile(r"^ghp_[A-Za-z0-9]{16,}$"),        # GitHub PAT
+    re.compile(r"^-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+# A reference we recognise: a Secret Manager / KMS / Vault style URI or an ARN.
+_REFERENCE_HINTS = (
+    "arn:",
+    "projects/",
+    "gcpkms://",
+    "vault:",
+    "secret://",
+    "sm://",
+    "op://",
+    "env:",
+)
+
+
+class ConfigError(ValueError):
+    """Rejected before touching Postgres. The message is safe to return to the caller."""
+
+
+def validate_credentials_ref(value: object, *, field: str = "credentials_ref") -> str:
+    """Return a validated credential REFERENCE, or raise :class:`ConfigError`.
+
+    Accepts the ambient-AWS sentinel, or a bounded non-empty string that does not look like a raw
+    key. We do not require a specific URI scheme: deployments use Secret Manager, KMS, Vault and
+    plain ARNs, and inventing an allowlist would reject valid setups. We DO reject the shapes that
+    are unambiguously secrets.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{field} is required")
+    ref = value.strip()
+    if ref == AMBIENT_AWS:
+        return ref
+    if len(ref) >= 512:
+        raise ConfigError(f"{field} must be shorter than 512 characters")
+    for pattern in _RAW_KEY_PATTERNS:
+        if pattern.match(ref):
+            raise ConfigError(
+                f"{field} looks like a raw credential. Store the secret in your secret manager and "
+                f"pass its reference (for example an ARN, a projects/... path, or '{AMBIENT_AWS}')."
+            )
+    return ref
+
+
+def looks_like_reference(ref: str) -> bool:
+    """Whether a validated ref matches a known secret-manager shape. Advisory only."""
+    return ref == AMBIENT_AWS or any(ref.startswith(h) for h in _REFERENCE_HINTS)
+
+
+def _clean_tag_filter(value: object, *, field: str) -> dict[str, str] | None:
+    """Coerce a tag/label filter to a flat string->string dict."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"{field} must be a JSON object") from exc
+    if not isinstance(value, dict):
+        raise ConfigError(f"{field} must be a JSON object")
+    out: dict[str, str] = {}
+    for key, val in value.items():
+        if not isinstance(key, str) or not isinstance(val, str):
+            raise ConfigError(f"{field} keys and values must both be strings")
+        if not key.strip():
+            raise ConfigError(f"{field} keys must be non-empty")
+        out[key.strip()] = val.strip()
+    return out
+
+
+def _clean_usd_per_gb(value: object) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        rate = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ConfigError("usd_per_gb must be a decimal number") from exc
+    if rate < 0:
+        raise ConfigError("usd_per_gb must be zero or positive")
+    return rate
+
+
+def _opt_str(value: object, *, field: str) -> str | None:
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ConfigError(f"{field} must be a string")
+    return value.strip() or None
+
+
+def _as_dict(value: Any) -> dict[str, str]:
+    if isinstance(value, str):
+        value = json.loads(value)
+    return dict(value or {})
+
+
+class TenantNotFound(ConfigError):
+    """The caller's tenant identifier does not resolve to a row in ``tenants``."""
+
+
+def _resolve_tenant_uuid(cur: Any, tenant_id: str) -> str:
+    """Map the caller's tenant identifier onto ``tenants.id``.
+
+    The config tables key on ``tenants(id)``, a UUID, but the dashboard and the local dev setup
+    identify a tenant by NAME (``local-dev``). Accept either: pass a UUID through untouched,
+    otherwise look the name up. Without this a name-based caller trips
+    ``InvalidTextRepresentation`` deep in the driver, which surfaces as an opaque 503.
+    """
+    try:
+        return str(uuid.UUID(tenant_id))
+    except (ValueError, AttributeError, TypeError):
+        pass
+    cur.execute("SELECT id FROM tenants WHERE name = %s", (tenant_id,))
+    row = cur.fetchone()
+    if row is None:
+        raise TenantNotFound(f"no tenant named '{tenant_id}'")
+    return str(row[0])
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorConfigView:
+    """Safe, dashboard-facing view of one configured connector row."""
+
+    connector: str
+    configured: bool
+    credentials_ref: str | None = None
+    is_reference: bool = True
+    details: dict[str, Any] | None = None
+    last_run_at: str | None = None
+    last_status: str | None = None
+    connected_at: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "connector": self.connector,
+            "configured": self.configured,
+            "credentials_ref": self.credentials_ref,
+            "is_reference": self.is_reference,
+            "details": self.details or {},
+            "last_run_at": self.last_run_at,
+            "last_status": self.last_status,
+            "connected_at": self.connected_at,
+        }
+
+
+class CostConnectorAdmin:
+    """Read/write the three cost-connector config tables for one tenant."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    # --- reads ---------------------------------------------------------------------------------
+
+    def list_configs(self, tenant_id: str) -> list[ConnectorConfigView]:
+        """Every configured connector for the tenant, as safe views."""
+        out: list[ConnectorConfigView] = []
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            tenant_id = _resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                """
+                SELECT cloud_provider, credentials_ref, tag_filter, bq_billing_export_table,
+                       label_filter, last_run_at, last_status, connected_at
+                FROM tenant_compute_config WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                provider = str(row[0])
+                connector = "aws_cost_explorer" if provider == "aws" else "gcp_billing"
+                details: dict[str, Any] = {"cloud_provider": provider}
+                if provider == "aws":
+                    details["tag_filter"] = _as_dict(row[2])
+                else:
+                    details["bq_billing_export_table"] = row[3] or ""
+                    details["label_filter"] = _as_dict(row[4])
+                out.append(
+                    ConnectorConfigView(
+                        connector=connector,
+                        configured=True,
+                        credentials_ref=str(row[1]),
+                        is_reference=looks_like_reference(str(row[1])),
+                        details=details,
+                        last_run_at=row[5].isoformat() if row[5] else None,
+                        last_status=row[6],
+                        connected_at=row[7].isoformat() if row[7] else None,
+                    )
+                )
+
+            cur.execute(
+                """
+                SELECT egress_provider, credentials_ref, resource_id, usd_per_gb,
+                       last_run_at, last_status, connected_at
+                FROM tenant_egress_config WHERE tenant_id = %s ORDER BY egress_provider
+                """,
+                (tenant_id,),
+            )
+            for erow in cur.fetchall():
+                provider = str(erow[0])
+                connector = {
+                    "cloudflare": "cloudflare",
+                    "aws": "aws_egress",
+                    "vercel": "vercel_egress",
+                }[provider]
+                out.append(
+                    ConnectorConfigView(
+                        connector=connector,
+                        configured=True,
+                        credentials_ref=str(erow[1]),
+                        is_reference=looks_like_reference(str(erow[1])),
+                        details={
+                            "egress_provider": provider,
+                            "resource_id": erow[2] or "",
+                            "usd_per_gb": str(erow[3]) if erow[3] is not None else None,
+                        },
+                        last_run_at=erow[4].isoformat() if erow[4] else None,
+                        last_status=erow[5],
+                        connected_at=erow[6].isoformat() if erow[6] else None,
+                    )
+                )
+
+            cur.execute(
+                """
+                SELECT access_token_ref, team_id, project_id, enabled, emit_egress,
+                       last_run_at, last_status, connected_at
+                FROM tenant_vercel_config WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            )
+            vrow = cur.fetchone()
+            if vrow is not None:
+                out.append(
+                    ConnectorConfigView(
+                        connector=VERCEL_CONNECTOR,
+                        configured=True,
+                        credentials_ref=str(vrow[0]),
+                        is_reference=looks_like_reference(str(vrow[0])),
+                        details={
+                            "team_id": vrow[1] or "",
+                            "project_id": vrow[2] or "",
+                            "enabled": bool(vrow[3]),
+                            "emit_egress": bool(vrow[4]),
+                        },
+                        last_run_at=vrow[5].isoformat() if vrow[5] else None,
+                        last_status=vrow[6],
+                        connected_at=vrow[7].isoformat() if vrow[7] else None,
+                    )
+                )
+        return out
+
+    # --- writes --------------------------------------------------------------------------------
+
+    def upsert(self, tenant_id: str, connector: str, body: dict[str, Any]) -> dict[str, Any]:
+        """Create or replace one connector's config row. Returns a note for the caller."""
+        if connector not in ALL_CONNECTORS:
+            raise ConfigError(f"unknown connector '{connector}'")
+        if connector in COMPUTE_CONNECTORS:
+            return self._upsert_compute(tenant_id, connector, body)
+        if connector in EGRESS_CONNECTORS:
+            return self._upsert_egress(tenant_id, connector, body)
+        return self._upsert_vercel(tenant_id, body)
+
+    def _upsert_compute(
+        self, tenant_id: str, connector: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        provider = COMPUTE_CONNECTORS[connector]
+        ref = validate_credentials_ref(body.get("credentials_ref"))
+        tag_filter = _clean_tag_filter(body.get("tag_filter"), field="tag_filter")
+        label_filter = _clean_tag_filter(body.get("label_filter"), field="label_filter")
+        bq_table = _opt_str(body.get("bq_billing_export_table"), field="bq_billing_export_table")
+        if provider == "gcp" and not bq_table:
+            raise ConfigError(
+                "bq_billing_export_table is required for GCP (project.dataset.table of the Cloud "
+                "Billing export)"
+            )
+
+        replaced: str | None = None
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            tenant_id = _resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                "SELECT cloud_provider FROM tenant_compute_config WHERE tenant_id = %s",
+                (tenant_id,),
+            )
+            existing = cur.fetchone()
+            if existing is not None and str(existing[0]) != provider:
+                replaced = str(existing[0])
+            # tenant_compute_config is keyed on tenant_id alone, so this REPLACES whichever cloud
+            # provider held the row. Surfaced to the caller via `replaced`.
+            cur.execute(
+                """
+                INSERT INTO tenant_compute_config
+                    (tenant_id, cloud_provider, credentials_ref, tag_filter,
+                     bq_billing_export_table, label_filter)
+                VALUES (%s, %s, %s,
+                        COALESCE(%s::jsonb, '{"tally:workload": "ai"}'::jsonb),
+                        %s,
+                        COALESCE(%s::jsonb, '{"tally-workload": "ai"}'::jsonb))
+                ON CONFLICT (tenant_id) DO UPDATE SET
+                    cloud_provider = EXCLUDED.cloud_provider,
+                    credentials_ref = EXCLUDED.credentials_ref,
+                    tag_filter = EXCLUDED.tag_filter,
+                    bq_billing_export_table = EXCLUDED.bq_billing_export_table,
+                    label_filter = EXCLUDED.label_filter,
+                    last_run_at = NULL,
+                    last_status = NULL
+                """,
+                (
+                    tenant_id,
+                    provider,
+                    ref,
+                    json.dumps(tag_filter) if tag_filter is not None else None,
+                    bq_table,
+                    json.dumps(label_filter) if label_filter is not None else None,
+                ),
+            )
+            conn.commit()
+        note = None
+        if replaced:
+            other = "gcp_billing" if replaced == "gcp" else "aws_cost_explorer"
+            note = (
+                f"Replaced the existing {replaced.upper()} compute connector. One compute provider "
+                f"per tenant, so {other} is now disconnected."
+            )
+        return {"connector": connector, "replaced": replaced, "note": note}
+
+    def _upsert_egress(self, tenant_id: str, connector: str, body: dict[str, Any]) -> dict[str, Any]:
+        provider = EGRESS_CONNECTORS[connector]
+        ref = validate_credentials_ref(body.get("credentials_ref"))
+        resource_id = _opt_str(body.get("resource_id"), field="resource_id")
+        usd_per_gb = _clean_usd_per_gb(body.get("usd_per_gb"))
+        if provider == "cloudflare":
+            # Cloudflare analytics report BYTES, not dollars. Without a rate the connector would
+            # have to invent a price, so the schema and the connector both require one.
+            if usd_per_gb is None:
+                raise ConfigError(
+                    "usd_per_gb is required for Cloudflare. Its analytics API reports bytes, not "
+                    "dollars, and we will not guess a price."
+                )
+            if not resource_id:
+                raise ConfigError("resource_id (the Cloudflare zone id) is required")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            tenant_id = _resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                """
+                INSERT INTO tenant_egress_config
+                    (tenant_id, egress_provider, credentials_ref, resource_id, usd_per_gb)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, egress_provider) DO UPDATE SET
+                    credentials_ref = EXCLUDED.credentials_ref,
+                    resource_id = EXCLUDED.resource_id,
+                    usd_per_gb = EXCLUDED.usd_per_gb,
+                    last_run_at = NULL,
+                    last_status = NULL
+                """,
+                (tenant_id, provider, ref, resource_id, usd_per_gb),
+            )
+            conn.commit()
+        note = None
+        if provider == "vercel":
+            note = (
+                "Vercel egress is now owned by the egress connector. Leave emit_egress off on the "
+                "Vercel compute connector so only one path emits."
+            )
+        return {"connector": connector, "replaced": None, "note": note}
+
+    def _upsert_vercel(self, tenant_id: str, body: dict[str, Any]) -> dict[str, Any]:
+        ref = validate_credentials_ref(body.get("access_token_ref"), field="access_token_ref")
+        team_id = _opt_str(body.get("team_id"), field="team_id")
+        project_id = _opt_str(body.get("project_id"), field="project_id")
+        emit_egress = bool(body.get("emit_egress", False))
+        enabled = bool(body.get("enabled", True))
+
+        note = None
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            tenant_id = _resolve_tenant_uuid(cur, tenant_id)
+            if emit_egress:
+                # Defence against the double-count the 0016 header warns about: if CTO-144 already
+                # owns Vercel egress for this tenant, refuse the flag rather than let both claim it.
+                cur.execute(
+                    """
+                    SELECT 1 FROM tenant_egress_config
+                    WHERE tenant_id = %s AND egress_provider = 'vercel'
+                    """,
+                    (tenant_id,),
+                )
+                if cur.fetchone() is not None:
+                    raise ConfigError(
+                        "emit_egress cannot be enabled while a Vercel egress connector is also "
+                        "configured. Disconnect one so exactly one path emits Vercel egress."
+                    )
+            cur.execute(
+                """
+                INSERT INTO tenant_vercel_config
+                    (tenant_id, access_token_ref, team_id, project_id, enabled, emit_egress)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id) DO UPDATE SET
+                    access_token_ref = EXCLUDED.access_token_ref,
+                    team_id = EXCLUDED.team_id,
+                    project_id = EXCLUDED.project_id,
+                    enabled = EXCLUDED.enabled,
+                    emit_egress = EXCLUDED.emit_egress,
+                    last_run_at = NULL,
+                    last_status = NULL
+                """,
+                (tenant_id, ref, team_id, project_id, enabled, emit_egress),
+            )
+            conn.commit()
+        if emit_egress:
+            note = "This connector now emits both Vercel compute and Vercel egress spans."
+        return {"connector": VERCEL_CONNECTOR, "replaced": None, "note": note}
+
+    # --- delete --------------------------------------------------------------------------------
+
+    def delete(self, tenant_id: str, connector: str) -> bool:
+        """Remove a connector's config row. Returns whether a row was actually deleted."""
+        if connector not in ALL_CONNECTORS:
+            raise ConfigError(f"unknown connector '{connector}'")
+        if connector in COMPUTE_CONNECTORS:
+            sql = "DELETE FROM tenant_compute_config WHERE tenant_id = %s AND cloud_provider = %s"
+            params: tuple[Any, ...] = (tenant_id, COMPUTE_CONNECTORS[connector])
+        elif connector in EGRESS_CONNECTORS:
+            sql = "DELETE FROM tenant_egress_config WHERE tenant_id = %s AND egress_provider = %s"
+            params = (tenant_id, EGRESS_CONNECTORS[connector])
+        else:
+            sql = "DELETE FROM tenant_vercel_config WHERE tenant_id = %s"
+            params = (tenant_id,)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            params = (_resolve_tenant_uuid(cur, tenant_id), *params[1:])
+            cur.execute(sql, params)
+            deleted = cur.rowcount > 0
+            conn.commit()
+        return deleted

--- a/infra/gateway/tests/test_connectors_config_admin.py
+++ b/infra/gateway/tests/test_connectors_config_admin.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validation rules for the cost-connector write path (CTO-176).
+
+Pure-logic coverage only: every test here runs without Postgres. The point is that a bad config is
+rejected at the edge, before it can reach a column, and that the rejection message tells the
+operator what to do instead.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from gateway.connectors.config_admin import (
+    ALL_CONNECTORS,
+    AMBIENT_AWS,
+    ConfigError,
+    _clean_tag_filter,
+    _clean_usd_per_gb,
+    looks_like_reference,
+    validate_credentials_ref,
+)
+
+
+class TestCredentialReferences:
+    """The hard rule from 0011/0012/0016: references only, never raw keys."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "AKIAIOSFODNN7EXAMPLE",
+            "ASIAIOSFODNN7EXAMPLE",
+            "sk-abcdefghijklmnopqrstuvwxyz",
+            "whsec_abcdefghijklmnopqrstuvwx",
+            "ghp_abcdefghijklmnopqrstuvwxyz",
+            "-----BEGIN PRIVATE KEY-----\nMIIE",
+        ],
+    )
+    def test_raw_credentials_are_rejected(self, raw: str) -> None:
+        with pytest.raises(ConfigError) as exc:
+            validate_credentials_ref(raw)
+        # The message has to be actionable, not just "invalid".
+        assert "secret manager" in str(exc.value).lower()
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            AMBIENT_AWS,
+            "arn:aws:iam::123456789012:role/tally-cost-reader",
+            "projects/my-proj/secrets/tally-billing-sa",
+            "vault:secret/cloudflare#analytics-token",
+            "gcpkms://projects/p/locations/l/keyRings/k",
+            "sm://tally/vercel-token",
+        ],
+    )
+    def test_references_are_accepted(self, ref: str) -> None:
+        assert validate_credentials_ref(ref) == ref
+        assert looks_like_reference(ref)
+
+    def test_empty_is_rejected(self) -> None:
+        for value in ("", "   ", None, 42):
+            with pytest.raises(ConfigError):
+                validate_credentials_ref(value)
+
+    def test_overlong_reference_is_rejected(self) -> None:
+        # The column bounds this at 512; reject before the driver does.
+        with pytest.raises(ConfigError):
+            validate_credentials_ref("arn:" + "x" * 600)
+
+    def test_ambient_chain_bypasses_length_and_shape_checks(self) -> None:
+        assert validate_credentials_ref(AMBIENT_AWS) == AMBIENT_AWS
+
+    def test_unknown_shape_is_allowed_but_not_flagged_as_reference(self) -> None:
+        # We deliberately do not allowlist URI schemes: deployments differ. A plausible-looking
+        # value passes, and `looks_like_reference` merely reports that we did not recognise it.
+        ref = validate_credentials_ref("my-corp-secret-store/tally/aws")
+        assert ref == "my-corp-secret-store/tally/aws"
+        assert not looks_like_reference(ref)
+
+    def test_field_name_appears_in_the_error(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            validate_credentials_ref("", field="access_token_ref")
+        assert "access_token_ref" in str(exc.value)
+
+
+class TestTagFilter:
+    def test_dict_round_trips_and_is_trimmed(self) -> None:
+        assert _clean_tag_filter({" tally:workload ": " ai "}, field="tag_filter") == {
+            "tally:workload": "ai"
+        }
+
+    def test_json_string_is_parsed(self) -> None:
+        assert _clean_tag_filter('{"tally:workload":"ai"}', field="tag_filter") == {
+            "tally:workload": "ai"
+        }
+
+    def test_none_passes_through_so_the_column_default_applies(self) -> None:
+        assert _clean_tag_filter(None, field="tag_filter") is None
+
+    @pytest.mark.parametrize("bad", ["not json", "[1,2]", 7, {"k": 1}, {"": "v"}])
+    def test_bad_shapes_are_rejected(self, bad: object) -> None:
+        with pytest.raises(ConfigError):
+            _clean_tag_filter(bad, field="tag_filter")
+
+
+class TestUsdPerGb:
+    def test_decimal_parsing_avoids_float(self) -> None:
+        assert _clean_usd_per_gb("0.09") == Decimal("0.09")
+
+    def test_blank_is_none_so_vercel_and_aws_stay_null(self) -> None:
+        assert _clean_usd_per_gb(None) is None
+        assert _clean_usd_per_gb("") is None
+
+    def test_negative_is_rejected(self) -> None:
+        with pytest.raises(ConfigError):
+            _clean_usd_per_gb("-1")
+
+    def test_non_numeric_is_rejected(self) -> None:
+        with pytest.raises(ConfigError):
+            _clean_usd_per_gb("free")
+
+
+def test_connector_ids_cover_every_configurable_source() -> None:
+    # The dashboard's CONFIGURABLE list (web/lib/costConnectors.ts) must stay in step with this.
+    assert ALL_CONNECTORS == {
+        "aws_cost_explorer",
+        "gcp_billing",
+        "vercel",
+        "cloudflare",
+        "aws_egress",
+        "vercel_egress",
+    }

--- a/web/app/connectors/ConnectForm.tsx
+++ b/web/app/connectors/ConnectForm.tsx
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// Connect / edit / disconnect one cloud cost connector (CTO-176). Before this, the page could only
+// say "configured in the backend connector runner" — config rows had to be inserted into Postgres
+// by hand. The form posts through a server action to the gateway, which owns all field validation.
+//
+// Credentials are references, never raw keys. The field asks for a Secret Manager / KMS / ARN
+// pointer and the gateway rejects anything shaped like an actual secret, so a pasted key fails at
+// the edge instead of landing in a column.
+import { useState, useTransition } from "react";
+
+import { connectCostConnectorAction, disconnectCostConnectorAction } from "./costConnectorActions";
+
+interface FieldDef {
+  name: string;
+  label: string;
+  placeholder?: string;
+  hint?: string;
+  required?: boolean;
+  type?: "text" | "checkbox";
+}
+
+/** Per-connector fields. Mirrors the required-field checks in gateway config_admin. */
+const FIELDS: Record<string, FieldDef[]> = {
+  aws_cost_explorer: [
+    {
+      name: "credentials_ref",
+      label: "Credential reference",
+      placeholder: "arn:aws:iam::123456789012:role/tally-cost-reader",
+      hint: "A role ARN or secret reference. Use 'aws-default-chain' for the ambient credential chain.",
+      required: true,
+    },
+    {
+      name: "tag_filter",
+      label: "Cost allocation tags (JSON)",
+      placeholder: '{"tally:workload":"ai"}',
+      hint: "Scopes the billing query to your AI workload. Leave blank for the default.",
+    },
+  ],
+  gcp_billing: [
+    {
+      name: "credentials_ref",
+      label: "Credential reference",
+      placeholder: "projects/my-proj/secrets/tally-billing-sa",
+      hint: "Secret Manager reference, or rely on Workload Identity / ADC in your deployment.",
+      required: true,
+    },
+    {
+      name: "bq_billing_export_table",
+      label: "Billing export table",
+      placeholder: "my-project.billing.gcp_billing_export_v1_XXXX",
+      hint: "GCP has no fine-grained cost API, so the source of truth is the BigQuery billing export.",
+      required: true,
+    },
+    {
+      name: "label_filter",
+      label: "Labels (JSON)",
+      placeholder: '{"tally-workload":"ai"}',
+      hint: "GCP label keys cannot contain ':', so this uses a '-' unlike the AWS tag filter.",
+    },
+  ],
+  vercel: [
+    {
+      name: "access_token_ref",
+      label: "Access token reference",
+      placeholder: "projects/my-proj/secrets/vercel-token",
+      hint: "Reference to the Vercel access token. Never the token itself.",
+      required: true,
+    },
+    { name: "team_id", label: "Team id", placeholder: "team_xxx", hint: "Public identifier, not a secret." },
+    { name: "project_id", label: "Project id", placeholder: "prj_xxx" },
+    {
+      name: "emit_egress",
+      label: "Also emit Vercel egress",
+      type: "checkbox",
+      hint: "Leave off if you connect Vercel egress separately. Only one path may own egress.",
+    },
+  ],
+  cloudflare: [
+    {
+      name: "credentials_ref",
+      label: "API token reference",
+      placeholder: "vault:secret/cloudflare#analytics-token",
+      required: true,
+    },
+    { name: "resource_id", label: "Zone id", placeholder: "023e105f4ecef8ad9ca31a8372d0c353", required: true },
+    {
+      name: "usd_per_gb",
+      label: "USD per GB",
+      placeholder: "0.09",
+      hint: "Required. Cloudflare reports bytes, not dollars, and we will not guess a price.",
+      required: true,
+    },
+  ],
+  aws_egress: [
+    {
+      name: "credentials_ref",
+      label: "Credential reference",
+      placeholder: "aws-default-chain",
+      hint: "Same Cost Explorer access as compute, filtered to DataTransfer-Out-Bytes.",
+      required: true,
+    },
+    { name: "resource_id", label: "Account id", placeholder: "123456789012" },
+  ],
+  vercel_egress: [
+    {
+      name: "credentials_ref",
+      label: "Access token reference",
+      placeholder: "projects/my-proj/secrets/vercel-token",
+      required: true,
+    },
+    { name: "resource_id", label: "Team id", placeholder: "team_xxx" },
+  ],
+};
+
+interface Props {
+  connector: string;
+  configured: boolean;
+  credentialsRef: string | null;
+  details: Record<string, unknown>;
+}
+
+function initialValues(connector: string, details: Record<string, unknown>, ref: string | null) {
+  const vals: Record<string, string> = {};
+  for (const f of FIELDS[connector] ?? []) {
+    if (f.name === "credentials_ref" || f.name === "access_token_ref") {
+      vals[f.name] = ref ?? "";
+      continue;
+    }
+    const raw = details[f.name];
+    if (raw === undefined || raw === null) {
+      vals[f.name] = f.type === "checkbox" ? "false" : "";
+    } else if (typeof raw === "object") {
+      vals[f.name] = JSON.stringify(raw);
+    } else {
+      vals[f.name] = String(raw);
+    }
+  }
+  return vals;
+}
+
+export function ConnectForm({ connector, configured, credentialsRef, details }: Props) {
+  const fields = FIELDS[connector];
+  const [open, setOpen] = useState(false);
+  const [values, setValues] = useState(() => initialValues(connector, details, credentialsRef));
+  const [status, setStatus] = useState<{ tone: "ok" | "err"; text: string } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  if (!fields) return <span className="text-xs text-muted">—</span>;
+
+  const submit = () => {
+    setStatus(null);
+    startTransition(async () => {
+      const res = await connectCostConnectorAction(connector, values);
+      if (res.ok) {
+        setStatus({ tone: "ok", text: res.note ?? "Saved. The next connector run will use it." });
+        setOpen(false);
+      } else {
+        setStatus({ tone: "err", text: res.error });
+      }
+    });
+  };
+
+  const disconnect = () => {
+    setStatus(null);
+    startTransition(async () => {
+      const res = await disconnectCostConnectorAction(connector);
+      if (res.ok) {
+        setStatus({ tone: "ok", text: "Disconnected." });
+        setOpen(false);
+      } else {
+        setStatus({ tone: "err", text: res.error });
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={`rounded-full border px-2.5 py-1 text-xs font-medium transition ${
+            configured
+              ? "border-edge bg-ink/40 text-muted hover:bg-ink/60"
+              : "border-accent/50 bg-accent/15 text-accent hover:bg-accent/25"
+          }`}
+        >
+          {configured ? "Edit" : "Connect"}
+        </button>
+        {configured && (
+          <button
+            type="button"
+            onClick={disconnect}
+            disabled={pending}
+            className="rounded-full border border-edge bg-ink/40 px-2.5 py-1 text-xs font-medium text-muted transition hover:bg-ink/60"
+          >
+            Disconnect
+          </button>
+        )}
+      </div>
+
+      {status && (
+        <span className={`max-w-xs text-right text-[11px] ${status.tone === "ok" ? "text-good" : "text-warn"}`}>
+          {status.text}
+        </span>
+      )}
+
+      {open && (
+        <div className="mt-2 w-80 rounded-lg border border-edge bg-ink/60 p-3 text-left">
+          <div className="space-y-3">
+            {fields.map((f) => (
+              <div key={f.name}>
+                <label className="block text-[11px] font-medium text-muted" htmlFor={`${connector}-${f.name}`}>
+                  {f.label}
+                  {f.required && <span className="text-warn"> *</span>}
+                </label>
+                {f.type === "checkbox" ? (
+                  <input
+                    id={`${connector}-${f.name}`}
+                    type="checkbox"
+                    checked={values[f.name] === "true"}
+                    onChange={(e) =>
+                      setValues((v) => ({ ...v, [f.name]: e.target.checked ? "true" : "false" }))
+                    }
+                    className="mt-1"
+                  />
+                ) : (
+                  <input
+                    id={`${connector}-${f.name}`}
+                    type="text"
+                    value={values[f.name] ?? ""}
+                    placeholder={f.placeholder}
+                    onChange={(e) => setValues((v) => ({ ...v, [f.name]: e.target.value }))}
+                    className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60"
+                  />
+                )}
+                {f.hint && <p className="mt-1 text-[10px] leading-snug text-muted">{f.hint}</p>}
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="rounded border border-edge px-2 py-1 text-xs text-muted hover:bg-ink/60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={pending}
+              className="rounded border border-accent/50 bg-accent/15 px-2 py-1 text-xs font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
+            >
+              {pending ? "Saving…" : "Save"}
+            </button>
+          </div>
+          <p className="mt-2 text-[10px] leading-snug text-muted">
+            Credentials are stored by reference. Paste a secret manager pointer, never the key
+            itself.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/connectors/costConnectorActions.ts
+++ b/web/app/connectors/costConnectorActions.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+"use server";
+
+// Server actions for the cloud cost-connector forms (CTO-176). These persist per-tenant connector
+// config through the gateway; nothing is written from the browser and no raw credential is ever
+// accepted — every credential field is a secret-manager reference.
+import { revalidatePath } from "next/cache";
+
+import {
+  type ConnectResult,
+  connectCostConnector,
+  disconnectCostConnector,
+  isConfigurable,
+} from "@/lib/costConnectors";
+
+export async function connectCostConnectorAction(
+  connector: string,
+  fields: Record<string, string>,
+): Promise<ConnectResult> {
+  if (!isConfigurable(connector)) {
+    return { ok: false, error: `unknown connector: ${connector}` };
+  }
+  // Drop empty strings so the gateway sees "absent" rather than "" and its required-field checks
+  // fire with the right message.
+  const payload: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === "") continue;
+    if (k === "emit_egress" || k === "enabled") {
+      payload[k] = v === "true";
+      continue;
+    }
+    if (k === "tag_filter" || k === "label_filter") {
+      try {
+        payload[k] = JSON.parse(v);
+      } catch {
+        return { ok: false, error: `${k} must be valid JSON, for example {"tally:workload":"ai"}` };
+      }
+      continue;
+    }
+    payload[k] = v;
+  }
+  const result = await connectCostConnector(connector, payload);
+  if (!result.ok) return result;
+  revalidatePath("/connectors");
+  // The cost layers this feeds show up on Home and /cost too.
+  revalidatePath("/", "layout");
+  return result;
+}
+
+export async function disconnectCostConnectorAction(connector: string): Promise<ConnectResult> {
+  if (!isConfigurable(connector)) {
+    return { ok: false, error: `unknown connector: ${connector}` };
+  }
+  const result = await disconnectCostConnector(connector);
+  if (!result.ok) return result;
+  revalidatePath("/connectors");
+  revalidatePath("/", "layout");
+  return result;
+}

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -10,7 +10,9 @@ import {
   connectedCount,
   liveAvailableCount,
 } from "@/lib/connectors";
+import { type CostConnectorConfig, isConfigurable, queryCostConnectorConfigs } from "@/lib/costConnectors";
 import { queryEnabledConnectors } from "@/lib/tenant";
+import { ConnectForm } from "./ConnectForm";
 import { ConnectorToggle } from "./ConnectorToggle";
 
 interface ConnectorsPayload {
@@ -54,9 +56,11 @@ function StateBadge({ row }: { row: ConnectorStatus }) {
 function ConnectorTable({
   rows,
   enabledLayers,
+  configs,
 }: {
   rows: ConnectorStatus[];
   enabledLayers: readonly string[];
+  configs: Map<string, CostConnectorConfig>;
 }) {
   return (
     <div className="overflow-x-auto">
@@ -68,6 +72,7 @@ function ConnectorTable({
             <th className="py-1 text-left font-medium">Status</th>
             <th className="py-1 text-right font-medium">Records (30d)</th>
             <th className="py-1 text-right font-medium">Last sync</th>
+            <th className="py-1 text-right font-medium">Connection</th>
             <th className="py-1 text-right font-medium">Banner</th>
           </tr>
         </thead>
@@ -94,6 +99,18 @@ function ConnectorTable({
                   {r.lastAt ? relativeAge(r.lastAt) : "—"}
                 </td>
                 <td className="py-2 text-right">
+                  {isConfigurable(r.id) ? (
+                    <ConnectForm
+                      connector={r.id}
+                      configured={configs.get(r.id)?.configured ?? false}
+                      credentialsRef={configs.get(r.id)?.credentialsRef ?? null}
+                      details={configs.get(r.id)?.details ?? {}}
+                    />
+                  ) : (
+                    <span className="text-xs text-muted">—</span>
+                  )}
+                </td>
+                <td className="py-2 text-right">
                   {layer && r.state !== "coming_soon" ? (
                     <ConnectorToggle layer={layer} initialEnabled={isEnabled} />
                   ) : (
@@ -110,10 +127,14 @@ function ConnectorTable({
 }
 
 export default async function ConnectorsPage() {
-  const [{ connectors, live }, enabledLayers] = await Promise.all([
+  const [{ connectors, live }, enabledLayers, costConfigs] = await Promise.all([
     apiGet<ConnectorsPayload>("/api/connectors"),
     queryEnabledConnectors(),
+    queryCostConnectorConfigs(),
   ]);
+  // `null` means the gateway is unreachable. Render the forms anyway (they report their own
+  // errors on submit) rather than hiding the only way to configure anything.
+  const configs = new Map((costConfigs ?? []).map((c) => [c.connector, c]));
   // Only cost-layer sources surface in the UI today; revenue/CDP and the third-party integration
   // cards were purely decorative (no real status), removed in the cleanup wave following #100.
   const visibleConnectors = connectors.filter((c) => c.category === "cost");
@@ -130,7 +151,7 @@ export default async function ConnectorsPage() {
         return (
           <Card key={s.category} title={`${s.title} — ${n}/${live} connected${suffix}`}>
             <p className="mb-3 max-w-prose text-xs text-muted">{s.blurb}</p>
-            <ConnectorTable rows={rows} enabledLayers={enabledLayers} />
+            <ConnectorTable rows={rows} enabledLayers={enabledLayers} configs={configs} />
           </Card>
         );
       })}
@@ -151,9 +172,10 @@ export default async function ConnectorsPage() {
       </div>
 
       <p className="max-w-prose text-sm text-muted">
-        Pluggable cost sources. Each normalizes one provider into the shared cost model;
-        credentials and sync schedules are configured in the backend connector runner. A source
-        shows <span className="text-good">Connected</span> once it has produced data.
+        Pluggable cost sources. Each normalizes one provider into the shared cost model. Connect a
+        source here by pointing it at a credential reference; sync schedules run in the backend
+        connector runner. A source shows <span className="text-good">Connected</span> once it has
+        produced data.
       </p>
 
       {live ? body : <SyntheticPreviewBanner workflow="Connectors">{body}</SyntheticPreviewBanner>}

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1203,21 +1203,36 @@ export async function queryConnectorActivity(): Promise<ConnectorActivity | null
     const records: Record<string, number> = {};
     const lastAt: Record<string, string> = {};
 
-    // Cost layers from telemetry. Map each layer back to the connector that feeds it.
-    const layerToId = new Map<Layer, string>();
+    // Cost layers from telemetry, resolved back to the connector that produced them.
+    //
+    // Two connectors can feed the same layer (AWS and GCP both feed `compute`; Vercel and
+    // Cloudflare both feed `egress`), so a plain layer→connector map collides and credits every
+    // row to whichever connector the catalog lists last. Group by GenAiSystem as well and prefer
+    // the connector that claims that system; fall back to the layer's sole connector when a layer
+    // has exactly one, so single-connector layers (llm, vector, tools) are unaffected.
+    const bySystem = new Map<string, string>();
+    const layerOwners = new Map<Layer, string[]>();
     for (const c of CONNECTORS) {
-      if (c.liveKey.kind === "cost-layer") layerToId.set(c.liveKey.layer, c.id);
+      if (c.liveKey.kind !== "cost-layer") continue;
+      const owners = layerOwners.get(c.liveKey.layer) ?? [];
+      owners.push(c.id);
+      layerOwners.set(c.liveKey.layer, owners);
+      for (const sys of c.liveKey.systems ?? []) bySystem.set(`${c.liveKey.layer}:${sys}`, c.id);
     }
-    const costRows = await rows<{ layer: Layer; n: string; last: string | null }>(
+    const costRows = await rows<{ layer: Layer; system: string; n: string; last: string | null }>(
       db,
-      `SELECT ${LAYER_CASE} AS layer, count() AS n, toString(max(Timestamp)) AS last
+      `SELECT ${LAYER_CASE} AS layer, GenAiSystem AS system, count() AS n,
+              toString(max(Timestamp)) AS last
        FROM otel_spans
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
-       GROUP BY layer`,
+       GROUP BY layer, system`,
       tenant,
     );
     for (const r of costRows) {
-      const id = layerToId.get(r.layer);
+      const owners = layerOwners.get(r.layer) ?? [];
+      // Exact system match wins; otherwise only credit a layer that has a single connector. A
+      // shared layer with an unrecognised system stays unattributed rather than guessing.
+      const id = bySystem.get(`${r.layer}:${r.system}`) ?? (owners.length === 1 ? owners[0] : null);
       if (!id) continue;
       const n = parseInt(r.n, 10) || 0;
       if (n <= 0) continue;

--- a/web/lib/connectors.ts
+++ b/web/lib/connectors.ts
@@ -16,15 +16,28 @@ export type ConnectorCategory = "cost" | "revenue";
 
 /** How a connector's live activity is found in the telemetry store. */
 export type LiveKey =
-  | { kind: "cost-layer"; layer: Layer }
+  | {
+      kind: "cost-layer";
+      layer: Layer;
+      /**
+       * `GenAiSystem` values that belong to this connector. Required whenever two connectors feed
+       * the SAME layer (AWS vs GCP on `compute`, Vercel vs Cloudflare on `egress`) — without it the
+       * layer→connector lookup collides and credits every row to whichever connector the catalog
+       * happens to list last.
+       */
+      systems?: readonly string[];
+    }
   | { kind: "revenue-source"; source: string };
 
 /**
  * Whether the backend ingest path for this connector actually exists today.
- * - `live`        — a real worker / SDK / webhook ingests data when configured (LLM proxy, Stripe)
+ * - `live`        — a real worker / SDK / webhook ingests data when configured.
  * - `coming_soon` — catalog entry only; no worker yet, the UI advertises a placeholder so users
- *                   know it's planned. Re-classify to `live` when the corresponding integration
- *                   ships (Pinecone, Tavily, AWS Cost Explorer, Vercel via CTO-127 follow-ups).
+ *                   know it's planned.
+ *
+ * The four cloud connectors moved to `live` once their workers shipped: AWS Cost Explorer and GCP
+ * Cloud Billing (CTO-143 / CTO-150) feed `compute`, Vercel (CTO-163) feeds `compute` and can feed
+ * `egress`, Cloudflare (CTO-144) feeds `egress`. Configure them from /connectors (CTO-176).
  */
 export type Availability = "live" | "coming_soon";
 
@@ -85,8 +98,8 @@ export const CONNECTORS: ConnectorDef[] = [
     category: "cost",
     feeds: "Compute cost",
     description: "Cloud billing line items for compute backing the AI workload.",
-    liveKey: { kind: "cost-layer", layer: "compute" },
-    availability: "coming_soon",
+    liveKey: { kind: "cost-layer", layer: "compute", systems: ["aws"] },
+    availability: "live",
   },
   {
     id: "gcp_billing",
@@ -94,8 +107,8 @@ export const CONNECTORS: ConnectorDef[] = [
     category: "cost",
     feeds: "Compute cost",
     description: "Cloud billing line items for compute backing the AI workload.",
-    liveKey: { kind: "cost-layer", layer: "compute" },
-    availability: "coming_soon",
+    liveKey: { kind: "cost-layer", layer: "compute", systems: ["gcp"] },
+    availability: "live",
   },
   {
     id: "vercel",
@@ -103,8 +116,8 @@ export const CONNECTORS: ConnectorDef[] = [
     category: "cost",
     feeds: "Egress cost",
     description: "Edge/serverless and bandwidth usage for the serving tier.",
-    liveKey: { kind: "cost-layer", layer: "egress" },
-    availability: "coming_soon",
+    liveKey: { kind: "cost-layer", layer: "egress", systems: ["vercel"] },
+    availability: "live",
   },
   {
     id: "cloudflare",
@@ -112,8 +125,8 @@ export const CONNECTORS: ConnectorDef[] = [
     category: "cost",
     feeds: "Egress cost",
     description: "CDN/egress bandwidth usage for the serving tier.",
-    liveKey: { kind: "cost-layer", layer: "egress" },
-    availability: "coming_soon",
+    liveKey: { kind: "cost-layer", layer: "egress", systems: ["cloudflare"] },
+    availability: "live",
   },
   {
     id: "segment",
@@ -187,9 +200,16 @@ export function connectedCount(rows: ConnectorStatus[]): number {
   return rows.filter((r) => r.state === "connected").length;
 }
 
-/** Number of rows that aren't connected today but are claimed to be possible to connect now. */
+/**
+ * Denominator for "N of M sources connected": every source that CAN be connected today, which is
+ * the connected ones plus the ones still merely available. Rows still marked `coming_soon` are
+ * excluded and counted separately, so the two numbers always add up to the row count.
+ *
+ * Previously this returned `availability === "live"` only, which counted a *smaller* set than
+ * `connectedCount` and produced headers like "4 of 1 sources connected".
+ */
 export function liveAvailableCount(rows: ConnectorStatus[]): number {
-  return rows.filter((r) => r.availability === "live").length;
+  return rows.filter((r) => r.state !== "coming_soon").length;
 }
 
 export function comingSoonCount(rows: ConnectorStatus[]): number {

--- a/web/lib/costConnectors.ts
+++ b/web/lib/costConnectors.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Cloud cost-connector configuration (CTO-176).
+//
+// Mirrors lib/stripeConnector.ts: the dashboard never talks to Postgres directly, it goes through
+// the gateway's /v1/tenant/cost-connectors endpoints. Every credential field here is a secret
+// manager REFERENCE, never a raw key, which is all the underlying columns are allowed to hold.
+
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+/** Connector ids the config endpoints understand. Matches config_admin.ALL_CONNECTORS. */
+export const CONFIGURABLE = [
+  "aws_cost_explorer",
+  "gcp_billing",
+  "vercel",
+  "cloudflare",
+  "aws_egress",
+  "vercel_egress",
+] as const;
+export type ConfigurableConnector = (typeof CONFIGURABLE)[number];
+
+export function isConfigurable(id: string): id is ConfigurableConnector {
+  return (CONFIGURABLE as readonly string[]).includes(id);
+}
+
+export interface CostConnectorConfig {
+  connector: string;
+  configured: boolean;
+  credentialsRef: string | null;
+  /** Whether the stored ref matches a known secret-manager shape. Advisory, drives a hint only. */
+  isReference: boolean;
+  details: Record<string, unknown>;
+  lastRunAt: string | null;
+  lastStatus: string | null;
+  connectedAt: string | null;
+}
+
+interface ConfigWire {
+  connector: string;
+  configured: boolean;
+  credentials_ref: string | null;
+  is_reference: boolean;
+  details: Record<string, unknown>;
+  last_run_at: string | null;
+  last_status: string | null;
+  connected_at: string | null;
+}
+
+/** Configured connectors for the tenant. `null` means the gateway is unreachable. */
+export async function queryCostConnectorConfigs(): Promise<CostConnectorConfig[] | null> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { configs: ConfigWire[] };
+    return (body.configs ?? []).map((c) => ({
+      connector: c.connector,
+      configured: c.configured,
+      credentialsRef: c.credentials_ref,
+      isReference: c.is_reference,
+      details: c.details ?? {},
+      lastRunAt: c.last_run_at,
+      lastStatus: c.last_status,
+      connectedAt: c.connected_at,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+export type ConnectResult =
+  | { ok: true; note: string | null }
+  | { ok: false; error: string };
+
+/** Create or replace one connector's config. Field validation lives in the gateway. */
+export async function connectCostConnector(
+  connector: ConfigurableConnector,
+  fields: Record<string, unknown>,
+): Promise<ConnectResult> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      body: JSON.stringify({ connector, ...fields }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) {
+      // The gateway returns operator-facing validation text in `detail`; surface it verbatim so a
+      // missing usd_per_gb reads as the real reason instead of a status code.
+      const detail = await res
+        .json()
+        .then((b: { detail?: string }) => b?.detail)
+        .catch(() => undefined);
+      return { ok: false, error: detail || `gateway HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as { note?: string | null };
+    return { ok: true, note: body.note ?? null };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+/** Remove a connector's config. Idempotent. */
+export async function disconnectCostConnector(
+  connector: ConfigurableConnector,
+): Promise<ConnectResult> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors/${connector}`, {
+      method: "DELETE",
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return { ok: false, error: `gateway HTTP ${res.status}` };
+    return { ok: true, note: null };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}


### PR DESCRIPTION
## What this fixes

The `/connectors` page advertised AWS Cost Explorer, GCP Cloud Billing, Vercel and Cloudflare as **"Coming soon"** and told the operator that credentials were *"configured in the backend connector runner"*. Both claims were wrong:

- All four connectors already shipped (CTO-143 / CTO-144 / CTO-150 / CTO-163).
- There was no runner UI. The `tenant_compute_config` / `tenant_egress_config` / `tenant_vercel_config` rows could only be inserted into Postgres by hand, so there was no way to connect anything from the product.

## The write path

New `gateway.connectors.config_admin` owns the write side of the cost-connector control plane, kept separate from `config_store` so the connector hot path stays a narrow reader. It maps the six dashboard connector ids onto the three config tables and exposes:

| Method | Route |
| --- | --- |
| GET | `/v1/tenant/cost-connectors` |
| POST | `/v1/tenant/cost-connectors` |
| DELETE | `/v1/tenant/cost-connectors/{connector}` |

The page gets a **Connect / Edit / Disconnect** control per source with per-provider fields.

### Credentials stay by reference

The 0011/0012/0016 hard rule holds. The form asks for a Secret Manager / KMS / ARN pointer, and the gateway rejects AWS key ids, `sk-` / `whsec_` / `ghp_` tokens and PEM blocks **before they reach a column**, so a pasted secret fails at the edge with an actionable message rather than landing in the database.

### Validation the schema implies but could not enforce

- **Cloudflare** requires `usd_per_gb` and a zone id. Its analytics API reports bytes, so without a rate the connector could only guess a price.
- **GCP** requires `bq_billing_export_table` (no fine-grained cost API exists).
- **`emit_egress`** is refused when a Vercel egress row already exists. The 0016 header called this out as convention only; it is now checked across tables, with the matching synthetic span id left as defence in depth.
- **`tenant_compute_config` is keyed on `tenant_id` alone**, so AWS and GCP compute are mutually exclusive per tenant. The API returns which provider it replaced so the operator is not surprised.

## Display fixes

**Header read "4 of 1 sources connected".** The denominator counted `availability === "live"`, a strictly smaller set than the connected rows. It now counts every source that can be connected today, so the two can't disagree.

**The four shipped cloud connectors move off "coming soon".**

**Connector activity was misattributed.** Two connectors can feed one layer (AWS and GCP feed `compute`; Vercel and Cloudflare feed `egress`), and the layer-to-connector map kept only the last one. `aws` compute spans were being credited to *GCP*, and `vercel` egress to *Cloudflare*. `queryConnectorActivity` now groups by `GenAiSystem` and only falls back to the layer when it has a single connector, leaving an unrecognised system unattributed rather than guessing.

## Found along the way

- **Migrations `0015` and `0016` were never mounted in `docker-compose.yml`**, so a fresh environment came up without the GCP compute columns or the Vercel config table at all. Mounts added.
- **Tenant id mismatch.** These tables key on `tenants(id)` (uuid) while the dashboard passes the tenant *name* (`local-dev`), which surfaced as an opaque 503. `config_admin` now accepts either. Worth noting `/v1/tenant/connectors` has the same latent mismatch, not addressed here.

## Docs

Specs for the three connectors under `docs/`, written against the real implementation and honest about what is missing. The largest remaining gap: **nothing schedules these connectors yet.** The classes and backfill scripts exist, but no daily worker calls `run()`, so connecting a source stores config that nothing acts on until a backfill script is run by hand. Vercel has no backfill script at all.

## Testing

- **464 gateway tests pass**, including 30 new ones covering the validation rules (all pure logic, no Postgres).
- `ruff check` clean, web `typecheck` and `lint` clean on touched files.
- Verified end to end against a live gateway and browser: raw-key rejection, the Cloudflare rate requirement, the GCP export-table requirement, AWS/GCP mutual exclusion, and the Vercel double-count refusal all behave correctly, and a save from the form lands in Postgres.
- `npm run test`: the only 2 failures (`api.test.ts` attribution / data-quality "falls back to mock when ClickHouse is unreachable") fail identically on clean `main` in this environment because a live ClickHouse is reachable here. They pass in CI, where it isn't. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)