### PR TITLE
refactor(web): migrate /connectors and /attribution onto the shared table and honest-value primitives

### DIFF
--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -1,14 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 // Client-side live wrapper for /attribution (CTO-108).
+//
+// Migrated onto the shared primitives in CTO-179: the per-provider table is a `DataTable` column
+// spec, and every number goes through `<Money>` / `<Pct>` so a blank cell carries the reason it is
+// blank. Value/user and margin/user are the blanks that matter here. They are empty because no
+// revenue source is wired for the tenant, not because those providers earn nothing, and until now
+// the page rendered a bare glyph that read as a bug.
 
 "use client";
 
+import { useMemo, type ReactNode } from "react";
+
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { DataTable, type Column } from "@/components/DataTable";
+import { Money, Pct } from "@/components/HonestValue";
 import { LiveIndicator } from "@/components/LiveIndicator";
 import type { AttributionReport, ProviderAttribution } from "@/lib/attribution";
-import { formatUSD } from "@/lib/types";
 import { useLivePoll } from "@/lib/useLivePoll";
+
+/**
+ * Why value/user is blank. `buildProviderRow` only fills it when monetary `business_events` exist
+ * for the provider, and the tenant's revenue source has to be configured for any to arrive. That
+ * configuration is workstream E of the cost-per-customer plan, so today the honest answer is "no
+ * revenue is wired", never "$0".
+ */
+const NO_REVENUE_WIRED =
+  "no revenue source is wired for this tenant, so there is no revenue to divide across users";
+
+/** Margin is value/user minus cost/user, so it inherits the missing half of the subtraction. */
+const NO_REVENUE_FOR_MARGIN =
+  "margin needs revenue: no revenue source is wired for this tenant, so only the cost side is known";
 
 export function AttributionLive({
   endpoint,
@@ -25,6 +47,99 @@ export function AttributionLive({
 }) {
   const { data: report, updatedAt } = useLivePoll<AttributionReport>(endpoint, initialData);
 
+  // Columns close over `outcome`, which comes from the URL filters, so they are rebuilt only when
+  // the filter changes rather than on every poll tick.
+  const columns = useMemo<Column<ProviderAttribution>[]>(
+    () => [
+      {
+        key: "provider",
+        header: "Provider",
+        cellClassName: "font-mono",
+        render: (p) => p.provider,
+      },
+      {
+        key: "sessions",
+        header: "Sessions",
+        align: "right",
+        render: (p) => p.sessions.toLocaleString(),
+      },
+      {
+        key: "conversions",
+        header: `${outcome}s`,
+        align: "right",
+        render: (p) => p.conversions.toLocaleString(),
+      },
+      {
+        key: "rate",
+        header: "Rate (95% CI)",
+        align: "right",
+        render: (p) => (
+          <>
+            <Pct value={p.conversionRate} />{" "}
+            <span className="text-xs text-muted">
+              [<Pct value={p.conversionRateLo} unit={false} />–
+              <Pct value={p.conversionRateHi} />]
+            </span>
+          </>
+        ),
+      },
+      {
+        key: "cost",
+        header: "LLM cost",
+        align: "right",
+        render: (p) => <Money micro={p.costMicroUsd} />,
+      },
+      {
+        key: "costPerConversion",
+        header: `$/${outcome}`,
+        align: "right",
+        cellClassName: "font-semibold",
+        render: (p) => (
+          <>
+            <Money
+              micro={p.costPerConversionMicroUsd}
+              reason={`no ${outcome} events for this provider in the window, so there is nothing to divide the cost by`}
+            />
+            <span className="sr-only"> per {outcome}</span>
+          </>
+        ),
+      },
+      {
+        key: "valuePerUser",
+        header: "Value/user",
+        align: "right",
+        render: (p) => <Money micro={p.valuePerUserMicroUsd} reason={NO_REVENUE_WIRED} />,
+      },
+      {
+        key: "marginPerUser",
+        header: "Margin/user",
+        align: "right",
+        render: (p) =>
+          p.marginPerUserMicroUsd === null ? (
+            <Money micro={p.marginPerUserMicroUsd} reason={NO_REVENUE_FOR_MARGIN} />
+          ) : (
+            <>
+              <div
+                className={
+                  p.marginPerUserMicroUsd >= 0
+                    ? "font-semibold text-good"
+                    : "font-semibold text-warn"
+                }
+              >
+                <Money micro={p.marginPerUserMicroUsd} />
+              </div>
+              {p.marginPct !== null && (
+                <div className="text-xs text-muted">
+                  <Pct value={p.marginPct} />
+                </div>
+              )}
+            </>
+          ),
+      },
+    ],
+    [outcome],
+  );
+
   const body = (
     <div className="space-y-6">
       <Card title="Headline">
@@ -34,13 +149,14 @@ export function AttributionLive({
             k={`${outcome} events`}
             v={report.totals.conversions.toLocaleString()}
           />
-          <Headline k="LLM cost" v={formatUSD(report.totals.costMicroUsd)} />
+          <Headline k="LLM cost" v={<Money micro={report.totals.costMicroUsd} />} />
           <Headline
             k={`$ / ${outcome}`}
             v={
-              report.totals.costPerConversionMicroUsd === null
-                ? "—"
-                : formatUSD(report.totals.costPerConversionMicroUsd)
+              <Money
+                micro={report.totals.costPerConversionMicroUsd}
+                reason={`no ${outcome} events in the window, so there is nothing to divide the cost by`}
+              />
             }
             highlight
           />
@@ -49,6 +165,8 @@ export function AttributionLive({
 
       <Card title={`Per-provider · ${outcome}`}>
         {report.perProvider.length === 0 ? (
+          // Deliberately not DataTable's `empty` slot. A first-run viewer needs the command that
+          // produces data, and a centered line under a header row of empty columns buries it.
           <p className="text-sm text-muted">
             No sessions match these filters yet. Run{" "}
             <code className="rounded bg-ink px-1 py-0.5 text-xs">
@@ -57,27 +175,13 @@ export function AttributionLive({
             from <code className="text-xs">infra/</code> to drive synthetic traffic.
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="text-xs uppercase text-muted">
-                <tr>
-                  <th className="py-1 text-left font-medium">Provider</th>
-                  <th className="py-1 text-right font-medium">Sessions</th>
-                  <th className="py-1 text-right font-medium">{outcome}s</th>
-                  <th className="py-1 text-right font-medium">Rate (95% CI)</th>
-                  <th className="py-1 text-right font-medium">LLM cost</th>
-                  <th className="py-1 text-right font-medium">$/{outcome}</th>
-                  <th className="py-1 text-right font-medium">Value/user</th>
-                  <th className="py-1 text-right font-medium">Margin/user</th>
-                </tr>
-              </thead>
-              <tbody>
-                {report.perProvider.map((p) => (
-                  <ProviderRow key={p.provider} p={p} outcome={outcome} />
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <DataTable
+            columns={columns}
+            rows={report.perProvider}
+            rowKey={(p) => p.provider}
+            // One row per provider, so a pager would be chrome around a two-row table.
+            pageSize={0}
+          />
         )}
         <p className="mt-3 text-xs text-muted">
           Intervals are Wilson 95% on the conversion rate — small samples produce
@@ -114,7 +218,9 @@ function Headline({
   highlight,
 }: {
   k: string;
-  v: string;
+  // ReactNode rather than string: the money headlines are <Money> now, so a missing one carries
+  // its own explanation instead of collapsing to a bare glyph on the way in.
+  v: ReactNode;
   highlight?: boolean;
 }) {
   return (
@@ -128,59 +234,3 @@ function Headline({
     </div>
   );
 }
-
-function ProviderRow({
-  p,
-  outcome,
-}: {
-  p: ProviderAttribution;
-  outcome: string;
-}) {
-  return (
-    <tr className="border-t border-edge">
-      <td className="py-2 font-mono">{p.provider}</td>
-      <td className="py-2 text-right tabular-nums">{p.sessions.toLocaleString()}</td>
-      <td className="py-2 text-right tabular-nums">{p.conversions.toLocaleString()}</td>
-      <td className="py-2 text-right tabular-nums">
-        {(p.conversionRate * 100).toFixed(1)}%{" "}
-        <span className="text-xs text-muted">
-          [{(p.conversionRateLo * 100).toFixed(1)}–
-          {(p.conversionRateHi * 100).toFixed(1)}%]
-        </span>
-      </td>
-      <td className="py-2 text-right tabular-nums">{formatUSD(p.costMicroUsd)}</td>
-      <td className="py-2 text-right font-semibold tabular-nums">
-        {p.costPerConversionMicroUsd === null
-          ? "—"
-          : formatUSD(p.costPerConversionMicroUsd)}
-        <span className="sr-only"> per {outcome}</span>
-      </td>
-      <td className="py-2 text-right tabular-nums">
-        {p.valuePerUserMicroUsd === null ? "—" : formatUSD(p.valuePerUserMicroUsd)}
-      </td>
-      <td className="py-2 text-right tabular-nums">
-        {p.marginPerUserMicroUsd === null ? (
-          "—"
-        ) : (
-          <>
-            <div
-              className={
-                p.marginPerUserMicroUsd >= 0
-                  ? "font-semibold text-good"
-                  : "font-semibold text-warn"
-              }
-            >
-              {formatUSD(p.marginPerUserMicroUsd)}
-            </div>
-            {p.marginPct !== null && (
-              <div className="text-xs text-muted">
-                {(p.marginPct * 100).toFixed(1)}%
-              </div>
-            )}
-          </>
-        )}
-      </td>
-    </tr>
-  );
-}
-

--- a/web/app/connectors/ConnectorTable.tsx
+++ b/web/app/connectors/ConnectorTable.tsx
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// The /connectors source table, on the shared `DataTable` (CTO-179).
+//
+// This lives in its own client module rather than inside page.tsx because `DataTable` takes a
+// column spec whose `render` entries are functions, and functions cannot cross the server/client
+// boundary. page.tsx is an async server component that fetches the catalog, so the column spec has
+// to be declared on the client side of the line. Every page migrating to `DataTable` will hit this,
+// which is the cost of a render-prop API and cheaper than the alternatives (a serializable cell
+// descriptor language, or a server table that cannot sort or page).
+
+import { useMemo } from "react";
+
+import { DataTable, type Column } from "@/components/DataTable";
+import { Blank } from "@/components/HonestValue";
+import type { ConnectorStatus } from "@/lib/connectors";
+import { relativeAge } from "@/lib/dataState";
+import { type CostConnectorConfig, isConfigurable } from "@/lib/costConnectors";
+import { ConnectForm } from "./ConnectForm";
+import { ConnectorToggle } from "./ConnectorToggle";
+
+function StateBadge({ row }: { row: ConnectorStatus }) {
+  if (row.state === "connected") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-good/40 bg-good/10 px-2 py-0.5 text-xs font-medium text-good">
+        <span className="h-1.5 w-1.5 rounded-full bg-good" />
+        Connected
+      </span>
+    );
+  }
+  if (row.state === "coming_soon") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink/40 px-2 py-0.5 text-xs font-medium text-muted">
+        <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+        Coming soon
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink/40 px-2 py-0.5 text-xs font-medium text-muted">
+      <span className="h-1.5 w-1.5 rounded-full bg-muted" />
+      Available
+    </span>
+  );
+}
+
+/**
+ * Only cost-layer connectors participate in the per-tenant declaration; revenue connectors have
+ * their own connectivity story that doesn't drive the layer banner.
+ */
+function layerOf(row: ConnectorStatus): string | null {
+  return row.liveKey.kind === "cost-layer" ? row.liveKey.layer : null;
+}
+
+export function ConnectorTable({
+  rows,
+  enabledLayers,
+  configs,
+}: {
+  rows: readonly ConnectorStatus[];
+  enabledLayers: readonly string[];
+  /**
+   * Flat list rather than the Map the page used to build. The page is a server component, so this
+   * crosses the serialization boundary and a plain array is the least surprising thing to send.
+   */
+  configs: readonly CostConnectorConfig[];
+}) {
+  const configByConnector = useMemo(
+    () => new Map(configs.map((c) => [c.connector, c])),
+    [configs],
+  );
+
+  const columns = useMemo<Column<ConnectorStatus>[]>(
+    () => [
+      {
+        key: "source",
+        header: "Source",
+        render: (r) => (
+          <>
+            <div className="font-medium">{r.name}</div>
+            <div className="max-w-prose text-xs text-muted">{r.description}</div>
+          </>
+        ),
+      },
+      {
+        key: "feeds",
+        header: "Feeds",
+        cellClassName: "text-muted",
+        render: (r) => r.feeds,
+      },
+      {
+        key: "status",
+        header: "Status",
+        render: (r) => <StateBadge row={r} />,
+      },
+      {
+        key: "records",
+        header: "Records (30d)",
+        align: "right",
+        render: (r) =>
+          r.records > 0 ? (
+            r.records.toLocaleString()
+          ) : (
+            // Zero records is exactly how "connected" is decided, so an empty count is never a
+            // real zero: the source has not delivered anything we can count yet.
+            <Blank reason="this source has not delivered any records in the last 30 days" />
+          ),
+      },
+      {
+        key: "lastSync",
+        header: "Last sync",
+        align: "right",
+        cellClassName: "text-muted",
+        render: (r) =>
+          r.lastAt ? (
+            relativeAge(r.lastAt)
+          ) : (
+            <Blank reason="this source has never synced, so there is no last-sync time" />
+          ),
+      },
+      {
+        key: "connection",
+        header: "Connection",
+        align: "right",
+        render: (r) =>
+          isConfigurable(r.id) ? (
+            <ConnectForm
+              connector={r.id}
+              configured={configByConnector.get(r.id)?.configured ?? false}
+              credentialsRef={configByConnector.get(r.id)?.credentialsRef ?? null}
+              details={configByConnector.get(r.id)?.details ?? {}}
+            />
+          ) : (
+            <Blank
+              className="text-xs"
+              reason="this source takes no credentials from the dashboard; it is configured where it is deployed"
+            />
+          ),
+      },
+      {
+        key: "banner",
+        header: "Banner",
+        align: "right",
+        render: (r) => {
+          const layer = layerOf(r);
+          return layer && r.state !== "coming_soon" ? (
+            <ConnectorToggle layer={layer} initialEnabled={enabledLayers.includes(layer)} />
+          ) : (
+            <Blank
+              className="text-xs"
+              reason="this source is not ingesting into a cost layer yet, so there is nothing for the partial-data banner to count"
+            />
+          );
+        },
+      },
+    ],
+    [configByConnector, enabledLayers],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      // The catalog is a fixed, short list shipped in lib/connectors, so paging it would add a
+      // pager that never has a second page to show.
+      pageSize={0}
+      rowClassName={() => "align-top"}
+    />
+  );
+}

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -2,7 +2,6 @@
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
-import { relativeAge } from "@/lib/dataState";
 import {
   type ConnectorCategory,
   type ConnectorStatus,
@@ -10,10 +9,9 @@ import {
   connectedCount,
   liveAvailableCount,
 } from "@/lib/connectors";
-import { type CostConnectorConfig, isConfigurable, queryCostConnectorConfigs } from "@/lib/costConnectors";
+import { queryCostConnectorConfigs } from "@/lib/costConnectors";
 import { queryEnabledConnectors } from "@/lib/tenant";
-import { ConnectForm } from "./ConnectForm";
-import { ConnectorToggle } from "./ConnectorToggle";
+import { ConnectorTable } from "./ConnectorTable";
 
 interface ConnectorsPayload {
   connectors: ConnectorStatus[];
@@ -28,104 +26,6 @@ const SECTIONS: { category: ConnectorCategory; title: string; blurb: string }[] 
   },
 ];
 
-function StateBadge({ row }: { row: ConnectorStatus }) {
-  if (row.state === "connected") {
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-good/40 bg-good/10 px-2 py-0.5 text-xs font-medium text-good">
-        <span className="h-1.5 w-1.5 rounded-full bg-good" />
-        Connected
-      </span>
-    );
-  }
-  if (row.state === "coming_soon") {
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink/40 px-2 py-0.5 text-xs font-medium text-muted">
-        <span className="h-1.5 w-1.5 rounded-full bg-muted" />
-        Coming soon
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-edge bg-ink/40 px-2 py-0.5 text-xs font-medium text-muted">
-      <span className="h-1.5 w-1.5 rounded-full bg-muted" />
-      Available
-    </span>
-  );
-}
-
-function ConnectorTable({
-  rows,
-  enabledLayers,
-  configs,
-}: {
-  rows: ConnectorStatus[];
-  enabledLayers: readonly string[];
-  configs: Map<string, CostConnectorConfig>;
-}) {
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead className="text-xs uppercase text-muted">
-          <tr>
-            <th className="py-1 text-left font-medium">Source</th>
-            <th className="py-1 text-left font-medium">Feeds</th>
-            <th className="py-1 text-left font-medium">Status</th>
-            <th className="py-1 text-right font-medium">Records (30d)</th>
-            <th className="py-1 text-right font-medium">Last sync</th>
-            <th className="py-1 text-right font-medium">Connection</th>
-            <th className="py-1 text-right font-medium">Banner</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => {
-            // Only cost-layer connectors participate in the per-tenant declaration; revenue
-            // connectors have their own connectivity story that doesn't drive the layer banner.
-            const layer = r.liveKey.kind === "cost-layer" ? r.liveKey.layer : null;
-            const isEnabled = layer ? enabledLayers.includes(layer) : false;
-            return (
-              <tr key={r.id} className="border-t border-edge align-top">
-                <td className="py-2">
-                  <div className="font-medium">{r.name}</div>
-                  <div className="max-w-prose text-xs text-muted">{r.description}</div>
-                </td>
-                <td className="py-2 text-muted">{r.feeds}</td>
-                <td className="py-2">
-                  <StateBadge row={r} />
-                </td>
-                <td className="py-2 text-right tabular-nums">
-                  {r.records > 0 ? r.records.toLocaleString() : "—"}
-                </td>
-                <td className="py-2 text-right tabular-nums text-muted">
-                  {r.lastAt ? relativeAge(r.lastAt) : "—"}
-                </td>
-                <td className="py-2 text-right">
-                  {isConfigurable(r.id) ? (
-                    <ConnectForm
-                      connector={r.id}
-                      configured={configs.get(r.id)?.configured ?? false}
-                      credentialsRef={configs.get(r.id)?.credentialsRef ?? null}
-                      details={configs.get(r.id)?.details ?? {}}
-                    />
-                  ) : (
-                    <span className="text-xs text-muted">—</span>
-                  )}
-                </td>
-                <td className="py-2 text-right">
-                  {layer && r.state !== "coming_soon" ? (
-                    <ConnectorToggle layer={layer} initialEnabled={isEnabled} />
-                  ) : (
-                    <span className="text-xs text-muted">—</span>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
 export default async function ConnectorsPage() {
   const [{ connectors, live }, enabledLayers, costConfigs] = await Promise.all([
     apiGet<ConnectorsPayload>("/api/connectors"),
@@ -134,7 +34,7 @@ export default async function ConnectorsPage() {
   ]);
   // `null` means the gateway is unreachable. Render the forms anyway (they report their own
   // errors on submit) rather than hiding the only way to configure anything.
-  const configs = new Map((costConfigs ?? []).map((c) => [c.connector, c]));
+  const configs = costConfigs ?? [];
   // Only cost-layer sources surface in the UI today; revenue/CDP and the third-party integration
   // cards were purely decorative (no real status), removed in the cleanup wave following #100.
   const visibleConnectors = connectors.filter((c) => c.category === "cost");

--- a/web/components/HonestValue.test.tsx
+++ b/web/components/HonestValue.test.tsx
@@ -85,6 +85,17 @@ describe("Pct (CTO-178)", () => {
     expect(container.textContent).toBe("0%");
   });
 
+  it("drops the trailing sign when unit is false, for the low end of a range", () => {
+    const { container } = render(<Pct value={0.099} unit={false} />);
+    expect(container.textContent).toBe("9.9");
+  });
+
+  it("keeps the same rounding whether or not the sign is printed", () => {
+    const bare = render(<Pct value={0.12345} unit={false} />).container.textContent;
+    const signed = render(<Pct value={0.12345} />).container.textContent;
+    expect(`${bare}%`).toBe(signed);
+  });
+
   it("renders an explained blank for null", () => {
     const { container } = render(<Pct value={null} reason="needs ≥50 spans in 7d" />);
     expect(container.textContent).toContain(BLANK);

--- a/web/components/HonestValue.tsx
+++ b/web/components/HonestValue.tsx
@@ -54,15 +54,26 @@ export function Money({
  * A percentage. `value` is a fraction (0.42 renders "42.0%"), matching how rates arrive from the
  * API everywhere in this app. `digits` because the existing surfaces disagree on precision:
  * attribution rates round to whole percent, error rates want two decimals.
+ *
+ * `unit` exists for ranges. A confidence band reads "9.9–10.3%", printing the sign once at the end
+ * rather than on both ends, so the low bound needs the same rounding as everything else but not the
+ * trailing "%". Without this the only options are re-implementing the formatting at the call site
+ * or changing how the band reads, and the band's format is deliberate.
  */
 export function Pct({
   value,
   digits = 1,
+  unit = true,
   reason,
   className,
-}: NullableProps<"value", number> & { digits?: number }) {
+}: NullableProps<"value", number> & { digits?: number; unit?: boolean }) {
   if (value === null || Number.isNaN(value)) {
     return <Blank reason={reason ?? "not enough samples to report a rate"} className={className} />;
   }
-  return <span className={className}>{(value * 100).toFixed(digits)}%</span>;
+  return (
+    <span className={className}>
+      {(value * 100).toFixed(digits)}
+      {unit ? "%" : ""}
+    </span>
+  );
 }


### PR DESCRIPTION
Closes CTO-179 (workstream A3 of the cost-per-customer plan).

**Stacked PR.** Based on `feat/honest-value-primitives`, which carries both dependencies: #167 (`DataTable`, CTO-177) and #168 (`HonestValue`, CTO-178). Review and merge those first; this targets #168's branch, not `main`.

## What changed

A1 and A2 shipped the shared table and the honest-value primitives, and nothing used them yet. This migrates the two pages A3 names. They were picked because they are structurally opposite: `/connectors` is per-row interactive controls, `/attribution` is dense numerics with Wilson bands and honest blanks. If the components fit both, they are the right components.

- `web/app/connectors/page.tsx`: the hand-rolled `<table>` becomes a `DataTable` column spec, extracted into `web/app/connectors/ConnectorTable.tsx`.
- `web/app/attribution/Live.tsx`: same, plus `<Money>` / `<Pct>` for every number and `<Blank reason>` for every blank.
- The page no longer builds a `Map` of connector configs before rendering; it passes the flat list and the table builds its own lookup.

## Reasons on the blanks

VALUE/USER and MARGIN/USER on `/attribution` were the blanks worth getting right. Per `docs/cost-per-customer-scope.md` and `docs/cost-per-customer-plan.md` (workstream E), they are empty because no revenue source is wired for the tenant, not because those providers earn nothing:

- Value/user: "no revenue source is wired for this tenant, so there is no revenue to divide across users"
- Margin/user: "margin needs revenue: no revenue source is wired for this tenant, so only the cost side is known"

`$/conversion` gets its own reason (no outcome events in the window, so no denominator), and the four `/connectors` blanks say which of "never synced", "no records in 30d", "takes no credentials from the dashboard", and "not ingesting into a cost layer yet" applies. Every reason is real; none is a generic fallback.

## Component fixes

Two places the components did not fit cleanly. Both were fixed in the component rather than worked around in the page.

**`Pct` gained a `unit` prop** (`web/components/HonestValue.tsx`). A confidence band reads `9.9–10.3%`, printing the sign once at the end. The low bound needs the same rounding as everything else but not the trailing `%`. Without the prop the only options were re-implementing the formatting at the call site or changing how the band reads, and the band's format is deliberate. Two tests cover it, including one asserting the rounding is identical with and without the sign.

**The `/connectors` table moved into its own client module.** `DataTable` takes a column spec whose `render` entries are functions, and functions cannot cross the server/client boundary; `page.tsx` is an async server component that fetches the catalog. Every page migrating to `DataTable` will hit this. It is the cost of a render-prop API, and cheaper than the alternatives (a serializable cell-descriptor language, or a server-rendered table that cannot sort or page). Worth knowing before the remaining eight pages migrate.

Two smaller judgement calls, flagged rather than hidden:

- **Sorting is not enabled on either page.** `DataTable`'s sort arrow holds layout space in the header even when inactive, so turning it on shifts the right-aligned headers by a few pixels. That is a visual regression, and A3's hard requirement is that there is none. Enabling it is a one-line change per column whenever the arrow's reserved space is reconsidered.
- **`/attribution` keeps its own empty state** rather than using `DataTable`'s `empty` slot. The existing copy tells a first-run viewer the command that produces data, and a centered line under a header row of empty columns buries it. This matches D5 in the plan ("Not a blank table, and not a bare 'no data' line").

## Verification

Docker stack up (ClickHouse, Postgres, gateway), so both pages rendered live data before and after.

- `/connectors`: identical. Same seven rows in the same order, same columns, same badges, same widths. Only the record counts moved, because live ingest kept running between the two screenshots.
- `/attribution`: identical, including the band format `10.1% [9.9–10.3%]`. Only the live figures drifted.
- The blanks are the one intended difference: they now carry the dotted-underline hover affordance that `Blank` ships, which is the point of the primitive.

Interactive controls confirmed working, not just rendering:

- **Edit** on AWS Cost Explorer opens `ConnectForm` with the stored credential reference and cost-allocation tags prefilled, which also proves the config list survives the new server-to-client hop.
- **Connect** / **Disconnect** render on the right rows.
- The **enable toggle** fires its server action and renders the gateway's response inline. Locally that response is `gateway HTTP 500`, which is pre-existing and not from this change: `curl -X POST localhost:8080/v1/tenant/connectors -H 'X-Tenant-Id: local-dev' -d '{"layer":"tools","enabled":true}'` returns the same 500, from `psycopg.errors.InvalidTextRepresentation: invalid input syntax for type uuid: "local-dev"` in the gateway log. The control is wired correctly and reports the error the way it always did.

CI, from `web/`:

- `npm run typecheck`: clean.
- `npm run lint`: clean apart from the three pre-existing warnings (`tag` / `provider` unused in `Live.tsx`, an unused eslint-disable in `useLivePoll.ts`), all present before this change.
- `npm run test`: 262 passed, 2 failed. The two failures are the documented pre-existing ones in `app/api/api.test.ts` (attribution + data-quality ClickHouse fallback, which fail locally when ClickHouse IS running). Baseline on the parent branch was 260 passed / 2 failed, so this adds two passing tests and no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
