### PR TITLE
feat(web): account detail view (CTO-190)

### DIFF
--- a/web/app/cost-per-customer/AccountIdentity.tsx
+++ b/web/app/cost-per-customer/AccountIdentity.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// How an account names itself, on the table and on the detail view (CTO-188 D2, CTO-190 D4).
+//
+// Extracted from AccountTable when the detail view landed, because "label where one exists, short
+// hash otherwise, full hash on hover and on copy" is a rule the two surfaces have to agree on
+// exactly. A reader who clicks "Acme Corp" must land on a page headed "Acme Corp", and a reader who
+// clicks a shortened hash must land on the same shortened hash; two copies of that rule would drift
+// the first time one of them was tweaked.
+//
+// Client module for the copy control: the clipboard is a browser API.
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { accountDisplayName } from "@/lib/accounts";
+
+/** Where an account's detail view lives. One function so the table and the page cannot disagree. */
+export function accountHref(accountIdHash: string): string {
+  return `/cost-per-customer/${encodeURIComponent(accountIdHash)}`;
+}
+
+/**
+ * Copies the FULL hash, never the shortened form.
+ *
+ * The short form is a display convenience and nothing else: it is not what the label API accepts,
+ * not what the lookup endpoint returns, and not what anyone can paste into a support conversation.
+ * Copying what is on screen rather than what identifies the account would hand people a string that
+ * silently fails everywhere they try to use it.
+ */
+export function CopyHashButton({
+  accountIdHash,
+  className = "",
+}: {
+  accountIdHash: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(accountIdHash);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can be refused (insecure origin, denied permission). The hash is already
+      // selectable in the title attribute, so there is nothing to recover and nothing to shout at
+      // the user about.
+      setCopied(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      title={`Copy the full account hash: ${accountIdHash}`}
+      className={`rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-white ${className}`.trim()}
+    >
+      {copied ? "Copied" : "Copy hash"}
+    </button>
+  );
+}
+
+/**
+ * The Account cell: label where the tenant set one, shortened hash otherwise, full hash on hover
+ * and on copy, linking through to the account's detail view.
+ *
+ * The full hash is what every other surface takes (the label API, a support conversation), so it
+ * has to be retrievable from the row. The short form is for width only.
+ */
+export function AccountCell({
+  accountIdHash,
+  label,
+  labelsUnavailable,
+}: {
+  accountIdHash: string;
+  label: string | undefined;
+  labelsUnavailable: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Link
+        href={accountHref(accountIdHash)}
+        title={accountIdHash}
+        className={`text-accent hover:underline ${label ? "font-medium" : "font-mono text-xs"}`}
+      >
+        {accountDisplayName(accountIdHash, label)}
+      </Link>
+      {!label && !labelsUnavailable ? (
+        <span className="text-[11px] text-muted" title="no label set for this account">
+          unlabelled
+        </span>
+      ) : null}
+      <CopyHashButton accountIdHash={accountIdHash} />
+    </span>
+  );
+}

--- a/web/app/cost-per-customer/AccountTable.test.tsx
+++ b/web/app/cost-per-customer/AccountTable.test.tsx
@@ -44,6 +44,18 @@ describe("AccountTable", () => {
     expect(screen.getByText(`${UNLABELLED.slice(0, 12)}…`)).toBeTruthy();
   });
 
+  it("links each account to its detail view by the FULL hash, never the shortened form", () => {
+    // The short form is a truncation for width and is not an id: a route built from it reaches no
+    // account at all, so a link carrying it would 'work' visually and dead-end for every reader.
+    renderTable([row(LABELLED), row(UNLABELLED)], { [LABELLED]: "Acme Corp" });
+    expect(screen.getByText("Acme Corp").closest("a")?.getAttribute("href")).toBe(
+      `/cost-per-customer/${LABELLED}`,
+    );
+    expect(
+      screen.getByText(`${UNLABELLED.slice(0, 12)}…`).closest("a")?.getAttribute("href"),
+    ).toBe(`/cost-per-customer/${UNLABELLED}`);
+  });
+
   it("keeps the full hash reachable on hover and on copy", () => {
     renderTable([row(UNLABELLED)]);
     expect(screen.getByTitle(UNLABELLED)).toBeTruthy();

--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -11,11 +11,8 @@ import { useMemo, useState, useTransition } from "react";
 
 import { DataTable, type Column } from "@/components/DataTable";
 import { Blank, Money } from "@/components/HonestValue";
-import {
-  type AccountCostRow,
-  costPerUser,
-  shortenAccountHash,
-} from "@/lib/accounts";
+import { type AccountCostRow, costPerUser } from "@/lib/accounts";
+import { AccountCell } from "./AccountIdentity";
 import { lookupAccountAction } from "./actions";
 
 interface SearchState {
@@ -215,58 +212,5 @@ export function AccountTable({
         empty={`No spans carried an account id in the last ${windowDays} days.`}
       />
     </div>
-  );
-}
-
-/**
- * The Account cell: label where the tenant set one, shortened hash otherwise, full hash on hover
- * and on copy.
- *
- * The full hash is what every other surface takes (the label API, a support conversation), so it
- * has to be retrievable from the row. The short form is for width only.
- */
-function AccountCell({
-  accountIdHash,
-  label,
-  labelsUnavailable,
-}: {
-  accountIdHash: string;
-  label: string | undefined;
-  labelsUnavailable: boolean;
-}) {
-  const [copied, setCopied] = useState(false);
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(accountIdHash);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard access can be refused (insecure origin, denied permission). The hash is already
-      // selectable in the title attribute, so there is nothing to recover and nothing to shout at
-      // the user about.
-      setCopied(false);
-    }
-  };
-
-  return (
-    <span className="inline-flex items-center gap-2">
-      <span title={accountIdHash} className={label ? "font-medium" : "font-mono text-xs"}>
-        {label ?? shortenAccountHash(accountIdHash)}
-      </span>
-      {!label && !labelsUnavailable ? (
-        <span className="text-[11px] text-muted" title="no label set for this account">
-          unlabelled
-        </span>
-      ) : null}
-      <button
-        type="button"
-        onClick={copy}
-        title={`Copy the full account hash: ${accountIdHash}`}
-        className="rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-white"
-      >
-        {copied ? "Copied" : "Copy hash"}
-      </button>
-    </span>
   );
 }

--- a/web/app/cost-per-customer/[account]/DetailTables.test.tsx
+++ b/web/app/cost-per-customer/[account]/DetailTables.test.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BLANK } from "@/components/HonestValue";
+import type { AccountFeatureCost, AccountRunCost } from "@/lib/accounts";
+import { FeatureTable, RunTable } from "./DetailTables";
+
+function feature(over: Partial<AccountFeatureCost> = {}): AccountFeatureCost {
+  return { feature: "research_agent", directCostMicroUsd: 750_000, spanCount: 80, ...over };
+}
+
+function run(over: Partial<AccountRunCost> = {}): AccountRunCost {
+  return {
+    runId: "trace-1",
+    agent: "aider",
+    accountCostMicroUsd: 8_000_000,
+    steps: 40,
+    outcome: "success",
+    ...over,
+  };
+}
+
+describe("FeatureTable", () => {
+  it("takes the share against the account's own spend, not the tenant's", () => {
+    render(
+      <FeatureTable
+        features={[feature({ directCostMicroUsd: 750_000 })]}
+        accountDirectMicroUsd={1_000_000}
+      />,
+    );
+    expect(screen.getByText("75.0%")).toBeTruthy();
+  });
+
+  it("blanks the share when the account has no direct spend, rather than printing 0%", () => {
+    // A share of a total that does not exist is not zero, it is unanswerable. `/compare` precedent.
+    render(<FeatureTable features={[feature()]} accountDirectMicroUsd={0} />);
+    const blank = screen.getByText(BLANK);
+    expect(blank.closest("[title]")?.getAttribute("title")).toContain(
+      "no directly attributable spend",
+    );
+  });
+
+  it("says why the list is empty rather than showing a bare blank table", () => {
+    render(<FeatureTable features={[]} accountDirectMicroUsd={1_000_000} />);
+    expect(screen.getByText(/no spans for this account carried a feature tag/i)).toBeTruthy();
+  });
+});
+
+describe("RunTable", () => {
+  it("labels the cost column as this account's share and links to the whole run", () => {
+    render(<RunTable runs={[run()]} />);
+    // The header has to say the scope out loud: the linked page shows the WHOLE run, so a reader
+    // clicking through to a bigger number needs to know that is a different scope, not a bug.
+    expect(screen.getByText("Cost to this account")).toBeTruthy();
+    const link = screen.getByText("trace-1").closest("a");
+    expect(link?.getAttribute("href")).toBe("/agents/runs/trace-1");
+  });
+
+  it("shows the outcome inferred from the span status", () => {
+    render(<RunTable runs={[run(), run({ runId: "trace-2", outcome: "failed" })]} />);
+    expect(screen.getByText("success")).toBeTruthy();
+    expect(screen.getByText("failed")).toBeTruthy();
+  });
+
+  it("says no runs carried this account rather than implying the account is idle", () => {
+    render(<RunTable runs={[]} />);
+    expect(screen.getByText(/no agent runs in the window carried this account id/i)).toBeTruthy();
+  });
+});

--- a/web/app/cost-per-customer/[account]/DetailTables.tsx
+++ b/web/app/cost-per-customer/[account]/DetailTables.tsx
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// The two DataTables on the account detail view (CTO-190, plan D4).
+//
+// Client module for the same reason AccountTable is one: `DataTable` takes a column spec whose
+// `render` entries are functions, and functions cannot cross the server/client boundary. The page
+// itself is an async server component, so the specs are declared on this side of the line.
+
+import Link from "next/link";
+import { useMemo } from "react";
+
+import { DataTable, type Column } from "@/components/DataTable";
+import { Blank, Money, Pct } from "@/components/HonestValue";
+import type { AccountFeatureCost, AccountRunCost } from "@/lib/accounts";
+
+/**
+ * Top features by spend for this account.
+ *
+ * `share` is of the account's OWN direct spend, not the tenant's. The reader is asking "where does
+ * this customer's money go", and a share of the tenant total would answer a question nobody on this
+ * page is asking while looking exactly like the answer to the one they are.
+ */
+export function FeatureTable({
+  features,
+  accountDirectMicroUsd,
+}: {
+  features: readonly AccountFeatureCost[];
+  accountDirectMicroUsd: number;
+}) {
+  const columns = useMemo<Column<AccountFeatureCost>[]>(
+    () => [
+      {
+        key: "feature",
+        header: "Feature",
+        render: (r) => <span className="font-medium">{r.feature}</span>,
+        sortValue: (r) => r.feature,
+      },
+      {
+        key: "cost",
+        header: "Direct cost",
+        align: "right",
+        render: (r) => <Money micro={r.directCostMicroUsd} />,
+        sortValue: (r) => r.directCostMicroUsd,
+      },
+      {
+        key: "share",
+        header: "Share of account",
+        align: "right",
+        render: (r) =>
+          accountDirectMicroUsd > 0 ? (
+            <Pct value={r.directCostMicroUsd / accountDirectMicroUsd} />
+          ) : (
+            <Blank reason="this account has no directly attributable spend in the window, so there is no total to take a share of" />
+          ),
+        sortValue: (r) =>
+          accountDirectMicroUsd > 0 ? r.directCostMicroUsd / accountDirectMicroUsd : null,
+      },
+      {
+        key: "spans",
+        header: "Spans",
+        align: "right",
+        render: (r) => r.spanCount.toLocaleString(),
+        sortValue: (r) => r.spanCount,
+      },
+    ],
+    [accountDirectMicroUsd],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={features}
+      rowKey={(r) => r.feature}
+      pageSize={0}
+      initialSort={{ key: "cost", direction: "desc" }}
+      empty="No spans for this account carried a feature tag, so there is nothing to rank by feature."
+    />
+  );
+}
+
+/**
+ * Heaviest agent runs attributed to this account.
+ *
+ * The cost column is the account's share of each run, not the run's total: see AccountRunCost. The
+ * run id links to the existing /agents drill-down, which shows the WHOLE run, so the two figures
+ * will differ for a run that served more than one customer. The column header and the note under
+ * the table both say so, because a reader who clicks through and finds a bigger number has to be
+ * able to tell "different scope" from "one of these is wrong".
+ */
+export function RunTable({ runs }: { runs: readonly AccountRunCost[] }) {
+  const columns = useMemo<Column<AccountRunCost>[]>(
+    () => [
+      {
+        key: "run",
+        header: "Run",
+        render: (r) => (
+          <Link
+            href={`/agents/runs/${encodeURIComponent(r.runId)}`}
+            className="font-mono text-xs text-accent hover:underline"
+          >
+            {r.runId}
+          </Link>
+        ),
+        sortValue: (r) => r.runId,
+      },
+      {
+        key: "agent",
+        header: "Agent",
+        render: (r) => r.agent,
+        sortValue: (r) => r.agent,
+      },
+      {
+        key: "outcome",
+        header: "Outcome",
+        render: (r) => <OutcomeBadge outcome={r.outcome} />,
+        sortValue: (r) => r.outcome,
+      },
+      {
+        key: "steps",
+        header: "Steps",
+        align: "right",
+        render: (r) => r.steps.toLocaleString(),
+        sortValue: (r) => r.steps,
+      },
+      {
+        key: "cost",
+        header: "Cost to this account",
+        align: "right",
+        render: (r) => <Money micro={r.accountCostMicroUsd} />,
+        sortValue: (r) => r.accountCostMicroUsd,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={runs}
+      rowKey={(r) => r.runId}
+      pageSize={0}
+      initialSort={{ key: "cost", direction: "desc" }}
+      empty="No agent runs in the window carried this account id."
+    />
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome: AccountRunCost["outcome"] }) {
+  const cls = outcome === "failed" ? "bg-bad/20 text-bad" : "bg-good/20 text-good";
+  return <span className={`rounded px-1.5 py-0.5 text-xs ${cls}`}>{outcome}</span>;
+}

--- a/web/app/cost-per-customer/[account]/TrendChart.tsx
+++ b/web/app/cost-per-customer/[account]/TrendChart.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Daily direct cost for one account (CTO-190, plan D4).
+//
+// A single-series bar chart rather than the stacked one from /cost. StackedBarChart takes a
+// CostSeries carrying all six layers plus a reconciled/estimated boundary, and neither applies
+// here: this account's spend is direct-only by construction (compute and egress carry no account),
+// and the rollup this reads has no reconciliation boundary in it. Feeding it a fabricated six-layer
+// series with two permanent zeroes and an invented boundary would draw a chart that says more than
+// we know. Same hand-rolled SVG house style, no chart library, deterministic output.
+
+import { type AccountTrendPoint, trendTotal } from "@/lib/accounts";
+import { LAYER_COLORS } from "@/lib/cost";
+import { formatUSD } from "@/lib/types";
+
+export function TrendChart({ trend }: { trend: readonly AccountTrendPoint[] }) {
+  const W = 720;
+  const H = 180;
+  const PAD_L = 8;
+  const PAD_R = 8;
+  const PAD_T = 12;
+  const PAD_B = 24;
+  const plotW = W - PAD_L - PAD_R;
+  const plotH = H - PAD_T - PAD_B;
+  const n = trend.length;
+
+  if (n === 0) {
+    return (
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="no trend data" className="w-full">
+        <text x={W / 2} y={H / 2} fontSize="12" fill="#8a93a6" textAnchor="middle">
+          no daily cost recorded for this account
+        </text>
+      </svg>
+    );
+  }
+
+  const step = plotW / n;
+  const barW = step * 0.7;
+  // A quiet account can be all zeroes across the window, which is a true and useful thing to see.
+  // The floor of 1 only keeps the height arithmetic from dividing by zero and emitting NaN into
+  // every <rect>; it never inflates a real bar, because every bar in that case is zero anyway.
+  const max = Math.max(1, ...trend.map((p) => p.directCostMicroUsd));
+  const total = trendTotal(trend);
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`daily direct cost for this account, ${n} days totalling ${formatUSD(total)}`}
+      className="w-full"
+    >
+      {trend.map((p, i) => {
+        const cx = PAD_L + i * step + step / 2;
+        const h = (p.directCostMicroUsd / max) * plotH;
+        return (
+          <g key={p.date}>
+            <rect
+              x={cx - barW / 2}
+              y={H - PAD_B - h}
+              width={barW}
+              // A day with real but tiny spend must not render as nothing: a sub-pixel bar is
+              // visually identical to a zero day, and those are different facts. Anything above
+              // zero gets at least one pixel.
+              height={p.directCostMicroUsd > 0 ? Math.max(1, h) : 0}
+              fill={LAYER_COLORS.llm}
+            >
+              <title>{`${p.date} · ${formatUSD(p.directCostMicroUsd)}`}</title>
+            </rect>
+            {i % 5 === 0 ? (
+              <text x={cx} y={H - 8} fontSize="9" fill="#8a93a6" textAnchor="middle">
+                {p.date.slice(5)}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/web/app/cost-per-customer/[account]/page.tsx
+++ b/web/app/cost-per-customer/[account]/page.tsx
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// One account (CTO-190, plan D4).
+//
+// Reached by clicking an account on /cost-per-customer. Four questions, in the order someone asks
+// them after seeing a row is expensive: what is the money made of (layer split), what is it being
+// spent on (top features), is it growing (30-day trend), and which individual runs are the heavy
+// ones (heaviest runs). The parent tab's posture carries over unchanged: this page only ever
+// reports DIRECT spend, and where it cannot stand behind a figure it prints an explained blank
+// rather than a plausible number.
+//
+// FOUR ENDINGS, kept apart on purpose. A valid hash with rows renders the report. A valid hash
+// with no rows says "no spend recorded for this account" and is not a 404: the lookup endpoint
+// (B6) hands out well-formed hashes for account ids nobody has ever emitted, so a typo and an idle
+// customer arrive here identically and "not found" would misdescribe both. A segment that is not a
+// hash at all is the only genuinely malformed case, and it says so. An unreachable store is the
+// fourth, and is never folded into the second: telling a reader "no spend recorded" while
+// ClickHouse is down is the page asserting something it cannot know.
+//
+// Reads the queries directly rather than through /api, matching the parent tab: no client-side
+// refetch, no second consumer of the payload, so a route handler would only add a hop.
+
+import Link from "next/link";
+
+import { Card } from "@/components/Card";
+import { Blank, Money, Pct } from "@/components/HonestValue";
+import {
+  DIRECT_LAYERS,
+  type AccountDetail,
+  type DirectLayer,
+  accountDisplayName,
+  costPerUser,
+  isAccountHash,
+  layerShare,
+  trendTotal,
+} from "@/lib/accounts";
+import { queryAccountLabels } from "@/lib/accountLabels";
+import { queryAccountDetailResult } from "@/lib/clickhouse";
+import { LAYERS, LAYER_LABEL, type Layer } from "@/lib/cost";
+import { CopyHashButton } from "../AccountIdentity";
+import { FeatureTable, RunTable } from "./DetailTables";
+import { TrendChart } from "./TrendChart";
+
+export const dynamic = "force-dynamic";
+
+/** Layers this page can never attribute to one account. Kept as the complement of DIRECT_LAYERS. */
+const EXCLUDED_LAYERS: readonly Layer[] = LAYERS.filter(
+  (l) => !(DIRECT_LAYERS as readonly string[]).includes(l),
+);
+
+export default async function AccountDetailPage({
+  params,
+}: {
+  params: Promise<{ account: string }>;
+}) {
+  const { account } = await params;
+  // The segment is user-editable, so its shape is checked before it reaches a query. This is a
+  // shape test only: a well-formed hash matching no rows is handled below as an ordinary answer.
+  const accountIdHash = decodeURIComponent(account);
+  if (!isAccountHash(accountIdHash)) {
+    return (
+      <Frame heading="Unknown account">
+        <Card title="Account">
+          <p className="max-w-prose text-sm text-muted">
+            That address is not an account id. An account is identified here by the 64-character hex
+            hash shown beside every row on the accounts table, which is also what its copy control
+            puts on your clipboard. Pick an account from the table rather than typing an address.
+          </p>
+        </Card>
+      </Frame>
+    );
+  }
+
+  const [result, labels] = await Promise.all([
+    queryAccountDetailResult(accountIdHash),
+    queryAccountLabels(),
+  ]);
+  const label = labels?.get(accountIdHash);
+  const heading = accountDisplayName(accountIdHash, label);
+
+  if (result.state === "unreachable") {
+    return (
+      <Frame heading={heading} accountIdHash={accountIdHash} labelled={label !== undefined}>
+        <Card title="Account">
+          <p className="max-w-prose text-sm text-muted">
+            The telemetry store could not be reached, so nothing about this account could be read.
+            This is deliberately not reported as &ldquo;no spend&rdquo;: an unreachable store and an
+            idle customer are different facts and only one of them is about the customer.
+          </p>
+          <div className="mt-3">
+            <Blank reason="the telemetry store is unreachable, so no cost could be read for this account" />
+          </div>
+        </Card>
+      </Frame>
+    );
+  }
+
+  if (result.state === "unknown") {
+    return (
+      <Frame heading={heading} accountIdHash={accountIdHash} labelled={label !== undefined}>
+        <Card title="Account">
+          <p className="max-w-prose text-sm text-muted">
+            No spend recorded for this account. The hash is well formed, and the account lookup
+            hands out a well-formed hash for any account id whether or not it has ever been emitted,
+            so this is what both a mistyped id and a customer with no activity in the window look
+            like. Nothing here says the account does not exist.
+          </p>
+        </Card>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame heading={heading} accountIdHash={accountIdHash} labelled={label !== undefined}>
+      <Report detail={result.detail} />
+    </Frame>
+  );
+}
+
+function Report({ detail }: { detail: AccountDetail }) {
+  const perUser = costPerUser(detail);
+  const windowDays = detail.trend.length;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-4">
+        <Stat label="Direct cost">
+          <Money micro={detail.directCostMicroUsd} />
+        </Stat>
+        <Stat label="Users">
+          {detail.distinctUsers > 0 ? (
+            detail.distinctUsers.toLocaleString()
+          ) : (
+            <Blank reason="no user id was recorded on this account's spans, so distinct users cannot be counted" />
+          )}
+        </Stat>
+        <Stat label="Spans">
+          <span className="tabular-nums">{detail.spanCount.toLocaleString()}</span>
+        </Stat>
+        <Stat label="Cost per user">
+          {perUser.micro === null ? (
+            <Blank reason={perUser.reason ?? "not enough data to divide cost by users"} />
+          ) : (
+            <Money micro={perUser.micro} />
+          )}
+        </Stat>
+      </div>
+
+      <p className="max-w-prose text-sm text-muted">
+        Directly attributable spend (LLM, tool calls, vector, embeddings) for this account over the
+        last {windowDays} days. Compute and egress are excluded throughout: no span carries an
+        account for them, so every figure on this page understates what the account truly costs.
+      </p>
+
+      <Card title="Cost by layer">
+        <LayerSplit detail={detail} />
+      </Card>
+
+      <Card title="Top features by spend">
+        <FeatureTable
+          features={detail.topFeatures}
+          accountDirectMicroUsd={detail.directCostMicroUsd}
+        />
+      </Card>
+
+      <Card title={`Daily direct cost, last ${windowDays} days`}>
+        <TrendChart trend={detail.trend} />
+        <TrendReconciliation detail={detail} />
+      </Card>
+
+      <Card title="Heaviest runs">
+        <RunTable runs={detail.topRuns} />
+        <p className="mt-3 max-w-prose text-xs text-muted">
+          Costed at this account&apos;s spans only. A run that served several customers carries a
+          larger total on its own page, which is the whole run rather than this account&apos;s share
+          of it; charging every account the full run would put the same money on several bills.
+        </p>
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * The six-layer split.
+ *
+ * Compute and egress appear, and they appear as explained blanks rather than as $0.00. Zero is a
+ * measurement and these are not measured: no span carries an account for infrastructure spend, so
+ * the true statement is "this cannot be attributed per account yet", and printing a zero beside
+ * four real numbers reads as "this customer used no compute", which is almost certainly false. The
+ * tenant-level figure they are missing from is the excluded-cost banner on the parent tab.
+ */
+function LayerSplit({ detail }: { detail: AccountDetail }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase text-muted">
+          <tr>
+            <th className="py-1 text-left font-medium">Layer</th>
+            <th className="py-1 text-right font-medium">Direct cost</th>
+            <th className="py-1 text-right font-medium">Share of account</th>
+          </tr>
+        </thead>
+        <tbody>
+          {LAYERS.map((layer) => {
+            const excluded = EXCLUDED_LAYERS.includes(layer);
+            const share = excluded ? null : layerShare(detail, layer as DirectLayer);
+            return (
+              <tr key={layer} className="border-t border-edge">
+                <td className={`py-2 ${excluded ? "text-muted" : "font-medium"}`}>
+                  {LAYER_LABEL[layer]}
+                </td>
+                <td className="py-2 text-right tabular-nums">
+                  {excluded ? (
+                    <Blank reason={`${LAYER_LABEL[layer]} spend carries no account id, so none of it can be attributed to this account. It is reported at tenant level on the accounts tab.`} />
+                  ) : (
+                    <Money micro={detail.byLayer[layer as DirectLayer]} />
+                  )}
+                </td>
+                <td className="py-2 text-right tabular-nums">
+                  {excluded ? (
+                    <Blank reason="excluded from per-account cost, so it has no share of this account's spend" />
+                  ) : share === null ? (
+                    <Blank reason="this account has no directly attributable spend in the window, so there is no total to take a share of" />
+                  ) : (
+                    <Pct value={share} />
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+          <tr className="border-t border-edge bg-ink/40 font-medium">
+            <td className="py-2">attributable total</td>
+            <td className="py-2 text-right tabular-nums">
+              <Money micro={detail.directCostMicroUsd} />
+            </td>
+            <td className="py-2 text-right tabular-nums">
+              {detail.directCostMicroUsd > 0 ? (
+                "100.0%"
+              ) : (
+                <Blank reason="no directly attributable spend recorded for this account in the window" />
+              )}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * States when the chart's own sum disagrees with the total printed above it.
+ *
+ * These two figures come from separate reads (a per-day group and a per-layer group), so they are
+ * two chances to disagree, and the way they historically disagreed was silent: a day list built
+ * from the Node clock instead of the window ClickHouse reported is shifted against the SQL window
+ * across a midnight boundary, and the oldest day falls out of the chart while still counting toward
+ * the total. Nothing on screen showed it. This says it out loud instead of leaving a reader to add
+ * up thirty bars by eye.
+ */
+function TrendReconciliation({ detail }: { detail: AccountDetail }) {
+  const charted = trendTotal(detail.trend);
+  if (charted === detail.directCostMicroUsd) return null;
+  return (
+    <p className="mt-2 max-w-prose text-xs text-warn">
+      The days above add up to <Money micro={charted} />, which is not the{" "}
+      <Money micro={detail.directCostMicroUsd} /> reported for this account. Read the chart as the
+      shape of the spend rather than as its total until that is resolved.
+    </p>
+  );
+}
+
+/** Breadcrumb, heading, and copy control. Shared by all four endings so they cannot look broken. */
+function Frame({
+  heading,
+  accountIdHash,
+  labelled = false,
+  children,
+}: {
+  heading: string;
+  accountIdHash?: string;
+  labelled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2 text-sm text-muted">
+        <Link href="/cost-per-customer" className="text-accent hover:underline">
+          Cost per customer
+        </Link>
+        <span>/</span>
+        <span>account</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <h1
+          className={`text-xl font-semibold ${labelled ? "" : "font-mono"}`}
+          title={accountIdHash}
+        >
+          {heading}
+        </h1>
+        {accountIdHash ? (
+          <>
+            {!labelled ? (
+              <span className="text-xs text-muted" title="no label set for this account">
+                unlabelled
+              </span>
+            ) : null}
+            <CopyHashButton accountIdHash={accountIdHash} />
+          </>
+        ) : null}
+      </div>
+
+      {children}
+    </div>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-edge bg-panel p-4">
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{children}</div>
+    </div>
+  );
+}

--- a/web/lib/accounts.test.ts
+++ b/web/lib/accounts.test.ts
@@ -2,15 +2,20 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ACCOUNT_HASH_CHARS,
   MIN_SPANS_FOR_COST_PER_USER,
   SHORT_HASH_CHARS,
   type AccountCostRow,
   type AccountCosts,
+  accountDisplayName,
   attributedSpend,
   costPerUser,
   emptyAccountRow,
   formatShare,
+  isAccountHash,
+  layerShare,
   shortenAccountHash,
+  trendTotal,
   unattributedShare,
 } from "./accounts";
 
@@ -127,5 +132,88 @@ describe("attributedSpend", () => {
     });
     expect(attributedSpend(c)).toBe(500_000);
     expect(attributedSpend(c)).toBe(accounts.reduce((s, a) => s + a.directCostMicroUsd, 0));
+  });
+});
+
+// --- Account detail view (CTO-190, plan D4) -----------------------------------------------------
+
+describe("isAccountHash", () => {
+  it("accepts a stored 64-character lowercase hex hash", () => {
+    expect(isAccountHash("a".repeat(ACCOUNT_HASH_CHARS))).toBe(true);
+    expect(isAccountHash("0123456789abcdef".repeat(4))).toBe(true);
+  });
+
+  it("rejects anything that could never have been a hash", () => {
+    // The shortened display form in particular: it is a truncation for width and is not an id, so
+    // a route built from it must not reach a query and must not read as a real account.
+    expect(isAccountHash(shortenAccountHash("a".repeat(ACCOUNT_HASH_CHARS)))).toBe(false);
+    expect(isAccountHash("")).toBe(false);
+    expect(isAccountHash("a".repeat(63))).toBe(false);
+    expect(isAccountHash("a".repeat(65))).toBe(false);
+    expect(isAccountHash("g".repeat(ACCOUNT_HASH_CHARS))).toBe(false);
+    // Uppercase is not what the gateway emits, so accepting it would let one account reach the
+    // page under two addresses, only one of which matches a row.
+    expect(isAccountHash("A".repeat(ACCOUNT_HASH_CHARS))).toBe(false);
+  });
+
+  it("is not fooled by a hash with something appended", () => {
+    expect(isAccountHash(`${"a".repeat(ACCOUNT_HASH_CHARS)}/../cost`)).toBe(false);
+    expect(isAccountHash(`${"a".repeat(ACCOUNT_HASH_CHARS)}\n`)).toBe(false);
+  });
+});
+
+describe("accountDisplayName", () => {
+  const HASH = "b".repeat(ACCOUNT_HASH_CHARS);
+
+  it("prefers the label and falls back to the shortened hash", () => {
+    // The rule the table and the detail header share: clicking "Acme Corp" has to land on a page
+    // headed "Acme Corp", and clicking a shortened hash on the same shortened hash.
+    expect(accountDisplayName(HASH, "Acme Corp")).toBe("Acme Corp");
+    expect(accountDisplayName(HASH, undefined)).toBe(shortenAccountHash(HASH));
+  });
+});
+
+describe("layerShare", () => {
+  it("divides a layer by the account's own direct total", () => {
+    const r = row({
+      byLayer: { llm: 750_000, tools: 250_000, vector: 0, embeddings: 0 },
+      directCostMicroUsd: 1_000_000,
+    });
+    expect(layerShare(r, "llm")).toBe(0.75);
+    expect(layerShare(r, "tools")).toBe(0.25);
+    expect(layerShare(r, "vector")).toBe(0);
+  });
+
+  it("returns null rather than 0 when the account has no direct spend", () => {
+    // "0% of spend is LLM" describes a distribution that does not exist. The page renders a blank.
+    expect(layerShare(row({ directCostMicroUsd: 0 }), "llm")).toBeNull();
+  });
+});
+
+describe("trendTotal", () => {
+  it("sums the charted days", () => {
+    expect(
+      trendTotal([
+        { date: "2026-08-01", directCostMicroUsd: 1_000_000 },
+        { date: "2026-08-02", directCostMicroUsd: 0 },
+        { date: "2026-08-03", directCostMicroUsd: 250_000 },
+      ]),
+    ).toBe(1_250_000);
+  });
+
+  it("is zero for an empty trend", () => {
+    expect(trendTotal([])).toBe(0);
+  });
+
+  it("catches a day dropped from the chart but still counted in the total", () => {
+    // The two-clocks bug: a day list built from the Node clock is shifted against the SQL window,
+    // so the oldest day has no slot and falls out of the chart while still counting toward the
+    // account's total. The disagreement is invisible on screen unless something states it.
+    const full = [
+      { date: "2026-07-28", directCostMicroUsd: 500_000 },
+      { date: "2026-07-29", directCostMicroUsd: 500_000 },
+    ];
+    expect(trendTotal(full)).toBe(1_000_000);
+    expect(trendTotal(full.slice(1))).not.toBe(trendTotal(full));
   });
 });

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -93,11 +93,38 @@ export interface AccountTrendPoint {
   directCostMicroUsd: MicroUSD;
 }
 
+/** Heaviest runs are capped for the same reason as features: a shortlist, not an audit trail. */
+export const MAX_ACCOUNT_TOP_RUNS = 8;
+
+/**
+ * One agent run, costed at THIS account's spans only (CTO-190, plan D4).
+ *
+ * A trace can carry spans for more than one account: a batch job that serves several customers in
+ * one run is a normal shape, and so is a run where only some steps were tagged. So the figure here
+ * is the account's share of the run, not the run's total, and it will be smaller than the number
+ * the same run shows on /agents whenever the run is shared. Reporting the run total on a
+ * per-account page would double-count the shared part across every account it touched.
+ */
+export interface AccountRunCost {
+  /** Trace id. Links to the existing /agents/runs/[runId] drill-down, which shows the WHOLE run. */
+  runId: string;
+  /** ServiceName, or `'untagged'` where the run carries none. Matches /agents. */
+  agent: string;
+  /** Cost of this account's spans in the run. See the note above: not the run's total. */
+  accountCostMicroUsd: MicroUSD;
+  /** Spans in the run attributed to this account, again not the run's total step count. */
+  steps: number;
+  /** Only success/failed are inferable from OTel StatusCode; `abandoned` is not tracked. */
+  outcome: "success" | "failed";
+}
+
 export interface AccountDetail extends AccountCostRow {
   /** Heaviest features for this account, capped at {@link MAX_ACCOUNT_TOP_FEATURES}. */
   topFeatures: AccountFeatureCost[];
   /** One point per calendar day across the window, oldest first, gaps filled with zero. */
   trend: AccountTrendPoint[];
+  /** Heaviest runs for this account, capped at {@link MAX_ACCOUNT_TOP_RUNS}. */
+  topRuns: AccountRunCost[];
 }
 
 // --- Presentation helpers for the /cost-per-customer tab (CTO-188, plan D2) ----------------------
@@ -200,4 +227,57 @@ export function formatShare(share: number): string {
 /** Direct spend that IS attributed to an account: the total less the unattributed bucket. */
 export function attributedSpend(costs: AccountCosts): MicroUSD {
   return costs.totalDirectMicroUsd - costs.unattributed.directCostMicroUsd;
+}
+
+// --- Presentation helpers for the account detail view (CTO-190, plan D4) -------------------------
+
+/** Characters in a stored account hash: HMAC-SHA256 rendered hex. */
+export const ACCOUNT_HASH_CHARS = 64;
+
+/**
+ * Whether a URL segment is a well-formed account hash.
+ *
+ * The detail route's parameter is user-editable, so it is checked for shape before it reaches a
+ * query. This is a shape test and nothing more: a well-formed hash that matches no rows is a
+ * perfectly ordinary answer (an account with no spend in the window), and the page says so rather
+ * than treating it as an error. Only a segment that could never have been a hash gets the
+ * "that is not an account id" treatment.
+ */
+export function isAccountHash(segment: string): boolean {
+  return new RegExp(`^[0-9a-f]{${ACCOUNT_HASH_CHARS}}$`).test(segment);
+}
+
+/**
+ * What the Account column and the detail header both print for an account.
+ *
+ * One function so the two surfaces cannot drift: a reader who clicks "Acme Corp" in the table must
+ * land on a page headed "Acme Corp", and a reader who clicks a shortened hash must land on the same
+ * shortened hash. `undefined` label (no label set, or labels unavailable) falls back to the short
+ * form; the full hash stays reachable through the copy control on both surfaces.
+ */
+export function accountDisplayName(accountIdHash: string, label: string | undefined): string {
+  return label ?? shortenAccountHash(accountIdHash);
+}
+
+/**
+ * Share of an account's direct spend sitting in one layer, or `null` when it has no direct spend.
+ *
+ * `null` rather than 0 for the same reason {@link unattributedShare} returns it: "0% of spend is
+ * LLM" is a claim about a distribution that does not exist. The caller renders a blank.
+ */
+export function layerShare(row: AccountCostRow, layer: DirectLayer): number | null {
+  if (row.directCostMicroUsd <= 0) return null;
+  return row.byLayer[layer] / row.directCostMicroUsd;
+}
+
+/**
+ * The trend's own total, for the chart to state beside the account total it is drawn under.
+ *
+ * These two are computed from different reads (a per-day group and a per-layer group), so they are
+ * two chances to disagree, and the day-list-from-the-wrong-clock bug drops a day from the chart
+ * while leaving it in the total. Exposing the chart's sum makes the disagreement visible instead of
+ * silent, and the detail page asserts on it.
+ */
+export function trendTotal(trend: readonly AccountTrendPoint[]): MicroUSD {
+  return trend.reduce((sum, p) => sum + p.directCostMicroUsd, 0);
 }

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -410,7 +410,13 @@ describe("queryAccountCosts — SQL contract (CTO-187)", () => {
 describe("queryAccountDetail (CTO-187)", () => {
   const WINDOW_START = "2026-07-28";
 
-  function respondDetail(opts: { seen: string; spans: string; users: string; trend?: RowShape[] }) {
+  function respondDetail(opts: {
+    seen: string;
+    spans: string;
+    users: string;
+    trend?: RowShape[];
+    runs?: RowShape[];
+  }) {
     respondRows([
       { seen: opts.seen, spans: opts.spans, users: opts.users, windowStart: WINDOW_START },
     ]);
@@ -420,6 +426,11 @@ describe("queryAccountDetail (CTO-187)", () => {
     ]);
     respondRows([{ feature: "research_agent", cost: "9", spans: "80" }]);
     respondRows(opts.trend ?? [{ day: "2026-08-01", cost: "12.75" }]);
+    respondRows(
+      opts.runs ?? [
+        { runId: "trace-1", agent: "aider", cost: "8", steps: "40", maxStatus: "0" },
+      ],
+    );
   }
 
   it("returns null for an account the tenant has never seen", async () => {
@@ -480,5 +491,116 @@ describe("queryAccountDetail (CTO-187)", () => {
     const featureSql = (queryMock.mock.calls[2][0] as { query: string }).query;
     expect(featureSql).toContain("LIMIT 5");
     expect(featureSql).toContain("FeatureTag != ''");
+  });
+});
+
+describe("queryAccountDetail heaviest runs (CTO-190)", () => {
+  const WINDOW_START = "2026-07-28";
+
+  function respondDetail(runs?: RowShape[]) {
+    respondRows([{ seen: "12", spans: "100", users: "7", windowStart: WINDOW_START }]);
+    respondRows([{ layer: "llm", cost: "10.5" }]);
+    respondRows([]);
+    respondRows([]);
+    respondRows(
+      runs ?? [
+        { runId: "trace-1", agent: "aider", cost: "8", steps: "40", maxStatus: "0" },
+        { runId: "trace-2", agent: "", cost: "3", steps: "9", maxStatus: "2" },
+      ],
+    );
+  }
+
+  /** The runs read is the 5th and last query the detail path issues. */
+  function runSql(): string {
+    return (queryMock.mock.calls[4][0] as { query: string }).query;
+  }
+
+  it("returns the account's share of each run, ranked, capped, with the outcome", async () => {
+    const { queryAccountDetail } = await freshSut();
+    respondDetail();
+    const out = await queryAccountDetail(ACCT_A);
+    expect(out!.topRuns).toEqual([
+      {
+        runId: "trace-1",
+        agent: "aider",
+        accountCostMicroUsd: 8_000_000,
+        steps: 40,
+        outcome: "success",
+      },
+      {
+        // An untagged ServiceName reads as "untagged" rather than as an empty agent name, which is
+        // what /agents does for the same row.
+        runId: "trace-2",
+        agent: "untagged",
+        accountCostMicroUsd: 3_000_000,
+        steps: 9,
+        outcome: "failed",
+      },
+    ]);
+    expect(runSql()).toContain("LIMIT 8");
+  });
+
+  it("groups this account's spans, never whole traces that merely touch the account", async () => {
+    const { queryAccountDetail } = await freshSut();
+    respondDetail();
+    await queryAccountDetail(ACCT_A);
+    const sql = runSql();
+    // The account predicate has to sit in the WHERE, not in a HAVING or a subquery that widens
+    // back out to the trace: a run serving several customers would otherwise report its full cost
+    // against every one of them and the same money would land on several bills.
+    expect(sql).toContain("AccountIdHash = {account:String}");
+    expect(sql).toContain("GROUP BY TraceId");
+  });
+
+  it("uses the same calendar-aligned window as the totals it sits under", async () => {
+    const { queryAccountDetail } = await freshSut();
+    respondDetail();
+    await queryAccountDetail(ACCT_A);
+    // A rolling `now() - INTERVAL 30 DAY` here would let a run appear in the list that the account
+    // total above it does not count.
+    expect(runSql()).toContain("Timestamp >= toDate(now()) - INTERVAL 29 DAY");
+    expect(runSql()).not.toContain("now() - INTERVAL 30 DAY");
+    expect(runSql()).toContain("GenAiOperation NOT IN ('compute', 'egress')");
+  });
+
+  it("reads run grain from otel_spans, which is the only table carrying a trace id", async () => {
+    const { queryAccountDetail } = await freshSut();
+    respondDetail();
+    await queryAccountDetail(ACCT_A);
+    expect(runSql()).toContain("otel_spans");
+    // Every other read on this path stays on the rollup.
+    for (const i of [0, 1, 2, 3]) {
+      expect((queryMock.mock.calls[i][0] as { query: string }).query).toContain(
+        "daily_account_rollup",
+      );
+    }
+  });
+});
+
+describe("queryAccountDetailResult (CTO-190)", () => {
+  const WINDOW_START = "2026-07-28";
+
+  it("separates an unknown account from an unreachable store", async () => {
+    const { queryAccountDetailResult } = await freshSut();
+    // Reachable, no rollup rows: an account we have never seen. Not an error, and not a 404.
+    respondRows([{ seen: "0", spans: "0", users: "0", windowStart: WINDOW_START }]);
+    expect(await queryAccountDetailResult(ACCT_A)).toEqual({ state: "unknown" });
+
+    // The store itself refusing. queryAccountDetail collapses this into the same null as the case
+    // above, which would have the page say "no spend recorded" about an account it cannot read.
+    queryMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    expect(await queryAccountDetailResult(ACCT_A)).toEqual({ state: "unreachable" });
+  });
+
+  it("returns the detail when there is one", async () => {
+    const { queryAccountDetailResult } = await freshSut();
+    respondRows([{ seen: "12", spans: "100", users: "7", windowStart: WINDOW_START }]);
+    respondRows([{ layer: "llm", cost: "10.5" }]);
+    respondRows([]);
+    respondRows([]);
+    respondRows([]);
+    const result = await queryAccountDetailResult(ACCT_A);
+    expect(result.state).toBe("ok");
+    expect(result.state === "ok" && result.detail.accountIdHash).toBe(ACCT_A);
   });
 });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -36,6 +36,7 @@ import type {
 import {
   DIRECT_LAYERS,
   MAX_ACCOUNT_TOP_FEATURES,
+  MAX_ACCOUNT_TOP_RUNS,
   UNATTRIBUTED_ACCOUNT,
   emptyAccountRow,
   totalDirect,
@@ -336,6 +337,12 @@ export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<F
 const ACCOUNT_WINDOW_DAYS = 30;
 const ACCOUNT_WINDOW = "Day >= toDate(now()) - INTERVAL 29 DAY";
 
+// The same window expressed against otel_spans, whose time column is a Timestamp rather than a Day.
+// Deliberately the SAME calendar-aligned boundary rather than `now() - INTERVAL 30 DAY`: the run
+// list on the detail view sits under the account total, and a rolling boundary would let a run
+// appear that the total above it does not count.
+const ACCOUNT_SPAN_WINDOW = "Timestamp >= toDate(now()) - INTERVAL 29 DAY";
+
 /** The four directly attributable layers, expressed as an operation filter. See DIRECT_LAYERS. */
 const DIRECT_ONLY = "GenAiOperation NOT IN ('compute', 'egress')";
 
@@ -441,7 +448,44 @@ export async function queryAccountCosts(): Promise<AccountCosts | null> {
  * as a real row with zeroes, which is a different and true statement.
  */
 export async function queryAccountDetail(accountIdHash: string): Promise<AccountDetail | null> {
-  return tryLive(async (db, tenant) => {
+  return tryLive((db, tenant) => accountDetail(db, tenant, accountIdHash));
+}
+
+/**
+ * What the detail view actually knows about an account (CTO-190, plan D4).
+ *
+ * {@link queryAccountDetail} collapses two very different facts into one `null`: "ClickHouse is
+ * down" and "this tenant has never emitted a span for this account". A page that renders them the
+ * same way tells a reader "no spend recorded for this account" while the store is unreachable,
+ * which is the page confidently asserting something it cannot know. The three states are kept
+ * apart here so the view can say which one it is looking at.
+ */
+export type AccountDetailResult =
+  | { state: "ok"; detail: AccountDetail }
+  /** Reachable, and it holds no rollup row for this account in the window. */
+  | { state: "unknown" }
+  /** ClickHouse could not be read at all, so nothing is known either way. */
+  | { state: "unreachable" };
+
+export async function queryAccountDetailResult(
+  accountIdHash: string,
+): Promise<AccountDetailResult> {
+  // Boxed so the two nulls stay distinguishable: tryLive's own null (query threw) is the outer one,
+  // and the query's null (no such account) is the inner one. Without the box they are the same
+  // value and the caller has to guess.
+  const boxed = await tryLive(async (db, tenant) => ({
+    detail: await accountDetail(db, tenant, accountIdHash),
+  }));
+  if (boxed === null) return { state: "unreachable" };
+  return boxed.detail === null ? { state: "unknown" } : { state: "ok", detail: boxed.detail };
+}
+
+async function accountDetail(
+  db: ClickHouseClient,
+  tenant: string,
+  accountIdHash: string,
+): Promise<AccountDetail | null> {
+  {
     const params = { tenant, account: accountIdHash };
     // Comparing FixedString(64) to a String parameter works in both directions: ClickHouse pads the
     // literal, so `''` matches the unattributed bucket and a 64-char hex hash matches exactly.
@@ -515,6 +559,37 @@ export async function queryAccountDetail(accountIdHash: string): Promise<Account
       if (point) point.directCostMicroUsd = micro(r.cost);
     }
 
+    // Heaviest runs. This is the ONE read here that cannot come from daily_account_rollup: the
+    // rollup is grouped to (account, day, feature, operation) and has no trace id in it at all, so
+    // run-grain has to come from otel_spans. That is a wider scan than the rollup reads above, but
+    // it is bounded by the same tenant + account + 30 day predicate and returns at most
+    // MAX_ACCOUNT_TOP_RUNS rows.
+    //
+    // Grouping is over THIS ACCOUNT'S SPANS only, not over whole traces that happen to touch the
+    // account. A trace serving several customers would otherwise report its full cost against each
+    // of them, so the same money would appear on several customers' pages. See AccountRunCost.
+    const runRows = await rowsP<{
+      runId: string;
+      agent: string;
+      cost: string;
+      steps: string;
+      maxStatus: string;
+    }>(
+      db,
+      `SELECT TraceId AS runId,
+              any(ServiceName) AS agent,
+              sum(EstimatedCost) AS cost,
+              count() AS steps,
+              max(StatusCode) AS maxStatus
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND AccountIdHash = {account:String}
+         AND ${ACCOUNT_SPAN_WINDOW} AND ${DIRECT_ONLY}
+       GROUP BY TraceId
+       ORDER BY cost DESC
+       LIMIT ${MAX_ACCOUNT_TOP_RUNS}`,
+      params,
+    );
+
     return {
       accountIdHash,
       unattributed: accountIdHash === UNATTRIBUTED_ACCOUNT,
@@ -528,8 +603,15 @@ export async function queryAccountDetail(accountIdHash: string): Promise<Account
         spanCount: parseInt(r.spans, 10) || 0,
       })),
       trend: [...byDay.values()],
+      topRuns: runRows.map((r) => ({
+        runId: r.runId,
+        agent: r.agent || "untagged",
+        accountCostMicroUsd: micro(r.cost),
+        steps: parseInt(r.steps, 10) || 0,
+        outcome: parseInt(r.maxStatus, 10) === 2 ? ("failed" as const) : ("success" as const),
+      })),
     };
-  });
+  }
 }
 
 // --- Hidden-cost alerts (CTO-122) ---------------------------------------------------------------


### PR DESCRIPTION
Implements **CTO-190 (D4)**, the account detail view at `/cost-per-customer/[account]`, reached by clicking an account in the table.

**Stacked on #184** (CTO-188, D2), which carries the shared components, the account dimension, the label store, the lookup endpoint, and the per-account cost queries. Base is `feat/cost-per-customer-page`, so review that one first.

**Possible conflict with CTO-189 (D3, the excluded-cost banner)**, which is in flight on the same base and modifies `app/cost-per-customer/page.tsx`. This PR adds a new route and does not touch that file at all. The one shared file is `AccountTable.tsx`, where the Account cell moved into a new `AccountIdentity.tsx` and gained a link; whichever lands second should be a mechanical merge.

## What is on the page

Four questions, in the order someone asks them after seeing that a row is expensive.

- **Cost by layer**, all six of them. Compute and egress render as explained blanks rather than `$0.00`.
- **Top features by spend**, with each feature's share of *this account's* spend.
- **Daily direct cost** across the window, one bar per calendar day.
- **Heaviest runs**, linking through to the existing `/agents/runs/[runId]` drill-down.

Header follows the same rule as the table: label from B7 where one exists, shortened hash with a copy control otherwise.

## Decisions worth a reviewer's attention

- **Heaviest runs groups this account's spans, not whole traces that touch the account.** It is the one read here that cannot come from `daily_account_rollup`, which is grouped to `(account, day, feature, operation)` and carries no trace id, so run grain has to come from `otel_spans`. A trace serving several customers is a normal shape, and reporting its full cost against each of them would put the same money on several bills. So the column reads "cost to this account", and the note under the table says the linked run page shows a larger figure on purpose, because a reader who clicks through has to be able to tell "different scope" from "one of these is wrong". It uses the same calendar-aligned window as the totals it sits under, not a rolling 30 days, so a run can never appear that the total above it does not count.

- **`queryAccountDetail` collapses two different facts into one `null`**: ClickHouse is down, and this tenant has never emitted a span for this account. A page that renders them the same way says "no spend recorded for this account" while the store is unreachable, which is the page asserting something it cannot know. `queryAccountDetailResult` boxes the inner null so `ok` / `unknown` / `unreachable` stay apart, and the view has a distinct ending for each. `queryAccountDetail` itself is unchanged.

- **An unknown account is not a 404.** The B6 lookup hands out well-formed hashes for account ids nobody has ever emitted, so a typo and an idle customer arrive here identically; "not found" would misdescribe both. A segment that is not 64 hex characters is the only genuinely malformed case and says so separately.

- **Compute and egress are blanks, not zeroes.** Zero is a measurement and these are not measured: no span carries an account for infrastructure spend. Printing `$0.00` beside four real numbers reads as "this customer used no compute", which is almost certainly false. The reason on the blank points at the tenant-level figure, which is CTO-189's banner.

- **Traps from the ticket, all three.** The `FixedString(64)` NUL padding stays normalised in SQL and nothing here compares a hash to `''` by hand. Distinct users still comes from a single account-grain `uniqMerge`, never summed across layers. The trend day list still comes from the window ClickHouse reports; on top of that, the chart now **states out loud** when its own days fail to add up to the total above it, since the way that bug presented was silent.

- **`AccountCell` moved out of `AccountTable` into `AccountIdentity`** so the table and the detail header cannot drift on the label-else-short-hash rule: clicking "Acme Corp" has to land on a page headed "Acme Corp". Links carry the **full** hash, never the shortened display form, which is a truncation for width and reaches no account at all. There is a test for that.

## Verification

From `web/` on this branch:

- `npm run typecheck` clean.
- `npm run lint` clean; the only warnings are the pre-existing ones in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`.
- `npm run test` **319 passing, 2 failing**. Both failures are the known pre-existing `app/api/api.test.ts` ones that appear when ClickHouse runs locally (`/api/data-quality`, `/api/attribution` mock fallback). Baseline on the base branch was 293 passing / the same 2 failing. **No new failures.** This PR adds 22 tests across `lib/accounts.test.ts`, `lib/clickhouse.test.ts`, `app/cost-per-customer/[account]/DetailTables.test.tsx`, and one more in `AccountTable.test.tsx`.

**In the browser.** Dev server from this worktree on a spare port (`:3457`) against live `local-dev` data, which is what the ticket describes: ~99.99% unattributed, three tagged accounts all under the 50-span floor. Screenshot taken during verification; text capture of the same render:

```
Cost per customer / account

cccccccccccc…  unlabelled  [Copy hash]

DIRECT COST     USERS     SPANS     COST PER USER
$0.0001         1         2         —

Directly attributable spend (LLM, tool calls, vector, embeddings) for this
account over the last 30 days. Compute and egress are excluded throughout: no
span carries an account for them, so every figure on this page understates
what the account truly costs.

COST BY LAYER
LAYER               DIRECT COST     SHARE OF ACCOUNT
LLM                     $0.0001                100.0%
Vector DB                 $0.00                  0.0%
Tool calls                $0.00                  0.0%
Compute                       —                     —
Embeddings                $0.00                  0.0%
Egress                        —                     —
attributable total      $0.0001                100.0%

TOP FEATURES BY SPEND
FEATURE          DIRECT COST↓     SHARE OF ACCOUNT     SPANS
cto182-e2e            $0.0001               100.0%         2

DAILY DIRECT COST, LAST 30 DAYS
[one bar at the right edge; 07-28 … 08-22 axis]

HEAVIEST RUNS
RUN                          AGENT       OUTCOME   STEPS   COST TO THIS ACCOUNT↓
e2ecto182000…000000000000    cto182-e2e  success       2                $0.0001
  Costed at this account's spans only. A run that served several customers
  carries a larger total on its own page, which is the whole run rather than
  this account's share of it; charging every account the full run would put
  the same money on several bills.
```

The three blanks in that capture are the honest ones and each carries its reason on hover: cost per user is suppressed at 2 spans against the 50-span floor, and compute and egress cannot be attributed per account at all.

Both non-report endings were exercised on the same server. A well-formed hash with no rows renders "No spend recorded for this account…", not a 404. A segment that is not a hash renders "That address is not an account id…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
