### PR TITLE
feat(web): revenue and gross margin per account (CTO-197)

### DIFF
--- a/web/app/cost-per-customer/AccountTable.test.tsx
+++ b/web/app/cost-per-customer/AccountTable.test.tsx
@@ -27,9 +27,21 @@ function row(hash: string, over: Partial<AccountCostRow> = {}): AccountCostRow {
   };
 }
 
-function renderTable(rows: AccountCostRow[], labels: Record<string, string> = {}) {
+function renderTable(
+  rows: AccountCostRow[],
+  labels: Record<string, string> = {},
+  revenue: Record<string, number | null> = {},
+  revenueUnavailable = false,
+) {
   return render(
-    <AccountTable rows={rows} labels={labels} labelsUnavailable={false} windowDays={30} />,
+    <AccountTable
+      rows={rows}
+      labels={labels}
+      labelsUnavailable={false}
+      revenue={revenue}
+      revenueUnavailable={revenueUnavailable}
+      windowDays={30}
+    />,
   );
 }
 
@@ -91,5 +103,78 @@ describe("AccountTable", () => {
 
     await waitFor(() => expect(screen.getByText(/Account lookup unavailable/)).toBeTruthy());
     expect(screen.getByText("Acme Corp")).toBeTruthy();
+  });
+
+  // --- Revenue and margin (CTO-197, plan E4) ----------------------------------------------------
+
+  it("prints a measured zero as $0.00 and an unknown as a blank, never the same cell", () => {
+    renderTable(
+      [row(LABELLED, { directCostMicroUsd: 1_000_000 }), row(UNLABELLED)],
+      { [LABELLED]: "Netted Out", [UNLABELLED]: "No Source" },
+      // Netted to zero by a refund: a measurement. Absent from the record: an unknown.
+      { [LABELLED]: 0 },
+    );
+
+    // The zero-revenue account: revenue $0.00, margin minus its cost. Both are real numbers.
+    expect(screen.getByText("$0.00")).toBeTruthy();
+    expect(screen.getByText("-$1.00")).toBeTruthy();
+    // The unknown account gets a blank that says why, and no invented margin of minus cost.
+    expect(screen.getAllByText(/No value: no revenue source wired/i).length).toBe(2);
+  });
+
+  it("distinguishes an unreadable revenue source from an unwired one", () => {
+    renderTable([row(LABELLED)], {}, {}, true);
+    expect(screen.getAllByText(/No value: revenue could not be read/i).length).toBe(2);
+    expect(screen.queryByText(/no revenue source wired/i)).toBeNull();
+  });
+
+  it("marks a margin whose cost side is too thin to stand behind", () => {
+    // The shape of the current tenant: real revenue, a handful of attributed spans.
+    renderTable(
+      [row(LABELLED, { spanCount: 4, directCostMicroUsd: 130 })],
+      {},
+      { [LABELLED]: 20_000_000_000 },
+    );
+    const mark = screen.getByTestId(`margin-caveat-${LABELLED}`);
+    expect(mark.getAttribute("title")).toMatch(/compute and egress are excluded/i);
+    expect(mark.getAttribute("title")).toMatch(/below the 50-span floor/i);
+    expect(mark.getAttribute("title")).toMatch(/under 1% of revenue/i);
+  });
+
+  it("still marks a well-measured margin, because v1 excludes compute and egress for everyone", () => {
+    renderTable(
+      [row(LABELLED, { spanCount: 5_000, directCostMicroUsd: 4_000_000 })],
+      {},
+      { [LABELLED]: 10_000_000 },
+    );
+    const mark = screen.getByTestId(`margin-caveat-${LABELLED}`);
+    expect(mark.getAttribute("title")).toMatch(/compute and egress are excluded/i);
+    expect(mark.getAttribute("title")).not.toMatch(/span floor/i);
+  });
+
+  it("ranks by margin and keeps unknown-revenue accounts at the bottom of both directions", () => {
+    const LOSS = "4".repeat(64);
+    renderTable(
+      [
+        row(UNLABELLED, { directCostMicroUsd: 1_000_000 }),
+        row(LABELLED, { directCostMicroUsd: 1_000_000 }),
+        row(LOSS, { directCostMicroUsd: 9_000_000 }),
+      ],
+      { [LABELLED]: "Profitable", [UNLABELLED]: "Unknown", [LOSS]: "Loss Maker" },
+      { [LABELLED]: 5_000_000, [LOSS]: 1_000_000 },
+    );
+
+    const names = () =>
+      screen.getAllByRole("row").slice(1).map((r) => r.querySelector("td")?.textContent ?? "");
+
+    // Default sort is margin descending: most profitable first, unknown last.
+    expect(names()[0]).toMatch(/Profitable/);
+    expect(names()[2]).toMatch(/Unknown/);
+
+    fireEvent.click(screen.getByRole("button", { name: /Gross margin/i }));
+    // Ascending puts the customer losing money first, and the unknown STAYS last: it is neither the
+    // most nor the least profitable customer, because it is not a measurement at all.
+    expect(names()[0]).toMatch(/Loss Maker/);
+    expect(names()[2]).toMatch(/Unknown/);
   });
 });

