### PR TITLE
C1: shared-cost allocation engine (CTO-192)

### DIFF
--- a/web/lib/allocation.test.ts
+++ b/web/lib/allocation.test.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import {
+  ALLOCATION_RULES,
+  DEFAULT_ALLOCATION_RULE,
+  type AccountDirectSpend,
+  type AllocationRule,
+  allocateShared,
+} from "./allocation";
+
+function accts(...direct: number[]): AccountDirectSpend[] {
+  return direct.map((d, i) => ({ accountId: `acct-${i}`, directMicroUsd: d }));
+}
+
+/**
+ * The assertion the whole feature rests on. Run against every case below, not just the tidy ones:
+ * a rounding bug shows up on awkward input, never on 100 split three ways.
+ */
+function expectReconciles(
+  accounts: readonly AccountDirectSpend[],
+  shared: number,
+  rule: AllocationRule,
+) {
+  const r = allocateShared(accounts, shared, rule);
+
+  const allocatedSum = r.accounts.reduce((s, a) => s + a.allocatedMicroUsd, 0);
+  // Allocated shares sum EXACTLY to the shared total, nothing lost, nothing double-counted.
+  expect(allocatedSum + r.unallocatedMicroUsd).toBe(shared);
+  expect(r.allocatedTotalMicroUsd).toBe(allocatedSum);
+
+  // Direct plus allocated sums exactly to the tenant total.
+  const totalSum = r.accounts.reduce((s, a) => s + a.totalMicroUsd, 0);
+  expect(totalSum + r.unallocatedMicroUsd).toBe(r.tenantTotalMicroUsd);
+  expect(r.tenantTotalMicroUsd).toBe(r.directTotalMicroUsd + shared);
+
+  for (const a of r.accounts) {
+    expect(Number.isSafeInteger(a.allocatedMicroUsd)).toBe(true);
+    expect(Number.isSafeInteger(a.totalMicroUsd)).toBe(true);
+    expect(a.totalMicroUsd).toBe(a.directMicroUsd + a.allocatedMicroUsd);
+  }
+  return r;
+}
+
+describe("pro rata on direct spend", () => {
+  it("splits in proportion to direct spend", () => {
+    const r = expectReconciles(accts(1_000_000, 3_000_000), 4_000_000, "pro_rata_direct");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([1_000_000, 3_000_000]);
+    expect(r.effectiveRule).toBe("pro_rata_direct");
+  });
+
+  it("is the default rule", () => {
+    expect(DEFAULT_ALLOCATION_RULE).toBe("pro_rata_direct");
+    const explicit = allocateShared(accts(1, 2), 90, "pro_rata_direct");
+    expect(allocateShared(accts(1, 2), 90)).toEqual(explicit);
+  });
+
+  it("gives an account with zero direct spend zero allocated cost", () => {
+    const r = expectReconciles(accts(0, 5_000_000), 1_000_000, "pro_rata_direct");
+    expect(r.accounts[0].allocatedMicroUsd).toBe(0);
+    expect(r.accounts[1].allocatedMicroUsd).toBe(1_000_000);
+  });
+
+  it("hands the rounding remainder to the largest remainders, losing nothing", () => {
+    // 10 micro-USD over three equal accounts: 3, 3, 3 leaves 1 over.
+    const r = expectReconciles(accts(1, 1, 1), 10, "pro_rata_direct");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([4, 3, 3]);
+  });
+
+  it("breaks remainder ties by input order, deterministically", () => {
+    const a = allocateShared(accts(1, 1, 1, 1), 6, "pro_rata_direct");
+    const b = allocateShared(accts(1, 1, 1, 1), 6, "pro_rata_direct");
+    expect(a.accounts.map((x) => x.allocatedMicroUsd)).toEqual([2, 2, 1, 1]);
+    expect(b.accounts.map((x) => x.allocatedMicroUsd)).toEqual(
+      a.accounts.map((x) => x.allocatedMicroUsd),
+    );
+  });
+
+  it("does not lose a unit on a large bill that divides badly", () => {
+    // Roughly the shape of the demo tenant: shared is about 47 percent of the bill.
+    const direct = [12_345_679, 7_777_777, 3_333_333, 991, 1];
+    expectReconciles(accts(...direct), 20_874_953, "pro_rata_direct");
+  });
+});
+
+describe("even split", () => {
+  it("divides the shared total by account count", () => {
+    const r = expectReconciles(accts(1_000_000, 3_000_000), 4_000_000, "even_split");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([2_000_000, 2_000_000]);
+  });
+
+  it("ignores direct spend entirely, which is why it flatters heavy accounts", () => {
+    const r = allocateShared(accts(0, 99_000_000), 1_000_000, "even_split");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([500_000, 500_000]);
+  });
+
+  it("spreads an indivisible total to the first accounts, summing exactly", () => {
+    const r = expectReconciles(accts(5, 5, 5), 100, "even_split");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([34, 33, 33]);
+  });
+});
+
+describe("awkward inputs", () => {
+  it("a single account absorbs the whole shared total under either rule", () => {
+    for (const rule of ALLOCATION_RULES) {
+      const r = expectReconciles(accts(7), 999_999, rule);
+      expect(r.accounts[0].allocatedMicroUsd).toBe(999_999);
+      expect(r.accounts[0].totalMicroUsd).toBe(1_000_006);
+    }
+  });
+
+  it("zero accounts reports the shared total as unallocated rather than dropping it", () => {
+    for (const rule of ALLOCATION_RULES) {
+      const r = expectReconciles([], 4_200_000, rule);
+      expect(r.accounts).toEqual([]);
+      expect(r.unallocatedMicroUsd).toBe(4_200_000);
+      expect(r.tenantTotalMicroUsd).toBe(4_200_000);
+    }
+  });
+
+  it("falls back to an even split when every account has zero direct spend", () => {
+    const r = expectReconciles(accts(0, 0, 0), 10, "pro_rata_direct");
+    expect(r.rule).toBe("pro_rata_direct");
+    expect(r.effectiveRule).toBe("even_split"); // the page must be able to say the rule changed
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([4, 3, 3]);
+  });
+
+  it("allocates zero to everyone when there is no shared cost, without dividing by zero", () => {
+    for (const rule of ALLOCATION_RULES) {
+      const r = expectReconciles(accts(0, 0), 0, rule);
+      expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([0, 0]);
+    }
+  });
+
+  it("no accounts and no shared cost is still consistent", () => {
+    const r = expectReconciles([], 0, "pro_rata_direct");
+    expect(r.tenantTotalMicroUsd).toBe(0);
+  });
+
+  it("gives a negative direct balance no pro-rata weight but keeps it in the totals", () => {
+    const r = expectReconciles(accts(-500, 1_000), 100, "pro_rata_direct");
+    expect(r.accounts[0].allocatedMicroUsd).toBe(0);
+    expect(r.accounts[1].allocatedMicroUsd).toBe(100);
+    expect(r.directTotalMicroUsd).toBe(500);
+    expect(r.accounts[0].totalMicroUsd).toBe(-500);
+  });
+
+  it("falls back to even split when every account balance is negative", () => {
+    const r = expectReconciles(accts(-1, -2), 7, "pro_rata_direct");
+    expect(r.effectiveRule).toBe("even_split");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([4, 3]);
+  });
+
+  it("carries the sign of a negative shared total (a cloud credit) onto the accounts", () => {
+    const r = expectReconciles(accts(1, 1, 1), -10, "pro_rata_direct");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([-4, -3, -3]);
+  });
+
+  it("keeps exact shares when weight times total exceeds the float integer range", () => {
+    // 4e15 micro-USD is a $4bn account: absurd, but weight x total is then ~4e21, far past 2^53.
+    // Float arithmetic would drift here, and drift is exactly what breaks the sum guarantee.
+    const big = 4_000_000_000_000_000;
+    const r = expectReconciles(accts(big, big, 3), 1_000_003, "pro_rata_direct");
+    expect(r.accounts.map((a) => a.allocatedMicroUsd)).toEqual([500_002, 500_001, 0]);
+  });
+});
+
+describe("inputs that would break reconciliation", () => {
+  it("rejects float dollars posing as micro-USD", () => {
+    expect(() => allocateShared(accts(1), 10.5)).toThrow(TypeError);
+    expect(() => allocateShared([{ accountId: "a", directMicroUsd: 0.1 }], 10)).toThrow(TypeError);
+  });
+
+  it("rejects non-finite money", () => {
+    expect(() => allocateShared(accts(1), Number.NaN)).toThrow(TypeError);
+    expect(() => allocateShared(accts(1), Number.POSITIVE_INFINITY)).toThrow(TypeError);
+  });
+
+  it("rejects duplicate account ids, which a caller keying by id would silently lose", () => {
+    const dupes = [
+      { accountId: "a", directMicroUsd: 1 },
+      { accountId: "a", directMicroUsd: 2 },
+    ];
+    expect(() => allocateShared(dupes, 10)).toThrow(/duplicate accountId/);
+  });
+});
+
+describe("reconciliation holds across generated inputs", () => {
+  // Deterministic pseudo-random sweep: awkward account counts, awkward totals, both rules. Seeded so
+  // a failure is reproducible rather than a flaky CI run nobody can chase down.
+  let seed = 20260825;
+  const next = () => {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    return seed / 2147483648;
+  };
+
+  it("allocated shares always sum exactly to the shared total", () => {
+    for (let trial = 0; trial < 500; trial += 1) {
+      const count = Math.floor(next() * 12); // includes 0 and 1
+      const accounts = accts(
+        ...Array.from({ length: count }, () => Math.floor(next() * 5_000_003)),
+      );
+      const shared = Math.floor(next() * 9_999_991);
+      for (const rule of ALLOCATION_RULES) {
+        expectReconciles(accounts, shared, rule);
+      }
+    }
+  });
+});

