### PR TITLE
docs: scope seven features and plan the cost-per-customer build

### DIFF
--- a/docs/ci-cost-check-scope.md
+++ b/docs/ci-cost-check-scope.md
@@ -1,0 +1,228 @@
+# Scope: CI cost check (GitHub Action)
+
+**Status: proposal, not built.** A GitHub Action that comments on a pull request with the projected
+cost impact of the change: "this PR raises cost per request 22 percent."
+
+The strategic case is that this reaches teams who will never install a dashboard. It lands in the
+workflow they already have, and the artifact is a PR comment rather than a login.
+
+## The "80 percent done" claim, checked
+
+Mostly true, for a narrower set of changes than it first appears.
+
+`POST /v1/replay/estimate` already does the hard part. It accepts a `candidate_model`
+(`{provider, model}`) and an optional `system_prompt_override`, replays them against a sample of
+captured production envelopes through the same executor as `/v1/replay`, and returns a projection
+with per-corpus extrapolation plus an honesty and diagnostics block.
+
+Behind it: `sdk/python/src/tally/projection.py` is a real, tested engine (`test_projection.py`,
+`test_replay.py`) that reports p99 cost per run rather than the mean, on the reasoning that a change
+can leave the average flat while fattening the tail. `replay_sampler.py` builds the tail-weighted
+sample, and `tenant_replay_config` already carries a `daily_budget_usd` cap.
+
+So for the two most common cost-affecting changes, a model swap and a system prompt edit, the
+projection machinery genuinely exists and is exercised. What does not exist is everything between a
+git diff and that endpoint.
+
+One caveat on maturity: the `/estimate` page is currently hidden from the nav because it renders mock
+fixtures, and `web/lib/estimate.ts` is explicitly mock data. The engine is real; the surface over it
+is not. This feature would be the first real consumer.
+
+## The honest limitation, stated up front
+
+The estimator models **declarative** changes. It cannot model **behavioral** ones.
+
+`candidate_model` and `system_prompt_override` describe a different way of making the same calls. A
+PR that adds a retry loop, introduces a second LLM call, raises `top_k` from 5 to 20 in a retriever,
+or changes an agent's stopping condition changes the *number and shape* of calls, and no prompt
+override expresses that. Projecting it properly would mean executing the PR's code, which is a
+substantially larger feature and a different security posture.
+
+This matters because the changes most likely to blow up cost are behavioral. An agent that loops
+twice as often is the classic incident, and v1 would miss it.
+
+The right response is not to hide this. The comment should say what it analysed and what it could
+not:
+
+> Analysed: system prompt change on `research_agent`.
+> Not analysed: 3 other changed files that may affect call volume.
+
+A cost check that silently ignores half a diff and prints a confident number is worse than no check.
+
+## Decision 1: which changes are in scope for v1
+
+| Change | Expressible today | In v1 |
+| --- | --- | --- |
+| Model swap (`gpt-4o` to `gpt-4o-mini`) | `candidate_model` | Yes |
+| System prompt edit | `system_prompt_override` | Yes |
+| Prompt template edit (Jinja, YAML, registry) | Same, once extracted | Yes if extractable |
+| `max_tokens` / sampling parameter change | Not today, small addition | Stretch |
+| Retrieval `top_k`, retry policy, agent control flow | Requires executing the PR | No |
+
+Recommendation: ship the first two, detect the rest and say they were not analysed.
+
+## Decision 2: extracting intent from a diff
+
+This is the genuinely new work, and the part most likely to be underestimated.
+
+Something has to turn "these 14 files changed" into "the system prompt for `research_agent` changed
+from A to B". Prompts live in string literals, Jinja templates, YAML, JSON, or a prompt registry, and
+model names live in config, environment variables, or inline calls. A general solution is a research
+project.
+
+Three approaches:
+
+**Declared, via a config file** (recommended). The repo carries `.tally-ci.yml` naming where prompts
+and models live:
+
+```yaml
+features:
+  research_agent:
+    system_prompt: prompts/research_system.txt
+    model_config: config/models.yaml#research.model
+```
+
+Explicit, boring, debuggable, and it fails loudly when a path moves. The cost is that a team must
+write it, which is a real adoption tax on a feature whose whole pitch is low friction.
+
+**Convention.** Scan for `prompts/*.txt`, known SDK call sites, common config keys. Zero setup, and
+wrong often enough to erode trust.
+
+**SDK-assisted.** The SDK already knows the resolved prompt at runtime and could emit a stable
+identifier tying a feature tag to a source location. Best long-term answer, and it needs the prompt
+hash wiring described in `docs/waste-detection-scope.md`, which is currently an orphan column.
+
+Recommendation: config file for v1, convention-based detection as a suggestion that generates the
+config file on first run, SDK-assisted later.
+
+## Decision 3: baseline, and what "22 percent" means
+
+`/v1/replay/estimate` projects one candidate. CI needs a comparison, and the baseline choice changes
+the number.
+
+Options: replay both the base branch's prompt and the PR's prompt over the same sample (a true
+paired comparison, twice the replay cost), or compare the PR's projection against observed production
+cost for that feature (cheaper, and it conflates the change with drift in traffic mix).
+
+Recommendation: paired replay over one shared sample. It is the only version where "22 percent" is
+attributable to the change rather than to the week. It also halves the variance, since both arms see
+identical inputs.
+
+The headline should be **cost per request**, not projected monthly cost. Per-request is a property of
+the change; monthly depends on volume the PR author does not control. Show projected monthly as a
+secondary line for context.
+
+Report p99 alongside the mean, following the engine's existing posture. A change that leaves the mean
+flat and doubles p99 is exactly the change worth catching, and a mean-only comment would pass it.
+
+## Decision 4: significance, and not crying wolf
+
+With a sample of 50 replayed runs, a 3 percent difference is noise. The comment must not report it as
+a finding.
+
+The engine already computes a bootstrap and a Wilson interval, so the honest output is a delta with a
+confidence interval, plus an explicit "no significant change detected" state when the interval spans
+zero. `/v1/replay` already treats fewer than 50 replayed responses as too thin to report on, and that
+threshold should carry over.
+
+Three outcomes: significant increase, significant decrease, no detectable change. Anything else is
+false precision.
+
+## Cost of running it
+
+This feature spends real money on every run, which makes it unlike any other CI check.
+
+Each PR check replays N production envelopes against a live model, twice for a paired comparison.
+`tenant_replay_config.daily_budget_usd` defaults to **$5.00**, which at realistic per-call costs is a
+handful of checks per day. That default was chosen for a manual workflow, not for something firing on
+every push.
+
+Controls needed:
+
+- **Cache by content hash.** The same prompt and model pair on a re-push should reuse the prior
+  result. Most PR pushes do not change the prompt, so this alone removes most of the spend.
+- **Debounce.** Run on PR open and on pushes that touch declared paths, not on every commit.
+- **A per-repo daily cap**, surfaced in the comment when exhausted ("skipped, daily replay budget
+  reached") rather than silently not commenting.
+- **Sample size as a knob**, traded off against confidence width.
+
+The comment should state what the check itself cost. A tool that reports on spend and hides its own
+is not credible.
+
+## The Action
+
+A composite action:
+
+```yaml
+- uses: ai-tally/cost-check@v1
+  with:
+    api-key: ${{ secrets.TALLY_API_KEY }}
+    config: .tally-ci.yml
+```
+
+It resolves the changed files, reads the config, extracts baseline and candidate prompt or model,
+calls `/v1/replay/estimate` twice, and posts a **sticky comment** updated in place rather than a new
+comment per push.
+
+A status check is worth offering but should default to non-blocking. A cost regression is
+information, not a build failure, and a team can opt into failing above a threshold. Blocking merges
+on a sampled projection by default would get the action uninstalled within a week.
+
+Authentication is a tenant API key in repo secrets. Worth noting this is a second outbound-facing
+surface, alongside the alerts destination in `docs/cost-alerts-scope.md`.
+
+## The comment
+
+Concrete, and short enough to read in a PR:
+
+> **ai-tally cost check**
+> Cost per request: **+22%** ($0.0141 to $0.0172), 95% CI +14% to +29%
+> p99 per request: +31%
+> Projected monthly at current volume: +$3,180
+> Analysed: system prompt for `research_agent` (prompts/research_system.txt)
+> Not analysed: 2 changed files that may affect call volume
+> Based on 50 replayed production requests. Check cost: $0.38.
+
+Every number in that comment is defensible or labelled. The "not analysed" line is what keeps it
+honest.
+
+## Phasing
+
+1. **The config file format and diff extraction** for prompts and models.
+2. **A CI-facing endpoint** that takes baseline and candidate and returns a paired comparison, so the
+   action does not orchestrate two calls and compute statistics itself.
+3. **The Action**: sticky comment, non-blocking status, auth.
+4. **Caching, debounce and budget controls.** Before any wide rollout, not after.
+5. **Detection and reporting of un-analysable changes.**
+6. Parameter changes (`max_tokens`, sampling), then SDK-assisted extraction.
+
+## Open questions
+
+1. Does this require production traffic in ai-tally already? Yes today, since replay samples captured
+   envelopes. That makes the "never install a dashboard" pitch partly circular: you need to be
+   ingesting before CI checks work. Worth deciding whether a synthetic corpus is an acceptable
+   fallback for a first-run experience, and being clear it is weaker evidence.
+2. GitHub only, or GitLab and others? The projection work is shared; only the comment surface differs.
+3. Who pays for replay spend on an open source repo where anyone can open a PR? Forked PRs must not
+   be able to drain a budget or read secrets.
+4. Does the check need per-feature scoping when one PR touches several features?
+5. Should a decrease be celebrated as loudly as an increase? A comment that only ever appears with bad
+   news gets read as a nag.
+
+## Risks
+
+**Circularity in the pitch.** The adoption story is that teams who would never install a dashboard
+adopt this instead. But replay needs captured production traffic, which means the SDK or proxy is
+already deployed. The action is a great *expansion* surface for existing tenants and a weaker
+*acquisition* one than it first appears. Worth being clear-eyed about which it is.
+
+**Missing behavioral regressions.** v1 cannot see a new retry loop, which is the most common way cost
+actually blows up. If the comment reads as a general cost check rather than a prompt and model check,
+it will be trusted for something it does not do.
+
+**Noise gets it uninstalled.** A check that fires on every push with a different number, or blocks
+merges on a sampled estimate, is removed quickly. Non-blocking by default, sticky comments, and a
+real significance test are what keep it installed.
+
+**Spend on CI.** Every check costs money against a budget that currently defaults to $5 a day. Without
+caching and caps, a busy repo exhausts it before lunch and the feature looks broken.

--- a/docs/cost-alerts-scope.md
+++ b/docs/cost-alerts-scope.md
@@ -1,0 +1,186 @@
+# Scope: cost alerts with Slack delivery
+
+**Status: proposal, not built.** Alert a tenant when AI spend crosses a threshold per day, week or
+month, and deliver it to Slack.
+
+## What exists, and what does not
+
+A `cost_cap` guardrail kind already exists (`db/postgres/0006_tenant_guardrails.sql`), but it solves
+a different problem. Guardrails are **preventive**: the SDK engine enforces them in-flight and can
+alter agent behavior (`observe` / `warn` / `graceful` / `hard_stop`). An alert is **detective**: it
+watches aggregate spend after the fact and tells a human. A cap stops one expensive run. An alert
+tells you the bill tripled last Tuesday. Both are wanted, and neither substitutes for the other.
+
+What does not exist is more important:
+
+**There is no outbound notification of any kind, anywhere in the product.** No Slack, no webhook, no
+email. Every integration today is inbound (Stripe webhook, HubSpot, Segment, Pendo pull). This
+feature introduces the first path where ai-tally initiates contact with the outside world, which
+brings retry semantics, delivery failure handling, and secret storage for a destination we push to.
+
+**Nothing is scheduled.** As with the cost connectors, the repo has workers but no scheduler calling
+them on a timer. An alert evaluator is useless without one, so this feature either builds the
+scheduler or inherits it from whatever lands first. This is now the third feature blocked on the
+same missing piece, which argues for building it properly once.
+
+## Decision 1: what the threshold means
+
+"Cost goes up beyond X per day" has two readings and they need different machinery.
+
+**Absolute.** "Tell me when a day costs more than $500." Easy to build, easy to explain, and it
+either fires constantly or never as the business grows. Static thresholds go stale.
+
+**Relative.** "Tell me when today is 40 percent above the trailing 7-day median." Catches the thing
+people actually care about (a regression, a runaway loop, a bad deploy) and does not need retuning
+as the business scales.
+
+Recommendation: support both, ship absolute first. Absolute is what people ask for and it is
+honest and obvious. Relative is what keeps the feature useful in month six. A relative rule needs a
+minimum history (at least 14 days) before it can fire, and should say so rather than firing on a
+thin baseline.
+
+Explicitly out of scope for v1: statistical anomaly detection. Seasonality in AI spend is real
+(weekday and weekend differ sharply) and a naive model will cry wolf. A median-based relative rule
+gets most of the value without pretending to be a forecaster.
+
+## Decision 2: the late-data problem
+
+This is the one that will make or break the feature's credibility, and it is easy to miss.
+
+Cost data is not complete when the day ends:
+
+- Connector-sourced compute and egress spend arrives from a **daily** cloud billing pull, and cloud
+  bills themselves lag by hours.
+- Reconciled cost replaces estimated cost later, through `reconciliation_runs`.
+- Telemetry can be sampled, so totals shift as sampling is accounted for.
+
+An evaluator that checks "yesterday's spend" at 00:05 will see the LLM half of the bill and none of
+the infra half, then see the rest arrive later. On the current demo tenant the infra layers are
+about 47 percent of spend, so the same day could read $50k at midnight and $95k by noon. Alerting on
+the first number produces both false negatives and, once the rest lands, a confusing second alert.
+
+Options: wait a fixed grace period before evaluating a closed period (simple, recommended, roughly
+6 to 24 hours configurable); or evaluate continuously and mark alerts provisional until the period
+is settled (more responsive, much more explaining to do in Slack).
+
+Recommendation: grace period for v1, and the alert message states the window it evaluated and
+whether reconciled cost was included. An alert that cannot say what it measured is not actionable.
+
+## Decision 3: Slack delivery
+
+Two ways in.
+
+**Incoming webhook URL.** The tenant creates a webhook in Slack and pastes the URL. Simple, no OAuth,
+no app review. The URL is itself a secret and must be stored by reference like every other credential
+in this codebase (see `gateway.connectors.config_admin`), never raw.
+
+**Slack app with OAuth.** Nicer (channel picker, richer formatting, threading), and it means building
+and maintaining a distributed Slack app, an OAuth callback, and token refresh.
+
+Recommendation: webhook for v1. It is a fraction of the work and covers the ask. Design the
+notification layer behind a transport interface so a Slack app, email, PagerDuty or a generic webhook
+can be added without touching the evaluator. Given this is the product's first outbound path, the
+seam matters more than the first implementation.
+
+## Data model
+
+```
+tenant_cost_alerts
+  tenant_id        uuid      references tenants(id)
+  alert_id         text
+  period           text      check (period in ('day','week','month'))
+  kind             text      check (kind in ('absolute','relative'))
+  threshold_micro  bigint    -- absolute: the cost ceiling
+  threshold_pct    numeric   -- relative: percent above trailing median
+  scope_kind       text      check (scope_kind in ('tenant','feature','model','layer'))
+  scope_value      text      -- '' for tenant-wide
+  destination_ref  text      -- secret reference to the Slack webhook, never the raw URL
+  channel_hint     text      -- display only, e.g. '#ai-costs'
+  state            text      check (state in ('enabled','shadow','disabled'))
+  cooldown_minutes int       default 1440
+  last_fired_at    timestamptz
+  primary key (tenant_id, alert_id)
+
+tenant_cost_alert_events        -- what fired, when, what it measured, delivery outcome
+  tenant_id, alert_id, fired_at, period_start, period_end,
+  observed_micro, threshold_micro, baseline_micro,
+  delivery_status text check (delivery_status in ('sent','failed','suppressed')),
+  delivery_error text
+```
+
+The `shadow` state is worth keeping for the same reason guardrails have it: a tenant can watch what
+an alert *would* have fired for a week before letting it page anyone. That graduation ladder is
+already the product's posture and alerts should inherit it.
+
+`tenant_cost_alert_events` is not just a log. It powers cooldown, dedupe, and an "alert history"
+view, and it is how you answer "why did this fire?" a month later.
+
+## Suppression
+
+An alert that fires every hour for the same overspend is noise, and noise gets muted, which means
+the next real alert is missed. Three mechanisms, all needed:
+
+- **Cooldown.** Do not re-fire the same alert within `cooldown_minutes`. Default 24 hours for a daily
+  alert.
+- **One alert per closed period.** A daily alert fires at most once for a given day.
+- **Recovery.** When spend returns below threshold, post a short resolution message rather than
+  leaving the channel with an unresolved alarm.
+
+## The evaluator
+
+A worker that, per tenant, per enabled alert: resolves the period window (respecting the grace
+period), queries spend for the scope, compares against threshold or trailing baseline, checks
+cooldown, and delivers. Delivery outcome is written to `tenant_cost_alert_events` whether it
+succeeded or not.
+
+Cost queries reuse the existing shapes in `web/lib/clickhouse.ts` (the layer case, the tenant and
+window filters), so scoping an alert to a feature or a layer is a `WHERE` clause, not new machinery.
+
+Failure posture matches the rest of the product: if the evaluator cannot compute a number it records
+a failed run and stays quiet. It never sends a guessed figure, and it never silently skips. A tenant
+should be able to see that the evaluator ran and found nothing, which is different from not running.
+
+## UI
+
+Extend `/guardrails`, or a new `/alerts` tab. Recommendation is a new tab: guardrails are about
+changing agent behavior and alerts are about telling humans, and merging them muddles a page that
+currently has one clear story.
+
+Per alert: period, scope, threshold, destination, state, last fired, and the recent history from the
+events table. A "test alert" button that posts to Slack immediately is worth building, because the
+first thing anyone does after configuring a webhook is wonder whether it works.
+
+## Phasing
+
+1. **Notification transport plus Slack webhook**, with a test-send. Standalone and independently
+   useful.
+2. **Absolute thresholds, tenant-wide, daily**, with the scheduler and the grace period.
+3. **Weekly and monthly periods, plus scoping** to feature, model or layer.
+4. **Relative thresholds** against a trailing median, with a minimum-history guard.
+5. **Shadow mode and alert history** in the UI.
+
+## Open questions
+
+1. Who owns the scheduler? Three features now need it (connectors, alerts, and any waste scan). It
+   should be built once, deliberately, rather than three times.
+2. Does an alert evaluate estimated cost, reconciled cost, or both? They differ, and the answer
+   changes when an alert can fire.
+3. Per-tenant or per-user destinations? A tenant with several teams may want the research agent's
+   alerts in one channel and support's in another. The schema above allows it per alert; the UI
+   needs to make it obvious.
+4. What happens when Slack delivery fails? Retry with backoff, surface in the UI, both?
+5. Is there a global rate limit on alerts per tenant per hour, to protect against a misconfigured
+   rule spamming a channel?
+
+## Risks
+
+**Alert fatigue is the failure mode.** A cost alerting feature that fires too often gets muted in
+week two and provides negative value from then on. Suppression and shadow mode are not polish here,
+they are the feature.
+
+**First outbound path.** Pushing to an external service introduces a class of problem the product has
+not had: partial delivery, retry storms, and a stored secret that lets us post into a customer's
+Slack. Treat the destination reference with the same care as any other credential.
+
+**A wrong alert is worse than no alert.** If the late-data problem is not handled, the first alert a
+customer receives will be wrong, and they will not trust the second one.

--- a/docs/cost-per-customer-plan.md
+++ b/docs/cost-per-customer-plan.md
@@ -1,0 +1,260 @@
+# Build plan: Cost per customer
+
+Implementation plan for the feature scoped in `docs/cost-per-customer-scope.md`. Common components
+first, then the account dimension, then the tab.
+
+Each numbered item below is intended to be one Linear ticket.
+
+## Decisions taken
+
+**Decision 1. Optional account label, falling back to the hash.**
+A tenant may attach a human-readable label to an account. Where one exists the tab shows it; where
+one does not, it shows a shortened hash. Labels are opt-in per account, so a tenant that wants no
+customer names in our system simply sets none and the tab still works.
+
+Where the label lives matters, and it should not be a span column. A label is mutable metadata that
+can be renamed, and stamping it on every span both wastes storage and creates the question of which
+of two labels wins. It also puts customer names in the telemetry store, which is the thing the hash
+exists to avoid.
+
+So: labels live in a Postgres control-plane table (B7), keyed on the account hash, joined at render
+time. Telemetry stays name-free. The label can be set through the API or picked up opportunistically
+from an optional `account_label` SDK attribute that the gateway upserts into the table and does not
+write to the span.
+
+B6 stays in scope: it is how an operator finds an account that has no label.
+
+**Decision 2. Direct cost only for v1. No allocation.**
+Workstream C moves out of v1 and becomes a follow-up. The tab reports directly attributable spend
+(LLM, tools, vector, embeddings) and excludes compute and egress.
+
+Consequence to design around: on the current demo tenant that excludes about 47 percent of spend, so
+every account figure understates true cost by roughly half. This must be stated on the page, and
+stated with the tenant's real number rather than a vague disclaimer. We already know the excluded
+total, so D3 becomes a banner that reads "excludes $44,500 (47%) of compute and egress that cannot
+yet be attributed per account", computed live per tenant.
+
+---
+
+## Workstream A: shared components
+
+Build first. Justified independently of this feature: 10 pages currently hand-roll `<table>` markup
+and the honest-blank `—` is hand-written across 10 files. Every later tab in the backlog needs the
+same primitives.
+
+**A1. `DataTable` component.**
+A typed table taking a column spec (key, header, align, render) and rows. Handles right-aligned
+numerics with `tabular-nums`, the shared header style, empty state, and horizontal overflow.
+Includes column sorting and pagination from the start: account lists are unbounded, and retrofitting
+paging into a component three pages already use is more expensive than building it once.
+
+**A2. Honest-value primitives.**
+`<Money>`, `<Pct>`, and `<Blank reason>`. `Blank` renders the `—` with a hover explaining *why* it is
+blank ("no revenue events wired", "below 50 samples"). Today that reason is either missing or a
+hand-written `title` attribute. This is the product's central posture and it should be one component,
+not 21 copies.
+
+**A3. Migrate two existing pages onto A1 and A2.**
+`/connectors` and `/attribution`. Proves the abstraction against real usage before the new tab depends
+on it, and pays down duplication. Deliberately not migrating all 10: if the component does not fit two
+very different pages, it is the wrong component.
+
+---
+
+## Workstream B: the account dimension
+
+The foundation. Nothing in the tab works without it, and it ships dark until a customer instruments
+it.
+
+**B1. ClickHouse migration: `AccountIdHash`.**
+Add `AccountIdHash FixedString(64)` and `AccountIdHashKeyVersion` to `otel_spans`, and
+`AccountIdHash` to `business_events`. Additive, defaults to `''`, which the UI reads as unattributed
+rather than as a customer named "unknown". Next free migration number is 0022.
+
+**B2. SDK: `account_id`.**
+Accept `account_id` alongside `user_id`, hash it with the existing per-tenant HMAC path in
+`hmac_keys.py`, and emit `gen_ai.account_id_hash` plus the key version. Same treatment as user ids:
+never stored raw, not joinable across tenants.
+
+**B3. Gateway: map the attribute.**
+`mapping.py` writes the new columns. The Go edge proxy passes an account header through for tenants
+who use the proxy rather than the SDK.
+
+**B4. `daily_account_rollup` table and materialized view.**
+Mirrors `daily_feature_rollup`: keyed on `(TenantId, AccountIdHash, Day)` with `FeatureTag` and
+`GenAiOperation`, carrying cost, span count, and a `uniq` state for distinct users. Keeps the tab fast
+when an account count runs into the thousands.
+
+**B5. `account_id` in the identity graph.**
+Add to the `IdentityAType` and `IdentityBType` enums so a CRM or CDP connector can stitch users to
+accounts. This is the path for tenants who cannot tag every span. Stitched accounts must be
+distinguishable from tagged ones in the UI.
+
+**B6. Account lookup endpoint.**
+`POST /v1/tenant/account-lookup` taking a plaintext account id and returning its hash, computed with
+the tenant's own HMAC key. Per Decision 1 this is how an operator locates an account that carries no label.
+The plaintext is used to compute the hash and is never persisted or logged. Feeds a search box on
+the tab.
+
+**B7. Account label store.**
+Postgres table `tenant_account_labels (tenant_id, account_id_hash, label, updated_at)` with CRUD
+through the gateway, plus an optional `account_label` SDK attribute the gateway upserts here rather
+than writing to the span. Labels are optional per account. ClickHouse never holds a customer name.
+Deleting a label reverts that account to its hash, which is the escape hatch for a tenant who
+changes their mind.
+
+---
+
+## Workstream C: allocation (deferred, not in v1)
+
+Out of scope per Decision 2. Kept here because the tab is incomplete without it and it should be the first
+follow-up. The reconciliation test in C1 is the reason this cannot be bolted on carelessly later.
+
+**C1. Allocation engine, pure functions.**
+Given per-account direct spend and a tenant-level shared total, return each account's allocated
+share. Implements the rule chosen in D2, plus even-split as an alternative. Pure and unit-tested with
+no I/O, matching the house style of `unitEconomics.ts` and `projection.py`.
+
+The test that matters: allocated shares must sum to the shared total, and direct plus allocated must
+sum to the tenant total. If per-account costs do not reconcile with `/cost`, the tab loses trust
+immediately.
+
+**C2. Per-tenant allocation config.**
+Which rule is in force, stored on a tenant config row and surfaced on the page. Small, and it stops
+the rule from being a hardcoded assumption nobody can see.
+
+---
+
+## Workstream D: the tab
+
+**D1. Queries.**
+`queryAccountCosts` (per account: direct by layer, distinct users, span count) and
+`queryAccountDetail` (one account: layer split, top features, 30-day trend). Both follow the existing
+tenant-scoped helpers in `clickhouse.ts`. Include an explicit unattributed bucket.
+
+**D2. The page.**
+Route `/cost-per-customer`, added to `NAV` in `Shell.tsx`. Headline carries total attributed spend,
+account count, and **the share of spend with no account**, which is the honesty valve: if 60 percent
+is unattributed, the page says so at the top rather than ranking the other 40 percent as if it were
+the whole picture. Table built on A1 and A2. The Account column renders the label from B7 when one
+exists and a shortened hash otherwise, with the full hash available on hover and copy.
+
+**D3. Excluded-cost banner.**
+Per Decision 2 the tab shows direct cost only, so the page must say what it leaves out, using the tenant's
+real figure rather than a generic caveat. Queries the compute and egress total for the window and
+renders "excludes $X (N%) of compute and egress that cannot yet be attributed per account". Replaced
+by the allocated columns when workstream C lands.
+
+**D4. Account detail view.**
+Layer split, top features, cost trend, heaviest agent runs. Mostly existing query shapes with one
+extra `WHERE AccountIdHash = ...`.
+
+**D5. Onboarding empty state.**
+Every existing tenant sees an empty tab on day one because nobody emits an account id yet. The empty
+state does two jobs, in this order:
+
+1. **Explain what this page is for.** Someone landing here has never seen it. Say plainly that it
+   breaks AI spend down by the tenant's own customers, so they can see which accounts are expensive
+   and which are worth their price, and what it will look like once data arrives.
+2. **Say how to turn it on.** The `account_id` SDK snippet, the optional label, and a note that data
+   appears as soon as the next spans land.
+
+Not a blank table, and not a bare "no data" line.
+
+---
+
+## Workstream E: revenue and margin
+
+Where the tab stops being a cost report. Two findings from scoping reshaped this stream.
+
+**Stripe revenue is already account-shaped.** `StripeConnector` sets `user_id` to the Stripe
+**customer** id, and a Stripe Customer is the account in B2B SaaS. So account-level revenue is
+already arriving; it is being hashed into `UserIdHash` as though it were an end user. HubSpot does
+the same with a deal or company object id. Routing those into `AccountIdHash` is most of the work,
+and it is far less than building a new revenue pipeline.
+
+**That mismatch is probably why margin is blank**, alongside the source filter. Spans hash an end
+user; Stripe events hash a customer. The two only join if a tenant happens to use one identifier for
+both.
+
+**E1. Revenue source configuration.**
+Replace the hardcoded `Source = 'stripe'` filter in `queryAttribution`. `business_events.ValueType`
+already distinguishes `monetary`, `mrr`, `refund` and `count`, which is the right discriminator, and
+`Source` is an unconstrained string. Config names which sources count as revenue for a tenant,
+defaulting to any monetary source from a configured revenue connector. Fixes the underlying design
+rather than loosening one filter.
+
+**E2. Route Stripe and HubSpot identity to `AccountIdHash`.**
+The Stripe customer id and the HubSpot company or deal id become the account, not the user. Covers
+subscription revenue and closed-won contract revenue with no new ingestion path.
+
+**E3. Revenue per account query.**
+Sum `ValueAmountMicro` by `AccountIdHash`, netting refunds, over the same window as cost.
+
+**E4. Margin column and profitability ranking.**
+Revenue minus total cost per account. Renders a blank when revenue is unknown, never 0.
+
+**E5. CSV revenue upload.**
+For tenants whose revenue lives in a finance system with no usable API, or in a spreadsheet. Upload
+`account_id, period, amount, currency`, mapped to the same `business_events` shape as every other
+source so nothing downstream special-cases it.
+
+Two things this must get right. It is a **point-in-time snapshot**: revenue changes monthly and an
+upload that is never refreshed goes stale silently, so the page shows an "as of" date and a
+staleness badge in the same way the reconciliation freshness badge already works. And re-uploading
+the same period must replace rather than append, or revenue doubles.
+
+**E6. Generic revenue API.**
+A documented endpoint accepting `{account_id, amount, currency, occurred_at, event_name}` for
+Chargebee, Recurly, Zuora, or a home-grown biller. `WebhookIngestor` already exists in the SDK, so
+this is largely a matter of exposing and documenting a stable contract.
+
+Deliberately not in scope: a data-warehouse connector (Snowflake, BigQuery) that queries revenue
+where it is already modelled. That is the highest-fidelity source for a company of any size and the
+right long-term answer, but it is its own project and should not gate this tab.
+
+## Sequencing
+
+```
+A1, A2 ──► A3
+              └──► D1, D2, D3, D4, D5
+B1 ──► B2 ──► B3 ──► B4 ──┘
+   ├──► B5 (parallel, optional for v1)
+   ├──► B6 (v1: find an unlabelled account)
+   └──► B7 (v1: optional labels)
+E1 ──► E2 ──► E3 ──► E4 (after D2 ships)
+   E5, E6 parallel, either can precede E3
+C1 ──► C2 (follow-up, replaces D3)
+```
+
+A1, A2 and B1 can start now and are independent of each other. B2 through B4 are a chain. B6 and B7
+need only B1. D needs A and B. E needs E1 resolved before anything else in that stream, and should
+not gate the tab shipping. C is deferred.
+
+**Minimum shippable:** A1, A2, B1 to B4, B6, B7, D1, D2, D3, D5. A working tab showing direct cost
+per account, labelled where the tenant chose to label and searchable where they did not, stating
+both the unattributed share and the excluded infra cost.
+
+## Constraints decided
+
+**One user belongs to one account. Multi-account users are not supported.**
+This closes open question 4 in the scope and removes the reconciliation hazard that came with it:
+nothing splits or duplicates a user's cost across accounts, so per-account totals sum cleanly to the
+tenant total.
+
+Cost attribution is unaffected either way, because each span carries its own `AccountIdHash` at emit
+time. The assumption only bites on the stitching path (B5) and on revenue (E2), where an account is
+inferred from a user rather than stated. There, if a user is observed against more than one account,
+the pipeline does not guess: it attributes nothing for that user and raises it as a data-quality
+finding, so the situation is visible rather than silently mis-attributed.
+
+## Risks carried from the scope
+
+- Ships dark: empty for every existing tenant until someone instruments `account_id`.
+- Reconciliation: per-account totals must sum to the tenant total or the tab contradicts `/cost`.
+- A user belonging to several accounts is unresolved (open question 4 in the scope). Duplicating cost
+  across accounts inflates the total and breaks the reconciliation test in C1.
+- Accounts with no label still show as a hash, so a tenant who sets no labels gets a table they can
+  search (B6) but not scan. Acceptable because labelling is entirely in their control.
+- Direct-cost-only (Decision 2) means every figure understates true cost by roughly half on current data. The
+  D3 banner is the mitigation and it is not optional.

--- a/docs/cost-per-customer-scope.md
+++ b/docs/cost-per-customer-scope.md
@@ -1,0 +1,210 @@
+# Scope: "Cost per customer" tab
+
+**Status: proposal, not built.** This is a scoping doc for a new dashboard tab that answers "what
+does each of our customers cost us in AI spend, and are they profitable?"
+
+The short version: the reporting and UI are the easy half. The hard half is that ai-tally has no
+concept of a customer today, and roughly half of a tenant's bill cannot be attributed to one
+without an allocation rule we have to choose deliberately.
+
+## The ask
+
+A B2B AI product charges per seat or per account. Its AI costs do not scale the same way: one
+enterprise account running a research agent all day can cost more than a thousand self-serve
+accounts combined. Today a tenant can see cost per feature (`/cost`), cost per user (Home's ROI
+snapshot) and cost per conversion (`/attribution`), but not cost per account. So they cannot answer:
+
+- Which customers are unprofitable at their current price?
+- Which customers should be on an enterprise plan?
+- What is gross margin per account, and how has it moved since we shipped the agent?
+- Is our biggest logo also our biggest cost centre?
+
+That last question is the one that sells the tab.
+
+## Why this does not exist today
+
+There is no account dimension anywhere in the pipeline. This is the central finding of the scope.
+
+`otel_spans` carries `TenantId` (the ai-tally customer) and `UserIdHash` (an individual end user),
+with no column between them. `business_events` and `attribution_records` are the same: keyed on
+`UserIdHash`. `identity_graph` types are `user_id`, `anonymous_id`, `session_id`, `email` and
+`external_id`, none of which is an account.
+
+"Cost per user" already works because `UserIdHash` is on every span. Cost per customer needs a
+grouping that nothing currently emits. Everything below follows from closing that one gap.
+
+## Decision 1: what is a customer
+
+Three readings, and they produce different products.
+
+**An account or organisation** (recommended). The tenant's own paying customer: a company, a
+workspace, a team. This is what a B2B SaaS means by "customer" and what makes the margin question
+answerable, because revenue arrives per account (a Stripe subscription, a contract).
+
+**An individual end user.** Already available as cost per user, and adding a tab for it would
+duplicate the ROI snapshot. Not worth a tab.
+
+**A billing subscription.** Precise for margin but wrong for product questions, since one account
+can hold several subscriptions and churn between them.
+
+Recommendation: model the account, and let a tenant map subscriptions onto accounts later. Concretely
+this means one new identity, `AccountIdHash`, that a tenant sets on its telemetry the same way it
+sets `user_id` today.
+
+## Decision 2: names, and the PII invariant
+
+This is the decision most likely to be got wrong quietly, so it needs settling before code.
+
+User ids are never stored raw. They are HMAC-SHA256'd under a per-tenant key
+(`sdk/python/src/tally/hmac_keys.py`) so a hash cannot be reversed or joined across tenants. Account
+ids carry the same risk and should be hashed the same way.
+
+But a "Cost per customer" table where every row reads `9f86d081884c7d65...` is useless. The operator
+needs to see "Acme Corp" to act on it. Three options:
+
+1. **Hash only, tenant resolves names client-side.** Safest, and the least usable. The tenant would
+   have to paste a lookup table into the browser for the page to mean anything.
+2. **Hash for storage, optional display label supplied at query time.** The tenant's own system holds
+   the mapping and passes labels through the dashboard session. We never persist the name.
+3. **Store an account display name alongside the hash.** Most usable, and it puts customer names in
+   our database, which is a change to the product's privacy posture and needs an explicit decision
+   plus a DPA review.
+
+Recommendation: build on option 2, and treat option 3 as a separate opt-in with its own ticket.
+Account names are business-confidential rather than personal data in most cases, so option 3 is
+defensible, but it should be a deliberate choice and not a side effect of shipping a tab.
+
+## Decision 3: allocating shared cost, the hard part
+
+Direct LLM, tool, vector and embedding spend can be attributed to an account, because those spans
+carry the account once it is set. Compute and egress cannot. They arrive from cloud bills through
+the connectors (see `docs/connector-aws-cost-explorer.md`) as one synthetic span per provider per
+day at tenant level, with no per-request detail to attribute.
+
+On the current demo tenant, compute and egress are about 47 percent of the bill. So a cost-per-customer
+number that silently ignores them would understate the true cost of every account by roughly half,
+which is exactly the failure the product exists to fix. Reporting only the directly attributable half
+would be the single worst outcome of this feature.
+
+Four allocation rules, in increasing order of defensibility:
+
+| Rule | How | Honest? |
+| --- | --- | --- |
+| Ignore shared cost | Report direct spend only | No. Understates every account, contradicts the hidden-cost thesis |
+| Even split | Shared cost / account count | Weakly. Punishes small accounts, flatters heavy ones |
+| Pro rata on direct spend | Share shared cost in proportion to each account's direct LLM spend | Reasonable default. Assumes infra scales with model usage |
+| Pro rata on a driver | Share on requests, tokens, or GB served per account | Best, needs the driver metered per account |
+
+Recommendation: pro rata on direct spend for v1, with the rule named on screen and the allocated
+portion shown as a separate column rather than folded silently into one total. An allocated number
+presented as a measured one is the kind of quiet dishonesty the rest of this product avoids. The UI
+should let the reader see direct, allocated, and total side by side.
+
+## Data model
+
+One new identity column, mirroring `UserIdHash` in type and treatment:
+
+```
+otel_spans.AccountIdHash          FixedString(64)   -- HMAC-SHA256, per-tenant key, '' when unset
+otel_spans.AccountIdHashKeyVersion LowCardinality(String)
+business_events.AccountIdHash     FixedString(64)
+```
+
+Additive and backward compatible: existing rows get `''`, which the UI reads as unattributed rather
+than as a customer named "unknown". A tenant that never sets an account sees an empty tab with an
+onboarding prompt, not a broken one.
+
+A rollup mirroring `daily_feature_rollup` keeps the page fast at high account counts:
+
+```
+daily_account_rollup (TenantId, Day, AccountIdHash, FeatureTag, GenAiOperation)
+  EstimatedCost, ReconciledCost, SpanCount, UserCountState AggregateFunction(uniq, FixedString(64))
+ORDER BY (TenantId, AccountIdHash, Day)
+```
+
+Add `account_id` to the `identity_graph` type enum so CDP and CRM connectors can stitch an account
+to its users, which is what makes the tab work for a tenant that cannot easily tag every span.
+
+## Ingestion
+
+**SDK.** `account_id` alongside `user_id`, hashed with the same per-tenant HMAC path, emitted as
+`gen_ai.account_id_hash`. This is the primary path and the one to build first.
+
+**Gateway.** `mapping.py` maps the attribute onto the new column. The proxy passes it through from a
+header for tenants that use the edge proxy rather than the SDK.
+
+**Stitching, for tenants that cannot tag spans.** Derive the account from the user via
+`identity_graph` when a CRM or CDP connector supplies the user-to-account edge. Lower confidence, and
+the UI should say which accounts were stitched rather than tagged.
+
+## The page
+
+Route `/cost-per-customer`, added to `NAV` in `web/components/Shell.tsx`.
+
+Headline: total attributed spend, count of accounts with spend, and the count unattributed. That
+last number is the honesty valve. If 60 percent of spend has no account, the page says so at the top
+instead of ranking the 40 percent as if it were the whole picture.
+
+Main table, one row per account, sorted by total cost:
+
+| Column | Notes |
+| --- | --- |
+| Account | Display label when available, else a short hash |
+| Users | Distinct `UserIdHash` seen for the account |
+| Direct cost | LLM, tools, vector, embeddings. Measured |
+| Allocated cost | Compute and egress share. Clearly labelled as allocated |
+| Total cost | Direct plus allocated |
+| Revenue | From `business_events` when the account maps to monetary events, else `—` |
+| Gross margin | Revenue minus total cost. `—` when revenue is unknown |
+| Cost per user | Total cost / distinct users |
+
+Detail view per account: cost split by the six layers, top features, cost trend over 30 days, and
+the heaviest agent runs for that account. Most of this reuses existing query shapes with one extra
+`WHERE AccountIdHash = ...`.
+
+Honest-under-uncertainty applies throughout, as elsewhere in the product. Margin renders `—` when
+revenue is not wired, never 0. Accounts below a minimum span count render a low-sample marker rather
+than a noisy cost-per-user figure.
+
+## Phasing
+
+**Phase 1, make it possible.** The `AccountIdHash` column, SDK and gateway support, migrations, the
+rollup. No UI. A tenant can tag spans and query by account. This is the phase that carries all the
+risk and most of the value.
+
+**Phase 2, the tab.** The table, direct cost only, with an explicit banner saying shared infra cost
+is not yet included. Ships something usable while the allocation debate is settled.
+
+**Phase 3, allocation.** Pro rata shared cost, direct and allocated shown as separate columns, the
+rule named on screen and configurable per tenant.
+
+**Phase 4, margin.** Join revenue per account, gross margin, and a profitability ranking. This is
+where the tab stops being a cost report and becomes the thing people buy.
+
+Phases 1 and 2 are the minimum that ships anything. Phase 3 is what makes the number trustworthy.
+
+## Open questions
+
+1. Do we store account display names, or resolve them at query time? Decision 2. Blocks the UI
+   design and needs a privacy call, not an engineering one.
+2. Which allocation rule ships as the default, and is it tenant-configurable? Decision 3.
+3. Should an account with no revenue mapping show `—` for margin, or should the tab require Stripe to
+   be connected before it appears in the nav at all?
+4. How do we handle an end user who belongs to several accounts (a consultant, a shared support
+   inbox)? Split the cost, duplicate it, or attribute to first-seen? Duplicating inflates the total,
+   which breaks reconciliation against the tenant's bill.
+5. What is the expected account cardinality? A tenant with 5 accounts and one with 500,000 need
+   different table designs and different pages.
+
+## Risks
+
+**The tab is empty for every existing tenant on day one.** Nobody is emitting an account id, so this
+ships dark and only lights up after a customer instruments it. The onboarding prompt matters more
+than usual here, and Phase 1 should land well before the tab is announced.
+
+**Reconciliation.** Per-account costs must sum to the tenant total, or the tab will contradict
+`/cost` and lose trust immediately. Duplicated attribution (open question 4) and rounding across
+many small accounts are both live ways to break that. This deserves a test that asserts the sum.
+
+**Scope creep into a billing product.** Cost per customer plus revenue per customer is one step from
+customer-level invoicing and margin forecasting. Worth deciding early where this tab stops.

--- a/docs/enforcing-guardrails-scope.md
+++ b/docs/enforcing-guardrails-scope.md
@@ -1,0 +1,220 @@
+# Scope: guardrails that stop things
+
+**Status: proposal, not built.** A budget ceiling per feature and per tenant that can downgrade the
+model or refuse the call.
+
+## One correction: refusal already works
+
+The premise is that OBSERVE mode exists and enforcement is the missing half. Enforcement is further
+along than that. `sdk/python/src/tally/guardrails.py` already implements all four modes end to end:
+
+- `OBSERVE` records what would have fired and always proceeds.
+- `WARN` proceeds and returns a warning the agent can act on at `warn_at` (default 80 percent).
+- `GRACEFUL` raises a localized `CostLimitExceededException` for the framework to catch and return a
+  degraded response.
+- `HARD_STOP` refuses, opt-in, documented as being for idempotent or read-only agents.
+
+It tracks `cost`, `steps` and `tool_calls`, emits verdicts as span attributes
+(`enforced` / `shadow_observed` / `passed`), and the `wouldHaveFiredThisWeek` count is already the
+graduation signal in the UI. The control plane (`tenant_guardrails`) carries a `cost_cap` kind and
+defaults `state` to `shadow`.
+
+So a per-run cost cap that refuses a call is built. Three specific things are missing, and they are
+what this scope is about.
+
+## What is actually missing
+
+### 1. Scope: caps are per-run, not per-budget
+
+`GuardrailState` is keyed on `trace_id` and counts within one process. The module says so plainly:
+"v1 is single-process (counters are per-process)", with a shared counter deferred to CTO-83.
+
+That means today's cap answers "this *run* must not exceed $2", not "this *feature* must not exceed
+$5,000 this month". A budget ceiling is a shared, durable counter over a calendar window, across
+every process and machine serving that feature. Nothing in the codebase holds that state.
+
+This is the bulk of the work, and it is a distributed systems problem rather than a rules problem.
+
+### 2. There is no downgrade action
+
+The engine's outcomes are proceed, warn, or raise. There is no path that substitutes a cheaper model
+and continues. Grepping for a downgrade or fallback model turns up nothing outside Stripe plan
+changes. This is genuinely new behavior, and it is the more commercially interesting half: refusing a
+call breaks a product, while serving Haiku instead of Sonnet at 90 percent of budget usually does not.
+
+### 3. Enforcement is Python only
+
+The guardrail engine lives in the Python SDK, so it protects Python callers and nobody else. The Go
+edge proxy (`infra/edge-proxy/`) sits in the request path for every language and currently does not
+enforce anything. A tenant using the proxy from TypeScript has no cap available.
+
+## Your design instinct is already the codebase's
+
+OBSERVE as default with ENFORCE as explicit opt-in is not a change to argue for. It is what is built:
+`GuardrailConfig.mode` defaults to `OBSERVE`, the `tenant_guardrails.state` column defaults to
+`shadow`, `GUARDRAIL_MODES` carries an explicit `enforcing` flag, and the UI is organised around a
+graduation ladder from observe to enforcing. This scope keeps all of it. The new budget rules should
+default to shadow and require a deliberate flip, exactly like the existing ones.
+
+## Decision 1: where the shared counter lives
+
+A budget cap needs a counter that every process can read and increment cheaply, checked before an
+outbound call.
+
+| Option | Latency | Durability | Notes |
+| --- | --- | --- | --- |
+| ClickHouse aggregate | Too slow for a hot path | Good | Fine for reporting, wrong for a gate |
+| Postgres row with an atomic increment | Tens of ms, contended | Good | Simple, becomes a bottleneck at volume |
+| Redis counter with periodic reconcile | Sub-ms | Weak alone | Standard answer for rate and budget limits |
+| Gateway-held counter | One network hop | Medium | Reuses the existing per-tenant rate limiter |
+
+Recommendation: a Redis-style counter owned by the gateway, incremented from observed spend, and
+reconciled against ClickHouse periodically so drift does not accumulate. The gateway already runs a
+per-tenant rate limiter, so the shape is familiar.
+
+The counter is necessarily approximate. Cost is known only after a call returns, so a check before
+the call is always reading a slightly stale number. A budget cap will overshoot by roughly one call
+per concurrent worker, and the docs should say so rather than implying a hard ceiling.
+
+### The window
+
+Daily, weekly and monthly windows, with the same late-data caveat as
+`docs/cost-alerts-scope.md`: connector-sourced compute and egress arrive on a daily pull and are
+about 47 percent of spend on the demo tenant. A budget counter fed only by live LLM spend is
+measuring half the bill. Either the cap is explicitly an **LLM spend cap** (honest, simple,
+recommended for v1) or it waits on infra cost that arrives a day late, which cannot gate a live call.
+
+Call it what it is. "LLM spend cap" is defensible; "budget cap" that silently ignores half the bill
+is not.
+
+## Decision 2: what downgrade means
+
+The most valuable new action, and the one with the most product risk.
+
+A downgrade rule needs a substitution map: at breach, `claude-sonnet-4-5` becomes
+`claude-haiku-4-5`. Per feature, tenant-configured, because only the tenant knows which substitutions
+are acceptable for their workload.
+
+Three things this must get right:
+
+**It is a quality change, not just a cost change.** An end user gets a worse answer. That is usually
+better than an error, but it must not be invisible. The substitution should be recorded on the span
+(`gen_ai.guardrail.downgraded_from`) and returned to the caller so the application can disclose it if
+it wants to. Silently serving a cheaper model and reporting nothing would be the wrong default for a
+product whose posture is honesty about what it does and does not know.
+
+**Tiering beats a cliff.** The useful shape is graduated: warn at 80 percent, downgrade at 100
+percent, refuse at 120 percent. That gives a team a soft landing instead of a wall, and it is the
+version people will actually enable. The existing `warn_at` field is the seed of this.
+
+**Model availability is not guaranteed.** The target model must exist for the provider and be priced
+in the catalog. `models.py` already does discovery and family classification, so validate the
+substitution at config time rather than discovering it at breach time in production.
+
+## Decision 3: fail-open, and this one is not close
+
+If the counter is unavailable, does the call proceed?
+
+**Fail open.** An observability tool must never take down a customer's product. If Redis is down or
+the gateway is unreachable, calls proceed uncapped and the incident is recorded loudly. A spend
+overrun is recoverable; an outage caused by the monitoring layer ends the vendor relationship.
+
+The only defensible exception is a tenant explicitly opting into fail-closed for a workload where
+runaway spend is worse than downtime (a batch job, an internal tool). That should be a per-rule flag,
+off by default, with the consequence spelled out in the UI.
+
+This should be stated in the docs and on the settings screen, because a customer buying a "spend cap"
+will assume it is a hard guarantee, and it is not.
+
+## Decision 4: where enforcement happens
+
+**SDK.** Already there, richest context (it knows the agent run, the step count), Python only.
+
+**Edge proxy.** Language-agnostic and sees every call, so it is the only way to cap a TypeScript or
+Go customer. It is also in the latency path for everyone, and the repo already has an
+`overhead_test.go`, so the bar for added latency is established.
+
+Recommendation: both, sharing one counter and one config. The proxy is the enforcement point that
+makes this a product rather than a Python library feature, and it is where the "teams will pay for a
+spend cap" argument actually gets paid. Ship SDK first because the engine exists, then the proxy.
+
+Latency budget matters: a cached counter read with a short TTL, not a synchronous round trip per
+call. Overshoot slightly rather than adding tens of milliseconds to every request.
+
+## Data model
+
+Extend `tenant_guardrails` rather than inventing a parallel system. The `params` JSONB already
+absorbs rule-specific config, and `kind` already allows `cost_cap`.
+
+```
+kind = 'budget_cap'
+params = {
+  "window": "month",                 -- day | week | month
+  "amount_micro": 5000000000,        -- $5,000
+  "scope_kind": "feature",           -- tenant | feature | model
+  "scope_value": "research_agent",
+  "actions": [
+    {"at_pct": 80,  "action": "warn"},
+    {"at_pct": 100, "action": "downgrade",
+     "map": {"claude-sonnet-4-5": "claude-haiku-4-5"}},
+    {"at_pct": 120, "action": "refuse"}
+  ],
+  "fail_closed": false
+}
+state = 'shadow'                     -- default, as with every other rule
+```
+
+`tenant_guardrail_changes` already exists as an audit table, which matters more once a rule can
+refuse production traffic. Who enabled the thing that broke checkout is a question someone will ask.
+
+## Shadow mode has to be real here
+
+For a budget cap, shadow is not a formality. It must answer "if I had enabled this last month, how
+many calls would have been refused and which features would have degraded?" That is the number that
+makes a team comfortable flipping the switch, and it is computable from history without enforcing
+anything.
+
+The existing `wouldHaveFiredThisWeek` is the right primitive. Extend it to report, per rule, the
+count of would-be warns, downgrades and refusals, and the spend that would have been avoided. The
+last figure is the sales argument.
+
+## Phasing
+
+1. **The shared counter** in the gateway, with periodic reconciliation. Nothing works without it.
+2. **`budget_cap` rule kind** plus config UI on `/guardrails`, shadow only. No enforcement yet.
+3. **Shadow reporting**: would-have-fired counts and avoided spend, per rule.
+4. **Enforcement in the SDK**: warn, then refuse, reusing the existing modes.
+5. **The downgrade action**, with substitution validation and span disclosure.
+6. **Enforcement in the edge proxy**, which is what makes it language-agnostic.
+
+Phases 1 through 3 are shippable without enforcing anything and are independently valuable: a tenant
+learns what a cap would have done. Phase 4 onward is the part people pay for.
+
+## Open questions
+
+1. Is the cap on estimated or reconciled cost? Reconciled arrives too late to gate a live call, so it
+   has to be estimated, and it will disagree with the invoice. Say so up front.
+2. What happens at window rollover mid-incident? A cap that resets at midnight while a runaway agent
+   is looping will let it run again.
+3. Does a refused call count as an error to the customer's application, or is there a structured
+   response the SDK returns? `CostLimitExceededException` is the current answer for Python; the proxy
+   needs an HTTP equivalent, and picking the wrong status code will break retry logic in client
+   libraries.
+4. Per-feature caps summing above the tenant cap: allowed with the tenant cap winning, or rejected at
+   config time?
+5. Who can enable enforcement? This is the first setting that can break production, so it deserves a
+   distinct permission once the hosted role model exists.
+
+## Risks
+
+**A guardrail that breaks production is worse than no guardrail.** Fail-open, shadow by default, and
+graduated actions are the mitigations, and none is optional.
+
+**The counter will be approximate and someone will file a bug.** Cost is known after the call, so
+caps overshoot under concurrency. Document the bound rather than implying precision.
+
+**"Budget cap" overpromises if it only counts LLM spend.** Roughly half the bill arrives from daily
+connector pulls and cannot gate a live call. Naming the feature accurately is the fix.
+
+**Downgrade changes what the end user receives.** Shipping it without disclosure on the span and to
+the caller would undercut the product's own posture on honesty.

--- a/docs/hosted-version-scope.md
+++ b/docs/hosted-version-scope.md
@@ -1,0 +1,151 @@
+# Scope: hosted ai-tally
+
+**Status: proposal, not built.** A managed multi-tenant service, so evaluating ai-tally does not
+require standing up ClickHouse, Postgres, Redpanda and MinIO first.
+
+## One correction to the premise
+
+It is not only docker-compose on a laptop. `deploy/` already carries real self-host artifacts: Helm
+charts for GKE and EKS, ECS task definitions and service definitions with IAM policies, Cloud Run
+service YAML, and a Vercel path. Someone who wants to self-host on AWS or GCP has a supported route
+today.
+
+What is missing is a version **we** run, where a prospect signs up and sends their first span in ten
+minutes. That is a different product with different problems, and the gap is not packaging. It is
+the two things below.
+
+## The two real blockers
+
+Everything else in this doc is ordinary infrastructure work. These two are the feature.
+
+### 1. The dashboard has no authentication at all
+
+There is no login page, no session handling, no middleware, no `next-auth`, nothing. Anyone who can
+reach the URL sees every number. That is defensible for a tool running on your own laptop or behind
+your own VPN. It is disqualifying for a hosted service.
+
+This is not a small addition. It means identity, sessions, an invite flow, password or SSO, roles,
+and an audit trail for who changed a connector or a guardrail.
+
+### 2. The tenant is a deploy-time environment variable
+
+Every data function in the dashboard resolves the tenant the same way:
+
+```ts
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+```
+
+That appears in `clickhouse.ts`, `tenant.ts`, `cac.ts`, `costConnectors.ts` and elsewhere. One
+dashboard deployment serves exactly one tenant, permanently, and the tenant is baked in at deploy
+time.
+
+Hosted multi-tenancy requires the tenant to come from the authenticated session on every request
+instead. That is a change to the signature of essentially every query function in `web/lib`, and it
+has to be done in a way where forgetting it is impossible rather than merely discouraged.
+
+The gateway is in better shape. It already resolves tenants per request from a bearer key or header
+(`_resolve_tenant_for_control_plane`), stamps `TenantId` on every row, and holds per-tenant HMAC key
+versions for user hashing. The backend was built multi-tenant. The dashboard was not.
+
+## Isolation, and the thing that will keep you up at night
+
+Tenant isolation today is **application-level filtering**. Every ClickHouse query carries
+`WHERE TenantId = {tenant:String}`. There is no row-level security, no per-tenant database, and no
+enforcement below the query text. One missing `WHERE` clause in one query leaks one customer's spend
+to another.
+
+On a single-tenant self-hosted deployment that risk is theoretical, because there is only ever one
+tenant's data present. Hosted makes it a live, unbounded risk.
+
+Three ways to harden it, in increasing cost:
+
+| Approach | Isolation | Cost |
+| --- | --- | --- |
+| Keep app-level filtering, add a lint or test that every query is tenant-scoped | Weakest, one bug from a leak | Low |
+| Route all reads through a single tenant-scoped query helper that cannot be bypassed | Strong if the seam holds | Medium |
+| Database or cluster per tenant | Strongest, and it kills noisy neighbors too | High, and it complicates migrations |
+
+Recommendation: the query helper seam, plus a test that fails when a raw query string containing a
+table name appears outside it. Make the safe path the only path. Consider a separate ClickHouse
+cluster for large enterprise tenants later, sold as a feature rather than built for everyone.
+
+Worth noting what is already right: user ids are HMAC'd under a **per-tenant** key, so a hash cannot
+be joined across tenants even if data did mix. That decision pays off here.
+
+## Metering and billing
+
+`gateway/metering.py` already exists, which is a head start. Hosted needs a billing model, and the
+choice shapes the architecture:
+
+- **Per span or event ingested.** Predictable for us, scary for a customer whose traffic spikes.
+- **Per tracked spend.** A percentage of the AI spend observed. Aligns incentives and is easy to
+  explain, but it prices the customer's growth rather than our cost.
+- **Seats or flat tiers.** Simplest to sell, weakest link to our actual cost, which is dominated by
+  ClickHouse storage and query volume.
+
+Whatever is chosen, storage retention becomes a pricing lever and therefore a product decision. The
+tiering work in `db/clickhouse/storage_tiering.sql` is the mechanism.
+
+## What else hosted needs that self-host does not
+
+**Onboarding without a terminal.** Sign up, create a tenant, mint an API key, see a curl or an SDK
+snippet, watch the first span land. The `/onboarding` page is a start; it assumes the tenant already
+exists.
+
+**Operations.** On-call, alerting on our own infrastructure, backup and restore that someone has
+actually rehearsed, a status page, and an upgrade path that does not involve a customer running
+migrations by hand. Today migrations are mounted into a container's init directory, which only runs
+on first boot. That was already a real bug for self-host (two connector migrations never applied).
+Hosted needs a proper migration runner.
+
+**Compliance.** SOC 2 is the usual price of entry for the buyers this product targets, since it sits
+next to their spend data. That is a months-long programme, not a sprint, and it should start early
+because it constrains logging, access, and retention decisions.
+
+**Data residency.** Some buyers will require EU-only storage. Deciding this late means re-architecting
+storage; deciding it early means one more axis in the deployment model.
+
+**Limits.** Per-tenant rate limits already exist in the gateway. Hosted also needs query-side limits,
+because one tenant running expensive dashboard queries degrades everyone.
+
+## Phasing
+
+1. **Dashboard auth and session-derived tenancy.** Nothing else can ship first. This is the bulk of
+   the work and the highest risk.
+2. **The isolation seam** plus the test that enforces it. Do this alongside phase 1, not after.
+3. **Self-serve onboarding**: signup, tenant creation, API key issuance, first-span confirmation.
+4. **Operations**: migration runner, backups, monitoring, status page.
+5. **Metering and billing.**
+6. **Compliance and residency**, started in parallel because of lead time.
+
+Phases 1 and 2 are the feature. Phases 3 through 6 are what makes it a business.
+
+## Open questions
+
+1. Single-tenant-per-deployment hosted (we run an isolated stack per customer) or true multi-tenant?
+   The first is far easier to secure and far more expensive to run. It is a viable first step for
+   enterprise deals and a bad long-term answer for self-serve.
+2. Does hosted stay feature-identical with self-host, or do they diverge? Divergence is where open
+   core products usually get into trouble.
+3. What is the free tier, and what stops it from being a way to store unlimited telemetry for free?
+4. Who is on call, and what is the SLA? A cost observability tool being down is annoying; losing a
+   customer's telemetry is not recoverable.
+5. Is the tenant model one tenant per company, or per team? The current schema assumes a tenant is
+   the unit of isolation and billing, and teams within a company will want separation without
+   separate billing.
+
+## Risks
+
+**Underestimating the auth and tenancy work.** "Add login" sounds like a sprint. Replacing a
+process-level tenant constant with a session-derived one across every query function, safely, is not.
+
+**A leak ends the company.** This product holds customers' AI spend, which is competitively
+sensitive. Application-level filtering with no defence in depth is the current posture, and it needs
+upgrading before the first external tenant, not after.
+
+**Running ClickHouse as a service is its own job.** It is not a database you operate casually at
+multi-tenant scale. Managed ClickHouse Cloud is worth pricing against the engineering cost.
+
+**Self-host stops being a first-class citizen.** Once hosted exists it gets the attention, and the
+self-host path quietly rots. Worth deciding up front whether self-host remains supported and how
+that is tested.

--- a/docs/spend-forecasting-scope.md
+++ b/docs/spend-forecasting-scope.md
@@ -1,0 +1,162 @@
+# Scope: spend forecasting and burn-down
+
+**Status: proposal, not built.** Projected month-end spend against a budget, with a burn-down chart.
+
+## What exists
+
+A projection engine exists but answers a different question. `sdk/python/src/tally/projection.py`
+and `/estimate` do **pre-deploy** estimation: "if I ship this prompt or model change, what happens to
+cost per run?" It projects p99 cost per run and a blow-up probability over a replayed sample. That is
+change-impact forecasting, not calendar forecasting.
+
+Its posture is worth stealing: it reports p99 rather than the mean, on the grounds that a change can
+leave the average flat while fattening the tail. The same instinct applies here.
+
+**There is no budget concept for a tenant.** The only budgets in the schema are
+`tenant_replay_config.daily_budget_usd` and `tenant_eval_config.daily_budget_usd`, which cap what
+ai-tally itself spends running replays and evals. Nothing records what a customer intends to spend
+on AI. That has to be built before "versus budget" means anything.
+
+The inputs for the forecast half are all present: `daily_feature_rollup`, the cost series queries in
+`web/lib/clickhouse.ts`, and 30 days of history per tenant.
+
+## Decision 1: the projection method
+
+Four options, and the differences matter most early in the month.
+
+**Naive run-rate.** `spend_so_far / days_elapsed * days_in_month`. One line of code, and badly wrong
+on day 2, and wrong every weekend. Fine as a floor, not as the headline.
+
+**Day-of-week weighted.** AI spend has strong weekday and weekend structure: a B2B product can
+easily run at a third of weekday volume on a Sunday. Weighting the remaining days by their day-of-week
+profile from trailing history fixes the largest systematic error for very little complexity.
+
+**Trailing median run-rate.** Project the remaining days from a trailing 7 or 14 day median rather
+than the month-to-date mean. Robust to a single spike distorting the whole projection.
+
+**Time series model.** Holt-Winters or similar. More machinery than the data supports at 30 days of
+history, and it will look authoritative while being wrong.
+
+Recommendation: day-of-week weighted median for the point estimate, and show the naive run-rate
+alongside it as a sanity line. Explicitly out of scope: anything that needs more than a few months
+of history, since most tenants will not have it.
+
+## Decision 2: say how uncertain it is
+
+A single projected number invites a precision it does not have. Two honest options:
+
+- **A range.** Project a low and high band from the variance of trailing daily spend. "Between $78k
+  and $96k, most likely $86k."
+- **A confidence that degrades with time.** On day 2 of the month the projection is nearly
+  meaningless; on day 25 it is nearly certain. The UI should visibly reflect that, for example by
+  widening the cone early and narrowing it as the month closes.
+
+Recommendation: both. A cone that narrows through the month is the clearest possible statement of
+"this gets more trustworthy as we go", and it stops anyone treating a day-3 number as a commitment.
+
+Refuse to project at all below a minimum history, the same way `/compare` renders a dash rather than
+a quality score below 10 judged samples. A forecast from four days of data should say "not enough
+history yet", not print a number.
+
+## Decision 3: late data, again
+
+The same problem the alerts scope has, and it bites harder here because a forecast compounds it.
+
+Connector-sourced compute and egress arrive on a daily pull and lag the cloud bill. Reconciliation
+replaces estimated cost with invoiced cost afterwards. On the current demo tenant, infra layers are
+about 47 percent of spend, so today's partial number is roughly half the eventual total.
+
+A run-rate computed over a window whose last day is half-reported will systematically **underestimate**
+month-end. The fix is to exclude unsettled days from the baseline and to say which days the
+projection was computed from. A forecast that cannot state its input window is not auditable.
+
+## The budget model
+
+```
+tenant_budgets
+  tenant_id      uuid references tenants(id)
+  budget_id      text
+  period         text    check (period in ('month','quarter'))
+  amount_micro   bigint
+  scope_kind     text    check (scope_kind in ('tenant','feature','model','layer'))
+  scope_value    text    -- '' for tenant-wide
+  starts_on      date
+  ends_on        date
+  primary key (tenant_id, budget_id)
+```
+
+Scoped budgets matter more than they first appear. "The research agent gets $30k a month" is how
+teams actually govern spend, and it makes the burn-down useful to a feature owner rather than only
+to finance.
+
+## The page
+
+Either a section on `/cost` or its own `/forecast` tab. Recommendation is a section on `/cost` first:
+it is the same question a user already came to that page with, and a separate tab for one chart is
+premature.
+
+**Headline.** Projected month-end spend, the range, month-to-date actual, budget, and projected
+variance in both dollars and percent. The variance sign is the whole point, so it should be the most
+legible thing on screen.
+
+**Burn-down chart.** Cumulative spend to date as a solid line, the projection as a widening cone, and
+budget as a flat reference line. Where the cone crosses the budget line is the forecast breach date,
+and that date is the single most useful output of the feature. "You cross budget on the 22nd" beats
+any percentage.
+
+**Layer split.** Because hidden cost is the product's core story, the forecast should break down by
+layer, not just total. "You will land 12 percent over, and compute is the reason" is actionable in a
+way a single number is not.
+
+Honest-under-uncertainty throughout: no budget configured renders the forecast without a variance
+rather than assuming a budget of zero, and insufficient history renders a prompt instead of a number.
+
+## Relationship to alerts
+
+This shares most of its machinery with `docs/cost-alerts-scope.md`, and the two should be designed
+together rather than sequentially:
+
+- A budget breach is the most valuable alert this product can send, and it is a *forecast* alert:
+  "at current run-rate you will exceed budget on the 22nd" arrives days before "you exceeded budget",
+  which arrives too late to act on.
+- Both need the same period windows, the same late-data grace period, and the same scoping.
+- Both need the scheduler that does not exist yet.
+
+If only one ships, the forecast is the more valuable half, because a forecast alert is strictly
+better than a threshold alert for budget governance.
+
+## Phasing
+
+1. **The budget model** plus a settings UI to enter one.
+2. **Month-to-date actual versus budget**, no projection. Useful immediately and nearly free.
+3. **The projection**: day-of-week weighted, with the minimum-history guard and the unsettled-day
+   exclusion.
+4. **The burn-down chart** with the cone and the breach date.
+5. **Layer and feature-scoped budgets and forecasts.**
+6. **Forecast breach alerts**, once the alerting transport exists.
+
+## Open questions
+
+1. Calendar month or the tenant's billing month? These differ for most cloud contracts, and a
+   forecast against the wrong period is useless to finance.
+2. Estimated cost, reconciled cost, or both? A forecast on estimates and a budget tracked on invoices
+   will not reconcile, and someone will notice.
+3. Does the budget roll over, and is an annual budget divided evenly or seasonally?
+4. Who sets budgets, and is that a permission distinct from viewing them? Relevant to the hosted
+   scope's role model.
+5. Should the forecast account for known future changes, for example a model migration already
+   scheduled? That is where this feature meets `/estimate`, and it is a natural but large extension.
+
+## Risks
+
+**A wrong forecast early in the month.** Day-2 projections are volatile, and a customer who sees
+"projected $340k" against a $90k budget will lose confidence permanently. The minimum-history guard
+and the widening cone are the mitigations, and neither is optional.
+
+**Budget becomes a compliance object.** Once finance sees a budget field, it becomes a number people
+are measured against, and the accuracy bar rises accordingly. Worth being clear that this is a
+forecast and not a commitment.
+
+**Double-counting with reconciliation.** If the projection mixes estimated and reconciled cost
+carelessly, month-end actual will not match the last projection, and the feature will look broken
+even when it is right.

--- a/docs/waste-detection-scope.md
+++ b/docs/waste-detection-scope.md
@@ -1,0 +1,207 @@
+# Scope: waste detection
+
+**Status: proposal, not built.** Find the spend that produced nothing: the gap between "here is your
+bill" and "here is the $3k a month you are burning for no reason".
+
+This is the most demo-able idea in the product. It is also the one most able to damage trust,
+because every number it prints is a claim about money you could have saved, and that claim is a
+counterfactual. The scope below is organised around that tension.
+
+## The honesty problem, first
+
+"We found $4,200 a month of pure waste" is not a measurement. It is a prediction about what would
+have happened under a different setup. Some of these categories can be measured almost exactly
+(cache savings left on the table), and some cannot be known without changing the application
+(whether a retrieved chunk influenced an answer).
+
+If the tab presents all five with equal confidence, the weakest number defines the credibility of
+the whole feature. The first customer who acts on a $4,200 estimate and saves $600 will not trust
+the dashboard again.
+
+So the design rule: **every waste figure carries its assumption and a confidence tier**, and the
+headline sums only what we can defend.
+
+- **Measured.** Arithmetic on data we already have. Example: tokens billed at full rate that a cache
+  would have served, priced from the catalog.
+- **Estimated.** Real signal, modelled saving. Example: near-duplicate requests, where the saving
+  depends on a cache hit rate we assume.
+- **Indicative.** A smell worth investigating, no dollar claim. Example: a system prompt that grew
+  40 percent last week.
+
+A headline that reads "$2,100 measured, $2,100 more estimated" is both more honest and more
+persuasive than "$4,200", because the first number survives scrutiny.
+
+## What the pipeline can support today
+
+I checked each of the five against the actual schema and SDK. The results differ a lot, and this
+should drive the build order.
+
+| Category | Signal today | Verdict |
+| --- | --- | --- |
+| Prompt cache hit rate | `otel_spans.CachedInputTokens` exists **and is mapped** by the gateway; SDK emits `gen_ai.usage.cached_input_tokens` | Buildable now |
+| Retry and failed-call spend | `StatusCode` exists; `AgentRunId` / `AgentStepIndex` exist. **No retry attribute** anywhere in the SDK | Partly buildable, needs SDK work |
+| Oversized system prompts | Only `InputTokens`, a single total. No prompt segmentation | Needs SDK work |
+| Unused retrieved chunks | `ResolvedContextRef` exists in schema and SDK, but nothing records which chunks influenced the answer | Research, largest gap |
+| Near-duplicate requests | `ResolvedPromptHash` column exists in ClickHouse but **nothing writes it**: it is absent from the SDK schema and from `gateway/mapping.py` | Orphan column, needs wiring |
+
+Note the demo tenant currently has all of these at zero (`CachedInputTokens`, `StatusCode != 0`,
+`ResolvedPromptHash`, `ResolvedContextRef` are unpopulated across 281,094 spans), because the
+backfill does not emit them. So even the buildable category has no data to show until real traffic
+or a richer backfill exists.
+
+## The invariant this feature keeps bumping into
+
+The product does not put bodies in telemetry. No prompts, no completions, no retrieved text. Counts
+and hashes only, with PII scrubbed. That is a core promise, and it is exactly what three of these
+five categories want to inspect.
+
+The resolution is to compute the signal **where the content already is** (in the SDK, in the
+customer's process) and emit only a derived number:
+
+- Oversized system prompt: the SDK measures the system-prompt token count and emits an integer. We
+  never see the prompt.
+- Near-duplicate: the SDK emits a hash of the normalised prompt. Exact duplicates are detectable
+  from hash collisions alone, with no text leaving the customer.
+- Unused chunks: the SDK emits chunk ids and, if the application can supply it, which ids were cited.
+  Ids, not text.
+
+This is more SDK work than dashboard work, which is the opposite of how this feature is usually
+imagined. Worth being clear about that up front: **waste detection is mostly an instrumentation
+project**, and the tab is the last 20 percent.
+
+## The five categories
+
+### 1. Prompt cache hit rate and savings left on the table
+
+The strongest one, and the right place to start. `CachedInputTokens` already flows end to end.
+
+Two numbers, both defensible:
+
+- **Realised saving.** Cached tokens billed at the cached rate instead of full input rate. Priced
+  from the existing catalog, which already carries cache pricing per model. This is measured.
+- **Saving left on the table.** Input tokens that were re-sent uncached but appeared in a prior call
+  within the provider's cache TTL. Requires knowing the repeated prefix, which needs the prompt hash
+  from category 5. Estimated, and the assumption (TTL, minimum cacheable prefix) must be stated.
+
+Provider caveat that has to be modelled honestly: cache semantics differ per provider (minimum
+prefix length, TTL, explicit versus automatic). A single blended rule will be wrong for someone.
+
+### 2. Retry and failed-call spend
+
+Money for zero output. Conceptually the cleanest waste there is.
+
+Failed calls that still consumed tokens are computable today from `StatusCode` plus token counts.
+Retries are not: nothing marks a call as attempt N of a sequence. `AgentRunId` and `AgentStepIndex`
+give ordering within an agent run but do not distinguish "retried the same call" from "took the next
+step".
+
+Needs a small SDK addition: an attempt number and a retry-of reference. With those, "spend on calls
+that ultimately failed" and "spend on superseded attempts" become measured numbers.
+
+Subtlety worth stating on screen: a retry that eventually succeeds is not pure waste, it bought
+reliability. The honest framing is "spend on attempts that produced no output", not "money wasted".
+
+### 3. Oversized system prompts sent on every call
+
+High value because it multiplies: 2,000 wasted tokens on every one of a million calls is real money.
+
+Not computable today. `InputTokens` is one number with no breakdown. Needs the SDK to emit a token
+count per prompt segment (system, context, user), which is cheap to compute where the prompt is
+assembled.
+
+With that, the tab can show system-prompt tokens as a share of all input tokens, the trend over time
+(a system prompt that grew is a specific, actionable finding), and the cost of the fixed prefix at
+current volume. The saving claim is Estimated: we can price the tokens exactly, but only a human can
+say which parts of the prompt are unnecessary. The right output is "your system prompt costs $890 a
+month at current volume", not "you are wasting $890".
+
+### 4. Retrieved chunks that never influenced the answer
+
+The most valuable and the least tractable. RAG pipelines routinely retrieve 20 chunks and use two,
+paying input tokens on all 20.
+
+The blocker is that influence is not observable from outside the model. Options, none clean:
+
+- **Citation-based.** If the application already tracks which chunks were cited, it emits those ids.
+  Accurate, and only works for apps that cite.
+- **Position and rank heuristics.** Cheap, and weak enough that a dollar claim is not defensible.
+- **Attribution probing.** Re-run without a chunk and compare. Accurate, expensive, and it doubles
+  spend to measure waste, which is a hard sell.
+
+Recommendation: v1 emits chunk count and retrieved-context token cost, and reports it as Indicative,
+"you spend $X a month on retrieved context, of which N chunks per call". No savings claim. Take the
+citation path only for tenants who can supply citations. Resist the temptation to guess here: this is
+the category most likely to produce a confident wrong number.
+
+### 5. Near-duplicate requests a semantic cache would kill
+
+`ResolvedPromptHash` is an orphan column: it exists in ClickHouse but no writer populates it. Wiring
+it is the unlock for both this category and the "left on the table" half of category 1.
+
+Two tiers:
+
+- **Exact duplicates.** Same normalised prompt hash within a window. Purely measured once the hash
+  flows. Strong finding: the same question asked 4,000 times a month at $0.02 each is a number nobody
+  argues with.
+- **Semantic near-duplicates.** Requires embedding prompts and clustering by distance, which means
+  either embedding in the SDK (cost and latency in the customer's hot path) or receiving prompt text
+  (violates the invariant). Neither is free.
+
+Recommendation: ship exact-duplicate detection, which is cheap and defensible, and treat semantic
+clustering as a separate proposal. The demo lands fine on exact duplicates.
+
+## The page
+
+Route `/waste`, in the nav. Structure that follows the honesty rule:
+
+Headline: total identified waste, **split into measured and estimated**, over the last 30 days, with
+the equivalent annual figure. Under it, a plain sentence naming what is excluded.
+
+Then one card per category, each with: the dollar figure, its confidence tier, the assumption in one
+line, how many calls or tokens it covers, and a concrete next action ("enable prompt caching for
+claude-sonnet on the research agent"). A finding without an action is trivia.
+
+Each card links to the underlying spans so a sceptical engineer can check the arithmetic. This
+matters more here than anywhere else in the product: the first question any good engineer asks of a
+"$4,200 wasted" claim is "show me".
+
+## Phasing
+
+1. **Wire `ResolvedPromptHash`** through SDK and gateway. Small, and unblocks two categories.
+2. **Exact-duplicate detection** and **prompt cache realised savings**. Both measured, both shippable
+   on existing plus newly wired signal. This is the demo.
+3. **SDK: prompt segment token counts and retry or attempt markers.** The instrumentation half.
+4. **Oversized system prompt and retry or failure spend cards.**
+5. **Retrieved-context reporting**, Indicative only.
+6. Semantic near-duplicates and citation-based chunk analysis, each as its own proposal.
+
+Phases 1 and 2 are the minimum that produces a credible demo. Everything after that widens coverage.
+
+## Open questions
+
+1. Does the headline sum measured only, or measured plus estimated? Recommendation is measured, with
+   estimated shown beside it. This is a product positioning call as much as a technical one.
+2. Do we need a richer demo backfill? Today's demo data has zero cache, zero errors and zero prompt
+   hashes, so the tab would be empty in exactly the demo it is meant to sell.
+3. How much SDK overhead is acceptable in the customer's hot path? Hashing a prompt is cheap;
+   embedding one is not.
+4. Do waste findings feed the alerts feature (`docs/cost-alerts-scope.md`), for example "notify me
+   when cache hit rate drops below 40 percent"? That is a natural pairing and worth designing for.
+5. Is waste scanned continuously or on demand? Continuous needs the scheduler that three features now
+   want.
+
+## Risks
+
+**Overclaiming.** The single biggest risk. A headline number that does not survive a customer's own
+analysis costs more trust than the feature earns. The confidence tiers are the mitigation and they
+should not be dropped for a cleaner headline.
+
+**It is an instrumentation project wearing a dashboard costume.** Most of the work is in the SDK, and
+the value only appears after customers upgrade and redeploy. Plan for the lag.
+
+**Empty for existing tenants.** Like cost per customer, this ships dark until the new signals flow.
+The cache category is the exception, and it is the reason to start there.
+
+**Provider-specific correctness.** Cache rules, retry semantics and token accounting differ per
+provider. A blended model will be confidently wrong for someone, which is worse than being narrow
+and right.


### PR DESCRIPTION
Seven scoping docs plus the cost-per-customer build plan (CTO-176).

Each scope was checked against the actual schema and SDK rather than assumed. Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)