### PR TITLE
feat(db): add AccountIdHash to otel_spans and business_events (CTO-180)

### DIFF
--- a/db/clickhouse/attribution.sql
+++ b/db/clickhouse/attribution.sql
@@ -27,6 +27,13 @@ CREATE TABLE IF NOT EXISTS business_events
     BusinessEventId   String,
     EventName         LowCardinality(String),
     UserIdHash        FixedString(64),
+    -- Account dimension (CTO-180). Mirrors otel_spans.AccountIdHash: the tenant's own paying
+    -- customer, HMAC-SHA256 hex under the per-tenant key, never the raw id and never a name.
+    -- Value events need it for the same reason spans do. Revenue arrives per ACCOUNT (a
+    -- subscription, a contract), so margin per customer is only answerable if both sides of the
+    -- join carry the account. DEFAULT '' means every event written before this column existed
+    -- reads back as unattributed, which is a fact about our instrumentation and not a customer.
+    AccountIdHash     FixedString(64) DEFAULT '',
     OccurredAt        DateTime64(9),
     IngestedAt        DateTime64(9),
     ValueAmountMicro  Nullable(Int64),
@@ -74,3 +81,13 @@ CREATE TABLE IF NOT EXISTS unattributed_events
 )
 ENGINE = ReplacingMergeTree(LastCheckedAt)
 ORDER BY (TenantId, BusinessEventId);
+
+-- CTO-180 additive migration for business_events. Idempotent `ADD COLUMN IF NOT EXISTS` with a
+-- DEFAULT, so it is metadata-only against an existing populated table and needs no backfill:
+-- nothing ever emitted an account id, so historical events stay unattributed rather than guessed.
+--
+-- As with otel_spans, an existing deployment will NOT pick this up on its own. The compose initdb
+-- directory that mounts this file runs only on a first boot against an empty volume. Replay the
+-- canonical DDL with `make ch-migrate` from infra/ to apply it to a stack that is already running.
+ALTER TABLE business_events
+    ADD COLUMN IF NOT EXISTS AccountIdHash FixedString(64) DEFAULT '';

--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -26,6 +26,29 @@ CREATE TABLE IF NOT EXISTS otel_spans
     SessionId              String                   CODEC(ZSTD(1)),
     UserIdHash             FixedString(64)          CODEC(ZSTD(1)),  -- HMAC-SHA256 hex
     UserIdHashKeyVersion   LowCardinality(String),                  -- HMAC rotation (CTO-74)
+
+    -- Account dimension (CTO-180). The tenant's own paying customer: the company, workspace or
+    -- team that the end user belongs to. It sits between TenantId (the ai-tally customer) and
+    -- UserIdHash (an individual end user), which is a gap nothing filled before. Cost per USER
+    -- already works because UserIdHash is on every span; cost per CUSTOMER needs this grouping.
+    --
+    -- Same type and same treatment as UserIdHash: HMAC-SHA256 hex under the per-tenant key, so
+    -- an account hash cannot be reversed and cannot be joined across tenants. Raw account ids
+    -- never reach this table. AccountIdHashKeyVersion mirrors UserIdHashKeyVersion so an account
+    -- survives a key rotation the same way a user does (CTO-74).
+    --
+    -- DEFAULT '' is load-bearing. Every span written before this column existed, and every span
+    -- from a tenant that has not instrumented account_id, reads back as ''. That is the
+    -- UNATTRIBUTED bucket and callers must render it as such: it is not a customer named
+    -- "unknown", and it must never be ranked alongside real accounts.
+    --
+    -- There is deliberately NO account label / display name column here. A label is mutable
+    -- metadata: stamping it on every span wastes storage and creates a "which label wins"
+    -- question the moment an account is renamed. It would also put customer names in the
+    -- telemetry store, which is precisely what hashing the id exists to prevent. Labels live in
+    -- the Postgres control plane, keyed on this hash and joined at render time.
+    AccountIdHash          FixedString(64) DEFAULT ''  CODEC(ZSTD(1)),  -- HMAC-SHA256 hex
+    AccountIdHashKeyVersion LowCardinality(String),                     -- HMAC rotation (CTO-74)
     IdempotencyKey         String                   CODEC(ZSTD(1)),
 
     -- GenAI core (gen_ai.* semconv)
@@ -112,3 +135,19 @@ ALTER TABLE otel_spans
 ALTER TABLE otel_spans
     ADD COLUMN IF NOT EXISTS SamplingStratum LowCardinality(String) DEFAULT 'unsampled',
     ADD COLUMN IF NOT EXISTS SamplingRate    Float32                DEFAULT 1.0 CODEC(ZSTD(1));