--- a/web/lib/allocation.ts
+++ b/web/lib/allocation.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Shared-cost allocation engine (CTO-192). Pure functions, no I/O.
+//
+// Direct spend (LLM, tools, vector, embeddings) carries an account on the span, so it can be
+// attributed. Compute and egress cannot: they arrive from the cloud billing connectors as one
+// synthetic span per provider per day at TENANT level, with no per-request detail. On current data
+// that is about 47 percent of the bill, so an account figure that ignores it understates the true
+// cost of every account by roughly half. Allocation is how the other half gets attributed.
+//
+// An allocated number is not a measured one, and the UI is expected to show direct and allocated as
+// separate columns with the rule named on screen (scope Decision 3). This module deliberately
+// returns both parts rather than one fused total, so a caller cannot present an estimate as a
+// measurement by accident.
+//
+// THE INVARIANT, and the reason this is its own module with its own tests: the allocated shares plus
+// whatever could not be allocated sum EXACTLY to the shared total, and direct plus allocated sums
+// exactly to the tenant total. If per-account cost does not reconcile with what `/cost` reports, the
+// feature loses trust the first time someone adds up a column.
+//
+// Money is integer micro-USD throughout (mirrors `unitEconomics.ts` and `tally.pricing`); never
+// float dollars. The division is done with BigInt because a tenant total times an account weight
+// overflows the 2^53 exact-integer range long before the bill itself gets large, and a float
+// rounding error here is precisely the bug the invariant exists to catch.
+
+/** How a tenant's shared infra cost is split across its accounts. */
+export type AllocationRule = "pro_rata_direct" | "even_split";
+
+/** All supported rules, in recommendation order. Useful for a config surface (plan item C2). */
+export const ALLOCATION_RULES: readonly AllocationRule[] = [
+  "pro_rata_direct",
+  "even_split",
+] as const;
+
+/** The rule that ships as the default: infra broadly scales with model usage. */
+export const DEFAULT_ALLOCATION_RULE: AllocationRule = "pro_rata_direct";
+
+/** One account's directly attributable spend for the window. */
+export interface AccountDirectSpend {
+  /** `AccountIdHash`, or any stable per-account key. Must be unique within the input. */
+  accountId: string;
+  /** Measured direct spend, integer micro-USD. */
+  directMicroUsd: number;
+}
+
+/** One account's allocation. `total = direct + allocated`, all integer micro-USD. */
+export interface AccountAllocation {
+  accountId: string;
+  /** Measured. */
+  directMicroUsd: number;
+  /** Estimated share of the tenant-level shared total. */
+  allocatedMicroUsd: number;
+  /** `directMicroUsd + allocatedMicroUsd`. Part measured, part estimated. */
+  totalMicroUsd: number;
+}
+
+export interface AllocationResult {
+  /** The rule that was asked for. */
+  rule: AllocationRule;
+  /**
+   * The rule actually applied. Differs from `rule` when pro rata had no denominator (every account
+   * at zero direct spend) and fell back to an even split. Surface this: a reader comparing two
+   * accounts deserves to know the named rule did not apply.
+   */
+  effectiveRule: AllocationRule;
+  /** One entry per input account, in input order. */
+  accounts: AccountAllocation[];
+  /** The tenant-level shared total that was fed in. */
+  sharedMicroUsd: number;
+  /** Sum of `allocatedMicroUsd` across accounts. */
+  allocatedTotalMicroUsd: number;
+  /**
+   * Shared cost with nowhere to go, which happens only when there are no accounts. Non-zero here
+   * means the page must show an unallocated bucket rather than quietly dropping the money.
+   */
+  unallocatedMicroUsd: number;
+  /** Sum of `directMicroUsd` across accounts. */
+  directTotalMicroUsd: number;
+  /** `directTotal + shared`. What the per-account rows must add up to. */
+  tenantTotalMicroUsd: number;
+}
+
+/**
+ * Allocate a tenant-level shared total across accounts.
+ *
+ * Guarantees, for every rule and every input:
+ *   1. `sum(allocated) + unallocated === sharedMicroUsd`
+ *   2. `sum(direct) + sum(allocated) + unallocated === tenantTotalMicroUsd`
+ *   3. every returned amount is a safe integer
+ *
+ * Rounding uses largest-remainder: each account gets the floor of its exact share, and the leftover
+ * micro-USD go one each to the largest remainders, ties broken by input order. Every unit lands
+ * somewhere and no unit lands twice, which is what makes guarantee 1 hold on totals that do not
+ * divide evenly. Deterministic, so two renders of the same window never disagree.
+ *
+ * Edge cases, decided here rather than left to the caller:
+ *
+ *   * **No accounts.** Nothing to allocate to. The whole shared total comes back as
+ *     `unallocatedMicroUsd` rather than vanishing.
+ *   * **Every account at zero direct spend.** Pro rata has no denominator. Rather than return zeros
+ *     (which would silently drop the shared half of the bill) or divide by zero, this falls back to
+ *     an even split and says so in `effectiveRule`. An account with no LLM spend in the window still
+ *     consumed infra.
+ *   * **Zero shared cost.** Every allocation is zero. No division happens at all.
+ *   * **Negative direct spend** (a credit or a corrected bill) contributes zero pro-rata weight: a
+ *     refund should not earn an account a negative share of infra it still used. The negative value
+ *     is preserved untouched in `directMicroUsd` and in the totals, so reconciliation still holds.
+ *   * **Negative shared total** (a cloud credit) is allocated by the same rules with the sign
+ *     carried through, so a credit lands on the accounts that caused the spend.
+ *
+ * Throws on inputs that would silently break reconciliation: non-integer or non-finite money, and
+ * duplicate account ids (a caller keying rows by account id would lose one).
+ */
+export function allocateShared(
+  accounts: readonly AccountDirectSpend[],
+  sharedMicroUsd: number,
+  rule: AllocationRule = DEFAULT_ALLOCATION_RULE,
+): AllocationResult {
+  assertMicroUsd(sharedMicroUsd, "sharedMicroUsd");
+
+  const seen = new Set<string>();
+  for (const a of accounts) {
+    assertMicroUsd(a.directMicroUsd, `directMicroUsd for account ${a.accountId}`);
+    if (seen.has(a.accountId)) {
+      throw new Error(`allocateShared: duplicate accountId ${a.accountId}`);
+    }
+    seen.add(a.accountId);
+  }
+
+  const directTotal = accounts.reduce((sum, a) => sum + a.directMicroUsd, 0);
+
+  if (accounts.length === 0) {
+    return {
+      rule,
+      effectiveRule: rule,
+      accounts: [],
+      sharedMicroUsd,
+      allocatedTotalMicroUsd: 0,
+      unallocatedMicroUsd: sharedMicroUsd,
+      directTotalMicroUsd: 0,
+      tenantTotalMicroUsd: sharedMicroUsd,
+    };
+  }
+
+  // Only positive direct spend earns pro-rata weight; see the negative-credit note above.
+  const weights = accounts.map((a) => (a.directMicroUsd > 0 ? BigInt(a.directMicroUsd) : 0n));
+  const weightTotal = weights.reduce((sum, w) => sum + w, 0n);
+
+  // Pro rata with no denominator is not an error, it is a tenant whose accounts had no direct spend
+  // in the window. Even split is the honest fallback, and the caller is told it happened.
+  const effectiveRule: AllocationRule =
+    rule === "pro_rata_direct" && weightTotal === 0n ? "even_split" : rule;
+
+  const shares =
+    effectiveRule === "pro_rata_direct"
+      ? largestRemainder(sharedMicroUsd, weights)
+      : largestRemainder(
+          sharedMicroUsd,
+          accounts.map(() => 1n),
+        );
+
+  const allocated = accounts.map((a, i) => ({
+    accountId: a.accountId,
+    directMicroUsd: a.directMicroUsd,
+    allocatedMicroUsd: shares[i],
+    totalMicroUsd: a.directMicroUsd + shares[i],
+  }));
+
+  return {
+    rule,
+    effectiveRule,
+    accounts: allocated,
+    sharedMicroUsd,
+    // By construction of largestRemainder this equals sharedMicroUsd. Summed rather than assumed, so
+    // the returned object stays self-consistent even if that ever stops being true.
+    allocatedTotalMicroUsd: allocated.reduce((sum, a) => sum + a.allocatedMicroUsd, 0),
+    unallocatedMicroUsd: 0,
+    directTotalMicroUsd: directTotal,
+    tenantTotalMicroUsd: directTotal + sharedMicroUsd,
+  };
+}
+
+/**
+ * Split `total` across the given weights so the parts sum exactly to `total`.
+ *
+ * Largest-remainder: floor each exact share, then hand the leftover units out one at a time to the
+ * largest fractional remainders. Sign is carried separately so a negative total (a cloud credit)
+ * rounds the same way a positive one does instead of drifting a unit per account.
+ */
+function largestRemainder(total: number, weights: readonly bigint[]): number[] {
+  const shares = weights.map(() => 0);
+  const weightTotal = weights.reduce((sum, w) => sum + w, 0n);
+  if (total === 0 || weightTotal === 0n) return shares;
+
+  const sign = total < 0 ? -1 : 1;
+  const magnitude = BigInt(Math.abs(total));
+
+  const remainders: { index: number; remainder: bigint }[] = [];
+  let assigned = 0n;
+  weights.forEach((w, index) => {
+    const exact = magnitude * w;
+    const base = exact / weightTotal; // BigInt division truncates, and both operands are >= 0 here.
+    shares[index] = Number(base) * sign;
+    assigned += base;
+    remainders.push({ index, remainder: exact % weightTotal });
+  });
+
+  // Leftover is strictly less than the weight count, so this loop is bounded by the account count.
+  let leftover = magnitude - assigned;
+  remainders.sort((a, b) => {
+    if (a.remainder === b.remainder) return a.index - b.index; // input order breaks ties, so output
+    return a.remainder > b.remainder ? -1 : 1; //                  is deterministic across renders
+  });
+  for (const { index } of remainders) {
+    if (leftover <= 0n) break;
+    shares[index] += sign;
+    leftover -= 1n;
+  }
+
+  return shares;
+}
+
+function assertMicroUsd(value: number, label: string): void {
+  if (!Number.isSafeInteger(value)) {
+    // Money is integer micro-USD everywhere in this codebase. Truncating a float here would break
+    // the reconciliation guarantee silently, which is worse than failing loudly.
+    throw new TypeError(`allocateShared: ${label} must be a safe integer micro-USD, got ${value}`);
+  }
+}


