### PR TITLE
feat(revenue): net revenue per account, blank when unknown (CTO-196)

### DIFF
--- a/web/lib/accountRevenue.test.ts
+++ b/web/lib/accountRevenue.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// CTO-196: revenue per account, and the null-vs-zero distinction the margin column depends on.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  REVENUE_WINDOW_SQL,
+  UNATTRIBUTED_ACCOUNT,
+  accountRevenueFromRow,
+  accountRevenueReport,
+  accountRevenueSql,
+  revenueForAccount,
+  type AccountRevenueSqlRow,
+} from "./accountRevenue";
+import { DEFAULT_REVENUE_POLICY, type RevenuePolicy } from "./revenueSources";
+
+const ACCT_A = "a".repeat(64);
+const ACCT_B = "b".repeat(64);
+
+function row(overrides: Partial<AccountRevenueSqlRow> = {}): AccountRevenueSqlRow {
+  return {
+    account_id_hash: ACCT_A,
+    gross_micro: "0",
+    refund_micro: "0",
+    revenue_events: "0",
+    distinct_users: "0",
+    ...overrides,
+  };
+}
+
+describe("null vs zero", () => {
+  it("returns null, not 0, for an account with no revenue events", () => {
+    // The whole point of the ticket. 0 would read as "this customer generates no revenue", which
+    // is a claim we cannot support; null reads as "we do not know", which is the truth.
+    const rec = accountRevenueFromRow(row({ revenue_events: "0" }));
+    expect(rec.revenueMicroUsd).toBeNull();
+    expect(rec.revenueMicroUsd).not.toBe(0);
+  });
+
+  it("treats an account with only `count` engagement events as unknown", () => {
+    // `count` events carry no amount. An account that has them and nothing else has produced
+    // sums of 0, which must not be mistaken for measured zero revenue.
+    const rec = accountRevenueFromRow(
+      row({ gross_micro: "0", refund_micro: "0", revenue_events: "0", distinct_users: "12" }),
+    );
+    expect(rec.revenueMicroUsd).toBeNull();
+    expect(rec.distinctUsers).toBe(12);
+  });
+
+  it("keeps a genuine measured zero as 0", () => {
+    // A charge fully refunded is knowledge, not absence. This is the other half of the
+    // distinction: null and 0 must both be reachable and must mean different things.
+    const rec = accountRevenueFromRow(
+      row({ gross_micro: "5000000", refund_micro: "5000000", revenue_events: "2" }),
+    );
+    expect(rec.revenueMicroUsd).toBe(0);
+    expect(rec.revenueMicroUsd).not.toBeNull();
+  });
+
+  it("returns null for an account the report has no row for", () => {
+    const report = accountRevenueReport([
+      row({ account_id_hash: ACCT_A, gross_micro: "100", revenue_events: "1" }),
+    ]);
+    expect(revenueForAccount(report, ACCT_B)).toBeNull();
+    expect(revenueForAccount(null, ACCT_A)).toBeNull();
+    expect(revenueForAccount(report, ACCT_A)).toBe(100);
+  });
+
+  it("passes a null revenue through the lookup rather than coercing it", () => {
+    const report = accountRevenueReport([row({ account_id_hash: ACCT_A, revenue_events: "0" })]);
+    expect(revenueForAccount(report, ACCT_A)).toBeNull();
+  });
+});
+
+describe("refunds net off", () => {
+  it("subtracts refunds from gross", () => {
+    const rec = accountRevenueFromRow(
+      row({ gross_micro: "1200000", refund_micro: "200000", revenue_events: "3" }),
+    );
+    expect(rec.revenueMicroUsd).toBe(1_000_000);
+    expect(rec.grossMicroUsd).toBe(1_200_000);
+    expect(rec.refundMicroUsd).toBe(200_000);
+  });
+
+  it("lets refunds exceeding gross go negative rather than clamping", () => {
+    // A net negative account is a real finding (a churned customer refunded last month's
+    // invoice). Clamping to 0 would hide it from the profitability ranking.
+    const rec = accountRevenueFromRow(
+      row({ gross_micro: "0", refund_micro: "750000", revenue_events: "1" }),
+    );
+    expect(rec.revenueMicroUsd).toBe(-750_000);
+  });
+});
+
+describe("accountRevenueSql", () => {
+  const sqlOf = (p: RevenuePolicy = DEFAULT_REVENUE_POLICY) => accountRevenueSql(p).sql;
+
+  it("zero-fills every sumIf over the Nullable(Int64) amount", () => {
+    // The NULL trap E1 hit: sumIf over a Nullable column returns NULL for a group with no matching
+    // row, and NULL minus anything is NULL, so on a tenant with zero refunds the refund term
+    // swallowed the entire subtraction. Every sumIf argument must be ifNull(..., 0).
+    const sql = sqlOf();
+    const sumIfs = sql.match(/sumIf\([^)]*\)*/g) ?? [];
+    expect(sumIfs.length).toBeGreaterThanOrEqual(2);
+    for (const frag of sumIfs) {
+      expect(frag).toContain("ifNull(");
+    }
+    expect(sql).not.toMatch(/sumIf\(\s*b\.ValueAmountMicro/);
+    expect(sql).not.toMatch(/sumIf\(\s*abs\(b\.ValueAmountMicro/);
+  });
+
+  it("uses the same calendar-aligned window as the cost queries", () => {
+    expect(REVENUE_WINDOW_SQL).toBe("toDate(now()) - INTERVAL 29 DAY");
+    expect(sqlOf()).toContain("b.OccurredAt >= toDate(now()) - INTERVAL 29 DAY");
+  });
+
+  it("groups on AccountIdHash and never re-keys revenue off a user", () => {
+    const sql = sqlOf();
+    expect(sql).toContain("GROUP BY account_id_hash");
+    // Joining business_events to spans on UserIdHash would split or duplicate one account's
+    // revenue. E2's AccountLinker owns that decision at ingest.
+    expect(sql).not.toContain("JOIN");
+    expect(sql).not.toContain("otel_spans");
+  });
+
+  it("discriminates on ValueType, not a hardcoded source or event name", () => {
+    const sql = sqlOf();
+    expect(sql).toContain("b.ValueType IN {positiveTypes:Array(String)}");
+    expect(sql).toContain("b.ValueType = {refundType:String}");
+    expect(sql).not.toContain("EventName");
+    expect(sql).not.toContain("'stripe'");
+  });
+
+  it("binds the policy's value types, honouring include_mrr", () => {
+    expect(accountRevenueSql(DEFAULT_REVENUE_POLICY).params.positiveTypes).toEqual([
+      "monetary",
+      "mrr",
+    ]);
+    expect(
+      accountRevenueSql({ sources: null, includeMrr: false }).params.positiveTypes,
+    ).toEqual(["monetary"]);
+  });
+
+  it("narrows by source only when the tenant configured one", () => {
+    const open = accountRevenueSql(DEFAULT_REVENUE_POLICY);
+    expect(open.sql).not.toContain("lower(b.Source)");
+    expect(open.params.revenueSources).toBeUndefined();
+
+    const narrowed = accountRevenueSql({ sources: ["stripe", "csv-upload"], includeMrr: true });
+    expect(narrowed.sql).toContain("lower(b.Source) IN {revenueSources:Array(String)}");
+    expect(narrowed.params.revenueSources).toEqual(["stripe", "csv-upload"]);
+  });
+
+  it("does not filter out accounts with no revenue events", () => {
+    // Dropping them would collapse "engagement but no revenue wiring" into "never heard of it".
+    expect(sqlOf()).not.toContain("HAVING");
+  });
+});
+
+describe("accountRevenueReport", () => {
+  it("keeps the unattributed bucket separate from the ranked accounts", () => {
+    const report = accountRevenueReport([
+      row({ account_id_hash: ACCT_A, gross_micro: "300", revenue_events: "1" }),
+      row({ account_id_hash: UNATTRIBUTED_ACCOUNT, gross_micro: "999", revenue_events: "9" }),
+    ]);
+    expect(report.accounts.map((a) => a.accountIdHash)).toEqual([ACCT_A]);
+    expect(report.unattributed?.revenueMicroUsd).toBe(999);
+    expect(report.windowDays).toBe(30);
+  });
+
+  it("recognises the NUL-padded FixedString(64) default as unattributed", () => {
+    const report = accountRevenueReport([
+      row({ account_id_hash: "\0".repeat(64), gross_micro: "5", revenue_events: "1" }),
+    ]);
+    expect(report.accounts).toHaveLength(0);
+    expect(report.unattributed?.accountIdHash).toBe(UNATTRIBUTED_ACCOUNT);
+  });
+
+  it("reports no unattributed bucket when every event carries an account", () => {
+    const report = accountRevenueReport([
+      row({ account_id_hash: ACCT_A, gross_micro: "1", revenue_events: "1" }),
+    ]);
+    expect(report.unattributed).toBeNull();
+  });
+
+  it("ranks known revenue first and sinks unknown to the bottom", () => {
+    // An account we know nothing about must not outrank one we know is losing money.
+    const report = accountRevenueReport([
+      row({ account_id_hash: ACCT_B, revenue_events: "0" }),
+      row({ account_id_hash: ACCT_A, refund_micro: "50", revenue_events: "1" }),
+    ]);
+    expect(report.accounts.map((a) => a.revenueMicroUsd)).toEqual([-50, null]);
+  });
+});

--- a/web/lib/accountRevenue.ts
+++ b/web/lib/accountRevenue.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// Revenue per account (CTO-196, plan item E3).
+//
+// Sums `business_events.ValueAmountMicro` grouped by `AccountIdHash` over the same window the cost
+// queries use, netting refunds off the total. Pure helpers live here; the ClickHouse round trip is
+// `queryAccountRevenue` in lib/clickhouse.ts. Splitting them this way is what lets the null-vs-zero
+// rule below be tested without infra, which is the rule the margin column depends on.
+//
+// Three things this module is deliberate about.
+//
+// 1. It reuses the E1 revenue policy (lib/revenueSources.ts). `ValueType` is the discriminator,
+//    never a hardcoded source or event name, so uploaded revenue (E5) and connector revenue (E2)
+//    flow through exactly one policy. A tenant that narrows its revenue sources narrows both.
+//
+// 2. It reports null, not 0, for an account with no revenue events. Zero reads as "this customer
+//    generates no revenue", which is a claim; null reads as "we do not know", which is the truth
+//    when nothing has been wired up. An account whose only events are `count` engagement signals
+//    is in that second category, not the first, so the row count that decides this counts only
+//    money-typed events. Netting a real refund down to exactly 0 stays 0, because that is a
+//    measurement rather than an absence.
+//
+// 3. It groups on the `AccountIdHash` already stamped on the row at ingest. It does NOT join
+//    business_events to spans on `UserIdHash` to infer an account. One user belongs to one
+//    account, and E2's `AccountLinker` (sdk/python/src/tally/account_identity.py) is where that is
+//    decided: a user seen against two accounts is marked ambiguous, the event lands with an empty
+//    `AccountIdHash`, and an `AccountConflict` finding goes to the data-quality surface. Re-deriving
+//    the mapping here would either duplicate that revenue across accounts or silently disagree with
+//    the finding an operator is looking at. Ambiguous revenue arrives in the unattributed bucket,
+//    which the page reports rather than hides.
+
+import {
+  REFUND_VALUE_TYPE,
+  positiveValueTypes,
+  revenueSourceFilter,
+  type RevenuePolicy,
+} from "./revenueSources";
+
+/**
+ * The window, as a SQL expression. Calendar aligned and identical to the one every cost query in
+ * clickhouse.ts uses (`Timestamp >= toDate(now()) - INTERVAL 29 DAY`), so revenue and cost cover
+ * the same period and a margin is a subtraction of two figures measured over the same days.
+ * `toDate` truncates to midnight, which is why 29 and not 30 gives a 30 day window.
+ */
+export const REVENUE_WINDOW_SQL = "toDate(now()) - INTERVAL 29 DAY";
+
+/** Days covered by REVENUE_WINDOW_SQL, for labelling the figure in the UI. */
+export const REVENUE_WINDOW_DAYS = 30;
+
+/** `AccountIdHash` value meaning "no account could be established honestly". */
+export const UNATTRIBUTED_ACCOUNT = "";
+
+/** Net revenue for one account over the window. */
+export interface AccountRevenue {
+  /** The account hash, or `UNATTRIBUTED_ACCOUNT` for the no-account bucket. */
+  accountIdHash: string;
+  /**
+   * Gross minus refunds, in integer micro-USD, or `null` when this account has no money-typed
+   * event at all. Never 0 to mean "unknown": see the note at the top of this file.
+   */
+  revenueMicroUsd: number | null;
+  /** Sum of the positive (`monetary`, and `mrr` unless the tenant opted out) amounts. */
+  grossMicroUsd: number;
+  /** Sum of the `refund` amounts, as a positive number. Subtracted from gross. */
+  refundMicroUsd: number;
+  /** Money-typed events seen, refunds included. Zero is what makes `revenueMicroUsd` null. */
+  revenueEvents: number;
+  /** Distinct users who produced them. */
+  distinctUsers: number;
+}
+
+/** Per-account revenue for a tenant, with the unattributed bucket kept separate. */
+export interface AccountRevenueReport {
+  /** Accounts carrying at least one money-typed event, highest net revenue first. */
+  accounts: AccountRevenue[];
+  /**
+   * Revenue that could not be tied to an account: never tagged, or tied to a user that E2 marked
+   * ambiguous. `null` when there is none. The page shows this rather than dropping it, so a tenant
+   * ranking accounts can see how much of the total the ranking leaves out.
+   */
+  unattributed: AccountRevenue | null;
+  /** Window the figures cover, matching the cost side. */
+  windowDays: number;
+}
+
+/** Raw row shape ClickHouse returns. Int64 sums arrive as strings in JSONEachRow. */
+export interface AccountRevenueSqlRow {
+  account_id_hash: string;
+  gross_micro: string | number | null;
+  refund_micro: string | number | null;
+  revenue_events: string | number | null;
+  distinct_users: string | number | null;
+}
+
+function int(v: string | number | null | undefined): number {
+  const n = typeof v === "number" ? v : parseInt(v ?? "0", 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * SQL for the per-account revenue sum, plus the parameters it binds.
+ *
+ * Every `sumIf` zero-fills its argument with `ifNull(..., 0)`. `ValueAmountMicro` is
+ * `Nullable(Int64)`, so a `sumIf` matching no row in a group returns NULL rather than 0, and NULL
+ * minus anything is NULL. The E1 agent hit exactly this: on a tenant with no refunds the refund
+ * term swallowed the whole subtraction and revenue came back NULL for everyone. The zero-fill is
+ * what stops that, and it is why "no revenue events" is decided by `revenue_events` rather than by
+ * a NULL sum. Same fix, same shape, as the queryAttribution revenue expression.
+ *
+ * Amounts stay in micro-USD end to end. There is no divide by 1e6 and re-multiply, so no account
+ * total picks up a float rounding error on the way through.
+ *
+ * There is deliberately no `HAVING revenue_events > 0`. Filtering those groups out would hide the
+ * difference between an account we have engagement data for but no revenue wiring, and an account
+ * we have never heard of. Both end up blank in the UI, but only one of them is a connector the
+ * tenant can go and configure, so the row is worth returning.
+ */
+export function accountRevenueSql(policy: RevenuePolicy): {
+  sql: string;
+  params: Record<string, unknown>;
+} {
+  const positiveTypes = positiveValueTypes(policy);
+  const sourceFilter = revenueSourceFilter(policy, "b");
+  const moneyTyped =
+    `(b.ValueType IN {positiveTypes:Array(String)} ` +
+    `OR b.ValueType = {refundType:String})`;
+
+  return {
+    sql: `SELECT
+        b.AccountIdHash AS account_id_hash,
+        sumIf(ifNull(b.ValueAmountMicro, 0), b.ValueType IN {positiveTypes:Array(String)}) AS gross_micro,
+        sumIf(abs(ifNull(b.ValueAmountMicro, 0)), b.ValueType = {refundType:String})       AS refund_micro,
+        countIf(${moneyTyped})                                                             AS revenue_events,
+        uniqExactIf(b.UserIdHash, ${moneyTyped})                                           AS distinct_users
+      FROM business_events b
+      WHERE b.TenantId = {tenant:String}
+        AND b.OccurredAt >= ${REVENUE_WINDOW_SQL}
+        ${sourceFilter.sql}
+      GROUP BY account_id_hash`,
+    params: {
+      positiveTypes,
+      refundType: REFUND_VALUE_TYPE,
+      ...sourceFilter.params,
+    },
+  };
+}
+
+/** Map one ClickHouse row onto the typed shape, applying the null-vs-zero rule. */
+export function accountRevenueFromRow(row: AccountRevenueSqlRow): AccountRevenue {
+  const gross = int(row.gross_micro);
+  const refund = int(row.refund_micro);
+  const revenueEvents = int(row.revenue_events);
+  return {
+    accountIdHash: row.account_id_hash ?? UNATTRIBUTED_ACCOUNT,
+    // No money-typed event means we have not been told this account's revenue. An account whose
+    // only events are `count` signals lands here, and must read as unknown rather than as zero.
+    revenueMicroUsd: revenueEvents > 0 ? gross - refund : null,
+    grossMicroUsd: gross,
+    refundMicroUsd: refund,
+    revenueEvents,
+    distinctUsers: int(row.distinct_users),
+  };
+}
+
+/** Build the report from raw rows, splitting the unattributed bucket out and ranking the rest. */
+export function accountRevenueReport(rows: AccountRevenueSqlRow[]): AccountRevenueReport {
+  let unattributed: AccountRevenue | null = null;
+  const accounts: AccountRevenue[] = [];
+
+  for (const raw of rows) {
+    const rec = accountRevenueFromRow(raw);
+    // FixedString(64) pads with NUL bytes, so the default '' can arrive as a run of them.
+    if (rec.accountIdHash.replace(/\0/g, "") === UNATTRIBUTED_ACCOUNT) {
+      unattributed = { ...rec, accountIdHash: UNATTRIBUTED_ACCOUNT };
+    } else {
+      accounts.push(rec);
+    }
+  }
+
+  // Known revenue ranks first, highest to lowest. Unknown sinks to the bottom rather than sorting
+  // as 0, which would otherwise rank an account we know nothing about above one we know is negative.
+  accounts.sort((a, b) => {
+    const aKnown = a.revenueMicroUsd !== null;
+    const bKnown = b.revenueMicroUsd !== null;
+    if (aKnown !== bKnown) return aKnown ? -1 : 1;
+    if (aKnown && bKnown && a.revenueMicroUsd !== b.revenueMicroUsd) {
+      return (b.revenueMicroUsd as number) - (a.revenueMicroUsd as number);
+    }
+    return a.accountIdHash.localeCompare(b.accountIdHash);
+  });
+  return { accounts, unattributed, windowDays: REVENUE_WINDOW_DAYS };
+}
+
+/**
+ * Revenue for one account, for the margin column.
+ *
+ * Returns `null` for an account the report has no row for, which is the same answer as an account
+ * with no money-typed events: we do not know. The caller renders a blank either way, and must not
+ * substitute 0.
+ */
+export function revenueForAccount(
+  report: AccountRevenueReport | null,
+  accountIdHash: string,
+): number | null {
+  if (!report) return null;
+  const hit = report.accounts.find((a) => a.accountIdHash === accountIdHash);
+  return hit ? hit.revenueMicroUsd : null;
+}

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -47,6 +47,12 @@ import {
   queryRevenuePolicy,
   revenueSourceFilter,
 } from "./revenueSources";
+import {
+  accountRevenueReport,
+  accountRevenueSql,
+  type AccountRevenueReport,
+  type AccountRevenueSqlRow,
+} from "./accountRevenue";
 
 const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
@@ -1433,6 +1439,33 @@ export async function queryAttribution(
 
     if (perProvider.length === 0) return emptyReport(filters);
     return { filters, perProvider, totals, isMock: false };
+  });
+}
+
+// --- Revenue per account (CTO-196) --------------------------------------------------------------
+
+/**
+ * Net revenue per account over the same 30 day window the cost queries use.
+ *
+ * The SQL and the null-vs-zero rule live in lib/accountRevenue.ts, which documents both; this is
+ * only the round trip. Two properties worth restating here because they are easy to break:
+ *
+ * - The tenant's E1 revenue policy decides what counts, so uploaded revenue and connector revenue
+ *   go through one filter. A gateway outage falls back to the default policy rather than blanking
+ *   the figure, same as queryAttribution.
+ * - The grouping key is the `AccountIdHash` already on the row. Revenue is never re-keyed from a
+ *   user here: E2's AccountLinker owns the one user, one account rule and lands ambiguous revenue
+ *   unattributed with an AccountConflict finding, and the unattributed bucket is reported rather
+ *   than dropped.
+ *
+ * Returns null on any ClickHouse error, so a caller falls back rather than rendering a zero.
+ */
+export async function queryAccountRevenue(): Promise<AccountRevenueReport | null> {
+  return tryLive(async (db, tenant) => {
+    const policy = await queryRevenuePolicy();
+    const { sql, params } = accountRevenueSql(policy);
+    const rows = await rowsP<AccountRevenueSqlRow>(db, sql, { tenant, ...params });
+    return accountRevenueReport(rows);
   });
 }
 


### PR DESCRIPTION
Plan item **E3**. Sums `business_events.ValueAmountMicro` grouped by `AccountIdHash` over the same window cost uses, netting refunds off, and reports **null rather than 0** for an account whose revenue we have not been told.

## Stacked PR

Base is `feat/revenue-account-identity`, the head of **#177** (CTO-195, E2), which is itself stacked on `feat/account-revenue-base` carrying **#171** (CTO-194, E1) and **#170** (CTO-180, B1). Review after those; merge after those.

> Note for the author: the ticket said to base on `worktree-agent-af795485071d86b64`. That ref is commit `7ff56aa` ("docs: scope seven features…"), an **ancestor** of the chain, not #177: it has no `revenueSources.ts`, no `account_identity.py`, no `AccountIdHash`. Based on `feat/revenue-account-identity` instead, which is what #177 actually is.

## What it does

`web/lib/accountRevenue.ts` holds the SQL builder and the pure mapping; `queryAccountRevenue` in `web/lib/clickhouse.ts` is the round trip. The split exists so the null-vs-zero rule is testable without infra.

- **One policy for all revenue.** Uses E1's `RevenuePolicy` (`ValueType` as the discriminator, plus the optional per-tenant source narrowing), so uploaded revenue and connector revenue flow through the same filter. No hardcoded source, no `EventName`. A test asserts the SQL contains neither.
- **Same window as cost.** `b.OccurredAt >= toDate(now()) - INTERVAL 29 DAY`, the calendar-aligned expression the cost queries use, so a margin subtracts two figures measured over the same days.
- **Refunds net off**, and are allowed to go negative rather than clamping. A churned customer who refunded last month's invoice is a real finding for the profitability ranking.
- **Amounts stay in micro-USD end to end.** No divide by 1e6 and re-multiply, so no account total picks up a float rounding error.

## Null, not zero

`0` reads as "this customer generates no revenue", which is a claim. `null` reads as "we do not know", which is the truth when nothing is wired up. The margin column renders an honest blank off that distinction.

The decision is made on a `countIf` of money-typed events, **not** on the sum being 0, because an account whose only events are `count` engagement signals also sums to 0. Both outcomes stay reachable and distinct: a charge netted fully down by a refund stays `0`, because that is a measurement rather than an absence.

There is deliberately no `HAVING revenue_events > 0`: filtering those groups out would collapse "engagement data but no revenue wiring" into "never heard of this account", and only one of those is a connector the tenant can go and configure.

## The NULL trap

Every `sumIf` zero-fills with `ifNull(..., 0)`, same as E1's fix. Not theoretical, reproduced on `local-dev` (which has zero refunds, the exact trigger):

```
account_id_hash                     net_no_zerofill   net_zerofilled
cf0f8e14…f441b5765                  \N                20000000000
c861664f…410a41a1                   \N                 4200500000
'' (unattributed)                   \N              1619776003759
```

Without the zero-fill the refund term is NULL, NULL minus anything is NULL, and every account's revenue vanishes. A test asserts every `sumIf` argument is wrapped.

## One user, one account

The grouping key is the `AccountIdHash` already on the row at ingest. Revenue is **never** re-keyed off a user in SQL. E2's `AccountLinker` (`sdk/python/src/tally/account_identity.py`) owns that rule: a user seen against two accounts is marked permanently ambiguous, the event lands with an empty `AccountIdHash`, and an `AccountConflict` finding goes to the data-quality surface (the "Account stitching" card from CTO-184 / #176). Re-deriving the mapping here would either duplicate that revenue across accounts or silently disagree with the finding an operator is reading.

Ambiguous and untagged revenue lands in the `unattributed` bucket, which the report keeps separate and **reports rather than drops**, so a tenant ranking accounts can see how much of the total the ranking leaves out. Tests assert the SQL contains no `JOIN` and no `otel_spans`.

## Live verification

Against the running local ClickHouse. `queryAccountRevenue()` on tenant `local-dev`:

```json
{
  "accounts": [
    { "accountIdHash": "cf0f8e14…f441b5765", "revenueMicroUsd": 20000000000,
      "grossMicroUsd": 20000000000, "refundMicroUsd": 0, "revenueEvents": 1, "distinctUsers": 1 },
    { "accountIdHash": "c861664f…410a41a1", "revenueMicroUsd": 4200500000,
      "grossMicroUsd": 4200500000, "refundMicroUsd": 0, "revenueEvents": 1, "distinctUsers": 1 }
  ],
  "unattributed": {
    "accountIdHash": "", "revenueMicroUsd": 1619776003759,
    "grossMicroUsd": 1619776003759, "refundMicroUsd": 0,
    "revenueEvents": 13512, "distinctUsers": 13512
  },
  "windowDays": 30
}
```

$20,000.00 and $4,200.50 across two accounts, both from `Source='csv_upload'`. The honest headline is the rest: **$1,619,776.00 across 13,512 events is unattributed**, because the demo data predates E2 and carries no account id. That is 99.99% of in-window revenue, and the page must say so rather than rank two accounts as if they were the picture.

`local-dev` has zero refunds and zero account-tagged `count` events, so it cannot exercise the netting or the null-vs-zero rule end to end. Seeded a scratch tenant `cto196-verify` with six rows covering all four cases, ran the real `queryAccountRevenue()` against it, then deleted the tenant (`SELECT TenantId, count() FROM business_events GROUP BY TenantId` is back to `local-dev 96569`):

| account | events | gross µ$ | refund µ$ | `revenueMicroUsd` | meaning |
|---|---|---|---|---|---|
| `aaaa…` | monetary + refund | 1,000,000 | 250,000 | `750000` | refunds net off |
| `cccc…` | monetary + refund | 500,000 | 500,000 | **`0`** | measured zero |
| `bbbb…` | `count` only | 0 | 0 | **`null`** | unknown, not zero |
| `''` | monetary | 300,000 | 0 | `300000` | unattributed bucket |

`bbbb…` and `cccc…` both sum to 0 and only one of them reports 0. That is the acceptance criterion, confirmed against real ClickHouse rather than only in a unit test.

## Checks

From `web/`:

- `npm run typecheck` clean.
- `npm run lint` clean (3 pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`, none in touched files).
- `npm run test`: **246 passed, 2 failed**. Both failures are the documented pre-existing `app/api/api.test.ts` ones that appear when ClickHouse runs locally. **No new failures.** 18 new tests in `lib/accountRevenue.test.ts`.

Gateway untouched, so no `pytest` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
