### PR TITLE
feat(cost-per-customer): size the compute and egress the table excludes (CTO-189)

### DIFF
--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -14,6 +14,10 @@
 //    share before the table, every time, including when it is 100 percent, which is exactly what a
 //    tenant that has not instrumented `account_id` yet will see.
 //
+// 3. WHAT IS MISSING IS SIZED, NOT WAVED AT. The table is direct cost only, and compute and egress
+//    are roughly half of spend on current data. ExcludedCostBanner (CTO-189) queries that total
+//    live per tenant so the page names the money it omits instead of a generic caveat.
+//
 // Reads the query directly rather than through /api, matching how the page-level gateway reads on
 // /connectors work: there is no client-side refetch here and no second consumer of the payload, so
 // a route handler would only add a hop.
@@ -22,12 +26,14 @@ import { Card } from "@/components/Card";
 import { Blank, Money } from "@/components/HonestValue";
 import {
   attributedSpend,
+  excludedShare,
   formatShare,
   unattributedShare,
   type AccountCosts,
+  type ExcludedInfraCost,
 } from "@/lib/accounts";
 import { queryAccountLabels } from "@/lib/accountLabels";
-import { queryAccountCosts } from "@/lib/clickhouse";
+import { queryAccountCosts, queryExcludedInfraCost } from "@/lib/clickhouse";
 import { AccountTable } from "./AccountTable";
 
 export const dynamic = "force-dynamic";