### PR DESCRIPTION
## What

Adds `web/lib/allocation.ts` and `web/lib/allocation.test.ts`: pure functions, no I/O, that attribute a tenant-level shared infra total (compute and egress) to individual accounts. Matches the house style of `web/lib/unitEconomics.ts` and `sdk/python/src/tally/projection.py`.

Two rules:

- **Pro rata on direct spend** (`pro_rata_direct`, the default). An account's share of shared cost is proportional to its direct LLM spend. Assumes infra scales with model usage, which is roughly true.
- **Even split** (`even_split`). Shared total divided by account count. Offered as an alternative; it punishes small accounts and flatters heavy ones.

The result keeps direct and allocated as separate fields rather than one fused total, so a caller cannot present an estimate as a measurement by accident.

## Why

Compute and egress arrive from the cloud billing connectors as one synthetic span per provider per day at tenant level, with no per-request detail, so they cannot be attributed to an account directly. They are about 47 percent of spend on current data. Until this lands, every per-account cost figure understates true cost by roughly half, which is the failure this product exists to fix.

## Reconciliation guarantee

The property the whole feature rests on, asserted for every rule and every input in the tests:

1. `sum(allocated) + unallocated === sharedMicroUsd`
2. `sum(direct) + sum(allocated) + unallocated === tenantTotalMicroUsd`
3. every returned amount is a safe integer