--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -13,6 +13,8 @@ import { DataTable, type Column } from "@/components/DataTable";
 import { Blank, Money } from "@/components/HonestValue";
 import {
   type AccountCostRow,
+  type AccountMargin,
+  accountMargin,
   costPerUser,
   shortenAccountHash,
 } from "@/lib/accounts";
@@ -31,6 +33,8 @@ export function AccountTable({
   rows,
   labels,
   labelsUnavailable,
+  revenue,
+  revenueUnavailable,
   windowDays,
 }: {
   rows: readonly AccountCostRow[];
@@ -41,6 +45,16 @@ export function AccountTable({
   labels: Record<string, string>;
   /** True when the gateway could not be reached, so an unlabelled row is not proof of no label. */
   labelsUnavailable: boolean;
+  /**
+   * Hash to net revenue in micro-USD, for accounts that have one (CTO-197, plan E4).
+   *
+   * A missing key and an explicit `null` mean the same thing and both render blank: we have not
+   * been told this account's revenue. A `0` is a measurement (a charge fully netted by a refund)
+   * and prints as $0.00. Nothing here may treat the two alike.
+   */
+  revenue: Record<string, number | null>;
+  /** True when the revenue read failed, so a blank is not proof that no revenue source is wired. */
+  revenueUnavailable: boolean;
   windowDays: number;
 }) {
   const [query, setQuery] = useState("");
@@ -89,6 +103,15 @@ export function AccountTable({
       });
     });
   };
