### PR TITLE
feat(web): shared typed DataTable component (CTO-177)

### DIFF
--- a/web/components/DataTable.test.tsx
+++ b/web/components/DataTable.test.tsx
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  type Column,
+  DataTable,
+  clampPage,
+  compareValues,
+  nextSort,
+  pageCount,
+  pageSlice,
+  sortRows,
+} from "./DataTable";
+
+interface Account {
+  id: string;
+  name: string;
+  costMicroUsd: number;
+  revenueMicroUsd: number | null;
+}
+
+const COLUMNS: Column<Account>[] = [
+  { key: "name", header: "Account", render: (r) => r.name, sortValue: (r) => r.name },
+  {
+    key: "cost",
+    header: "Cost",
+    align: "right",
+    render: (r) => r.costMicroUsd,
+    sortValue: (r) => r.costMicroUsd,
+  },
+  {
+    key: "revenue",
+    header: "Revenue",
+    align: "right",
+    render: (r) => r.revenueMicroUsd ?? "—",
+    sortValue: (r) => r.revenueMicroUsd,
+  },
+  // Deliberately unsortable: stands in for the action / sparkline columns existing pages carry.
+  { key: "actions", header: "Actions", render: () => "…" },
+];
+
+const ROWS: Account[] = [
+  { id: "b", name: "beta", costMicroUsd: 300, revenueMicroUsd: null },
+  { id: "a", name: "alpha", costMicroUsd: 100, revenueMicroUsd: 50 },
+  { id: "c", name: "gamma", costMicroUsd: 200, revenueMicroUsd: 900 },
+];
+
+function makeRows(n: number): Account[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `acct-${i}`,
+    name: `acct-${String(i).padStart(3, "0")}`,
+    costMicroUsd: i,
+    revenueMicroUsd: i,
+  }));
+}
+
+/** Body cell text, page-visible only, as a grid. */
+function bodyRows(): string[][] {
+  const body = document.querySelectorAll("tbody tr");
+  return Array.from(body).map((tr) => Array.from(tr.querySelectorAll("td")).map((td) => td.textContent ?? ""));
+}
+
+describe("compareValues", () => {
+  it("orders numbers numerically rather than lexically", () => {
+    expect(compareValues(9, 100, "asc")).toBeLessThan(0);
+    expect(compareValues(9, 100, "desc")).toBeGreaterThan(0);
+  });
+
+  it("orders strings with localeCompare in both directions", () => {
+    expect(compareValues("alpha", "beta", "asc")).toBeLessThan(0);
+    expect(compareValues("alpha", "beta", "desc")).toBeGreaterThan(0);
+  });
+
+  it("sorts missing values last in BOTH directions (a blank is not a zero)", () => {
+    expect(compareValues(null, 5, "asc")).toBeGreaterThan(0);
+    expect(compareValues(null, 5, "desc")).toBeGreaterThan(0);
+    expect(compareValues(5, undefined, "desc")).toBeLessThan(0);
+    expect(compareValues(null, undefined, "asc")).toBe(0);
+  });
+
+  it("sorts NaN last as well", () => {
+    expect(compareValues(Number.NaN, 1, "asc")).toBeGreaterThan(0);
+    expect(compareValues(Number.NaN, 1, "desc")).toBeGreaterThan(0);
+  });
+
+  it("orders booleans false before true ascending", () => {
+    expect(compareValues(false, true, "asc")).toBeLessThan(0);
+    expect(compareValues(false, true, "desc")).toBeGreaterThan(0);
+  });
+});
+
+describe("sortRows", () => {
+  it("sorts ascending and descending on a numeric column", () => {
+    const asc = sortRows(ROWS, COLUMNS, { key: "cost", direction: "asc" });
+    expect(asc.map((r) => r.id)).toEqual(["a", "c", "b"]);
+    const desc = sortRows(ROWS, COLUMNS, { key: "cost", direction: "desc" });
+    expect(desc.map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("sorts a string column alphabetically", () => {
+    expect(sortRows(ROWS, COLUMNS, { key: "name", direction: "asc" }).map((r) => r.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("keeps rows with no value at the bottom when sorting descending", () => {
+    const desc = sortRows(ROWS, COLUMNS, { key: "revenue", direction: "desc" });
+    expect(desc.map((r) => r.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("leaves order untouched for an unsortable or unknown key", () => {
+    expect(sortRows(ROWS, COLUMNS, { key: "actions", direction: "asc" }).map((r) => r.id)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(sortRows(ROWS, COLUMNS, { key: "nope", direction: "asc" }).map((r) => r.id)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(sortRows(ROWS, COLUMNS, null).map((r) => r.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("is stable on ties and does not mutate the input", () => {
+    const tied: Account[] = [
+      { id: "x", name: "x", costMicroUsd: 1, revenueMicroUsd: 0 },
+      { id: "y", name: "y", costMicroUsd: 1, revenueMicroUsd: 0 },
+      { id: "z", name: "z", costMicroUsd: 1, revenueMicroUsd: 0 },
+    ];
+    expect(sortRows(tied, COLUMNS, { key: "cost", direction: "desc" }).map((r) => r.id)).toEqual([
+      "x",
+      "y",
+      "z",
+    ]);
+    sortRows(ROWS, COLUMNS, { key: "cost", direction: "asc" });
+    expect(ROWS.map((r) => r.id)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("nextSort", () => {
+  it("opens text columns ascending and numeric (right-aligned) columns descending", () => {
+    expect(nextSort(COLUMNS[0], null)).toEqual({ key: "name", direction: "asc" });
+    expect(nextSort(COLUMNS[1], null)).toEqual({ key: "cost", direction: "desc" });
+  });
+
+  it("toggles direction when the same column is clicked again", () => {
+    expect(nextSort(COLUMNS[1], { key: "cost", direction: "desc" })).toEqual({
+      key: "cost",
+      direction: "asc",
+    });
+    expect(nextSort(COLUMNS[1], { key: "cost", direction: "asc" })).toEqual({
+      key: "cost",
+      direction: "desc",
+    });
+  });
+
+  it("starts fresh when switching columns", () => {
+    expect(nextSort(COLUMNS[0], { key: "cost", direction: "asc" })).toEqual({
+      key: "name",
+      direction: "asc",
+    });
+  });
+});
+
+describe("page boundaries", () => {
+  it("counts pages, rounding a partial last page up", () => {
+    expect(pageCount(0, 10)).toBe(1);
+    expect(pageCount(10, 10)).toBe(1);
+    expect(pageCount(11, 10)).toBe(2);
+    expect(pageCount(25, 10)).toBe(3);
+  });
+
+  it("treats a page size of 0 as a single unpaged page", () => {
+    expect(pageCount(500, 0)).toBe(1);
+    expect(pageSlice(makeRows(5), 3, 0)).toHaveLength(5);
+  });
+
+  it("clamps a page index into range instead of stranding the viewer", () => {
+    expect(clampPage(-4, 30, 10)).toBe(0);
+    expect(clampPage(99, 30, 10)).toBe(2);
+    expect(clampPage(1, 0, 10)).toBe(0);
+    expect(clampPage(Number.NaN, 30, 10)).toBe(0);
+  });
+
+  it("slices exactly one page, with the remainder on the last page", () => {
+    const rows = makeRows(25);
+    expect(pageSlice(rows, 0, 10).map((r) => r.id)).toEqual(rows.slice(0, 10).map((r) => r.id));
+    expect(pageSlice(rows, 1, 10).map((r) => r.id)).toEqual(rows.slice(10, 20).map((r) => r.id));
+    expect(pageSlice(rows, 2, 10)).toHaveLength(5);
+    // Past the end clamps back to the last page rather than returning nothing.
+    expect(pageSlice(rows, 9, 10)).toHaveLength(5);
+  });
+});
+
+describe("<DataTable />", () => {
+  it("renders the shared header style and right-aligns numeric cells with tabular-nums", () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} rowKey={(r) => r.id} />);
+    const head = document.querySelector("thead");
+    expect(head?.className).toContain("text-xs");
+    expect(head?.className).toContain("uppercase");
+    expect(head?.className).toContain("text-muted");
+
+    const firstRow = document.querySelectorAll("tbody tr")[0];
+    const cells = firstRow.querySelectorAll("td");
+    expect(cells[0].className).not.toContain("text-right");
+    expect(cells[1].className).toContain("text-right");
+    expect(cells[1].className).toContain("tabular-nums");
+  });
+
+  it("keeps wide tables scrolling inside their own container", () => {
+    const { container } = render(<DataTable columns={COLUMNS} rows={ROWS} rowKey={(r) => r.id} />);
+    const wrapper = container.querySelector("table")?.parentElement;
+    expect(wrapper?.className).toContain("overflow-x-auto");
+  });
+
+  it("shows the empty state spanning every column when there are no rows", () => {
+    render(
+      <DataTable columns={COLUMNS} rows={[]} rowKey={(r) => r.id} empty="No accounts yet." />,
+    );
+    const cell = screen.getByText("No accounts yet.");
+    expect(cell.getAttribute("colspan")).toBe(String(COLUMNS.length));
+  });
+
+  it("sorts on header click and toggles on a second click", () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} rowKey={(r) => r.id} />);
+    expect(bodyRows().map((r) => r[0])).toEqual(["beta", "alpha", "gamma"]);
+
+    // Cost is right-aligned, so the first click opens descending.
+    fireEvent.click(screen.getByRole("button", { name: /Cost/ }));
+    expect(bodyRows().map((r) => r[1])).toEqual(["300", "200", "100"]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Cost/ }));
+    expect(bodyRows().map((r) => r[1])).toEqual(["100", "200", "300"]);
+  });
+
+  it("marks the sorted column with aria-sort and leaves unsortable columns as plain headers", () => {
+    render(
+      <DataTable
+        columns={COLUMNS}
+        rows={ROWS}
+        rowKey={(r) => r.id}
+        initialSort={{ key: "name", direction: "asc" }}
+      />,
+    );
+    expect(bodyRows().map((r) => r[0])).toEqual(["alpha", "beta", "gamma"]);
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers[0].getAttribute("aria-sort")).toBe("ascending");
+    expect(headers[1].getAttribute("aria-sort")).toBe("none");
+    expect(within(headers[3]).queryByRole("button")).toBeNull();
+    expect(headers[3].getAttribute("aria-sort")).toBeNull();
+  });
+
+  it("paginates, and Previous/Next stop at the first and last page", () => {
+    render(<DataTable columns={COLUMNS} rows={makeRows(25)} rowKey={(r) => r.id} pageSize={10} />);
+    expect(bodyRows()).toHaveLength(10);
+    expect(screen.getByText("Page 1 of 3")).toBeTruthy();
+    expect(screen.getByText("1–10 of 25")).toBeTruthy();
+
+    const prev = screen.getByRole("button", { name: "Previous" });
+    const next = screen.getByRole("button", { name: "Next" });
+    expect((prev as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(next);
+    expect(bodyRows()[0][0]).toBe("acct-010");
+    expect(screen.getByText("11–20 of 25")).toBeTruthy();
+    expect((prev as HTMLButtonElement).disabled).toBe(false);
+
+    // Last page holds the 5-row remainder and Next goes dead.
+    fireEvent.click(next);
+    expect(bodyRows()).toHaveLength(5);
+    expect(screen.getByText("21–25 of 25")).toBeTruthy();
+    expect((next as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(prev);
+    expect(screen.getByText("Page 2 of 3")).toBeTruthy();
+  });
+
+  it("hides the pager when everything fits on one page", () => {
+    render(<DataTable columns={COLUMNS} rows={makeRows(10)} rowKey={(r) => r.id} pageSize={10} />);
+    expect(screen.queryByRole("button", { name: "Next" })).toBeNull();
+  });
+
+  it("renders every row when pageSize is 0", () => {
+    render(<DataTable columns={COLUMNS} rows={makeRows(40)} rowKey={(r) => r.id} pageSize={0} />);
+    expect(bodyRows()).toHaveLength(40);
+    expect(screen.queryByRole("button", { name: "Next" })).toBeNull();
+  });
+
+  it("returns to page 1 when the sort changes, so the viewer sees the new top", () => {
+    render(<DataTable columns={COLUMNS} rows={makeRows(25)} rowKey={(r) => r.id} pageSize={10} />);
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Page 2 of 3")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Cost/ }));
+    expect(screen.getByText("Page 1 of 3")).toBeTruthy();
+    expect(bodyRows()[0][1]).toBe("24");
+  });
+});

--- a/web/components/DataTable.tsx
+++ b/web/components/DataTable.tsx
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// Shared dashboard table (CTO-177, plan workstream A1). Ten pages hand-roll the same <table>
+// markup, so the visual conventions here are copied verbatim from them rather than reinvented:
+// `w-full text-sm`, an uppercase `text-xs text-muted` header, `border-t border-edge` row rules,
+// and `text-right tabular-nums` on numerics so digits line up column-wise.
+//
+// Sorting and pagination ship with the first version on purpose. Account lists are unbounded, and
+// retrofitting paging into a component several pages already consume costs more than building it
+// once. No page is migrated here; that is CTO-179.
+
+import { useMemo, useState, type ReactNode } from "react";
+
+export type SortDirection = "asc" | "desc";
+
+/** What a cell can be sorted on. `null` means "no value", which always sorts last. */
+export type SortValue = string | number | boolean | null | undefined;
+
+export interface Column<Row> {
+  /** Stable identity for the column. Also the sort key, so it must be unique within a table. */
+  key: string;
+  header: ReactNode;
+  /** Numerics belong on the right; text on the left. Defaults to left. */
+  align?: "left" | "right";
+  render: (row: Row) => ReactNode;
+  /**
+   * Makes the column sortable. Omit it for columns with no meaningful order (a button, a
+   * distribution sparkline), which then render as plain headers.
+   */
+  sortValue?: (row: Row) => SortValue;
+  /** Extra classes on the <th>/<td>, for the `pl-3` gutters some existing tables use. */
+  headerClassName?: string;
+  cellClassName?: string;
+}
+
+export interface DataTableProps<Row> {
+  columns: readonly Column<Row>[];
+  rows: readonly Row[];
+  /** React key per row. Index is a fallback only; prefer a real id from the row. */
+  rowKey: (row: Row, index: number) => string;
+  /** Shown in place of the body when there are no rows at all. */
+  empty?: ReactNode;
+  /** Rows per page. Pass 0 to render every row and hide the pager. */
+  pageSize?: number;
+  initialSort?: { key: string; direction: SortDirection };
+  /** Per-row classes, for the locked/muted row treatment /unit-economics uses. */
+  rowClassName?: (row: Row) => string;
+}
+
+interface SortState {
+  key: string;
+  direction: SortDirection;
+}
+
+const DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Ordering for one cell against another. Missing values sort last in both directions: an account
+ * with no revenue wired is not "the cheapest", and floating it to the top of a descending sort
+ * would read as a real zero.
+ */
+export function compareValues(a: SortValue, b: SortValue, direction: SortDirection): number {
+  const aMissing = a === null || a === undefined;
+  const bMissing = b === null || b === undefined;
+  if (aMissing || bMissing) {
+    if (aMissing && bMissing) return 0;
+    return aMissing ? 1 : -1;
+  }
+  const flip = direction === "asc" ? 1 : -1;
+  if (typeof a === "number" && typeof b === "number") {
+    if (Number.isNaN(a) || Number.isNaN(b)) {
+      if (Number.isNaN(a) && Number.isNaN(b)) return 0;
+      return Number.isNaN(a) ? 1 : -1;
+    }
+    return (a - b) * flip;
+  }
+  if (typeof a === "boolean" && typeof b === "boolean") {
+    return (Number(a) - Number(b)) * flip;
+  }
+  return String(a).localeCompare(String(b)) * flip;
+}
+
+/**
+ * Sorted copy of `rows`. Returns the input order untouched when the sort key names no sortable
+ * column, so a stale saved sort can never blank or scramble a table. Array#sort is stable in every
+ * engine we target, which keeps ties in their source order.
+ */
+export function sortRows<Row>(
+  rows: readonly Row[],
+  columns: readonly Column<Row>[],
+  sort: SortState | null,
+): Row[] {
+  if (!sort) return [...rows];
+  const column = columns.find((c) => c.key === sort.key);
+  if (!column?.sortValue) return [...rows];
+  const sortValue = column.sortValue;
+  return [...rows].sort((a, b) => compareValues(sortValue(a), sortValue(b), sort.direction));
+}
+
+/** Total pages, never below 1 so "Page 1 of 1" holds for an empty table. */
+export function pageCount(total: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+/**
+ * Page index clamped into range. Derived rather than stored, so shrinking the row set (a filter
+ * upstream, a deleted account) cannot strand the viewer on a page that no longer exists.
+ */
+export function clampPage(page: number, total: number, pageSize: number): number {
+  if (!Number.isFinite(page)) return 0;
+  return Math.min(Math.max(0, Math.trunc(page)), pageCount(total, pageSize) - 1);
+}
+
+/** The slice of rows visible on `page`. `pageSize` of 0 means "everything on one page". */
+export function pageSlice<Row>(rows: readonly Row[], page: number, pageSize: number): Row[] {
+  if (pageSize <= 0) return [...rows];
+  const safe = clampPage(page, rows.length, pageSize);
+  return rows.slice(safe * pageSize, safe * pageSize + pageSize);
+}
+
+/**
+ * Direction a fresh click on a column should apply. Right-aligned columns are money and counts,
+ * where the interesting end is the top spender, so they open descending.
+ */
+export function nextSort<Row>(column: Column<Row>, current: SortState | null): SortState {
+  if (current?.key === column.key) {
+    return { key: column.key, direction: current.direction === "asc" ? "desc" : "asc" };
+  }
+  return { key: column.key, direction: column.align === "right" ? "desc" : "asc" };
+}
+
+function SortArrow({ direction }: { direction: SortDirection | null }) {
+  // The inactive arrow stays in the layout at low opacity so the header row does not reflow by a
+  // few pixels every time the sort moves.
+  return (
+    <span aria-hidden className={direction ? "text-accent" : "opacity-0"}>
+      {direction === "desc" ? "↓" : "↑"}
+    </span>
+  );
+}
+
+export function DataTable<Row>({
+  columns,
+  rows,
+  rowKey,
+  empty = "No data yet.",
+  pageSize = DEFAULT_PAGE_SIZE,
+  initialSort,
+  rowClassName,
+}: DataTableProps<Row>) {
+  const [sort, setSort] = useState<SortState | null>(initialSort ?? null);
+  const [page, setPage] = useState(0);
+
+  const sorted = useMemo(() => sortRows(rows, columns, sort), [rows, columns, sort]);
+  const totalPages = pageCount(sorted.length, pageSize);
+  const safePage = clampPage(page, sorted.length, pageSize);
+  const visible = pageSlice(sorted, safePage, pageSize);
+
+  const showPager = pageSize > 0 && sorted.length > pageSize;
+  const firstShown = sorted.length === 0 ? 0 : safePage * pageSize + 1;
+  const lastShown = safePage * pageSize + visible.length;
+
+  return (
+    <div>
+      {/* The table scrolls inside this box; the page body never scrolls sideways. */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              {columns.map((c) => {
+                const align = c.align === "right" ? "text-right" : "text-left";
+                const active = sort?.key === c.key ? sort.direction : null;
+                const classes = `py-1 font-medium ${align} ${c.headerClassName ?? ""}`.trim();
+                if (!c.sortValue) {
+                  return (
+                    <th key={c.key} scope="col" className={classes}>
+                      {c.header}
+                    </th>
+                  );
+                }
+                return (
+                  <th
+                    key={c.key}
+                    scope="col"
+                    className={classes}
+                    aria-sort={active === "asc" ? "ascending" : active === "desc" ? "descending" : "none"}
+                  >
+                    <button
+                      type="button"
+                      // Sorting restarts at page 1: staying on page 7 after a re-sort shows a
+                      // slice the viewer never asked for.
+                      onClick={() => {
+                        setSort((current) => nextSort(c, current));
+                        setPage(0);
+                      }}
+                      className={`inline-flex items-center gap-1 uppercase hover:text-white ${
+                        c.align === "right" ? "flex-row-reverse" : ""
+                      }`}
+                    >
+                      <span>{c.header}</span>
+                      <SortArrow direction={active} />
+                    </button>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.length === 0 ? (
+              <tr className="border-t border-edge">
+                <td colSpan={columns.length} className="py-6 text-center text-sm text-muted">
+                  {empty}
+                </td>
+              </tr>
+            ) : (
+              visible.map((row, i) => (
+                <tr
+                  key={rowKey(row, safePage * pageSize + i)}
+                  className={`border-t border-edge ${rowClassName?.(row) ?? ""}`.trim()}
+                >
+                  {columns.map((c) => (
+                    <td
+                      key={c.key}
+                      className={`py-2 ${
+                        c.align === "right" ? "text-right tabular-nums" : ""
+                      } ${c.cellClassName ?? ""}`.trim()}
+                    >
+                      {c.render(row)}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {showPager ? (
+        <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted">
+          <span className="tabular-nums">
+            {firstShown}–{lastShown} of {sorted.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <PagerButton disabled={safePage === 0} onClick={() => setPage(safePage - 1)}>
+              Previous
+            </PagerButton>
+            <span className="tabular-nums">
+              Page {safePage + 1} of {totalPages}
+            </span>
+            <PagerButton
+              disabled={safePage >= totalPages - 1}
+              onClick={() => setPage(safePage + 1)}
+            >
+              Next
+            </PagerButton>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PagerButton({
+  disabled,
+  onClick,
+  children,
+}: {
+  disabled: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="rounded-md border border-edge px-2 py-1 hover:text-white disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-muted"
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## What

Adds `web/components/DataTable.tsx`, a typed, reusable table for the dashboard, plus `web/components/DataTable.test.tsx` (26 vitest cases).

The API is a typed column spec plus rows:

```ts
interface Column<Row> {
  key: string;
  header: ReactNode;
  align?: "left" | "right";
  render: (row: Row) => ReactNode;
  sortValue?: (row: Row) => string | number | boolean | null | undefined;
  headerClassName?: string;
  cellClassName?: string;
}
```

Covered: right-aligned numerics with `tabular-nums`, the shared uppercase `text-xs text-muted` header, an empty state spanning all columns, horizontal overflow contained in its own `overflow-x-auto` box, column sorting, and pagination.

## Why

Ten pages currently hand-roll the same `<table>` markup, and every tab still in the backlog needs the same primitives (plan workstream A1). The markup here was copied from the existing pages rather than reinvented (`w-full text-sm`, uppercase `text-xs text-muted` head, `border-t border-edge` row rules, `py-1`/`py-2` padding), so migrating a page is a like-for-like swap.

Sorting and pagination ship in the first version instead of being deferred: account lists are unbounded, and retrofitting paging into a component several pages already consume costs more than building it once.

**No existing page is migrated in this PR.** That is CTO-179.

## Reviewer notes

Three behaviours worth a look, all of them judgement calls:

- **Missing values sort last in both directions.** A blank is not a zero. Floating a null revenue to the top of a descending sort would read as a real result, which contradicts the product's honest-blank posture. `NaN` is treated the same way.
- **Page index is derived and clamped, not stored.** `clampPage` runs on every render, so a shrinking row set (an upstream filter, a deleted account) cannot strand the viewer on a page that no longer exists. Changing the sort also resets to page 1, since staying on page 7 after a re-sort shows a slice nobody asked for.
- **First click direction depends on alignment.** Right-aligned columns are money and counts, where the interesting end is the top spender, so they open descending; text columns open ascending. `nextSort` is exported and unit-tested if this should be an explicit per-column prop instead.

Also: `sortRows` returns the input order untouched for an unknown or unsortable sort key, so a stale saved sort can never blank a table. Columns without `sortValue` render as plain non-interactive headers, which is what the action and sparkline columns on existing pages need.

## Verification

From `web/`: `npm run typecheck` clean, `npm run lint` clean (only the two pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`), `npm run test` 246 passed / 2 failed. The 2 failures are the known pre-existing ones in `app/api/api.test.ts` (attribution and data-quality "falls back to mock when ClickHouse is unreachable") that fail locally when ClickHouse is running. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
