### PR TITLE
feat(cost-per-customer): onboarding empty state for an untagged tenant (CTO-191)

### DIFF
--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -209,9 +209,10 @@ export function AccountTable({
         // A row the search found is filtered to on its own, so the highlight is belt and braces for
         // the case where a tenant later labels two hashes of the same account and both rows show.
         rowClassName={(r) => (matchedSet.has(r.accountIdHash) ? "bg-accent/5" : "")}
-        // Deliberately plain. The onboarding empty state that explains what this page is for and
-        // how to switch it on is CTO-191, stacked on this ticket; a half-built version here would
-        // be the thing that ticket then has to unpick.
+        // Deliberately plain, and unreachable from the page as it stands: with no rows at all the
+        // page renders the CTO-191 onboarding explainer in place of this table, and a search that
+        // matches nothing does not filter. This stays as the honest fallback for any future caller
+        // that renders the table without that branch.
         empty={`No spans carried an account id in the last ${windowDays} days.`}
       />
     </div>

--- a/web/app/cost-per-customer/Onboarding.tsx
+++ b/web/app/cost-per-customer/Onboarding.tsx
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// The /cost-per-customer onboarding empty state (CTO-191, plan D5).
+//
+// This tab ships dark. Nothing emits `account_id` yet, so on release every existing tenant lands
+// here with an empty table, having never seen the page before and with no way to tell "you have not
+// switched this on" apart from "this product is broken". The empty state does two jobs, in order:
+// say what the page is, then say how to turn it on.
+//
+// Client module only for the copy button on the snippet. Everything else is static.
+//
+// WHY THERE IS NO PREVIEW TABLE. The house pattern for a pre-data surface is
+// SyntheticPreviewBanner, which wraps invented numbers in a "SAMPLE DATA" label. It is deliberately
+// not used here, for the reason page.tsx and lib/accounts.ts both state: a plausible list of fake
+// customer names is the single most misleading thing this page could show, and this is the one
+// surface where a reader could not tell the fixture from their own book of business. So "what it
+// will look like once data arrives" is answered by naming the columns and what each one will hold,
+// which is concrete without inventing a customer.
+
+import { useState } from "react";
+
+/**
+ * The snippet, kept in one place so the copy button and the rendered block cannot drift.
+ *
+ * This MUST match the API that shipped in CTO-181 (sdk/python/README.md, "Tagging spend with a
+ * customer account"): context-scoped via `with_account`, with an optional wire-only label. A
+ * copy-pasteable snippet that does not match the shipped API is worse than no snippet, because it
+ * fails after the reader has already decided to trust us.
+ */
+const SNIPPET = `from tally.context import start_trace, with_account
+
+# In request middleware: resolve the customer once, wrap the handler.
+with start_trace(), with_account("acct_northwind", label="Northwind Traders"):
+    client.record_llm_call(provider="openai", model="gpt-4o", usage=usage)
+    client.record_tool_call(provider="openai", tool="web_search")
+    # ...every span emitted inside this block carries the same account.`;
+
+/** What each column of the table will hold. Named, rather than mocked up with invented rows. */
+const COLUMNS: readonly { name: string; body: string }[] = [
+  {
+    name: "Account",
+    body: "one row per customer, shown by the label you set, or by a shortened hash if you set none.",
+  },
+  {
+    name: "Users",
+    body: "how many distinct people were seen under that account in the window.",
+  },
+  {
+    name: "Direct cost",
+    body: "what that customer's LLM, tool, vector and embedding calls cost you over the window.",
+  },
+  {
+    name: "Cost per user",
+    body: "direct cost divided by those users, left blank on accounts too small for the ratio to mean anything.",
+  },
+];
+
+/**
+ * The full explainer, shown when not one span in the window carried an account.
+ *
+ * Deliberately not phrased as an error and not phrased as a promise that data exists. The
+ * surrounding page still states the unattributed share above this block, so the reader gets the
+ * honest number first and the explanation second.
+ */
+export function OnboardingEmptyState({ windowDays }: { windowDays: number }) {
+  return (
+    <section className="rounded-xl border border-edge bg-panel p-5">
+      <h2 className="text-sm font-medium uppercase tracking-wide text-muted">
+        Nothing is tagged with an account yet
+      </h2>
+
+      <div className="mt-4 space-y-3">
+        <h3 className="text-base font-semibold">What this page is for</h3>
+        <p className="max-w-prose text-sm text-muted">
+          It breaks your AI spend down by <span className="text-white">your own customers</span>, so
+          you can see which accounts are expensive to serve and which ones are worth what they pay.
+          Everywhere else in this dashboard groups spend by model, feature or provider. This is the
+          only tab that groups it by who you are serving.
+        </p>
+        <p className="max-w-prose text-sm text-muted">
+          Spend is grouped by the account id your own code puts on each span, so nothing can appear
+          here until your spans carry one. That is why this page is empty rather than wrong.
+        </p>
+
+        <div className="rounded-lg border border-edge bg-ink/40 p-4">
+          <p className="text-xs uppercase tracking-wide text-muted">
+            Once accounts arrive, the table below will show
+          </p>
+          <dl className="mt-3 space-y-2 text-sm">
+            {COLUMNS.map((c) => (
+              <div key={c.name} className="flex flex-wrap gap-x-2">
+                <dt className="font-medium">{c.name}:</dt>
+                <dd className="max-w-prose flex-1 text-muted">{c.body}</dd>
+              </div>
+            ))}
+          </dl>
+          <p className="mt-3 max-w-prose text-xs text-muted">
+            Ranked most expensive first, over the same {windowDays} days the rest of this page
+            covers. Compute and egress stay out of it: no span carries an account for them, so they
+            are reported separately rather than split by a rule nobody agreed to.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-3">
+        <h3 className="text-base font-semibold">How to turn it on</h3>
+        <p className="max-w-prose text-sm text-muted">
+          Set the account once per request and every span inside the block picks it up. A single
+          call can pass <code className="rounded bg-ink px-1 py-0.5 text-xs">account_id=</code> to
+          override the scope, which is what a batch job walking several customers needs.
+        </p>
+
+        <Snippet code={SNIPPET} />
+
+        <ul className="max-w-prose list-disc space-y-1.5 pl-5 text-sm text-muted">
+          <li>
+            <span className="text-white">The label is optional.</span> Leave it out and the account
+            shows as a shortened hash, which is a supported way to run. The label is wire-only: it
+            is stored against the hash and never written to the telemetry store, so no customer name
+            lands in your span data.
+          </li>
+          <li>
+            <span className="text-white">The raw account id never leaves your process.</span> It is
+            HMAC-SHA256&apos;d under your per-tenant key at emit time, exactly like a user id, which
+            is also why the table can only show you a hash you already know.
+          </li>
+          <li>
+            <span className="text-white">
+              Rows appear as soon as the next tagged spans land.
+            </span>{" "}
+            The hash is written at emit time, so spans already recorded stay unattributed. The
+            window fills forward from your deploy rather than backfilling.
+          </li>
+        </ul>
+
+        <p className="max-w-prose text-xs text-muted">
+          Full reference, including{" "}
+          <code className="rounded bg-ink px-1 py-0.5 text-xs">with_account(None)</code> to stop a
+          background task inheriting its caller&apos;s customer, is in{" "}
+          <code className="text-xs">sdk/python/README.md</code>.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The same snippet in a compact disclosure, for the partial state.
+ *
+ * The partial state already has a banner saying most spend is untagged (D2's UnattributedNotice),
+ * so repeating the whole explainer under a table the reader can plainly see would be noise. What
+ * they are missing is the call to finish the job, and the code to do it, one click away.
+ */
+export function HowToTagDetails() {
+  return (
+    <details className="rounded-lg border border-edge bg-ink/40 p-4">
+      <summary className="cursor-pointer text-sm font-medium">
+        How to tag the rest of your spend
+      </summary>
+      <p className="mt-3 max-w-prose text-sm text-muted">
+        Set the account once per request and every span inside the block picks it up. The label is
+        optional, and rows appear as soon as the next tagged spans land: nothing is backfilled.
+      </p>
+      <div className="mt-3">
+        <Snippet code={SNIPPET} />
+      </div>
+    </details>
+  );
+}
+
+/** Code block with a copy control. Copy failure is silent for the same reason it is in AccountCell:
+ * the text is already selectable, so there is nothing to recover and nothing to shout about. */
+function Snippet({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <pre className="overflow-x-auto rounded-lg border border-edge bg-ink p-4 pr-24 text-xs leading-relaxed">
+        <code>{code}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        className="absolute right-2 top-2 rounded border border-edge bg-panel px-2 py-1 text-[11px] text-muted hover:text-white"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -18,6 +18,14 @@
 //    are roughly half of spend on current data. ExcludedCostBanner (CTO-189) queries that total
 //    live per tenant so the page names the money it omits instead of a generic caveat.
 //
+// 4. EMPTY IS EXPLAINED, NOT SHRUGGED AT (CTO-191). Because nothing emits `account_id` yet, the
+//    common case on release is a tenant with no accounts at all, seeing this tab for the first
+//    time. `accountsView` sorts a successful query into three readings that need different copy:
+//    no accounts (explain the page, then how to switch it on), a partial ranking (show it, and
+//    offer the snippet that finishes it), and a normal one. An unreachable store is deliberately
+//    not one of them, because answering our own outage with an onboarding pitch would blame the
+//    reader for it.
+//
 // Reads the query directly rather than through /api, matching how the page-level gateway reads on
 // /connectors work: there is no client-side refetch here and no second consumer of the payload, so
 // a route handler would only add a hop.
@@ -25,6 +33,7 @@
 import { Card } from "@/components/Card";
 import { Blank, Money } from "@/components/HonestValue";
 import {
+  accountsView,
   attributedSpend,
   excludedShare,
   formatShare,
@@ -35,11 +44,9 @@ import {
 import { queryAccountLabels } from "@/lib/accountLabels";
 import { queryAccountCosts, queryExcludedInfraCost } from "@/lib/clickhouse";
 import { AccountTable } from "./AccountTable";
+import { HowToTagDetails, OnboardingEmptyState } from "./Onboarding";
 
 export const dynamic = "force-dynamic";
-
-/** Above this share, the unattributed bucket is the story rather than a footnote. */
-const MAJORITY_UNATTRIBUTED = 0.5;
 
 export default async function CostPerCustomerPage() {
   const [costs, labels, excluded] = await Promise.all([
@@ -85,6 +92,7 @@ function Report({
 }) {
   const share = unattributedShare(costs);
   const attributed = attributedSpend(costs);
+  const view = accountsView(costs);
 
   return (
     <div className="space-y-6">
@@ -108,26 +116,42 @@ function Report({
         </Stat>
       </div>
 
-      {share !== null && share >= MAJORITY_UNATTRIBUTED ? (
+      {view !== "attributed" && share !== null ? (
         <UnattributedNotice costs={costs} share={share} />
       ) : null}
 
       <ExcludedCostBanner costs={costs} excluded={excluded} />
 
-      <Card title="Accounts by direct cost">
-        <AccountTable
-          rows={costs.accounts}
-          labels={labels ? Object.fromEntries(labels) : {}}
-          labelsUnavailable={labels === null}
-          windowDays={costs.windowDays}
-        />
-        {labels === null ? (
-          <p className="mt-3 text-xs text-warn">
-            Account labels could not be read from the gateway, so every account shows as a hash. An
-            unlabelled row here is not proof that no label is set.
-          </p>
-        ) : null}
-      </Card>
+      {/* No accounts at all is not an empty table, it is a reader who has never seen this page.
+          The onboarding state replaces the table entirely (CTO-191); the honest headline figures
+          and the unattributed notice above it still render, so the explainer never stands in for
+          a number the page owes. */}
+      {view === "onboarding" ? (
+        <OnboardingEmptyState windowDays={costs.windowDays} />
+      ) : (
+        <Card title="Accounts by direct cost">
+          <AccountTable
+            rows={costs.accounts}
+            labels={labels ? Object.fromEntries(labels) : {}}
+            labelsUnavailable={labels === null}
+            windowDays={costs.windowDays}
+          />
+          {labels === null ? (
+            <p className="mt-3 text-xs text-warn">
+              Account labels could not be read from the gateway, so every account shows as a hash.
+              An unlabelled row here is not proof that no label is set.
+            </p>
+          ) : null}
+          {/* Partial instrumentation: the ranking above is real but covers a minority of spend, so
+              the snippet that finishes the job sits one click away rather than repeating the whole
+              onboarding explainer under a table the reader can already see. */}
+          {view === "partial" ? (
+            <div className="mt-4">
+              <HowToTagDetails />
+            </div>
+          ) : null}
+        </Card>
+      )}
     </div>
   );
 }
@@ -137,8 +161,11 @@ function Report({
  *
  * Written to read as a deliberate statement rather than a broken page, because on a tenant that has
  * not instrumented `account_id` this is the normal state and it will be the first thing anyone
- * sees. It names the number, says what the table below it does and does not cover, and stops. The
- * "here is how to switch it on" onboarding state is CTO-191.
+ * sees. It names the number and says what the table below it does and does not cover.
+ *
+ * It stops there on purpose. What follows it differs by state (CTO-191): with no accounts at all
+ * the whole onboarding explainer takes over from the table, and with a partial ranking the snippet
+ * sits in a disclosure under it. Putting the instructions in here as well would show them twice.
  */
 function UnattributedNotice({ costs, share }: { costs: AccountCosts; share: number }) {
   const complete = costs.accounts.length === 0;
@@ -156,8 +183,8 @@ function UnattributedNotice({ costs, share }: { costs: AccountCosts; share: numb
       </div>
       <p className="mt-2 max-w-prose text-sm text-muted">
         {complete
-          ? `Nothing in the last ${costs.windowDays} days is tagged with an account, so there is no per-customer breakdown to rank yet. This is what the page looks like before an account id is emitted, not an error.`
-          : `The accounts below cover the remaining spend only. Ranking them as though they were the whole picture would misstate what each customer costs, so read them as a partial view until more spans carry an account id.`}
+          ? `Nothing in the last ${costs.windowDays} days is tagged with an account, so there is no per-customer breakdown to rank yet. This is what the page looks like before an account id is emitted, not an error. What the page does once one is, and how to emit it, is below.`
+          : `The accounts below cover the remaining spend only. Ranking them as though they were the whole picture would misstate what each customer costs, so read them as a partial view until more spans carry an account id. The snippet under the table tags the rest.`}
       </p>
     </div>
   );

--- a/web/lib/accounts.test.ts
+++ b/web/lib/accounts.test.ts
@@ -2,11 +2,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAJORITY_UNATTRIBUTED,
   MIN_SPANS_FOR_COST_PER_USER,
   SHORT_HASH_CHARS,
   type AccountCostRow,
   type AccountCosts,
   type ExcludedInfraCost,
+  accountsView,
   attributedSpend,
   costPerUser,
   emptyAccountRow,
@@ -184,5 +186,73 @@ describe("excludedShare (CTO-189)", () => {
       costs({ totalDirectMicroUsd: 100 }),
     );
     expect(formatShare(share!)).toBe(">99.9%");
+  });
+});
+
+describe("accountsView", () => {
+  // The state machine behind the empty states (CTO-191, plan D5). Each branch produces different
+  // copy, and picking the wrong one is how a page tells a tenant with data that it has none, or
+  // tells a tenant that already instrumented the SDK to go install it.
+
+  it("is onboarding when not one span in the window carried an account", () => {
+    expect(
+      accountsView(
+        costs({
+          unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: 9_000_000 },
+          totalDirectMicroUsd: 9_000_000,
+        }),
+      ),
+    ).toBe("onboarding");
+  });
+
+  it("is onboarding when the tenant recorded no direct spend at all", () => {
+    // Nothing to attribute and nothing to explain away: still a first-run reader, still needs the
+    // explainer rather than an empty table.
+    expect(accountsView(costs())).toBe("onboarding");
+  });
+
+  it("is partial once real accounts exist but most spend still has none", () => {
+    expect(
+      accountsView(
+        costs({
+          accounts: [row({ directCostMicroUsd: 1_000_000 })],
+          unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: 9_000_000 },
+          totalDirectMicroUsd: 10_000_000,
+        }),
+      ),
+    ).toBe("partial");
+  });
+
+  it("treats the threshold itself as partial, so a coin-flip split gets the honest copy", () => {
+    const half = 5_000_000;
+    const view = accountsView(
+      costs({
+        accounts: [row({ directCostMicroUsd: half })],
+        unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: half },
+        totalDirectMicroUsd: half * 2,
+      }),
+    );
+    expect(MAJORITY_UNATTRIBUTED).toBe(0.5);
+    expect(view).toBe("partial");
+  });
+
+  it("is attributed when most spend carries an account", () => {
+    expect(
+      accountsView(
+        costs({
+          accounts: [row({ directCostMicroUsd: 9_000_000 })],
+          unattributed: { ...emptyAccountRow("", true), directCostMicroUsd: 1_000_000 },
+          totalDirectMicroUsd: 10_000_000,
+        }),
+      ),
+    ).toBe("attributed");
+  });
+
+  it("does not send a fully instrumented but quiet tenant back to onboarding", () => {
+    // Accounts exist with zero spend in the window: a quiet week, not an uninstrumented tenant.
+    // Telling this reader to install the SDK they already installed would be plainly wrong.
+    expect(
+      accountsView(costs({ accounts: [row({ directCostMicroUsd: 0, spanCount: 0 })] })),
+    ).toBe("attributed");
   });
 });

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -240,3 +240,40 @@ export function excludedShare(excluded: ExcludedInfraCost, costs: AccountCosts):
   if (all <= 0) return null;
   return excluded.totalMicroUsd / all;
 }
+
+// --- Which of the tab's states to render (CTO-191, plan D5) --------------------------------------
+
+/**
+ * Above this share, the unattributed bucket is the story rather than a footnote.
+ *
+ * Lives here rather than in page.tsx because the state machine below is the thing worth testing,
+ * and a threshold the test cannot see is a threshold the test cannot pin.
+ */
+export const MAJORITY_UNATTRIBUTED = 0.5;
+
+/**
+ * The three honest readings of a successful query.
+ *
+ *   - `onboarding`: not one span in the window carried an account, so there is no breakdown to
+ *     show and the reader has almost certainly never seen this page. Explain the page, then say
+ *     how to switch it on.
+ *   - `partial`: some accounts exist but most spend still has none, so the ranking is real and
+ *     incomplete at the same time. Show it, and say what it is missing.
+ *   - `attributed`: most spend carries an account. The table speaks for itself.
+ *
+ * A failed query is deliberately NOT a state here. "ClickHouse is unreachable" is a different fact
+ * from "you have not instrumented this yet", and answering an outage with an onboarding pitch would
+ * blame the reader for our own broken dependency. page.tsx branches on `costs === null` first, and
+ * this function is only ever reached with data in hand.
+ */
+export type AccountsView = "onboarding" | "partial" | "attributed";
+
+export function accountsView(costs: AccountCosts): AccountsView {
+  // Keyed on "are there any accounts", not on "is spend zero". A tenant can have real accounts and
+  // no spend in the window, which is a quiet week rather than an uninstrumented one, and telling it
+  // to go install the SDK it already installed would be wrong.
+  if (costs.accounts.length === 0) return "onboarding";
+  const share = unattributedShare(costs);
+  if (share !== null && share >= MAJORITY_UNATTRIBUTED) return "partial";
+  return "attributed";
+}


### PR DESCRIPTION
CTO-191 (D5). **Stacked on #185** (CTO-189, the excluded-cost banner), which is itself stacked on **#184** (CTO-188, the page). Base is `feat/excluded-cost-banner`; review those two first, and this diff is the 5 files on top of them. Based on D3 rather than D2 on purpose, since D3 also edits `page.tsx`.

**Possible conflict with #186 (CTO-190, D4).** That branch is in flight on the D2 base and edits `page.tsx` to link table rows. My `page.tsx` change is confined to the `Report` body (one added `view` local, one branch around the existing `<Card>`) plus comments, so a conflict should be mechanical: keep D4's row-linking inside the `<Card>` branch and keep the `view === "onboarding"` branch around it.

## Why

This tab ships dark. Nobody emits `account_id` yet, so on release **every existing tenant** lands here with no data, having never seen the page, and with no way to tell "you have not switched this on" apart from "this product is broken". D2 shipped an honest "mostly unattributed" headline and a plain table. That is the right number and the wrong first experience: it explains nothing about what the page is or how to make it work.

## The three states, and why they need different copy

| Situation | What renders |
|---|---|
| **No accounts at all** | The honest headline and unattributed notice as before, then the full explainer **in place of** the table: what the page is for, what each column will hold, and the SDK snippet. |
| **Some accounts, most spend untagged** | Unchanged table and D2 banner, plus a `<details>` disclosure under it carrying the snippet. Extends the existing banner rather than duplicating it. |
| **ClickHouse unreachable** | Unchanged. |

That last row is the important one. An outage is **not** an onboarding gap, and answering our own broken dependency with a "here is how to install the SDK" pitch would blame the reader for it. `page.tsx` still branches on `costs === null` before anything else, and `accountsView` is only ever reached with data in hand. Its docstring says so, and there is a test.

`accountsView` also refuses to send a **fully instrumented but quiet** tenant back to onboarding: the branch keys on "are there any accounts", not "is spend zero", so a quiet week does not tell someone to install the SDK they already installed. Tested.

## The snippet is the shipped API

Taken verbatim against the section CTO-181 added to `sdk/python/README.md`: context-scoped `with_account`, a per-call `account_id=` override, an optional label.

```python
from tally.context import start_trace, with_account

# In request middleware: resolve the customer once, wrap the handler.
with start_trace(), with_account("acct_northwind", label="Northwind Traders"):
    client.record_llm_call(provider="openai", model="gpt-4o", usage=usage)
    client.record_tool_call(provider="openai", tool="web_search")
    # ...every span emitted inside this block carries the same account.
```

A copy-pasteable snippet that does not match the shipped API is worse than no snippet, because it fails **after** the reader has already decided to trust us. One `SNIPPET` constant feeds both the rendered block and the copy button, so those two cannot drift either.

The three notes beside it are the ones a reader actually needs and none of them are promises we cannot keep: the label is optional and wire-only, the raw id never leaves their process, and **rows appear as soon as the next tagged spans land** because the hash is written at emit time, so nothing is backfilled and the window fills forward from their deploy.

## No preview table, deliberately

The house pattern for a pre-data surface is `SyntheticPreviewBanner`, which wraps invented numbers in a SAMPLE DATA label. It is not used here, for the reason `page.tsx` and `lib/accounts.ts` both already state: a plausible list of fake customer names is the single most misleading thing this page could show, and this is the one surface where a reader could not tell the fixture from their own book of business. So "what it will look like once data arrives" is answered by **naming the four columns and what each one will hold**, which is concrete without inventing a customer. The component carries that reasoning as a comment so the next person does not helpfully add the fixture back.

## Verified in a browser

Live ClickHouse, worktree dev server on port 3100, since the shared `web` launch config serves the main checkout. Screenshots of all three states taken in-session.

**No accounts, with untagged spend** (`TALLY_TENANT_ID=cto199-verify`, a tenant whose only rows are unattributed). This is the release-day experience:

> Attributed spend **$0.00** · Accounts **0** · Spend with no account **100.0%**
>
> **MOSTLY UNATTRIBUTED**  100.0% of direct spend ($12.50 of $12.50) carries no account id.
> Nothing in the last 30 days is tagged with an account, so there is no per-customer breakdown to rank yet. This is what the page looks like before an account id is emitted, not an error. What the page does once one is, and how to emit it, is below.
>
> **NOTHING IS TAGGED WITH AN ACCOUNT YET** → "What this page is for" → the column list → "How to turn it on" → snippet.

The honest number still leads. The explainer never stands in for a figure the page owes.

**No accounts, no spend at all** (a tenant id with no rows): identical, except "Spend with no account" is a `<Blank>` rather than 100.0%, which is D2's existing valve doing its job. A first-run reader still gets the explainer.

**Partial** (`local-dev`, the default): >99.9% unattributed, 3 accounts, the table and both banners exactly as on #185, with "How to tag the rest of your spend" as a closed disclosure under the table. Expanded, it shows the same snippet.

**Unreachable** (`TALLY_CLICKHOUSE_URL` pointed at a dead port): byte-identical to #185. No onboarding pitch, no regression.

No real data was deleted to produce any of these; the empty states came from pointing at other tenants and the failure state from an unreachable URL.

## Verification

From `web/`:

- `npm run typecheck` clean.
- `npm run lint` clean; only the pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`.
- `npm run test`: 315 passed, the 2 pre-existing `app/api/api.test.ts` failures that appear when ClickHouse runs locally, **no new ones**. 6 new tests on `accountsView`: onboarding with untagged spend, onboarding with no spend at all, partial, the threshold boundary itself (a 50/50 split reads as partial), attributed, and the quiet-but-instrumented tenant that must not be sent back to onboarding.

`MAJORITY_UNATTRIBUTED` moved from `page.tsx` into `lib/accounts.ts` alongside the new function, so the threshold is visible to the test rather than buried in JSX. The `DataTable` `empty` string in `AccountTable.tsx` is now unreachable from this page; it stays as an honest fallback for any future caller, with a comment saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
