### PR TITLE
feat(web): honest-value primitives (Money, Pct, Blank)

### DIFF
--- a/web/components/HonestValue.test.tsx
+++ b/web/components/HonestValue.test.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BLANK, Blank, Money, Pct } from "./HonestValue";
+
+describe("Blank (CTO-178)", () => {
+  it("renders the glyph with the reason on hover", () => {
+    const { container } = render(<Blank reason="no revenue events wired" />);
+    expect(container.textContent).toContain(BLANK);
+    expect(container.querySelector("[title='no revenue events wired']")).toBeTruthy();
+  });
+
+  it("also exposes the reason to assistive tech, not just the mouse", () => {
+    render(<Blank reason="below 50 samples" />);
+    expect(screen.getByText(/No value: below 50 samples/i)).toBeTruthy();
+  });
+
+  it("carries a visual affordance so the hover is discoverable", () => {
+    const { container } = render(<Blank reason="no eval pass has run" />);
+    const cls = container.firstElementChild?.className ?? "";
+    expect(cls).toContain("cursor-help");
+    expect(cls).toContain("decoration-dotted");
+  });
+});
+
+describe("Money (CTO-178)", () => {
+  it("formats a real amount through formatUSD", () => {
+    const { container } = render(<Money micro={12_500_000} />);
+    expect(container.textContent).toBe("$12.50");
+  });
+
+  it("keeps sub-cent precision rather than flooring it to $0.00", () => {
+    const { container } = render(<Money micro={3_200} />);
+    expect(container.textContent).toBe("$0.0032");
+  });
+
+  it("renders $0.00 for a genuine zero, which is a known value and not a blank", () => {
+    const { container } = render(<Money micro={0} />);
+    expect(container.textContent).toBe("$0.00");
+  });
+
+  it("renders an explained blank for null", () => {
+    const { container } = render(<Money micro={null} reason="no revenue events wired" />);
+    expect(container.textContent).toContain(BLANK);
+    expect(screen.getByText(/No value: no revenue events wired/i)).toBeTruthy();
+  });
+
+  it("falls back to a generic reason rather than an unexplained blank", () => {
+    const nothing: number | null = null;
+    render(<Money micro={nothing} reason={undefined as unknown as string} />);
+    expect(screen.getByText(/No value: no cost data for this period/i)).toBeTruthy();
+  });
+});
+
+// Compile-time half of the contract: `npm run typecheck` fails if omitting `reason` on a nullable
+// value ever stops being an error, which is the guarantee that keeps blanks explained.
+describe("nullable values must carry a reason", () => {
+  it("is enforced by the type checker", () => {
+    const unknown: number | null = null;
+    expect(() => (
+      <>
+        {/* @ts-expect-error a nullable amount must carry a reason */}
+        <Money micro={unknown} />
+        {/* @ts-expect-error a nullable percentage must carry a reason */}
+        <Pct value={unknown} />
+      </>
+    )).toBeTruthy();
+  });
+});
+
+describe("Pct (CTO-178)", () => {
+  it("renders a fraction as a percentage, one decimal by default", () => {
+    const { container } = render(<Pct value={0.4217} />);
+    expect(container.textContent).toBe("42.2%");
+  });
+
+  it("honours the digits prop, since surfaces disagree on precision", () => {
+    const { container } = render(<Pct value={0.4217} digits={0} />);
+    expect(container.textContent).toBe("42%");
+  });
+
+  it("renders 0% for a genuine zero rate", () => {
+    const { container } = render(<Pct value={0} digits={0} />);
+    expect(container.textContent).toBe("0%");
+  });
+
+  it("renders an explained blank for null", () => {
+    const { container } = render(<Pct value={null} reason="needs ≥50 spans in 7d" />);
+    expect(container.textContent).toContain(BLANK);
+    expect(screen.getByText(/No value: needs ≥50 spans in 7d/i)).toBeTruthy();
+  });
+
+  it("falls back to a generic reason rather than an unexplained blank", () => {
+    const nothing: number | null = null;
+    render(<Pct value={nothing} reason={undefined as unknown as string} />);
+    expect(screen.getByText(/No value: not enough samples to report a rate/i)).toBeTruthy();
+  });
+});