+
+-- CTO-180 additive migration. Same idempotent pattern as CTO-118/CTO-119: `ADD COLUMN IF NOT
+-- EXISTS` plus a DEFAULT makes this metadata-only, so it applies to an already-populated table
+-- without rewriting a single part and without blocking ingest. There is no backfill step because
+-- there is nothing to backfill from: no span ever carried an account id, so historical rows stay
+-- '' and are reported as unattributed rather than guessed at.
+--
+-- APPLYING THIS TO AN EXISTING DEPLOYMENT. The compose initdb directory that mounts this file
+-- runs ONLY on a first boot against an empty volume, so a stack that is already up will never
+-- see the statement below on its own. Replay the canonical DDL with `make ch-migrate` from
+-- infra/ (every statement in db/clickhouse is IF NOT EXISTS, so replaying is safe and repeatable).
+-- This is not a hypothetical: the Postgres side of this repo has already shipped migrations
+-- (0011, 0012, 0015, 0016) that silently never reached an existing volume for exactly this reason.
+ALTER TABLE otel_spans
+    ADD COLUMN IF NOT EXISTS AccountIdHash           FixedString(64) DEFAULT '' CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS AccountIdHashKeyVersion LowCardinality(String);

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,7 +2,7 @@
 COMPOSE := docker compose
 GATEWAY := ai-tally-gateway
 
-.PHONY: help up down nuke logs ps seed demo aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
+.PHONY: help up down nuke logs ps seed demo ch-migrate aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
@@ -20,6 +20,25 @@ down: ## Stop the stack (keep data volumes)
 
 nuke: ## Stop and wipe all data volumes (DDL re-applies on next up)
 	$(COMPOSE) down -v
+
+# Canonical ClickHouse DDL, in the same dependency order compose mounts it into initdb.
+CH_DDL := ../db/clickhouse/otel_spans.sql ../db/clickhouse/rollups.sql \
+          ../db/clickhouse/last_touch_index.sql ../db/clickhouse/attribution.sql
+
+ch-migrate: ## Apply db/clickhouse DDL to a RUNNING stack (initdb only fires on a fresh volume)
+	@# The /docker-entrypoint-initdb.d mounts in docker-compose.yml run ONLY on a first boot
+	@# against an empty volume. Anyone whose stack is already up therefore never sees a new
+	@# column added to those files, which is how the Postgres side of this repo ended up with
+	@# migrations 0011/0012/0015/0016 that had silently never been applied. This target closes
+	@# that gap for ClickHouse: every statement in db/clickhouse is CREATE ... IF NOT EXISTS or
+	@# ALTER ... ADD COLUMN IF NOT EXISTS, so replaying the whole set is idempotent, cheap
+	@# (metadata-only for additive columns) and safe to run against a populated database.
+	@for f in $(CH_DDL); do \
+	  echo "  applying $$f"; \
+	  $(COMPOSE) exec -T clickhouse clickhouse-client -u tally --password tally -d default \
+	    --multiquery < $$f || exit 1; \
+	done
+	@echo "ClickHouse DDL applied."
 
 logs: ## Tail the gateway logs
 	$(COMPOSE) logs -f gateway

--- a/infra/README.md
+++ b/infra/README.md
@@ -16,6 +16,12 @@ the move to managed services later is a config change, not a rewrite.
 The canonical DDL in [`../db`](../db) is mounted into the containers and applied automatically on
 first boot — `otel_spans` and the rollup MVs into ClickHouse, the control-plane schema into Postgres.
 
+> **First boot only.** The init directory runs once, against an empty volume. A stack that is
+> already up will not pick up a column added to those files later. For ClickHouse, replay the DDL
+> with `make ch-migrate`: every statement is `IF NOT EXISTS`, so it is idempotent and safe against a
+> populated database. Postgres has no equivalent yet, which is why migrations 0011, 0012, 0015 and
+> 0016 need applying by hand on an existing volume.
+
 > The Go edge proxy (transparent OpenAI passthrough) lives in [`edge-proxy/`](./edge-proxy) and is
 > intentionally **not** wired into this Docker stack — the SDK ingestion path covers end-to-end flow
 > without it, and the proxy is a standalone, stateless binary you run wherever the customer's


### PR DESCRIPTION
Implements **CTO-180 (B1)** from `docs/cost-per-customer-plan.md`. Foundation ticket for the "Cost per customer" epic (CTO-176).

