### PR TITLE
feat(identity): add account_id to the identity graph (CTO-184)

### DIFF
--- a/db/clickhouse/attribution.sql
+++ b/db/clickhouse/attribution.sql
@@ -3,13 +3,23 @@
 -- identity bridging (CTO-74). Defined pre-data — adding columns later is a backfill incident.
 
 -- identity_graph: transitive identity edges (anonymous <-> user <-> session, across key versions).
+--
+-- 'account_id' (CTO-184) is the sixth identity type. It is the stitching path for the account
+-- dimension CTO-180 added to otel_spans / business_events: a tenant who cannot stamp an
+-- `account_id` on every span can instead let a CRM or CDP connector assert `user_id <-> account_id`
+-- here, and the account is inferred from the user at attribution time.
+--
+-- APPEND ONLY, NEVER RENUMBER. ClickHouse stores an Enum8 as its integer, not its name, so
+-- changing 'email'=4 to anything else would silently reinterpret every row already on disk as a
+-- different identity type. New values therefore take the next free ordinal (6) and existing
+-- ordinals 1-5 are frozen forever. The same rule applies to whatever comes after this.
 CREATE TABLE IF NOT EXISTS identity_graph
 (
     TenantId              LowCardinality(String),
     IdentityA             FixedString(64),
-    IdentityAType         Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5),
+    IdentityAType         Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5,'account_id'=6),
     IdentityB             FixedString(64),
-    IdentityBType         Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5),
+    IdentityBType         Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5,'account_id'=6),
     UserIdHashKeyVersion  LowCardinality(String),
     Confidence            Float32,
     ObservedAt            DateTime64(9),
@@ -91,3 +101,26 @@ ORDER BY (TenantId, BusinessEventId);
 -- canonical DDL with `make ch-migrate` from infra/ to apply it to a stack that is already running.
 ALTER TABLE business_events
     ADD COLUMN IF NOT EXISTS AccountIdHash FixedString(64) DEFAULT '';
+
+-- CTO-184 additive migration for identity_graph. Widening an Enum8 is NOT an ADD COLUMN, so the
+-- IF NOT EXISTS trick above does not apply; the idempotent form is MODIFY COLUMN to the full
+-- target type. Restating a type ClickHouse already has is a no-op that costs one metadata write,
+-- which is what makes replaying this file through `make ch-migrate` safe and repeatable.
+--
+-- This is metadata-only and does NOT rewrite parts, for one specific reason: every pre-existing
+-- name keeps its pre-existing ordinal. An Enum8 column is stored on disk as the Int8 ordinal, and
+-- the name is only a display mapping held in the table metadata. Appending 'account_id'=6 leaves
+-- every byte already written meaning exactly what it meant before. Renumbering, or reusing an
+-- ordinal for a different name, would instead silently reinterpret stored rows with no error and
+-- no way to tell after the fact, so it is not something a later migration may do either.
+--
+-- As with CTO-180, an existing deployment will NOT pick this up on its own: the compose initdb
+-- directory that mounts this file runs only on a first boot against an empty volume. Replay the
+-- canonical DDL with `make ch-migrate` from infra/ to apply it to a stack that is already running.
+ALTER TABLE identity_graph
+    MODIFY COLUMN IdentityAType
+        Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5,'account_id'=6);
+
+ALTER TABLE identity_graph
+    MODIFY COLUMN IdentityBType
+        Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5,'account_id'=6);

--- a/sdk/python/src/tally/identity.py
+++ b/sdk/python/src/tally/identity.py
@@ -31,6 +31,27 @@ class IdentityType(str, Enum):
     SESSION_ID = "session_id"
     EMAIL = "email"
     EXTERNAL_ID = "external_id"
+    #: The tenant's own paying customer (CTO-184), hashed like every other identity here.
+    #:
+    #: Unlike the five above, an account is NOT a person. It is a container that many people
+    #: belong to, which is why it is deliberately excluded from person-identity traversal in
+    #: :meth:`IdentityGraph.resolve_identity` and has its own resolver,
+    #: :meth:`IdentityGraph.resolve_account`. Values mirror the ClickHouse
+    #: ``identity_graph.IdentityAType`` enum in ``db/clickhouse/attribution.sql``.
+    ACCOUNT_ID = "account_id"
+
+
+#: Identity types that denote a *person*. Traversal in :meth:`IdentityGraph.resolve_identity` is
+#: confined to these, because the whole point of that walk is "which hashes are the same human".
+PERSON_IDENTITY_TYPES = frozenset(
+    {
+        IdentityType.USER_ID,
+        IdentityType.ANONYMOUS_ID,
+        IdentityType.SESSION_ID,
+        IdentityType.EMAIL,
+        IdentityType.EXTERNAL_ID,
+    }
+)
 
 
 # Source tag for a synthetic edge linking the same identity across HMAC key versions (CTO-74).
@@ -49,6 +70,37 @@ class IdentityEdge:
     source: str = "sdk"
     confidence: float = 1.0
     key_version: str = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class AccountResolution:
+    """The outcome of asking "which account does this person belong to?" (CTO-184).
+
+    Three states, and the caller must handle all three distinctly:
+
+    * ``account_hash`` set                 -> exactly one account. Attribute to it, as *stitched*.
+    * ``account_hash is None``, 0 candidates -> nobody has stitched this person yet. Normal.
+    * ``account_hash is None``, 2+ candidates -> ``conflict``. Attribute NOTHING and raise a
+      data-quality finding. Never split, duplicate, or pick first-seen.
+
+    ``account_hash`` is deliberately ``None`` rather than an empty string in both no-attribution
+    cases, so a caller cannot accidentally write it into a column whose empty value already means
+    "unattributed" and lose the distinction between "not stitched" and "refused to guess".
+    """
+
+    user_hash: str
+    account_hash: str | None
+    candidates: tuple[str, ...] = ()
+
+    @property
+    def conflict(self) -> bool:
+        """True when this person was observed against more than one account."""
+        return len(self.candidates) > 1
+
+    @property
+    def attributable(self) -> bool:
+        """True only when exactly one account resolved."""
+        return self.account_hash is not None
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,6 +240,13 @@ class IdentityGraph:
         Edges with ``observed_at > as_of`` are ignored so a historical attribution never "leaks" an
         identity link learned after the fact. Bounded depth + the visited-set make cycles and
         runaway fan-out safe.