+
+  // One place that pairs a row with its revenue, so the render path and the sort path can never
+  // disagree about what an account earns. `revenue[hash]` is `undefined` for an account the revenue
+  // query returned no row for, which means exactly what an explicit `null` means: unknown.
+  const margin = useMemo(
+    () => (r: AccountCostRow) =>
+      accountMargin(r, revenue[r.accountIdHash] ?? null, revenueUnavailable),
+    [revenue, revenueUnavailable],
+  );
 
   const columns = useMemo<Column<AccountCostRow>[]>(
     () => [
@@ -141,8 +164,33 @@ export function AccountTable({
         // suppressed account never floats to the top of a "cheapest per user" sort.
         sortValue: (r) => costPerUser(r).micro,
       },
+      {
+        key: "revenue",
+        header: "Revenue",
+        align: "right",
+        render: (r) => {
+          const { revenueMicroUsd, reason } = margin(r);
+          // `0` is a real measurement and prints as $0.00; `null` is an absence and prints blank.
+          // Money's own null path would blur that, so the branch is explicit here.
+          return revenueMicroUsd === null ? (
+            <Blank reason={reason ?? "revenue unknown for this account"} />
+          ) : (
+            <Money micro={revenueMicroUsd} />
+          );
+        },
+        sortValue: (r) => margin(r).revenueMicroUsd,
+      },
+      {
+        key: "margin",
+        header: "Gross margin",
+        align: "right",
+        render: (r) => <MarginCell row={r} margin={margin(r)} />,
+        // Unknown revenue means unknown margin, and `null` sorts last in both directions, so an
+        // account we know nothing about never ranks as the most OR the least profitable customer.
+        sortValue: (r) => margin(r).marginMicroUsd,
+      },
     ],
-    [labels, labelsUnavailable],
+    [labels, labelsUnavailable, margin],
   );
 
   return (
@@ -205,7 +253,10 @@ export function AccountTable({
         columns={columns}
         rows={visibleRows}
         rowKey={(r) => r.accountIdHash}
-        initialSort={{ key: "cost", direction: "desc" }}
+        // Ranked by profitability, most profitable first, which is the question this tab exists to
+        // answer. Sorting ascending puts the customers losing money at the top; accounts with
+        // unknown revenue stay at the bottom either way rather than posing as the answer.
+        initialSort={{ key: "margin", direction: "desc" }}
         // A row the search found is filtered to on its own, so the highlight is belt and braces for
         // the case where a tenant later labels two hashes of the same account and both rows show.
         rowClassName={(r) => (matchedSet.has(r.accountIdHash) ? "bg-accent/5" : "")}
@@ -214,7 +265,56 @@ export function AccountTable({
         // be the thing that ticket then has to unpick.
         empty={`No spans carried an account id in the last ${windowDays} days.`}
       />
+
+      {/* The margin column's own caveat, kept next to the column rather than only at the top of the
+          page. The tenant-wide excluded-cost banner with the real dollar figure is CTO-189, running
+          concurrently; when it lands this line can point at it instead of restating it. Until then
+          a profitability ranking would otherwise sit here with nothing beside it saying that half
+          the cost base is missing. */}
+      <p className="max-w-prose text-xs text-warn">
+        Gross margin is revenue minus <em>direct</em> cost only. Compute and egress are excluded
+        from every account, so cost is understated and every margin above is overstated by the same
+        amount. Rows marked ▲ carry a further reason not to read them at face value; hover the mark
+        to see it. Ranking by this column tells you the order to look in, not what a customer
+        actually earns you.
+      </p>
     </div>
+  );
+}
+
+/**
+ * The Gross margin cell: revenue minus direct cost, with the reasons it cannot be taken at face
+ * value attached to the number itself.
+ *
+ * The caveat marker is not decoration. Every margin in v1 is overstated because compute and egress
+ * are excluded from the cost side, and on a lightly-instrumented account it is overstated by so
+ * much that the figure is really just revenue. The page header says this too, but the header
+ * scrolls away and this is the cell someone screenshots into a pricing discussion.
+ */
+function MarginCell({ row, margin }: { row: AccountCostRow; margin: AccountMargin }) {
+  if (margin.marginMicroUsd === null) {
+    return <Blank reason={margin.reason ?? "margin unknown for this account"} />;
+  }
+  const negative = margin.marginMicroUsd < 0;
+  return (
+    <span className="inline-flex items-center justify-end gap-1">
+      <Money
+        micro={margin.marginMicroUsd}
+        className={negative ? "text-warn" : undefined}
+      />
+      {margin.caveats.length > 0 ? (
+        <span
+          title={margin.caveats.join("\n\n")}
+          className="cursor-help text-[11px] text-warn"
+          data-testid={`margin-caveat-${row.accountIdHash}`}
+        >
+          <span aria-hidden>▲</span>
+          <span className="sr-only">
+            Read with care: {margin.caveats.join(" ")}
+          </span>
+        </span>
+      ) : null}
+    </span>
   );
 }
 

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -27,7 +27,8 @@ import {
   type AccountCosts,
 } from "@/lib/accounts";
 import { queryAccountLabels } from "@/lib/accountLabels";
-import { queryAccountCosts } from "@/lib/clickhouse";
+import { type AccountRevenueReport } from "@/lib/accountRevenue";
+import { queryAccountCosts, queryAccountRevenue } from "@/lib/clickhouse";
 import { AccountTable } from "./AccountTable";
 
 export const dynamic = "force-dynamic";
@@ -36,7 +37,11 @@ export const dynamic = "force-dynamic";
 const MAJORITY_UNATTRIBUTED = 0.5;
 
 export default async function CostPerCustomerPage() {
-  const [costs, labels] = await Promise.all([queryAccountCosts(), queryAccountLabels()]);
+  const [costs, labels, revenue] = await Promise.all([
+    queryAccountCosts(),
+    queryAccountLabels(),
+    queryAccountRevenue(),
+  ]);
 
   return (
     <div className="space-y-6">
@@ -55,7 +60,11 @@ export default async function CostPerCustomerPage() {
         splitting them per customer would mean inventing an allocation rule.
       </p>
 
-      {costs === null ? <Unreachable /> : <Report costs={costs} labels={labels} />}
+      {costs === null ? (
+        <Unreachable />
+      ) : (
+        <Report costs={costs} labels={labels} revenue={revenue} />
+      )}
     </div>
   );
 }
@@ -63,12 +72,21 @@ export default async function CostPerCustomerPage() {
 function Report({
   costs,
   labels,
+  revenue,
 }: {
   costs: AccountCosts;
   labels: Map<string, string> | null;
+  /** `null` when the revenue read failed: a different statement from "no revenue is wired". */
+  revenue: AccountRevenueReport | null;
 }) {
   const share = unattributedShare(costs);
   const attributed = attributedSpend(costs);
+  // Hash to net revenue, straight from the report. Accounts the report has no row for are simply
+  // absent, which the table reads as unknown; an account present with `revenueMicroUsd: null` says
+  // the same thing, and an account with `0` says something different and keeps its zero.
+  const revenueByAccount = Object.fromEntries(
+    (revenue?.accounts ?? []).map((a) => [a.accountIdHash, a.revenueMicroUsd]),
+  );
 
   return (
     <div className="space-y-6">
@@ -96,11 +114,13 @@ function Report({
         <UnattributedNotice costs={costs} share={share} />
       ) : null}
 
-      <Card title="Accounts by direct cost">
+      <Card title="Accounts by gross margin">
         <AccountTable
           rows={costs.accounts}
           labels={labels ? Object.fromEntries(labels) : {}}
           labelsUnavailable={labels === null}
+          revenue={revenueByAccount}
+          revenueUnavailable={revenue === null}
           windowDays={costs.windowDays}
         />
         {labels === null ? (

--- a/web/lib/accounts.test.ts
+++ b/web/lib/accounts.test.ts
@@ -2,10 +2,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MARGIN_EXCLUDES_INFRA,
   MIN_SPANS_FOR_COST_PER_USER,
+  MIN_SPANS_FOR_MARGIN,
   SHORT_HASH_CHARS,
   type AccountCostRow,
   type AccountCosts,
+  accountMargin,
   attributedSpend,
   costPerUser,
   emptyAccountRow,
@@ -127,5 +130,58 @@ describe("attributedSpend", () => {
     });
     expect(attributedSpend(c)).toBe(500_000);
     expect(attributedSpend(c)).toBe(accounts.reduce((s, a) => s + a.directCostMicroUsd, 0));
+  });
+});
+
+describe("accountMargin", () => {
+  it("treats a netted-to-zero revenue as a measurement, not as an unknown", () => {
+    const m = accountMargin(row({ directCostMicroUsd: 1_000_000 }), 0);
+    expect(m.revenueMicroUsd).toBe(0);
+    // A charge fully refunded is real information: this customer cost us money and paid nothing.
+    expect(m.marginMicroUsd).toBe(-1_000_000);
+    expect(m.reason).toBeNull();
+  });
+
+  it("refuses to compute a margin against an assumed zero when revenue is unknown", () => {
+    const m = accountMargin(row({ directCostMicroUsd: 1_000_000 }), null);
+    expect(m.revenueMicroUsd).toBeNull();
+    expect(m.marginMicroUsd).toBeNull();
+    expect(m.reason).toMatch(/no revenue source wired/i);
+    // No caveats on a blank: there is no number to qualify.
+    expect(m.caveats).toEqual([]);
+  });
+
+  it("says so when the revenue read failed, rather than blaming the tenant's wiring", () => {
+    const m = accountMargin(row(), null, true);
+    expect(m.reason).toMatch(/could not be read/i);
+    expect(m.reason).toMatch(/not evidence/i);
+  });
+
+  it("carries the excluded-infrastructure caveat on every margin it prints", () => {
+    const m = accountMargin(row({ spanCount: 5_000, directCostMicroUsd: 4_000_000 }), 10_000_000);
+    expect(m.marginMicroUsd).toBe(6_000_000);
+    expect(m.caveats).toContain(MARGIN_EXCLUDES_INFRA);
+    // Well measured: no extra caveats beyond the one that applies to every account in v1.
+    expect(m.caveats).toHaveLength(1);
+  });
+
+  it("flags a margin computed against a cost side we barely measured", () => {
+    // The live tenant's shape: $20,000 of uploaded revenue against a few cents of attributed spend.
+    const m = accountMargin(row({ spanCount: 4, directCostMicroUsd: 130 }), 20_000_000_000);
+    expect(m.marginMicroUsd).toBe(20_000_000_000 - 130);
+    expect(m.caveats).toContain(MARGIN_EXCLUDES_INFRA);
+    expect(m.caveats.some((c) => c.includes(`${MIN_SPANS_FOR_MARGIN}-span floor`))).toBe(true);
+    expect(m.caveats.some((c) => /under 1% of revenue/.test(c))).toBe(true);
+  });
+
+  it("does not raise the cost-to-revenue flag on a normal account", () => {
+    const m = accountMargin(row({ spanCount: 900, directCostMicroUsd: 300_000 }), 1_000_000);
+    expect(m.caveats.some((c) => /under 1% of revenue/.test(c))).toBe(false);
+  });
+
+  it("does not divide by a zero revenue when checking the cost-to-revenue ratio", () => {
+    const m = accountMargin(row({ spanCount: 900, directCostMicroUsd: 300_000 }), 0);
+    expect(m.marginMicroUsd).toBe(-300_000);
+    expect(m.caveats.some((c) => /under 1% of revenue/.test(c))).toBe(false);
   });
 });

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -201,3 +201,115 @@ export function formatShare(share: number): string {
 export function attributedSpend(costs: AccountCosts): MicroUSD {
   return costs.totalDirectMicroUsd - costs.unattributed.directCostMicroUsd;
 }
+
+// --- Revenue and gross margin (CTO-197, plan E4) -------------------------------------------------
+//
+// The column that turns this tab from a cost report into a profitability view, and the one place on
+// the page where a wrong number gets acted on: someone reads "this customer is unprofitable" and
+// goes and reprices them. So both of the ways this figure can mislead are handled here rather than
+// left to the JSX.
+//
+// 1. NULL IS NOT ZERO. `queryAccountRevenue` (lib/accountRevenue.ts) separates them deliberately.
+//    An account whose only events are `count` engagement signals returns null, meaning we were
+//    never told its revenue. A charge fully netted by a refund returns 0, which is a measurement.
+//    Collapsing the two would either invent revenue for a customer we know nothing about, or claim
+//    a paying customer generates none. So margin is null exactly when revenue is null, and 0
+//    revenue produces a real margin of minus the cost.
+//
+// 2. THE MARGIN IS OVERSTATED, ALWAYS, IN V1. Cost here is direct cost only: compute and egress are
+//    excluded (Decision 2 in docs/cost-per-customer-plan.md, roughly 47 percent of spend on the
+//    current tenant). Every margin on this page is therefore too high by whatever share of that
+//    account's real cost sits in those two layers. That caveat travels with the number, on the cell
+//    itself, because a ranking that silently ignores half the cost base is worse than no ranking.
+
+/**
+ * Why every margin on this page reads high. Attached to each printed margin, not only to the page
+ * header, because the header scrolls away and the number is what gets copied into a pricing
+ * conversation.
+ */
+export const MARGIN_EXCLUDES_INFRA =
+  "understated cost: compute and egress are excluded from every account, so this margin is too high by whatever share of this customer's cost sits in those layers";
+
+/**
+ * Ratio of direct cost to revenue below which the margin is arithmetically indistinguishable from
+ * revenue itself.
+ *
+ * One percent. Under it, subtracting cost moves the figure by less than rounding does, so "margin"
+ * is really just "revenue with a cost column that never arrived". That is the exact shape of the
+ * current tenant: real uploaded revenue against near-zero attributed spend, which would otherwise
+ * render as a flawless customer rather than as a customer we have barely measured.
+ */
+export const MIN_COST_TO_REVENUE_RATIO = 0.01;
+
+/**
+ * Spans of attributed cost an account needs before its margin is read as a cost measurement.
+ *
+ * Shares the floor `costPerUser` uses, for the same reason: below it the account's cost side is a
+ * handful of spans, and a margin computed against it describes our instrumentation coverage rather
+ * than the customer's economics.
+ */
+export const MIN_SPANS_FOR_MARGIN = MIN_SPANS_FOR_COST_PER_USER;
+
+/** Revenue, margin, and everything the reader needs in order not to over-read them. */
+export interface AccountMargin {
+  /** Net revenue in micro-USD, or `null` for "we have not been told". Never 0 to mean unknown. */
+  revenueMicroUsd: MicroUSD | null;
+  /** Revenue minus direct cost. `null` exactly when `revenueMicroUsd` is null. */
+  marginMicroUsd: MicroUSD | null;
+  /** Why revenue and margin are blank. `null` when they are not. */
+  reason: string | null;
+  /**
+   * Why a printed margin must not be read as this customer's true profitability. Never empty when a
+   * margin prints: {@link MARGIN_EXCLUDES_INFRA} applies to every account in v1.
+   */
+  caveats: string[];
+}
+
+/**
+ * Revenue and gross margin for one account row.
+ *
+ * `revenueMicroUsd` is what {@link revenueForAccount} returned: the account's net revenue, or null
+ * for both "no row" and "no money-typed event". Those are the same statement to a reader, so they
+ * get the same blank. `revenueUnavailable` is a third and different case: the revenue read itself
+ * failed, so a blank here is not evidence that nothing is wired up, and the reason says so.
+ */
+export function accountMargin(
+  row: AccountCostRow,
+  revenueMicroUsd: MicroUSD | null,
+  revenueUnavailable = false,
+): AccountMargin {
+  if (revenueMicroUsd === null) {
+    return {
+      revenueMicroUsd: null,
+      marginMicroUsd: null,
+      reason: revenueUnavailable
+        ? "revenue could not be read for this window, so no margin can be computed. This blank is not evidence that no revenue source is wired"
+        : "no revenue source wired for this account, so its revenue is unknown. An unknown is not zero, and a margin against an assumed zero would be invented",
+      caveats: [],
+    };
+  }
+
+  const caveats = [MARGIN_EXCLUDES_INFRA];
+  // Two separate ways the cost side can be too thin to carry a margin, deliberately not merged: one
+  // is about how little we measured, the other about how little what we measured amounts to.
+  if (row.spanCount < MIN_SPANS_FOR_MARGIN) {
+    caveats.push(
+      `thin cost data: ${row.spanCount.toLocaleString()} attributed spans in the window, below the ${MIN_SPANS_FOR_MARGIN}-span floor, so this is closer to raw revenue than to a measured margin`,
+    );
+  }
+  if (
+    revenueMicroUsd > 0 &&
+    row.directCostMicroUsd / revenueMicroUsd < MIN_COST_TO_REVENUE_RATIO
+  ) {
+    caveats.push(
+      "attributed cost is under 1% of revenue, so subtracting it barely moves the figure. Read this as revenue with the cost side largely missing, not as a near-perfect margin",
+    );
+  }
+
+  return {
+    revenueMicroUsd,
+    marginMicroUsd: revenueMicroUsd - row.directCostMicroUsd,
+    reason: null,
+    caveats,
+  };
+}


### PR DESCRIPTION
Stacked on **#184** (D2, the `/cost-per-customer` page and `AccountTable`) and **#181** (E3, `queryAccountRevenue`), both already merged into `feat/margin-base`. Base this PR's review on the diff against `feat/margin-base` only.

Implements CTO-197 (plan item E4): Revenue and Gross margin columns on the account table, ranked by profitability.

## Null is not zero

`queryAccountRevenue` distinguishes the two deliberately, and this column preserves that distinction rather than flattening it:

| Case | Renders |
| --- | --- |
| No money-typed event (only `count` engagement signals) | `<Blank reason="no revenue source wired for this account, so its revenue is unknown. An unknown is not zero, and a margin against an assumed zero would be invented">` |
| Account absent from the revenue report entirely | the same blank, because it is the same statement to a reader |
| A charge fully netted by a refund | `$0.00`, and a real margin of minus the cost |
| The revenue read itself failed | a blank whose reason says the blank is **not** evidence that no source is wired |

The zero case is the one that is easy to lose: it is a measurement (this customer cost us money and paid nothing), and it has to survive as a number. `accountMargin` in `web/lib/accounts.ts` is where the rule lives, as a pure function, with unit tests covering each row of that table.

## The margin is overstated, and the column says so

CTO-189's excluded-cost banner has **not** landed on this base, so this PR carries its own caveat, in two places, both scoped to the margin column:

1. **On every printed margin.** A `▲` mark beside the number, whose tooltip always includes "compute and egress are excluded from every account, so this margin is too high by whatever share of this customer's cost sits in those layers". Not only in the page header: the header scrolls away, and the cell is what gets screenshotted into a pricing conversation.
2. **Under the table**, in prose: gross margin is revenue minus *direct* cost only, and ranking by this column tells you the order to look in, not what a customer actually earns you.

Two further caveats join the first when the cost side cannot carry a margin:
- **below the 50-span floor** (the same floor `costPerUser` uses),
- **attributed cost under 1 percent of revenue**, where subtracting cost moves the figure by less than rounding does.

That second one exists for exactly the shape of the current tenant: real uploaded revenue against near-zero attributed spend, which would otherwise render as a flawless customer instead of a customer we have barely measured. For the same reason there is **no margin percentage column**: a percentage against near-zero attributed cost reads as "99.99% margin" and is pure instrumentation gap, not economics.

### Overlap with CTO-189

When the banner lands, the paragraph under the table should point at it and drop the restatement of the excluded total. The per-cell `▲` should stay: the banner is a page-level statement and the caveat that matters is the one attached to the number. The `MARGIN_EXCLUDES_INFRA` constant is the single place to change, and the banner can supply the tenant's real dollar figure to it.

## Sorting

Default sort is **margin descending**, most profitable first; ascending puts the customers losing money at the top. `sortValue` returns `null` for an unknown margin, so `DataTable`'s existing missing-value rule keeps those accounts last in **both** directions. An account we know nothing about is neither the most nor the least profitable customer. Covered by a test that clicks the header and asserts the unknown stays at the bottom.

## Scope, for the two siblings in flight

`page.tsx` changes are three mechanical edits (add `queryAccountRevenue` to the existing `Promise.all`, build a hash-to-revenue record, pass two props) plus one card title. Everything else is in `AccountTable.tsx` and `lib/accounts.ts`, so conflicts with CTO-189 and CTO-190 should stay trivial.

## Verification

- `npm run typecheck`: clean.
- `npm run lint`: clean (2 pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`, untouched).
- `npm run test`: 335 passed, the 2 known pre-existing `app/api/api.test.ts` failures (`data-quality`, `attribution` mock fallback) and **no new ones**. 13 new tests across `lib/accounts.test.ts` and `app/cost-per-customer/AccountTable.test.tsx`.
- Browser: dev server on port 3210 from this worktree, `/cost-per-customer` against the live local tenant.

### What the browser showed, and one thing it could not

Screenshot captured from `http://localhost:3210/cost-per-customer` at 800x1000. GitHub has no CLI path for attaching an image, so the rendered state is transcribed here verbatim rather than linked:

```
ATTRIBUTED SPEND $4.00   ACCOUNTS 3   SPEND WITH NO ACCOUNT >99.9%
MOSTLY UNATTRIBUTED  >99.9% of direct spend ($48,712.15 of $48,716.15) carries no account id.

ACCOUNTS BY GROSS MARGIN
ACCOUNT          USERS  DIRECT COST  COST PER USER  REVENUE  ↓ GROSS MARGIN
cf0f8e1442e6…      1        $2.50        —             —          —
c861664f5a0b…      1        $1.50        —             —          —
cccccccccccc…      1      $0.0001        —             —          —

Gross margin is revenue minus direct cost only. Compute and egress are excluded
from every account, so cost is understated and every margin above is overstated
by the same amount. Rows marked ▲ carry a further reason not to read them at face
value; hover the mark to see it. Ranking by this column tells you the order to
look in, not what a customer actually earns you.
```

Every revenue and margin cell carries the full blank reason on hover and in its `sr-only` text.

**The live tenant does not currently have the CSV-uploaded revenue described in the ticket.** `business_events` on this local ClickHouse holds no rows with a non-empty `AccountIdHash` at all: the only revenue present is ~14.8k `vercel-chatbot-backfill` monetary events, all unattributed. E5 (CSV upload) is not on this base, which is the likely reason. So the browser confirms the **null** path end to end on real data, and the numeric paths (a measured `$0.00`, a negative margin, the thin-cost `▲`, and the sort ordering) are covered by the rendering tests in `AccountTable.test.tsx` rather than by the live page. I did not seed revenue rows into the local store to manufacture a nicer screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
