### PR TITLE
feat(gateway): account lookup endpoint for cost per customer (CTO-185)

### DIFF
--- a/infra/gateway/src/gateway/account_lookup.py
+++ b/infra/gateway/src/gateway/account_lookup.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Plaintext account id -> ``AccountIdHash``, for the cost-per-customer search box (CTO-185, B6).
+
+WHY this exists. The cost-per-customer tab lists accounts by ``AccountIdHash`` (CTO-180). A label
+is optional per account by design (see ``docs/cost-per-customer-plan.md``, Decision 1), so a tenant
+who sets none gets a table of 64-character hex strings. Those rows are not merely ugly, they are
+unfindable: an operator who knows their customer as ``acme-corp`` has no way to reach the row,
+because the hash is one-way and nothing anywhere maps back. This module is the forward direction,
+computed on demand, which is the only direction that exists.
+
+WHY the plaintext is never kept. Storing an ``account_id -> hash`` table would rebuild the reverse
+map that hashing exists to prevent, and would put the tenant's customer identifiers in our storage.
+The plaintext lives for the length of one HMAC call and is then gone: not persisted, not logged,
+not echoed in an error. :func:`hash_account_id` therefore takes a value and returns digests, and
+every failure it can produce is described without quoting the input.
+
+WHY it reuses ``HmacKeyRegistry``. Parity with the SDK is the whole point: a hash that does not
+equal the one the emitting path stamped on the span matches nothing. So this calls the SDK's own
+``tally.hmac_keys`` derivation (provision, then hash under the tenant's active key version), the
+same way ``gateway.stripe_ingest.hash_customer_email`` and ``gateway.integration_workers``
+``build_hasher`` already do. There is no second implementation to drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from tally.hmac_keys import HmacKeyRegistry
+
+from gateway.tenant_identity import TenantKey
+
+# Guards against a caller pasting a document into the search box. Real account ids are short;
+# anything past this is a mistake and is rejected without echoing what was sent.
+MAX_ACCOUNT_ID_BYTES = 512
+
+
+class AccountLookupError(ValueError):
+    """Invalid lookup input. Messages here are written to be safe to log and safe to return."""
+
+
+@dataclass(frozen=True, slots=True)
+class AccountHash:
+    """One ``AccountIdHash`` plus the tenant spelling and key version that produced it."""
+
+    account_id_hash: str
+    key_version: str
+    tenant_key_form: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "account_id_hash": self.account_id_hash,
+            "key_version": self.key_version,
+            "tenant_key_form": self.tenant_key_form,
+        }
+
+
+def normalize_account_id(value: object) -> str:
+    """Validate and trim a plaintext account id.
+
+    Trimming only. No lowercasing, unlike the Stripe email hasher: an account id is an opaque
+    tenant-side identifier and ``Acme`` may well be a different customer from ``acme``, so folding
+    case here would merge two accounts into one row.
+
+    Raises :class:`AccountLookupError` with a message that never contains ``value``.
+    """
+    if not isinstance(value, str):
+        raise AccountLookupError("account_id must be a string")
+    trimmed = value.strip()
+    if not trimmed:
+        raise AccountLookupError("account_id must be a non-empty string")
+    if len(trimmed.encode("utf-8")) > MAX_ACCOUNT_ID_BYTES:
+        raise AccountLookupError(f"account_id must be at most {MAX_ACCOUNT_ID_BYTES} bytes")
+    return trimmed
+
+
+def hash_account_id(
+    registry: HmacKeyRegistry,
+    tenant_keys: Sequence[TenantKey],
+    account_id: str,
+) -> tuple[AccountHash, ...]:
+    """Hash ``account_id`` under each spelling of the tenant, in the order given.
+
+    One digest per spelling because the tenant identifier is key material: see
+    :mod:`gateway.tenant_identity`. The caller matches spans against the whole set, so a dashboard
+    that addresses the gateway by name still finds spans emitted under the UUID and vice versa.
+
+    Returns an empty tuple only when ``tenant_keys`` is empty, which the endpoint prevents.
+    """
+    out: list[AccountHash] = []
+    seen: set[str] = set()
+    for key in tenant_keys:
+        if not key.value or key.value in seen:
+            continue
+        seen.add(key.value)
+        registry.provision(key.value)
+        stamped = registry.hash(key.value, account_id)
+        out.append(
+            AccountHash(
+                account_id_hash=stamped.value,
+                key_version=stamped.key_version,
+                tenant_key_form=key.form,
+            )
+        )
+    return tuple(out)

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -36,6 +36,11 @@ from tally.wire import (
     uuid7,
 )
 
