### PR TITLE
feat(web): cost per customer page (CTO-188)

### DIFF
--- a/web/app/cost-per-customer/AccountTable.test.tsx
+++ b/web/app/cost-per-customer/AccountTable.test.tsx
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type AccountCostRow, emptyAccountRow } from "@/lib/accounts";
+import { AccountTable } from "./AccountTable";
+
+// The search box calls a server action. Mocked here so the test covers the matching rule (which is
+// where the interesting bug lives) rather than the transport.
+const lookup = vi.fn();
+vi.mock("./actions", () => ({
+  lookupAccountAction: (id: string) => lookup(id),
+}));
+
+const LABELLED = "1".repeat(64);
+const UNLABELLED = "2".repeat(64);
+/** The same account under the other spelling of the tenant id: a different HMAC key space. */
+const OTHER_KEY_FORM = "3".repeat(64);
+
+function row(hash: string, over: Partial<AccountCostRow> = {}): AccountCostRow {
+  return {
+    ...emptyAccountRow(hash, false),
+    directCostMicroUsd: 2_000_000,
+    distinctUsers: 4,
+    spanCount: 500,
+    ...over,
+  };
+}
+
+function renderTable(rows: AccountCostRow[], labels: Record<string, string> = {}) {
+  return render(
+    <AccountTable rows={rows} labels={labels} labelsUnavailable={false} windowDays={30} />,
+  );
+}
+
+describe("AccountTable", () => {
+  beforeEach(() => {
+    lookup.mockReset();
+  });
+
+  it("shows the label where one exists and a shortened hash where none does", () => {
+    renderTable([row(LABELLED), row(UNLABELLED)], { [LABELLED]: "Acme Corp" });
+    expect(screen.getByText("Acme Corp")).toBeTruthy();
+    expect(screen.getByText(`${UNLABELLED.slice(0, 12)}…`)).toBeTruthy();
+  });
+
+  it("keeps the full hash reachable on hover and on copy", () => {
+    renderTable([row(UNLABELLED)]);
+    expect(screen.getByTitle(UNLABELLED)).toBeTruthy();
+    expect(screen.getByTitle(`Copy the full account hash: ${UNLABELLED}`)).toBeTruthy();
+  });
+
+  it("blanks cost per user below the sample floor instead of printing a noisy ratio", () => {
+    renderTable([row(UNLABELLED, { spanCount: 3, distinctUsers: 1 })]);
+    expect(screen.getByText(/No value: needs ≥50 spans/i)).toBeTruthy();
+  });
+
+  it("matches a searched account on any of the candidate hashes, not just the first", async () => {
+    // The row was ingested under the second spelling of the tenant id. Testing only hashes[0]
+    // would report a real, spending customer as having no spend.
+    lookup.mockResolvedValue({ ok: true, hashes: [UNLABELLED, OTHER_KEY_FORM] });
+    renderTable([row(LABELLED), row(OTHER_KEY_FORM)], { [LABELLED]: "Acme Corp" });
+
+    fireEvent.change(screen.getByLabelText("Find account"), { target: { value: "acme-corp" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => expect(screen.getByText(/Showing the matching account/)).toBeTruthy());
+    // Filtered down to the matched row: the other account is gone from the table.
+    expect(screen.queryByText("Acme Corp")).toBeNull();
+  });
+
+  it("says an account has no spend rather than emptying the table", async () => {
+    lookup.mockResolvedValue({ ok: true, hashes: ["9".repeat(64)] });
+    renderTable([row(LABELLED)], { [LABELLED]: "Acme Corp" });
+
+    fireEvent.change(screen.getByLabelText("Find account"), { target: { value: "ghost" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/no directly attributable spend in the last 30 days/)).toBeTruthy(),
+    );
+    expect(screen.getByText("Acme Corp")).toBeTruthy();
+  });
+
+  it("surfaces a lookup failure without clearing the table", async () => {
+    lookup.mockResolvedValue({ ok: false, error: "Account lookup unavailable: timeout" });
+    renderTable([row(LABELLED)], { [LABELLED]: "Acme Corp" });
+
+    fireEvent.change(screen.getByLabelText("Find account"), { target: { value: "acme-corp" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => expect(screen.getByText(/Account lookup unavailable/)).toBeTruthy());
+    expect(screen.getByText("Acme Corp")).toBeTruthy();
+  });
+});

--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// The /cost-per-customer account table and its search box (CTO-188, plan D2).
+//
+// Client module for the same reason ConnectorTable is one: `DataTable` takes a column spec whose
+// `render` entries are functions, and functions cannot cross the server/client boundary. page.tsx
+// is an async server component, so the spec is declared on this side of the line.
+
+import { useMemo, useState, useTransition } from "react";
+
+import { DataTable, type Column } from "@/components/DataTable";
+import { Blank, Money } from "@/components/HonestValue";
+import {
+  type AccountCostRow,
+  costPerUser,
+  shortenAccountHash,
+} from "@/lib/accounts";
+import { lookupAccountAction } from "./actions";
+
+interface SearchState {
+  /** Hashes the searched id could have been emitted under. Empty until a search succeeds. */
+  matched: string[];
+  /** Whether any of those hashes is actually a row in the window. */
+  found: boolean;
+  message: string;
+  tone: "ok" | "warn" | "err";
+}
+
+export function AccountTable({
+  rows,
+  labels,
+  labelsUnavailable,
+  windowDays,
+}: {
+  rows: readonly AccountCostRow[];
+  /**
+   * Hash to label. A plain record rather than a Map because this crosses the serialization
+   * boundary from a server component.
+   */
+  labels: Record<string, string>;
+  /** True when the gateway could not be reached, so an unlabelled row is not proof of no label. */
+  labelsUnavailable: boolean;
+  windowDays: number;
+}) {
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState<SearchState | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const matchedSet = useMemo(
+    () => new Set(search?.found ? search.matched : []),
+    [search],
+  );
+
+  // A found account filters the table down to its row, which is how you "jump" to a row inside a
+  // sorted, paginated table: the row you asked for may be on page 14 of an unbounded list, and
+  // scrolling to an offset that a re-sort invalidates would be worse than showing it alone.
+  // A search that matched nothing does NOT filter: an empty table would read as "you broke it"
+  // when the true statement is "this account has no spend in the window".
+  const visibleRows = useMemo(
+    () => (matchedSet.size > 0 ? rows.filter((r) => matchedSet.has(r.accountIdHash)) : rows),
+    [rows, matchedSet],
+  );
+
+  const runSearch = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      setSearch(null);
+      return;
+    }
+    startTransition(async () => {
+      const result = await lookupAccountAction(trimmed);
+      if (!result.ok) {
+        setSearch({ matched: [], found: false, message: result.error, tone: "err" });
+        return;
+      }
+      // Match against the WHOLE set of candidate hashes. The tenant identifier is HMAC key
+      // material, so the same account has a different digest per spelling of the tenant id and the
+      // endpoint refuses to canonicalize. Testing only the first would miss the account outright
+      // whenever its spans were ingested under the other spelling.
+      const hit = rows.some((r) => result.hashes.includes(r.accountIdHash));
+      setSearch({
+        matched: result.hashes,
+        found: hit,
+        message: hit
+          ? "Showing the matching account. Clear the search to see every account again."
+          : `That account id hashes to a valid account, but it has no directly attributable spend in the last ${windowDays} days.`,
+        tone: hit ? "ok" : "warn",
+      });
+    });
+  };
+
+  const columns = useMemo<Column<AccountCostRow>[]>(
+    () => [
+      {
+        key: "account",
+        header: "Account",
+        render: (r) => (
+          <AccountCell
+            accountIdHash={r.accountIdHash}
+            label={labels[r.accountIdHash]}
+            labelsUnavailable={labelsUnavailable}
+          />
+        ),
+        // Sorts by what the reader can see: labelled accounts read alphabetically, unlabelled ones
+        // by hash. Sorting by the hash under a label would look like no sort at all.
+        sortValue: (r) => labels[r.accountIdHash] ?? r.accountIdHash,
+      },
+      {
+        key: "users",
+        header: "Users",
+        align: "right",
+        render: (r) =>
+          r.distinctUsers > 0 ? (
+            r.distinctUsers.toLocaleString()
+          ) : (
+            <Blank reason="no user id was recorded on this account's spans, so distinct users cannot be counted" />
+          ),
+        sortValue: (r) => r.distinctUsers,
+      },
+      {
+        key: "cost",
+        header: "Direct cost",
+        align: "right",
+        render: (r) => <Money micro={r.directCostMicroUsd} />,
+        sortValue: (r) => r.directCostMicroUsd,
+      },
+      {
+        key: "costPerUser",
+        header: "Cost per user",
+        align: "right",
+        render: (r) => {
+          const { micro, reason } = costPerUser(r);
+          return micro === null ? (
+            <Blank reason={reason ?? "not enough data to divide cost by users"} />
+          ) : (
+            <Money micro={micro} />
+          );
+        },
+        // Low-sample rows carry no value, and `null` sorts last in both directions by design, so a
+        // suppressed account never floats to the top of a "cheapest per user" sort.
+        sortValue: (r) => costPerUser(r).micro,
+      },
+    ],
+    [labels, labelsUnavailable],
+  );
+
+  return (
+    <div className="space-y-3">
+      <form
+        className="flex flex-wrap items-center gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          runSearch(query);
+        }}
+      >
+        <label htmlFor="account-search" className="text-xs uppercase tracking-wide text-muted">
+          Find account
+        </label>
+        <input
+          id="account-search"
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="your own account id, e.g. acme-corp"
+          className="min-w-64 flex-1 rounded-md border border-edge bg-ink/40 px-3 py-1.5 text-sm placeholder:text-muted focus:border-accent/60 focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border border-accent/50 bg-accent/15 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
+        >
+          {pending ? "Hashing…" : "Search"}
+        </button>
+        {search ? (
+          <button
+            type="button"
+            onClick={() => {
+              setQuery("");
+              setSearch(null);
+            }}
+            className="rounded-md border border-edge px-3 py-1.5 text-sm text-muted hover:text-white"
+          >
+            Clear
+          </button>
+        ) : null}
+      </form>
+
+      <p className="max-w-prose text-xs text-muted">
+        The id is hashed with this tenant&apos;s own key to find its row. It is never stored, logged,
+        or shown back to you, which is also why there is no way to search the other direction.
+      </p>
+
+      {search ? (
+        <p
+          className={`text-xs ${
+            search.tone === "ok" ? "text-good" : search.tone === "warn" ? "text-warn" : "text-warn"
+          }`}
+        >
+          {search.message}
+        </p>
+      ) : null}
+
+      <DataTable
+        columns={columns}
+        rows={visibleRows}
+        rowKey={(r) => r.accountIdHash}
+        initialSort={{ key: "cost", direction: "desc" }}
+        // A row the search found is filtered to on its own, so the highlight is belt and braces for
+        // the case where a tenant later labels two hashes of the same account and both rows show.
+        rowClassName={(r) => (matchedSet.has(r.accountIdHash) ? "bg-accent/5" : "")}
+        // Deliberately plain. The onboarding empty state that explains what this page is for and
+        // how to switch it on is CTO-191, stacked on this ticket; a half-built version here would
+        // be the thing that ticket then has to unpick.
+        empty={`No spans carried an account id in the last ${windowDays} days.`}
+      />
+    </div>
+  );
+}
+
+/**
+ * The Account cell: label where the tenant set one, shortened hash otherwise, full hash on hover
+ * and on copy.
+ *
+ * The full hash is what every other surface takes (the label API, a support conversation), so it
+ * has to be retrievable from the row. The short form is for width only.
+ */
+function AccountCell({
+  accountIdHash,
+  label,
+  labelsUnavailable,
+}: {
+  accountIdHash: string;
+  label: string | undefined;
+  labelsUnavailable: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(accountIdHash);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can be refused (insecure origin, denied permission). The hash is already
+      // selectable in the title attribute, so there is nothing to recover and nothing to shout at
+      // the user about.
+      setCopied(false);
+    }
+  };
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span title={accountIdHash} className={label ? "font-medium" : "font-mono text-xs"}>
+        {label ?? shortenAccountHash(accountIdHash)}
+      </span>
+      {!label && !labelsUnavailable ? (
+        <span className="text-[11px] text-muted" title="no label set for this account">
+          unlabelled
+        </span>
+      ) : null}
+      <button
+        type="button"
+        onClick={copy}
+        title={`Copy the full account hash: ${accountIdHash}`}
+        className="rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-white"
+      >
+        {copied ? "Copied" : "Copy hash"}
+      </button>
+    </span>
+  );
+}