--- a/web/components/HonestValue.tsx
+++ b/web/components/HonestValue.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Honest-value primitives (CTO-178, plan A2). "Honest under uncertainty" is the product's central
+// posture: where we do not know a number we render a blank instead of fabricating one. That blank
+// was hand-written across 10 files, and the reason it is blank was either missing or an ad-hoc
+// `title`. One component, so a reader can always find out WHY a cell is empty.
+
+import { formatUSD, type MicroUSD } from "@/lib/types";
+
+/** The blank glyph itself. Exported so call sites can assert on it without re-typing it. */
+export const BLANK = "—";
+
+/**
+ * A value we do not have, with the reason attached.
+ *
+ * The reason is carried three ways because each reaches a different reader: `title` for the mouse,
+ * an sr-only sentence for assistive tech, and a dotted underline plus help cursor so a sighted
+ * reader knows there is something to hover at all. A bare glyph with only a `title` is invisible
+ * as an affordance, which is how blanks ended up feeling like bugs.
+ */
+export function Blank({ reason, className = "" }: { reason: string; className?: string }) {
+  return (
+    <span
+      title={reason}
+      className={`cursor-help text-muted underline decoration-dotted decoration-muted/60 underline-offset-4 ${className}`.trim()}
+    >
+      <span aria-hidden>{BLANK}</span>
+      <span className="sr-only">No value: {reason}</span>
+    </span>
+  );
+}
+
+/**
+ * `reason` is required exactly when the value can be null. A caller passing a definite number is
+ * not asked to invent an explanation, and a caller passing a nullable one cannot forget to give
+ * one. The whole point of the primitive is that the blank is never unexplained.
+ */
+type NullableProps<K extends string, V> =
+  | ({ [P in K]: V } & { reason?: string; className?: string })
+  | ({ [P in K]: V | null } & { reason: string; className?: string });
+
+/** Money, in the micro-USD integers the wire and mock layers both speak. */
+export function Money({
+  micro,
+  reason,
+  className,
+}: NullableProps<"micro", MicroUSD>) {
+  if (micro === null || Number.isNaN(micro)) {
+    return <Blank reason={reason ?? "no cost data for this period"} className={className} />;
+  }
+  return <span className={className}>{formatUSD(micro)}</span>;
+}
+
+/**
+ * A percentage. `value` is a fraction (0.42 renders "42.0%"), matching how rates arrive from the
+ * API everywhere in this app. `digits` because the existing surfaces disagree on precision:
+ * attribution rates round to whole percent, error rates want two decimals.
+ */
+export function Pct({
+  value,
+  digits = 1,
+  reason,
+  className,
+}: NullableProps<"value", number> & { digits?: number }) {
+  if (value === null || Number.isNaN(value)) {
+    return <Blank reason={reason ?? "not enough samples to report a rate"} className={className} />;
+  }
+  return <span className={className}>{(value * 100).toFixed(digits)}%</span>;
+}


### PR DESCRIPTION
## What

Adds `web/components/HonestValue.tsx` with three render primitives and a vitest suite covering the null paths (CTO-178, plan item A2).

- **`<Blank reason="..." />`** renders the em-dash glyph and carries the reason three ways: a `title` for the mouse, an sr-only sentence for assistive tech, and a dotted underline plus help cursor so a sighted reader can tell there is something to hover at all.
- **`<Money micro={...} />`** wraps the existing `formatUSD` from `web/lib/types.ts`. Null renders an explained blank; a genuine `0` renders `$0.00`, because zero is a known value and not a blank.
- **`<Pct value={...} digits={1} />`** takes a fraction (`0.42` renders `42.0%`) and a precision, since existing surfaces disagree: attribution rates round to whole percent, error rates want two decimals.

## Why

"Honest under uncertainty" is the product's central posture, but the blank that expresses it is hand-written across 10 files and the reason it is blank is either missing or an ad-hoc `title`. A reader looking at an empty cell had no reliable way to find out why it was empty. One component, not 21 copies.

## Reviewer notes

- **`reason` is required exactly when the value can be null.** A caller passing a definite number is not asked to invent an explanation; a caller passing a `number | null` cannot forget to give one. That is what the props union in the file does, and the test file pins it with two `@ts-expect-error` lines so `npm run typecheck` keeps enforcing it if the types are ever refactored.
- Default reasons exist as a last resort so a blank is never bare, but the type contract means you should not hit them in practice.
- **No existing page is migrated here.** That is CTO-179, per the ticket.
- Test style follows `web/components/DataStateBanner.test.tsx` (no jest-dom).

## Verification

From `web/`: `npm run typecheck` clean, `npm run lint` clean (only the three pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`), `npm run test` at 234 passed / 2 failed. The 2 failures are the documented pre-existing `app/api/api.test.ts` ClickHouse-fallback cases that fail whenever ClickHouse is actually running locally. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