Money is integer micro-USD throughout, never float dollars. Rounding uses largest-remainder: each account gets the floor of its exact share, then leftover micro-USD go one each to the largest remainders, ties broken by input order. Every unit lands somewhere and no unit lands twice. Intermediates are BigInt, because weight times total leaves the exact-float integer range well before a realistic bill does, and a float drift here is exactly the bug the invariant exists to catch. Output is deterministic, so two renders of the same window never disagree.

Both properties are asserted on the awkward cases: a single account, zero accounts, accounts with zero direct spend, negative balances, a negative shared total, totals that do not divide evenly, values past 2^53, and a seeded sweep of 500 generated inputs against both rules.

## Edge-case decisions

- **No accounts.** Nothing to allocate to. The whole shared total comes back as `unallocatedMicroUsd` rather than vanishing, so a page can show an explicit unallocated bucket.
- **Every account at zero direct spend.** Pro rata has no denominator. Returning zeros would silently drop the shared half of the bill, so this falls back to an even split and reports it in `effectiveRule`, separate from the requested `rule`. An account with no LLM spend in the window still consumed infra, and a reader deserves to know the named rule did not apply.
- **Zero shared cost.** Every allocation is zero. No division happens at all.
- **Negative direct spend** (a credit or corrected bill) earns zero pro-rata weight, since a refund should not buy an account a negative share of infra it still used. The negative value is preserved in `directMicroUsd` and the totals, so reconciliation still holds.
- **Negative shared total** (a cloud credit) is allocated by the same rules with the sign carried through, so the credit lands on the accounts that caused the spend.
- **Throws** on non-integer or non-finite money and on duplicate account ids. Both would break reconciliation silently downstream, and failing loudly is better.

## Scope

Not wired into any page. That is CTO-193.

## Verification

From `web/`: `npm run typecheck` clean, `npm run lint` clean (only pre-existing warnings in unrelated files), `npm run test` 242 passing. The 2 failures in `app/api/api.test.ts` are the known pre-existing ones that fail locally when ClickHouse is running. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
