### PR TITLE
feat(revenue): documented generic revenue API, idempotent on a caller id (CTO-199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ stripe listen --forward-to http://localhost:8080/v1/stripe/webhook?tenant=local-
 
 Once events start landing, `/attribution` adds two columns: **Value/user** and **Margin/user** (with margin %). Cells stay `—` until enough events arrive. We never fabricate numbers from absent data.
 
+### Not on Stripe?
+
+`POST /v1/revenue/events` takes `{event_id, account_id, amount, currency, occurred_at, event_name}`
+from any biller: Chargebee, Recurly, Zuora, or a home-grown one. It is idempotent on your own
+`event_id`, so a retry cannot double-count, and it writes the same `business_events` rows the
+connectors do. See [`docs/revenue-api.md`](docs/revenue-api.md).
+
 ## Per-tenant control plane
 
 Stored in Postgres (`db/postgres/*.sql`, migrations `0001`–`0012`), accessed only through the gateway (the web app never talks to Postgres directly):

--- a/docs/revenue-api.md
+++ b/docs/revenue-api.md
@@ -1,0 +1,182 @@
+# Generic revenue API (CTO-199)
+
+`POST /v1/revenue/events` accepts one revenue event from any billing system. It exists for tenants
+whose biller we have no connector for: Chargebee, Recurly, Zuora, or something home-grown. It is the
+automatable alternative to a CSV upload, and everything it writes is an ordinary `business_events`
+row, so revenue that arrives this way is indistinguishable downstream from revenue that arrives
+through the Stripe or HubSpot connectors.
+
+- Endpoint: `infra/gateway/src/gateway/app.py` (`ingest_revenue_event`)
+- Payload contract and validation: `tally.cdp_connectors.GenericRevenueConnector`
+- Hashing and the wire mapping: `infra/gateway/src/gateway/revenue_api.py`
+
+Not in scope, deliberately: a data-warehouse connector (Snowflake, BigQuery) that queries revenue
+where it is already modelled. That is the higher-fidelity answer for a large company and it is its
+own project.
+
+## Request
+
+```
+POST /v1/revenue/events
+Authorization: Bearer <tenant api key>     # or X-Tenant-Id when auth is disabled (local dev)
+Content-Type: application/json
+```
+
+| Field         | Required | Type   | Notes                                                                           |
+| ------------- | -------- | ------ | ------------------------------------------------------------------------------- |
+| `event_id`    | yes      | string | Your stable id for this event. The idempotency key. Max 200 chars.              |
+| `account_id`  | yes      | string | Your paying customer. Hashed on ingest, never stored raw. Max 512 chars.        |
+| `amount`      | yes\*    | string or number | Major units of `currency`, non-negative. A string avoids float rounding. |
+| `currency`    | no       | string | 3-letter ISO-4217. Defaults to `USD`. Recorded, never converted.                |
+| `occurred_at` | yes      | string | ISO-8601. When the money moved, not when you posted it. Naive is read as UTC.   |
+| `event_name`  | yes      | string | Your label, e.g. `invoice_paid`, `subscription_renewed`. Max 128 chars.         |
+| `value_type`  | no       | string | `monetary` (default), `mrr`, `refund`, or `count`.                              |
+| `user_id`     | no       | string | The individual end user, when you have one. Hashed like `account_id`.           |
+| `properties`  | no       | object | Free-form. Kept out of storage; see "What is not stored" below.                 |
+
+\* Required except when `value_type` is `count`, which must not carry an amount.
+
+`occurred_at` is the event's own timestamp and is what every window is computed against. Posting a
+July invoice in August puts the revenue in July, which is what makes late arrivals and reconciliation
+work.
+
+### value_type
+
+Mirrors the `business_events.ValueType` enum, which is what the attribution reader discriminates
+revenue on (CTO-194):
+
+- `monetary` for one-off money, `mrr` for a recurring amount. If your biller emits both for the same
+  subscription, set `include_mrr: false` on `POST /v1/tenant/revenue-sources/config` so they are not
+  counted twice.
+- `refund` nets off. Send it as a **positive** amount with `value_type: "refund"`. A negative
+  `amount` is rejected rather than guessed at.
+- `count` is an engagement signal with no money. Its `ValueAmountMicro` is stored NULL, never 0: an
+  event that says nothing about revenue must not read back as a customer who generated none.
+
+## Idempotency
+
+**A retry never double-counts.** `event_id` becomes `business_events.BusinessEventId`, and the table
+is a `ReplacingMergeTree` sorted by `(TenantId, BusinessEventId)`. Two guards sit in front of it:
+
+1. an in-process deduplicator shared with the connector webhooks, and
+2. a ClickHouse lookup on that key, which is what still holds after a gateway restart or across
+   replicas. The attribution revenue sum reads `business_events` without `FINAL`, so waiting for the
+   engine's own merge to collapse a duplicate would leave a window where the money is counted twice.
+
+Retrying a stored `event_id` returns `200` with `"deduplicated": true` instead of `201`. The body of
+the retry is ignored: the id decides, so re-posting the same id with a different amount does not
+change the stored row. To correct an amount, post a `refund` for the difference under a new
+`event_id`.
+
+`event_id` is required and the endpoint will not mint one. An auto-generated id would turn every
+network-timeout retry into a second payment.
+
+A write that fails returns `503` and leaves the `event_id` retryable. Losing revenue to a swallowed
+retry is the same size of bug as double counting it.
+
+## Response
+
+`201` on a stored event:
+
+```json
+{
+  "ok": true,
+  "deduplicated": false,
+  "stored": true,
+  "event_id": "cb_inv_2026_08_0042",
+  "event_name": "invoice_paid",
+  "account_id_hash": "eb9ecb6d055e7213...",
+  "value_amount_micro": 1499000000,
+  "currency": "USD",
+  "value_type": "monetary",
+  "source": "revenue-api",
+  "counted_as_revenue": true
+}
+```
+
+`counted_as_revenue` answers whether the tenant's own revenue source configuration (CTO-194) will
+count this event on `/attribution`. A tenant who has narrowed `revenue_sources` to `["stripe"]` and
+then posts here would otherwise watch their revenue land in ClickHouse and never appear on the
+dashboard, with nothing anywhere saying why. Fix it by adding `revenue-api` to the list:
+
+```bash
+curl -X POST http://localhost:8080/v1/tenant/revenue-sources/config \
+  -H 'X-Tenant-Id: local-dev' -H 'Content-Type: application/json' \
+  -d '{"revenue_sources": ["stripe", "revenue-api"], "change_id": "'"$(uuidgen)"'"}'
+```
+
+`counted_as_revenue` is `null`, not `false`, when the configuration could not be read. An unknown
+answer is reported as unknown; the event is still stored either way, because the configuration
+decides what is *counted*, not what is *accepted*.
+
+`422` names the field at fault (`{"detail": "event_id is required and must be a non-empty string"}`).
+`503` means storage was unavailable: retry, it is safe.
+
+## Worked example
+
+Verified against the local stack (`docker compose -f infra/docker-compose.yml up -d`):
+
+```bash
+curl -X POST http://localhost:8080/v1/revenue/events \
+  -H 'Content-Type: application/json' \
+  -H 'X-Tenant-Id: local-dev' \
+  -d '{
+        "event_id": "cb_inv_2026_08_0042",
+        "account_id": "acct_northwind",
+        "amount": "1499.00",
+        "currency": "USD",
+        "occurred_at": "2026-08-25T12:00:00Z",
+        "event_name": "invoice_paid"
+      }'
+```
+
+```
+HTTP 201
+{"ok":true,"deduplicated":false,"stored":true,"event_id":"cb_inv_2026_08_0042",
+ "event_name":"invoice_paid","account_id_hash":"eb9ecb6d055e72136a09468e7cabfa4b6ae966521c7da05868b72f3e4b3988af",
+ "value_amount_micro":1499000000,"currency":"USD","value_type":"monetary","source":"revenue-api",
+ "counted_as_revenue":true}
+```
+
+Run the identical command again, and again after `docker compose restart gateway`:
+
+```
+HTTP 200  {"ok":true,"deduplicated":true,"event_id":"cb_inv_2026_08_0042","stored":false}
+HTTP 200  {"ok":true,"deduplicated":true,"event_id":"cb_inv_2026_08_0042","stored":true}
+```
+
+```sql
+SELECT count(), sum(ValueAmountMicro)
+FROM business_events
+WHERE TenantId = 'local-dev' AND BusinessEventId = 'cb_inv_2026_08_0042';
+-- 1   1499000000
+```
+
+In production, replace `-H 'X-Tenant-Id: local-dev'` with `-H "Authorization: Bearer $TALLY_API_KEY"`.
+
+## Identity and the account dimension
+
+`account_id` is HMAC-SHA256'd under the tenant's own key (`tally.hmac_keys`) and stored in
+`business_events.AccountIdHash`, the account dimension the cost-per-customer tab is built on
+(CTO-180). The raw id never reaches ClickHouse and an account hash cannot be reversed or correlated
+across tenants.
+
+When `user_id` is omitted, the account id also fills `UserIdHash`. That mirrors the Stripe connector,
+which puts the Stripe *customer* id there, a customer being the account in B2B SaaS, and it is what
+makes revenue posted here join in the attribution query exactly like connector-sourced revenue rather
+than behaving as a special case. Both columns are filled from the same deterministic hash, so they
+agree.
+
+### What is not stored
+
+`RawPayload` is left empty. The payload's distinguishing content is the raw `account_id`, which is
+the one thing hashing exists to keep out of the telemetry store, and `properties` is not persisted
+for the same reason.
+
+## Related
+
+- `docs/cost-per-customer-plan.md` (workstream E) for where this sits.
+- `POST /v1/tenant/revenue-sources/config` (CTO-194) for the revenue policy.
+- This source does not yet appear as a card on `/connectors`: the `tenant_integration_runs` connector
+  column has a CHECK constraint listing the five webhook integrations, so adding it needs a migration
+  and belongs with that change.

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -108,6 +108,7 @@ from gateway.tenant_revenue_sources import (
     RevenueSourceConfigInput,
     TenantRevenueSourceStore,
 )
+from gateway.revenue_api import revenue_policy_note, to_wire_event
 from gateway.tenant_stripe import TenantStripeStore
 from gateway.tenant_unit_economics import (
     TenantUnitEconomicsStore,
@@ -116,6 +117,7 @@ from gateway.tenant_unit_economics import (
 )
 from gateway.validation import SpanValidator, span_item_id
 
+from tally.cdp_connectors import RevenuePayloadError, WebhookIngestor
 from tally.hmac_keys import HmacKeyRegistry
 
 logger = logging.getLogger("tally.gateway")
@@ -188,6 +190,11 @@ async def lifespan(app: FastAPI):
     # revenue on /attribution. A tenant with no row counts every source and discriminates on
     # ValueType, which is what replaced the old hardcoded Source='stripe' filter.
     app.state.tenant_revenue_sources = TenantRevenueSourceStore(settings)
+    # Generic revenue API (CTO-199): the SDK's WebhookIngestor, shared between the connector
+    # webhooks and POST /v1/revenue/events so one deduplicator covers both. This is only the fast
+    # in-process guard; the durable idempotency is the ClickHouse probe in the endpoint, which is
+    # what still holds after a restart or across replicas.
+    app.state.revenue_ingestor = WebhookIngestor()
     # Replay infra (CTO-113): per-tenant opt-in sampling + cross-provider projection.
     # The blob store is in-memory by default — swappable for MinIO/S3 via app.state override in
     # a deployment shim. Replay runs accumulate in-memory until ClickHouse writeback lands
@@ -1384,6 +1391,109 @@ async def upsert_tenant_revenue_source_config(
     except RevenueSourceConfigError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     return JSONResponse({"tenant_id": tenant_id, "config": config.as_dict()}, status_code=200)
+
+
+# --------------------------------------------------------------------------------------------
+# Generic revenue API (CTO-199).
+# --------------------------------------------------------------------------------------------
+
+
+@app.post("/v1/revenue/events")
+async def ingest_revenue_event(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Post one revenue event for a biller we have no connector for (CTO-199).
+
+    Body: ``{event_id, account_id, amount, currency, occurred_at, event_name}`` plus optional
+    ``value_type`` (``monetary`` default, or ``mrr`` / ``refund`` / ``count``), ``user_id`` and
+    ``properties``. Documented with a worked example in ``docs/revenue-api.md``.
+
+    Idempotent on the caller-supplied ``event_id``, structurally rather than by convention. That id
+    becomes ``business_events.BusinessEventId``, the table's own sort key, and a retry is refused
+    twice over: an in-process deduplicator shared with the connector webhooks, and a ClickHouse
+    probe on that key which is what still holds after a gateway restart. The endpoint will not mint
+    an id for a caller who omits one, because an auto-generated id turns every retry into a second
+    payment.
+
+    Nothing here bypasses the revenue policy. The row is an ordinary ``business_events`` row, and
+    the response reports whether the tenant's own configured revenue sources (CTO-194) will count
+    it, so a narrowed policy shows up on the first request rather than as a blank dashboard later.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+
+    ingestor: WebhookIngestor = app.state.revenue_ingestor
+    try:
+        result = ingestor.ingest_revenue_api(tenant_id, body)
+    except RevenuePayloadError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    event_id = str(body.get("event_id")).strip() if isinstance(body, dict) else ""
+    if not result.accepted:
+        # Seen in this process already: the cheap half of the idempotency guard.
+        return JSONResponse(
+            {"ok": True, "deduplicated": True, "event_id": event_id, "stored": False},
+            status_code=200,
+        )
+
+    event = result.accepted[0]
+    registry: HmacKeyRegistry = app.state.hmac_registry
+    wire_event = to_wire_event(registry, tenant_id, event)
+    store: ClickHouseStore = app.state.store
+
+    try:
+        already_stored = store.business_event_exists(tenant_id, wire_event.business_event_id)
+    except Exception:  # noqa: BLE001
+        # Un-mark before failing: leaving the id marked would make the caller's retry look like a
+        # duplicate and lose the revenue outright, which is the same bug as double counting.
+        ingestor.forget(tenant_id, wire_event.business_event_id)
+        logger.exception("clickhouse idempotency probe failed for tenant %s", tenant_id)
+        raise HTTPException(status_code=503, detail="storage unavailable") from None
+
+    if already_stored:
+        return JSONResponse(
+            {"ok": True, "deduplicated": True, "event_id": event_id, "stored": True},
+            status_code=200,
+        )
+
+    try:
+        store.insert_business_events(tenant_id, [wire_event])
+    except Exception:  # noqa: BLE001
+        ingestor.forget(tenant_id, wire_event.business_event_id)
+        logger.exception("clickhouse insert (revenue api) failed for tenant %s", tenant_id)
+        raise HTTPException(status_code=503, detail="storage unavailable") from None
+
+    counted = revenue_policy_note(
+        app.state.tenant_revenue_sources, tenant_id, wire_event.source, wire_event.value_type
+    )
+
+    # Deliberately no tenant_integration_runs stamp (CTO-117). That table's connector column has a
+    # CHECK constraint listing the five webhook integrations, so adding this source means a
+    # migration; the /connectors card for it belongs with that migration, not wedged in here.
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "deduplicated": False,
+            "stored": True,
+            "event_id": wire_event.business_event_id,
+            "event_name": wire_event.event_name,
+            "account_id_hash": wire_event.account_id_hash,
+            "value_amount_micro": wire_event.value_amount_micro,
+            "currency": wire_event.value_currency,
+            "value_type": wire_event.value_type,
+            "source": wire_event.source,
+            # null, not false, when the tenant's revenue policy could not be read. An unknown
+            # answer is reported as unknown.
+            "counted_as_revenue": counted,
+        },
+        status_code=201,
+    )
 
 
 def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, Any]:

--- a/infra/gateway/src/gateway/revenue_api.py
+++ b/infra/gateway/src/gateway/revenue_api.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generic revenue API: the storage-side half of CTO-199 (E6).
+
+``POST /v1/revenue/events`` is the documented, automatable alternative to a CSV upload for tenants
+billing through Chargebee, Recurly, Zuora or something home-grown. The payload shape and its
+validation live in :class:`tally.cdp_connectors.GenericRevenueConnector`, because normalization is
+the SDK's job and this endpoint is deliberately not a second revenue pipeline. What lives here is
+everything that only makes sense next to storage: hashing the identifiers, mapping onto the
+``business_events`` wire row, and answering whether the tenant's own revenue policy will count what
+they just posted.
+
+Three things this module is careful about.
+
+**Hashing goes through the per-tenant HMAC path.** ``account_id`` never reaches ClickHouse in the
+clear; it is HMAC-SHA256'd under the tenant's key (:mod:`tally.hmac_keys`) exactly like every other
+identifier, so an account hash cannot be reversed or correlated across tenants.
+
+**The account id doubles as the user identity when no ``user_id`` is given.** Today's attribution
+revenue query joins ``business_events.UserIdHash`` to ``otel_spans.UserIdHash``, and the Stripe
+connector already puts the Stripe *customer* id there, a customer being the account in B2B SaaS.
+Mirroring that is what makes revenue posted here land in the margin numbers identically to
+connector-sourced revenue instead of behaving like a special case. Both columns are filled from the
+same deterministic HMAC, so they agree, and E2 (routing connector identity to ``AccountIdHash``)
+converges on the same value rather than fighting it.
+
+**The raw payload is not stored.** ``business_events.RawPayload`` stays empty: the payload's whole
+distinguishing content is the raw ``account_id``, which is the one thing hashing exists to keep out
+of the telemetry store.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tally.cdp_connectors import (
+    GENERIC_REVENUE_SOURCE,
+    BusinessEvent as NormalizedEvent,
+)
+from tally.hmac_keys import HmacKeyRegistry
+from tally.wire import BusinessEvent as WireBusinessEvent
+
+from gateway.tenant_revenue_sources import RevenueSourceConfig, TenantRevenueSourceStore
+
+logger = logging.getLogger("tally.gateway")
+
+#: ``ValueType`` values the attribution reader sums as positive revenue, mirroring
+#: ``POSITIVE_VALUE_TYPES`` in web/lib/revenueSources.ts.
+POSITIVE_VALUE_TYPES = ("monetary", "mrr")
+REFUND_VALUE_TYPE = "refund"
+
+
+def to_wire_event(
+    registry: HmacKeyRegistry, tenant_id: str, event: NormalizedEvent
+) -> WireBusinessEvent:
+    """Hash the identifiers and map a normalized event onto the ``business_events`` wire row.
+
+    ``account_id`` is required by the connector, so ``AccountIdHash`` is always populated here:
+    an event through this endpoint is never in the unattributed bucket. ``user_id`` is optional and
+    falls back to the account id (see the module docstring).
+    """
+    registry.provision(tenant_id)
+    account_hash = registry.hash(tenant_id, event.account_id or "").value
+    user_source = event.user_id or event.account_id or ""
+    user_hash = registry.hash(tenant_id, user_source).value if user_source else ""
+
+    # A 'count' event carries no money. NULL, not 0: a zero would be a claim that this customer
+    # generated no revenue, which is not what an engagement signal says.
+    amount = event.value_micro_usd if event.value_type != "count" else None
+
+    return WireBusinessEvent(
+        business_event_id=event.business_event_id,
+        event_name=event.event_name,
+        user_id_hash=user_hash,
+        occurred_at_ns=int(event.occurred_at.timestamp() * 1_000_000_000),
+        value_amount_micro=amount,
+        value_currency=event.currency,
+        value_type=event.value_type or "monetary",
+        # Lowercased to match the normalization web/lib/revenueSources.ts compares Source against.
+        source=GENERIC_REVENUE_SOURCE.lower(),
+        account_id_hash=account_hash,
+    )
+
+
+def counts_as_revenue(config: RevenueSourceConfig | None, source: str, value_type: str) -> bool:
+    """Would the tenant's revenue policy count this event on /attribution?
+
+    A pure mirror of ``revenueSourceFilter`` + ``positiveValueTypes`` in web/lib/revenueSources.ts,
+    evaluated for one event. This is the reason the endpoint is not a bypass: a tenant who has
+    narrowed ``revenue_sources`` to ``['stripe']`` and then posts here would otherwise watch their
+    revenue land in ClickHouse and never appear on the dashboard, with nothing anywhere saying why.
+    The answer is returned on the 200 so the integration surfaces it on the first request.
+
+    ``config is None`` means the tenant has no row, which is the default policy: every source
+    counts, monetary and mrr are revenue, refunds net off.
+    """
+    if value_type == REFUND_VALUE_TYPE:
+        counted_type = True
+    elif value_type == "mrr":
+        counted_type = config is None or config.include_mrr
+    else:
+        counted_type = value_type in POSITIVE_VALUE_TYPES
+    if not counted_type:
+        return False
+    if config is None or not config.revenue_sources:
+        return True
+    return source.lower() in tuple(s.lower() for s in config.revenue_sources)
+
+
+def revenue_policy_note(
+    store: TenantRevenueSourceStore, tenant_id: str, source: str, value_type: str
+) -> bool | None:
+    """``counts_as_revenue`` against the tenant's stored policy, or ``None`` if it can't be read.
+
+    Best-effort by design. The ingest must not fail because the control-plane database blinked, and
+    an unknown answer is reported as unknown rather than as a confident ``true``, the same
+    honest-under-uncertainty rule the dashboard renders blanks under.
+    """
+    try:
+        config = store.get_for_caller(tenant_id)
+    except Exception:  # noqa: BLE001 (a policy read must never fail an accepted revenue event)
+        logger.warning("revenue policy lookup failed for tenant %s", tenant_id, exc_info=True)
+        return None
+    return counts_as_revenue(config, source, value_type)

--- a/infra/gateway/src/gateway/store.py
+++ b/infra/gateway/src/gateway/store.py
@@ -13,8 +13,8 @@ from gateway.config import Settings
 from gateway.mapping import COLUMNS
 
 _BUSINESS_EVENT_COLS = (
-    "TenantId", "BusinessEventId", "EventName", "UserIdHash", "OccurredAt", "IngestedAt",
-    "ValueAmountMicro", "ValueCurrency", "ValueType", "Source", "RawPayload",
+    "TenantId", "BusinessEventId", "EventName", "UserIdHash", "AccountIdHash", "OccurredAt",
+    "IngestedAt", "ValueAmountMicro", "ValueCurrency", "ValueType", "Source", "RawPayload",
 )
 
 _IDENTITY_COLS = (
@@ -67,6 +67,24 @@ class ClickHouseStore:
         )
         return result.result_rows[0][0] > 0
 
+    def business_event_exists(self, tenant_id: str, business_event_id: str) -> bool:
+        """Return True if this tenant already has a business event with this id.
+
+        The durable half of the generic revenue API's idempotency (CTO-199). ``business_events`` is
+        a ``ReplacingMergeTree`` ordered by ``(TenantId, BusinessEventId)``, so a re-posted event
+        collapses onto the original *eventually*, but the attribution revenue sum reads the table
+        without ``FINAL``, so between the second insert and the next merge the money would be
+        counted twice. Probing first is what makes a retry safe now rather than at merge time.
+
+        Cheap: the id is the table's own sort key, so this is a primary-index lookup.
+        """
+        result = self.client.query(
+            "SELECT count() FROM business_events "
+            "WHERE TenantId = %(t)s AND BusinessEventId = %(b)s",
+            parameters={"t": tenant_id, "b": business_event_id},
+        )
+        return result.result_rows[0][0] > 0
+
     def insert_business_events(self, tenant_id: str, events: list[BusinessEvent]) -> int:
         if not events:
             return 0
@@ -77,6 +95,7 @@ class ClickHouseStore:
                 e.business_event_id,
                 e.event_name,
                 e.user_id_hash[:64],
+                e.account_id_hash[:64],
                 _ts(e.occurred_at_ns),
                 now,
                 e.value_amount_micro,

--- a/infra/gateway/src/gateway/tenant_revenue_sources.py
+++ b/infra/gateway/src/gateway/tenant_revenue_sources.py
@@ -28,6 +28,7 @@ import psycopg
 from psycopg.types.json import Json
 
 from gateway.config import Settings
+from gateway.connectors.config_admin import _resolve_tenant_uuid
 
 
 class RevenueSourceConfigError(ValueError):
@@ -140,6 +141,19 @@ class TenantRevenueSourceStore:
     def get(self, tenant_id: str) -> RevenueSourceConfig | None:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
             cur.execute(_SELECT, (tenant_id,))
+            row = cur.fetchone()
+            return _row_to_config(row) if row else None
+
+    def get_for_caller(self, tenant_id: str) -> RevenueSourceConfig | None:
+        """:meth:`get`, but accepting a tenant NAME as well as a ``tenants.id`` UUID.
+
+        ``tenant_revenue_source_config.tenant_id`` is a UUID, while ingest callers and the local
+        dev setup identify a tenant by name (``local-dev``). Handing a name straight to a UUID
+        column trips ``InvalidTextRepresentation`` deep in the driver and surfaces as an opaque
+        503, so the name is resolved on the same cursor first (CTO-199).
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(_SELECT, (_resolve_tenant_uuid(cur, tenant_id),))
             row = cur.fetchone()
             return _row_to_config(row) if row else None
 

--- a/infra/gateway/tests/test_app_revenue_api.py
+++ b/infra/gateway/tests/test_app_revenue_api.py
@@ -1,0 +1,315 @@
+"""App-level tests for POST /v1/revenue/events (CTO-199).
+
+Verification path: fake the ClickHouse store so we can assert exactly what got inserted and can
+make the durable idempotency probe answer the way a restarted gateway would, and fake the revenue
+source config store so the policy answer on the response is exercised without Postgres.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.revenue_api import counts_as_revenue
+from gateway.tenant_revenue_sources import RevenueSourceConfig
+from tally.cdp_connectors import WebhookIngestor
+from tally.wire import BusinessEvent
+
+TENANT = "t-acme"
+
+
+def _payload(**overrides) -> dict:
+    body = {
+        "event_id": "inv_2026_08_0001",
+        "account_id": "acct_northwind",
+        "amount": "1499.00",
+        "currency": "USD",
+        "occurred_at": "2026-08-25T12:00:00Z",
+        "event_name": "invoice_paid",
+    }
+    body.update(overrides)
+    return {k: v for k, v in body.items() if v is not _OMIT}
+
+
+_OMIT = object()
+
+
+class FakeCHStore:
+    """Records inserts; ``existing`` seeds ids a previous gateway process already wrote.
+
+    Keyed on ``(tenant, id)`` because the real probe is tenant-scoped: two tenants may legitimately
+    use the same invoice number.
+    """
+
+    def __init__(self, existing: set[str] | None = None, tenant: str = TENANT) -> None:
+        self.events: list[BusinessEvent] = []
+        self.existing: set[tuple[str, str]] = {(tenant, e) for e in (existing or ())}
+        self.probe_calls = 0
+        self.fail_probe = False
+        self.fail_insert = False
+
+    def business_event_exists(self, tenant_id: str, business_event_id: str) -> bool:
+        self.probe_calls += 1
+        if self.fail_probe:
+            raise RuntimeError("clickhouse down")
+        return (tenant_id, business_event_id) in self.existing
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        if self.fail_insert:
+            raise RuntimeError("clickhouse down")
+        self.events.extend(events)
+        self.existing.update((tenant_id, e.business_event_id) for e in events)
+        return len(events)
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+class FakeRevenueSourceStore:
+    def __init__(self, config: RevenueSourceConfig | None = None, raises: bool = False) -> None:
+        self._config = config
+        self._raises = raises
+
+    def get_for_caller(self, tenant_id: str) -> RevenueSourceConfig | None:
+        if self._raises:
+            raise RuntimeError("postgres down")
+        return self._config
+
+
+def _config(sources, include_mrr: bool = True) -> RevenueSourceConfig:
+    return RevenueSourceConfig(
+        revenue_sources=sources,
+        include_mrr=include_mrr,
+        created_at=None,
+        updated_at=None,
+        updated_by=None,
+    )
+
+
+@contextmanager
+def _client(
+    store: FakeCHStore | None = None,
+    revenue_sources: FakeRevenueSourceStore | None = None,
+) -> Iterator[tuple[TestClient, FakeCHStore]]:
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = False
+        ch = store or FakeCHStore()
+        app.state.store = ch
+        app.state.tenant_revenue_sources = revenue_sources or FakeRevenueSourceStore()
+        # Fresh deduplicator per test: the in-process guard is process-lifetime state.
+        app.state.revenue_ingestor = WebhookIngestor()
+        yield client, ch
+
+
+def _post(client: TestClient, body: dict, tenant: str = TENANT):
+    return client.post("/v1/revenue/events", json=body, headers={"X-Tenant-Id": tenant})
+
+
+# ----------------------------------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------------------------------
+def test_accepts_a_revenue_event_and_writes_one_business_event():
+    with _client() as (client, ch):
+        res = _post(client, _payload())
+        assert res.status_code == 201
+        body = res.json()
+        assert body["deduplicated"] is False
+        assert body["value_amount_micro"] == 1_499_000_000
+        assert body["value_type"] == "monetary"
+        assert body["source"] == "revenue-api"
+        assert body["counted_as_revenue"] is True
+
+        assert len(ch.events) == 1
+        ev = ch.events[0]
+        assert ev.business_event_id == "inv_2026_08_0001"
+        assert ev.value_currency == "USD"
+        # The account id is hashed, never stored raw, and lands in the account dimension.
+        assert len(ev.account_id_hash) == 64
+        assert "acct_northwind" not in ev.account_id_hash
+        assert body["account_id_hash"] == ev.account_id_hash
+
+
+def test_account_id_doubles_as_the_user_identity_when_no_user_id_is_given():
+    # Parity with the Stripe connector, which hashes the customer id into UserIdHash. It is what
+    # makes this revenue join in the attribution query like connector-sourced revenue.
+    with _client() as (client, ch):
+        _post(client, _payload())
+        ev = ch.events[0]
+        assert ev.user_id_hash == ev.account_id_hash
+
+
+def test_an_explicit_user_id_is_hashed_separately_from_the_account():
+    with _client() as (client, ch):
+        _post(client, _payload(user_id="u_dana"))
+        ev = ch.events[0]
+        assert len(ev.user_id_hash) == 64
+        assert ev.user_id_hash != ev.account_id_hash
+
+
+def test_count_event_stores_a_null_amount_never_zero():
+    with _client() as (client, ch):
+        res = _post(
+            client,
+            _payload(value_type="count", amount=_OMIT, event_name="seat_activated"),
+        )
+        assert res.status_code == 201
+        assert ch.events[0].value_amount_micro is None
+        assert res.json()["counted_as_revenue"] is False
+
+
+def test_currency_is_recorded_not_converted():
+    with _client() as (client, ch):
+        res = _post(client, _payload(currency="eur", amount="100.00"))
+        assert res.status_code == 201
+        assert ch.events[0].value_currency == "EUR"
+        assert ch.events[0].value_amount_micro == 100_000_000
+
+
+# ----------------------------------------------------------------------------------------------
+# Idempotency: the requirement most likely to be got wrong
+# ----------------------------------------------------------------------------------------------
+def test_retry_with_the_same_event_id_does_not_double_count():
+    with _client() as (client, ch):
+        first = _post(client, _payload())
+        second = _post(client, _payload())
+        assert first.status_code == 201
+        assert second.status_code == 200
+        assert second.json()["deduplicated"] is True
+        assert len(ch.events) == 1
+
+
+def test_retry_after_a_restart_is_still_deduped_by_the_clickhouse_probe():
+    # A fresh process has an empty in-process set, so the durable probe is the only thing left.
+    ch = FakeCHStore(existing={"inv_2026_08_0001"})
+    with _client(store=ch) as (client, store):
+        res = _post(client, _payload())
+        assert res.status_code == 200
+        assert res.json() == {
+            "ok": True,
+            "deduplicated": True,
+            "event_id": "inv_2026_08_0001",
+            "stored": True,
+        }
+        assert store.events == []
+
+
+def test_a_changed_amount_under_a_reused_event_id_does_not_add_revenue():
+    with _client() as (client, ch):
+        _post(client, _payload())
+        res = _post(client, _payload(amount="99999.00"))
+        assert res.status_code == 200
+        assert len(ch.events) == 1
+        assert ch.events[0].value_amount_micro == 1_499_000_000
+
+
+def test_idempotency_is_tenant_scoped():
+    with _client() as (client, ch):
+        assert _post(client, _payload(), tenant="t-one").status_code == 201
+        assert _post(client, _payload(), tenant="t-two").status_code == 201
+        assert len(ch.events) == 2
+
+
+def test_a_failed_write_leaves_the_event_id_retryable():
+    # The mirror-image bug of double counting: swallowing the retry and losing the revenue.
+    ch = FakeCHStore()
+    ch.fail_insert = True
+    with _client(store=ch) as (client, store):
+        assert _post(client, _payload()).status_code == 503
+        store.fail_insert = False
+        assert _post(client, _payload()).status_code == 201
+        assert len(store.events) == 1
+
+
+def test_a_failed_idempotency_probe_refuses_rather_than_risking_a_double_write():
+    ch = FakeCHStore()
+    ch.fail_probe = True
+    with _client(store=ch) as (client, store):
+        assert _post(client, _payload()).status_code == 503
+        assert store.events == []
+        store.fail_probe = False
+        assert _post(client, _payload()).status_code == 201
+
+
+# ----------------------------------------------------------------------------------------------
+# Validation: a documented endpoint has to say what is wrong
+# ----------------------------------------------------------------------------------------------
+def test_a_missing_event_id_is_rejected_rather_than_auto_generated():
+    with _client() as (client, ch):
+        res = _post(client, _payload(event_id=_OMIT))
+        assert res.status_code == 422
+        assert "event_id" in res.json()["detail"]
+        assert ch.events == []
+
+
+def test_bad_fields_name_the_field_at_fault():
+    with _client() as (client, _ch):
+        assert "occurred_at" in _post(client, _payload(occurred_at="soon")).json()["detail"]
+        assert "amount" in _post(client, _payload(amount="lots")).json()["detail"]
+        assert "currency" in _post(client, _payload(currency="dollars")).json()["detail"]
+
+
+def test_a_negative_amount_is_rejected_with_the_refund_route_named():
+    with _client() as (client, _ch):
+        res = _post(client, _payload(amount="-10.00"))
+        assert res.status_code == 422
+        assert "refund" in res.json()["detail"]
+
+
+def test_tenant_header_is_required_when_auth_is_off():
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = False
+        app.state.store = FakeCHStore()
+        app.state.revenue_ingestor = WebhookIngestor()
+        assert client.post("/v1/revenue/events", json=_payload()).status_code == 422
+
+
+# ----------------------------------------------------------------------------------------------
+# Revenue policy (CTO-194): this endpoint narrows under it, it does not bypass it
+# ----------------------------------------------------------------------------------------------
+def test_a_narrowed_policy_that_excludes_this_source_says_so_on_the_response():
+    store = FakeRevenueSourceStore(_config(("stripe",)))
+    with _client(revenue_sources=store) as (client, ch):
+        res = _post(client, _payload())
+        assert res.status_code == 201
+        # Still stored: the tenant's config decides what is *counted*, not what is accepted.
+        assert len(ch.events) == 1
+        assert res.json()["counted_as_revenue"] is False
+
+
+def test_a_policy_naming_this_source_counts_it():
+    store = FakeRevenueSourceStore(_config(("stripe", "revenue-api")))
+    with _client(revenue_sources=store) as (client, _ch):
+        assert _post(client, _payload()).json()["counted_as_revenue"] is True
+
+
+def test_an_unreadable_policy_reports_unknown_not_a_confident_yes():
+    store = FakeRevenueSourceStore(raises=True)
+    with _client(revenue_sources=store) as (client, ch):
+        res = _post(client, _payload())
+        assert res.status_code == 201
+        assert res.json()["counted_as_revenue"] is None
+        assert len(ch.events) == 1
+
+
+def test_counts_as_revenue_mirrors_the_reader_defaults():
+    assert counts_as_revenue(None, "revenue-api", "monetary") is True
+    assert counts_as_revenue(None, "revenue-api", "mrr") is True
+    assert counts_as_revenue(None, "revenue-api", "refund") is True
+    assert counts_as_revenue(None, "revenue-api", "count") is False
+    # include_mrr=False is the "our biller emits both for one subscription" case.
+    assert counts_as_revenue(_config(None, include_mrr=False), "revenue-api", "mrr") is False
+    assert counts_as_revenue(_config(None, include_mrr=False), "revenue-api", "monetary") is True
+    # Source comparison is case-insensitive, matching lower(Source) in the reader.
+    assert counts_as_revenue(_config(("Revenue-API",)), "revenue-api", "monetary") is True

--- a/sdk/python/src/tally/cdp_connectors.py
+++ b/sdk/python/src/tally/cdp_connectors.py
@@ -28,6 +28,10 @@ Correctness rules baked in
   :class:`ConnectorResult` (skipped), not an exception — a bad webhook must not
   take down the ingest path.
 
+Also here: :class:`GenericRevenueConnector` (CTO-199), the documented shape a tenant on a biller we
+have no connector for posts directly. It is a fifth entry in the same registry rather than a
+parallel pipeline, so revenue arriving that way dedupes and normalizes exactly like the rest.
+
 Scope: parsing/normalization + dedup only. Stitching (CTO-69) and the ROI UI
 (CTO-70) are out of scope. This module is self-contained apart from the
 identity event types it reuses from :mod:`tally.identity`.
@@ -47,6 +51,14 @@ from tally.schema import DEFAULT_CURRENCY, usd_to_micro
 #: micro-USD per cent — Stripe amounts arrive in the smallest currency unit.
 _MICRO_PER_CENT = 10_000
 
+#: ``business_events.ValueType``, the ClickHouse enum in db/clickhouse/attribution.sql, which is
+#: what the attribution reader discriminates revenue on (CTO-194). ``monetary`` and ``mrr`` carry
+#: money, ``refund`` nets off, ``count`` is an engagement signal with no amount.
+VALUE_TYPES = ("monetary", "count", "mrr", "refund")
+
+#: ``Source`` stamped on events arriving through the generic revenue API (CTO-199).
+GENERIC_REVENUE_SOURCE = "revenue-api"
+
 
 # --------------------------------------------------------------------------- #
 # Normalized value event
@@ -59,6 +71,13 @@ class BusinessEvent:
     micro-USD (0 for a non-revenue conversion). ``occurred_at`` is the event's
     own timestamp (UTC), never ingest time. ``business_event_id`` is the
     provider's stable id and the idempotency key.
+
+    ``account_id`` is the tenant's own paying customer (a subscription, a
+    contract), raw here and HMAC-hashed into ``business_events.AccountIdHash``
+    at the point of storage (CTO-180). ``value_type`` names the
+    ``business_events.ValueType`` enum member the event belongs to; ``None``
+    means this connector does not classify it, which is deliberately NOT the
+    same as claiming it is money.
     """
 
     business_event_id: str
@@ -71,6 +90,8 @@ class BusinessEvent:
     user_id: str | None = None
     anonymous_id: str | None = None
     properties: Mapping[str, object] = field(default_factory=dict)
+    account_id: str | None = None
+    value_type: str | None = None
 
     def __post_init__(self) -> None:
         if not self.business_event_id:
@@ -81,6 +102,8 @@ class BusinessEvent:
             raise ValueError("value_micro_usd must be an int")
         if self.value_micro_usd < 0:
             raise ValueError("value_micro_usd must be non-negative")
+        if self.value_type is not None and self.value_type not in VALUE_TYPES:
+            raise ValueError(f"value_type must be one of {VALUE_TYPES} or None")
 
     @property
     def is_revenue(self) -> bool:
@@ -98,6 +121,8 @@ class BusinessEvent:
             "user_id": self.user_id,
             "anonymous_id": self.anonymous_id,
             "properties": dict(self.properties),
+            "account_id": self.account_id,
+            "value_type": self.value_type,
         }
 
 
@@ -369,6 +394,144 @@ class HubSpotConnector:
 
 
 # --------------------------------------------------------------------------- #
+# Generic revenue API (CTO-199)
+# --------------------------------------------------------------------------- #
+class RevenuePayloadError(ValueError):
+    """A generic-revenue payload a caller must fix. Surfaces as HTTP 422."""
+
+
+#: Currencies are stored as submitted and never converted. See the note on
+#: :class:`GenericRevenueConnector`.
+_CURRENCY_LEN = 3
+
+
+def _require_str(payload: Mapping[str, object], key: str, *, max_len: int) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RevenuePayloadError(f"{key} is required and must be a non-empty string")
+    text = value.strip()
+    if len(text) > max_len:
+        raise RevenuePayloadError(f"{key} must be at most {max_len} characters")
+    return text
+
+
+class GenericRevenueConnector:
+    """The documented revenue contract for billers we have no connector for (CTO-199).
+
+    Chargebee, Recurly, Zuora and home-grown billing all know how to POST JSON, so the
+    alternative to a per-biller connector is one stable, documented shape:
+
+    ``{event_id, account_id, amount, currency, occurred_at, event_name}``
+
+    plus the optional ``value_type`` (defaults to ``monetary``), ``user_id`` and
+    ``properties``. Everything downstream sees an ordinary ``business_events`` row, so this is a
+    normalization front door and not a second revenue pipeline: the same ``ValueType``
+    discrimination and the same per-tenant source narrowing (CTO-194) decide whether it counts.
+
+    Two deliberate strictnesses, both because this is a public contract rather than a webhook we
+    receive on someone else's terms:
+
+    * **``event_id`` is required.** It is the caller's idempotency key and the row's
+      ``BusinessEventId``. Minting one here would make a retry a second payment.
+    * **Bad payloads raise.** :meth:`parse_strict` raises :class:`RevenuePayloadError` with the
+      field at fault so the caller gets a 422 they can act on. :meth:`parse` keeps the
+      never-raises :class:`CDPConnector` contract for the shared ingest path.
+
+    Currency is recorded, never converted: ``amount`` is in major units of ``currency`` and is
+    stored as micro-units of that same currency. We hold no FX rates, and inventing one would put
+    a fabricated number in the margin column.
+    """
+
+    source = GENERIC_REVENUE_SOURCE
+
+    def parse_strict(self, tenant_id: str, payload: Mapping[str, object]) -> BusinessEvent:
+        """Normalize one payload, raising :class:`RevenuePayloadError` on anything unusable."""
+        if not isinstance(payload, Mapping):
+            raise RevenuePayloadError("body must be a JSON object")
+        if not tenant_id:
+            raise RevenuePayloadError("tenant_id must be non-empty")
+
+        event_id = _require_str(payload, "event_id", max_len=200)
+        account_id = _require_str(payload, "account_id", max_len=512)
+        event_name = _require_str(payload, "event_name", max_len=128)
+
+        occurred_at = _parse_iso(payload.get("occurred_at"))
+        if occurred_at is None:
+            raise RevenuePayloadError(
+                "occurred_at is required and must be an ISO-8601 timestamp "
+                "(e.g. 2026-08-25T12:00:00Z); a naive timestamp is read as UTC"
+            )
+
+        value_type = payload.get("value_type", "monetary")
+        if not isinstance(value_type, str) or value_type not in VALUE_TYPES:
+            raise RevenuePayloadError(f"value_type must be one of {VALUE_TYPES}")
+
+        currency = payload.get("currency", DEFAULT_CURRENCY)
+        if not isinstance(currency, str) or len(currency.strip()) != _CURRENCY_LEN:
+            raise RevenuePayloadError("currency must be a 3-letter ISO-4217 code, e.g. USD")
+        currency = currency.strip().upper()
+
+        amount = payload.get("amount")
+        if value_type == "count":
+            # An engagement signal carries no money. Refusing an amount here is what stops a
+            # 'count' row from being summed as revenue by a reader that trusts ValueType.
+            if amount not in (None, 0):
+                raise RevenuePayloadError("a 'count' event must not carry an amount")
+            value_micro = 0
+        else:
+            value_micro = _strict_amount_micro(amount)
+
+        user_id = payload.get("user_id")
+        if user_id is not None and not isinstance(user_id, str):
+            raise RevenuePayloadError("user_id must be a string when provided")
+        properties = payload.get("properties", {})
+        if not isinstance(properties, Mapping):
+            raise RevenuePayloadError("properties must be a JSON object when provided")
+
+        return BusinessEvent(
+            business_event_id=event_id,
+            tenant_id=tenant_id,
+            source=self.source,
+            event_name=event_name,
+            occurred_at=occurred_at,
+            value_micro_usd=value_micro,
+            currency=currency,
+            user_id=(user_id.strip() or None) if isinstance(user_id, str) else None,
+            properties=dict(properties),
+            account_id=account_id,
+            value_type=value_type,
+        )
+
+    def parse(self, tenant_id: str, payload: Mapping[str, object]) -> ConnectorResult:
+        """:class:`CDPConnector` entry point: never raises, empty result on a bad payload."""
+        try:
+            return ConnectorResult(business_events=(self.parse_strict(tenant_id, payload),))
+        except (RevenuePayloadError, ValueError):
+            return ConnectorResult()
+
+
+def _strict_amount_micro(value: object) -> int:
+    """``amount`` (major units, number or numeric string) to micro-units. Raises on junk.
+
+    A refund is submitted as a positive amount with ``value_type: "refund"``; the reader is what
+    subtracts it. A negative amount is rejected rather than quietly flipped, because guessing
+    which of the two a caller meant is how revenue silently goes the wrong way.
+    """
+    if value is None or isinstance(value, bool):
+        raise RevenuePayloadError("amount is required (a number or numeric string in major units)")
+    try:
+        micro = usd_to_micro(Decimal(str(value)))
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise RevenuePayloadError(f"amount is not a valid decimal: {value!r}") from exc
+    if micro < 0:
+        raise RevenuePayloadError(
+            "amount must be non-negative; submit a refund as a positive amount "
+            "with value_type: 'refund'"
+        )
+    return micro
+
+
+# --------------------------------------------------------------------------- #
 # Deduplication (idempotency + replay safety)
 # --------------------------------------------------------------------------- #
 class EventDeduplicator:
@@ -393,6 +556,20 @@ class EventDeduplicator:
         if business_event_id in bucket:
             return False
         bucket.add(business_event_id)
+        return True
+
+    def forget(self, tenant_id: str, business_event_id: str) -> bool:
+        """Un-mark an id. Returns True if it was marked.
+
+        The rollback half of :meth:`mark`. A caller that marks an id and then fails to durably
+        store the event must forget it, or the retry it just asked the client to make would be
+        swallowed as a duplicate and the revenue lost. Dropping revenue is the same size of bug as
+        double counting it, in the opposite direction.
+        """
+        bucket = self._seen.get(tenant_id)
+        if bucket is None or business_event_id not in bucket:
+            return False
+        bucket.discard(business_event_id)
         return True
 
     def count(self, tenant_id: str) -> int:
@@ -422,13 +599,20 @@ class ConnectorRegistry:
 
 
 def default_registry() -> ConnectorRegistry:
-    """A registry wired with all four v1 connectors."""
+    """A registry wired with the four v1 webhook connectors plus the generic revenue API.
+
+    ``revenue-api`` (CTO-199) is not a provider webhook. It is the documented shape a tenant on
+    Chargebee, Recurly, Zuora or a home-grown biller posts directly. It belongs here so it shares
+    one deduplicator with the webhook sources: an event id already accepted from a connector
+    cannot be re-posted through the API under the same id, and vice versa.
+    """
     return ConnectorRegistry(
         (
             SegmentConnector(),
             RudderstackConnector(),
             StripeConnector(),
             HubSpotConnector(),
+            GenericRevenueConnector(),
         )
     )
 
@@ -508,3 +692,26 @@ class WebhookIngestor:
             identifies=result.identifies,
             aliases=result.aliases,
         )
+
+    def ingest_revenue_api(self, tenant_id: str, payload: Mapping[str, object]) -> IngestResult:
+        """Strict front door for the generic revenue API (CTO-199).
+
+        Identical to :meth:`ingest` on the happy path (same registry, same deduplicator), but a
+        payload the connector cannot use raises :class:`RevenuePayloadError` instead of being
+        silently skipped. A webhook we did not ask for is best dropped; a documented endpoint a
+        customer is integrating against has to say what is wrong with the request.
+
+        Costs one extra parse on the failure path only: the strict re-parse runs solely to recover
+        the reason the normal path produced nothing.
+        """
+        result = self.ingest(GENERIC_REVENUE_SOURCE, tenant_id, payload)
+        if result.accepted or result.duplicates:
+            return result
+        connector = self._registry.get(GENERIC_REVENUE_SOURCE)
+        if isinstance(connector, GenericRevenueConnector):
+            connector.parse_strict(tenant_id, payload)  # raises RevenuePayloadError
+        raise RevenuePayloadError("payload produced no revenue event")
+
+    def forget(self, tenant_id: str, business_event_id: str) -> bool:
+        """Roll back a :meth:`ingest` acceptance whose durable write then failed."""
+        return self._dedup.forget(tenant_id, business_event_id)

--- a/sdk/python/src/tally/wire.py
+++ b/sdk/python/src/tally/wire.py
@@ -57,6 +57,11 @@ class BusinessEvent:
     value_currency: str = "USD"
     value_type: str = "monetary"
     source: str = "sdk"
+    # Hashed account the value belongs to: the tenant's own paying customer (CTO-180). HMAC-SHA256
+    # hex under the per-tenant key, exactly like user_id_hash, never a raw id and never a name.
+    # Empty means the writer did not know the account, which reads back as the unattributed bucket
+    # rather than as a customer.
+    account_id_hash: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/sdk/python/tests/test_cdp_connectors.py
+++ b/sdk/python/tests/test_cdp_connectors.py
@@ -11,7 +11,9 @@ from tally.cdp_connectors import (
     BusinessEvent,
     ConnectorRegistry,
     EventDeduplicator,
+    GenericRevenueConnector,
     HubSpotConnector,
+    RevenuePayloadError,
     RudderstackConnector,
     SegmentConnector,
     StripeConnector,
@@ -253,9 +255,9 @@ def test_deduplicator_is_tenant_scoped():
 # --------------------------------------------------------------------------- #
 # Registry
 # --------------------------------------------------------------------------- #
-def test_default_registry_has_four_sources():
+def test_default_registry_has_the_webhook_sources_plus_the_revenue_api():
     reg = default_registry()
-    assert reg.sources == ("hubspot", "rudderstack", "segment", "stripe")
+    assert reg.sources == ("hubspot", "revenue-api", "rudderstack", "segment", "stripe")
     assert reg.get("segment") is not None
     assert reg.get("unknown") is None
 
@@ -373,3 +375,110 @@ def test_ingest_stripe_revenue_end_to_end():
     assert r.total_value_micro_usd == 10_000 * 10_000  # $100
     # Stripe re-sends the same event id on retry -> deduped
     assert ing.ingest("stripe", "t1", payload).accepted_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# Generic revenue API (CTO-199)
+# --------------------------------------------------------------------------- #
+def _revenue(**overrides):
+    payload = {
+        "event_id": "inv_2026_08_0001",
+        "account_id": "acct_northwind",
+        "amount": "1499.00",
+        "currency": "usd",
+        "occurred_at": "2026-08-25T12:00:00Z",
+        "event_name": "invoice_paid",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_generic_revenue_parses_the_documented_shape():
+    ev = GenericRevenueConnector().parse_strict("t1", _revenue())
+    assert ev.business_event_id == "inv_2026_08_0001"
+    assert ev.account_id == "acct_northwind"
+    assert ev.value_micro_usd == 1_499_000_000
+    assert ev.currency == "USD"  # normalized, never converted
+    assert ev.value_type == "monetary"
+    assert ev.source == "revenue-api"
+    assert ev.occurred_at == datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    assert ev.user_id is None
+
+
+@pytest.mark.parametrize(
+    "overrides, fragment",
+    [
+        ({"event_id": ""}, "event_id"),
+        ({"account_id": None}, "account_id"),
+        ({"event_name": "  "}, "event_name"),
+        ({"occurred_at": "yesterday"}, "occurred_at"),
+        ({"amount": "not-a-number"}, "amount"),
+        ({"amount": None}, "amount"),
+        ({"amount": "-5"}, "non-negative"),
+        ({"currency": "dollars"}, "currency"),
+        ({"value_type": "revenue"}, "value_type"),
+        ({"user_id": 7}, "user_id"),
+        ({"properties": "a=b"}, "properties"),
+        ({"value_type": "count", "amount": "10"}, "count"),
+    ],
+)
+def test_generic_revenue_rejects_bad_payloads_by_field(overrides, fragment):
+    with pytest.raises(RevenuePayloadError) as exc:
+        GenericRevenueConnector().parse_strict("t1", _revenue(**overrides))
+    assert fragment in str(exc.value)
+
+
+def test_generic_revenue_parse_never_raises_for_the_shared_path():
+    # The CDPConnector contract: a bad payload is an empty result, not an exception.
+    assert GenericRevenueConnector().parse("t1", _revenue(amount="junk")).is_empty
+    assert GenericRevenueConnector().parse("t1", ["not", "a", "mapping"]).is_empty
+
+
+def test_generic_revenue_count_event_carries_no_money():
+    ev = GenericRevenueConnector().parse_strict(
+        "t1", _revenue(value_type="count", amount=None, event_name="seat_activated")
+    )
+    assert ev.value_type == "count"
+    assert ev.value_micro_usd == 0
+
+
+def test_generic_revenue_refund_is_a_positive_amount_with_a_refund_type():
+    ev = GenericRevenueConnector().parse_strict(
+        "t1", _revenue(value_type="refund", amount="99.50", event_name="refund")
+    )
+    assert ev.value_type == "refund"
+    assert ev.value_micro_usd == 99_500_000
+
+
+def test_generic_revenue_is_idempotent_on_the_caller_supplied_event_id():
+    ing = WebhookIngestor()
+    first = ing.ingest_revenue_api("t1", _revenue())
+    assert first.accepted_count == 1
+    # Same event_id, retried (and with a different amount; the id is what decides).
+    retry = ing.ingest_revenue_api("t1", _revenue(amount="2000.00"))
+    assert retry.accepted_count == 0
+    assert retry.duplicates == 1
+    # A different tenant with the same id is untouched.
+    assert ing.ingest_revenue_api("t2", _revenue()).accepted_count == 1
+
+
+def test_ingest_revenue_api_raises_on_a_payload_the_caller_must_fix():
+    ing = WebhookIngestor()
+    with pytest.raises(RevenuePayloadError):
+        ing.ingest_revenue_api("t1", _revenue(event_id=None))
+
+
+def test_forget_restores_a_retry_after_a_failed_write():
+    ing = WebhookIngestor()
+    assert ing.ingest_revenue_api("t1", _revenue()).accepted_count == 1
+    # Pretend the durable write failed: the caller retries and must not be told "duplicate".
+    assert ing.forget("t1", "inv_2026_08_0001") is True
+    assert ing.ingest_revenue_api("t1", _revenue()).accepted_count == 1
+    assert ing.forget("t1", "never-seen") is False
+
+
+def test_business_event_rejects_an_unknown_value_type():
+    with pytest.raises(ValueError):
+        BusinessEvent(
+            "id", "t1", "revenue-api", "e", datetime(2026, 5, 1, tzinfo=UTC), value_type="cash"
+        )


### PR DESCRIPTION
**Stacked PR.** Based on `feat/account-revenue-base`, which carries #170 (CTO-180, `AccountIdHash`
on `otel_spans` and `business_events`) and #171 (CTO-194, `ValueType`-based revenue query and the
per-tenant revenue source config). Review those first; this diff is only the commit on top.

**Possible conflict with CTO-198** (E5, CSV revenue upload), in flight on the same base. Both add a
revenue ingest path to `infra/gateway/src/gateway/app.py`. This change is additive: one new endpoint
appended after the revenue-source config routes, one new module, one new test file. The conflict
should be mechanical.

## What this adds

`POST /v1/revenue/events` for tenants on a biller we have no connector for: Chargebee, Recurly,
Zuora, or home-grown. Takes `{event_id, account_id, amount, currency, occurred_at, event_name}` and
writes an ordinary `business_events` row. Documented in [`docs/revenue-api.md`](docs/revenue-api.md)
with a worked curl.

- `account_id` is HMAC-hashed under the per-tenant key into `AccountIdHash`. #170 added the column;
  this adds the write-side plumbing it needs (`tally.wire.BusinessEvent.account_id_hash` and the
  ClickHouse insert).
- Revenue flows through the **same** CTO-194 policy, not around it. The row carries `ValueType` and
  `Source` like any other, and the `201` reports `counted_as_revenue` so a tenant who narrowed
  `revenue_sources` to `["stripe"]` learns it on the first request rather than from a blank
  dashboard. That field is `null`, not `false`, when the config cannot be read.
- Reuses `WebhookIngestor`: `GenericRevenueConnector` is a fifth entry in the SDK's existing
  registry, sharing its routing and its deduplicator. It parses strictly so a caller gets a `422`
  naming the field at fault, while keeping the never-raises `CDPConnector` contract for the shared
  webhook path.
- When `user_id` is omitted the account id also fills `UserIdHash`, mirroring what the Stripe
  connector does with the customer id. That is what makes this revenue join in `queryAttribution`
  identically to connector-sourced revenue, rather than as a special case.
- `RawPayload` stays empty. Its distinguishing content is the raw `account_id`, which is the one
  thing hashing exists to keep out of the telemetry store.

## Idempotency, and why it is structural

`event_id` is required and the endpoint will not mint one: an auto-generated id turns every
network-timeout retry into a second payment. It becomes `BusinessEventId`, the table's own sort key,
and two guards sit in front of the insert:

1. the in-process deduplicator, shared with the connector webhooks, and
2. a ClickHouse lookup on `(TenantId, BusinessEventId)`, which is what still holds after a restart or
   across replicas. Needed because the attribution revenue sum reads `business_events` without
   `FINAL`, so relying on the `ReplacingMergeTree` merge would leave a window where the money counts
   twice.

A failed write un-marks the id so the caller's retry is not swallowed. Losing revenue is the same
size of bug as double counting it, in the other direction.

### Proof, against the running local gateway

```bash
curl -X POST http://localhost:8080/v1/revenue/events -H 'Content-Type: application/json' \
  -H 'X-Tenant-Id: local-dev' \
  -d '{"event_id":"cb_inv_2026_08_0042","account_id":"acct_northwind","amount":"1499.00",
       "currency":"USD","occurred_at":"2026-08-25T12:00:00Z","event_name":"invoice_paid"}'
```

```
HTTP 201  {"ok":true,"deduplicated":false,"stored":true,"event_id":"cb_inv_2026_08_0042",
           "account_id_hash":"eb9ecb6d055e72136a09468e7cabfa4b6ae966521c7da05868b72f3e4b3988af",
           "value_amount_micro":1499000000,"value_type":"monetary","source":"revenue-api",
           "counted_as_revenue":true}
```

Same request again, then again after `docker compose restart gateway` (empty in-process set, so only
the durable probe is left), the third one deliberately carrying `"amount":"9999.00"`:

```
HTTP 200  {"ok":true,"deduplicated":true,"event_id":"cb_inv_2026_08_0042","stored":false}
HTTP 200  {"ok":true,"deduplicated":true,"event_id":"cb_inv_2026_08_0042","stored":true}
```

```sql
SELECT count(), sum(ValueAmountMicro) FROM business_events
WHERE TenantId = 'local-dev' AND BusinessEventId = 'cb_inv_2026_08_0042';
-- 1   1499000000        one row, original amount, three POSTs
```

And the revenue expression from `queryAttribution` run verbatim over a posted event plus a matching
span returns it like any connector row:

```
provider  revenue  users  accounts
openai    500      1      1
```

Rejections are specific: `{"detail":"event_id is required and must be a non-empty string"}`, and
`{"detail":"amount must be non-negative; submit a refund as a positive amount with value_type: 'refund'"}`.

Verification rows were removed from the local ClickHouse afterwards.

## Not in scope

A data-warehouse connector (Snowflake, BigQuery) that queries revenue where it is already modelled,
per the plan doc. CSV upload is CTO-198.

## Checks

- `infra/gateway`: 495 passed, `ruff check` clean
- `sdk/python`: full suite passed, `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