--- a/web/app/cost-per-customer/actions.ts
+++ b/web/app/cost-per-customer/actions.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+"use server";
+
+// Server action behind the account search box (CTO-188, plan D2 / B6).
+//
+// A server action rather than a route handler or a client fetch, matching the connectors page: the
+// gateway URL is server config, and the plaintext account id must not reach the browser's network
+// tab or a URL. It goes into one POST body, produces hashes, and is dropped. Nothing is cached and
+// nothing is revalidated, because a lookup changes no state.
+
+import { lookupAccountHashes, type AccountLookup } from "@/lib/accountLabels";
+
+export async function lookupAccountAction(accountId: string): Promise<AccountLookup> {
+  return lookupAccountHashes(accountId);
+}

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Cost per customer (CTO-188, plan D2).
+//
+// Direct spend broken down by the tenant's own accounts, ranked by cost. Two things make this page
+// different from the rest of the dashboard, and both are deliberate:
+//
+// 1. NO SAMPLE DATA. Every other tab ships a canned fixture because its page landed before the
+//    telemetry did; lib/accounts.ts ships none on purpose. A plausible list of fake customer names
+//    is the single most misleading thing this page could show, so when there is nothing to report
+//    it says so.
+//
+// 2. THE UNATTRIBUTED SHARE LEADS. If 60 percent of spend carries no account, ranking the other 40
+//    percent as though it were the whole picture is a lie of omission. The headline states the
+//    share before the table, every time, including when it is 100 percent, which is exactly what a
+//    tenant that has not instrumented `account_id` yet will see.
+//
+// Reads the query directly rather than through /api, matching how the page-level gateway reads on
+// /connectors work: there is no client-side refetch here and no second consumer of the payload, so
+// a route handler would only add a hop.
+
+import { Card } from "@/components/Card";
+import { Blank, Money } from "@/components/HonestValue";
+import {
+  attributedSpend,
+  formatShare,
+  unattributedShare,
+  type AccountCosts,
+} from "@/lib/accounts";
+import { queryAccountLabels } from "@/lib/accountLabels";
+import { queryAccountCosts } from "@/lib/clickhouse";
+import { AccountTable } from "./AccountTable";
+
+export const dynamic = "force-dynamic";
+
+/** Above this share, the unattributed bucket is the story rather than a footnote. */
+const MAJORITY_UNATTRIBUTED = 0.5;
+
+export default async function CostPerCustomerPage() {
+  const [costs, labels] = await Promise.all([queryAccountCosts(), queryAccountLabels()]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Cost per customer</h1>
+        {costs ? (
+          <span className="text-sm text-muted">
+            Direct spend, last {costs.windowDays} days
+          </span>
+        ) : null}
+      </div>
+
+      <p className="max-w-prose text-sm text-muted">
+        Directly attributable spend (LLM, tools, vector, embeddings) grouped by the account each span
+        was tagged with. Compute and egress are excluded: no span carries an account for them, so
+        splitting them per customer would mean inventing an allocation rule.
+      </p>
+
+      {costs === null ? <Unreachable /> : <Report costs={costs} labels={labels} />}
+    </div>
+  );
+}
+
+function Report({
+  costs,
+  labels,
+}: {
+  costs: AccountCosts;
+  labels: Map<string, string> | null;
+}) {
+  const share = unattributedShare(costs);
+  const attributed = attributedSpend(costs);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Stat label="Attributed spend">
+          <Money micro={attributed} />
+        </Stat>
+        <Stat label="Accounts">
+          <span className="tabular-nums">{costs.accounts.length.toLocaleString()}</span>
+        </Stat>
+        <Stat label="Spend with no account">
+          {/* The valve. `null` only when the tenant recorded no direct spend at all, where "0%
+              unattributed" would claim perfect coverage of nothing. */}
+          {share === null ? (
+            <Blank
+              reason={`no directly attributable spend recorded in the last ${costs.windowDays} days, so there is no share to report`}
+            />
+          ) : (
+            formatShare(share)
+          )}
+        </Stat>
+      </div>
+
+      {share !== null && share >= MAJORITY_UNATTRIBUTED ? (
+        <UnattributedNotice costs={costs} share={share} />
+      ) : null}
+
+      <Card title="Accounts by direct cost">
+        <AccountTable
+          rows={costs.accounts}
+          labels={labels ? Object.fromEntries(labels) : {}}
+          labelsUnavailable={labels === null}
+          windowDays={costs.windowDays}
+        />
+        {labels === null ? (
+          <p className="mt-3 text-xs text-warn">
+            Account labels could not be read from the gateway, so every account shows as a hash. An
+            unlabelled row here is not proof that no label is set.
+          </p>
+        ) : null}
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * The honest headline when most spend carries no account.
+ *
+ * Written to read as a deliberate statement rather than a broken page, because on a tenant that has
+ * not instrumented `account_id` this is the normal state and it will be the first thing anyone
+ * sees. It names the number, says what the table below it does and does not cover, and stops. The
+ * "here is how to switch it on" onboarding state is CTO-191.
+ */
+function UnattributedNotice({ costs, share }: { costs: AccountCosts; share: number }) {
+  const complete = costs.accounts.length === 0;
+  return (
+    <div className="rounded-xl border border-warn/40 bg-warn/5 p-4">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="rounded bg-warn/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-warn">
+          Mostly unattributed
+        </span>
+        <span className="text-sm">
+          <span className="font-semibold">{formatShare(share)}</span> of direct spend (
+          <Money micro={costs.unattributed.directCostMicroUsd} /> of{" "}
+          <Money micro={costs.totalDirectMicroUsd} />) carries no account id.
+        </span>
+      </div>
+      <p className="mt-2 max-w-prose text-sm text-muted">
+        {complete
+          ? `Nothing in the last ${costs.windowDays} days is tagged with an account, so there is no per-customer breakdown to rank yet. This is what the page looks like before an account id is emitted, not an error.`
+          : `The accounts below cover the remaining spend only. Ranking them as though they were the whole picture would misstate what each customer costs, so read them as a partial view until more spans carry an account id.`}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * ClickHouse unreachable. No fixture stands in: an invented customer list is worse than an empty
+ * page, and this is the one surface where the fallback would be indistinguishable from real data.
+ */
+function Unreachable() {
+  return (
+    <Card title="Accounts by direct cost">
+      <p className="max-w-prose text-sm text-muted">
+        The telemetry store could not be reached, so there is nothing to report. This page has no
+        sample data by design: a made-up list of customer accounts would be impossible to tell from
+        a real one.
+      </p>
+      <div className="mt-3">
+        <Blank reason="the telemetry store is unreachable, so no per-account cost could be read" />
+      </div>
+    </Card>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-edge bg-panel p-4">
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{children}</div>
+    </div>
+  );
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -10,6 +10,7 @@ const NAV: { label: string; href: string }[] = [
   { label: "Compare", href: "/compare" },
   { label: "Attribution", href: "/attribution" },
   { label: "Unit Economics", href: "/unit-economics" },
+  { label: "Cost per Customer", href: "/cost-per-customer" },
   { label: "Connectors", href: "/connectors" },
   { label: "Guardrails", href: "/guardrails" },
   // Hidden from the nav until they have real signal end-to-end (pages still render at the URL):

--- a/web/lib/accountLabels.ts
+++ b/web/lib/accountLabels.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Dashboard client for the account control plane (CTO-188, plan D2).
+//
+// Two gateway endpoints, one module, because they answer the two halves of the same question "which
+// customer is this row?":
+//
+//   * B7 `/v1/tenant/account-labels` — the optional human-readable name for a hash. Labels live in
+//     Postgres and are joined at render time, so ClickHouse never holds a customer name.
+//   * B6 `/v1/tenant/account-lookup` — plaintext account id to hash, the forward direction of a
+//     one-way function. Without it an UNLABELLED account cannot be found at all and the tab is a
+//     list of opaque hex.
+//
+// Server-only, like lib/tenant.ts: the gateway URL and tenant scoping are server config, and the
+// lookup body carries a customer identifier that has no business travelling from a browser.
+//
+// The plaintext account id is handled the way the gateway handles it: used for one call and then
+// dropped. It is never cached, never returned in an error message, and never logged. Every warning
+// below reports the transport failure only.
+
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+/** A slow gateway must not hold a page render open. Same budget lib/tenant.ts uses. */
+const TIMEOUT_MS = 2000;
+
+/** One `(account hash) -> label` mapping, as the tab consumes it. */
+export interface AccountLabel {
+  accountIdHash: string;
+  label: string;
+  updatedAt: string;
+}
+
+interface AccountLabelsResponse {
+  tenant_id: string;
+  labels: Array<{ account_id_hash: string; label: string; updated_at: string }>;
+}
+
+interface AccountLookupResponse {
+  tenant_id: string;
+  account_id_hash: string;
+  key_version: string;
+  hashes: Array<{ account_id_hash: string; key_version: string; tenant_key_form: string }>;
+}
+
+/**
+ * Every label this tenant has set, keyed by account hash.
+ *
+ * Returns `null` when the gateway is unreachable or refuses, which the page renders as "labels
+ * unavailable, showing hashes" rather than as "this tenant has no labels". The two look identical
+ * in a table of hex and only one of them is the tenant's own choice.
+ */
+export async function queryAccountLabels(): Promise<Map<string, string> | null> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/account-labels`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      console.warn(`[accounts] /v1/tenant/account-labels HTTP ${res.status}; rendering hashes`);
+      return null;
+    }
+    const body = (await res.json()) as AccountLabelsResponse;
+    const out = new Map<string, string>();
+    for (const row of body.labels ?? []) {
+      if (row?.account_id_hash && row?.label) out.set(row.account_id_hash, row.label);
+    }
+    return out;
+  } catch (err) {
+    console.warn("[accounts] /v1/tenant/account-labels unreachable:", (err as Error).message);
+    return null;
+  }
+}
+
+export type AccountLookup =
+  | {
+      ok: true;
+      /**
+       * EVERY hash the account could have been emitted under, not one.
+       *
+       * The tenant identifier is HMAC key material, so `local-dev` and its `tenants.id` UUID derive
+       * different key spaces and the endpoint deliberately refuses to pick a winner. Spans ingested
+       * through one door carry one digest and spans through the other carry another, for the same
+       * customer. Matching on `hashes[0]` alone would find the account only half the time, and the
+       * half it missed would look like a customer with no spend.
+       */
+      hashes: string[];
+    }
+  | { ok: false; error: string };
+
+/**
+ * Plaintext account id to candidate hashes, via the gateway's own HMAC keys.
+ *
+ * An id nobody has ever emitted is not an error here, exactly as it is not one at the endpoint: it
+ * comes back `ok` with well-formed hashes that simply match no rows, and the caller says "no spend
+ * recorded". Answering "not found" would make a typo indistinguishable from an idle customer.
+ */
+export async function lookupAccountHashes(accountId: string): Promise<AccountLookup> {
+  const trimmed = accountId.trim();
+  if (!trimmed) return { ok: false, error: "Enter an account id to search for." };
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/account-lookup`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      body: JSON.stringify({ account_id: trimmed }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      // The gateway's own 422 messages are written to never quote the submitted value, so they are
+      // safe to show. Anything else is reported as a status code without a body.
+      const detail = res.status === 422 ? await readDetail(res) : null;
+      return {
+        ok: false,
+        error: detail ?? `Account lookup failed (gateway HTTP ${res.status}).`,
+      };
+    }
+    const body = (await res.json()) as AccountLookupResponse;
+    const hashes = (body.hashes ?? [])
+      .map((h) => h?.account_id_hash)
+      .filter((h): h is string => typeof h === "string" && h.length > 0);
+    if (hashes.length === 0 && body.account_id_hash) hashes.push(body.account_id_hash);
+    if (hashes.length === 0) {
+      return { ok: false, error: "Account lookup returned no hash for this tenant." };
+    }
+    return { ok: true, hashes };
+  } catch (err) {
+    // (err as Error).message here is a transport message: a timeout or a connection refusal. It
+    // cannot contain the account id, which only ever left this process inside the request body.
+    return { ok: false, error: `Account lookup unavailable: ${(err as Error).message}` };
+  }
+}
+
+async function readDetail(res: Response): Promise<string | null> {
+  try {
+    const body = (await res.json()) as { detail?: unknown };
+    return typeof body.detail === "string" ? body.detail : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/lib/accounts.test.ts
+++ b/web/lib/accounts.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_SPANS_FOR_COST_PER_USER,
+  SHORT_HASH_CHARS,
+  type AccountCostRow,
+  type AccountCosts,
+  attributedSpend,
+  costPerUser,
+  emptyAccountRow,
+  formatShare,
+  shortenAccountHash,
+  unattributedShare,
+} from "./accounts";
+
+function row(over: Partial<AccountCostRow> = {}): AccountCostRow {
+  return {
+    ...emptyAccountRow("a".repeat(64), false),
+    directCostMicroUsd: 1_000_000,
+    distinctUsers: 4,
+    spanCount: 500,
+    ...over,
+  };
+}
+
+function costs(over: Partial<AccountCosts> = {}): AccountCosts {
+  return {
+    windowDays: 30,
+    accounts: [],
+    unattributed: emptyAccountRow("", true),
+    totalDirectMicroUsd: 0,
+    ...over,
+  };
+}
+
+describe("costPerUser", () => {
+  it("divides direct cost by distinct users above the sample floor", () => {
+    expect(costPerUser(row({ directCostMicroUsd: 1_000_000, distinctUsers: 4 }))).toEqual({
+      micro: 250_000,
+      reason: null,
+    });
+  });
+
+  it("suppresses the ratio below the sample floor, naming the shortfall", () => {
+    const result = costPerUser(row({ spanCount: MIN_SPANS_FOR_COST_PER_USER - 1 }));
+    expect(result.micro).toBeNull();
+    expect(result.reason).toContain(String(MIN_SPANS_FOR_COST_PER_USER));
+  });
+
+  it("prints the ratio exactly at the floor", () => {
+    expect(costPerUser(row({ spanCount: MIN_SPANS_FOR_COST_PER_USER })).micro).not.toBeNull();
+  });
+
+  it("blanks with a different reason when there are no users to divide by", () => {
+    // Distinct from the low-sample blank on purpose: a busy account with no user ids is a
+    // different fact from a quiet one, and dividing by zero would print Infinity.
+    const result = costPerUser(row({ distinctUsers: 0, spanCount: 10_000 }));
+    expect(result.micro).toBeNull();
+    expect(result.reason).toContain("nothing to divide by");
+  });
+});
+
+describe("shortenAccountHash", () => {
+  it("truncates a full hash and marks the truncation", () => {
+    const hash = "cf0f8e1442e65b0367807e613417a147067c30117dfe7ca0bc6b803f441b5765";
+    const short = shortenAccountHash(hash);
+    expect(short.startsWith(hash.slice(0, SHORT_HASH_CHARS))).toBe(true);
+    expect(short.endsWith("…")).toBe(true);
+  });
+
+  it("leaves an already-short value alone rather than adding a misleading ellipsis", () => {
+    expect(shortenAccountHash("abc")).toBe("abc");
+  });
+});
+
+describe("unattributedShare", () => {
+  it("reports the share of direct spend with no account", () => {
+    const c = costs({
+      unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: 750_000 },
+      totalDirectMicroUsd: 1_000_000,
+    });
+    expect(unattributedShare(c)).toBeCloseTo(0.75);
+  });
+
+  it("reports 100 percent when nothing is tagged, which is the local-tenant state", () => {
+    const c = costs({
+      unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: 500_000 },
+      totalDirectMicroUsd: 500_000,
+    });
+    expect(unattributedShare(c)).toBe(1);
+  });
+
+  it("is null with no direct spend at all, never a flattering zero", () => {
+    expect(unattributedShare(costs())).toBeNull();
+  });
+});
+
+describe("formatShare", () => {
+  it("prints an ordinary share to one decimal", () => {
+    expect(formatShare(0.6234)).toBe("62.3%");
+  });
+
+  it("refuses to round a near-total share up to a flat 100%", () => {
+    // The live local tenant sits here: three real accounts against a huge unattributed bucket.
+    // "100.0%" beside a table of three customers contradicts the table.
+    expect(formatShare(0.99999)).toBe(">99.9%");
+  });
+
+  it("refuses to round a sliver down to a flat 0%", () => {
+    expect(formatShare(0.0000004)).toBe("<0.1%");
+  });
+
+  it("prints the round numbers only when they are exact", () => {
+    expect(formatShare(1)).toBe("100.0%");
+    expect(formatShare(0)).toBe("0.0%");
+  });
+});
+
+describe("attributedSpend", () => {
+  it("is the total less the unattributed bucket, so it reconciles with the table", () => {
+    const accounts = [row({ directCostMicroUsd: 300_000 }), row({ directCostMicroUsd: 200_000 })];
+    const c = costs({
+      accounts,
+      unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: 500_000 },
+      totalDirectMicroUsd: 1_000_000,
+    });
+    expect(attributedSpend(c)).toBe(500_000);
+    expect(attributedSpend(c)).toBe(accounts.reduce((s, a) => s + a.directCostMicroUsd, 0));
+  });
+});

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -99,3 +99,105 @@ export interface AccountDetail extends AccountCostRow {
   /** One point per calendar day across the window, oldest first, gaps filled with zero. */
   trend: AccountTrendPoint[];
 }
+
+// --- Presentation helpers for the /cost-per-customer tab (CTO-188, plan D2) ----------------------
+//
+// Pure functions, no I/O, so the honesty rules the page depends on are unit-testable rather than
+// buried in JSX. Every one of them exists to stop the tab printing a number it cannot stand behind.
+
+/**
+ * Spans an account needs in the window before a per-user figure is printed.
+ *
+ * Follows the `/compare` precedent ("needs ≥50 spans in 7d", and MIN_SPANS_FOR_LATENCY_ERROR in
+ * clickhouse.ts). Cost per user is a ratio of two small numbers on a quiet account: one expensive
+ * retry against a single user reads as an eye-watering per-seat cost, and a reader cannot tell that
+ * apart from a real one. Below the floor the cell is blank with the reason attached.
+ */
+export const MIN_SPANS_FOR_COST_PER_USER = 50;
+
+/** A value the tab either has, or does not have and can say why. `micro` and `reason` are exclusive. */
+export interface HonestMicro {
+  micro: MicroUSD | null;
+  reason: string | null;
+}
+
+/**
+ * Direct cost divided by distinct users, or a blank carrying its reason.
+ *
+ * Two separate blanks, deliberately not collapsed into one: too few spans to trust the ratio, and
+ * no users to divide by at all. Those are different facts about the account, and a reader chasing
+ * an empty cell wants the one that applies.
+ *
+ * `distinctUsers` is a HyperLogLog approximation (see {@link AccountCostRow}), which is fine as a
+ * divisor for one account's row and is why this figure is never summed into a headline.
+ */
+export function costPerUser(row: AccountCostRow): HonestMicro {
+  if (row.distinctUsers <= 0) {
+    return {
+      micro: null,
+      reason: "no distinct users recorded for this account, so there is nothing to divide by",
+    };
+  }
+  if (row.spanCount < MIN_SPANS_FOR_COST_PER_USER) {
+    return {
+      micro: null,
+      reason: `needs ≥${MIN_SPANS_FOR_COST_PER_USER} spans in the window; this account has ${row.spanCount.toLocaleString()}`,
+    };
+  }
+  return { micro: Math.round(row.directCostMicroUsd / row.distinctUsers), reason: null };
+}
+
+/** Leading hex characters shown when an account carries no label. */
+export const SHORT_HASH_CHARS = 12;
+
+/**
+ * The shortened hash shown in the Account column when no label exists.
+ *
+ * Truncated for width only. The full hash stays available on hover and through the copy control,
+ * because the short form is not an identifier: it is not what the lookup endpoint returns and it is
+ * not what a label write accepts.
+ */
+export function shortenAccountHash(accountIdHash: string): string {
+  if (accountIdHash.length <= SHORT_HASH_CHARS) return accountIdHash;
+  return `${accountIdHash.slice(0, SHORT_HASH_CHARS)}…`;
+}
+
+/**
+ * Share of direct spend carrying no account, as a fraction, or `null` when the tenant recorded no
+ * direct spend at all in the window.
+ *
+ * `null` rather than 0: with nothing to attribute, "0% unattributed" is a claim of perfect coverage
+ * and the exact opposite of what is true. This is the page's honesty valve, so it fails to a blank
+ * rather than to a flattering number.
+ */
+export function unattributedShare(costs: AccountCosts): number | null {
+  if (costs.totalDirectMicroUsd <= 0) return null;
+  return costs.unattributed.directCostMicroUsd / costs.totalDirectMicroUsd;
+}
+
+/** Decimal places the unattributed share is printed to. */
+export const SHARE_DIGITS = 1;
+
+/**
+ * The unattributed share as text, with the rounding boundaries called out.
+ *
+ * A share of 0.99999 rounds to "100.0%", and printing that beside a table of three real accounts is
+ * a small lie in both directions: it says nothing is attributed while something plainly is. The
+ * same trap sits at the other end, where a genuine sliver rounds to "0.0%" and reads as perfect
+ * coverage. So the two boundaries print as ">99.9%" and "<0.1%", and only an exact 1 or 0 gets the
+ * round number. This is the page's headline honesty figure; it is the last place to let a rounding
+ * rule overstate the answer.
+ */
+export function formatShare(share: number): string {
+  if (share >= 1) return "100.0%";
+  if (share <= 0) return "0.0%";
+  const rounded = (share * 100).toFixed(SHARE_DIGITS);
+  if (Number(rounded) >= 100) return ">99.9%";
+  if (Number(rounded) <= 0) return "<0.1%";
+  return `${rounded}%`;
+}
+
+/** Direct spend that IS attributed to an account: the total less the unattributed bucket. */
+export function attributedSpend(costs: AccountCosts): MicroUSD {
+  return costs.totalDirectMicroUsd - costs.unattributed.directCostMicroUsd;
+}


### PR DESCRIPTION
Implements **CTO-188 (D2)**, the `/cost-per-customer` page: direct spend grouped by the account each span was tagged with, on the shared `DataTable` and the honest-value primitives, with a search box wired to the gateway's account-lookup endpoint.

Based on `feat/cost-per-customer-integration`, which combines the dependencies: **#167 #168 #174** (DataTable, HonestValue, two migrated pages), **#170 #175 #180** (`AccountIdHash`, `POST /v1/tenant/account-lookup`, the account label store), **#172 #179** (`daily_account_rollup`, `queryAccountCosts` / `queryAccountDetail`).

## What is on the page

- **Headline**: attributed spend, account count, and the **share of spend with no account**. That last figure is the honesty valve. When it is the majority, a banner states the number outright and says the table below covers the remainder only.
- **Table** (sorted by cost, paginated): Account (label from B7 where set, shortened hash otherwise, full hash on hover and on copy), Users, Direct cost, Cost per user.
- **Search box** wired to B6: type a plaintext account id, and the matching row is shown on its own.

## Decisions worth a reviewer's attention

- **The search matches the whole `hashes` array, never `hashes[0]`.** The tenant identifier is HMAC key material, so `local-dev` and its UUID derive different key spaces and the endpoint deliberately refuses to canonicalize. Matching one spelling would report a real, spending customer as having no spend. There is a test for exactly that.
- **A found account filters the table to its row**, because "jump to the row" in a sorted, paginated, unbounded list means showing it alone. A search that matches nothing does **not** filter: an empty table reads as a broken page when the true statement is "no spend for this account in the window".
- **Cost per user is suppressed below 50 spans in the window**, following the `/compare` precedent. It is a ratio of two small numbers, and one expensive retry against a single user is indistinguishable from a real per-seat cost. The blank names the account's actual span count.
- **`formatShare` refuses to round `0.99999` up to a flat "100.0%".** Printed beside a table of three real accounts, that figure contradicts the table. The boundaries render as `>99.9%` and `<0.1%`, so only an exact 1 or 0 gets the round number. This is visible in the verification below.
- **The plaintext account id goes into one POST body and is dropped.** Never stored, logged, or echoed in an error, which is why the search runs through a server action rather than a client fetch.
- **No sample data, and no raw NUL comparison.** `lib/accounts.ts` ships no fixture on purpose; when ClickHouse is unreachable the page says so rather than inventing a customer list. The `FixedString(64)` NUL padding stays normalised in D1's SQL (`ACCOUNT_ID`); nothing here compares the hash to `''` by hand.

## Not in this PR

The excluded-cost banner (CTO-189), the account detail view (CTO-190), and the onboarding empty state (CTO-191) stack on this one. The table's `empty` prop carries a plain one-liner with a comment marking the seam for CTO-191.

## Verification

From `web/` on this branch:

- `npm run typecheck` — clean.
- `npm run lint` — clean; the only warnings are the pre-existing ones in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`.
- `npm run test` — **297 passing, 2 failing**, and both failures are the known pre-existing `app/api/api.test.ts` ones that appear when ClickHouse runs locally (`/api/data-quality` attribution rate, `/api/attribution` mock fallback). Baseline before this PR was 293 passing / the same 2 failing. **No new failures.** This PR adds 16 tests (`lib/accounts.test.ts`, `app/cost-per-customer/AccountTable.test.tsx`).

**In the browser.** Dev server from this worktree on a spare port (`:3311`), pointed at a gateway built from this branch on `:8081` so the B6/B7 endpoints are the ones under test — the shared Docker gateway image predates them. Live `local-dev` data, which is what the ticket describes: overwhelmingly unattributed, with three tagged accounts, one of which I gave a label through `POST /v1/tenant/account-labels` to exercise the join.

The rendered page (screenshot taken during verification; text capture of the same render):

```
Cost per customer                                   Direct spend, last 30 days

Directly attributable spend (LLM, tools, vector, embeddings) grouped by the
account each span was tagged with. Compute and egress are excluded: no span
carries an account for them, so splitting them per customer would mean
inventing an allocation rule.

ATTRIBUTED SPEND     ACCOUNTS      SPEND WITH NO ACCOUNT
$4.00                3             >99.9%

[MOSTLY UNATTRIBUTED]  >99.9% of direct spend ($48,712.15 of $48,716.15)
                       carries no account id.
  The accounts below cover the remaining spend only. Ranking them as though
  they were the whole picture would misstate what each customer costs, so
  read them as a partial view until more spans carry an account id.

ACCOUNTS BY DIRECT COST
FIND ACCOUNT [                                              ] [Search]
  The id is hashed with this tenant's own key to find its row. It is never
  stored, logged, or shown back to you, which is also why there is no way to
  search the other direction.

ACCOUNT                          USERS   DIRECT COST↓   COST PER USER
Acme Corp            [Copy hash]     1         $2.50               —
   (hover: needs ≥50 spans in the window; this account has 1)
c861664f5a0b… unlabelled [Copy hash] 1         $1.50               —
   (hover: needs ≥50 spans in the window; this account has 1)
cccccccccccc… unlabelled [Copy hash] 1       $0.0001               —
   (hover: needs ≥50 spans in the window; this account has 2)
```

Checks made against that render:

- The label join works (`Acme Corp` on the labelled hash, shortened hash plus an `unlabelled` marker on the others), and the full hash is on the cell's `title` and on the copy control.
- `>99.9%` rather than `100.0%`, with three accounts in the table below it. This is the rounding rule doing its job.
- Every blank is a `<Blank reason>` with a real reason, carried to assistive tech as well as the tooltip.
- **Search, end to end against the live B6 endpoint**: searching `acme-corp` hits `POST /v1/tenant/account-lookup`, which returns two candidate hashes (`tenant_key_form: name` and `tenant_key_form: uuid`). Neither has spend in the window, so the page says *"That account id hashes to a valid account, but it has no directly attributable spend in the last 30 days"* and leaves the table intact. Clear restores the full list. The positive-match path (including the match-on-the-second-key-form case) is covered by `AccountTable.test.tsx`, since no plaintext id maps to the hand-inserted hashes currently in the local rollup.
- No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
