### PR TITLE
feat(gateway,edge-proxy): carry account_id_hash from the wire into ClickHouse (CTO-182)

### DIFF
--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -47,6 +47,8 @@ These are enforced by tests, not just documented:
 | `EDGE_PROXY_LISTEN` | `:8088` | bind address |
 | `EDGE_PROXY_UPSTREAM` | `https://api.openai.com` | provider origin |
 | `EDGE_PROXY_TENANT_HEADER` | `X-Tenant-Key` | control header carrying the tenant id (stripped before upstream) |
+| `EDGE_PROXY_FEATURE_TAG_HEADER` | `X-Tally-Feature-Tag` | optional control header carrying a per-request feature/agent tag (stripped before upstream) |
+| `EDGE_PROXY_ACCOUNT_ID_HASH_HEADER` | `X-Tally-Account-Id-Hash` | optional control header carrying the **already-hashed** account id (stripped before upstream), see below |
 | `EDGE_PROXY_REQUIRE_TENANT` | `false` | reject requests missing the tenant header with `400` |
 | `EDGE_PROXY_UPSTREAM_TIMEOUT` | `10m` | per-request bound (generous: completions stream for minutes) |
 | `EDGE_PROXY_MODE` | `passthrough` | `passthrough` (app sends the provider key) or `broker` (provider key stays in KMS — see below) |
@@ -56,6 +58,33 @@ These are enforced by tests, not just documented:
 | `EDGE_PROXY_TELEMETRY_URL` | — | collector endpoint for metadata-only `TraceRecord`s; empty disables shipping |
 
 `/healthz` is the one path the proxy owns (liveness); everything else is forwarded.
