### PR TITLE
feat(clickhouse): daily_account_rollup table and materialized view (CTO-183)

### DIFF
--- a/db/clickhouse/account_rollups.sql
+++ b/db/clickhouse/account_rollups.sql
@@ -1,0 +1,139 @@
+-- Account rollup materialized view (ai-tally telemetry store)
+-- Implements CTO-183 (B4). Builds on CTO-180, which added otel_spans.AccountIdHash.
+--
+-- WHY THIS TABLE EXISTS. The per-customer cost tab answers "what does each of my customers cost
+-- me?". Without a rollup that question is a scan of otel_spans grouped by AccountIdHash, and
+-- AccountIdHash is nowhere near the front of that table's ORDER BY
+-- (TenantId, FeatureTag, ServiceName, SpanName, Timestamp) — so ClickHouse cannot skip a single
+-- granule on the account dimension and the query degrades into a full tenant scan. That is
+-- survivable for a tenant with a dozen accounts and is not survivable for a tenant with thousands,
+-- which is exactly the shape of customer this tab is built for.
+--
+-- WHAT IT MAKES FAST. ORDER BY leads with (TenantId, AccountIdHash, Day), so the two reads the tab
+-- actually issues both become index range scans instead of scans:
+--   1. rank every account for a tenant over a window   -> one contiguous range per tenant
+--   2. drill into ONE account's cost over time         -> one contiguous range per account
+-- It also outlives raw retention. otel_spans drops raw rows at 90d (CTO-22/CTO-29); this rollup is
+-- an independent table with no such TTL, so per-customer history keeps working after the spans
+-- behind it are gone. Same reasoning as daily_feature_rollup in rollups.sql.
+--
+-- WHY IT IS SEPARATE FROM daily_feature_rollup. That table's key is
+-- (TenantId, FeatureTag, GenAiResponseModel, Day) with no account dimension at all, so it cannot
+-- answer a per-customer question. Adding AccountIdHash to it instead would multiply every existing
+-- row by the account cardinality and slow down the dashboard queries that read it today. A second
+-- narrow table is cheaper than widening the hot one.
+--
+-- WHY GenAiOperation IS CARRIED. It is the input to the six-layer cost split (llm, tools,
+-- embeddings, vector, compute, egress) — see LAYER_CASE in web/lib/clickhouse.ts, which maps
+-- operation to layer with a multiIf. Keeping the raw operation here rather than a pre-computed
+-- layer string means the mapping stays owned by one place in the app and can be corrected without
+-- rebuilding this table. It is also what lets a later change separate DIRECT customer cost from
+-- ALLOCATED shared cost (allocation keys off the operation) without a second table.
+--
+-- Columns follow daily_feature_rollup exactly: Decimal64(8) for money (never Float64), and
+-- UserCountState as an AggregateFunction state. Query the state with the -Merge combinator:
+--   SELECT uniqMerge(UserCountState) FROM daily_account_rollup WHERE ...
+-- Summing UserCountState or reading it raw is meaningless.
+--
+-- AccountIdHash = '' is the UNATTRIBUTED bucket, not a customer. Callers must render it as such
+-- and must never rank it alongside real accounts. See the CTO-180 comment in otel_spans.sql.
+
+CREATE TABLE IF NOT EXISTS daily_account_rollup
+(
+    TenantId            LowCardinality(String),
+    Day                 Date,
+    AccountIdHash       FixedString(64),
+    FeatureTag          LowCardinality(String),
+    GenAiOperation      LowCardinality(String),
+    EstimatedCost       Decimal64(8),
+    ReconciledCost      Decimal64(8),
+    SpanCount           UInt64,
+    UserCountState      AggregateFunction(uniq, FixedString(64))
+)
+ENGINE = SummingMergeTree
+PARTITION BY toYYYYMM(Day)
+-- The (TenantId, AccountIdHash, Day) PREFIX is the access path the per-customer tab needs, and it
+-- leads deliberately: TenantId first is load-bearing on a shared cluster (CTO-18), AccountIdHash
+-- second is what turns "rank thousands of accounts" into a range scan, Day third bounds the window.
+--
+-- FeatureTag and GenAiOperation are appended to the key rather than left out of it, and that is
+-- required for correctness, not a preference. SummingMergeTree collapses rows that share the
+-- FULL sorting key and gives every non-key, non-aggregate column an ARBITRARY value from the
+-- collapsed set. Were these two columns outside the key, a background merge would quietly fold a
+-- day's rows for an account together and stamp whichever FeatureTag and GenAiOperation it happened
+-- to see last onto the summed total — silently destroying the per-layer split this table carries
+-- them for. Appending them keeps the prefix, and therefore the fast path, exactly as intended
+-- while making the grain of a row honest: one row per account per day per feature per operation.
+ORDER BY (TenantId, AccountIdHash, Day, FeatureTag, GenAiOperation);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS daily_account_rollup_mv
+TO daily_account_rollup
+AS SELECT
+    TenantId,
+    toDate(Timestamp)                      AS Day,
+    AccountIdHash,
+    FeatureTag,
+    GenAiOperation,
+    sum(EstimatedCost)                     AS EstimatedCost,
+    -- ReconciledCost is Nullable on otel_spans and NOT NULL here. ifNull(..., 0) is what makes the
+    -- SummingMergeTree column safe to sum: a NULL would poison the total. A day that has not been
+    -- reconciled therefore reads as 0 reconciled, and callers compare against EstimatedCost rather
+    -- than treating 0 as "this cost nothing".
+    sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+    count()                                AS SpanCount,
+    uniqState(UserIdHash)                  AS UserCountState
+FROM otel_spans
+GROUP BY TenantId, Day, AccountIdHash, FeatureTag, GenAiOperation;
+
+-- APPLYING THIS TO AN EXISTING DEPLOYMENT, AND BACKFILLING.
+--
+-- Two separate problems, and skipping either one leaves the tab reading an empty table.
+--
+-- 1. GETTING THE DDL IN. compose mounts db/clickhouse into /docker-entrypoint-initdb.d, which runs
+--    ONLY on a first boot against an empty volume. A stack that is already up will never execute
+--    the statements above on its own. Replay the canonical DDL with `make ch-migrate` from infra/
+--    (this file is in that target's CH_DDL list and in the compose mount list). Every statement
+--    here is CREATE ... IF NOT EXISTS, so replaying is idempotent and safe against a populated
+--    database. This is not hypothetical: the Postgres side of this repo has already shipped
+--    migrations (0011, 0012, 0015, 0016) that silently never reached an existing volume this way.
+--
+-- 2. GETTING THE EXISTING DATA IN. A ClickHouse materialized view is an INSERT trigger, not a
+--    view over history. daily_account_rollup_mv captures rows inserted AFTER it is created and
+--    nothing before, so on any database that already holds spans the table starts empty and then
+--    silently begins mid-history. Backfill explicitly, once, right after creating the MV:
+--
+--      INSERT INTO daily_account_rollup
+--      SELECT
+--          TenantId,
+--          toDate(Timestamp)                              AS Day,
+--          AccountIdHash,
+--          FeatureTag,
+--          GenAiOperation,
+--          sum(EstimatedCost)                             AS EstimatedCost,
+--          sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+--          count()                                        AS SpanCount,
+--          uniqState(UserIdHash)                          AS UserCountState
+--      FROM otel_spans
+--      WHERE Timestamp < '<cutoff>'          -- see the double-count warning below
+--      GROUP BY TenantId, Day, AccountIdHash, FeatureTag, GenAiOperation;
+--
+--    DOUBLE COUNTING IS THE ONLY REAL HAZARD. The MV is already live by the time the backfill runs,
+--    so any span inserted after MV creation is counted by the MV AND would be counted again by an
+--    unbounded backfill. SummingMergeTree adds those rows together rather than rejecting them, so
+--    the damage is silent inflated cost. Pick a `<cutoff>` at or before the MV creation time and
+--    backfill strictly below it. If a backfill is ever run wrong, do not try to subtract: TRUNCATE
+--    the table and redo both steps, because the source of truth is otel_spans and rebuilding is
+--    cheap for as long as the raw rows are still inside the 90d retention window.
+--
+--    Backfill month by month (`AND toYYYYMM(Timestamp) = 202601`) on a large table to keep peak
+--    memory bounded — the GROUP BY is over the whole scanned range otherwise.
+--
+--    VERIFY after backfilling. The rollup must reconcile exactly against the raw table:
+--
+--      SELECT sum(EstimatedCost), sum(SpanCount) FROM daily_account_rollup
+--       WHERE TenantId = 'local-dev' AND Day >= today() - 29;
+--      SELECT sum(EstimatedCost), count()        FROM otel_spans
+--       WHERE TenantId = 'local-dev' AND toDate(Timestamp) >= today() - 29;
+--
+--    Costs are Decimal64(8) on both sides, so this is an exact equality, not an approximate one.
+--    A mismatch means a double-counted or missed window, not a rounding artifact.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -23,6 +23,7 @@ nuke: ## Stop and wipe all data volumes (DDL re-applies on next up)
 
 # Canonical ClickHouse DDL, in the same dependency order compose mounts it into initdb.
 CH_DDL := ../db/clickhouse/otel_spans.sql ../db/clickhouse/rollups.sql \
+          ../db/clickhouse/account_rollups.sql \
           ../db/clickhouse/last_touch_index.sql ../db/clickhouse/attribution.sql
 
 ch-migrate: ## Apply db/clickhouse DDL to a RUNNING stack (initdb only fires on a fresh volume)

--- a/infra/README.md
+++ b/infra/README.md
@@ -22,6 +22,15 @@ first boot — `otel_spans` and the rollup MVs into ClickHouse, the control-plan
 > populated database. Postgres has no equivalent yet, which is why migrations 0011, 0012, 0015 and
 > 0016 need applying by hand on an existing volume.
 
+> **A new materialized view needs a backfill too.** `make ch-migrate` creates the table and the MV,
+> but a ClickHouse MV is an INSERT trigger, not a view over history: it only sees rows written after
+> it exists. On a database that already holds spans, a freshly created rollup starts empty and then
+> begins mid-history, which reads as "this customer appeared last Tuesday" on the dashboard. Run the
+> explicit `INSERT INTO <rollup> SELECT ... FROM otel_spans` documented at the bottom of the rollup's
+> own DDL file (see [`../db/clickhouse/account_rollups.sql`](../db/clickhouse/account_rollups.sql)),
+> bounded by a timestamp cutoff at or before MV creation. Without that bound the MV and the backfill
+> both count the overlap and SummingMergeTree adds them together, silently inflating cost.
+
 > The Go edge proxy (transparent OpenAI passthrough) lives in [`edge-proxy/`](./edge-proxy) and is
 > intentionally **not** wired into this Docker stack — the SDK ingestion path covers end-to-end flow
 > without it, and the proxy is a standalone, stateless binary you run wherever the customer's

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -38,8 +38,9 @@ services:
       # spans table must exist before the rollup MVs that target it.
       - ../db/clickhouse/otel_spans.sql:/docker-entrypoint-initdb.d/01_otel_spans.sql:ro
       - ../db/clickhouse/rollups.sql:/docker-entrypoint-initdb.d/02_rollups.sql:ro
-      - ../db/clickhouse/last_touch_index.sql:/docker-entrypoint-initdb.d/03_last_touch_index.sql:ro
-      - ../db/clickhouse/attribution.sql:/docker-entrypoint-initdb.d/04_attribution.sql:ro
+      - ../db/clickhouse/account_rollups.sql:/docker-entrypoint-initdb.d/03_account_rollups.sql:ro
+      - ../db/clickhouse/last_touch_index.sql:/docker-entrypoint-initdb.d/04_last_touch_index.sql:ro
+      - ../db/clickhouse/attribution.sql:/docker-entrypoint-initdb.d/05_attribution.sql:ro
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
       interval: 5s


### PR DESCRIPTION
> **Stacked on #170** (CTO-180, B1), which adds `otel_spans.AccountIdHash`. Base is `worktree-agent-a53b7cbc2d8752dbf`, not `main`. Merge #170 first; the diff here will then reduce to this change alone.

## What

Adds `db/clickhouse/account_rollups.sql`: a `daily_account_rollup` SummingMergeTree plus the `daily_account_rollup_mv` materialized view that populates it, mirroring the `daily_feature_rollup` pattern in `rollups.sql`.

## Why

The per-customer cost tab groups by `AccountIdHash`, which sits nowhere near the front of `otel_spans`' `ORDER BY (TenantId, FeatureTag, ServiceName, SpanName, Timestamp)`. ClickHouse can skip no granules on the account dimension, so the query degrades into a full tenant scan. Survivable at a dozen accounts, not at thousands, which is the shape of tenant this tab is built for.

The rollup's `(TenantId, AccountIdHash, Day)` key prefix turns both reads the tab issues into index range scans: ranking every account for a tenant, and drilling into one account over time. Like `daily_feature_rollup` it also outlives the 90d raw retention (CTO-22/CTO-29), so per-customer history keeps working after the underlying spans are dropped.

`GenAiOperation` is carried raw rather than pre-mapped to a layer, so the six-layer mapping stays owned by `LAYER_CASE` in `web/lib/clickhouse.ts` and can be corrected without rebuilding the table. It is also what will let direct customer cost be split from allocated shared cost later without a second table.

## One deliberate deviation from the ticket

The ticket specified `ORDER BY (TenantId, AccountIdHash, Day)`. Shipped key is `(TenantId, AccountIdHash, Day, FeatureTag, GenAiOperation)` — same prefix, same access path, two columns appended.

This is a correctness fix, not a preference. `SummingMergeTree` collapses rows sharing the **full** sorting key and gives every non-key, non-aggregate column an **arbitrary** value from the collapsed set. With `FeatureTag` and `GenAiOperation` outside the key, a background merge would fold an account's daily rows together and stamp whichever values it happened to see last onto the summed total, silently destroying the per-layer split those columns are carried for. Appending them keeps the requested prefix intact and makes the row grain honest: one row per account per day per feature per operation. Verified below that totals survive `OPTIMIZE ... FINAL`.

## Migration wiring

The compose initdb mount only fires on a first boot against an empty volume — the same trap that left Postgres migrations 0011/0012/0015/0016 unapplied. So:

- added to `CH_DDL` in `infra/Makefile`, so `make ch-migrate` picks it up
- added to the compose initdb mounts as `03_account_rollups.sql` (later files renumbered to `04`/`05` to keep the alphabetical dependency order: spans table before the MVs targeting it)
- every statement is `CREATE ... IF NOT EXISTS`, so replaying is idempotent

## Backfill (required, and it is not optional on a populated DB)

A ClickHouse MV is an INSERT trigger, not a view over history. `daily_account_rollup_mv` sees nothing written before it existed, so on any database that already holds spans the table starts empty and then begins mid-history — which reads on the dashboard as "this customer appeared last Tuesday".

The full `INSERT INTO daily_account_rollup SELECT ... FROM otel_spans` is documented at the bottom of `account_rollups.sql`, and `infra/README.md` gained a note pointing at it.

The hazard is double counting: the MV is already live when the backfill runs, so an unbounded backfill counts the overlap twice and `SummingMergeTree` adds those rows rather than rejecting them — silent inflated cost, no error. Bound the backfill with `WHERE Timestamp < '<cutoff>'` at or before MV creation time. If it is ever run wrong, `TRUNCATE` and redo both steps rather than trying to subtract; `otel_spans` is the source of truth and rebuilding is cheap inside the 90d window. Chunk by `toYYYYMM(Timestamp)` on a large table to bound peak memory.

## Reconciliation check

Applied with `make ch-migrate` against the running local stack, then backfilled with a `now()` cutoff. Tenant `local-dev`, 303,937 spans.

Full history, rollup vs. direct `otel_spans` aggregate:

```
src     est             rec  spans   users
rollup  98027.097964    0    303937  135385
raw     98027.097964    0    303937  135385
```

30d window:

```
src     est             spans
rollup  90775.071291    274607
raw     90775.071291    274607
```

Per-layer split through `LAYER_CASE`, identical on both sides:

```
compute      44300
egress       200
embeddings   0
llm          53527.097964
tools        0
```

Costs are `Decimal64(8)` on both sides, so these are exact equalities, not approximations.

Two further checks:

- **MV live-capture**, on a throwaway `mv-test` tenant: three spans across two accounts and two operations landed in the rollup at the right grain, matching raw exactly. Rows cleaned up afterwards.
- **Merge safety**: after `OPTIMIZE TABLE daily_account_rollup FINAL`, `local-dev` totals were byte-identical (98027.097964 / 303937 / 135385 across 689 rows). This is the check that would have caught the ORDER BY problem described above.

## Verification

- `infra/gateway`: `uv run --extra dev pytest -q` → **464 passed**; `uv run ruff check .` → **All checks passed**
- `web/`: `npm run typecheck` → clean; `npm run test` → **220 passed, 2 failed**, both the documented pre-existing `app/api/api.test.ts` `isMock` assertions that fail whenever ClickHouse is running locally. **No new failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