@@ -36,7 +42,11 @@ export const dynamic = "force-dynamic";
 const MAJORITY_UNATTRIBUTED = 0.5;
 
 export default async function CostPerCustomerPage() {
-  const [costs, labels] = await Promise.all([queryAccountCosts(), queryAccountLabels()]);
+  const [costs, labels, excluded] = await Promise.all([
+    queryAccountCosts(),
+    queryAccountLabels(),
+    queryExcludedInfraCost(),
+  ]);
 
   return (
     <div className="space-y-6">
@@ -51,11 +61,15 @@ export default async function CostPerCustomerPage() {
 
       <p className="max-w-prose text-sm text-muted">
         Directly attributable spend (LLM, tools, vector, embeddings) grouped by the account each span
-        was tagged with. Compute and egress are excluded: no span carries an account for them, so
-        splitting them per customer would mean inventing an allocation rule.
+        was tagged with. Compute and egress are excluded, because no span carries an account for
+        them.
       </p>
 
-      {costs === null ? <Unreachable /> : <Report costs={costs} labels={labels} />}
+      {costs === null ? (
+        <Unreachable />
+      ) : (
+        <Report costs={costs} labels={labels} excluded={excluded} />
+      )}
     </div>
   );
 }
@@ -63,9 +77,11 @@ export default async function CostPerCustomerPage() {
 function Report({
   costs,
   labels,
+  excluded,
 }: {
   costs: AccountCosts;
   labels: Map<string, string> | null;
+  excluded: ExcludedInfraCost | null;
 }) {
   const share = unattributedShare(costs);
   const attributed = attributedSpend(costs);
@@ -95,6 +111,8 @@ function Report({
       {share !== null && share >= MAJORITY_UNATTRIBUTED ? (
         <UnattributedNotice costs={costs} share={share} />
       ) : null}
+
+      <ExcludedCostBanner costs={costs} excluded={excluded} />
 
       <Card title="Accounts by direct cost">
         <AccountTable
@@ -140,6 +158,78 @@ function UnattributedNotice({ costs, share }: { costs: AccountCosts; share: numb
         {complete
           ? `Nothing in the last ${costs.windowDays} days is tagged with an account, so there is no per-customer breakdown to rank yet. This is what the page looks like before an account id is emitted, not an error.`
           : `The accounts below cover the remaining spend only. Ranking them as though they were the whole picture would misstate what each customer costs, so read them as a partial view until more spans carry an account id.`}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * What the table leaves out, sized (CTO-189, plan D3).
+ *
+ * REMOVE THIS WHEN CTO-193 LANDS. Workstream C replaces the whole banner with direct/allocated/
+ * total columns on the table itself: once compute and egress can be allocated per account there is
+ * nothing left excluded to warn about, and a stale banner beside allocated columns would be worse
+ * than no banner at all.
+ *
+ * Why it is not a static caveat. The table shows direct cost only, and on current data compute and
+ * egress are roughly 47 percent of spend, so every row understates true cost by about half. A
+ * reader who is told "some costs are excluded" cannot tell that apart from a rounding footnote;
+ * they need the size. So the figure is queried live per tenant over the same window as the table.
+ *
+ * Three states, and each says something different:
+ *   - a real excluded total: name it, in money and as a share of all spend
+ *   - exactly zero: say nothing, because "excludes $0.00 (0%)" is noise that trains readers to
+ *     ignore the banner on the tenants where it matters
+ *   - unreadable: say that, because silence would read as the zero case, which is the most
+ *     flattering possible reading of a failed query
+ */
+function ExcludedCostBanner({
+  costs,
+  excluded,
+}: {
+  costs: AccountCosts;
+  excluded: ExcludedInfraCost | null;
+}) {
+  if (excluded === null) {
+    return (
+      <div className="rounded-xl border border-edge bg-panel p-4 text-sm text-muted">
+        <p className="max-w-prose">
+          Compute and egress are excluded from every figure on this page, and their total could not
+          be read, so how much this table leaves out is unknown:{" "}
+          <Blank reason="the compute and egress total could not be read from the telemetry store, so the excluded share is unknown" />
+          . Treat the accounts below as a floor on true cost, not a total.
+        </p>
+      </div>
+    );
+  }
+
+  // Nothing excluded is a real answer, and it needs no banner: this tenant's direct cost IS its
+  // cost. Saying "excludes $0.00 (0%)" would be technically true and pure noise.
+  if (excluded.totalMicroUsd <= 0) return null;
+
+  const share = excludedShare(excluded, costs);
+  if (share === null) return null; // Unreachable: a positive excluded total makes the denominator positive.
+
+  return (
+    <div className="rounded-xl border border-warn/40 bg-warn/5 p-4">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="rounded bg-warn/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-warn">
+          Excluded
+        </span>
+        <span className="text-sm">
+          Excludes <span className="font-semibold">
+            <Money micro={excluded.totalMicroUsd} />
+          </span>{" "}
+          (<span className="font-semibold">{formatShare(share)}</span>) of compute and egress that
+          cannot yet be attributed per account.
+        </span>
+      </div>
+      <p className="mt-2 max-w-prose text-sm text-muted">
+        Compute (<Money micro={excluded.computeMicroUsd} />) and egress (
+        <Money micro={excluded.egressMicroUsd} />) arrive from the cloud billing connectors as
+        tenant-level daily totals over the same {excluded.windowDays} days, with no account on them.
+        Splitting them per customer needs an allocation rule that does not exist yet, so every
+        account figure below is a floor on what that customer actually costs, not a total.
       </p>
     </div>
   );

--- a/web/lib/accounts.test.ts
+++ b/web/lib/accounts.test.ts
@@ -6,9 +6,11 @@ import {
   SHORT_HASH_CHARS,
   type AccountCostRow,
   type AccountCosts,
+  type ExcludedInfraCost,
   attributedSpend,
   costPerUser,
   emptyAccountRow,
+  excludedShare,
   formatShare,
   shortenAccountHash,
   unattributedShare,
@@ -127,5 +129,60 @@ describe("attributedSpend", () => {
     });
     expect(attributedSpend(c)).toBe(500_000);
     expect(attributedSpend(c)).toBe(accounts.reduce((s, a) => s + a.directCostMicroUsd, 0));
+  });
+});
+
+describe("excludedShare (CTO-189)", () => {
+  function excluded(over: Partial<ExcludedInfraCost> = {}): ExcludedInfraCost {
+    const compute = over.computeMicroUsd ?? 0;
+    const egress = over.egressMicroUsd ?? 0;
+    return {
+      windowDays: 30,
+      computeMicroUsd: compute,
+      egressMicroUsd: egress,
+      totalMicroUsd: compute + egress,
+      ...over,
+    };
+  }
+
+  it("is excluded over ALL spend, so it reads as a share of the whole bill", () => {
+    // The plan's worked example: direct 53, excluded 47, banner says 47 percent.
+    const share = excludedShare(
+      excluded({ computeMicroUsd: 40_000_000, egressMicroUsd: 7_000_000 }),
+      costs({ totalDirectMicroUsd: 53_000_000 }),
+    );
+    expect(share).toBeCloseTo(0.47);
+  });
+
+  it("never exceeds 100 percent when infrastructure outweighs the model bill", () => {
+    // Dividing by direct spend alone would print 400%. The denominator is the total for a reason.
+    const share = excludedShare(
+      excluded({ computeMicroUsd: 4_000_000 }),
+      costs({ totalDirectMicroUsd: 1_000_000 }),
+    );
+    expect(share).toBeCloseTo(0.8);
+    expect(share!).toBeLessThanOrEqual(1);
+  });
+
+  it("is the whole bill when a tenant's only spend is compute and egress", () => {
+    const share = excludedShare(
+      excluded({ computeMicroUsd: 2_000_000 }),
+      costs({ totalDirectMicroUsd: 0 }),
+    );
+    expect(share).toBe(1);
+  });
+
+  it("is null when the window holds no spend at all, never a flattering zero", () => {
+    expect(excludedShare(excluded(), costs({ totalDirectMicroUsd: 0 }))).toBeNull();
+  });
+
+  it("hands formatShare a value it will not round to a flat 100%", () => {
+    // A sliver of direct spend against a mountain of compute. "100.0%" would say the table below
+    // covers nothing, while it plainly covers something. Same trap D2 hit on the unattributed share.
+    const share = excludedShare(
+      excluded({ computeMicroUsd: 100_000_000 }),
+      costs({ totalDirectMicroUsd: 100 }),
+    );
+    expect(formatShare(share!)).toBe(">99.9%");
   });
 });

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -201,3 +201,42 @@ export function formatShare(share: number): string {
 export function attributedSpend(costs: AccountCosts): MicroUSD {
   return costs.totalDirectMicroUsd - costs.unattributed.directCostMicroUsd;
 }
+
+// --- Excluded infrastructure cost (CTO-189, plan D3) ---------------------------------------------
+
+/**
+ * Compute and egress over the same window the per-account table covers.
+ *
+ * These are the two layers {@link DIRECT_LAYERS} deliberately leaves out. They arrive from the
+ * cloud billing connectors as tenant-level daily totals that carry no account, so the tab cannot
+ * split them per customer without an allocation rule, and that rule is workstream C (CTO-192/193).
+ * Carrying the figure here is what lets the page state the SIZE of what it omits rather than a
+ * vague "some costs are excluded": on current data the omission is roughly half of all spend, and
+ * an account figure that quietly understates true cost by half is the exact failure this product
+ * exists to fix.
+ */
+export interface ExcludedInfraCost {
+  /** Calendar days covered. Must match {@link AccountCosts.windowDays} or the share is meaningless. */
+  windowDays: number;
+  computeMicroUsd: MicroUSD;
+  egressMicroUsd: MicroUSD;
+  /** `compute + egress`, summed from the same rounded parts so it cannot contradict them. */
+  totalMicroUsd: MicroUSD;
+}
+
+/**
+ * Excluded spend as a share of ALL spend in the window, or `null` when there is nothing to divide.
+ *
+ * The denominator is direct plus excluded, i.e. the tenant's whole bill for the window, because the
+ * sentence this feeds ("excludes $X, N% of spend") is only meaningful against the total. Dividing
+ * by direct spend alone would print a share above 100 percent the moment infrastructure outweighs
+ * the model bill, which on a compute-heavy tenant it does.
+ *
+ * Both inputs are read over the same window from the same rollup under complementary filters, so
+ * they add to the tenant total exactly and this share reconciles with /cost.
+ */
+export function excludedShare(excluded: ExcludedInfraCost, costs: AccountCosts): number | null {
+  const all = costs.totalDirectMicroUsd + excluded.totalMicroUsd;
+  if (all <= 0) return null;
+  return excluded.totalMicroUsd / all;
+}

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -407,6 +407,70 @@ describe("queryAccountCosts — SQL contract (CTO-187)", () => {
   });
 });
 
+describe("queryExcludedInfraCost: what the per-account table leaves out (CTO-189)", () => {
+  async function sqlOf(): Promise<string> {
+    const { queryExcludedInfraCost } = await freshSut();
+    respondRows([]);
+    await queryExcludedInfraCost();
+    return (queryMock.mock.calls[0][0] as { query: string }).query;
+  }
+
+  it("sums compute and egress separately and totals them", async () => {
+    const { queryExcludedInfraCost } = await freshSut();
+    respondRows([
+      { layer: "compute", cost: "40.5" },
+      { layer: "egress", cost: "6.5" },
+    ]);
+    const out = await queryExcludedInfraCost();
+    expect(out).toEqual({
+      windowDays: 30,
+      computeMicroUsd: 40_500_000,
+      egressMicroUsd: 6_500_000,
+      totalMicroUsd: 47_000_000,
+    });
+  });
+
+  it("reports a real zero when the tenant has no infrastructure spend", async () => {
+    const { queryExcludedInfraCost } = await freshSut();
+    respondRows([]);
+    const out = await queryExcludedInfraCost();
+    expect(out!.totalMicroUsd).toBe(0);
+  });
+
+  it("returns null when ClickHouse is unreachable, so the page cannot read failure as zero", async () => {
+    const { queryExcludedInfraCost } = await freshSut();
+    queryMock.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+    expect(await queryExcludedInfraCost()).toBeNull();
+  });
+
+  it("ignores a direct layer that somehow reaches it rather than folding it into the excluded total", async () => {
+    // Belt and braces against the SQL filter regressing: an llm row here would otherwise inflate
+    // the banner and understate the coverage of the table beneath it.
+    const { queryExcludedInfraCost } = await freshSut();
+    respondRows([
+      { layer: "llm", cost: "100.0" },
+      { layer: "compute", cost: "1.0" },
+    ]);
+    const out = await queryExcludedInfraCost();
+    expect(out!.totalMicroUsd).toBe(1_000_000);
+  });
+
+  it("reads exactly the complement of the direct-cost filter, so the two sum to the tenant total", async () => {
+    expect(await sqlOf()).toContain("NOT (GenAiOperation NOT IN ('compute', 'egress'))");
+  });
+
+  it("uses the same rollup and the same calendar-aligned window as the table", async () => {
+    const q = await sqlOf();
+    expect(q).toContain("FROM daily_account_rollup");
+    expect(q).toContain("Day >= toDate(now()) - INTERVAL 29 DAY");
+    expect(q).not.toContain("otel_spans");
+  });
+
+  it("is scoped to one tenant", async () => {
+    expect(await sqlOf()).toContain("TenantId = {tenant:String}");
+  });
+});
+
 describe("queryAccountDetail (CTO-187)", () => {
   const WINDOW_START = "2026-07-28";
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -32,6 +32,7 @@ import type {
   AccountTrendPoint,
   DirectLayer,
   DirectSpendByLayer,
+  ExcludedInfraCost,
 } from "./accounts";
 import {
   DIRECT_LAYERS,
@@ -427,6 +428,48 @@ export async function queryAccountCosts(): Promise<AccountCosts | null> {
       // reconcile with /cost's direct spend for the same window.
       totalDirectMicroUsd:
         accounts.reduce((s, a) => s + a.directCostMicroUsd, 0) + unattributed.directCostMicroUsd,
+    };
+  });
+}
+
+/**
+ * Compute and egress for the window, the exact complement of what {@link queryAccountCosts} counts.
+ *
+ * This is the other half of the tenant's bill, and the per-customer tab cannot attribute it: these
+ * rows land from the cloud billing connectors as tenant-level daily totals with no account on them.
+ * The page states the figure so a reader knows how much of their spend the table below leaves out
+ * (CTO-189). Read from the same rollup, over the same window, under the negation of DIRECT_ONLY,
+ * so direct plus excluded is the tenant total for the window with nothing double counted and
+ * nothing dropped.
+ *
+ * Returns `null` (via tryLive) when ClickHouse is unreachable; the caller must not read that as
+ * zero excluded cost, which would be the most flattering possible reading of a failed query.
+ */
+export async function queryExcludedInfraCost(): Promise<ExcludedInfraCost | null> {
+  return tryLive(async (db, tenant) => {
+    // Grouped by layer rather than summed flat so the two figures stay separable: compute and
+    // egress have very different fixes, and a later drill-down needs them apart. LAYER_CASE is
+    // reused rather than reading GenAiOperation directly so the operation-to-layer mapping keeps
+    // living in exactly one place.
+    const out = await rows<{ layer: string; cost: string }>(
+      db,
+      `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
+       FROM daily_account_rollup
+       WHERE TenantId = {tenant:String} AND ${ACCOUNT_WINDOW} AND NOT (${DIRECT_ONLY})
+       GROUP BY layer`,
+      tenant,
+    );
+    let computeMicroUsd = 0;
+    let egressMicroUsd = 0;
+    for (const r of out) {
+      if (r.layer === "compute") computeMicroUsd = micro(r.cost);
+      else if (r.layer === "egress") egressMicroUsd = micro(r.cost);
+    }
+    return {
+      windowDays: ACCOUNT_WINDOW_DAYS,
+      computeMicroUsd,
+      egressMicroUsd,
+      totalMicroUsd: computeMicroUsd + egressMicroUsd,
     };
   });
 }


### PR DESCRIPTION
CTO-189 (D3). **Stacked on #184** (CTO-188, the `/cost-per-customer` page). Base is `feat/cost-per-customer-page`; review that one first, and this diff is the 5 files on top of it.

## Why

The tab reports **direct cost only** (LLM, tools, vector, embeddings). Compute and egress arrive from the cloud billing connectors as tenant-level daily totals with no account on them, so they cannot be split per customer without an allocation rule, and that rule is deliberately deferred to workstream C (CTO-192/193).

On the local tenant that leaves out **46.3% of all spend**, so every account figure understates true cost by close to half. The page previously carried a one-line "compute and egress are excluded" caveat, which a reader cannot tell apart from a rounding footnote. Shipping a per-customer cost table that quietly omits half the bill is precisely the failure this product exists to fix, so the page now states the **size** of what it leaves out, computed live per tenant rather than hardcoded.

## Live figures on the local tenant

Read straight from `daily_account_rollup`, 29 day calendar-aligned window:

| | |
|---|---|
| direct (llm/tools/vector/embeddings) | $48,716.15 |
| compute | $41,883.58 |
| egress | $179.33 |
| **excluded total** | **$42,062.92** |
| all spend | $90,779.07 |
| **excluded share** | **46.3%** |

Which renders as:

> **EXCLUDED**  Excludes **$42,062.92 (46.3%)** of compute and egress that cannot yet be attributed per account.
>
> Compute ($41,883.58) and egress ($179.33) arrive from the cloud billing connectors as tenant-level daily totals over the same 30 days, with no account on them. Splitting them per customer needs an allocation rule that does not exist yet, so every account figure below is a floor on what that customer actually costs, not a total.

Verified in a browser against a live ClickHouse (worktree dev server on a spare port, since the shared `web` launch config serves the main checkout). Screenshot of the rendered page taken in-session; the banner sits directly below the existing "mostly unattributed" notice and above the accounts table, so the unattributed share still leads the page. `/v1/tenant/account-labels` 404s against the shared gateway image, which is why the table shows hashes; unrelated to this change.

## How

**`queryExcludedInfraCost`** (`web/lib/clickhouse.ts`) reads the same rollup, over the same window, under the **exact negation** of the direct-cost filter (`NOT (GenAiOperation NOT IN ('compute', 'egress'))`). Direct plus excluded is therefore the tenant total for the window with nothing double counted and nothing dropped, and the share reconciles with `/cost`. It groups by `LAYER_CASE` rather than reading `GenAiOperation` directly so the operation-to-layer mapping keeps living in one place, and keeps compute and egress separable rather than summing them flat.

**`excludedShare`** (`web/lib/accounts.ts`) divides by direct **plus** excluded, i.e. the whole bill. Dividing by direct spend alone would print a share above 100% the moment infrastructure outweighs the model bill, which on a compute-heavy tenant it does. It returns `null` when there is no spend at all rather than a flattering zero.

### The rounding trap D2 already hit

The share goes through `formatShare` from D2, not a naive `toFixed`. A sliver of direct spend against a mountain of compute reads `>99.9%` rather than a flat `100.0%` that would claim the table below covers nothing while it plainly covers something. There is a test for exactly that case.

### Three states, each saying something different

- **A real excluded total:** name it, in money and as a share of all spend.
- **Exactly zero:** render nothing. "Excludes $0.00 (0%)" is noise that trains readers to ignore the banner on the tenants where it matters.
- **Unreadable** (`queryExcludedInfraCost` returned `null`): say so, with `<Blank reason>` carrying why. Silence would read as the zero case, which is the most flattering possible reading of a failed query.

## Removal

The banner is replaced by direct/allocated/total columns when workstream C lands. The component carries a comment naming **CTO-193** so whoever does that knows this is the thing to delete; a stale banner beside allocated columns would be worse than no banner.

## Verification

From `web/`:

- `npm run typecheck` clean.
- `npm run lint` clean; the only warnings are the pre-existing ones in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`.
- `npm run test`: 309 passed, the 2 pre-existing `app/api/api.test.ts` failures that show up when ClickHouse runs locally, **no new ones**. 11 new tests: 5 on `excludedShare` (denominator, >100% guard, all-infra tenant, null, the `formatShare` boundary) and 6 on `queryExcludedInfraCost` (layer split, real zero, null on unreachable, ignoring a direct layer, and the SQL contract: complement filter, same rollup, same window, tenant scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