+
+## Account attribution (CTO-182)
+
+Cost per *customer* needs a dimension between the ai-tally tenant and the individual end user: the
+tenant's own paying customer (company, workspace, or team). The Python SDK supplies it via
+`with_account(...)`, which emits the `gen_ai.account_id_hash` span attribute. Non-Python callers get
+the same dimension through the proxy by sending one control header:
+
+```
+X-Tally-Account-Id-Hash: <64-char HMAC-SHA256 hex of the account id>
+```
+
+Rules, all deliberate:
+
+- **The value must already be hashed.** The proxy holds no HMAC key and will not hash for you. Send
+  a raw account id and you have put a customer identifier into telemetry, which is exactly what the
+  hash exists to prevent. Compute it the same way the SDK does
+  (`HmacKeyRegistry.hash_account`) so proxied and SDK traffic land on the same hash.
+- **It is optional and never rejected.** A request without the header ingests cleanly and lands in
+  the *unattributed* bucket (empty string), which is not a customer named "unknown" and must never
+  be ranked alongside real accounts.
+- **It is stripped before the request leaves for the provider**, exactly like `X-Tenant-Key` and
+  `X-Tally-Feature-Tag`. Upstream never sees ai-tally internals.
+- **It reaches storage as `otel_spans.AccountIdHash`**, the same column the SDK path writes.
+
+There is deliberately no account *label* / display-name header here. Labels are mutable metadata
+and belong in the Postgres control plane keyed on the hash (CTO-186), not in the span store.
 
 ## Self-host & BYO-deployment (CTO-43)
 

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -67,6 +67,18 @@ type Config struct {
 	// segment traffic by feature (CTO-104). Unlike the tenant key, the feature tag is purely
 	// informational — missing/empty is fine and never rejected.
 	FeatureTagHeader string
+	// AccountIdHashHeader names an optional control header carrying the HMAC-SHA256 hex of the
+	// caller's own paying customer / account id (default X-Tally-Account-Id-Hash). It exists so
+	// non-Python callers get the same cost-per-customer dimension the Python SDK's with_account()
+	// provides (CTO-182). Like TenantHeader and FeatureTagHeader it is stripped before the request
+	// leaves for the upstream provider, and like the feature tag it is purely informational:
+	// missing/empty is fine and never rejected, landing in the unattributed bucket downstream.
+	//
+	// The value must ALREADY be hashed by the caller. The proxy never sees, and must never be sent,
+	// a raw account id: the whole point of the hash is that a customer identifier cannot be
+	// reversed or joined across tenants. The proxy does not hash on the caller's behalf because it
+	// does not hold the tenant's HMAC key.
+	AccountIdHashHeader string
 	// RequireTenant rejects requests missing TenantHeader with 400 when true.
 	RequireTenant bool
 	// UpstreamTimeout bounds a single forwarded request end-to-end (0 = no timeout, for streaming).
@@ -102,6 +114,9 @@ const (
 	DefaultGeminiUpstream   = "https://generativelanguage.googleapis.com"
 	DefaultTenantHeader     = "X-Tenant-Key"
 	DefaultFeatureTagHeader = "X-Tally-Feature-Tag"
+	// DefaultAccountIdHashHeader carries the pre-hashed account id (CTO-182). Named to match the
+	// existing X-Tally-* control-header convention and the gen_ai.account_id_hash wire attribute.
+	DefaultAccountIdHashHeader = "X-Tally-Account-Id-Hash"
 	// DefaultUpstreamTimeout is generous because LLM completions are slow and may stream for
 	// minutes; the proxy must not be the thing that cuts a long generation short.
 	DefaultUpstreamTimeout = 10 * time.Minute
@@ -118,10 +133,12 @@ func FromEnv(lookup Env) (Config, error) {
 		ListenAddr:       firstNonEmpty(lookup("EDGE_PROXY_LISTEN"), DefaultListenAddr),
 		TenantHeader:     firstNonEmpty(lookup("EDGE_PROXY_TENANT_HEADER"), DefaultTenantHeader),
 		FeatureTagHeader: firstNonEmpty(lookup("EDGE_PROXY_FEATURE_TAG_HEADER"), DefaultFeatureTagHeader),
-		UpstreamTimeout:  DefaultUpstreamTimeout,
-		Mode:             ModePassthrough,
-		BrokerTTL:        DefaultBrokerTTL,
-		TelemetryURL:     lookup("EDGE_PROXY_TELEMETRY_URL"),
+		AccountIdHashHeader: firstNonEmpty(
+			lookup("EDGE_PROXY_ACCOUNT_ID_HASH_HEADER"), DefaultAccountIdHashHeader),
+		UpstreamTimeout: DefaultUpstreamTimeout,
+		Mode:            ModePassthrough,
+		BrokerTTL:       DefaultBrokerTTL,
+		TelemetryURL:    lookup("EDGE_PROXY_TELEMETRY_URL"),
 	}
 
 	// Provider is orthogonal to upstream selection but changes the default upstream: a gemini proxy

--- a/infra/edge-proxy/internal/config/config_test.go
+++ b/infra/edge-proxy/internal/config/config_test.go
@@ -203,3 +203,28 @@ func TestProviderSelection(t *testing.T) {
 		t.Error("expected error for unknown provider")
 	}
 }
+
+// TestAccountIdHashHeaderDefault: the account control header (CTO-182) defaults to the X-Tally-*
+// name documented in the README, matching the existing feature-tag convention.
+func TestAccountIdHashHeaderDefault(t *testing.T) {
+	cfg, err := FromEnv(envMap(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AccountIdHashHeader != DefaultAccountIdHashHeader {
+		t.Errorf("AccountIdHashHeader = %q, want %q", cfg.AccountIdHashHeader, DefaultAccountIdHashHeader)
+	}
+	if DefaultAccountIdHashHeader != "X-Tally-Account-Id-Hash" {
+		t.Errorf("default header name changed to %q; update the README", DefaultAccountIdHashHeader)
+	}
+}
+
+func TestAccountIdHashHeaderOverride(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_ACCOUNT_ID_HASH_HEADER": "X-Acct"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AccountIdHashHeader != "X-Acct" {
+		t.Errorf("AccountIdHashHeader = %q", cfg.AccountIdHashHeader)
+	}
+}

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -153,6 +153,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.cfg.FeatureTagHeader != "" {
 		featureTag = r.Header.Get(p.cfg.FeatureTagHeader)
 	}
+	// Account hash is optional on the same terms as the feature tag: capture if present, never
+	// reject when absent (CTO-182). The value is already hashed by the caller and is passed through
+	// untouched -- the proxy holds no HMAC key and must never receive a raw account id.
+	var accountIdHash string
+	if p.cfg.AccountIdHashHeader != "" {
+		accountIdHash = r.Header.Get(p.cfg.AccountIdHashHeader)
+	}
 
 	start := p.now()
 
@@ -186,6 +193,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.cfg.FeatureTagHeader != "" {
 		r.Header.Del(p.cfg.FeatureTagHeader)
 	}
+	if p.cfg.AccountIdHashHeader != "" {
+		r.Header.Del(p.cfg.AccountIdHashHeader)
+	}
 
 	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 	// Mark whether the upstream was reachable so the telemetry copy can distinguish a real 502
@@ -201,6 +211,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.sink.Record(TraceRecord{
 		TenantKey:        tenant,
 		FeatureTag:       featureTag,
+		AccountIdHash:    accountIdHash,
 		Method:           r.Method,
 		Path:             r.URL.Path,
 		Model:            meta.Model,

--- a/infra/edge-proxy/internal/proxy/proxy_test.go
+++ b/infra/edge-proxy/internal/proxy/proxy_test.go
@@ -376,6 +376,63 @@ func TestFeatureTagHeaderAbsent(t *testing.T) {
 	}
 }
 
+// TestAccountIdHashHeaderRecordedAndStripped is CTO-182's structural guarantee: a pre-hashed
+// account id arriving on X-Tally-Account-Id-Hash is captured on the TraceRecord and stripped from
+// the upstream-bound request, mirroring the tenant- and feature-tag-header contracts. This is what
+// lets a non-Python caller attribute cost per customer without the SDK.
+func TestAccountIdHashHeaderRecordedAndStripped(t *testing.T) {
+	const hash = "3f2a8c1d4e5b6079aabbccddeeff00112233445566778899aabbccddeeff0011"
+	var sawAccountHeader bool
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawAccountHeader = r.Header["X-Tally-Account-Id-Hash"]
+		w.WriteHeader(http.StatusOK)
+	})
+	front, sink := newTestProxy(t, false, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	req.Header.Set("X-Tenant-Key", "tk_live_acme")
+	req.Header.Set("X-Tally-Account-Id-Hash", hash)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	if sawAccountHeader {
+		t.Error("X-Tally-Account-Id-Hash leaked to upstream")
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last().AccountIdHash; got != hash {
+		t.Errorf("AccountIdHash = %q, want %q", got, hash)
+	}
+}
+
+// TestAccountIdHashHeaderAbsent: omitting the header leaves AccountIdHash empty and the request
+// still succeeds. Attribution is opt-in; an unattributed request is a normal request, and the
+// empty string is the unattributed bucket rather than a placeholder account.
+func TestAccountIdHashHeaderAbsent(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	front, sink := newTestProxy(t, false, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	req.Header.Set("X-Tenant-Key", "tk_live_acme")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last().AccountIdHash; got != "" {
+		t.Errorf("AccountIdHash = %q, want empty", got)
+	}
+}
+
 // TestTraceRecordCarriesNoBodyContent is a structural guard: the telemetry type must not gain a
 // field that could hold prompt/completion/key content. If someone adds a `Body string`, this fails.
 func TestTraceRecordCarriesNoBodyContent(t *testing.T) {

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -18,8 +18,14 @@ type TraceRecord struct {
 	// (X-Tally-Feature-Tag). Optional and informational only — empty when the caller didn't tag
 	// the request. Downstream telemetry uses this to segment cost and traces by feature (CTO-104).
 	FeatureTag string
-	Method     string
-	Path       string
+	// AccountIdHash is the HMAC-SHA256 hex of the caller's own paying customer / account id, taken
+	// verbatim from the control header (X-Tally-Account-Id-Hash) and never computed here (CTO-182).
+	// Optional and informational: empty when the caller did not attribute the request, which is the
+	// unattributed bucket downstream, not a customer named "unknown". Because it is a hash, this
+	// field cannot carry a raw customer identifier and keeps the CTO-42 metadata-only guarantee.
+	AccountIdHash string
+	Method        string
+	Path          string
 	// Model is the model id for the request, extracted from the response (or request path for
 	// Gemini) when a provider protocol is configured (CTO-167). Empty in pure pass-through mode or
 	// when the response carried no recognizable model. It is a short identifier

--- a/infra/edge-proxy/internal/telemetry/telemetry.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry.go
@@ -35,32 +35,37 @@ const (
 // plus the deployment label; nothing else. Durations are serialized as integer nanoseconds and
 // timestamps as Unix nanoseconds so the format is language-neutral and stable.
 type wireRecord struct {
-	Deployment  Deployment `json:"deployment"`
-	TenantKey   string     `json:"tenant_key"`
-	FeatureTag  string     `json:"feature_tag"`
-	Method      string     `json:"method"`
-	Path        string     `json:"path"`
-	StatusCode  int        `json:"status_code"`
-	ReqBytes    int64      `json:"req_bytes"`
-	RespBytes   int64      `json:"resp_bytes"`
-	DurationNs  int64      `json:"duration_ns"`
-	StartedAtNs int64      `json:"started_at_ns"`
-	Failed      bool       `json:"failed"`
+	Deployment Deployment `json:"deployment"`
+	TenantKey  string     `json:"tenant_key"`
+	FeatureTag string     `json:"feature_tag"`
+	// AccountIdHash mirrors the gen_ai.account_id_hash span attribute so a proxied request lands in
+	// the same ClickHouse AccountIdHash column a Python-SDK span does (CTO-182). Empty means
+	// unattributed.
+	AccountIdHash string `json:"account_id_hash"`
+	Method        string `json:"method"`
+	Path          string `json:"path"`
+	StatusCode    int    `json:"status_code"`
+	ReqBytes      int64  `json:"req_bytes"`
+	RespBytes     int64  `json:"resp_bytes"`
+	DurationNs    int64  `json:"duration_ns"`
+	StartedAtNs   int64  `json:"started_at_ns"`
+	Failed        bool   `json:"failed"`
 }
 
 func toWire(dep Deployment, rec proxy.TraceRecord) wireRecord {
 	return wireRecord{
-		Deployment:  dep,
-		TenantKey:   rec.TenantKey,
-		FeatureTag:  rec.FeatureTag,
-		Method:      rec.Method,
-		Path:        rec.Path,
-		StatusCode:  rec.StatusCode,
-		ReqBytes:    rec.ReqBytes,
-		RespBytes:   rec.RespBytes,
-		DurationNs:  rec.Duration.Nanoseconds(),
-		StartedAtNs: rec.StartedAt.UnixNano(),
-		Failed:      rec.Failed,
+		Deployment:    dep,
+		TenantKey:     rec.TenantKey,
+		FeatureTag:    rec.FeatureTag,
+		AccountIdHash: rec.AccountIdHash,
+		Method:        rec.Method,
+		Path:          rec.Path,
+		StatusCode:    rec.StatusCode,
+		ReqBytes:      rec.ReqBytes,
+		RespBytes:     rec.RespBytes,
+		DurationNs:    rec.Duration.Nanoseconds(),
+		StartedAtNs:   rec.StartedAt.UnixNano(),
+		Failed:        rec.Failed,
 	}
 }
 

--- a/infra/edge-proxy/internal/telemetry/telemetry_test.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry_test.go
@@ -79,7 +79,9 @@ func TestEncodeCarriesNoBodyContent(t *testing.T) {
 	}
 	allowed := map[string]bool{
 		"deployment": true, "tenant_key": true, "feature_tag": true,
-		"method": true, "path": true,
+		// account_id_hash is a hash, not an identifier: it cannot carry a name or a body (CTO-182).
+		"account_id_hash": true,
+		"method":          true, "path": true,
 		"status_code": true, "req_bytes": true, "resp_bytes": true,
 		"duration_ns": true, "started_at_ns": true, "failed": true,
 	}

--- a/infra/gateway/src/gateway/mapping.py
+++ b/infra/gateway/src/gateway/mapping.py
@@ -21,6 +21,8 @@ _PROMOTED_GENAI = frozenset(
         GenAI.SESSION_ID,
         GenAI.USER_ID_HASH,
         GenAI.USER_ID_HASH_KEY_VERSION,
+        GenAI.ACCOUNT_ID_HASH,
+        GenAI.ACCOUNT_ID_HASH_KEY_VERSION,
         GenAI.IDEMPOTENCY_KEY,
         GenAI.SYSTEM,
         GenAI.REQUEST_MODEL,
@@ -43,6 +45,33 @@ _PROMOTED_GENAI = frozenset(
         GenAI.SAMPLING_RATE,
     }
 )
+
+# Wire-only gen_ai.* keys: accepted on ingest, deliberately NOT written to ClickHouse: neither as
+# a typed column nor as a SpanAttributes entry. They are listed here so the long-tail loop below
+# drops them explicitly rather than letting them fall through into the map by accident.
+#
+# gen_ai.account_label (CTO-181) is the only member today. An account label is mutable,
+# human-readable customer metadata: stamping it on every span would put customer names in the
+# telemetry store, which is exactly what hashing the account id exists to prevent (see the comment
+# on otel_spans.AccountIdHash in db/clickhouse/otel_spans.sql). Labels belong in the Postgres
+# control plane, keyed on the account hash and joined at render time.
+#
+# SEAM FOR CTO-186 (B7): the label store does not exist yet. When it lands, the upsert hangs off
+# :func:`wire_only_account_label` below. The value is already parsed out of the span here, so B7
+# adds a store call at the ingest site and nothing in this module has to change.
+_WIRE_ONLY_GENAI = frozenset({GenAI.ACCOUNT_LABEL})
+
+
+def wire_only_account_label(span: dict[str, object]) -> str | None:
+    """Return the wire-only ``gen_ai.account_label`` for this span, or None when absent.
+
+    This is the seam CTO-186 (B7) hangs the Postgres label-store upsert on. Today nothing calls it
+    on the write path: the label is accepted, validated, and dropped. It is never persisted to
+    ClickHouse and never appears in a row tuple or in ``SpanAttributes``.
+    """
+    v = span.get(GenAI.ACCOUNT_LABEL)
+    return v if isinstance(v, str) and v else None
+
 
 # Hard PII guard (CTO-118): any incoming attribute whose key tail-segment matches one of
 # these is dropped on the floor. The contract is "counts only, never bodies"; if a caller
@@ -94,6 +123,9 @@ COLUMNS: tuple[str, ...] = (
     "SessionId",
     "UserIdHash",
     "UserIdHashKeyVersion",
+    # Account dimension (CTO-180/182). Placed to mirror the DDL, immediately after the user hash.
+    "AccountIdHash",
+    "AccountIdHashKeyVersion",
     "IdempotencyKey",
     "GenAiSystem",
     "GenAiRequestModel",
@@ -178,6 +210,9 @@ def span_to_row(
     for k, v in span.items():
         if k in _PROMOTED_GENAI or k in _STRUCTURAL or v is None:
             continue
+        # Wire-only keys (gen_ai.account_label) never reach ClickHouse, not even via the map.
+        if k in _WIRE_ONLY_GENAI:
+            continue
         if _is_body_key(str(k)):
             continue
         extra[str(k)] = str(v)
@@ -196,6 +231,10 @@ def span_to_row(
         _s(span.get(GenAI.SESSION_ID)),
         _fixed64(span.get(GenAI.USER_ID_HASH)),
         _s(span.get(GenAI.USER_ID_HASH_KEY_VERSION)),
+        # CTO-182: an absent account hash writes '' (the UNATTRIBUTED bucket the DDL documents),
+        # never a null and never a placeholder like 'unknown' that could rank as a real account.
+        _fixed64(span.get(GenAI.ACCOUNT_ID_HASH)),
+        _s(span.get(GenAI.ACCOUNT_ID_HASH_KEY_VERSION)),
         _s(span.get(GenAI.IDEMPOTENCY_KEY)),
         _s(span.get(GenAI.SYSTEM)),
         _s(span.get(GenAI.REQUEST_MODEL)),

--- a/infra/gateway/src/gateway/validation.py
+++ b/infra/gateway/src/gateway/validation.py
@@ -54,8 +54,13 @@ _STR_KEYS = frozenset(
     {
         GenAI.SYSTEM, GenAI.REQUEST_MODEL, GenAI.RESPONSE_MODEL, GenAI.OPERATION_NAME,
         GenAI.COST_CURRENCY, GenAI.FEATURE_TAG, GenAI.SESSION_ID, GenAI.USER_ID_HASH,
+        GenAI.ACCOUNT_ID_HASH,
     }
 )
+
+# Identifier keys that must arrive already HMAC-hashed. A raw account id is as much a raw
+# identifier as a raw user id, so the account hash gets the same guard (CTO-182).
+_HASHED_ID_KEYS = frozenset({GenAI.USER_ID_HASH, GenAI.ACCOUNT_ID_HASH})
 
 DEFAULT_MAX_SPAN_BYTES = 64 * 1024
 
@@ -80,15 +85,15 @@ def _iter_str_values(span: dict[str, object]) -> Iterable[tuple[str, str]]:
             yield str(k), v
 
 
-def _looks_unhashed(user_id_hash: str) -> bool:
+def _looks_unhashed(value: str) -> bool:
     """A real HMAC-SHA256 hex is 64 lowercase hex chars. Reject obvious raw ids / e-mails.
 
     Heuristic, deliberately conservative to avoid false positives: only flag when the value clearly
     isn't a hash — contains '@', or contains non-hex characters (a raw username/id would).
     """
-    if "@" in user_id_hash:
+    if "@" in value:
         return True
-    s = user_id_hash.strip().lower()
+    s = value.strip().lower()
     if not s:
         return False
     is_hexish = all(c in "0123456789abcdef" for c in s) and len(s) >= 16
@@ -148,9 +153,9 @@ class SpanValidator:
             if str(key).lower() in _FORBIDDEN_PII_KEYS:
                 return f"forbidden raw-PII key present: {key!r}"
         for key, value in _iter_str_values(span):
-            if key == GenAI.USER_ID_HASH:
+            if key in _HASHED_ID_KEYS:
                 if _looks_unhashed(value):
-                    return "gen_ai.user_id_hash is not a hash (raw identifier?)"
+                    return f"{key} is not a hash (raw identifier?)"
                 continue
             if _EMAIL_RE.search(value):
                 return f"raw e-mail detected in {key!r}"

--- a/infra/gateway/tests/test_mapping_account.py
+++ b/infra/gateway/tests/test_mapping_account.py
@@ -1,0 +1,119 @@
+"""Span -> row promotion of the CTO-182 account dimension.
+
+Three contracts checked here:
+
+1. Presence — ``gen_ai.account_id_hash`` / ``gen_ai.account_id_hash_key_version`` land in the
+   ``AccountIdHash`` / ``AccountIdHashKeyVersion`` typed columns, exactly like the user hash.
+2. Absence — a span with no account attribute still maps cleanly, writing ``''`` (the
+   unattributed bucket the DDL documents), never a null and never a placeholder that could be
+   mistaken for a real account.
+3. Label passthrough — ``gen_ai.account_label`` is wire-only. It is accepted without error and is
+   NOT persisted: not as a column, not in the ``SpanAttributes`` long-tail map. The Postgres label
+   store it belongs in is CTO-186 (B7).
+"""
+
+from __future__ import annotations
+
+from gateway.mapping import COLUMNS, span_to_row, wire_only_account_label
+from gateway.validation import SpanValidator
+
+_HASH = "a" * 64
+_OTHER_HASH = "b" * 64
+
+
+def _row_dict(row: tuple[object, ...]) -> dict[str, object]:
+    assert len(row) == len(COLUMNS)
+    return dict(zip(COLUMNS, row, strict=True))
+
+
+def test_account_hash_promoted_to_typed_columns() -> None:
+    span = {
+        "gen_ai.account_id_hash": _HASH,
+        "gen_ai.account_id_hash_key_version": "v2",
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    assert row["AccountIdHash"] == _HASH
+    assert row["AccountIdHashKeyVersion"] == "v2"
+
+
+def test_account_hash_absent_writes_empty_string_not_null() -> None:
+    """The unattributed bucket is '' — never None, never a 'unknown'-style placeholder."""
+    row = _row_dict(span_to_row({}, tenant_id="t1", effective_ts_ns=0))
+    assert row["AccountIdHash"] == ""
+    assert row["AccountIdHashKeyVersion"] == ""
+
+
+def test_account_columns_sit_alongside_user_columns() -> None:
+    """Account and user hashes are independent dimensions and must not overwrite each other."""
+    span = {
+        "gen_ai.user_id_hash": _OTHER_HASH,
+        "gen_ai.user_id_hash_key_version": "v1",
+        "gen_ai.account_id_hash": _HASH,
+        "gen_ai.account_id_hash_key_version": "v2",
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+    assert row["UserIdHash"] == _OTHER_HASH
+    assert row["UserIdHashKeyVersion"] == "v1"
+    assert row["AccountIdHash"] == _HASH
+    assert row["AccountIdHashKeyVersion"] == "v2"
+
+
+def test_account_attrs_not_duplicated_in_span_attributes_map() -> None:
+    span = {
+        "gen_ai.account_id_hash": _HASH,
+        "gen_ai.account_id_hash_key_version": "v2",
+    }
+    extra = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))["SpanAttributes"]
+    assert isinstance(extra, dict)
+    assert "gen_ai.account_id_hash" not in extra
+    assert "gen_ai.account_id_hash_key_version" not in extra
+
+
+def test_account_label_is_accepted_but_never_persisted() -> None:
+    """CTO-186 seam: the label rides the wire, ingests fine, and reaches no ClickHouse column."""
+    span = {
+        "gen_ai.account_id_hash": _HASH,
+        "gen_ai.account_id_hash_key_version": "v2",
+        "gen_ai.account_label": "Acme Robotics",
+    }
+    row = _row_dict(span_to_row(span, tenant_id="t1", effective_ts_ns=0))
+
+    # The hash still lands: carrying a label must not disturb attribution.
+    assert row["AccountIdHash"] == _HASH
+
+    # There is no label column at all, and it did not leak into the long-tail map either.
+    assert "AccountLabel" not in COLUMNS
+    extra = row["SpanAttributes"]
+    assert isinstance(extra, dict)
+    assert "gen_ai.account_label" not in extra
+    # Belt and braces: the label string appears nowhere in the row.
+    assert "Acme Robotics" not in [v for v in row.values() if isinstance(v, str)]
+    assert "Acme Robotics" not in extra.values()
+
+
+def test_wire_only_account_label_seam_reads_the_label() -> None:
+    """The seam CTO-186 (B7) will hang the Postgres upsert on returns the parsed label."""
+    assert wire_only_account_label({"gen_ai.account_label": "Acme Robotics"}) == "Acme Robotics"
+    assert wire_only_account_label({"gen_ai.account_label": ""}) is None
+    assert wire_only_account_label({"gen_ai.account_label": 7}) is None
+    assert wire_only_account_label({}) is None
+
+
+def test_validator_accepts_a_hashed_account_and_a_label() -> None:
+    v = SpanValidator()
+    verdict = v.validate(
+        {
+            "gen_ai.account_id_hash": _HASH,
+            "gen_ai.account_id_hash_key_version": "v2",
+            "gen_ai.account_label": "Acme Robotics",
+        }
+    )
+    assert verdict.accepted, verdict.message
+
+
+def test_validator_rejects_a_raw_account_id() -> None:
+    """Only the hash reaches storage: a raw account id is a raw identifier and is refused."""
+    v = SpanValidator()
+    verdict = v.validate({"gen_ai.account_id_hash": "acme-robotics-inc"})
+    assert not verdict.accepted
+    assert "not a hash" in (verdict.message or "")


### PR DESCRIPTION
## Stacked PR

Base: `feat/sdk-account-id` (**PR #173**, CTO-181, B2), which is itself stacked on **PR #170** (CTO-180, B1). Review and merge #170, then #173, then this.

> Note on the base branch: the ticket named `worktree-agent-ad0161a0610fa381b`, which does not exist on the remote. PR #173's actual head branch is `feat/sdk-account-id` and it carries both the ClickHouse columns from #170 and the SDK support from #173, so that is what this is based on.

## What and why

B1 added the `AccountIdHash` columns and B2 taught the SDK to emit the attributes, but nothing joined the two. The account dimension stopped at the gateway boundary and never reached storage, which left the whole cost-per-customer epic inert. This is the connecting piece.

### 1. Gateway mapping

`infra/gateway/src/gateway/mapping.py` promotes `gen_ai.account_id_hash` and `gen_ai.account_id_hash_key_version` onto `AccountIdHash` / `AccountIdHashKeyVersion`, following the `UserIdHash` handling exactly:

- same `_fixed64` coercion for the `FixedString(64)` column,
- same placement in `COLUMNS` and in the row tuple (immediately after the user hash, mirroring the DDL),
- same membership in `_PROMOTED_GENAI`, so the keys are not also duplicated into the `SpanAttributes` map.

An absent attribute writes `''`, the unattributed bucket the DDL documents. Never a null, and never a placeholder like `"unknown"` that could be ranked alongside a real account.

### 2. Validation

The account hash joins the user hash under the already-hashed guard in `validation.py`. A raw account id is as much a raw identifier as a raw user id, and only the hash may reach storage, so an unhashed value is rejected rather than persisted.

### 3. Edge proxy header

**The header is `X-Tally-Account-Id-Hash`** (overridable via `EDGE_PROXY_ACCOUNT_ID_HASH_HEADER`).

Naming rationale: it matches the existing `X-Tally-*` control-header convention (`X-Tally-Feature-Tag`) and reads as the direct transport of the `gen_ai.account_id_hash` wire attribute, so there is one name to learn across the SDK and the proxy. `-Hash` is in the name deliberately, as a standing reminder that the value is pre-hashed.

It is treated exactly like the feature tag: captured on the `TraceRecord`, stripped before the request leaves for the upstream provider, and never required (absent means unattributed, not an error). The value must arrive already hashed. The proxy holds no HMAC key and will not hash on the caller's behalf, so a raw customer id cannot enter this path. Documented in `infra/edge-proxy/README.md` with a new "Account attribution" section plus config-table rows (the previously undocumented `EDGE_PROXY_FEATURE_TAG_HEADER` got a row too while I was there).

### 4. Label passthrough, not persistence

`gen_ai.account_label` is wire-only. It is accepted and validated without error and then **explicitly dropped**: it lands neither in a column nor in the `SpanAttributes` long-tail map. Stamping a mutable display name on every span would put customer names in the telemetry store, which is precisely what hashing the id exists to prevent.

A named seam, `mapping.wire_only_account_label`, parses the value out and carries a comment naming **CTO-186 (B7)**, so B7 can hang the Postgres label-store upsert on it without reworking this module. The store itself is not built here.

## End-to-end proof

Against the running local stack (`docker compose -f infra/docker-compose.yml up -d --build gateway`), three spans posted to `http://localhost:8080/v1/batches` in one batch:

```
200 {"batch_id":"cto182-e2e-...","status":"accepted","accepted_spans":3,"partial_errors":[],...}
```

All three accepted, zero partial errors. Then in ClickHouse:

```
SELECT SpanId, AccountIdHash, AccountIdHashKeyVersion, length(AccountIdHash), mapKeys(SpanAttributes)
FROM otel_spans WHERE ServiceName='cto182-e2e' ORDER BY SpanId FORMAT Vertical
```

```
SpanId:                  cto182label00000     -- posted WITH gen_ai.account_label
AccountIdHash:           cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
AccountIdHashKeyVersion: v1
length(AccountIdHash):   64
mapKeys(SpanAttributes): []

SpanId:                  cto182with000000     -- posted WITH the attribute
AccountIdHash:           cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
AccountIdHashKeyVersion: v1
length(AccountIdHash):   64

SpanId:                  cto182without000     -- posted WITHOUT the attribute
AccountIdHash:
AccountIdHashKeyVersion:
```

Bucket counts and the label absence check:

```
SELECT countIf(AccountIdHash = '') AS unattributed, countIf(AccountIdHash != '') AS attributed
FROM otel_spans WHERE ServiceName='cto182-e2e'
-- 1  2

SELECT count() FROM otel_spans
WHERE positionCaseInsensitive(toString(SpanAttributes), 'Acme Robotics') > 0
-- 0
```

Acceptance criteria, all three met: a span with the attribute lands with a populated `AccountIdHash`; a span without it ingests cleanly as `''`; a span carrying `gen_ai.account_label` ingests fine and the label appears nowhere in ClickHouse.

## Verification

| Check | Result |
|---|---|
| `cd infra/gateway && uv run --extra dev pytest -q` | 472 passed |
| `cd infra/gateway && uv run ruff check .` | All checks passed |
| `cd infra/edge-proxy && go build ./...` | clean |
| `cd infra/edge-proxy && go test ./...` | all packages ok |
| `cd infra/edge-proxy && gofmt -l .` | no files reported |
| `cd sdk/python && uv run --extra dev pytest -q` | passed |

New tests: `infra/gateway/tests/test_mapping_account.py` (8 cases covering promotion, the `''` default, user/account independence, no map duplication, label non-persistence, the CTO-186 seam, and validator accept/reject), plus `TestAccountIdHashHeaderRecordedAndStripped` / `TestAccountIdHashHeaderAbsent` in the proxy and default/override coverage in config. The telemetry wire-format allowlist guard was extended for the new field, which keeps the metadata-only invariant enforced rather than bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