## What changed

`otel_spans` (`db/clickhouse/otel_spans.sql`):
- `AccountIdHash FixedString(64) DEFAULT '' CODEC(ZSTD(1))`
- `AccountIdHashKeyVersion LowCardinality(String)`

`business_events` (`db/clickhouse/attribution.sql`):
- `AccountIdHash FixedString(64) DEFAULT ''`

Both added to the `CREATE TABLE` bodies (fresh deployments) and as trailing idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` blocks (existing deployments), matching the CTO-118 / CTO-119 / CTO-125 pattern already in the repo.

Also adds `make ch-migrate` in `infra/Makefile` and a note in `infra/README.md`.

## Why

`otel_spans` carries `TenantId` (the ai-tally customer) and `UserIdHash` (an individual end user) with nothing between them. Cost per USER works today only because that hash is on every span; cost per CUSTOMER has no grouping to hang off. This adds the one column everything else in the epic depends on.

Design points worth reviewing:

- **Mirrors `UserIdHash` exactly.** HMAC-SHA256 hex under the per-tenant key, so an account hash cannot be reversed or joined across tenants, with a key version alongside it for rotation (CTO-74). Raw account ids never reach the telemetry store.
- **`DEFAULT ''` is load-bearing.** Every pre-existing row, and every span from a tenant that has not instrumented `account_id`, reads back as `''`. That is the *unattributed* bucket. Callers must render it as such, never as a customer named "unknown", and never ranked alongside real accounts. No backfill exists or is possible: nothing ever emitted an account id.
- **No account label / display-name column, deliberately.** A label is mutable metadata: stamping it on every span wastes storage and creates a "which label wins" question the moment an account is renamed, and it would put customer names in the telemetry store, which is exactly what hashing the id exists to prevent. Labels land in Postgres in B7 and are joined at render time.
- **No bloom-filter index on `AccountIdHash`.** Kept out of scope: per the scope doc the per-account page is served by the `daily_account_rollup` in B4, not by scanning raw spans. Easy to add later if the detail view (D4) needs it.

## Reviewer notes: applying this to an existing deployment

This is the caveat to look at. The ClickHouse DDL in `db/clickhouse` is mounted into `/docker-entrypoint-initdb.d`, which **only runs on a first boot against an empty volume**. A stack that is already up will never see the new `ALTER` statements on its own. This is not hypothetical: the Postgres side of this repo has already shipped migrations 0011, 0012, 0015 and 0016 that silently never reached an existing volume for exactly this reason.

So the PR adds `make ch-migrate` (run from `infra/`), which replays the canonical ClickHouse DDL against a running instance in the same dependency order compose mounts it. Every statement in `db/clickhouse` is `CREATE ... IF NOT EXISTS` or `ALTER ... ADD COLUMN IF NOT EXISTS`, so the replay is idempotent, metadata-only for additive columns, and safe against a populated database.

**Postgres still has no equivalent.** Out of scope here, but 0011/0012/0015/0016 remain unapplied on existing volumes and still need a hand-run. `infra/README.md` now says so rather than leaving it as folklore.

## Verification

Against the running local ClickHouse, which is populated:

- `make ch-migrate` applied cleanly. `DESCRIBE otel_spans` and `DESCRIBE business_events` show the new columns.
- 303,937 spans and 96,567 business events, all reading back as `''` (unattributed). No rewritten parts, no blocked ingest.
- Repeat run of the `ALTER` is a no-op.
- Existing queries unaffected: the per-`FeatureTag` cost aggregation returns identical results. The rollup MVs select explicit columns, so they are untouched; nothing in `web/lib` or the gateway does `SELECT *` on these tables.
- Fresh-deployment path checked by building both files into a scratch database from `CREATE TABLE` alone: both get the columns.

Required suites:
- `infra/gateway`: `uv run pytest -q` 464 passed, `uv run ruff check .` clean.
- `web/`: `npm run typecheck` clean, `npm run test` 220 passed / 2 failed. The 2 failures are the known pre-existing `app/api/api.test.ts` cases that fail when ClickHouse *is* running locally. No new failures.
- `sdk/python`: `test_otel_spans_ddl.py` and `test_views_ddl.py` still pass.

## Follow-ups (not this ticket)

B2 (SDK `account_id`), B3 (gateway `mapping.py` writes the columns), B4 (`daily_account_rollup`), B7 (Postgres label store). Until B2/B3 land, the columns are present and always empty, which is intended: this ships dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