+from gateway.account_lookup import (
+    AccountLookupError,
+    hash_account_id,
+    normalize_account_id,
+)
 from gateway.auth import ApiKeyAuth
 from gateway.backpressure import Backpressure
 from gateway.config import get_settings
@@ -96,6 +101,7 @@ from gateway.connectors.config_admin import (
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
+from gateway.tenant_identity import TenantIdentityResolver
 from gateway.tenant_guardrails import (
     ALLOWED_KINDS as GUARDRAIL_KINDS,
     ALLOWED_STATES as GUARDRAIL_STATES,
@@ -194,6 +200,10 @@ async def lifespan(app: FastAPI):
     # Per-tenant HMAC key registry — used to hash Stripe customer emails into the same
     # UserIdHash space the SDK uses, so the attribution join lights up (CTO-110).
     app.state.hmac_registry = HmacKeyRegistry()
+    # Tenant name <-> tenants.id UUID (CTO-185). Both spellings reach the gateway and each derives
+    # a different HMAC key, so /v1/tenant/account-lookup hashes under every spelling rather than
+    # guessing one and returning a hash that silently matches nothing.
+    app.state.tenant_identity = TenantIdentityResolver(settings)
     # In-process dedup set for Stripe webhook redeliveries. ClickHouse's ReplacingMergeTree
     # will collapse late duplicates at merge time, but this short-circuits the second insert
     # so the 200 stays well under Stripe's 30s timeout window.
@@ -1052,6 +1062,79 @@ def get_tenant_reconciliation_status(
     run = store.get_latest(tenant_id)
     return JSONResponse(
         {"tenant_id": tenant_id, "run": run.as_dict() if run is not None else None},
+        status_code=200,
+    )
+
+
+@app.post("/v1/tenant/account-lookup")
+async def lookup_account_id(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Plaintext account id -> ``AccountIdHash``, for the cost-per-customer search box (CTO-185).
+
+    WHY. The cost-per-customer tab groups spend by ``AccountIdHash`` (CTO-180), and an account
+    label is optional per tenant by design, so an unlabelled account renders as a 64-character
+    hex string. There is no reverse map from hash to id and there deliberately never will be, so
+    without this endpoint an operator who knows their customer as ``acme-corp`` cannot locate that
+    row at all and the tab is a list of opaque strings. This is the forward direction, computed on
+    demand, which is the only direction a one-way hash has.
+
+    Body: ``{"account_id": "acme-corp"}``. Response carries ``account_id_hash`` (the best match)
+    plus every candidate in ``hashes``.
+
+    Two properties this endpoint exists to hold:
+
+    * **Parity with the emitting path.** The digest comes from the SDK's own
+      :class:`tally.hmac_keys.HmacKeyRegistry` under the tenant's active key version, the same
+      derivation ``hash_customer_email`` and ``build_hasher`` already use. A hash computed any
+      other way would be well-formed and match nothing.
+
+    * **The plaintext is transient.** It is used for one HMAC call and then dropped. It is never
+      written to a row, never logged, and never quoted back in an error: every rejection message
+      in :mod:`gateway.account_lookup` describes the problem without echoing the value. That is
+      also why this is a POST with a body rather than a GET with a query string, which would put
+      a customer identifier into access logs.
+
+    An account id nobody has ever emitted is NOT an error. It returns 200 with a perfectly valid
+    hash that simply matches no rows, and the tab renders "no spend recorded for this account".
+    Answering 404 here would leak the difference between an account this tenant has and one it
+    does not, and would also make a genuine typo indistinguishable from a genuinely idle customer.
+
+    ``hashes`` holds one entry per spelling of the tenant identifier (see
+    :mod:`gateway.tenant_identity`): the tenant name and the ``tenants.id`` UUID derive different
+    HMAC keys, so callers should match spans against the whole set rather than assume a spelling.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        # Deliberately no `{exc}` interpolation, unlike the neighbouring endpoints: a decoder
+        # message can quote the offending bytes, and those bytes are the account id.
+        raise HTTPException(status_code=422, detail="body is not valid JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    try:
+        account_id = normalize_account_id(body.get("account_id"))
+    except AccountLookupError as exc:
+        # Safe by construction: AccountLookupError messages never contain the submitted value.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    resolver: TenantIdentityResolver = app.state.tenant_identity
+    registry: HmacKeyRegistry = app.state.hmac_registry
+    hashes = hash_account_id(registry, resolver.key_forms(tenant_id), account_id)
+    if not hashes:
+        raise HTTPException(status_code=422, detail="tenant id must be non-empty")
+    # No log line here, at any level. The only interesting thing to report would be what was
+    # looked up, and that is precisely the thing that must not be recorded.
+    return JSONResponse(
+        {
+            "tenant_id": tenant_id,
+            "account_id_hash": hashes[0].account_id_hash,
+            "key_version": hashes[0].key_version,
+            "hashes": [h.as_dict() for h in hashes],
+        },
         status_code=200,
     )
 

--- a/infra/gateway/src/gateway/tenant_identity.py
+++ b/infra/gateway/src/gateway/tenant_identity.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Both spellings of one tenant: the ``tenants.id`` UUID and the ``tenants.name`` (CTO-185).
+
+WHY this exists. A tenant is identified by two different strings depending on which door the
+request came through. Ingest under ``require_api_key`` carries ``api_keys.tenant_id``, a UUID.
+Ingest with auth off, and the dashboard on every control-plane call, carries a NAME
+(``local-dev``). :func:`gateway.connectors.config_admin._resolve_tenant_uuid` already had to paper
+over exactly this for the config tables, which key on the UUID.
+
+For the config tables the mismatch is merely an awkward lookup. For anything HMAC'd it is worse,
+because the tenant identifier is *key material*: ``HmacKeyRegistry`` derives a tenant's key from
+the identifier string it is handed, so ``local-dev`` and ``5f1c...`` produce two unrelated key
+spaces and therefore two unrelated hashes for the same account id. A lookup that guessed the wrong
+spelling would return a well-formed 64-hex hash that silently matches nothing, which is the worst
+possible failure: indistinguishable from an account that genuinely has no spend.
+
+So the account-lookup endpoint does not guess. It resolves the caller's tenant to BOTH spellings
+and hashes under each, and the caller matches on the set. Resolution is fail-soft: if Postgres is
+unreachable we still answer with the spelling the caller gave us, because that is the one the
+matching ingest path would have used anyway.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+import psycopg
+
+from gateway.config import Settings
+
+logger = logging.getLogger("tally.gateway")
+
+# How a tenant identifier is spelled. ``uuid`` is ``tenants.id``, ``name`` is ``tenants.name``.
+FORM_UUID = "uuid"
+FORM_NAME = "name"
+
+
+def key_form(tenant_id: str) -> str:
+    """Which spelling ``tenant_id`` is, decided purely by whether it parses as a UUID."""
+    try:
+        uuid.UUID(tenant_id)
+    except (ValueError, AttributeError, TypeError):
+        return FORM_NAME
+    return FORM_UUID
+
+
+@dataclass(frozen=True, slots=True)
+class TenantKey:
+    """One spelling of a tenant identifier, and therefore one HMAC key space."""
+
+    value: str
+    form: str
+
+
+class TenantIdentityResolver:
+    """Expands a tenant identifier into every spelling that names the same tenant row."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def key_forms(self, tenant_id: str) -> tuple[TenantKey, ...]:
+        """Return the caller's spelling first, then the other one when Postgres knows it.
+
+        Caller-first ordering is deliberate: it is the spelling the ingest path used under the
+        same auth mode, so it is the likeliest match and belongs at the head of the response.
+
+        Never raises. A missing tenant row, an unreachable control plane, or a driver error all
+        degrade to the single spelling we were given rather than failing the lookup.
+        """
+        given = TenantKey(value=tenant_id, form=key_form(tenant_id))
+        other = self._other_form(given)
+        if other is None or other.value == given.value:
+            return (given,)
+        return (given, other)
+
+    def _other_form(self, given: TenantKey) -> TenantKey | None:
+        if not given.value:
+            return None
+        if given.form == FORM_UUID:
+            sql, wanted = "SELECT name FROM tenants WHERE id = %s", FORM_NAME
+        else:
+            sql, wanted = "SELECT id FROM tenants WHERE name = %s", FORM_UUID
+        try:
+            with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+                cur.execute(sql, (given.value,))
+                row = cur.fetchone()
+        except Exception as exc:  # noqa: BLE001 - lookup is an enrichment, never a hard failure
+            # Type name only. The tenant identifier is not secret, but driver messages can quote
+            # the whole statement and we keep this line boring on principle.
+            logger.warning("tenant identity lookup failed: %s", type(exc).__name__)
+            return None
+        if row is None or row[0] is None:
+            return None
+        return TenantKey(value=str(row[0]), form=wanted)

--- a/infra/gateway/tests/test_app_account_lookup.py
+++ b/infra/gateway/tests/test_app_account_lookup.py
@@ -1,0 +1,282 @@
+"""POST /v1/tenant/account-lookup: plaintext account id to AccountIdHash (CTO-185).
+
+The load-bearing test here is :func:`test_hash_matches_sdk_derivation`: the endpoint's digest must
+equal the one the SDK's own ``tally.hmac_keys`` path produces for the same tenant and account id,
+or the search box returns a well-formed hash that matches no span. The rest of the file guards the
+privacy invariant (the plaintext reaches no log line and no stored row) and the two tenant-identifier
+spellings the gateway has to live with.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.account_lookup import (
+    AccountLookupError,
+    MAX_ACCOUNT_ID_BYTES,
+    normalize_account_id,
+)
+from gateway.app import app
+from gateway.tenant_identity import FORM_NAME, FORM_UUID, TenantKey, key_form
+from tally.hmac_keys import HmacKeyRegistry
+
+TENANT_NAME = "local-dev"
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+ACCOUNT_ID = "acme-corp"
+
+
+class FakeIdentityResolver:
+    """Stands in for :class:`TenantIdentityResolver` so no Postgres is needed.
+
+    Mirrors the real contract: caller's spelling first, the other one second when known.
+    """
+
+    def __init__(self, pairs: dict[str, str] | None = None) -> None:
+        # name -> uuid, both directions resolvable
+        self._pairs = pairs if pairs is not None else {TENANT_NAME: TENANT_UUID}
+
+    def key_forms(self, tenant_id: str) -> tuple[TenantKey, ...]:
+        given = TenantKey(value=tenant_id, form=key_form(tenant_id))
+        for name, uuid_value in self._pairs.items():
+            if tenant_id == name:
+                return (given, TenantKey(value=uuid_value, form=FORM_UUID))
+            if tenant_id == uuid_value:
+                return (given, TenantKey(value=name, form=FORM_NAME))
+        return (given,)
+
+
+class OfflineIdentityResolver:
+    """Postgres unreachable: the resolver degrades to the caller's spelling and never raises."""
+
+    def key_forms(self, tenant_id: str) -> tuple[TenantKey, ...]:
+        return (TenantKey(value=tenant_id, form=key_form(tenant_id)),)
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_identity = FakeIdentityResolver()
+        app.state.hmac_registry = HmacKeyRegistry()
+        yield c
+
+
+def _lookup(client: TestClient, account_id: object, tenant: str = TENANT_NAME):
+    return client.post(
+        "/v1/tenant/account-lookup",
+        headers={"X-Tenant-Id": tenant},
+        json={"account_id": account_id},
+    )
+
+
+# --- SDK parity: the acceptance criterion ------------------------------------------------------
+
+
+def test_hash_matches_sdk_derivation(client: TestClient) -> None:
+    """The endpoint and the SDK's own hmac_keys path must agree, digit for digit.
+
+    Both paths are exercised here: the HTTP endpoint on one side, and on the other a bare
+    HmacKeyRegistry driven exactly as an emitting SDK would drive it (provision the tenant, hash
+    under the active key version). If these ever diverge, every hash the search box returns stops
+    matching the spans the SDK stamped.
+    """
+    r = _lookup(client, ACCOUNT_ID)
+    assert r.status_code == 200
+    body = r.json()
+
+    sdk_registry = HmacKeyRegistry()
+    sdk_registry.provision(TENANT_NAME)
+    expected = sdk_registry.hash(TENANT_NAME, ACCOUNT_ID)
+
+    assert body["account_id_hash"] == expected.value
+    assert body["key_version"] == expected.key_version
+    # AccountIdHash is FixedString(64) hex in ClickHouse (CTO-180), so the digest must fit it.
+    assert len(body["account_id_hash"]) == 64
+    assert int(body["account_id_hash"], 16) >= 0
+
+
+def test_hash_matches_sdk_derivation_for_uuid_spelling(client: TestClient) -> None:
+    """Parity holds for a UUID-spelled tenant too, which is what API-key auth resolves to."""
+    r = _lookup(client, ACCOUNT_ID, tenant=TENANT_UUID)
+    assert r.status_code == 200
+
+    sdk_registry = HmacKeyRegistry()
+    sdk_registry.provision(TENANT_UUID)
+    expected = sdk_registry.hash(TENANT_UUID, ACCOUNT_ID)
+    assert r.json()["account_id_hash"] == expected.value
+
+
+def test_hash_is_stable_and_account_specific(client: TestClient) -> None:
+    first = _lookup(client, ACCOUNT_ID).json()["account_id_hash"]
+    second = _lookup(client, ACCOUNT_ID).json()["account_id_hash"]
+    other = _lookup(client, "globex-inc").json()["account_id_hash"]
+    assert first == second
+    assert first != other
+
+
+def test_hash_is_not_joinable_across_tenants(client: TestClient) -> None:
+    """Per-tenant keys: the same account id under two tenants must not collide."""
+    app.state.tenant_identity = OfflineIdentityResolver()
+    mine = _lookup(client, ACCOUNT_ID, tenant="tenant-a").json()["account_id_hash"]
+    theirs = _lookup(client, ACCOUNT_ID, tenant="tenant-b").json()["account_id_hash"]
+    assert mine != theirs
+
+
+# --- unknown accounts are not errors -----------------------------------------------------------
+
+
+def test_unknown_account_id_returns_a_hash_not_an_error(client: TestClient) -> None:
+    """An id nobody ever emitted still gets a valid hash. The tab renders "no spend recorded".
+
+    Answering 404 would leak whether the tenant has this account, and would make a typo
+    indistinguishable from a real customer who happens to have no spend in the window.
+    """
+    r = _lookup(client, "no-such-customer-9f3a")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["account_id_hash"]) == 64
+    # Nothing about the response claims a match; matching is the caller's ClickHouse query.
+    assert "matched" not in body
+    assert body["account_id_hash"] != _lookup(client, ACCOUNT_ID).json()["account_id_hash"]
+
+
+# --- the plaintext never escapes ---------------------------------------------------------------
+
+
+def test_plaintext_never_appears_in_any_log_line(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    secret = "acme-corp-super-distinctive-7Q4Z"
+    with caplog.at_level(logging.DEBUG):
+        assert _lookup(client, secret).status_code == 200
+    joined = "\n".join(r.getMessage() for r in caplog.records) + "\n".join(caplog.messages)
+    assert secret not in joined
+    assert "acme-corp-super" not in joined
+
+
+def test_plaintext_never_appears_in_the_response(client: TestClient) -> None:
+    secret = "acme-corp-super-distinctive-7Q4Z"
+    r = _lookup(client, secret)
+    assert secret not in r.text
+
+
+def test_rejection_messages_never_echo_the_input(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A rejected lookup is the sneakiest leak path: 422 detail strings get logged by callers."""
+    oversized = "x" * 40 + "@leaky-customer.example"
+    with caplog.at_level(logging.DEBUG):
+        r = client.post(
+            "/v1/tenant/account-lookup",
+            headers={"X-Tenant-Id": TENANT_NAME},
+            json={"account_id": {"nested": oversized}},
+        )
+    assert r.status_code == 422
+    assert "leaky-customer" not in r.text
+    assert "leaky-customer" not in "\n".join(caplog.messages)
+
+
+def test_malformed_json_body_is_rejected_without_quoting_it(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/account-lookup",
+        headers={"X-Tenant-Id": TENANT_NAME, "Content-Type": "application/json"},
+        content=b'{"account_id": "leaky-customer-value"',
+    )
+    assert r.status_code == 422
+    assert "leaky-customer" not in r.text
+
+
+def test_lookup_writes_no_row_anywhere(client: TestClient) -> None:
+    """The endpoint touches no store. A persisted plaintext would rebuild the reverse map."""
+
+    class ExplodingStore:
+        def close(self) -> None:
+            """Allowed: lifespan shutdown closes the store after the test body has run."""
+
+        def __getattr__(self, name: str):
+            raise AssertionError(f"account lookup must not touch storage (called {name})")
+
+    app.state.store = ExplodingStore()
+    app.state.tenant_connectors = ExplodingStore()
+    app.state.tenant_feature_value_events = ExplodingStore()
+    assert _lookup(client, ACCOUNT_ID).status_code == 200
+
+
+# --- tenant spellings --------------------------------------------------------------------------
+
+
+def test_both_tenant_spellings_are_returned(client: TestClient) -> None:
+    """Name and UUID derive different keys, so the caller gets both and matches on the set."""
+    by_name = _lookup(client, ACCOUNT_ID, tenant=TENANT_NAME).json()
+    by_uuid = _lookup(client, ACCOUNT_ID, tenant=TENANT_UUID).json()
+
+    assert [h["tenant_key_form"] for h in by_name["hashes"]] == [FORM_NAME, FORM_UUID]
+    assert [h["tenant_key_form"] for h in by_uuid["hashes"]] == [FORM_UUID, FORM_NAME]
+    # The caller's own spelling leads, and the two callers cover the same pair of digests.
+    assert by_name["account_id_hash"] == by_name["hashes"][0]["account_id_hash"]
+    assert {h["account_id_hash"] for h in by_name["hashes"]} == {
+        h["account_id_hash"] for h in by_uuid["hashes"]
+    }
+
+
+def test_unresolvable_tenant_still_answers_with_one_hash(client: TestClient) -> None:
+    """Postgres down or tenant absent: degrade to the caller's spelling, never fail the lookup."""
+    app.state.tenant_identity = OfflineIdentityResolver()
+    body = _lookup(client, ACCOUNT_ID).json()
+    assert len(body["hashes"]) == 1
+    assert body["hashes"][0]["tenant_key_form"] == FORM_NAME
+
+    sdk_registry = HmacKeyRegistry()
+    sdk_registry.provision(TENANT_NAME)
+    assert body["account_id_hash"] == sdk_registry.hash(TENANT_NAME, ACCOUNT_ID).value
+
+
+# --- input validation and tenant resolution ----------------------------------------------------
+
+
+def test_tenant_header_is_required(client: TestClient) -> None:
+    r = client.post("/v1/tenant/account-lookup", json={"account_id": ACCOUNT_ID})
+    assert r.status_code == 422
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", 17, ["acme"], {"a": 1}])
+def test_invalid_account_ids_are_422(client: TestClient, bad: object) -> None:
+    assert _lookup(client, bad).status_code == 422
+
+
+def test_oversized_account_id_is_422(client: TestClient) -> None:
+    assert _lookup(client, "z" * (MAX_ACCOUNT_ID_BYTES + 1)).status_code == 422
+
+
+def test_body_must_be_an_object(client: TestClient) -> None:
+    r = client.post(
+        "/v1/tenant/account-lookup", headers={"X-Tenant-Id": TENANT_NAME}, json=["acme-corp"]
+    )
+    assert r.status_code == 422
+
+
+# --- normalize_account_id, directly ------------------------------------------------------------
+
+
+def test_normalize_trims_but_does_not_fold_case() -> None:
+    """Case matters: an account id is opaque, and `Acme` may be a different customer from `acme`."""
+    assert normalize_account_id("  acme-corp  ") == "acme-corp"
+    assert normalize_account_id("Acme-Corp") == "Acme-Corp"
+    assert normalize_account_id("Acme-Corp") != normalize_account_id("acme-corp")
+
+
+def test_normalize_error_messages_carry_no_input() -> None:
+    oversized = "y" * (MAX_ACCOUNT_ID_BYTES + 1)
+    with pytest.raises(AccountLookupError) as exc:
+        normalize_account_id(oversized)
+    assert oversized not in str(exc.value)
+    assert "yyyy" not in str(exc.value)
+
+    for blank in ("", "   "):
+        with pytest.raises(AccountLookupError):
+            normalize_account_id(blank)
+    with pytest.raises(AccountLookupError):
+        normalize_account_id(None)

--- a/infra/gateway/tests/test_tenant_identity.py
+++ b/infra/gateway/tests/test_tenant_identity.py
@@ -1,0 +1,123 @@
+"""TenantIdentityResolver: tenant name <-> tenants.id UUID, fail-soft (CTO-185).
+
+The gateway is handed a tenant NAME by the dashboard and a ``tenants.id`` UUID by API-key auth.
+Anything HMAC'd treats that string as key material, so the two spellings are two key spaces. These
+tests pin the expansion and, more importantly, pin that a control-plane outage degrades to the
+caller's own spelling instead of failing the lookup.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from gateway import tenant_identity
+from gateway.tenant_identity import (
+    FORM_NAME,
+    FORM_UUID,
+    TenantIdentityResolver,
+    key_form,
+)
+
+NAME = "local-dev"
+UUID_VALUE = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+
+
+class _Settings:
+    postgres_dsn = "postgresql://unused"
+
+
+class _FakeCursor:
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._row
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def __enter__(self) -> "_FakeConn":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def _patch_connect(monkeypatch: pytest.MonkeyPatch, row: tuple[Any, ...] | None) -> _FakeCursor:
+    cursor = _FakeCursor(row)
+    monkeypatch.setattr(
+        tenant_identity.psycopg, "connect", lambda *_a, **_k: _FakeConn(cursor)
+    )
+    return cursor
+
+
+def test_key_form_splits_on_uuid_parsing() -> None:
+    assert key_form(UUID_VALUE) == FORM_UUID
+    assert key_form(NAME) == FORM_NAME
+    assert key_form("") == FORM_NAME
+
+
+def test_name_expands_to_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _patch_connect(monkeypatch, (UUID_VALUE,))
+    keys = TenantIdentityResolver(_Settings()).key_forms(NAME)
+    assert [(k.value, k.form) for k in keys] == [(NAME, FORM_NAME), (UUID_VALUE, FORM_UUID)]
+    assert "WHERE name" in cursor.executed[0][0]
+
+
+def test_uuid_expands_to_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _patch_connect(monkeypatch, (NAME,))
+    keys = TenantIdentityResolver(_Settings()).key_forms(UUID_VALUE)
+    assert [(k.value, k.form) for k in keys] == [(UUID_VALUE, FORM_UUID), (NAME, FORM_NAME)]
+    assert "WHERE id" in cursor.executed[0][0]
+
+
+def test_unknown_tenant_yields_only_the_caller_spelling(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_connect(monkeypatch, None)
+    keys = TenantIdentityResolver(_Settings()).key_forms("not-a-tenant")
+    assert [k.value for k in keys] == ["not-a-tenant"]
+
+
+def test_postgres_failure_degrades_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(tenant_identity.psycopg, "connect", _boom)
+    keys = TenantIdentityResolver(_Settings()).key_forms(NAME)
+    assert [k.value for k in keys] == [NAME]
+
+
+def test_failure_log_line_carries_only_the_exception_type(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("SELECT id FROM tenants WHERE name = 'leaky-value'")
+
+    monkeypatch.setattr(tenant_identity.psycopg, "connect", _boom)
+    with caplog.at_level("DEBUG"):
+        TenantIdentityResolver(_Settings()).key_forms(NAME)
+    assert "leaky-value" not in "\n".join(caplog.messages)
+
+
+def test_empty_tenant_id_is_not_looked_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("must not hit Postgres for an empty tenant id")
+
+    monkeypatch.setattr(tenant_identity.psycopg, "connect", _boom)
+    assert [k.value for k in TenantIdentityResolver(_Settings()).key_forms("")] == [""]


### PR DESCRIPTION
Implements **CTO-185 (B6)**: `POST /v1/tenant/account-lookup`.

> **Stacked PR.** Based on **#170** (CTO-180, B1), which added `AccountIdHash` to `otel_spans` and `business_events`. Base branch is `worktree-agent-a53b7cbc2d8752dbf`, not `main`. Review/merge #170 first; the diff here is only the two new modules, the endpoint, and their tests.

## Why

The cost-per-customer tab groups spend by `AccountIdHash`. An account label is optional per tenant by design (`docs/cost-per-customer-plan.md`, Decision 1), so a tenant who sets none gets a table of 64-character hex strings. The hash is one-way and nothing maps back, so an operator who knows their customer as `acme-corp` cannot reach that row at all. This is the forward direction, computed on demand, which is the only direction a one-way hash has.

## SDK parity proof

The digest must equal the one the emitting path stamped on the span, or the search box returns a well-formed hash that matches nothing. The endpoint calls the SDK's own `tally.hmac_keys` derivation (`provision`, then `hash` under the active key version), the same call shape `hash_customer_email` and `build_hasher` already use. There is no second implementation to drift.

`test_hash_matches_sdk_derivation` drives both sides and asserts they agree digit for digit. Confirmed live against the running local stack:

```
$ curl -s -X POST localhost:8080/v1/tenant/account-lookup \
    -H 'X-Tenant-Id: local-dev' -d '{"account_id":"acme-corp"}'
{"tenant_id":"local-dev",
 "account_id_hash":"b8130993da2a485dc214bed0fbe6ef418d1b2e7c966d19169c06c27fe41a03e0",
 "key_version":"v1", ...}

$ uv run python -c "from tally.hmac_keys import HmacKeyRegistry; \
    r=HmacKeyRegistry(); r.provision('local-dev'); \
    print(r.hash('local-dev','acme-corp').value)"
b8130993da2a485dc214bed0fbe6ef418d1b2e7c966d19169c06c27fe41a03e0
```

Identical. Parity also holds for the UUID spelling (`test_hash_matches_sdk_derivation_for_uuid_spelling`).

## The plaintext never escapes

Used for one HMAC call, then dropped. Not persisted, not logged, not echoed in an error.

- Every rejection message in `account_lookup` is written without the submitted value, and the JSON decode error is deliberately **not** interpolated (unlike the neighbouring endpoints) because a decoder message can quote the offending bytes.
- POST with a body rather than GET with a query string, so no customer identifier reaches access logs.
- Four tests pin it: no plaintext in any log record at DEBUG, none in the response, none in a 422 detail, and `test_lookup_writes_no_row_anywhere` swaps in a store that raises on any attribute access.

Verified live: `grep -c` over 10 minutes of gateway logs covering successful, unknown, and rejected lookups returns **0** occurrences of the submitted ids. Access lines carry the path only.

## The tenant-spelling trap

`_resolve_tenant_uuid` in `connectors/config_admin.py` already had to paper over the dashboard saying `local-dev` while the tables key on a `tenants.id` UUID. For the config tables that is an awkward lookup. For anything HMAC'd it is worse: the tenant identifier **is key material**, so the two spellings are two unrelated key spaces. Guessing wrong returns a valid 64-hex hash that silently matches nothing, which is indistinguishable from an account that genuinely has no spend.

So `TenantIdentityResolver` resolves both spellings and the endpoint hashes under each, caller's spelling first (it is the one the matching ingest path used under the same auth mode). Callers match spans against the whole `hashes` set. Resolution is fail-soft: an unreachable control plane degrades to the caller's own spelling rather than failing the lookup.

Both entry points confirmed live to produce the same pair of digests, reordered by which spelling the caller used.

## Unknown account ids are not errors

200 with a valid hash that matches no rows; the tab renders "no spend recorded for this account". A 404 would leak whether the tenant has that account, and would make a typo indistinguishable from a real but idle customer.

## Verification

- `uv run --extra dev pytest -q` gives **494 passed** (30 new)
- `uv run ruff check .` gives **All checks passed**
- Exercised against the rebuilt local gateway: parity, both tenant spellings, unknown id, empty id, malformed JSON, missing tenant header, and the log audit above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