+
+        Account edges (:attr:`IdentityType.ACCOUNT_ID`, CTO-184) are skipped entirely. An account is
+        a container, not a person: two colleagues share one account hash, so walking through an
+        account node would fuse them into a single identity and let one person's trace be
+        attributed to the other person's conversion. That is a silent mis-attribution of exactly
+        the kind this codebase refuses to make, so accounts are neither traversed nor returned
+        here. Use :meth:`resolve_account` for the account question.
         """
         seen: set[str] = {start}
         frontier: list[tuple[str, int]] = [(start, 0)]
@@ -200,9 +259,106 @@ class IdentityGraph:
                     continue
                 if neighbour in seen:
                     continue
+                if self._neighbour_type(node, neighbour, edge) not in PERSON_IDENTITY_TYPES:
+                    continue
                 seen.add(neighbour)
                 frontier.append((neighbour, depth + 1))
         return seen
+
+    @staticmethod
+    def _neighbour_type(node: str, neighbour: str, edge: IdentityEdge) -> IdentityType:
+        """The type of ``neighbour`` on ``edge``, given we arrived from ``node``.
+
+        Edges are stored once and read from both ends, so which of ``edge.a_type`` / ``edge.b_type``
+        describes the neighbour depends on the direction of travel.
+        """
+        if edge.a == node and edge.b == neighbour:
+            return edge.b_type
+        if edge.b == node and edge.a == neighbour:
+            return edge.a_type
+        # Self-edge or a malformed edge: fall back to the side that matches the neighbour's value.
+        return edge.b_type if edge.b == neighbour else edge.a_type
+
+    def resolve_account(
+        self,
+        tenant_id: str,
+        start: str,
+        *,
+        max_depth: int = 2,
+        as_of: datetime | None = None,
+    ) -> AccountResolution:
+        """Resolve the account a person belongs to, or refuse to (CTO-184).
+
+        This is the stitching path for tenants who cannot stamp an ``account_id`` on every span: a
+        CRM or CDP connector asserts ``user_id <-> account_id`` edges and the account is inferred
+        from the user instead of stated at emit time.
+
+        **One user belongs to one account. Multi-account users are not supported.** If this person
+        is observed against more than one account, the result carries ``account_hash=None`` and
+        ``conflict=True``, and the caller must attribute NOTHING for them. Not a split, not a
+        duplicate, not first-seen. Duplicating a user's cost across two accounts inflates the
+        tenant total, so per-account spend would stop summing to what ``/cost`` reports and the
+        whole per-customer surface would become untrustworthy. See the "Constraints decided"
+        section of ``docs/cost-per-customer-plan.md``.
+
+        Resolution is transitive across *person* identities (so an account asserted against a
+        user's email or external id still resolves from their anonymous id) but only ever one hop
+        from a person to an account. Accounts are never traversed through, so a colleague's account
+        edge can never reach this person.
+        """
+        person_identities = self.resolve_identity(
+            tenant_id, start, max_depth=max_depth, as_of=as_of
+        )
+        accounts: set[str] = set()
+        for node in person_identities:
+            for neighbour, edge in self._adj.get((tenant_id, node), set()):
+                if as_of is not None and edge.observed_at > as_of:
+                    continue
+                if self._neighbour_type(node, neighbour, edge) is IdentityType.ACCOUNT_ID:
+                    accounts.add(neighbour)
+        ordered = tuple(sorted(accounts))
+        # Exactly one account resolves. Zero means "not stitched yet", which is a different and
+        # entirely normal state from "conflicting", and both are reported as no attribution.
+        return AccountResolution(
+            user_hash=start,
+            account_hash=ordered[0] if len(ordered) == 1 else None,
+            candidates=ordered,
+        )
+
+    def account_conflicts(
+        self,
+        tenant_id: str,
+        *,
+        max_depth: int = 2,
+        as_of: datetime | None = None,
+    ) -> list[AccountResolution]:
+        """Every person in this tenant's graph who resolves to more than one account.
+
+        The data-quality feed for the constraint above: the multi-account case has to be *visible*
+        rather than silently swallowed, because the fix lives in the tenant's CRM and nobody can
+        make it if nobody can see it. Sorted by user hash so the output is stable to diff.
+        """
+        people: set[str] = set()
+        for (tid, node), neighbours in self._adj.items():
+            if tid != tenant_id:
+                continue
+            for _neighbour, edge in neighbours:
+                # The node's OWN type, not the neighbour's: a user whose only edge is to an
+                # account is still a person and still has to be checked.
+                own = edge.a_type if edge.a == node else edge.b_type
+                if own in PERSON_IDENTITY_TYPES:
+                    people.add(node)
+                    break
+        out = [
+            res
+            for person in sorted(people)
+            if (
+                res := self.resolve_account(
+                    tenant_id, person, max_depth=max_depth, as_of=as_of
+                )
+            ).conflict
+        ]
+        return out
 
     # Back-compat alias: the stitcher (CTO-69) and its tests call ``resolve``.
     resolve = resolve_identity

--- a/sdk/python/tests/test_identity.py
+++ b/sdk/python/tests/test_identity.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 from tally.identity import (
     KEY_ROTATION_SOURCE,
+    PERSON_IDENTITY_TYPES,
     AliasEvent,
     IdentifyEvent,
     IdentityEdge,
@@ -154,3 +155,122 @@ def test_late_alias_relinks_anonymous_to_authenticated() -> None:
     g.ingest_identify(T, IdentifyEvent(user_id="u_alice", anonymous_id="anon_1", observed_at=NOW))
     assert g.resolve_identity(T, "anon_1") == {"anon_1", "u_alice"}
     assert g.resolve_identity(T, "u_alice") == {"u_alice", "anon_1"}
+
+
+# --- account_id in the identity graph (CTO-184) --------------------------------------------------
+#
+# One user belongs to one account. Multi-account users are explicitly NOT supported: where a person
+# resolves to more than one account the pipeline attributes nothing and raises a data-quality
+# finding, because splitting or duplicating the cost would inflate the tenant total and break
+# reconciliation against /cost.
+
+
+def _account_edge(user: str, account: str, when: datetime = NOW) -> IdentityEdge:
+    return IdentityEdge(
+        user, IdentityType.USER_ID, account, IdentityType.ACCOUNT_ID, when, source="crm"
+    )
+
+
+def test_account_id_is_a_distinct_identity_type() -> None:
+    assert IdentityType.ACCOUNT_ID.value == "account_id"
+    assert IdentityType.ACCOUNT_ID not in PERSON_IDENTITY_TYPES
+
+
+def test_single_account_resolves() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    res = g.resolve_account(T, "u_alice")
+    assert res.account_hash == "acct_widgets"
+    assert res.attributable is True
+    assert res.conflict is False
+
+
+def test_unstitched_user_resolves_to_nothing_without_conflict() -> None:
+    g = _g()
+    res = g.resolve_account(T, "u_alice")
+    assert res.account_hash is None
+    assert res.candidates == ()
+    # Not stitched yet is a normal state, NOT a data-quality finding.
+    assert res.conflict is False
+    assert res.attributable is False
+
+
+def test_account_resolves_transitively_through_person_identities() -> None:
+    g = _g()
+    # The CRM asserts the account against the user; the SDK knows the anonymous id is that user.
+    g.ingest_identify(T, IdentifyEvent(user_id="u_alice", anonymous_id="anon_1", observed_at=NOW))
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    assert g.resolve_account(T, "anon_1").account_hash == "acct_widgets"
+
+
+def test_multi_account_user_attributes_nothing() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    g.add_edge(T, _account_edge("u_alice", "acct_gadgets"))
+    res = g.resolve_account(T, "u_alice")
+    # Not split, not duplicated, not first-seen. Nothing.
+    assert res.account_hash is None
+    assert res.attributable is False
+    assert res.conflict is True
+    assert res.candidates == ("acct_gadgets", "acct_widgets")
+
+
+def test_multi_account_conflict_is_reported_as_a_finding() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    g.add_edge(T, _account_edge("u_alice", "acct_gadgets"))
+    g.add_edge(T, _account_edge("u_bob", "acct_widgets"))
+    findings = g.account_conflicts(T)
+    # Visible, not silently swallowed: exactly the one ambiguous user, with both candidates.
+    assert [f.user_hash for f in findings] == ["u_alice"]
+    assert findings[0].candidates == ("acct_gadgets", "acct_widgets")
+
+
+def test_no_conflict_when_every_user_has_one_account() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    g.add_edge(T, _account_edge("u_bob", "acct_gadgets"))
+    assert g.account_conflicts(T) == []
+
+
+def test_account_conflicts_do_not_leak_across_tenants() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    g.add_edge("t-other", _account_edge("u_alice", "acct_gadgets"))
+    # Same user hash in two tenants is two different people; neither is ambiguous.
+    assert g.account_conflicts(T) == []
+    assert g.resolve_account(T, "u_alice").account_hash == "acct_widgets"
+    assert g.resolve_account("t-other", "u_alice").account_hash == "acct_gadgets"
+
+
+def test_colleagues_are_not_fused_into_one_person() -> None:
+    # The hazard that makes account_id different from every other identity type: an account is a
+    # container, not a person. If resolution walked THROUGH the account node, Alice and Bob would
+    # come back as the same identity and Bob's trace could be attributed to Alice's conversion.
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    g.add_edge(T, _account_edge("u_bob", "acct_widgets"))
+    assert g.resolve_identity(T, "u_alice", max_depth=3) == {"u_alice"}
+
+
+def test_account_edges_are_excluded_from_person_identity_sets() -> None:
+    # The account hash must not end up in the set the stitcher uses to query last-touch, or every
+    # span belonging to any colleague would match.
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets"))
+    assert g.resolve_identity(T, "u_alice") == {"u_alice"}
+
+
+def test_account_edge_observed_after_as_of_is_ignored() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets", NOW + timedelta(days=1)))
+    # Honest under uncertainty: an edge we had not learned yet cannot retroactively attribute.
+    assert g.resolve_account(T, "u_alice", as_of=NOW).account_hash is None
+
+
+def test_as_of_can_resolve_a_conflict_that_only_appears_later() -> None:
+    g = _g()
+    g.add_edge(T, _account_edge("u_alice", "acct_widgets", NOW - timedelta(days=1)))
+    g.add_edge(T, _account_edge("u_alice", "acct_gadgets", NOW + timedelta(days=1)))
+    assert g.resolve_account(T, "u_alice", as_of=NOW).account_hash == "acct_widgets"
+    assert g.resolve_account(T, "u_alice").conflict is True

--- a/sdk/python/tests/test_views_ddl.py
+++ b/sdk/python/tests/test_views_ddl.py
@@ -72,6 +72,36 @@ def test_attribution_carries_key_version(attribution):
     assert attribution.count("UserIdHashKeyVersion") >= 2
 
 
+def test_identity_graph_carries_account_id(attribution):
+    # CTO-184: a CRM/CDP connector stitches users to accounts through this enum.
+    assert attribution.count("'account_id'=6") >= 2  # IdentityAType and IdentityBType
+
+
+def test_identity_type_enum_ordinals_are_never_renumbered(attribution):
+    # An Enum8 is stored on disk as its ordinal, so reusing or renumbering a value silently
+    # reinterprets every row already written. These five are frozen forever; new values append.
+    frozen = {
+        "'user_id'": 1,
+        "'anonymous_id'": 2,
+        "'session_id'": 3,
+        "'email'": 4,
+        "'external_id'": 5,
+    }
+    for name, ordinal in frozen.items():
+        assert f"{name}={ordinal}" in attribution
+        # And no other ordinal is ever attached to that name.
+        for other in range(1, 10):
+            if other != ordinal:
+                assert f"{name}={other}" not in attribution
+
+
+def test_identity_graph_enum_widening_has_a_migration_path(attribution):
+    # initdb only fires on a fresh volume, so an existing deployment needs an explicit ALTER
+    # (replayed idempotently by `make ch-migrate`). Enum widening is MODIFY, not ADD COLUMN.
+    assert "MODIFY COLUMN IdentityAType" in attribution
+    assert "MODIFY COLUMN IdentityBType" in attribution
+
+
 def test_unattributed_is_modeled(attribution):
     assert "unattributed_events" in attribution
     assert "no_trace_in_window" in attribution  # reasons enumerated, not silent drop

--- a/web/app/data-quality/page.tsx
+++ b/web/app/data-quality/page.tsx
@@ -7,12 +7,19 @@ import {
 } from "@/components/DataStateBanner";
 import { apiGet } from "@/lib/api";
 import { asOfLabel, deriveDataState, relativeAge } from "@/lib/dataState";
-import { classify, type DataQualityReport, type Health } from "@/lib/dq";
+import {
+  classify,
+  classifyAccountStitching,
+  withheldByConflicts,
+  type AccountStitching,
+  type DataQualityReport,
+  type Health,
+} from "@/lib/dq";
 import { formatUSD } from "@/lib/types";
 
 export default async function DataQualityPage() {
   const dq = await apiGet<DataQualityReport>("/api/data-quality");
-  const { overall, attribution, contextDrops, calibration, sampling } = dq;
+  const { overall, attribution, contextDrops, calibration, sampling, accountStitching } = dq;
 
   // Latest reconciled calibration day is the freshness boundary; absence ⇒ pre-data.
   const reconciledThrough = calibration.length > 0 ? calibration[calibration.length - 1].date : "1970-01-01";
@@ -119,6 +126,8 @@ export default async function DataQualityPage() {
           </tbody>
         </table>
       </Card>
+
+      <AccountStitchingCard stitching={accountStitching} />
 
       <Card title="Estimate vs. reconciled — last 7 reconciled days">
         <table className="w-full text-sm">
@@ -252,6 +261,118 @@ function KpiCard({
       <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
       <div className={`mt-2 text-3xl font-semibold tabular-nums ${textFor(health)}`}>{value}</div>
       <div className="mt-2 text-xs text-muted">{hint}</div>
+    </div>
+  );
+}
+
+/**
+ * Account stitching, and the users we refuse to attribute (CTO-184).
+ *
+ * Two jobs. First, separate directly-tagged accounts from stitched ones, because they are not
+ * equally trustworthy: a direct account was stamped on the span at emit time, a stitched one was
+ * inferred from a CRM or CDP assertion and is only as good as that connector.
+ *
+ * Second, and the reason this card exists at all: one user belongs to one account. When a user
+ * turns up against two, the pipeline attributes nothing for them rather than splitting the cost,
+ * duplicating it, or picking first-seen, because duplication inflates the tenant total and breaks
+ * reconciliation against /cost. That refusal is correct but it must not be quiet. The fix is in
+ * the tenant's CRM, so the table names the ambiguous users, both candidate accounts, and the
+ * spend being held back, which is the number that tells them whether it is worth fixing.
+ */
+function AccountStitchingCard({ stitching }: { stitching?: AccountStitching }) {
+  // No account dimension instrumented, or an older payload without the field: say so plainly.
+  // Not a warning and not a fabricated zero. Nothing is wrong, there is just nothing there.
+  if (!stitching || (stitching.directAccounts === 0 && stitching.stitchedAccounts === 0)) {
+    return (
+      <Card title="Account stitching">
+        <p className="text-sm text-muted">
+          No account dimension yet. Tag spans with <code className="font-mono">account_id</code>,
+          or connect a CRM or CDP that asserts one, and coverage appears here.
+        </p>
+      </Card>
+    );
+  }
+
+  const { directAccounts, stitchedAccounts, stitchedUsers, conflicts } = stitching;
+  const health = classifyAccountStitching(stitching);
+  const withheld = withheldByConflicts(conflicts);
+
+  return (
+    <Card title="Account stitching">
+      <div className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-3">
+        <Stat
+          label="Tagged directly"
+          value={directAccounts.toLocaleString()}
+          hint="account_id on the span itself, as certain as the span"
+        />
+        <Stat
+          label="Stitched from identity"
+          value={stitchedAccounts.toLocaleString()}
+          hint={`inferred from CRM/CDP account_id edges across ${stitchedUsers.toLocaleString()} users`}
+        />
+        <Stat
+          label="Users withheld"
+          value={<HealthText h={health}>{conflicts.length.toLocaleString()}</HealthText>}
+          hint="observed against more than one account, so nothing is attributed for them"
+        />
+      </div>
+
+      {conflicts.length > 0 && (
+        <>
+          <p className="mt-5 text-sm text-bad">
+            {conflicts.length.toLocaleString()}{" "}
+            {conflicts.length === 1 ? "user belongs" : "users belong"} to more than one account, so{" "}
+            {formatUSD(withheld)} of their spend is attributed to no account at all. One user
+            belongs to one account: we will not split or duplicate this, because duplicating would
+            inflate your tenant total and stop per-account spend reconciling with Cost. Resolve the
+            duplicate membership in the source system and it attributes on the next pass.
+          </p>
+          <table className="mt-3 w-full text-sm">
+            <thead className="text-xs uppercase text-muted">
+              <tr>
+                <th className="py-1 text-left font-medium">User</th>
+                <th className="py-1 text-left font-medium">Accounts observed</th>
+                <th className="py-1 text-right font-medium">Withheld (30d)</th>
+                <th className="py-1 text-right font-medium">Spans (30d)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {conflicts.map((c) => (
+                <tr key={c.userIdHash} className="border-t border-edge">
+                  <td className="py-2 font-mono text-xs text-gray-300" title={c.userIdHash}>
+                    {c.userIdHash.slice(0, 12)}…
+                  </td>
+                  <td className="py-2 font-mono text-xs text-gray-300" title={c.accounts.join(", ")}>
+                    {c.accounts.map((a) => a.slice(0, 8)).join(" · ")}
+                  </td>
+                  <td className="py-2 text-right tabular-nums">
+                    <HealthText h="bad">{formatUSD(c.withheldMicroUsd)}</HealthText>
+                  </td>
+                  <td className="py-2 text-right tabular-nums">{c.spans30d.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: React.ReactNode;
+  hint: string;
+}) {
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+      <div className="mt-1 text-xs text-muted">{hint}</div>
     </div>
   );
 }

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -274,3 +274,84 @@ describe("queryReconcilerLastRun (CTO-169)", () => {
     expect(await queryReconcilerLastRun()).toBeNull();
   });
 });
+
+// CTO-184: account stitching + the multi-account refusal.
+//
+// Same shape as the tests above: we stub @clickhouse/client and exercise the adapter that turns
+// rows into the typed result. The queries fire in a fixed order (coverage, direct accounts,
+// conflicting users, then, only when there are any, their withheld cost) so the stubs queue in
+// that order.
+describe("queryAccountStitching (CTO-184)", () => {
+  it("counts direct and stitched accounts separately so the UI can show confidence", async () => {
+    const { queryAccountStitching } = await freshSut();
+    respondRows([{ stitched_accounts: "42", stitched_users: "1340" }]);
+    respondRows([{ direct_accounts: "18" }]);
+    respondRows([]); // no conflicts
+    const out = await queryAccountStitching();
+    expect(out).toEqual({
+      directAccounts: 18,
+      stitchedAccounts: 42,
+      stitchedUsers: 1340,
+      conflicts: [],
+    });
+  });
+
+  it("skips the cost query entirely when nothing is ambiguous", async () => {
+    const { queryAccountStitching } = await freshSut();
+    respondRows([{ stitched_accounts: "3", stitched_users: "9" }]);
+    respondRows([{ direct_accounts: "0" }]);
+    respondRows([]);
+    await queryAccountStitching();
+    expect(queryMock).toHaveBeenCalledTimes(3); // no fourth query over an empty user list
+  });
+
+  it("surfaces a multi-account user as a finding, with both accounts and the withheld spend", async () => {
+    const { queryAccountStitching } = await freshSut();
+    respondRows([{ stitched_accounts: "5", stitched_users: "80" }]);
+    respondRows([{ direct_accounts: "2" }]);
+    respondRows([{ person_hash: "u_alice", accounts: ["acct_gadgets", "acct_widgets"] }]);
+    respondRows([{ user_hash: "u_alice", cost: "4.82", spans: "312" }]);
+    const out = await queryAccountStitching();
+    // Nothing is attributed for this user; the conflict is reported instead of guessed at.
+    expect(out!.conflicts).toEqual([
+      {
+        userIdHash: "u_alice",
+        accounts: ["acct_gadgets", "acct_widgets"],
+        withheldMicroUsd: 4_820_000,
+        spans30d: 312,
+      },
+    ]);
+  });
+
+  it("reports a conflict even when the user has no spend to withhold", async () => {
+    const { queryAccountStitching } = await freshSut();
+    respondRows([{ stitched_accounts: "5", stitched_users: "80" }]);
+    respondRows([{ direct_accounts: "2" }]);
+    respondRows([{ person_hash: "u_bob", accounts: ["acct_a", "acct_b"] }]);
+    respondRows([]); // no spans matched, but the ambiguity is still a finding
+    const out = await queryAccountStitching();
+    expect(out!.conflicts).toHaveLength(1);
+    expect(out!.conflicts[0].withheldMicroUsd).toBe(0);
+    expect(out!.conflicts[0].spans30d).toBe(0);
+  });
+
+  it("trims FixedString NUL padding off hashes so they still join", async () => {
+    // A FixedString(64) read back shorter than 64 bytes comes over NUL-padded.
+    const PAD = "\u0000\u0000";
+    const { queryAccountStitching } = await freshSut();
+    respondRows([{ stitched_accounts: "1", stitched_users: "1" }]);
+    respondRows([{ direct_accounts: "0" }]);
+    respondRows([{ person_hash: `u_pad${PAD}`, accounts: [`acct_a${PAD}`, "acct_b"] }]);
+    respondRows([{ user_hash: `u_pad${PAD}`, cost: "1.00", spans: "1" }]);
+    const out = await queryAccountStitching();
+    expect(out!.conflicts[0].userIdHash).toBe("u_pad");
+    expect(out!.conflicts[0].accounts).toEqual(["acct_a", "acct_b"]);
+    expect(out!.conflicts[0].withheldMicroUsd).toBe(1_000_000);
+  });
+
+  it("returns null when ClickHouse is unreachable, so the route falls back to mock", async () => {
+    const { queryAccountStitching } = await freshSut();
+    queryMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    expect(await queryAccountStitching()).toBeNull();
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -26,6 +26,8 @@ import type { CostDayPoint, CostSeries, FeatureCostRow, HiddenCostAlert } from "
 import { LAYERS, type Layer } from "./cost";
 import type { AttributionDiagnostics, FeatureEconomics } from "./features";
 import type {
+  AccountStitchConflict,
+  AccountStitching,
   AttributionByFeature,
   CalibrationDay,
   ContextDropsByService,
@@ -663,6 +665,122 @@ export async function queryAttributionDiagnostics(): Promise<AttributionDiagnost
   };
 }
 
+// --- Account stitching (CTO-184) ----------------------------------------------------------------
+
+/**
+ * Normalises `identity_graph` edges into (person, account) pairs.
+ *
+ * `account_id` is the sixth `IdentityAType` / `IdentityBType` value (CTO-184) and either side of an
+ * edge may carry it, so we pick whichever side is the account and take the other as the person.
+ * The `!=` on the two booleans is an XOR: it keeps edges where EXACTLY ONE side is an account.
+ * Account-to-account edges say nothing about a person and person-to-person edges are the ordinary
+ * identity graph, so both are excluded rather than half-interpreted.
+ */
+const ACCOUNT_PAIRS_CTE = `
+  WITH pairs AS (
+    SELECT
+      if(IdentityAType = 'account_id', IdentityB, IdentityA) AS person_hash,
+      if(IdentityAType = 'account_id', IdentityA, IdentityB) AS account_hash
+    FROM identity_graph
+    WHERE TenantId = {tenant:String}
+      AND ((IdentityAType = 'account_id') != (IdentityBType = 'account_id'))
+  )`;
+
+/**
+ * Account-dimension coverage plus the multi-account conflicts that block attribution (CTO-184).
+ *
+ * Two things a consumer needs and cannot get anywhere else:
+ *
+ * 1. **Direct vs stitched.** A directly-tagged account was stamped on the span at emit time
+ *    (`otel_spans.AccountIdHash`, CTO-180) and is exactly as trustworthy as the span. A stitched
+ *    account was inferred from an `account_id` edge a CRM or CDP connector asserted, and is only
+ *    as trustworthy as that connector. They are counted separately so the UI can say which it is
+ *    showing rather than blending two very different confidences into one number.
+ *
+ * 2. **Conflicts.** One user belongs to one account. Where a user is observed against more than
+ *    one, we attribute NOTHING for them: no split, no duplication, no first-seen. Duplicating a
+ *    user's spend across accounts inflates the tenant total, per-account figures then stop summing
+ *    to what /cost reports, and the per-customer surface loses its reconciliation guarantee. The
+ *    query returns the conflicting users so the refusal is visible instead of silent, along with
+ *    the spend actually held back by it, so a tenant can weigh fixing their CRM.
+ *
+ * `withheldMicroUsd` counts only spans with an EMPTY `AccountIdHash`. A conflicted user's directly
+ * tagged spans are unaffected: they carry their own account and never needed stitching, so
+ * counting them here would overstate the damage.
+ */
+export async function queryAccountStitching(): Promise<AccountStitching | null> {
+  return tryLive(async (db, tenant) => {
+    const coverage = await rows<{ stitched_accounts: string; stitched_users: string }>(
+      db,
+      `${ACCOUNT_PAIRS_CTE}
+       SELECT uniqExact(account_hash) AS stitched_accounts,
+              uniqExact(person_hash)  AS stitched_users
+       FROM pairs`,
+      tenant,
+    );
+
+    const direct = await rows<{ direct_accounts: string }>(
+      db,
+      `SELECT uniqExact(AccountIdHash) AS direct_accounts
+       FROM otel_spans
+       WHERE TenantId = {tenant:String}
+         AND Timestamp >= now() - INTERVAL 30 DAY
+         AND AccountIdHash != ''`,
+      tenant,
+    );
+
+    const conflicting = await rows<{ person_hash: string; accounts: string[] }>(
+      db,
+      `${ACCOUNT_PAIRS_CTE}
+       SELECT person_hash, arraySort(groupUniqArray(account_hash)) AS accounts
+       FROM pairs
+       GROUP BY person_hash
+       HAVING length(accounts) > 1
+       ORDER BY person_hash
+       LIMIT 100`,
+      tenant,
+    );
+
+    // Nothing ambiguous: skip the cost query entirely rather than run an `IN ()` over no users.
+    const users = conflicting.map((r) => r.person_hash.replace(/\0+$/, ""));
+    const costByUser = new Map<string, { cost: string; spans: string }>();
+    if (users.length > 0) {
+      const costs = await rowsP<{ user_hash: string; cost: string; spans: string }>(
+        db,
+        `SELECT UserIdHash AS user_hash, sum(EstimatedCost) AS cost, count() AS spans
+         FROM otel_spans
+         WHERE TenantId = {tenant:String}
+           AND Timestamp >= now() - INTERVAL 30 DAY
+           AND AccountIdHash = ''
+           AND UserIdHash IN {users:Array(String)}
+         GROUP BY user_hash`,
+        { tenant, users },
+      );
+      for (const c of costs) {
+        costByUser.set(c.user_hash.replace(/\0+$/, ""), { cost: c.cost, spans: c.spans });
+      }
+    }
+
+    const conflicts: AccountStitchConflict[] = conflicting.map((r) => {
+      const user = r.person_hash.replace(/\0+$/, "");
+      const c = costByUser.get(user);
+      return {
+        userIdHash: user,
+        accounts: r.accounts.map((a) => a.replace(/\0+$/, "")),
+        withheldMicroUsd: micro(c?.cost),
+        spans30d: parseInt(c?.spans ?? "0", 10) || 0,
+      };
+    });
+
+    return {
+      directAccounts: parseInt(direct[0]?.direct_accounts ?? "0", 10) || 0,
+      stitchedAccounts: parseInt(coverage[0]?.stitched_accounts ?? "0", 10) || 0,
+      stitchedUsers: parseInt(coverage[0]?.stitched_users ?? "0", 10) || 0,
+      conflicts,
+    };
+  });
+}
+
 // --- Data Quality (dedicated report) ------------------------------------------------------------
 
 export async function queryDataQualityReport(): Promise<DataQualityReport | null> {
@@ -775,6 +893,11 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
       };
     });
 
+    // CTO-184: account coverage + multi-account conflicts. This runs inside the same tryLive as
+    // the rest of the report, so if `identity_graph` is missing the whole report falls back to
+    // mock rather than half-rendering, the same failure posture every other section has.
+    const accountStitching = await queryAccountStitching();
+
     return {
       overall: {
         attributionRate: totalEvents > 0 ? attributed / totalEvents : 1,
@@ -787,6 +910,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
       contextDrops,
       calibration,
       sampling,
+      accountStitching: accountStitching ?? undefined,
     };
   });
 }

--- a/web/lib/dq.test.ts
+++ b/web/lib/dq.test.ts
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from "vitest";
-import { classify, dq } from "./dq";
+import {
+  classify,
+  classifyAccountStitching,
+  dq,
+  withheldByConflicts,
+  type AccountStitchConflict,
+} from "./dq";
 
 describe("data-quality", () => {
   it("classifies attribution thresholds", () => {
@@ -31,5 +37,63 @@ describe("data-quality", () => {
     const body = dq.sampling.find((s) => s.stratum === "body")!;
     const mid = dq.sampling.find((s) => s.stratum === "mid")!;
     expect(body.ciHalfWidthPct!).toBeGreaterThan(mid.ciHalfWidthPct!);
+  });
+});
+
+// CTO-184. One user belongs to one account. The multi-account case must be VISIBLE, so the
+// contract these tests pin is: a conflict never attributes, and it never fails to be reported.
+describe("account stitching (CTO-184)", () => {
+  const conflict = (withheldMicroUsd: number): AccountStitchConflict => ({
+    userIdHash: "9f2c41ab7d0e5583",
+    accounts: ["3b7e0c19aa41d2f8", "c04d19e6b7a35510"],
+    withheldMicroUsd,
+    spans30d: 12,
+  });
+
+  it("a conflicting user carries at least two candidate accounts", () => {
+    // The whole reason we withhold: there is no single right answer to pick.
+    expect(conflict(1).accounts.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("no conflicts is good", () => {
+    expect(
+      classifyAccountStitching({
+        directAccounts: 4,
+        stitchedAccounts: 9,
+        stitchedUsers: 100,
+        conflicts: [],
+      }),
+    ).toBe("good");
+  });
+
+  it("a single conflict is bad, not a warning", () => {
+    // Not a threshold: it means we are reporting nothing for a real user's real spend.
+    expect(
+      classifyAccountStitching({
+        directAccounts: 4,
+        stitchedAccounts: 9,
+        stitchedUsers: 100,
+        conflicts: [conflict(500_000)],
+      }),
+    ).toBe("bad");
+  });
+
+  it("an absent account dimension is good, not bad", () => {
+    // Nothing instrumented yet is a normal state for every existing tenant, not a defect.
+    expect(classifyAccountStitching(undefined)).toBe("good");
+  });
+
+  it("sums the spend held back across conflicting users", () => {
+    expect(withheldByConflicts([conflict(1_500_000), conflict(2_000_000)])).toBe(3_500_000);
+    expect(withheldByConflicts([])).toBe(0);
+  });
+
+  it("the mock carries a conflict so the surfaced state is exercised", () => {
+    const s = dq.accountStitching!;
+    expect(s.conflicts).toHaveLength(1);
+    expect(s.conflicts[0].accounts).toHaveLength(2);
+    // Direct and stitched are counted separately so the UI can show confidence.
+    expect(s.directAccounts).toBeGreaterThan(0);
+    expect(s.stitchedAccounts).toBeGreaterThan(0);
   });
 });

--- a/web/lib/dq.ts
+++ b/web/lib/dq.ts
@@ -36,6 +36,50 @@ export interface SampleByStratum {
   spans: number;
 }
 
+/**
+ * One user observed against more than one account (CTO-184).
+ *
+ * One user belongs to one account; multi-account users are explicitly not supported. When a user
+ * is stitched to two accounts the pipeline attributes NOTHING for them: it does not split the
+ * cost, does not duplicate it, and does not pick first-seen. Duplicating would inflate the tenant
+ * total so per-account spend would stop summing to what /cost reports, which is the one thing
+ * that would make the whole per-customer surface untrustworthy.
+ *
+ * Withholding is the safe behaviour but it is not a silent one, which is what this type is for:
+ * the fix lives in the tenant's CRM and nobody can make it if nobody can see the conflict.
+ */
+export interface AccountStitchConflict {
+  /** The ambiguous user's hash. Truncated for display; never a raw id. */
+  userIdHash: string;
+  /** Every distinct account hash observed for this user, sorted. Always length >= 2. */
+  accounts: string[];
+  /** Spend held back over the last 30d because of this ambiguity. */
+  withheldMicroUsd: number;
+  /** Spans behind that figure. */
+  spans30d: number;
+}
+
+/**
+ * Account-dimension coverage and its confidence (CTO-184).
+ *
+ * `directAccounts` and `stitchedAccounts` are the two ways an account can become known, and a
+ * consumer tells them apart by which one a hash appears in: a directly-tagged account was stamped
+ * on the span itself at emit time (`otel_spans.AccountIdHash != ''`, CTO-180) and is as certain as
+ * the span; a stitched account was inferred from an `account_id` edge asserted by a CRM or CDP
+ * connector in `identity_graph` and is only as good as that connector's data. The UI renders the
+ * second with lower confidence.
+ */
+export interface AccountStitching {
+  /** Accounts stamped directly on spans over the window. */
+  directAccounts: number;
+  /** Accounts known only from identity-graph `account_id` edges. */
+  stitchedAccounts: number;
+  /** Users carrying at least one `account_id` edge. */
+  stitchedUsers: number;
+  /** Users the stitcher refuses to attribute, because they resolve to more than one account. */
+  conflicts: AccountStitchConflict[];
+}
+
 export interface DataQualityReport {
   overall: {
     attributionRate: number;
@@ -47,6 +91,31 @@ export interface DataQualityReport {
   contextDrops: ContextDropsByService[];
   calibration: CalibrationDay[];
   sampling: SampleByStratum[];
+  /**
+   * CTO-184. Optional so a cached or older payload still type-checks; the page treats an absent
+   * value the same as "no account dimension instrumented yet", which is the honest reading.
+   */
+  accountStitching?: AccountStitching;
+}
+
+/**
+ * Total spend withheld from per-account attribution because of multi-account users (CTO-184).
+ * Pure so the page and the tests agree on one definition of "how much this is costing us".
+ */
+export function withheldByConflicts(conflicts: AccountStitchConflict[]): number {
+  return conflicts.reduce((sum, c) => sum + c.withheldMicroUsd, 0);
+}
+
+/**
+ * Health of the account-stitching signal. Any conflict at all is a `bad`: it is not a threshold
+ * question, it is a tenant CRM asserting two contradictory facts about the same person, and the
+ * consequence is that we report nothing for them. Zero conflicts with stitching in use is `good`;
+ * zero conflicts with nothing stitched is also `good`, because nothing is wrong, there is just
+ * nothing there.
+ */
+export function classifyAccountStitching(s: AccountStitching | undefined): Health {
+  if (!s || s.conflicts.length === 0) return "good";
+  return "bad";
 }
 
 export function classify(metric: "attribution" | "drops" | "calibration", v: number): Health {
@@ -90,4 +159,19 @@ export const dq: DataQualityReport = {
     { stratum: "mid", rate: 0.5, ciHalfWidthPct: 0.04, spans: 1840 },
     { stratum: "body", rate: 0.1, ciHalfWidthPct: 0.18, spans: 12_600 },
   ],
+  // CTO-184. The mock deliberately carries one conflict, because the empty case renders a
+  // reassuring green row and the interesting case is the one a reviewer needs to be able to see.
+  accountStitching: {
+    directAccounts: 18,
+    stitchedAccounts: 42,
+    stitchedUsers: 1_340,
+    conflicts: [
+      {
+        userIdHash: "9f2c41ab7d0e5583",
+        accounts: ["3b7e0c19aa41d2f8", "c04d19e6b7a35510"],
+        withheldMicroUsd: 4_820_000,
+        spans30d: 312,
+      },
+    ],
+  },
 };


### PR DESCRIPTION
> **Stacked on #170 (CTO-180, B1).** Base is `worktree-agent-a53b7cbc2d8752dbf`, not `main`. That PR added `AccountIdHash` to `otel_spans` and `business_events` and already touched `db/clickhouse/attribution.sql`, which this PR also modifies. Review or merge #170 first; the diff below is only this change.

Implements CTO-184 (B5). Adds `account_id` to the identity graph so a CRM or CDP connector can stitch users to accounts, which is the account path for tenants who cannot stamp an `account_id` on every span the way B1 assumes.

## The enum change

`IdentityAType` / `IdentityBType` gain `'account_id'=6`. Existing values keep their ordinals:

```
Enum8('user_id'=1,'anonymous_id'=2,'session_id'=3,'email'=4,'external_id'=5,'account_id'=6)
```

**Appended, never renumbered.** ClickHouse stores an `Enum8` as its integer ordinal and keeps the name only as table metadata. Reusing or shifting an existing ordinal would silently reinterpret every row already on disk as a different identity type, with no error at migration time and no way to tell afterwards. So 1-5 are frozen forever and new values take the next free number. `test_identity_type_enum_ordinals_are_never_renumbered` pins that, so a later change cannot quietly break it.

That is also what makes the migration metadata-only: every byte already written still means what it meant before, so no part is rewritten and ingest is not blocked.

## Migration path

Same dual treatment #170 used. The `CREATE TABLE` body carries the new value for a fresh volume, and an idempotent `ALTER TABLE` applies it to a stack already running, since the compose initdb mount only fires on a first boot against an empty volume.

Widening an enum is a `MODIFY COLUMN`, not an `ADD COLUMN`, so `ADD COLUMN IF NOT EXISTS` does not apply here. The idempotent form is restating the full target type: when ClickHouse already has it, the statement is a no-op costing one metadata write, which is what keeps `make ch-migrate` safe to replay.

Verified against the running local stack: `make ch-migrate` twice (second run clean), then `system.columns` confirms both columns carry all six values.

## The constraint: one user, one account

Multi-account users are explicitly not supported (`docs/cost-per-customer-plan.md`, "Constraints decided"). Three things implement the consequence rather than assuming it:

**1. Resolution refuses to guess.** `IdentityGraph.resolve_account` returns an account only when exactly one resolves. Two or more and it returns `account_hash=None` with `conflict=True`. No split, no duplication, no first-seen. Duplicating a user's spend across accounts inflates the tenant total, per-account figures then stop summing to what `/cost` reports, and the per-customer surface loses the reconciliation guarantee that C1 depends on.

It also distinguishes *zero* accounts from *conflicting* accounts. Not stitched yet is a normal state for every tenant on day one; conflicting is a finding. Both attribute nothing, but only one is a problem.

**2. Accounts are not traversed as people.** This is the part that would have bitten quietly. An account is a container, not a person: two colleagues share one account hash. If the existing `resolve_identity` walk had been left to traverse `account_id` edges, Alice and Bob would come back as the same identity, and Bob's spans would become eligible last-touch candidates for Alice's conversion. `PERSON_IDENTITY_TYPES` confines the walk, and `test_colleagues_are_not_fused_into_one_person` covers it.

**3. The refusal is visible.** The fix lives in the tenant's CRM and nobody can make it if nobody can see the conflict. `queryAccountStitching` surfaces it on the existing `/data-quality` page, following the pattern the other findings there use (typed query in `clickhouse.ts`, `tryLive` fallback to mock, a card with a `classify*` health call):

- the ambiguous users, with both candidate accounts
- the spend held back over 30d, so a tenant can weigh whether fixing it is worth it
- a `bad` health, not a `warn`. It is not a threshold question, it means real spend is being reported against no account.

`withheldMicroUsd` counts only spans with an empty `AccountIdHash`. A conflicted user's directly tagged spans carry their own account and never needed stitching, so counting them would overstate the damage.

Verified end to end against the running local ClickHouse on tenant `local-dev`: inserted `account_id` edges for one two-account user and one single-account user, and `/api/data-quality` returned exactly the one conflict with both accounts, with the single-account user correctly absent. Rows removed afterwards.

## Telling stitched from directly tagged

A consumer tells them apart by which count a hash appears in:

| | Source | Confidence |
|---|---|---|
| `directAccounts` | `otel_spans.AccountIdHash != ''` (B1) | Stamped at emit time. Exactly as trustworthy as the span. |
| `stitchedAccounts` | `identity_graph` edges where one side is `account_id` | Inferred from a CRM or CDP assertion. Only as trustworthy as that connector. |

They are counted and rendered separately and never blended into a single number, so the tab can show confidence rather than implying both are equally certain. The per-record equivalent already exists downstream: `attribution_records.AttributionConfidence` distinguishes `direct` from `identity_graph_stitched`.

## Verification

- `infra/gateway`: 464 passed, `ruff check` clean
- `sdk/python`: full suite passing (16 new identity tests, 3 new DDL tests), `ruff check` clean
- `web/`: `typecheck` clean, `lint` clean (only the 3 pre-existing warnings), `test` 232 passed. The 2 `app/api/api.test.ts` failures are the known pre-existing ones that appear when ClickHouse runs locally; no new failures.
- ClickHouse: `make ch-migrate` applied and replayed against the live local stack, schema confirmed via `system.columns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
