### PR TITLE
feat(sdk): tag telemetry with a customer account_id (CTO-181)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -14,3 +14,71 @@ uv run pytest
 
 Zero runtime dependencies today (the schema + safety + sampling + guardrail primitives are
 pure-Python). OTel/OpenLLMetry integration lands in later tickets.
+
+## Tagging spend with a customer account
+
+An `account_id` says which of *your* customers a call belongs to. It is what turns a cost total
+into cost per customer.
+
+The id is **context-scoped**: a web app knows the customer once, at request start, so you set it
+once and every span inside the scope picks it up. Requiring it on every call would be noise, and
+noise gets skipped.
+
+```python
+from tally.client import TallyClient
+from tally.context import start_trace, with_account
+from tally.hmac_keys import HmacKeyRegistry
+
+registry = HmacKeyRegistry()
+registry.provision("tenant-a")
+client = TallyClient(tenant_id="tenant-a", hmac_registry=registry)
+
+# In a request middleware: resolve the customer once, wrap the handler.
+with start_trace(feature_tag="support-bot"), with_account("acct_northwind"):
+    client.record_llm_call(provider="openai", model="gpt-4o", usage=usage)
+    client.record_tool_call(provider="openai", tool="web_search")
+    # ...every span emitted inside this block carries the same account.
+```
+
+One call can override the scope, which is what a batch job that walks several customers needs:
+
+```python
+with start_trace():
+    for account in accounts:
+        client.record_llm_call(
+            provider="openai", model="gpt-4o", usage=usage, account_id=account
+        )
+```
+
+`with_account(None)` clears the account for a block. That is the opt-out for a background task
+that must not inherit its caller's customer.
+
+### What actually goes on the wire
+
+The raw `account_id` never leaves your process. It is HMAC-SHA256'd under your **per-tenant** key
+at emit time, exactly like a user id, and the span carries only:
+
+| Attribute | Meaning |
+|---|---|
+| `gen_ai.account_id_hash` | HMAC-SHA256 hex of the account id |
+| `gen_ai.account_id_hash_key_version` | the key version that produced it, so rotation does not orphan history |
+| `gen_ai.account_label` | optional display name (see below) |
+
+Because the key is per tenant, the same account id hashes differently for two different tenants,
+so an account cannot be correlated across them.
+
+If the client has no `tenant_id` or no `hmac_registry`, the span is emitted **unattributed** with a
+one-time warning. It is never dropped and the raw id is never substituted.
+
+### The optional label
+
+```python
+with with_account("acct_northwind", label="Northwind Traders"):
+    ...
+```
+
+The label is **wire-only**. The gateway upserts it into a label store keyed on the account hash
+and does not write it to the span row, so no customer name lands in the telemetry store. Labels
+are optional per account: set none and the dashboard falls back to a shortened hash, which is a
+supported way to run. A label with no account id alongside it is dropped, since there is nothing
+to key it on.

--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -20,6 +20,7 @@ from typing import Protocol
 from tally.context import current_context, note_context_drop
 from tally.egress import BatchProcessor
 from tally.guardrails import GuardrailConfig, GuardrailEngine, GuardrailState, Verdict
