### PR TITLE
fix(attribution): discriminate revenue by ValueType, not a hardcoded source (CTO-194)

### DIFF
--- a/db/postgres/0022_tenant_revenue_sources.sql
+++ b/db/postgres/0022_tenant_revenue_sources.sql
@@ -1,0 +1,56 @@
+-- Per-tenant revenue source configuration for the attribution view (CTO-194).
+--
+-- queryAttribution used to sum revenue with a hardcoded `business_events.Source = 'stripe'` filter.
+-- `Source` is an unconstrained LowCardinality(String) — whatever string the ingesting connector
+-- happened to stamp on the row — so any tenant billing through something other than Stripe (or
+-- ingesting through a CDP, a backfill script, or a self-hosted biller) had every revenue event
+-- silently discarded and the VALUE/USER and MARGIN/USER columns rendered blank.
+--
+-- The correct discriminator is `business_events.ValueType`, which is a real enum:
+-- ('monetary'=1,'count'=2,'mrr'=3,'refund'=4). Engagement signals are 'count' and carry no amount;
+-- money is 'monetary' / 'mrr'; 'refund' must NET OFF rather than be ignored. This table narrows the
+-- ValueType-based default by naming which SOURCES a tenant considers revenue-bearing, for tenants
+-- who ingest monetary events from more than one system and only want some of them counted.
+--
+-- Defaults, applied when a tenant has NO row (so no existing tenant is broken by this migration):
+--   * every source counts (revenue_sources = NULL means "do not filter by Source")
+--   * ValueType IN ('monetary','mrr') counts as revenue, 'refund' subtracts, 'count' is ignored
+-- A row with a non-empty revenue_sources array restricts the sum to those sources; the ValueType
+-- rules are unchanged, because ValueType is the discriminator and Source is only ever a narrowing.
+--
+-- include_mrr exists because summing recurring 'mrr' amounts alongside one-off 'monetary' charges
+-- double counts for tenants whose biller emits both for the same subscription. Default TRUE keeps
+-- today's behaviour of counting everything monetary the tenant actually receives.
+--
+-- Reads/writes go through GET/POST /v1/tenant/revenue-sources/config — the web app never touches
+-- Postgres directly (same rule as tenant_unit_economics_config / tenant_guardrails). Companion
+-- table tenant_revenue_source_config_changes is the audit trail: every upsert appends one row keyed
+-- by a client-supplied change_id UUID, so a retried request is idempotent (both the config write and
+-- the audit row are no-ops on replay).
+
+CREATE TABLE IF NOT EXISTS tenant_revenue_source_config (
+    tenant_id        UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    -- NULL = every business_events.Source counts (the default). A non-empty array restricts the
+    -- revenue sum to those Source values. An empty array is rejected: "no source counts as revenue"
+    -- is indistinguishable from a misconfiguration and would silently blank the dashboard, which is
+    -- exactly the bug this table exists to fix.
+    revenue_sources  TEXT[],
+    include_mrr      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by       TEXT,
+    CHECK (revenue_sources IS NULL OR array_length(revenue_sources, 1) >= 1)
+);
+
+CREATE TABLE IF NOT EXISTS tenant_revenue_source_config_changes (
+    change_id   UUID NOT NULL,
+    tenant_id   UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    actor       TEXT,
+    before      JSONB,
+    after       JSONB,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, change_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_revenue_source_config_changes_tenant
+    ON tenant_revenue_source_config_changes(tenant_id, changed_at DESC);

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -103,6 +103,11 @@ from gateway.tenant_guardrails import (
 )
 from gateway.tenant_integrations import TenantIntegrationStore
 from gateway.tenant_replay import TenantReplayStore
+from gateway.tenant_revenue_sources import (
+    RevenueSourceConfigError,
+    RevenueSourceConfigInput,
+    TenantRevenueSourceStore,
+)
 from gateway.tenant_stripe import TenantStripeStore
 from gateway.tenant_unit_economics import (
     TenantUnitEconomicsStore,
@@ -179,6 +184,10 @@ async def lifespan(app: FastAPI):
     # Per-tenant LTV/CAC band thresholds (CTO-126): overrides the hardcoded B2B-SaaS defaults the
     # dashboard's ltvCacBand/paybackBand classifiers use. A tenant with no row keeps the defaults.
     app.state.tenant_unit_economics = TenantUnitEconomicsStore(settings)
+    # Per-tenant revenue source config (CTO-194): which business_events.Source values count as
+    # revenue on /attribution. A tenant with no row counts every source and discriminates on
+    # ValueType, which is what replaced the old hardcoded Source='stripe' filter.
+    app.state.tenant_revenue_sources = TenantRevenueSourceStore(settings)
     # Replay infra (CTO-113): per-tenant opt-in sampling + cross-provider projection.
     # The blob store is in-memory by default — swappable for MinIO/S3 via app.state override in
     # a deployment shim. Replay runs accumulate in-memory until ClickHouse writeback lands
@@ -1320,6 +1329,61 @@ async def upsert_tenant_unit_economics_config(
     return JSONResponse(
         {"tenant_id": tenant_id, "config": config.as_dict()}, status_code=200
     )
+
+
+@app.get("/v1/tenant/revenue-sources/config")
+def get_tenant_revenue_source_config(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Revenue source config for the caller's tenant (CTO-194).
+
+    Returns ``config: null`` when the tenant has no row — the web reader then applies the defaults
+    (every source counts; ValueType monetary + mrr are revenue; refunds net off). Same per-tenant
+    auth as the unit-economics route.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantRevenueSourceStore = app.state.tenant_revenue_sources
+    config = store.get(tenant_id)
+    return JSONResponse(
+        {"tenant_id": tenant_id, "config": config.as_dict() if config else None},
+        status_code=200,
+    )
+
+
+@app.post("/v1/tenant/revenue-sources/config")
+async def upsert_tenant_revenue_source_config(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Upsert the tenant's revenue source config. Idempotent on ``change_id`` (CTO-194).
+
+    Body: ``{revenue_sources: string[] | null, include_mrr?: bool, change_id, updated_by?}``.
+    ``revenue_sources: null`` means every source counts. An empty array is rejected (422) because
+    "nothing is revenue" silently blanks the dashboard and is never what a caller means.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    change_id = body.get("change_id")
+    if not isinstance(change_id, str) or not change_id:
+        raise HTTPException(status_code=422, detail="change_id required (uuid)")
+    try:
+        config_input = RevenueSourceConfigInput.from_json(body)
+        config = app.state.tenant_revenue_sources.upsert(
+            tenant_id,
+            config_input,
+            change_id=change_id,
+            actor=body.get("updated_by"),
+        )
+    except RevenueSourceConfigError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse({"tenant_id": tenant_id, "config": config.as_dict()}, status_code=200)
 
 
 def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, Any]:

--- a/infra/gateway/src/gateway/tenant_revenue_sources.py
+++ b/infra/gateway/src/gateway/tenant_revenue_sources.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-tenant revenue source configuration (CTO-194).
+
+The attribution view used to sum revenue with a hardcoded ``business_events.Source = 'stripe'``
+filter. ``Source`` is an unconstrained ``LowCardinality(String)`` set by whichever connector
+ingested the row, so a tenant on any other biller had every revenue event silently dropped.
+
+``business_events.ValueType`` is the correct discriminator — it is a real enum
+(``monetary`` / ``count`` / ``mrr`` / ``refund``) — and it is what the web reader keys off now.
+This module owns the optional per-tenant NARROWING of that default: which ``Source`` values count
+as revenue, and whether recurring ``mrr`` amounts are summed alongside one-off ``monetary`` ones.
+
+A tenant with no row gets the defaults (every source counts; monetary + mrr count; refunds net
+off), so the migration cannot break an existing tenant.
+
+Reads/writes go through ``GET/POST /v1/tenant/revenue-sources/config`` — the web app never touches
+Postgres directly (same rule as :mod:`gateway.tenant_unit_economics`). Every upsert appends a row to
+``tenant_revenue_source_config_changes`` keyed by a client-supplied ``change_id`` UUID, so a retried
+request is idempotent: both the config write and the audit row are no-ops on replay.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg
+from psycopg.types.json import Json
+
+from gateway.config import Settings
+
+
+class RevenueSourceConfigError(ValueError):
+    """Caller-facing validation error — surfaces as HTTP 422 in the gateway."""
+
+
+@dataclass(frozen=True, slots=True)
+class RevenueSourceConfig:
+    """One (tenant) row of revenue source configuration."""
+
+    # None means "every business_events.Source counts" — the default, and NOT the same as an empty
+    # list, which is rejected on the way in.
+    revenue_sources: tuple[str, ...] | None
+    include_mrr: bool
+    created_at: datetime | None
+    updated_at: datetime | None
+    updated_by: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "revenue_sources": list(self.revenue_sources) if self.revenue_sources else None,
+            "include_mrr": self.include_mrr,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "updated_by": self.updated_by,
+        }
+
+
+def _normalize_sources(v: object) -> tuple[str, ...] | None:
+    """Validate + canonicalize the source list.
+
+    ``None`` (or a missing key) means "every source counts". Sources are lowercased and de-duped
+    because ``business_events.Source`` is compared case-insensitively by the reader — the connector
+    ids on the /connectors page are lowercase, but hand-written config should not have to be.
+    """
+    if v is None:
+        return None
+    if isinstance(v, str) or not isinstance(v, (list, tuple)):
+        raise RevenueSourceConfigError("revenue_sources must be a list of strings or null")
+    out: list[str] = []
+    for item in v:
+        if not isinstance(item, str):
+            raise RevenueSourceConfigError("revenue_sources entries must be strings")
+        s = item.strip().lower()
+        if not s:
+            raise RevenueSourceConfigError("revenue_sources entries must be non-empty")
+        if s not in out:
+            out.append(s)
+    if not out:
+        # "No source counts as revenue" is indistinguishable from a misconfiguration and would
+        # blank the dashboard — the exact failure mode this config exists to fix. Send null to mean
+        # "all sources" instead.
+        raise RevenueSourceConfigError(
+            "revenue_sources must name at least one source, or be null for all sources"
+        )
+    return tuple(out)
+
+
+@dataclass(frozen=True, slots=True)
+class RevenueSourceConfigInput:
+    revenue_sources: tuple[str, ...] | None
+    include_mrr: bool
+    updated_by: str | None
+
+    @classmethod
+    def from_json(cls, body: object) -> "RevenueSourceConfigInput":
+        if not isinstance(body, dict):
+            raise RevenueSourceConfigError("body must be a JSON object")
+        updated_by = body.get("updated_by")
+        if updated_by is not None and not isinstance(updated_by, str):
+            raise RevenueSourceConfigError("updated_by must be a string when provided")
+        include_mrr = body.get("include_mrr", True)
+        if not isinstance(include_mrr, bool):
+            raise RevenueSourceConfigError("include_mrr must be a boolean")
+        return cls(
+            revenue_sources=_normalize_sources(body.get("revenue_sources")),
+            include_mrr=include_mrr,
+            updated_by=updated_by,
+        )
+
+
+def _row_to_config(row: tuple) -> RevenueSourceConfig:
+    sources = tuple(row[0]) if row[0] else None
+    return RevenueSourceConfig(
+        revenue_sources=sources,
+        include_mrr=bool(row[1]),
+        created_at=row[2],
+        updated_at=row[3],
+        updated_by=row[4],
+    )
+
+
+_SELECT = """
+    SELECT revenue_sources, include_mrr, created_at, updated_at, updated_by
+    FROM tenant_revenue_source_config
+    WHERE tenant_id = %s
+"""
+
+
+class TenantRevenueSourceStore:
+    """Postgres surface over ``tenant_revenue_source_config`` + its audit log.
+
+    ``get`` returns ``None`` for a tenant with no row; the web reader then applies the defaults
+    (all sources, monetary + mrr, refunds net off). ``upsert`` is idempotent on ``change_id``.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str) -> RevenueSourceConfig | None:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(_SELECT, (tenant_id,))
+            row = cur.fetchone()
+            return _row_to_config(row) if row else None
+
+    def upsert(
+        self,
+        tenant_id: str,
+        config: RevenueSourceConfigInput,
+        *,
+        change_id: str,
+        actor: str | None = None,
+    ) -> RevenueSourceConfig:
+        """Upsert the tenant's revenue source config. Idempotent on ``change_id``.
+
+        On a new change_id: capture the current row as ``before`` (NULL if absent), apply the
+        upsert, append an audit row with both before/after JSON. On a replayed change_id: no config
+        write — return the existing row unchanged.
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(_SELECT, (tenant_id,))
+            existing_row = cur.fetchone()
+            before = _row_to_config(existing_row) if existing_row else None
+
+            cur.execute(
+                """
+                INSERT INTO tenant_revenue_source_config_changes
+                    (change_id, tenant_id, actor, before, after)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, change_id) DO NOTHING
+                RETURNING change_id
+                """,
+                (
+                    change_id,
+                    tenant_id,
+                    actor or config.updated_by,
+                    Json(before.as_dict()) if before is not None else None,
+                    None,
+                ),
+            )
+            reserved = cur.fetchone()
+            if reserved is None:
+                # change_id already applied — replay is a no-op. Return the current row.
+                conn.commit()
+                if before is not None:
+                    return before
+                cur.execute(_SELECT, (tenant_id,))
+                row = cur.fetchone()
+                if row is None:
+                    raise RuntimeError("change_id reserved but config absent — out-of-band delete?")
+                return _row_to_config(row)
+
+            cur.execute(
+                """
+                INSERT INTO tenant_revenue_source_config
+                    (tenant_id, revenue_sources, include_mrr, updated_by)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (tenant_id) DO UPDATE
+                  SET revenue_sources = EXCLUDED.revenue_sources,
+                      include_mrr     = EXCLUDED.include_mrr,
+                      updated_by      = EXCLUDED.updated_by,
+                      updated_at      = now()
+                RETURNING revenue_sources, include_mrr, created_at, updated_at, updated_by
+                """,
+                (
+                    tenant_id,
+                    list(config.revenue_sources) if config.revenue_sources else None,
+                    config.include_mrr,
+                    config.updated_by,
+                ),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            after = _row_to_config(row)
+
+            cur.execute(
+                """
+                UPDATE tenant_revenue_source_config_changes
+                SET after = %s
+                WHERE tenant_id = %s AND change_id = %s
+                """,
+                (Json(after.as_dict()), tenant_id, change_id),
+            )
+            conn.commit()
+            return after

--- a/infra/gateway/tests/test_app_tenant_revenue_sources.py
+++ b/infra/gateway/tests/test_app_tenant_revenue_sources.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""/v1/tenant/revenue-sources/config — round-trip + idempotency + validation (CTO-194)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_revenue_sources import (
+    RevenueSourceConfig,
+    RevenueSourceConfigError,
+    RevenueSourceConfigInput,
+)
+
+T = "t-acme"
+
+
+class FakeRevenueSourceStore:
+    """In-memory stand-in mirroring TenantRevenueSourceStore's idempotent-on-change_id contract."""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, RevenueSourceConfig] = {}
+        self._changes: set[tuple[str, str]] = set()
+
+    def get(self, tenant_id: str) -> RevenueSourceConfig | None:
+        return self._rows.get(tenant_id)
+
+    def upsert(
+        self,
+        tenant_id: str,
+        config: RevenueSourceConfigInput,
+        *,
+        change_id: str,
+        actor: str | None = None,
+    ) -> RevenueSourceConfig:
+        key = (tenant_id, change_id)
+        if key in self._changes:
+            # Replay: no write, return current row unchanged.
+            return self._rows[tenant_id]
+        self._changes.add(key)
+        row = RevenueSourceConfig(
+            revenue_sources=config.revenue_sources,
+            include_mrr=config.include_mrr,
+            created_at=None,
+            updated_at=None,
+            updated_by=config.updated_by,
+        )
+        self._rows[tenant_id] = row
+        return row
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_revenue_sources = FakeRevenueSourceStore()
+        yield c
+
+
+def _payload(change_id: str = "chg-1", **overrides):
+    base = {
+        "revenue_sources": ["Stripe", "chargebee"],
+        "include_mrr": True,
+        "change_id": change_id,
+        "updated_by": "finance@acme.test",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_get_absent_returns_null_config(client: TestClient) -> None:
+    # No row means "use the defaults" — the web reader must never be handed a fabricated config.
+    r = client.get("/v1/tenant/revenue-sources/config", headers={"X-Tenant-Id": T})
+    assert r.status_code == 200, r.text
+    assert r.json()["config"] is None
+
+
+def test_upsert_round_trips_and_normalizes_sources(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/revenue-sources/config", headers={"X-Tenant-Id": T}, json=_payload()
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["revenue_sources"] == ["stripe", "chargebee"]
+
+    got = client.get("/v1/tenant/revenue-sources/config", headers={"X-Tenant-Id": T})
+    assert got.json()["config"]["revenue_sources"] == ["stripe", "chargebee"]
+    assert got.json()["config"]["include_mrr"] is True
+
+
+def test_null_sources_means_every_source_counts(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/revenue-sources/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(revenue_sources=None),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["revenue_sources"] is None
+
+
+def test_empty_source_list_rejected(client: TestClient) -> None:
+    # "Nothing is revenue" silently blanks the dashboard — the exact bug CTO-194 fixes.
+    r = client.post(
+        "/v1/tenant/revenue-sources/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(revenue_sources=[]),
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"revenue_sources": "stripe"},
+        {"revenue_sources": [1]},
+        {"revenue_sources": ["  "]},
+        {"include_mrr": "yes"},
+    ],
+)
+def test_validation_errors(client: TestClient, bad: dict) -> None:
+    r = client.post(
+        "/v1/tenant/revenue-sources/config", headers={"X-Tenant-Id": T}, json=_payload(**bad)
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_change_id_required(client: TestClient) -> None:
+    body = _payload()
+    del body["change_id"]
+    r = client.post("/v1/tenant/revenue-sources/config", headers={"X-Tenant-Id": T}, json=body)
+    assert r.status_code == 422, r.text
+
+
+def test_replayed_change_id_is_a_no_op(client: TestClient) -> None:
+    first = client.post(
+        "/v1/tenant/revenue-sources/config", headers={"X-Tenant-Id": T}, json=_payload()
+    )
+    assert first.status_code == 200
+    # Same change_id, different body: the replay must not apply the new values.
+    replay = client.post(
+        "/v1/tenant/revenue-sources/config",
+        headers={"X-Tenant-Id": T},
+        json=_payload(revenue_sources=["paddle"]),
+    )
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["config"]["revenue_sources"] == ["stripe", "chargebee"]
+
+
+def test_input_defaults_include_mrr_true() -> None:
+    cfg = RevenueSourceConfigInput.from_json({"revenue_sources": None})
+    assert cfg.include_mrr is True
+    assert cfg.revenue_sources is None
+
+
+def test_input_rejects_non_object_body() -> None:
+    with pytest.raises(RevenueSourceConfigError):
+        RevenueSourceConfigInput.from_json(["stripe"])

--- a/web/lib/attribution.ts
+++ b/web/lib/attribution.ts
@@ -31,8 +31,9 @@ export interface ProviderAttribution {
   conversionRate: number;
   conversionRateLo: number;
   conversionRateHi: number;
-  // Revenue per distinct user, from Stripe business_events (CTO-110). Null when no
-  // revenue events exist yet for the tenant — we surface "—" rather than fabricate.
+  // Revenue per distinct user, from the money-typed business_events of the tenant's configured
+  // revenue sources (CTO-110, CTO-194 — no longer Stripe-only). Null when no revenue events exist
+  // yet for the tenant — we surface "—" rather than fabricate.
   valuePerUserMicroUsd: MicroUSD | null;
   // Margin per distinct user = value/user − cost/user. Null when value/user is null.
   marginPerUserMicroUsd: MicroUSD | null;

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -41,6 +41,12 @@ import {
   emptyReport,
 } from "./attribution";
 import type { GuardrailMode, GuardrailRule, GuardrailScopeKind } from "./guardrails";
+import {
+  REFUND_VALUE_TYPE,
+  positiveValueTypes,
+  queryRevenuePolicy,
+  revenueSourceFilter,
+} from "./revenueSources";
 
 const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
@@ -1280,6 +1286,11 @@ export async function queryAttribution(
   filters: AttributionFilters,
 ): Promise<AttributionReport | null> {
   return tryLive(async (db, tenant) => {
+    // CTO-194: which sources/value types count as revenue for this tenant. Resolved from the
+    // control plane, and falls back to the defaults (all sources, monetary + mrr, refunds net off)
+    // when the tenant has no row or the gateway is unreachable — it never throws, so a gateway
+    // outage degrades to the default policy rather than blanking the whole attribution report.
+    const policy = await queryRevenuePolicy();
     const outcomeName = filters.outcome ?? "conversion";
     const tagSql = filters.tag ? `AND s.FeatureTag = {tag:String}` : "";
     // CTO-106: prefer the typed GenAiSystem column (the real shape post-CTO-106),
@@ -1339,10 +1350,24 @@ export async function queryAttribution(
       convByProvider.set(r.provider, parseInt(r.conversions, 10) || 0);
     }
 
-    // Revenue per provider (CTO-110): sum (conversion + subscription_renewal) − |refund|, and
-    // count distinct paying users. Joined on UserIdHash the same way as conversion counts. The
-    // sum is in USD decimal (ClickHouse Decimal arithmetic on Int64 micro), we then convert to
-    // integer micro-USD at the boundary like everywhere else.
+    // Revenue per provider (CTO-110, reworked in CTO-194).
+    //
+    // This used to require `b.Source = 'stripe'` and key off EventName. Both were wrong: `Source`
+    // is an unconstrained LowCardinality(String) chosen by whichever connector ingested the row, so
+    // any tenant on a non-Stripe biller had 100% of its revenue silently dropped, and EventName is
+    // equally freeform. `ValueType` is the real discriminator — a ClickHouse enum of
+    // ('monetary'=1,'count'=2,'mrr'=3,'refund'=4) — so we sum the money-typed events and subtract
+    // refunds, which net off rather than being ignored. Source is now only ever a per-tenant
+    // NARROWING, and absent config means every source counts (see lib/revenueSources.ts).
+    //
+    // `users` counts only users who actually carry a revenue-typed event; a user whose only event
+    // is a 'count' engagement signal must not dilute value/user into a fabricated number.
+    //
+    // ValueAmountMicro is Nullable(Int64), so `sumIf` over a group with no matching row yields NULL
+    // rather than 0 and the NULL then swallows the whole subtraction. The `ifNull(..., 0)` inside
+    // each sumIf is what keeps a tenant with zero refunds from reporting NULL revenue.
+    const positiveTypes = positiveValueTypes(policy);
+    const sourceFilter = revenueSourceFilter(policy, "b");
     const revenueRows = await rowsP<{
       provider: string;
       revenue: string;
@@ -1351,19 +1376,30 @@ export async function queryAttribution(
       db,
       `SELECT
          ${providerExpr} AS provider,
-         (sumIf(b.ValueAmountMicro, b.EventName IN ('conversion', 'subscription_renewal'))
-            - sumIf(abs(b.ValueAmountMicro), b.EventName = 'refund')) / 1000000 AS revenue,
-         uniqExact(b.UserIdHash) AS users
+         (sumIf(ifNull(b.ValueAmountMicro, 0), b.ValueType IN {positiveTypes:Array(String)})
+            - sumIf(abs(ifNull(b.ValueAmountMicro, 0)), b.ValueType = {refundType:String}))
+           / 1000000 AS revenue,
+         uniqExactIf(
+           b.UserIdHash,
+           b.ValueType IN {positiveTypes:Array(String)} OR b.ValueType = {refundType:String}
+         ) AS users
        FROM business_events b
        INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
-         AND b.Source = 'stripe'
          AND b.OccurredAt >= now() - INTERVAL 30 DAY
          AND b.UserIdHash != ''
+         ${sourceFilter.sql}
          ${tagSql}
          ${providerSql}
        GROUP BY provider`,
-      { tenant, tag: filters.tag ?? "", provider: filters.provider ?? "" },
+      {
+        tenant,
+        tag: filters.tag ?? "",
+        provider: filters.provider ?? "",
+        positiveTypes,
+        refundType: REFUND_VALUE_TYPE,
+        ...sourceFilter.params,
+      },
     );
     const revenueByProvider = new Map<
       string,

--- a/web/lib/revenueSources.test.ts
+++ b/web/lib/revenueSources.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// CTO-194: the revenue policy that replaced the hardcoded Source='stripe' filter.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_REVENUE_POLICY,
+  REFUND_VALUE_TYPE,
+  policyFromApi,
+  positiveValueTypes,
+  revenueSourceFilter,
+  type RevenueSourceConfigApi,
+} from "./revenueSources";
+
+function api(overrides: Partial<RevenueSourceConfigApi> = {}): RevenueSourceConfigApi {
+  return {
+    revenue_sources: null,
+    include_mrr: true,
+    created_at: null,
+    updated_at: null,
+    updated_by: null,
+    ...overrides,
+  };
+}
+
+describe("policyFromApi", () => {
+  it("uses the defaults when the tenant has no config row", () => {
+    // The whole point of the migration: an unconfigured tenant must keep working.
+    expect(policyFromApi(null)).toEqual(DEFAULT_REVENUE_POLICY);
+    expect(policyFromApi(null).sources).toBeNull();
+  });
+
+  it("lowercases and de-dupes the configured sources", () => {
+    const p = policyFromApi(api({ revenue_sources: ["Stripe", " stripe ", "Chargebee"] }));
+    expect(p.sources).toEqual(["stripe", "chargebee"]);
+  });
+
+  it("treats an unusable source list as all-sources rather than no-revenue", () => {
+    // Blanking the dashboard on bad config is the exact bug this replaced.
+    expect(policyFromApi(api({ revenue_sources: [] })).sources).toBeNull();
+    expect(policyFromApi(api({ revenue_sources: ["  "] })).sources).toBeNull();
+  });
+
+  it("honours include_mrr, defaulting to true", () => {
+    expect(policyFromApi(api({ include_mrr: false })).includeMrr).toBe(false);
+    expect(policyFromApi(api()).includeMrr).toBe(true);
+  });
+});
+
+describe("positiveValueTypes", () => {
+  it("counts monetary and mrr by default, never count or refund", () => {
+    const types = positiveValueTypes(DEFAULT_REVENUE_POLICY);
+    expect(types).toEqual(["monetary", "mrr"]);
+    expect(types).not.toContain("count");
+    expect(types).not.toContain(REFUND_VALUE_TYPE);
+  });
+
+  it("drops mrr when the tenant opted out", () => {
+    expect(positiveValueTypes({ sources: null, includeMrr: false })).toEqual(["monetary"]);
+  });
+});
+
+describe("revenueSourceFilter", () => {
+  it("emits no filter when every source counts", () => {
+    const f = revenueSourceFilter(DEFAULT_REVENUE_POLICY, "b");
+    expect(f.sql).toBe("");
+    expect(f.params).toEqual({});
+  });
+
+  it("binds the source list as a parameter rather than interpolating it", () => {
+    // Source values are tenant-supplied strings; they must never be spliced into SQL.
+    const f = revenueSourceFilter({ sources: ["chargebee"], includeMrr: true }, "b");
+    expect(f.sql).toBe("AND lower(b.Source) IN {revenueSources:Array(String)}");
+    expect(f.params).toEqual({ revenueSources: ["chargebee"] });
+    expect(f.sql).not.toContain("chargebee");
+  });
+});

--- a/web/lib/revenueSources.ts
+++ b/web/lib/revenueSources.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Which business events count as revenue, per tenant (CTO-194).
+//
+// The attribution revenue sum used to be gated on a hardcoded `business_events.Source = 'stripe'`.
+// `Source` is an unconstrained LowCardinality(String) stamped by whichever connector ingested the
+// row, so every tenant not billing through Stripe had its revenue silently dropped and the
+// VALUE/USER and MARGIN/USER columns rendered blank. On the local demo tenant that discarded ~14.8k
+// monetary events worth ~$1.7M, all carrying Source='vercel-chatbot-backfill'.
+//
+// `business_events.ValueType` is the correct discriminator: it is a real ClickHouse enum
+// ('monetary'=1,'count'=2,'mrr'=3,'refund'=4). Engagement signals are 'count' and carry no amount;
+// money is 'monetary'/'mrr'; refunds must NET OFF rather than be ignored.
+//
+// Per-tenant config (GET/POST /v1/tenant/revenue-sources/config, backed by Postgres — the web app
+// never touches Postgres directly, same rule as web/lib/unitEconomicsConfig.ts) only ever NARROWS
+// that default, by naming which sources a tenant considers revenue-bearing. A tenant with no row,
+// or an unreachable gateway (CI / fresh clone), gets the defaults, so nothing is broken by absence.
+
+/** Value types that carry money. Mirrors the ClickHouse enum in db/clickhouse/attribution.sql. */
+export const POSITIVE_VALUE_TYPES = ["monetary", "mrr"] as const;
+export const REFUND_VALUE_TYPE = "refund";
+
+/** Resolved policy the ClickHouse query builds its revenue expression from. */
+export interface RevenuePolicy {
+  /**
+   * Source values that count as revenue, lowercased. `null` means "every source counts" — the
+   * default, and deliberately distinct from an empty list (which the gateway rejects, because
+   * "nothing is revenue" is a misconfiguration that silently blanks the dashboard).
+   */
+  sources: string[] | null;
+  /**
+   * Whether recurring `mrr` amounts are summed alongside one-off `monetary` charges. Default true.
+   * Tenants whose biller emits both for the same subscription can turn this off to stop double
+   * counting.
+   */
+  includeMrr: boolean;
+}
+
+/** Defaults applied when the tenant has no config row. */
+export const DEFAULT_REVENUE_POLICY: RevenuePolicy = { sources: null, includeMrr: true };
+
+/** Wire shape of the gateway's config object (snake_case, matching the Postgres columns). */
+export interface RevenueSourceConfigApi {
+  revenue_sources: string[] | null;
+  include_mrr: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+  updated_by: string | null;
+}
+
+/** Map the gateway's snake_case config onto a resolved policy, falling back to the defaults. */
+export function policyFromApi(cfg: RevenueSourceConfigApi | null): RevenuePolicy {
+  if (!cfg) return DEFAULT_REVENUE_POLICY;
+  const raw = Array.isArray(cfg.revenue_sources) ? cfg.revenue_sources : null;
+  const sources = raw
+    ? Array.from(new Set(raw.map((s) => String(s).trim().toLowerCase()).filter(Boolean)))
+    : null;
+  return {
+    // An empty array after cleaning means the row said nothing usable. Treat that as "all sources"
+    // rather than "no revenue exists" — blanking the dashboard on bad config is the original bug.
+    sources: sources && sources.length > 0 ? sources : null,
+    includeMrr: cfg.include_mrr !== false,
+  };
+}
+
+/** The ValueType values that count positively under this policy. */
+export function positiveValueTypes(policy: RevenuePolicy): string[] {
+  return policy.includeMrr ? [...POSITIVE_VALUE_TYPES] : ["monetary"];
+}
+
+/**
+ * SQL fragment restricting a `business_events` alias to the tenant's revenue sources, plus the
+ * bound parameter it needs. Empty fragment when every source counts.
+ *
+ * `lower(Source)` matches the normalization the gateway applies on write and mirrors how
+ * queryConnectorActivity already compares Source values.
+ */
+export function revenueSourceFilter(
+  policy: RevenuePolicy,
+  alias: string,
+): { sql: string; params: Record<string, unknown> } {
+  if (!policy.sources) return { sql: "", params: {} };
+  return {
+    sql: `AND lower(${alias}.Source) IN {revenueSources:Array(String)}`,
+    params: { revenueSources: policy.sources },
+  };
+}
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+
+/**
+ * Fetch the tenant's revenue policy. Never throws and never returns null: a tenant with no row or
+ * an unreachable gateway yields DEFAULT_REVENUE_POLICY, which is the pre-existing behaviour for
+ * every tenant that was never configured.
+ */
+export async function queryRevenuePolicy(): Promise<RevenuePolicy> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-sources/config`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return DEFAULT_REVENUE_POLICY;
+    const body = (await res.json()) as { config: RevenueSourceConfigApi | null };
+    return policyFromApi(body.config ?? null);
+  } catch {
+    return DEFAULT_REVENUE_POLICY;
+  }
+}


### PR DESCRIPTION
## What changed

`queryAttribution` in `web/lib/clickhouse.ts` summed revenue behind `AND b.Source = 'stripe'`. `business_events.Source` is an unconstrained `LowCardinality(String)` stamped by whichever connector ingested the row, so any tenant not billing through Stripe had 100% of its revenue silently discarded.

Verified on the local demo tenant before touching anything:

```
Source                    EventName          ValueType  count   sum($)
vercel-chatbot-backfill   positive_feedback  count      81364   NULL
vercel-chatbot-backfill   conversion         monetary   14789   1776438.37
vercel-chatbot            session_engaged    count        235   NULL
vercel-chatbot            positive_feedback  count        102   NULL
vercel-chatbot            conversion         monetary      77   NULL
```

Zero rows with `Source = 'stripe'`. That is why VALUE/USER and MARGIN/USER rendered blank on `/attribution`.

The fix does not loosen the filter. `business_events.ValueType` is the correct discriminator because it is a real ClickHouse enum (`'monetary'=1,'count'=2,'mrr'=3,'refund'=4`): engagement signals are `count` and carry no amount, money is `monetary`/`mrr`, and refunds now **net off** instead of being ignored. The old query also keyed off `EventName IN ('conversion','subscription_renewal')` vs `'refund'`, which is exactly as freeform as `Source`; that is gone too.

`Source` becomes an optional per-tenant **narrowing** rather than a filter that has to match:

- `db/postgres/0022_tenant_revenue_sources.sql` — `tenant_revenue_source_config` (`revenue_sources TEXT[]` nullable, `include_mrr`) plus a `_changes` audit table, modelled on `0019_tenant_unit_economics_config.sql`.
- `infra/gateway/src/gateway/tenant_revenue_sources.py` — store, validation, idempotent-on-`change_id` upsert.
- `GET/POST /v1/tenant/revenue-sources/config` in `app.py`. The web app never touches Postgres directly, same rule as `tenant_unit_economics`.
- `web/lib/revenueSources.ts` — server-only reader plus the pure policy/SQL-fragment helpers.
- `web/lib/clickhouse.ts` — the reworked revenue query.

Defaults with **no config row**: every source counts, `monetary` + `mrr` count, `refund` subtracts, `count` is ignored. An unreachable gateway (CI, fresh clone) resolves to the same defaults instead of blanking the report, so nothing regresses for existing tenants.

Two smaller correctness points folded in:

- `users` is now `uniqExactIf(...)` over revenue-typed rows only. Previously a user whose only event was a `count` engagement signal inflated the denominator and diluted value/user into a number that was quietly wrong.
- A latent NULL bug inherited from the old expression: `sumIf` over the `Nullable(Int64)` `ValueAmountMicro` returns NULL for a group with no matching row, so on a tenant with zero refunds the refund term swallowed the whole subtraction and revenue came back NULL. I hit this while verifying the new query against live ClickHouse. Each `sumIf` now zero-fills.

## Acceptance

`/api/attribution` against the running local stack, `isMock: false`:

| provider  | value/user | margin/user | margin % |
|-----------|-----------:|------------:|---------:|
| openai    | $303.06    | $299.83     | 98.9%    |
| anthropic | $301.88    | $297.77     | 98.6%    |

Previously both money columns were `null`. A tenant on a non-Stripe biller is no longer silently excluded: with no config row every source counts, and the gateway rejects an empty `revenue_sources` array (422) precisely because "nothing is revenue" silently blanks the dashboard, which is the bug being fixed.

## Finding: `attribution_records` is empty, and that is expected

`attribution_records` has **0 rows** for `local-dev`, and so does `unattributed_events`. `last_touch_index` has **137,983** rows, so the ingest side is healthy — the materialized view in `db/clickhouse/last_touch_index.sql` is populating normally.

The stitcher has never run because **no production runner exists**. `sdk/python/src/tally/stitcher.py` is deliberately a pure in-memory library ("The stitcher is intentionally a pure library here: it operates on in-memory inputs... a backend implementing `TouchStore` is the only thing that changes"). Grepping the whole repo, the only non-test references to `attribution_records` are:

- `web/lib/clickhouse.ts` — readers (`queryFeatureEconomics`, the data-quality counters)
- `infra/gateway/src/gateway/bq_export.py` / `athena_export.py` — export *sources*
- the DDL and the export docs

There is no ClickHouse-backed `TouchStore`, no worker calling `stitch()`, and no writer of `attribution_records` or `unattributed_events` anywhere. So this is not a broken stitcher, it is an unimplemented one — the gap between the CTO-69 library and a deployed runner.

**Not fixed here, and intentionally so.** Doing it properly means a ClickHouse `TouchStore` over `last_touch_index` + `identity_graph`, per-tenant `AttributionRule` config (another control-plane table), a scheduled worker, ClickHouse writeback for both output tables, and the late-edge restitch path from §7.1. That is its own ticket, and it is independent of this one: `/attribution` joins `business_events` to `otel_spans` directly on `UserIdHash` and never reads `attribution_records`. What *is* blocked is the `/features` view — `queryFeatureEconomics` reads `attribution_records` exclusively, so per-feature value, payback, and attribution rate are honest-null today for every tenant.

## Reviewer notes

- The `Source` config is a narrowing only. If you are wondering whether a misconfigured row can reproduce the original bug: an empty array is rejected at the API (422) and at the DB (`CHECK`), and `policyFromApi` degrades an unusable list to "all sources" rather than "no revenue".
- Source values are bound as `{revenueSources:Array(String)}`, never interpolated. There is a test asserting the fragment does not contain the value.
- `include_mrr` defaults to true. It exists because summing recurring `mrr` alongside one-off `monetary` double counts for billers that emit both for the same subscription. The demo data has no `mrr` or `refund` rows, so those paths are covered by unit tests rather than by the live verification above.
- Migration is additive and needs no backfill.

## Verification

- `web/`: `npm run typecheck` clean, `npm run lint` clean (2 pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`, untouched files), `npm run test` 228 passed / 2 failed.
- The 2 failures are the documented pre-existing ones that fail when ClickHouse *is* running (`GET /api/data-quality`, `GET /api/attribution falls back to mock`). Confirmed identical on a stashed tree: 2 failed / 220 passed before, 2 failed / 228 passed after. **No new failures**; the 8 new tests are `web/lib/revenueSources.test.ts`.
- `infra/gateway`: `uv run --extra dev pytest -q` 476 passed, `uv run --extra dev ruff check .` clean. 12 new tests in `tests/test_app_tenant_revenue_sources.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