+from tally.hmac_keys import HmacKeyRegistry
 from tally.pricing import (
     PriceCatalog,
     PriceType,
@@ -45,6 +46,9 @@ _warned_tool_pairs: set[tuple[str, str]] = set()
 _warned_embedding_pairs: set[tuple[str, str]] = set()
 # Vector (provider, operation) pairs we've already warned about (CTO-142).
 _warned_vector_pairs: set[tuple[str, str]] = set()
+# Tenants we've already warned about for an unhashable account id (CTO-181). ``None`` covers the
+# no-tenant case. One WARN per tenant, not one per span.
+_warned_account_tenants: set[str | None] = set()
 
 
 class Exporter(Protocol):
@@ -92,7 +96,10 @@ class TallyClient:
             precedence over ``exporter`` when both are set.
         catalog: price catalog for server-agnostic cost estimation.
         sampler / billing_meter / guardrails: spine components (sensible defaults).
-        tenant_id: for per-tenant price overrides.
+        tenant_id: for per-tenant price overrides and for the per-tenant HMAC key.
+        hmac_registry: key registry used to hash account ids (CTO-181). Required together with
+            ``tenant_id`` for the account dimension to be emitted; without both, account tagging
+            degrades to a one-time WARN and the span is emitted unattributed rather than dropped.
     """
 
     def __init__(
@@ -108,6 +115,7 @@ class TallyClient:
         guardrails: GuardrailEngine | None = None,
         observability: SelfObservability | None = None,
         tenant_id: str | None = None,
+        hmac_registry: HmacKeyRegistry | None = None,
     ) -> None:
         self.obs = observability or SelfObservability()
         self._api_key = api_key
@@ -119,6 +127,7 @@ class TallyClient:
         self.billing = billing_meter or BillingMeter()
         self.guardrails = guardrails or GuardrailEngine()
         self.tenant_id = tenant_id
+        self.hmac_registry = hmac_registry
 
     @property
     def observability(self) -> SelfObservability:
@@ -152,6 +161,8 @@ class TallyClient:
         usage: Usage,
         signals: TraceSignals | None = None,
         at: date | None = None,
+        account_id: str | None = None,
+        account_label: str | None = None,
     ) -> LlmCallResult:
         """Record an LLM call end-to-end. Never raises.
 
@@ -169,6 +180,12 @@ class TallyClient:
           4. build a conformant span,
           5. make the sampling decision; emit the span only if kept,
           6. return a :class:`LlmCallResult` for the caller.
+
+        ``account_id`` tags the span with the tenant's own customer (CTO-181). Omit it and the
+        account set by :func:`~tally.context.with_account` for the surrounding scope applies;
+        pass it to override that for this one call. It is hashed with the tenant's HMAC key and
+        never travels raw. ``account_label`` is optional, wire-only, and only carried when a
+        hash was produced.
         """
 
         @safe(self.obs, where="TallyClient.record_llm_call", fallback=None)
@@ -194,6 +211,8 @@ class TallyClient:
                 trace_id or "no-trace", signals, feature_tag=ctx.feature_tag
             )
 
+            acct_hash, acct_version, acct_label = self._resolve_account(account_id, account_label)
+
             fields = SpanFields(
                 system=provider,
                 request_model=model,
@@ -210,6 +229,9 @@ class TallyClient:
                 # can compute per-stratum CIs without re-classifying after the fact.
                 sampling_stratum=decision.stratum.value,
                 sampling_rate=decision.sample_rate,
+                account_id_hash=acct_hash,
+                account_id_hash_key_version=acct_version,
+                account_label=acct_label,
             )
             attrs = build_span_attributes(fields)
             # NB: sample_rate travels at the batch level (wire Sampling, §12.2), not as a span
@@ -241,6 +263,8 @@ class TallyClient:
         output_tokens: int | None = None,
         latency_ms: int | None = None,
         call_id: str | None = None,
+        account_id: str | None = None,
+        account_label: str | None = None,
     ) -> None:
         """Record a tool call so the span lands in the gateway's ``tools`` cost-layer bucket.
 
@@ -253,6 +277,12 @@ class TallyClient:
 
         ``latency_ms`` is accepted for API symmetry with future span timing but is not yet emitted
         as a schema attribute (no latency key exists in the conformant set).
+
+        ``account_id`` tags the span with the tenant's own customer (CTO-181). Omit it and the
+        account set by :func:`~tally.context.with_account` for the surrounding scope applies;
+        pass it to override that for this one call. It is hashed with the tenant's HMAC key and
+        never travels raw. ``account_label`` is optional, wire-only, and only carried when a
+        hash was produced.
         """
 
         @safe(self.obs, where="TallyClient.record_tool_call")
@@ -286,6 +316,7 @@ class TallyClient:
                             tool,
                         )
 
+            acct_hash, acct_version, acct_label = self._resolve_account(account_id, account_label)
             fields = SpanFields(
                 system=provider,
                 operation="tool",
@@ -297,6 +328,9 @@ class TallyClient:
                 output_tokens=output_tokens,
                 feature_tag=ctx.feature_tag,
                 session_id=ctx.session_id,
+                account_id_hash=acct_hash,
+                account_id_hash_key_version=acct_version,
+                account_label=acct_label,
             )
             self._emit(build_span_attributes(fields))
 
@@ -310,12 +344,20 @@ class TallyClient:
         model: str,
         input_tokens: int,
         at: date | None = None,
+        account_id: str | None = None,
+        account_label: str | None = None,
     ) -> EmbeddingCallResult:
         """Record an embedding call so the span lands in the gateway's ``embeddings`` bucket.
 
         Bucketing is keyed off ``gen_ai.operation.name == 'embeddings'``. Cost is estimated from
         the catalog (input-side only). Unknown provider/model → cost stays None/0 with a one-time
         WARN. Never raises.
+
+        ``account_id`` tags the span with the tenant's own customer (CTO-181). Omit it and the
+        account set by :func:`~tally.context.with_account` for the surrounding scope applies;
+        pass it to override that for this one call. It is hashed with the tenant's HMAC key and
+        never travels raw. ``account_label`` is optional, wire-only, and only carried when a
+        hash was produced.
         """
 
         @safe(self.obs, where="TallyClient.record_embedding_call", fallback=None)
@@ -350,6 +392,7 @@ class TallyClient:
                             model,
                         )
 
+            acct_hash, acct_version, acct_label = self._resolve_account(account_id, account_label)
             fields = SpanFields(
                 system=provider,
                 request_model=model,
@@ -359,6 +402,9 @@ class TallyClient:
                 price_catalog_version=catalog_version,
                 feature_tag=ctx.feature_tag,
                 session_id=ctx.session_id,
+                account_id_hash=acct_hash,
+                account_id_hash_key_version=acct_version,
+                account_label=acct_label,
             )
             attrs = build_span_attributes(fields)
             self._emit(attrs)
@@ -384,6 +430,8 @@ class TallyClient:
         cost_micro_usd: int | None = None,
         record_count: int | None = None,
         latency_ms: int | None = None,
+        account_id: str | None = None,
+        account_label: str | None = None,
     ) -> None:
         """Record a vector-DB call so the span lands in the gateway's ``vector`` cost-layer bucket.
 
@@ -397,6 +445,12 @@ class TallyClient:
 
         ``record_count`` and ``latency_ms`` are accepted for API symmetry with future span fields
         but are not yet emitted as schema attributes (no conformant key exists for them).
+
+        ``account_id`` tags the span with the tenant's own customer (CTO-181). Omit it and the
+        account set by :func:`~tally.context.with_account` for the surrounding scope applies;
+        pass it to override that for this one call. It is hashed with the tenant's HMAC key and
+        never travels raw. ``account_label`` is optional, wire-only, and only carried when a
+        hash was produced.
         """
 
         @safe(self.obs, where="TallyClient.record_vector_call")
@@ -430,6 +484,7 @@ class TallyClient:
                             operation,
                         )
 
+            acct_hash, acct_version, acct_label = self._resolve_account(account_id, account_label)
             fields = SpanFields(
                 system=provider,
                 operation="vector",
@@ -438,6 +493,9 @@ class TallyClient:
                 price_catalog_version=catalog_version,
                 feature_tag=ctx.feature_tag,
                 session_id=ctx.session_id,
+                account_id_hash=acct_hash,
+                account_id_hash_key_version=acct_version,
+                account_label=acct_label,
             )
             self._emit(build_span_attributes(fields))
 
@@ -449,6 +507,55 @@ class TallyClient:
         GRACEFUL/HARD_STOP modes — that propagation is intentional (the agent framework catches it
         and degrades). Not wrapped in the safety boundary."""
         return self.guardrails.evaluate(state, config)
+
+    # --- account dimension (CTO-181) -------------------------------------------------------
+    def _resolve_account(
+        self,
+        account_id: str | None,
+        account_label: str | None,
+    ) -> tuple[str | None, str | None, str | None]:
+        """Resolve ``(hash, key_version, label)`` for a call. Never raises.
+
+        Precedence is per-call override, then the context set by
+        :func:`~tally.context.with_account`. That ordering is the whole point of the API shape:
+        a web app resolves the customer once per request and every span inside inherits it, while
+        one call that genuinely belongs to a different account says so inline.
+
+        The raw id is HMAC'd here, at the last possible moment, and discarded. If we cannot hash
+        it (no tenant, no registry, or the tenant has no provisioned key) we emit the span with no
+        account rather than dropping it or, worse, putting the raw id on the wire. An
+        unattributed span is honest; a raw customer id is a leak.
+        """
+        ctx = current_context()
+        raw = account_id if account_id is not None else ctx.account_id
+        label = account_label if account_label is not None else ctx.account_label
+        if not raw:
+            return None, None, None
+
+        if self.hmac_registry is None or not self.tenant_id:
+            self._warn_account_once(
+                "account_id supplied but no %s configured; span emitted unattributed",
+                "hmac_registry" if self.hmac_registry is None else "tenant_id",
+            )
+            return None, None, None
+
+        try:
+            stamped = self.hmac_registry.hash_account(self.tenant_id, raw)
+        except (KeyError, ValueError) as exc:
+            self._warn_account_once(
+                "could not hash account_id (%s); span emitted unattributed", exc
+            )
+            return None, None, None
+
+        # The label only means anything alongside a hash, since it is keyed on one in the
+        # gateway's label store, so it never travels alone.
+        return stamped.value, stamped.key_version, (label or None)
+
+    def _warn_account_once(self, msg: str, *args: object) -> None:
+        if self.tenant_id in _warned_account_tenants:
+            return
+        _warned_account_tenants.add(self.tenant_id)
+        _log.warning(msg, *args)
 
     def _emit(self, attributes: dict[str, object]) -> None:
         if self._processor is not None:

--- a/sdk/python/src/tally/context.py
+++ b/sdk/python/src/tally/context.py
@@ -11,12 +11,19 @@ Public surface:
 - :func:`with_trace_context` — context manager to set/restore explicitly (the escape hatch for
   places where automatic propagation fails: Celery, Temporal, Lambda cold starts, etc.).
 - :func:`current_context` — read the active context.
+- :func:`with_account` sets the tenant's own customer (``account_id``) for a block (CTO-181).
 - :func:`note_context_drop` — two modes (CTO-118):
     (a) record that an expected trace context was missing (feeds
         ``SelfObservability.context_drop_count``); or
     (b) emit ``gen_ai.context.*`` span attributes describing how many messages /
         tokens were trimmed to fit the model's context window. Counts only — never
         the dropped message text.
+
+The account dimension (CTO-181) rides here rather than on every call site. A web app knows which
+customer a request belongs to once, at request start, so it sets it once and every span inside the
+request picks it up; an individual call can still override it. The value held here is the RAW
+account id, and it stays raw only in process memory: it is HMAC'd at emit time in
+:class:`~tally.client.TallyClient` and only the digest plus its key version reach the wire.
 """
 
 from __future__ import annotations
@@ -32,6 +39,9 @@ from tally.safety import SelfObservability
 _trace_id: ContextVar[str | None] = ContextVar("tally_trace_id", default=None)
 _feature_tag: ContextVar[str | None] = ContextVar("tally_feature_tag", default=None)
 _session_id: ContextVar[str | None] = ContextVar("tally_session_id", default=None)
+# Raw account id + optional label (CTO-181). Never emitted raw; see the module docstring.
+_account_id: ContextVar[str | None] = ContextVar("tally_account_id", default=None)
+_account_label: ContextVar[str | None] = ContextVar("tally_account_label", default=None)
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +49,10 @@ class TraceContext:
     trace_id: str | None
     feature_tag: str | None
     session_id: str | None
+    #: Raw account id (CTO-181). Hashed at emit time; never placed on a span as-is.
+    account_id: str | None = None
+    #: Optional human-readable account label. Wire-only, for the gateway's label store.
+    account_label: str | None = None
 
     @property
     def is_active(self) -> bool:
@@ -51,7 +65,13 @@ def new_trace_id() -> str:
 
 def current_context() -> TraceContext:
     """Snapshot the active context (may be inactive)."""
-    return TraceContext(_trace_id.get(), _feature_tag.get(), _session_id.get())
+    return TraceContext(
+        _trace_id.get(),
+        _feature_tag.get(),
+        _session_id.get(),
+        _account_id.get(),
+        _account_label.get(),
+    )
 
 
 @contextmanager
@@ -60,6 +80,8 @@ def with_trace_context(
     trace_id: str | None = None,
     feature_tag: str | None = None,
     session_id: str | None = None,
+    account_id: str | None = None,
+    account_label: str | None = None,
     inherit: bool = True,
 ) -> Iterator[TraceContext]:
     """Set the trace context for the duration of the block, then restore prior values.
@@ -70,32 +92,90 @@ def with_trace_context(
     Args:
         trace_id: explicit id; if ``None`` and no active trace, a new one is generated.
         feature_tag / session_id: optional tags.
+        account_id: raw id of the tenant's own customer (CTO-181). Hashed at emit time.
+        account_label: optional display name for that account. Wire-only.
         inherit: when True, unset fields fall back to the currently-active context.
     """
     cur = current_context()
     resolved_trace = trace_id or (cur.trace_id if inherit else None) or new_trace_id()
     resolved_feature = feature_tag or (cur.feature_tag if inherit else None)
     resolved_session = session_id or (cur.session_id if inherit else None)
+    resolved_account = account_id or (cur.account_id if inherit else None)
+    resolved_label = account_label or (cur.account_label if inherit else None)
 
     t_tok = _trace_id.set(resolved_trace)
     f_tok = _feature_tag.set(resolved_feature)
     s_tok = _session_id.set(resolved_session)
+    a_tok = _account_id.set(resolved_account)
+    l_tok = _account_label.set(resolved_label)
     try:
-        yield TraceContext(resolved_trace, resolved_feature, resolved_session)
+        yield TraceContext(
+            resolved_trace, resolved_feature, resolved_session, resolved_account, resolved_label
+        )
     finally:
         _trace_id.reset(t_tok)
         _feature_tag.reset(f_tok)
         _session_id.reset(s_tok)
+        _account_id.reset(a_tok)
+        _account_label.reset(l_tok)
+
+
+@contextmanager
+def with_account(
+    account_id: str | None,
+    *,
+    label: str | None = None,
+) -> Iterator[TraceContext]:
+    """Scope an account to a block without touching the trace (CTO-181).
+
+    The intended shape for a web app: resolve the customer once in a request middleware, wrap the
+    handler, and every span emitted inside the request carries the account. Nothing else about the
+    context changes, so this composes with an already-active trace and with :func:`start_trace`
+    in either order.
+
+    ``account_id`` is the RAW id. It is HMAC'd per tenant at emit time and only the digest travels.
+    Passing ``None`` clears the account for the block, which is how a background job that must not
+    inherit a caller's account opts out.
+
+    ``label`` is optional and is carried on the wire for the gateway to upsert into its label
+    store. It is never written to the span row in ClickHouse, so a tenant that wants no customer
+    names in the telemetry store simply omits it and everything still works off the hash.
+    """
+    cur = current_context()
+    a_tok = _account_id.set(account_id)
+    l_tok = _account_label.set(label if account_id else None)
+    try:
+        yield TraceContext(
+            cur.trace_id,
+            cur.feature_tag,
+            cur.session_id,
+            account_id,
+            label if account_id else None,
+        )
+    finally:
+        _account_id.reset(a_tok)
+        _account_label.reset(l_tok)
 
 
 def start_trace(
-    *, feature_tag: str | None = None, session_id: str | None = None
+    *,
+    feature_tag: str | None = None,
+    session_id: str | None = None,
+    account_id: str | None = None,
+    account_label: str | None = None,
 ) -> AbstractContextManager[TraceContext]:
-    """Begin a fresh trace (always a new trace_id). Returns the context manager."""
+    """Begin a fresh trace (always a new trace_id). Returns the context manager.
+
+    ``account_id`` / ``account_label`` are here for the common case where the trace and the
+    account are both known at the same boundary (CTO-181). ``inherit=False`` means an outer
+    account is deliberately not carried in: a fresh trace is a fresh attribution.
+    """
     return with_trace_context(
         trace_id=new_trace_id(),
         feature_tag=feature_tag,
         session_id=session_id,
+        account_id=account_id,
+        account_label=account_label,
         inherit=False,
     )
 

--- a/sdk/python/src/tally/hmac_keys.py
+++ b/sdk/python/src/tally/hmac_keys.py
@@ -152,6 +152,24 @@ class HmacKeyRegistry:
         key = self._provider.material(tenant_id, key_version)
         return StampedHash(value=_hmac_hex(user_id, key), key_version=key_version)
 
+    def hash_account(self, tenant_id: str, account_id: str) -> StampedHash:
+        """Hash an *account* id (the tenant's own customer) under the tenant's active key.
+
+        Deliberately the same key and the same digest as :meth:`hash` rather than a separate
+        account key (CTO-181). Two reasons. First, the guarantee we owe an account id is exactly
+        the one we owe a user id: not reversible, not joinable across tenants, and stamped with a
+        version so Option B rotation carries it forward. Second, the revenue connectors already
+        hash what is really an account id (a Stripe customer, a HubSpot company) through this
+        path into ``UserIdHash``; keeping one key means routing those into ``AccountIdHash``
+        later is a column change, not a re-hash of history.
+
+        The consequence is that the same string tagged as both a user and an account produces the
+        same digest within a tenant. That is a correct identity statement, not a collision.
+        """
+        if not account_id:
+            raise ValueError("account_id must be non-empty")
+        return self.hash(tenant_id, account_id)
+
     def _require_provisioned(self, tenant_id: str) -> None:
         if tenant_id not in self._active:
             raise KeyError(f"tenant {tenant_id!r} has no provisioned HMAC key set")

--- a/sdk/python/src/tally/schema.py
+++ b/sdk/python/src/tally/schema.py
@@ -42,6 +42,19 @@ class GenAI:
     SESSION_ID = "gen_ai.session_id"
     USER_ID_HASH = "gen_ai.user_id_hash"  # HMAC-SHA256 hex
     USER_ID_HASH_KEY_VERSION = "gen_ai.user_id_hash_key_version"
+
+    # Account dimension (CTO-181 / B2 of the cost-per-customer plan). The tenant's own customer,
+    # sitting between TenantId (the ai-tally customer) and UserIdHash (one end user). Hashed
+    # exactly like a user id: HMAC-SHA256 hex under the per-tenant key, with the key version
+    # travelling alongside so a rotation (CTO-74) does not orphan history. The raw account id
+    # never leaves the process.
+    ACCOUNT_ID_HASH = "gen_ai.account_id_hash"  # HMAC-SHA256 hex
+    ACCOUNT_ID_HASH_KEY_VERSION = "gen_ai.account_id_hash_key_version"
+    # Optional human-readable label for the account. WIRE-ONLY: the gateway upserts it into the
+    # Postgres label store (CTO-186) keyed on the account hash and does NOT write it to the span
+    # row. Labels are mutable metadata and a customer name has no business in the telemetry
+    # store, which is the whole reason the id is hashed. Emitted only when an account hash is.
+    ACCOUNT_LABEL = "gen_ai.account_label"
     IDEMPOTENCY_KEY = "gen_ai.idempotency_key"
 
     AGENT_RUN_ID = "gen_ai.agent.run_id"
@@ -104,6 +117,9 @@ _STR_KEYS = frozenset(
         GenAI.SESSION_ID,
         GenAI.USER_ID_HASH,
         GenAI.USER_ID_HASH_KEY_VERSION,
+        GenAI.ACCOUNT_ID_HASH,
+        GenAI.ACCOUNT_ID_HASH_KEY_VERSION,
+        GenAI.ACCOUNT_LABEL,
         GenAI.IDEMPOTENCY_KEY,
         GenAI.AGENT_RUN_ID,
         GenAI.TOOL_NAME,
@@ -150,6 +166,9 @@ class SpanFields:
     session_id: str | None = None
     user_id_hash: str | None = None
     user_id_hash_key_version: str | None = None
+    account_id_hash: str | None = None
+    account_id_hash_key_version: str | None = None
+    account_label: str | None = None
     idempotency_key: str | None = None
     agent_run_id: str | None = None
     agent_step_index: int | None = None
@@ -177,6 +196,9 @@ _FIELD_TO_KEY = {
     "session_id": GenAI.SESSION_ID,
     "user_id_hash": GenAI.USER_ID_HASH,
     "user_id_hash_key_version": GenAI.USER_ID_HASH_KEY_VERSION,
+    "account_id_hash": GenAI.ACCOUNT_ID_HASH,
+    "account_id_hash_key_version": GenAI.ACCOUNT_ID_HASH_KEY_VERSION,
+    "account_label": GenAI.ACCOUNT_LABEL,
     "idempotency_key": GenAI.IDEMPOTENCY_KEY,
     "agent_run_id": GenAI.AGENT_RUN_ID,
     "agent_step_index": GenAI.AGENT_STEP_INDEX,

--- a/sdk/python/tests/test_account_id.py
+++ b/sdk/python/tests/test_account_id.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Account dimension — context scoping, per-call override, and hashing (CTO-181 / B2).
+
+The two properties worth guarding hardest:
+
+1. **A raw account id never reaches a span.** Everything downstream of this SDK assumes the
+   telemetry store holds no customer identifiers, so the tests assert on the absence of the
+   plaintext, not only on the presence of the digest.
+2. **The same account id under different tenant keys hashes differently.** That is the property
+   that makes an account hash non-joinable across tenants. If it ever regresses, two of our
+   customers could correlate their end customers through us.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tally.client import MemoryExporter, TallyClient
+from tally.context import current_context, start_trace, with_account, with_trace_context
+from tally.hmac_keys import HmacKeyRegistry
+from tally.pricing import Usage
+from tally.sampling import Sampler, SamplingConfig
+from tally.schema import GenAI, SpanFields, build_span_attributes, validate_span_attributes
+
+ACCOUNT = "acct_northwind"
+
+
+def _keep_everything() -> Sampler:
+    """Sampling is orthogonal here; keep every span so the assertions are about attribution."""
+    return Sampler(SamplingConfig(body_rate=1.0))
+
+
+def _client(tenant_id: str = "tenant-a") -> tuple[TallyClient, MemoryExporter, HmacKeyRegistry]:
+    registry = HmacKeyRegistry()
+    registry.provision(tenant_id)
+    exporter = MemoryExporter()
+    client = TallyClient(
+        exporter=exporter,
+        tenant_id=tenant_id,
+        hmac_registry=registry,
+        sampler=_keep_everything(),
+    )
+    return client, exporter, registry
+
+
+def _usage() -> Usage:
+    return Usage(input_tokens=100, output_tokens=50)
+
+
+# --- schema ---------------------------------------------------------------------------------
+
+
+def test_schema_keys_are_conformant():
+    attrs = build_span_attributes(
+        SpanFields(
+            account_id_hash="a" * 64,
+            account_id_hash_key_version="v1",
+            account_label="Northwind Traders",
+        )
+    )
+    assert attrs[GenAI.ACCOUNT_ID_HASH] == "a" * 64
+    assert attrs[GenAI.ACCOUNT_ID_HASH_KEY_VERSION] == "v1"
+    assert attrs[GenAI.ACCOUNT_LABEL] == "Northwind Traders"
+    assert validate_span_attributes(attrs) == []
+
+
+def test_schema_keys_are_namespaced_under_gen_ai():
+    assert GenAI.ACCOUNT_ID_HASH == "gen_ai.account_id_hash"
+    assert GenAI.ACCOUNT_ID_HASH_KEY_VERSION == "gen_ai.account_id_hash_key_version"
+    assert GenAI.ACCOUNT_LABEL == "gen_ai.account_label"
+
+
+def test_account_hash_must_be_a_non_empty_string():
+    assert validate_span_attributes({GenAI.ACCOUNT_ID_HASH: ""}) != []
+    assert validate_span_attributes({GenAI.ACCOUNT_ID_HASH: 7}) != []
+
+
+# --- hashing --------------------------------------------------------------------------------
+
+
+def test_hash_account_is_stamped_with_the_active_key_version():
+    reg = HmacKeyRegistry()
+    reg.provision("t1")
+    stamped = reg.hash_account("t1", ACCOUNT)
+    assert stamped.key_version == "v1"
+    assert len(stamped.value) == 64
+    assert ACCOUNT not in stamped.value
+
+
+def test_same_account_different_tenants_hashes_differently():
+    """The non-joinability guarantee. Two tenants must not be able to correlate an account."""
+    reg = HmacKeyRegistry()
+    reg.provision("tenant-a")
+    reg.provision("tenant-b")
+    a = reg.hash_account("tenant-a", ACCOUNT)
+    b = reg.hash_account("tenant-b", ACCOUNT)
+    assert a.value != b.value
+
+
+def test_same_account_same_tenant_is_stable():
+    reg = HmacKeyRegistry()
+    reg.provision("t1")
+    assert reg.hash_account("t1", ACCOUNT).value == reg.hash_account("t1", ACCOUNT).value
+
+
+def test_rotation_changes_the_hash_and_the_stamp():
+    reg = HmacKeyRegistry()
+    reg.provision("t1")
+    before = reg.hash_account("t1", ACCOUNT)
+    reg.rotate("t1")
+    after = reg.hash_account("t1", ACCOUNT)
+    assert (before.value, before.key_version) != (after.value, after.key_version)
+    assert after.key_version == "v2"
+
+
+def test_empty_account_id_is_rejected():
+    reg = HmacKeyRegistry()
+    reg.provision("t1")
+    with pytest.raises(ValueError):
+        reg.hash_account("t1", "")
+
+
+# --- context scoping ------------------------------------------------------------------------
+
+
+def test_context_is_unset_by_default():
+    ctx = current_context()
+    assert ctx.account_id is None
+    assert ctx.account_label is None
+
+
+def test_with_account_sets_and_restores():
+    with with_account(ACCOUNT, label="Northwind Traders"):
+        assert current_context().account_id == ACCOUNT
+        assert current_context().account_label == "Northwind Traders"
+    assert current_context().account_id is None
+
+
+def test_with_account_leaves_the_trace_alone():
+    with with_trace_context(trace_id="t1", feature_tag="research"):
+        with with_account(ACCOUNT):
+            ctx = current_context()
+            assert ctx.trace_id == "t1"
+            assert ctx.feature_tag == "research"
+            assert ctx.account_id == ACCOUNT
+
+
+def test_with_account_none_clears_for_the_block():
+    """The opt-out for a background job that must not inherit its caller's account."""
+    with with_account(ACCOUNT):
+        with with_account(None):
+            assert current_context().account_id is None
+        assert current_context().account_id == ACCOUNT
+
+
+def test_label_does_not_survive_a_cleared_account():
+    with with_account(ACCOUNT, label="Northwind"):
+        with with_account(None):
+            assert current_context().account_label is None
+
+
+def test_trace_context_inherits_the_account():
+    with with_account(ACCOUNT):
+        with with_trace_context(trace_id="t1"):
+            assert current_context().account_id == ACCOUNT
+
+
+def test_start_trace_carries_the_account():
+    with start_trace(account_id=ACCOUNT, account_label="Northwind"):
+        assert current_context().account_id == ACCOUNT
+        assert current_context().account_label == "Northwind"
+
+
+def test_start_trace_does_not_inherit_an_outer_account():
+    with with_account(ACCOUNT):
+        with start_trace():
+            assert current_context().account_id is None
+
+
+# --- client emission ------------------------------------------------------------------------
+
+
+def test_llm_call_picks_up_the_scoped_account():
+    client, exporter, registry = _client()
+    with start_trace(), with_account(ACCOUNT):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+
+    attrs = exporter.spans[0]
+    assert attrs[GenAI.ACCOUNT_ID_HASH] == registry.hash_account("tenant-a", ACCOUNT).value
+    assert attrs[GenAI.ACCOUNT_ID_HASH_KEY_VERSION] == "v1"
+    assert validate_span_attributes(attrs) == []
+
+
+def test_raw_account_id_never_reaches_the_span():
+    client, exporter, _ = _client()
+    with start_trace(), with_account(ACCOUNT, label="Northwind Traders"):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+
+    serialized = repr(exporter.spans[0])
+    assert ACCOUNT not in serialized
+
+
+def test_every_span_in_the_scope_is_tagged():
+    """The ergonomic claim of the API shape: set it once, everything inside inherits."""
+    client, exporter, _ = _client()
+    with start_trace(), with_account(ACCOUNT):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+        client.record_tool_call(provider="openai", tool="web_search", cost_micro_usd=10)
+        client.record_embedding_call(provider="openai", model="text-embedding-3-small",
+                                     input_tokens=10)
+        client.record_vector_call(provider="pinecone", index="docs", operation="query",
+                                  cost_micro_usd=1)
+
+    assert len(exporter.spans) == 4
+    hashes = {s.get(GenAI.ACCOUNT_ID_HASH) for s in exporter.spans}
+    assert len(hashes) == 1 and None not in hashes
+
+
+def test_per_call_override_beats_the_scope():
+    client, exporter, registry = _client()
+    with start_trace(), with_account(ACCOUNT):
+        client.record_llm_call(
+            provider="openai", model="gpt-4o", usage=_usage(), account_id="acct_other"
+        )
+    assert exporter.spans[0][GenAI.ACCOUNT_ID_HASH] == (
+        registry.hash_account("tenant-a", "acct_other").value
+    )
+
+
+def test_per_call_account_needs_no_scope():
+    client, exporter, _ = _client()
+    with start_trace():
+        client.record_llm_call(
+            provider="openai", model="gpt-4o", usage=_usage(), account_id=ACCOUNT
+        )
+    assert GenAI.ACCOUNT_ID_HASH in exporter.spans[0]
+
+
+def test_no_account_means_no_account_keys():
+    """Untagged spans are unchanged: no empty strings, no placeholder account."""
+    client, exporter, _ = _client()
+    with start_trace():
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+    attrs = exporter.spans[0]
+    assert GenAI.ACCOUNT_ID_HASH not in attrs
+    assert GenAI.ACCOUNT_ID_HASH_KEY_VERSION not in attrs
+    assert GenAI.ACCOUNT_LABEL not in attrs
+
+
+def test_user_id_behaviour_is_untouched():
+    """CTO-181 adds a dimension; it must not start populating the user one."""
+    client, exporter, _ = _client()
+    with start_trace(), with_account(ACCOUNT):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+    attrs = exporter.spans[0]
+    assert GenAI.USER_ID_HASH not in attrs
+    assert GenAI.USER_ID_HASH_KEY_VERSION not in attrs
+
+
+# --- label ----------------------------------------------------------------------------------
+
+
+def test_label_rides_along_when_scoped():
+    client, exporter, _ = _client()
+    with start_trace(), with_account(ACCOUNT, label="Northwind Traders"):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+    assert exporter.spans[0][GenAI.ACCOUNT_LABEL] == "Northwind Traders"
+
+
+def test_label_can_be_overridden_per_call():
+    client, exporter, _ = _client()
+    with start_trace(), with_account(ACCOUNT, label="Stale Name"):
+        client.record_llm_call(
+            provider="openai", model="gpt-4o", usage=_usage(), account_label="Fresh Name"
+        )
+    assert exporter.spans[0][GenAI.ACCOUNT_LABEL] == "Fresh Name"
+
+
+def test_label_without_an_account_is_dropped():
+    """A label is keyed on a hash in the gateway's store, so it never travels alone."""
+    client, exporter, _ = _client()
+    with start_trace():
+        client.record_llm_call(
+            provider="openai", model="gpt-4o", usage=_usage(), account_label="Orphan"
+        )
+    assert GenAI.ACCOUNT_LABEL not in exporter.spans[0]
+
+
+def test_account_is_usable_with_no_label():
+    """A tenant that wants no customer names in our system still gets the dimension."""
+    client, exporter, _ = _client()
+    with start_trace(), with_account(ACCOUNT):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+    attrs = exporter.spans[0]
+    assert GenAI.ACCOUNT_ID_HASH in attrs
+    assert GenAI.ACCOUNT_LABEL not in attrs
+
+
+# --- degradation ----------------------------------------------------------------------------
+
+
+def test_no_registry_emits_unattributed_rather_than_raw(caplog):
+    exporter = MemoryExporter()
+    client = TallyClient(
+        exporter=exporter, tenant_id="tenant-zzz", sampler=_keep_everything()
+    )  # no hmac_registry
+    with caplog.at_level(logging.WARNING, logger="tally"):
+        with start_trace(), with_account(ACCOUNT):
+            client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+
+    attrs = exporter.spans[0]
+    assert GenAI.ACCOUNT_ID_HASH not in attrs
+    assert ACCOUNT not in repr(attrs)
+    assert any("unattributed" in r.message for r in caplog.records)
+
+
+def test_unprovisioned_tenant_emits_unattributed():
+    exporter = MemoryExporter()
+    client = TallyClient(
+        exporter=exporter,
+        tenant_id="tenant-never-provisioned",
+        hmac_registry=HmacKeyRegistry(),
+        sampler=_keep_everything(),
+    )
+    with start_trace(), with_account(ACCOUNT):
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+    assert exporter.spans and GenAI.ACCOUNT_ID_HASH not in exporter.spans[0]
+
+
+def test_account_survives_an_await():
+    """contextvars propagate into asyncio tasks; the account must ride with them."""
+    import asyncio
+
+    client, exporter, _ = _client()
+
+    async def child() -> None:
+        client.record_llm_call(provider="openai", model="gpt-4o", usage=_usage())
+
+    async def main() -> None:
+        with start_trace(), with_account(ACCOUNT):
+            await asyncio.create_task(child())
+
+    asyncio.run(main())
+    assert GenAI.ACCOUNT_ID_HASH in exporter.spans[0]


### PR DESCRIPTION
**Stacked on #170 (CTO-180, B1).** Base is `worktree-agent-a53b7cbc2d8752dbf`, not `main`. Merge #170 first; this diff only makes sense against the `AccountIdHash` columns it adds.

B2 of the cost-per-customer plan: the SDK side that fills the column B1 created. Without it the column stays empty and the tab has nothing to group on.

## API shape: context-scoped, with a per-call override

```python
with start_trace(), with_account("acct_northwind"):
    client.record_llm_call(...)   # tagged
    client.record_tool_call(...)  # tagged
```

A web app knows which customer a request belongs to once, at request start. The alternative is requiring `account_id` at every call site, and noisy ergonomics get skipped, which on an opt-in dimension means the feature ships empty. A single call can still pass `account_id=` to override the scope, which is what a batch job walking several customers needs. `with_account(None)` clears it for a block, so a background task does not inherit its caller's customer.

This is public API and expensive to change after release, so it mirrors the existing `contextvars` pattern in `context.py` rather than inventing a mechanism. `start_trace()` and `with_trace_context()` also accept `account_id` / `account_label` for callers that know both at the same boundary.

## Hashing

Through the existing per-tenant HMAC path in `hmac_keys.py`, deliberately under the **same key** as user ids rather than a separate account key. The guarantee owed is identical (not reversible, not joinable across tenants, stamped with a key version so Option B rotation carries it forward), and the revenue connectors already hash what is really an account id (a Stripe customer, a HubSpot company) through that path, so routing them into `AccountIdHash` in E2 becomes a column change rather than a re-hash of history.

The raw id lives only in a contextvar and is HMAC'd at emit time. Only `gen_ai.account_id_hash` and `gen_ai.account_id_hash_key_version` reach the wire.

## The label is wire-only

`account_label` is optional and is **not** written to the span row in ClickHouse. The gateway upserts it into the Postgres label store keyed on the account hash (CTO-186 builds that store). A label is mutable metadata and a customer name has no business in the telemetry store, which is the reason the id is hashed at all. A label with no account id alongside it is dropped, since there is nothing to key it on.

## Degradation

No `tenant_id`, no registry, or an unprovisioned tenant means the span is emitted **unattributed** with a one-time WARN. Never dropped, and a raw customer id is never substituted. An unattributed span is honest; a raw id is a leak.

## Tests

30 new tests in `sdk/python/tests/test_account_id.py`, including the one the ticket calls out: the same `account_id` under two different tenant keys produces different hashes. Also asserts the plaintext never appears in an emitted span, that the account survives an `await`, and that `user_id` behaviour is untouched (the account path must not start populating the user keys).

## Verification

- `cd sdk/python && uv run pytest -q` green, `uv run ruff check .` clean
- `cd infra/gateway && uv run --extra dev pytest -q` still green (464 passed)

Gateway mapping of the new attributes into the columns is B3 (CTO-182), not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)