### PR TITLE
feat(cost-per-customer): allocate shared infra per account (CTO-193)

### DIFF
--- a/db/postgres/0024_tenant_allocation_config.sql
+++ b/db/postgres/0024_tenant_allocation_config.sql
@@ -1,0 +1,69 @@
+-- Per-tenant shared-cost allocation rule (CTO-193, plan C2).
+--
+-- WHY this row exists. The cost-per-customer tab reports direct spend (LLM, tools, vector,
+-- embeddings) per account and, since CTO-192, an ALLOCATED share of the tenant's compute and
+-- egress on top of it. Compute and egress arrive from the cloud billing connectors as one
+-- synthetic span per provider per day at tenant level with no account on them, so splitting them
+-- per customer means choosing a rule. On current data that shared half is roughly 47 percent of
+-- the bill, so the rule is not a detail: it decides about half of every number on the page.
+--
+-- A rule that decides half the page cannot be a constant compiled into the dashboard. Two tenants
+-- disagree about it honestly (a tenant whose infra scales with model calls wants pro rata; a
+-- tenant running a fixed cluster per customer wants an even split), and a reader who cannot see
+-- which rule produced their number has no way to argue with it. So it lives here, per tenant, and
+-- the page names the rule in force beside the column it produced.
+--
+-- Allowed values, mirroring `AllocationRule` in web/lib/allocation.ts exactly:
+--   * pro_rata_direct: each account's share of shared infra is proportional to its direct spend.
+--     THE DEFAULT. Assumes infra broadly scales with model usage, which is the least wrong
+--     assumption available without a per-account infra driver metered (that is the "pro rata on a
+--     driver" row of Decision 3 in docs/cost-per-customer-scope.md, and it needs telemetry that
+--     does not exist yet).
+--   * even_split: shared cost divided equally across participants. Weaker, since it flatters heavy
+--     accounts and punishes small ones. Offered because a tenant who provisions per customer
+--     rather than per request is genuinely better described by it.
+--
+-- INVARIANT: absence of a row is a fully supported state and means the default. There is no
+-- backfill and no placeholder row. Every tenant on this system today has no row, must keep
+-- working, and must get `pro_rata_direct`. The CHECK constraint is the second line of defence
+-- behind the API validation: an unknown rule string reaching the dashboard would either crash the
+-- page or silently fall back, and a silent fallback to a DIFFERENT rule than the one stored is the
+-- one failure mode that would make the named rule on screen a lie.
+--
+-- Reads and writes both go through GET/POST /v1/tenant/allocation-config. The web app never
+-- touches Postgres directly, same rule as tenant_account_labels (0023) and
+-- tenant_unit_economics_config (0019).
+--
+-- WHY there IS an audit companion here, unlike tenant_account_labels (0023). That table skips one
+-- because an audit row would preserve a deleted customer NAME, defeating its escape hatch. Nothing
+-- of the kind applies here: the payload is one enum value from a fixed set of two, and it carries
+-- no customer data at all. What it does carry is the answer to "why did every allocated figure on
+-- this page move overnight", which is precisely the question a reader asks when the rule changes
+-- underneath them. Same shape as tenant_unit_economics_config_changes: one row per upsert, keyed
+-- by a client-supplied change_id so a retried request is idempotent on both writes.
+
+CREATE TABLE IF NOT EXISTS tenant_allocation_config (
+    tenant_id        UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    allocation_rule  TEXT NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by       TEXT,
+    -- Kept in lockstep with ALLOCATION_RULES in web/lib/allocation.ts and ALLOCATION_RULES in
+    -- gateway/tenant_allocation.py. Adding a rule means touching all three, deliberately: a rule
+    -- the engine cannot apply must not be storable.
+    CONSTRAINT tenant_allocation_config_rule_known
+        CHECK (allocation_rule IN ('pro_rata_direct', 'even_split'))
+);
+
+CREATE TABLE IF NOT EXISTS tenant_allocation_config_changes (
+    change_id        UUID NOT NULL,
+    tenant_id        UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    actor            TEXT,
+    before           JSONB,
+    after            JSONB,
+    changed_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, change_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_allocation_config_changes_tenant
+    ON tenant_allocation_config_changes(tenant_id, changed_at DESC);

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       # /docker-entrypoint-initdb.d only runs when the data directory is empty, so on a running
       # local stack this file has to be applied by hand with psql (CTO-186).
       - ../db/postgres/0023_tenant_account_labels.sql:/docker-entrypoint-initdb.d/0023_tenant_account_labels.sql:ro
+      - ../db/postgres/0024_tenant_allocation_config.sql:/docker-entrypoint-initdb.d/0024_tenant_allocation_config.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -105,6 +105,15 @@ from gateway.tenant_account_labels import (
     normalize_account_id_hash,
     normalize_label,
 )
+from gateway.tenant_allocation import (
+    ALLOCATION_RULES,
+    DEFAULT_ALLOCATION_RULE,
+    AllocationConfigError,
+    TenantAllocationStore,
+    TenantNotFound as AllocationTenantNotFound,
+    normalize_rule,
+    normalize_updated_by,
+)
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
@@ -215,6 +224,10 @@ async def lifespan(app: FastAPI):
     # so ClickHouse never holds a customer name: the label is mutable metadata and stamping it on
     # every span would both waste storage and defeat the point of AccountIdHash.
     app.state.tenant_account_labels = TenantAccountLabelStore(settings)
+    # Per-tenant shared-cost allocation rule (CTO-193). Decides how compute and egress are split
+    # across accounts on /cost-per-customer, which is roughly half of every figure on that page.
+    # A tenant with no row gets pro_rata_direct and the page says the rule is the default.
+    app.state.tenant_allocation = TenantAllocationStore(settings)
     # In-process dedup set for Stripe webhook redeliveries. ClickHouse's ReplacingMergeTree
     # will collapse late duplicates at merge time, but this short-circuits the second insert
     # so the 200 stays well under Stripe's 30s timeout window.
@@ -1311,6 +1324,97 @@ async def delete_tenant_account_label(
         "removed": removed > 0,
         "rows_removed": removed,
     })
+
+
+@app.get("/v1/tenant/allocation-config")
+def get_tenant_allocation_config(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """The shared-cost allocation rule in force for the caller's tenant (CTO-193).
+
+    The response ALWAYS names a usable rule, and separately says whether anyone chose it:
+
+    * ``allocation_rule``: what /cost-per-customer must apply. Never null.
+    * ``configured``: false when the tenant has no row, i.e. the rule above is the default.
+    * ``config``: the stored row, or null. Carries ``updated_at`` / ``updated_by``.
+    * ``available_rules``: every rule this deployment can apply, so a config surface does not
+      have to hardcode the list and drift from the CHECK constraint.
+
+    Splitting "which rule applies" from "did someone pick it" is the whole point of the shape. The
+    page names the rule beside the column it produced, and "pro rata, the default" and "pro rata,
+    chosen by finance in March" are different claims to put in front of a reader.
+
+    A tenant with no ``tenants`` row is 404, not a silent default: that is a misrouted request, and
+    inventing an allocation rule for a tenant we do not know is not a recovery.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantAllocationStore = app.state.tenant_allocation
+    try:
+        config = store.get(tenant_id)
+    except AllocationTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return JSONResponse(
+        {
+            "tenant_id": tenant_id,
+            "allocation_rule": config.allocation_rule if config else DEFAULT_ALLOCATION_RULE,
+            "configured": config is not None,
+            "default_rule": DEFAULT_ALLOCATION_RULE,
+            "available_rules": list(ALLOCATION_RULES),
+            "config": config.as_dict() if config else None,
+        },
+        status_code=200,
+    )
+
+
+@app.post("/v1/tenant/allocation-config")
+async def upsert_tenant_allocation_config(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Set the tenant's shared-cost allocation rule. Idempotent on ``change_id`` (CTO-193).
+
+    Body: ``{"allocation_rule": "pro_rata_direct" | "even_split", "change_id": "<uuid>",
+    "updated_by": "finance@acme.test"?}``.
+
+    An unknown rule is a 422 rather than a fallback to the default. Storing one rule and applying
+    another would leave the page naming a rule that did not produce its numbers, which is exactly
+    the invisible assumption this config exists to remove.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail="body is not valid JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+    change_id = body.get("change_id")
+    if not isinstance(change_id, str) or not change_id.strip():
+        raise HTTPException(status_code=422, detail="change_id required (uuid)")
+
+    store: TenantAllocationStore = app.state.tenant_allocation
+    try:
+        rule = normalize_rule(body.get("allocation_rule"))
+        updated_by = normalize_updated_by(body.get("updated_by"))
+        config = store.upsert(
+            tenant_id, rule, change_id=change_id.strip(), updated_by=updated_by
+        )
+    except AllocationTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except AllocationConfigError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(
+        {
+            "tenant_id": tenant_id,
+            "allocation_rule": config.allocation_rule,
+            "configured": True,
+            "default_rule": DEFAULT_ALLOCATION_RULE,
+            "available_rules": list(ALLOCATION_RULES),
+            "config": config.as_dict(),
+        },
+        status_code=200,
+    )
 
 
 @app.post("/v1/stripe/webhook")

--- a/infra/gateway/src/gateway/tenant_allocation.py
+++ b/infra/gateway/src/gateway/tenant_allocation.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-tenant shared-cost allocation rule (CTO-193, plan C2).
+
+The cost-per-customer tab shows each account's DIRECT spend and, beside it, an ALLOCATED share of
+the tenant's compute and egress. Compute and egress carry no account, so splitting them per
+customer means picking a rule, and on current data that rule decides roughly half of every figure
+on the page. This module is where the choice is persisted.
+
+Two rules, matching ``AllocationRule`` in ``web/lib/allocation.ts`` one for one. ``pro_rata_direct``
+is the default and the only one a tenant gets without a row here. See
+``db/postgres/0024_tenant_allocation_config.sql`` for why the choice is per tenant rather than a
+constant.
+
+THE RULE OF THIS MODULE: absence of a row means the default, and that is a supported state rather
+than missing config. :meth:`TenantAllocationStore.get` returns ``None`` for a tenant with no row and
+the endpoint reports the default alongside ``configured: false``, so the dashboard can say "this is
+the default, nobody chose it" rather than presenting an unchosen rule as a decision.
+
+Reads and writes go through ``GET/POST /v1/tenant/allocation-config``. The web app never touches
+Postgres directly, same rule as :mod:`gateway.tenant_account_labels`.
+
+Writes are idempotent on a client-supplied ``change_id``, and append to
+``tenant_allocation_config_changes``. Changing the rule moves every allocated number on the page at
+once, so "who changed it, when, and from what" is the first question anyone asks afterwards.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg
+from psycopg.types.json import Json
+
+from gateway.config import Settings
+
+#: Every storable rule, in the same order as ``ALLOCATION_RULES`` in ``web/lib/allocation.ts``.
+#: Kept in lockstep with that list and with the CHECK constraint in migration 0024: a rule the
+#: allocation engine cannot apply must not be storable.
+ALLOCATION_RULES: tuple[str, ...] = ("pro_rata_direct", "even_split")
+
+#: What a tenant with no row gets. Infra broadly scales with model usage, so proportional to direct
+#: spend is the least wrong assumption available without a per-account infra driver.
+DEFAULT_ALLOCATION_RULE = "pro_rata_direct"
+
+#: Free text is capped: this is an operator identifier for the audit row, not a note field.
+MAX_UPDATED_BY_CHARS = 200
+
+
+class AllocationConfigError(ValueError):
+    """Caller-facing validation error. Surfaces as HTTP 422."""
+
+
+class TenantNotFound(AllocationConfigError):
+    """The caller's tenant identifier matches no ``tenants`` row."""
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationConfig:
+    """One tenant's stored allocation rule."""
+
+    allocation_rule: str
+    created_at: datetime | None
+    updated_at: datetime | None
+    updated_by: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "allocation_rule": self.allocation_rule,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "updated_by": self.updated_by,
+        }
+
+
+def normalize_rule(value: object) -> str:
+    """Validate an allocation rule against :data:`ALLOCATION_RULES`.
+
+    Rejects an unknown rule rather than falling back to the default, and that is the point. A
+    silent fallback would store one rule, apply another, and leave the page naming a rule that did
+    not produce its numbers, which is worse than a rejected write.
+    """
+    if not isinstance(value, str):
+        raise AllocationConfigError("allocation_rule must be a string")
+    trimmed = value.strip().lower()
+    if not trimmed:
+        raise AllocationConfigError("allocation_rule must be non-empty")
+    if trimmed not in ALLOCATION_RULES:
+        raise AllocationConfigError(
+            "allocation_rule must be one of: " + ", ".join(ALLOCATION_RULES)
+        )
+    return trimmed
+
+
+def normalize_updated_by(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AllocationConfigError("updated_by must be a string when provided")
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    if len(trimmed) > MAX_UPDATED_BY_CHARS:
+        raise AllocationConfigError(
+            f"updated_by must be at most {MAX_UPDATED_BY_CHARS} characters"
+        )
+    return trimmed
+
+
+def _resolve_tenant_uuid(cur: psycopg.Cursor, tenant_id: str) -> str:
+    """Map the caller's tenant identifier onto ``tenants.id``.
+
+    Same shape as :func:`gateway.tenant_account_labels._resolve_tenant_uuid` and
+    :func:`gateway.connectors.config_admin._resolve_tenant_uuid`. This table keys on the UUID
+    because of the foreign key, but the dashboard and local dev identify a tenant by NAME
+    (``local-dev``). Without this a name-based caller trips ``InvalidTextRepresentation`` deep in
+    the driver and surfaces as an opaque 503, which is the trap that has now caught three separate
+    features in this stack.
+    """
+    try:
+        return str(uuid.UUID(tenant_id))
+    except (ValueError, AttributeError, TypeError):
+        pass
+    cur.execute("SELECT id FROM tenants WHERE name = %s", (tenant_id,))
+    row = cur.fetchone()
+    if row is None:
+        raise TenantNotFound("no tenant matches the supplied identifier")
+    return str(row[0])
+
+
+def _row_to_config(row: tuple) -> AllocationConfig:
+    return AllocationConfig(
+        allocation_rule=str(row[0]),
+        created_at=row[1],
+        updated_at=row[2],
+        updated_by=row[3],
+    )
+
+
+_SELECT = """
+    SELECT allocation_rule, created_at, updated_at, updated_by
+    FROM tenant_allocation_config
+    WHERE tenant_id = %s
+"""
+
+
+class TenantAllocationStore:
+    """Postgres surface over ``tenant_allocation_config`` and its audit log."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str) -> AllocationConfig | None:
+        """The tenant's stored rule, or ``None`` when they have never chosen one.
+
+        ``None`` is not an error and not missing data. It is the overwhelmingly common case (every
+        tenant on the system today), and the caller renders it as the default.
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = _resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(_SELECT, (resolved,))
+            row = cur.fetchone()
+            return _row_to_config(row) if row else None
+
+    def upsert(
+        self,
+        tenant_id: str,
+        rule: str,
+        *,
+        change_id: str,
+        updated_by: str | None = None,
+    ) -> AllocationConfig:
+        """Set the tenant's allocation rule. Idempotent on ``change_id``.
+
+        On a new ``change_id``: reserve the audit row with the current config as ``before``, apply
+        the upsert, then fill in ``after``. On a replay: no write at all, and the current row comes
+        back unchanged. Same shape as
+        :meth:`gateway.tenant_unit_economics.TenantUnitEconomicsStore.upsert`, for the same reason:
+        a retried POST must not append a second audit row claiming a change that never happened.
+        """
+        rule = normalize_rule(rule)
+        updated_by = normalize_updated_by(updated_by)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = _resolve_tenant_uuid(cur, tenant_id)
+
+            cur.execute(_SELECT, (resolved,))
+            existing = cur.fetchone()
+            before = _row_to_config(existing) if existing else None
+
+            cur.execute(
+                """
+                INSERT INTO tenant_allocation_config_changes
+                    (change_id, tenant_id, actor, before, after)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, change_id) DO NOTHING
+                RETURNING change_id
+                """,
+                (
+                    change_id,
+                    resolved,
+                    updated_by,
+                    Json(before.as_dict()) if before is not None else None,
+                    None,
+                ),
+            )
+            if cur.fetchone() is None:
+                # Replayed change_id. The config write already happened on the first attempt, so
+                # repeating it here would bump updated_at for a change nobody made.
+                conn.commit()
+                if before is not None:
+                    return before
+                cur.execute(_SELECT, (resolved,))
+                row = cur.fetchone()
+                if row is None:
+                    raise RuntimeError(
+                        "change_id reserved but config absent (out-of-band delete?)"
+                    )
+                return _row_to_config(row)
+
+            cur.execute(
+                """
+                INSERT INTO tenant_allocation_config (tenant_id, allocation_rule, updated_by)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (tenant_id) DO UPDATE
+                  SET allocation_rule = EXCLUDED.allocation_rule,
+                      updated_by      = EXCLUDED.updated_by,
+                      updated_at      = now()
+                RETURNING allocation_rule, created_at, updated_at, updated_by
+                """,
+                (resolved, rule, updated_by),
+            )
+            row = cur.fetchone()
+            assert row is not None  # RETURNING on an upsert that cannot no-op
+            after = _row_to_config(row)
+
+            cur.execute(
+                """
+                UPDATE tenant_allocation_config_changes
+                SET after = %s
+                WHERE tenant_id = %s AND change_id = %s
+                """,
+                (Json(after.as_dict()), resolved, change_id),
+            )
+            conn.commit()
+            return after

--- a/infra/gateway/tests/test_app_allocation_config.py
+++ b/infra/gateway/tests/test_app_allocation_config.py
@@ -1,0 +1,250 @@
+"""GET/POST /v1/tenant/allocation-config: the shared-cost allocation rule (CTO-193, plan C2).
+
+Three tests carry the acceptance criteria:
+
+* :func:`test_tenant_with_no_row_gets_the_default_and_says_so`: the state every tenant on the
+  system is in today. It must return a usable rule AND report that nobody chose it.
+* :func:`test_unknown_rule_is_rejected_not_defaulted`: storing one rule and applying another
+  would make the rule named on the page a lie about the numbers beside it.
+* :func:`test_name_based_caller_does_not_500`: the tenant name-vs-UUID trap. The table keys on
+  ``tenants.id`` but the dashboard sends ``local-dev``.
+
+The rest guard idempotent replay and the audit trail around them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_allocation import (
+    ALLOCATION_RULES,
+    DEFAULT_ALLOCATION_RULE,
+    AllocationConfig,
+    AllocationConfigError,
+    TenantNotFound,
+    normalize_rule,
+    normalize_updated_by,
+)
+
+TENANT_NAME = "local-dev"
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+UNKNOWN_TENANT = "no-such-tenant"
+
+
+class FakeStore:
+    """In-memory stand-in for :class:`TenantAllocationStore`, so no Postgres is needed.
+
+    Mirrors the contract the endpoints depend on: absence means the default, a name and a UUID fold
+    onto ONE row the way the foreign key forces, an unknown rule raises, and a replayed change_id
+    is a no-op that leaves ``updated_at`` and the audit log alone.
+    """
+
+    def __init__(self, known_tenants: set[str] | None = None) -> None:
+        self._rows: dict[str, AllocationConfig] = {}
+        self._changes: list[tuple[str, str]] = []  # (tenant, change_id)
+        self._known = (
+            known_tenants if known_tenants is not None else {TENANT_NAME, TENANT_UUID}
+        )
+
+    def _resolve(self, tenant_id: str) -> str:
+        if tenant_id not in self._known:
+            raise TenantNotFound("no tenant matches the supplied identifier")
+        return TENANT_UUID if tenant_id in {TENANT_NAME, TENANT_UUID} else tenant_id
+
+    def get(self, tenant_id: str) -> AllocationConfig | None:
+        return self._rows.get(self._resolve(tenant_id))
+
+    def upsert(
+        self,
+        tenant_id: str,
+        rule: str,
+        *,
+        change_id: str,
+        updated_by: str | None = None,
+    ) -> AllocationConfig:
+        rule = normalize_rule(rule)
+        updated_by = normalize_updated_by(updated_by)
+        resolved = self._resolve(tenant_id)
+        existing = self._rows.get(resolved)
+        if (resolved, change_id) in self._changes:
+            assert existing is not None
+            return existing
+        self._changes.append((resolved, change_id))
+        now = datetime.now(tz=timezone.utc)
+        row = AllocationConfig(
+            allocation_rule=rule,
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+            updated_by=updated_by,
+        )
+        self._rows[resolved] = row
+        return row
+
+    def change_count(self, tenant_id: str) -> int:
+        resolved = self._resolve(tenant_id)
+        return sum(1 for t, _ in self._changes if t == resolved)
+
+
+@pytest.fixture
+def store() -> FakeStore:
+    return FakeStore()
+
+
+@pytest.fixture
+def client(store: FakeStore) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_allocation = store
+        yield c
+
+
+def _get(client: TestClient, tenant: str = TENANT_NAME):
+    return client.get("/v1/tenant/allocation-config", headers={"X-Tenant-Id": tenant})
+
+
+def _post(client: TestClient, body: dict, tenant: str = TENANT_NAME):
+    return client.post(
+        "/v1/tenant/allocation-config", headers={"X-Tenant-Id": tenant}, json=body
+    )
+
+
+# --- the acceptance paths ------------------------------------------------------------------------
+
+
+def test_tenant_with_no_row_gets_the_default_and_says_so(client: TestClient) -> None:
+    """No row is a supported state, not missing config.
+
+    Every tenant on the system is in this state today, so the endpoint has to answer usefully:
+    name a rule the page can actually apply, and separately admit that nobody chose it. Collapsing
+    the two would present the default as a decision somebody made.
+    """
+    res = _get(client)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["allocation_rule"] == DEFAULT_ALLOCATION_RULE == "pro_rata_direct"
+    assert body["configured"] is False
+    assert body["config"] is None
+    assert body["available_rules"] == list(ALLOCATION_RULES)
+
+
+def test_unknown_rule_is_rejected_not_defaulted(client: TestClient) -> None:
+    """An unknown rule is a 422 and writes nothing.
+
+    Falling back to the default here would store one rule and apply another, leaving the page
+    naming a rule that did not produce the numbers beside it. That is the exact invisible
+    assumption this config exists to remove, so a rejected write is the better failure.
+    """
+    res = _post(
+        client,
+        {"allocation_rule": "pro_rata_tokens", "change_id": str(uuid.uuid4())},
+    )
+    assert res.status_code == 422, res.text
+    assert "pro_rata_direct" in res.json()["detail"]
+    assert _get(client).json()["configured"] is False
+
+
+def test_name_based_caller_does_not_500(client: TestClient) -> None:
+    """A tenant NAME and its UUID address the same row.
+
+    The table keys on ``tenants.id`` but the dashboard identifies a tenant as ``local-dev``.
+    Without the resolver a name-based caller trips InvalidTextRepresentation deep in the driver and
+    surfaces as an opaque 503, which is the trap that has caught three features in this stack.
+    """
+    written = _post(
+        client, {"allocation_rule": "even_split", "change_id": str(uuid.uuid4())}
+    )
+    assert written.status_code == 200, written.text
+
+    by_name = _get(client, TENANT_NAME)
+    by_uuid = _get(client, TENANT_UUID)
+    assert by_name.status_code == 200 and by_uuid.status_code == 200
+    assert by_name.json()["allocation_rule"] == "even_split"
+    assert by_uuid.json()["allocation_rule"] == "even_split", (
+        "both spellings must address one row, or a tenant configures the rule through one door "
+        "and reads the default through the other"
+    )
+
+
+# --- invariants around them ----------------------------------------------------------------------
+
+
+def test_upsert_round_trips_and_reports_configured(client: TestClient) -> None:
+    res = _post(
+        client,
+        {
+            "allocation_rule": "even_split",
+            "change_id": str(uuid.uuid4()),
+            "updated_by": "finance@acme.test",
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["allocation_rule"] == "even_split"
+    assert res.json()["configured"] is True
+
+    read = _get(client).json()
+    assert read["allocation_rule"] == "even_split"
+    assert read["configured"] is True
+    assert read["config"]["updated_by"] == "finance@acme.test"
+
+
+def test_replayed_change_id_writes_once(client: TestClient, store: FakeStore) -> None:
+    """A retried POST must not append a second audit row claiming a change nobody made."""
+    change_id = str(uuid.uuid4())
+    body = {"allocation_rule": "even_split", "change_id": change_id}
+    first = _post(client, body)
+    second = _post(client, body)
+    assert first.status_code == 200 and second.status_code == 200
+    assert second.json()["allocation_rule"] == "even_split"
+    assert store.change_count(TENANT_NAME) == 1
+
+
+def test_change_id_is_required(client: TestClient) -> None:
+    res = _post(client, {"allocation_rule": "even_split"})
+    assert res.status_code == 422
+    assert "change_id" in res.json()["detail"]
+
+
+def test_unknown_tenant_is_404_not_a_default(client: TestClient) -> None:
+    """An unknown tenant is a misrouted request, not a tenant that wants the default."""
+    res = _get(client, UNKNOWN_TENANT)
+    assert res.status_code == 404, res.text
+
+
+def test_every_available_rule_is_actually_storable(client: TestClient) -> None:
+    """The advertised list and the accepted list are the same list.
+
+    A config surface renders ``available_rules``, so a rule advertised there but rejected by the
+    write would be a dead option in a dropdown.
+    """
+    for rule in ALLOCATION_RULES:
+        res = _post(client, {"allocation_rule": rule, "change_id": str(uuid.uuid4())})
+        assert res.status_code == 200, f"{rule}: {res.text}"
+        assert res.json()["allocation_rule"] == rule
+
+
+# --- normalizers ---------------------------------------------------------------------------------
+
+
+def test_normalize_rule_trims_and_lowercases() -> None:
+    assert normalize_rule("  Even_Split ") == "even_split"
+
+
+@pytest.mark.parametrize("bad", [None, 42, "", "   ", "pro rata", "ignore_shared"])
+def test_normalize_rule_rejects(bad: object) -> None:
+    with pytest.raises(AllocationConfigError):
+        normalize_rule(bad)
+
+
+def test_normalize_updated_by_blank_is_none() -> None:
+    assert normalize_updated_by("   ") is None
+    assert normalize_updated_by(None) is None
+
+
+def test_normalize_updated_by_rejects_oversize() -> None:
+    with pytest.raises(AllocationConfigError):
+        normalize_updated_by("x" * 5000)

--- a/web/app/cost-per-customer/AccountTable.test.tsx
+++ b/web/app/cost-per-customer/AccountTable.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type AccountCostRow, emptyAccountRow } from "@/lib/accounts";
-import { AccountTable } from "./AccountTable";
+import { AccountTable, type TableRow } from "./AccountTable";
 
 // The search box calls a server action. Mocked here so the test covers the matching rule (which is
 // where the interesting bug lives) rather than the transport.
@@ -91,5 +91,66 @@ describe("AccountTable", () => {
 
     await waitFor(() => expect(screen.getByText(/Account lookup unavailable/)).toBeTruthy());
     expect(screen.getByText("Acme Corp")).toBeTruthy();
+  });
+});
+
+describe("AccountTable allocated columns (CTO-193)", () => {
+  function allocatedRow(hash: string): TableRow {
+    return { ...row(hash), allocatedMicroUsd: 3_000_000, totalMicroUsd: 5_000_000 };
+  }
+
+  it("shows direct, allocated and total separately, with the rule named", () => {
+    // The core honesty requirement of the ticket. An allocated number folded into one total, or
+    // shown without the rule that produced it, is an estimate wearing a measurement's clothes.
+    render(
+      <AccountTable
+        rows={[allocatedRow(UNLABELLED)]}
+        labels={{}}
+        labelsUnavailable={false}
+        windowDays={30}
+        allocationRule="pro_rata_direct"
+      />,
+    );
+    expect(screen.getByText("Direct cost")).toBeTruthy();
+    expect(screen.getByText(/Allocated \(pro rata on direct spend\)/)).toBeTruthy();
+    expect(screen.getByText("Total cost")).toBeTruthy();
+    expect(screen.getByText("$2.00")).toBeTruthy(); // direct, measured
+    expect(screen.getByText("$3.00")).toBeTruthy(); // allocated, estimated
+    expect(screen.getByText("$5.00")).toBeTruthy(); // total
+  });
+
+  it("names the rule that actually applied, including a fallback", () => {
+    render(
+      <AccountTable
+        rows={[allocatedRow(UNLABELLED)]}
+        labels={{}}
+        labelsUnavailable={false}
+        windowDays={30}
+        allocationRule="even_split"
+      />,
+    );
+    expect(screen.getByText(/Allocated \(even split across accounts\)/)).toBeTruthy();
+  });
+
+  it("shows no allocated column at all when nothing was allocated", () => {
+    // Rather than an empty or zero column, which would read as "this account causes no
+    // infrastructure cost" when the truth is that the figure could not be computed.
+    renderTable([row(UNLABELLED)]);
+    expect(screen.queryByText(/Allocated/)).toBeNull();
+    expect(screen.queryByText("Total cost")).toBeNull();
+    expect(screen.getByText("Cost per user")).toBeTruthy();
+  });
+
+  it("labels the per-user ratio as direct once an allocated column sits beside it", () => {
+    render(
+      <AccountTable
+        rows={[allocatedRow(UNLABELLED)]}
+        labels={{}}
+        labelsUnavailable={false}
+        windowDays={30}
+        allocationRule="pro_rata_direct"
+      />,
+    );
+    expect(screen.getByText("Direct cost per user")).toBeTruthy();
   });
 });

--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -12,11 +12,24 @@ import { useMemo, useState, useTransition } from "react";
 import { DataTable, type Column } from "@/components/DataTable";
 import { Blank, Money } from "@/components/HonestValue";
 import {
+  ALLOCATION_RULE_DESCRIPTIONS,
+  ALLOCATION_RULE_LABELS,
   type AccountCostRow,
+  type AllocatedAccountRow,
   costPerUser,
   shortenAccountHash,
 } from "@/lib/accounts";
+import type { AllocationRule } from "@/lib/allocation";
 import { lookupAccountAction } from "./actions";
+
+/**
+ * A row that may or may not have been through allocation.
+ *
+ * Optional rather than two table components: the only difference between the allocated and
+ * unallocated renders is two extra columns, and `allocatedRule` is what says which one this is.
+ * The fields are present exactly when that prop is non-null.
+ */
+export type TableRow = AccountCostRow & Partial<Omit<AllocatedAccountRow, keyof AccountCostRow>>;
 
 interface SearchState {
   /** Hashes the searched id could have been emitted under. Empty until a search succeeds. */
@@ -32,8 +45,9 @@ export function AccountTable({
   labels,
   labelsUnavailable,
   windowDays,
+  allocationRule = null,
 }: {
-  rows: readonly AccountCostRow[];
+  rows: readonly TableRow[];
   /**
    * Hash to label. A plain record rather than a Map because this crosses the serialization
    * boundary from a server component.
@@ -42,6 +56,14 @@ export function AccountTable({
   /** True when the gateway could not be reached, so an unlabelled row is not proof of no label. */
   labelsUnavailable: boolean;
   windowDays: number;
+  /**
+   * The rule that produced the allocated figures, or `null` when nothing was allocated.
+   *
+   * Non-null adds the Allocated and Total columns AND names the rule in their headers. The two go
+   * together on purpose: an allocated column with no rule attached to it is an estimate presented
+   * as a measurement, which is the failure this whole ticket exists to avoid.
+   */
+  allocationRule?: AllocationRule | null;
 }) {
   const [query, setQuery] = useState("");
   const [search, setSearch] = useState<SearchState | null>(null);
@@ -90,7 +112,7 @@ export function AccountTable({
     });
   };
 
-  const columns = useMemo<Column<AccountCostRow>[]>(
+  const columns = useMemo<Column<TableRow>[]>(
     () => [
       {
         key: "account",
@@ -120,14 +142,70 @@ export function AccountTable({
       },
       {
         key: "cost",
-        header: "Direct cost",
+        header: (
+          <span title="LLM, tools, vector and embeddings spend recorded against this account. Measured, not estimated.">
+            Direct cost
+          </span>
+        ),
         align: "right",
         render: (r) => <Money micro={r.directCostMicroUsd} />,
         sortValue: (r) => r.directCostMicroUsd,
       },
+      // Allocated and Total only exist when a rule was actually applied, and they carry that rule
+      // in their headers. An estimate has to travel with the assumption that produced it: a column
+      // reading "Allocated" beside a measured one, with no rule named, is exactly how an estimate
+      // gets read as a measurement.
+      ...(allocationRule
+        ? ([
+            {
+              key: "allocated",
+              header: (
+                <span
+                  title={`Estimated, not measured. ${ALLOCATION_RULE_DESCRIPTIONS[allocationRule]}.`}
+                  className="underline decoration-dotted decoration-muted/60 underline-offset-4"
+                >
+                  Allocated ({ALLOCATION_RULE_LABELS[allocationRule]})
+                </span>
+              ),
+              align: "right",
+              render: (r) =>
+                r.allocatedMicroUsd === undefined ? (
+                  <Blank reason="no allocated share was computed for this row" />
+                ) : (
+                  <span className="text-muted" title="Estimated share of compute and egress">
+                    <Money micro={r.allocatedMicroUsd} />
+                  </span>
+                ),
+              sortValue: (r) => r.allocatedMicroUsd ?? null,
+            },
+            {
+              key: "total",
+              header: (
+                <span title="Direct plus allocated. Part measured, part estimated.">
+                  Total cost
+                </span>
+              ),
+              align: "right",
+              render: (r) =>
+                r.totalMicroUsd === undefined ? (
+                  <Blank reason="no total was computed for this row" />
+                ) : (
+                  <span className="font-medium">
+                    <Money micro={r.totalMicroUsd} />
+                  </span>
+                ),
+              sortValue: (r) => r.totalMicroUsd ?? null,
+            },
+          ] satisfies Column<TableRow>[])
+        : []),
       {
         key: "costPerUser",
-        header: "Cost per user",
+        // Named "Direct" once an Allocated column sits beside it, because this ratio divides
+        // direct cost only. Left as costPerUser's own definition rather than switched to total:
+        // dividing an estimate by an approximate user count would compound two uncertainties into
+        // a figure with a false air of precision, and the honest per-seat number is the measured
+        // one.
+        header: allocationRule ? "Direct cost per user" : "Cost per user",
         align: "right",
         render: (r) => {
           const { micro, reason } = costPerUser(r);
@@ -142,7 +220,7 @@ export function AccountTable({
         sortValue: (r) => costPerUser(r).micro,
       },
     ],
-    [labels, labelsUnavailable],
+    [labels, labelsUnavailable, allocationRule],
   );
 
   return (
@@ -205,7 +283,10 @@ export function AccountTable({
         columns={columns}
         rows={visibleRows}
         rowKey={(r) => r.accountIdHash}
-        initialSort={{ key: "cost", direction: "desc" }}
+        // Sorted by the most complete figure available: total where shared cost was allocated,
+        // direct where it could not be. Ranking by direct cost beside a Total column would put the
+        // second-most-expensive customer at the top of the list.
+        initialSort={{ key: allocationRule ? "total" : "cost", direction: "desc" }}
         // A row the search found is filtered to on its own, so the highlight is belt and braces for
         // the case where a tenant later labels two hashes of the same account and both rows show.
         rowClassName={(r) => (matchedSet.has(r.accountIdHash) ? "bg-accent/5" : "")}

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -14,9 +14,11 @@
 //    share before the table, every time, including when it is 100 percent, which is exactly what a
 //    tenant that has not instrumented `account_id` yet will see.
 //
-// 3. WHAT IS MISSING IS SIZED, NOT WAVED AT. The table is direct cost only, and compute and egress
-//    are roughly half of spend on current data. ExcludedCostBanner (CTO-189) queries that total
-//    live per tenant so the page names the money it omits instead of a generic caveat.
+// 3. NOTHING IS SILENTLY ESTIMATED. Compute and egress carry no account and are roughly half of
+//    spend, so they are ALLOCATED per account (CTO-193) rather than dropped. Allocated cost is its
+//    own column, never folded into one number, and the rule that produced it is named on screen.
+//    CTO-189's excluded-cost banner is gone: there is no longer an excluded half to warn about,
+//    and a stale banner beside allocated columns would be worse than no banner at all.
 //
 // Reads the query directly rather than through /api, matching how the page-level gateway reads on
 // /connectors work: there is no client-side refetch here and no second consumer of the payload, so
@@ -25,14 +27,19 @@
 import { Card } from "@/components/Card";
 import { Blank, Money } from "@/components/HonestValue";
 import {
+  ALLOCATION_RULE_DESCRIPTIONS,
+  ALLOCATION_RULE_LABELS,
+  allocateAccountCosts,
+  allocatedRowsTotal,
   attributedSpend,
-  excludedShare,
   formatShare,
   unattributedShare,
   type AccountCosts,
+  type AllocatedAccountCosts,
   type ExcludedInfraCost,
 } from "@/lib/accounts";
 import { queryAccountLabels } from "@/lib/accountLabels";
+import { queryAllocationRule, type AllocationRuleSetting } from "@/lib/allocationConfig";
 import { queryAccountCosts, queryExcludedInfraCost } from "@/lib/clickhouse";
 import { AccountTable } from "./AccountTable";
 
@@ -42,10 +49,11 @@ export const dynamic = "force-dynamic";
 const MAJORITY_UNATTRIBUTED = 0.5;
 
 export default async function CostPerCustomerPage() {
-  const [costs, labels, excluded] = await Promise.all([
+  const [costs, labels, excluded, allocationSetting] = await Promise.all([
     queryAccountCosts(),
     queryAccountLabels(),
     queryExcludedInfraCost(),
+    queryAllocationRule(),
   ]);
 
   return (
@@ -53,22 +61,26 @@ export default async function CostPerCustomerPage() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-xl font-semibold">Cost per customer</h1>
         {costs ? (
-          <span className="text-sm text-muted">
-            Direct spend, last {costs.windowDays} days
-          </span>
+          <span className="text-sm text-muted">Last {costs.windowDays} days</span>
         ) : null}
       </div>
 
       <p className="max-w-prose text-sm text-muted">
         Directly attributable spend (LLM, tools, vector, embeddings) grouped by the account each span
-        was tagged with. Compute and egress are excluded, because no span carries an account for
-        them.
+        was tagged with, plus each account&apos;s allocated share of compute and egress, which carry
+        no account of their own. Direct cost is measured. Allocated cost is an estimate, and the two
+        are never added into a single number without saying so.
       </p>
 
       {costs === null ? (
         <Unreachable />
       ) : (
-        <Report costs={costs} labels={labels} excluded={excluded} />
+        <Report
+          costs={costs}
+          labels={labels}
+          excluded={excluded}
+          allocationSetting={allocationSetting}
+        />
       )}
     </div>
   );
@@ -78,24 +90,40 @@ function Report({
   costs,
   labels,
   excluded,
+  allocationSetting,
 }: {
   costs: AccountCosts;
   labels: Map<string, string> | null;
   excluded: ExcludedInfraCost | null;
+  allocationSetting: AllocationRuleSetting;
 }) {
   const share = unattributedShare(costs);
   const attributed = attributedSpend(costs);
+  // `null` when the compute and egress total could not be read. Nothing is allocated in that case
+  // and the page says so; it does not print direct cost as though it were total cost.
+  const allocated = allocateAccountCosts(costs, excluded, allocationSetting.rule);
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-3">
-        <Stat label="Attributed spend">
-          <Money micro={attributed} />
+      <div className="grid gap-4 sm:grid-cols-4">
+        <Stat label="Direct spend (measured)">
+          <Money micro={costs.totalDirectMicroUsd} />
         </Stat>
-        <Stat label="Accounts">
-          <span className="tabular-nums">{costs.accounts.length.toLocaleString()}</span>
+        <Stat label="Allocated infra (estimated)">
+          {allocated === null ? (
+            <Blank reason="the compute and egress total could not be read, so nothing could be allocated" />
+          ) : (
+            <Money micro={allocated.allocatedTotalMicroUsd} />
+          )}
         </Stat>
-        <Stat label="Spend with no account">
+        <Stat label="Total cost">
+          {allocated === null ? (
+            <Blank reason="total cost needs the compute and egress figure, which could not be read" />
+          ) : (
+            <Money micro={allocated.tenantTotalMicroUsd} />
+          )}
+        </Stat>
+        <Stat label="Direct spend with no account">
           {/* The valve. `null` only when the tenant recorded no direct spend at all, where "0%
               unattributed" would claim perfect coverage of nothing. */}
           {share === null ? (
@@ -108,19 +136,29 @@ function Report({
         </Stat>
       </div>
 
+      <p className="max-w-prose text-xs text-muted">
+        Attributed direct spend is <Money micro={attributed} /> of{" "}
+        <Money micro={costs.totalDirectMicroUsd} /> across{" "}
+        {`${costs.accounts.length.toLocaleString()} ${
+          costs.accounts.length === 1 ? "account" : "accounts"
+        }.`}
+      </p>
+
       {share !== null && share >= MAJORITY_UNATTRIBUTED ? (
         <UnattributedNotice costs={costs} share={share} />
       ) : null}
 
-      <ExcludedCostBanner costs={costs} excluded={excluded} />
+      <AllocationNotice allocated={allocated} setting={allocationSetting} costs={costs} />
 
-      <Card title="Accounts by direct cost">
+      <Card title={allocated ? "Accounts by total cost" : "Accounts by direct cost"}>
         <AccountTable
-          rows={costs.accounts}
+          rows={allocated ? allocated.accounts : costs.accounts}
           labels={labels ? Object.fromEntries(labels) : {}}
           labelsUnavailable={labels === null}
           windowDays={costs.windowDays}
+          allocationRule={allocated ? allocated.effectiveRule : null}
         />
+        {allocated ? <UnattributedRow allocated={allocated} /> : null}
         {labels === null ? (
           <p className="mt-3 text-xs text-warn">
             Account labels could not be read from the gateway, so every account shows as a hash. An
@@ -128,6 +166,8 @@ function Report({
           </p>
         ) : null}
       </Card>
+
+      {allocated ? <Reconciliation allocated={allocated} /> : null}
     </div>
   );
 }
@@ -164,74 +204,212 @@ function UnattributedNotice({ costs, share }: { costs: AccountCosts; share: numb
 }
 
 /**
- * What the table leaves out, sized (CTO-189, plan D3).
+ * The rule that produced the allocated column, named (CTO-193, plan C2).
  *
- * REMOVE THIS WHEN CTO-193 LANDS. Workstream C replaces the whole banner with direct/allocated/
- * total columns on the table itself: once compute and egress can be allocated per account there is
- * nothing left excluded to warn about, and a stale banner beside allocated columns would be worse
- * than no banner at all.
+ * This replaces CTO-189's excluded-cost banner, which said how much the table left out. Nothing is
+ * left out now, so the honest thing to state is no longer a size but an ASSUMPTION: roughly half of
+ * every total on this page was produced by a rule rather than measured, and a reader who cannot see
+ * which rule it was has no way to judge or argue with the number. An allocation rule nobody can see
+ * is an invisible assumption, which is the same failure in a different disguise.
  *
- * Why it is not a static caveat. The table shows direct cost only, and on current data compute and
- * egress are roughly 47 percent of spend, so every row understates true cost by about half. A
- * reader who is told "some costs are excluded" cannot tell that apart from a rounding footnote;
- * they need the size. So the figure is queried live per tenant over the same window as the table.
- *
- * Three states, and each says something different:
- *   - a real excluded total: name it, in money and as a share of all spend
- *   - exactly zero: say nothing, because "excludes $0.00 (0%)" is noise that trains readers to
- *     ignore the banner on the tenants where it matters
- *   - unreadable: say that, because silence would read as the zero case, which is the most
- *     flattering possible reading of a failed query
+ * Four states, each saying something different:
+ *   - allocated, with the rule and where it came from (tenant choice, product default, or the
+ *     default applied because the config could not be read, which is NOT the same claim)
+ *   - allocated by a fallback rule because pro rata had no denominator: the engine says so and so
+ *     does this, because the rule in force is not the rule that was asked for
+ *   - nothing to allocate: no compute or egress in the window at all
+ *   - unreadable: the compute and egress total could not be read, so nothing was allocated and the
+ *     totals on this page are a floor rather than a total
  */
-function ExcludedCostBanner({
+function AllocationNotice({
+  allocated,
+  setting,
   costs,
-  excluded,
 }: {
+  allocated: AllocatedAccountCosts | null;
+  setting: AllocationRuleSetting;
   costs: AccountCosts;
-  excluded: ExcludedInfraCost | null;
 }) {
-  if (excluded === null) {
+  if (allocated === null) {
     return (
-      <div className="rounded-xl border border-edge bg-panel p-4 text-sm text-muted">
+      <div className="rounded-xl border border-warn/40 bg-warn/5 p-4 text-sm">
         <p className="max-w-prose">
-          Compute and egress are excluded from every figure on this page, and their total could not
-          be read, so how much this table leaves out is unknown:{" "}
-          <Blank reason="the compute and egress total could not be read from the telemetry store, so the excluded share is unknown" />
-          . Treat the accounts below as a floor on true cost, not a total.
+          Compute and egress could not be read for the last {costs.windowDays} days, so nothing has
+          been allocated and every figure here is direct cost only:{" "}
+          <Blank reason="the compute and egress total could not be read from the telemetry store, so no allocated share could be computed" />
+          . On a typical tenant that infrastructure is close to half the bill, so read the accounts
+          below as a floor on true cost, not a total.
         </p>
       </div>
     );
   }
 
-  // Nothing excluded is a real answer, and it needs no banner: this tenant's direct cost IS its
-  // cost. Saying "excludes $0.00 (0%)" would be technically true and pure noise.
-  if (excluded.totalMicroUsd <= 0) return null;
+  if (allocated.sharedMicroUsd <= 0) {
+    return (
+      <div className="rounded-xl border border-edge bg-panel p-4 text-sm text-muted">
+        <p className="max-w-prose">
+          No compute or egress was recorded in the last {allocated.windowDays} days, so there is
+          nothing to allocate and every total below is measured spend. Allocated cost stays at zero
+          until a cloud billing connector lands infrastructure spend for this tenant.
+        </p>
+      </div>
+    );
+  }
 
-  const share = excludedShare(excluded, costs);
-  if (share === null) return null; // Unreachable: a positive excluded total makes the denominator positive.
+  const rule = allocated.effectiveRule;
+  const fellBack = allocated.effectiveRule !== allocated.rule;
+  const unattributedAllocated = allocated.unattributed.allocatedMicroUsd;
+  const bucketShare =
+    allocated.allocatedTotalMicroUsd > 0
+      ? unattributedAllocated / allocated.allocatedTotalMicroUsd
+      : null;
 
   return (
-    <div className="rounded-xl border border-warn/40 bg-warn/5 p-4">
+    <div className="rounded-xl border border-edge bg-panel p-4">
       <div className="flex flex-wrap items-baseline gap-2">
-        <span className="rounded bg-warn/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-warn">
-          Excluded
+        <span className="rounded bg-accent/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-accent">
+          Allocated
         </span>
         <span className="text-sm">
-          Excludes <span className="font-semibold">
-            <Money micro={excluded.totalMicroUsd} />
-          </span>{" "}
-          (<span className="font-semibold">{formatShare(share)}</span>) of compute and egress that
-          cannot yet be attributed per account.
+          <Money micro={allocated.sharedMicroUsd} className="font-semibold" /> of compute and egress
+          is split across accounts{" "}
+          <span className="font-semibold">{ALLOCATION_RULE_LABELS[rule]}</span>{" "}
+          <RuleSource setting={setting} fellBack={fellBack} />.
         </span>
       </div>
       <p className="mt-2 max-w-prose text-sm text-muted">
-        Compute (<Money micro={excluded.computeMicroUsd} />) and egress (
-        <Money micro={excluded.egressMicroUsd} />) arrive from the cloud billing connectors as
-        tenant-level daily totals over the same {excluded.windowDays} days, with no account on them.
-        Splitting them per customer needs an allocation rule that does not exist yet, so every
-        account figure below is a floor on what that customer actually costs, not a total.
+        {/* The descriptions read as a clause so a column tooltip can prefix them; this is the one
+            place they open a sentence, so the first letter is raised here rather than duplicating
+            the text in two cases. */}
+        {ALLOCATION_RULE_DESCRIPTIONS[rule].charAt(0).toUpperCase()}
+        {ALLOCATION_RULE_DESCRIPTIONS[rule].slice(1)}. Those spans arrive from the cloud billing
+        connectors as
+        tenant-level daily totals with no account on them, so an allocated figure is an estimate and
+        is shown in its own column rather than folded into direct cost.
+      </p>
+      <p className="mt-2 max-w-prose text-sm text-muted">
+        {/* The unattributed-bucket decision, stated where the reader meets its consequences. On a
+            tenant that has barely instrumented account_id, this paragraph is the difference between
+            a page that reads as broken and one that reads as true. */}
+        Untagged traffic takes part in the split as one participant, so it carries{" "}
+        <Money micro={unattributedAllocated} />
+        {bucketShare === null ? "" : ` (${formatShare(bucketShare)})`} of the infrastructure it
+        caused. Excluding it would divide the whole infrastructure bill
+        across only the accounts that happen to be tagged today, which would overstate every one of
+        them and make each newly tagged account look like it cut the others&apos; costs.
       </p>
     </div>
+  );
+}
+
+/** Where the rule in force came from. Three different claims, so three different sentences. */
+function RuleSource({
+  setting,
+  fellBack,
+}: {
+  setting: AllocationRuleSetting;
+  fellBack: boolean;
+}) {
+  if (fellBack) {
+    // The engine could not apply the configured rule: pro rata needs a denominator and every
+    // account had zero direct spend. Naming the configured rule here would describe an arithmetic
+    // that did not happen.
+    return (
+      <span title={`Configured rule: ${ALLOCATION_RULE_LABELS[setting.rule]}`}>
+        {`(fallback: ${ALLOCATION_RULE_LABELS[setting.rule]} had no direct spend to divide by)`}
+      </span>
+    );
+  }
+  if (setting.source === "tenant") {
+    return (
+      <span title={setting.updatedBy ? `Last changed by ${setting.updatedBy}` : undefined}>
+        {`(this tenant's configured rule${
+          setting.updatedAt ? `, set ${setting.updatedAt.slice(0, 10)}` : ""
+        })`}
+      </span>
+    );
+  }
+  if (setting.source === "default") {
+    return <span>(the product default; no rule configured for this tenant)</span>;
+  }
+  // Applied the default WITHOUT being able to check the tenant's own choice. Saying "the default"
+  // flat would be a claim about their configuration that we did not verify.
+  return (
+    <span className="text-warn">
+      (the product default, applied because the allocation config could not be read)
+    </span>
+  );
+}
+
+/**
+ * The untagged bucket, below the table rather than inside it.
+ *
+ * It is not a customer and must never be ranked as one, but on the current data it carries most of
+ * the money, so leaving it out of the page entirely would make the table appear to lose the bill.
+ * Shown as its own panel with the same three figures, so the reconciliation line below adds up in
+ * front of the reader.
+ */
+function UnattributedRow({ allocated }: { allocated: AllocatedAccountCosts }) {
+  const row = allocated.unattributed;
+  return (
+    <div className="mt-4 rounded-lg border border-dashed border-edge bg-ink/20 p-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1 text-sm">
+        <span className="font-medium">
+          Untagged traffic{" "}
+          <span className="text-xs font-normal text-muted">
+            (not a customer: spans that carry no account id)
+          </span>
+        </span>
+        <span className="flex flex-wrap gap-x-6 tabular-nums">
+          <span>
+            <span className="text-xs uppercase tracking-wide text-muted">Direct </span>
+            <Money micro={row.directCostMicroUsd} />
+          </span>
+          <span className="text-muted">
+            <span className="text-xs uppercase tracking-wide">Allocated </span>
+            <Money micro={row.allocatedMicroUsd} />
+          </span>
+          <span className="font-medium">
+            <span className="text-xs uppercase tracking-wide text-muted">Total </span>
+            <Money micro={row.totalMicroUsd} />
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The reconciliation line: this page against `/cost`.
+ *
+ * The acceptance test of the whole feature, printed rather than merely unit-tested. If the rows do
+ * not add up to the tenant's bill, the tab contradicts `/cost` and loses trust the first time
+ * anyone sums a column, so the sum is put on screen where a reader can check it themselves.
+ *
+ * The total is summed from the rendered rows, not read back off the allocation result, so the line
+ * is an actual check on what was displayed. `allocateShared` guarantees the equality, which makes
+ * the mismatch branch dead code on every input the engine accepts. It is kept anyway: this claim is
+ * load-bearing enough that silently printing a wrong sum would be worse than admitting a bug.
+ */
+function Reconciliation({ allocated }: { allocated: AllocatedAccountCosts }) {
+  const summed = allocatedRowsTotal(allocated);
+  const reconciles = summed === allocated.tenantTotalMicroUsd;
+  return (
+    <p className="max-w-prose text-xs text-muted">
+      Direct <Money micro={allocated.directTotalMicroUsd} /> plus allocated{" "}
+      <Money micro={allocated.allocatedTotalMicroUsd} /> is{" "}
+      <Money micro={allocated.tenantTotalMicroUsd} className="font-medium" />, the tenant total for
+      the same {allocated.windowDays} days on the Cost tab. Every row above, untagged traffic
+      included, adds up to exactly that figure
+      {reconciles ? (
+        "."
+      ) : (
+        <span className="text-warn">
+          {", except they do not: the rows sum to "}
+          <Money micro={summed} />, which is a bug in this page rather than a fact about your bill.
+        </span>
+      )}
+    </p>
   );
 }
 

--- a/web/lib/accounts.test.ts
+++ b/web/lib/accounts.test.ts
@@ -2,11 +2,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ALLOCATION_RULE_DESCRIPTIONS,
+  ALLOCATION_RULE_LABELS,
   MIN_SPANS_FOR_COST_PER_USER,
   SHORT_HASH_CHARS,
   type AccountCostRow,
   type AccountCosts,
   type ExcludedInfraCost,
+  allocateAccountCosts,
+  allocatedRowsTotal,
   attributedSpend,
   costPerUser,
   emptyAccountRow,
@@ -15,6 +19,7 @@ import {
   shortenAccountHash,
   unattributedShare,
 } from "./accounts";
+import { ALLOCATION_RULES, type AllocationRule } from "./allocation";
 
 function row(over: Partial<AccountCostRow> = {}): AccountCostRow {
   return {
@@ -184,5 +189,161 @@ describe("excludedShare (CTO-189)", () => {
       costs({ totalDirectMicroUsd: 100 }),
     );
     expect(formatShare(share!)).toBe(">99.9%");
+  });
+});
+
+describe("allocateAccountCosts (CTO-193)", () => {
+  function shared(total: number): ExcludedInfraCost {
+    return {
+      windowDays: 30,
+      computeMicroUsd: total,
+      egressMicroUsd: 0,
+      totalMicroUsd: total,
+    };
+  }
+
+  /** Three tagged accounts plus a bucket, with the totals wired up the way the query returns them. */
+  function tenant(directs: number[], bucketDirect: number): AccountCosts {
+    const accounts = directs.map((d, i) => ({
+      ...emptyAccountRow(String(i).repeat(64), false),
+      directCostMicroUsd: d,
+    }));
+    const unattributed = {
+      ...emptyAccountRow("", true),
+      directCostMicroUsd: bucketDirect,
+    };
+    return {
+      windowDays: 30,
+      accounts,
+      unattributed,
+      totalDirectMicroUsd: directs.reduce((s, d) => s + d, 0) + bucketDirect,
+    };
+  }
+
+  // --- THE ACCEPTANCE TEST ----------------------------------------------------------------------
+
+  /**
+   * Direct plus allocated across every row equals the tenant total, exactly.
+   *
+   * This is the claim the page prints and the one the whole feature rests on: if these rows do not
+   * add up to what /cost reports, the tab contradicts the Cost tab and loses trust the first time
+   * someone sums a column. C1 guarantees the arithmetic; this asserts the WIRING does not break it,
+   * which is the only way it can break.
+   */
+  function expectReconciles(costs: AccountCosts, excludedTotal: number, rule: AllocationRule) {
+    const out = allocateAccountCosts(costs, shared(excludedTotal), rule)!;
+    expect(out).not.toBeNull();
+    expect(allocatedRowsTotal(out)).toBe(out.tenantTotalMicroUsd);
+    expect(out.tenantTotalMicroUsd).toBe(costs.totalDirectMicroUsd + excludedTotal);
+    expect(out.allocatedTotalMicroUsd).toBe(excludedTotal);
+    expect(out.directTotalMicroUsd).toBe(costs.totalDirectMicroUsd);
+    for (const r of [...out.accounts, out.unattributed]) {
+      expect(r.totalMicroUsd).toBe(r.directCostMicroUsd + r.allocatedMicroUsd);
+    }
+    return out;
+  }
+
+  it("reconciles on the live tenant's shape: three tiny accounts, a huge untagged bucket", () => {
+    // The real numbers, in micro-USD: direct $48,716.15 of which the bucket is all but $5.31, and
+    // $42,062.91 of compute and egress to allocate.
+    const costs = tenant([3_120_000, 1_450_000, 740_000], 48_710_840_000);
+    const out = expectReconciles(costs, 42_062_910_000, "pro_rata_direct");
+    expect(out.tenantTotalMicroUsd).toBe(90_779_060_000);
+    // Not an absurd per-account figure: each tagged account carries a share proportional to a
+    // handful of dollars of direct spend, not a third of a $42k infrastructure bill.
+    for (const a of out.accounts) {
+      expect(a.allocatedMicroUsd).toBeLessThan(5_000_000);
+    }
+    // The bucket carries essentially the whole infrastructure bill, because it caused it.
+    expect(out.unattributed.allocatedMicroUsd / out.allocatedTotalMicroUsd).toBeGreaterThan(0.999);
+  });
+
+  it("reconciles under an even split too, bucket included", () => {
+    const costs = tenant([3_120_000, 1_450_000, 740_000], 48_710_840_000);
+    const out = expectReconciles(costs, 42_062_910_000, "even_split");
+    // Four participants, so the bucket takes a quarter rather than its usage share. That is the
+    // rule doing what it says; the point of the assertion is that the bucket still participates.
+    expect(out.unattributed.allocatedMicroUsd).toBe(10_515_727_500);
+  });
+
+  it("reconciles on a total that does not divide evenly", () => {
+    // Rounding across many small accounts is one of the two named ways to break reconciliation.
+    expectReconciles(tenant([1, 1, 1], 1), 10, "pro_rata_direct");
+    expectReconciles(tenant([7, 11, 13], 17), 1_000_003, "pro_rata_direct");
+  });
+
+  // --- the unattributed-bucket decision ---------------------------------------------------------
+
+  it("gives the untagged bucket the infrastructure it caused, not the tagged accounts", () => {
+    const costs = tenant([1_000_000], 99_000_000);
+    const out = allocateAccountCosts(costs, shared(100_000_000), "pro_rata_direct")!;
+    expect(out.accounts[0].allocatedMicroUsd).toBe(1_000_000);
+    expect(out.unattributed.allocatedMicroUsd).toBe(99_000_000);
+  });
+
+  it("does not let a newly tagged account change what the others cost", () => {
+    // The property that rules out excluding the bucket. If the bucket sat out, tagging one more
+    // account would redistribute the entire infrastructure bill and halve the existing accounts'
+    // cost, so a customer's cost would depend on how many OTHER customers were instrumented.
+    const before = allocateAccountCosts(
+      tenant([1_000_000], 9_000_000),
+      shared(10_000_000),
+      "pro_rata_direct",
+    )!;
+    const after = allocateAccountCosts(
+      tenant([1_000_000, 2_000_000], 7_000_000),
+      shared(10_000_000),
+      "pro_rata_direct",
+    )!;
+    const firstBefore = before.accounts[0].allocatedMicroUsd;
+    const firstAfter = after.accounts.find((a) => a.directCostMicroUsd === 1_000_000)!;
+    expect(firstAfter.allocatedMicroUsd).toBe(firstBefore);
+  });
+
+  it("keeps the bucket flagged as unattributed so nothing can rank it as a customer", () => {
+    const out = allocateAccountCosts(tenant([1_000_000], 1_000_000), shared(10), "even_split")!;
+    expect(out.unattributed.unattributed).toBe(true);
+    expect(out.accounts.every((a) => !a.unattributed)).toBe(true);
+    expect(out.accounts.map((a) => a.accountIdHash)).not.toContain("");
+  });
+
+  // --- presentation contracts -------------------------------------------------------------------
+
+  it("ranks accounts by TOTAL cost, not direct", () => {
+    // Under an even split the cheaper account by direct spend can be the more expensive customer
+    // once infrastructure is counted. A table headed by a Total column must be sorted by it.
+    const costs = tenant([3_000_000, 2_000_000], 0);
+    costs.accounts[1].spanCount = 10; // irrelevant to cost, present to keep the rows distinct
+    const out = allocateAccountCosts(costs, shared(0), "even_split")!;
+    expect(out.accounts[0].totalMicroUsd).toBeGreaterThanOrEqual(out.accounts[1].totalMicroUsd);
+  });
+
+  it("reports the fallback rule when pro rata has no denominator", () => {
+    // Every participant at zero direct spend. Reporting "pro rata" here would name an arithmetic
+    // that never ran, so the page names the rule that actually applied.
+    const out = allocateAccountCosts(tenant([0, 0], 0), shared(1_000_000), "pro_rata_direct")!;
+    expect(out.rule).toBe("pro_rata_direct");
+    expect(out.effectiveRule).toBe("even_split");
+    expect(allocatedRowsTotal(out)).toBe(out.tenantTotalMicroUsd);
+  });
+
+  it("returns null when the shared total could not be read, never a silent zero", () => {
+    // A zero allocation would print direct cost as though it were total cost on every row, which
+    // is the understatement CTO-189's banner existed to flag, with no banner left to flag it.
+    expect(allocateAccountCosts(tenant([1_000_000], 0), null, "pro_rata_direct")).toBeNull();
+  });
+
+  it("allocates nothing when the window holds no infrastructure spend", () => {
+    const out = allocateAccountCosts(tenant([1_000_000], 0), shared(0), "pro_rata_direct")!;
+    expect(out.allocatedTotalMicroUsd).toBe(0);
+    expect(out.tenantTotalMicroUsd).toBe(1_000_000);
+    expect(allocatedRowsTotal(out)).toBe(1_000_000);
+  });
+
+  it("names every rule it can apply, so no column header can be blank", () => {
+    for (const rule of ALLOCATION_RULES) {
+      expect(ALLOCATION_RULE_LABELS[rule]).toBeTruthy();
+      expect(ALLOCATION_RULE_DESCRIPTIONS[rule]).toBeTruthy();
+    }
   });
 });

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -7,6 +7,11 @@
 // plausible-looking fake account list would be the single most misleading thing this page could
 // show. The empty state (D5) is the answer to no data, not invented data.
 
+import {
+  allocateShared,
+  type AllocationResult,
+  type AllocationRule,
+} from "./allocation";
 import type { MicroUSD, SpendByLayer } from "./types";
 
 /**
@@ -240,3 +245,151 @@ export function excludedShare(excluded: ExcludedInfraCost, costs: AccountCosts):
   if (all <= 0) return null;
   return excluded.totalMicroUsd / all;
 }
+
+// --- Allocated infrastructure cost (CTO-193, plan C2) --------------------------------------------
+//
+// This is where the excluded half of the bill stops being excluded. CTO-189 could only state the
+// SIZE of what the table left out; with an allocation rule in force (CTO-192 for the arithmetic,
+// C2 for the per-tenant rule) compute and egress can be attributed, and the table carries direct,
+// allocated and total per account instead of a banner apologising for the gap.
+//
+// THE DECISION THIS SECTION ENCODES, and the most consequential one in the ticket: THE
+// UNATTRIBUTED BUCKET PARTICIPATES IN ALLOCATION, as a first-class participant alongside the real
+// accounts.
+//
+// It is a synthetic row, not a customer, so treating it as one deserves a defence. The defence is
+// that every alternative is worse in the case that actually occurs. Shared infrastructure is caused
+// by ALL traffic, and untagged traffic is traffic: on the current tenant it is over 99.99 percent
+// of direct spend, so it is causing essentially all of the compute bill. Leaving the bucket out
+// would divide the whole shared total across only the accounts that happen to be tagged, and hand
+// three accounts with a few dollars of direct spend roughly fourteen thousand dollars of compute
+// each. That figure is not merely unhelpful, it is false, and it is worst exactly when a tenant is
+// earliest in rolling out `account_id` and least equipped to spot it. It also has a property no
+// cost report may have: instrumenting one more account would halve every existing account's cost.
+//
+// With the bucket participating, the same tenant reads honestly. The unattributed row carries
+// almost all of the shared cost, the tagged accounts carry a share proportional to what they
+// actually used, and the page can say plainly that most infrastructure cost belongs to traffic that
+// carries no account yet. The remedy that reading suggests, tag more spans, is the true one.
+//
+// The bucket keeps `unattributed: true` throughout, so no surface can rank it as a customer, and
+// the page labels its share as belonging to untagged traffic rather than to anybody.
+
+/** One table row once shared cost has been allocated. `total = direct + allocated`. */
+export interface AllocatedAccountRow extends AccountCostRow {
+  /** Estimated share of tenant-level compute and egress. NOT measured. */
+  allocatedMicroUsd: MicroUSD;
+  /** `directCostMicroUsd + allocatedMicroUsd`. Part measured, part estimated. */
+  totalMicroUsd: MicroUSD;
+}
+
+export interface AllocatedAccountCosts {
+  windowDays: number;
+  /** The rule asked for. */
+  rule: AllocationRule;
+  /**
+   * The rule actually applied. Differs from {@link AllocatedAccountCosts.rule} when pro rata had no
+   * denominator and the engine fell back to an even split. The page names this one, because it is
+   * the one that produced the numbers.
+   */
+  effectiveRule: AllocationRule;
+  /** Real accounts, ranked by TOTAL cost, most expensive first. */
+  accounts: AllocatedAccountRow[];
+  /** The unattributed bucket with its allocated share. Never ranked among the accounts. */
+  unattributed: AllocatedAccountRow;
+  /** Compute plus egress for the window: the pot that was shared out. */
+  sharedMicroUsd: MicroUSD;
+  directTotalMicroUsd: MicroUSD;
+  allocatedTotalMicroUsd: MicroUSD;
+  /** `direct + shared`. What the rows must add up to, and what `/cost` reports for the window. */
+  tenantTotalMicroUsd: MicroUSD;
+}
+
+/**
+ * Allocate the window's compute and egress across every account plus the unattributed bucket.
+ *
+ * Returns `null` when the excluded total could not be read. That is not a zero: allocating nothing
+ * would print a total equal to direct cost for every account, quietly restoring the understated
+ * figures CTO-189 existed to flag with no banner left to warn about them. The caller renders the
+ * unreadable case explicitly instead.
+ *
+ * RECONCILIATION, the acceptance test of this ticket:
+ *
+ *     sum(accounts.total) + unattributed.total === tenantTotalMicroUsd === direct + compute + egress
+ *
+ * exactly, in integer micro-USD, which is the same total `/cost` reports for the same window. The
+ * guarantee itself comes from `allocateShared`. The job here is to feed it EVERY row holding direct
+ * spend (which is why the unattributed bucket has to go in) and to add nothing to its output.
+ */
+export function allocateAccountCosts(
+  costs: AccountCosts,
+  excluded: ExcludedInfraCost | null,
+  rule: AllocationRule,
+): AllocatedAccountCosts | null {
+  if (excluded === null) return null;
+
+  // The bucket goes in last, so a remainder tie between it and a real account breaks toward the
+  // account: the engine breaks ties by input order. The stake is one micro-USD, so this is
+  // cosmetic, and it is ordered deliberately anyway because "why did the synthetic row get the
+  // spare unit" is a question someone eventually asks of a reconciliation report.
+  const participants = [...costs.accounts, costs.unattributed];
+  const result: AllocationResult = allocateShared(
+    participants.map((row) => ({
+      accountId: row.accountIdHash,
+      directMicroUsd: row.directCostMicroUsd,
+    })),
+    excluded.totalMicroUsd,
+    rule,
+  );
+
+  const allocatedRows: AllocatedAccountRow[] = participants.map((row, i) => ({
+    ...row,
+    allocatedMicroUsd: result.accounts[i].allocatedMicroUsd,
+    totalMicroUsd: result.accounts[i].totalMicroUsd,
+  }));
+  const unattributed = allocatedRows[allocatedRows.length - 1];
+  const accounts = allocatedRows.slice(0, -1);
+  // Ranked on TOTAL, not direct. With roughly half the bill allocated, the most expensive customer
+  // by direct spend is not necessarily the most expensive customer.
+  accounts.sort((a, b) => b.totalMicroUsd - a.totalMicroUsd);
+
+  return {
+    windowDays: costs.windowDays,
+    rule: result.rule,
+    effectiveRule: result.effectiveRule,
+    accounts,
+    unattributed,
+    sharedMicroUsd: excluded.totalMicroUsd,
+    directTotalMicroUsd: result.directTotalMicroUsd,
+    allocatedTotalMicroUsd: result.allocatedTotalMicroUsd,
+    tenantTotalMicroUsd: result.tenantTotalMicroUsd,
+  };
+}
+
+/**
+ * The sum the reconciliation line prints: every row's total, bucket included.
+ *
+ * Summed from the rendered rows rather than read back off `tenantTotalMicroUsd`, so the check is a
+ * real check. Reading the claimed total out of the same object would assert nothing about the
+ * numbers actually on screen.
+ */
+export function allocatedRowsTotal(allocated: AllocatedAccountCosts): MicroUSD {
+  return (
+    allocated.accounts.reduce((sum, r) => sum + r.totalMicroUsd, 0) +
+    allocated.unattributed.totalMicroUsd
+  );
+}
+
+/** Short display name for a rule. Shown wherever an allocated figure is. */
+export const ALLOCATION_RULE_LABELS: Record<AllocationRule, string> = {
+  pro_rata_direct: "pro rata on direct spend",
+  even_split: "even split across accounts",
+};
+
+/** One sentence saying what the rule did, for the reader who wants to check the arithmetic. */
+export const ALLOCATION_RULE_DESCRIPTIONS: Record<AllocationRule, string> = {
+  pro_rata_direct:
+    "each account carries a share of compute and egress in proportion to its own direct spend, so an account with twice the model bill carries twice the infrastructure",
+  even_split:
+    "compute and egress are divided equally across every account and the untagged bucket, regardless of how much each one used",
+};

--- a/web/lib/allocationConfig.test.ts
+++ b/web/lib/allocationConfig.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_ALLOCATION_RULE } from "./allocation";
+import { fallbackSetting, settingFromApi } from "./allocationConfig";
+
+describe("settingFromApi (CTO-193 wire mapping)", () => {
+  it("carries a tenant's configured rule through, with who set it and when", () => {
+    expect(
+      settingFromApi({
+        allocation_rule: "even_split",
+        configured: true,
+        config: { updated_at: "2026-03-04T10:00:00+00:00", updated_by: "finance@acme.test" },
+      }),
+    ).toEqual({
+      rule: "even_split",
+      source: "tenant",
+      updatedAt: "2026-03-04T10:00:00+00:00",
+      updatedBy: "finance@acme.test",
+    });
+  });
+
+  it("reports the default as the DEFAULT, not as a choice the tenant made", () => {
+    // The state every tenant is in today. The page says "the product default, nobody configured
+    // one", which is a weaker and truer claim than presenting it as a decision.
+    const setting = settingFromApi({
+      allocation_rule: "pro_rata_direct",
+      configured: false,
+      config: null,
+    });
+    expect(setting.rule).toBe(DEFAULT_ALLOCATION_RULE);
+    expect(setting.source).toBe("default");
+  });
+
+  it("distinguishes an unreadable config from an unconfigured tenant", () => {
+    // Both apply the default rule, but they are different claims about the tenant's configuration
+    // and the page words them differently. Collapsing them would assert something we never checked.
+    expect(settingFromApi(null)).toEqual(fallbackSetting("unavailable"));
+    expect(settingFromApi(null).source).not.toBe("default");
+  });
+
+  it("refuses a rule this dashboard cannot apply rather than pretending it was chosen", () => {
+    // A gateway newer than the web app. Applying the default is the only option, but reporting it
+    // as the tenant's rule would put a name on screen that did not produce the numbers beside it.
+    const setting = settingFromApi({ allocation_rule: "pro_rata_tokens", configured: true });
+    expect(setting.rule).toBe(DEFAULT_ALLOCATION_RULE);
+    expect(setting.source).toBe("unavailable");
+  });
+
+  it("treats a malformed rule field the same way", () => {
+    expect(settingFromApi({ allocation_rule: 7, configured: true }).source).toBe("unavailable");
+    expect(settingFromApi({}).source).toBe("unavailable");
+  });
+
+  it("drops non-string audit fields instead of rendering them", () => {
+    const setting = settingFromApi({
+      allocation_rule: "pro_rata_direct",
+      configured: true,
+      config: { updated_at: 1234, updated_by: null },
+    });
+    expect(setting.source).toBe("tenant");
+    expect(setting.updatedAt).toBeNull();
+    expect(setting.updatedBy).toBeNull();
+  });
+
+  it("always yields a usable rule, on every path", () => {
+    for (const body of [null, {}, { allocation_rule: "nope" }, { configured: true }]) {
+      expect(settingFromApi(body)).toHaveProperty("rule", DEFAULT_ALLOCATION_RULE);
+    }
+  });
+});

--- a/web/lib/allocationConfig.ts
+++ b/web/lib/allocationConfig.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Per-tenant shared-cost allocation rule, read via the gateway (CTO-193, plan C2).
+//
+// The rule decides how compute and egress are split across accounts on /cost-per-customer, which on
+// current data is roughly half of every figure on that page. It used to be a constant compiled into
+// the dashboard; it is now a tenant config row (GET/POST /v1/tenant/allocation-config). This module
+// is the server-only reader, same rule as lib/accountLabels.ts and lib/unitEconomicsConfig.ts: the
+// web app never touches Postgres directly.
+//
+// WHY this returns a source and not just a rule. The page names the rule beside the column it
+// produced, and "pro rata, the default" is a different claim from "pro rata, chosen by this
+// tenant". A reader deciding whether to argue with a number needs to know which one they are
+// looking at, and a third case exists that is more important than either: the gateway was
+// unreachable, so we applied the default WITHOUT being able to check whether this tenant had
+// chosen something else. Reporting that as "the default" would be a quiet false claim about the
+// tenant's own configuration, so it is its own source and the page says so.
+
+import { DEFAULT_ALLOCATION_RULE, type AllocationRule, ALLOCATION_RULES } from "./allocation";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+
+/** A slow gateway must not hold a page render open. Same budget lib/accountLabels.ts uses. */
+const TIMEOUT_MS = 2000;
+
+/** Wire shape of the gateway's allocation-config response (snake_case, as Postgres spells it). */
+export interface AllocationConfigApi {
+  allocation_rule?: unknown;
+  configured?: unknown;
+  default_rule?: unknown;
+  available_rules?: unknown;
+  config?: { updated_at?: unknown; updated_by?: unknown } | null;
+}
+
+/** Where the rule in force came from. Drives what the page is entitled to claim about it. */
+export type AllocationRuleSource =
+  /** A row exists: this tenant chose the rule. */
+  | "tenant"
+  /** No row: nobody chose it, so the product default applies. */
+  | "default"
+  /** The gateway could not be asked. The default applies, but we cannot say the tenant wanted it. */
+  | "unavailable";
+
+export interface AllocationRuleSetting {
+  /** The rule to apply. Always a usable value, on every path including failure. */
+  rule: AllocationRule;
+  source: AllocationRuleSource;
+  /** ISO timestamp of the tenant's last change, when there is one. */
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
+/** The setting a page falls back to when the tenant's own choice cannot be read. */
+export function fallbackSetting(source: Exclude<AllocationRuleSource, "tenant">): AllocationRuleSetting {
+  return { rule: DEFAULT_ALLOCATION_RULE, source, updatedAt: null, updatedBy: null };
+}
+
+/**
+ * Map the gateway's response onto the setting the page renders.
+ *
+ * An unrecognised rule string falls back to the default and reports `unavailable` rather than
+ * `tenant`. That combination is deliberate: this dashboard cannot apply a rule it does not
+ * implement, so it applies the default, and claiming the tenant chose the default when they chose
+ * something else would be worse than admitting the rule could not be determined. It only happens
+ * when a gateway is newer than the dashboard, which is exactly when a quiet lie is most likely to
+ * go unnoticed.
+ */
+export function settingFromApi(body: AllocationConfigApi | null): AllocationRuleSetting {
+  if (!body) return fallbackSetting("unavailable");
+  const raw = body.allocation_rule;
+  const known = (ALLOCATION_RULES as readonly string[]).includes(raw as string);
+  if (typeof raw !== "string" || !known) return fallbackSetting("unavailable");
+  if (body.configured !== true) return fallbackSetting("default");
+  const cfg = body.config ?? null;
+  return {
+    rule: raw as AllocationRule,
+    source: "tenant",
+    updatedAt: typeof cfg?.updated_at === "string" ? cfg.updated_at : null,
+    updatedBy: typeof cfg?.updated_by === "string" ? cfg.updated_by : null,
+  };
+}
+
+/**
+ * The tenant's allocation rule, or the default when they have not chosen one.
+ *
+ * Never throws and never returns null: a page that cannot read this config still has to render
+ * numbers, and refusing to allocate because a config endpoint timed out would be a worse answer
+ * than allocating by the default and saying which rule was used. The failure is carried in
+ * `source`, not in the absence of a value.
+ */
+export async function queryAllocationRule(): Promise<AllocationRuleSetting> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/allocation-config`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      console.warn(
+        `[accounts] /v1/tenant/allocation-config HTTP ${res.status}; applying the default rule`,
+      );
+      return fallbackSetting("unavailable");
+    }
+    return settingFromApi((await res.json()) as AllocationConfigApi);
+  } catch (err) {
+    console.warn(
+      "[accounts] /v1/tenant/allocation-config unreachable:",
+      (err as Error).message,
+    );
+    return fallbackSetting("unavailable");
+  }
+}


### PR DESCRIPTION
Last ticket of the Cost per customer epic (CTO-176). Stacked on **#185** (D3, the excluded-cost banner), **#184** (D2, the page) and **#169** (C1, the allocation engine), and based on `feat/allocation-base` which merges them.

## What lands

**1. Per-tenant allocation config (C2).** `db/postgres/0024_tenant_allocation_config.sql` plus `GET/POST /v1/tenant/allocation-config`, following the control-plane pattern: the web app never touches Postgres directly. Writes are idempotent on `change_id` and append to an audit companion, because changing the rule moves every allocated number on the page at once and "who changed it, and from what" is the first question that follows. Unlike `tenant_account_labels` there is no privacy reason to skip the audit log here: the payload is one enum value from a set of two and carries no customer data.

A tenant with no row gets `pro_rata_direct` and keeps working. The response separates *which rule applies* from *did anyone pick it* (`configured`), because "pro rata, the default" and "pro rata, chosen by finance in March" are different claims to put in front of a reader. An unknown rule is a 422, never a silent fallback: storing one rule and applying another would leave the page naming a rule that did not produce its numbers.

Tenant resolution: `gateway/tenant_lookup.py` is not on this base, so the store uses the same `_resolve_tenant_uuid` shape as `tenant_account_labels` / `connectors/config_admin`. A name-based caller resolves to `tenants.id` and does not 500; there is a test for it, and it is verified live below.

**2. The rule is named on the page.** Beside the column it produced, with three sources kept distinct: the tenant's configured rule (with when and by whom), the product default with nothing configured, and the default applied *because the config could not be read*. The third is not the same claim as the second and is not worded as one. `effectiveRule` is what gets named, so a pro-rata fallback to even split says so rather than describing arithmetic that did not run.

**3. Direct / Allocated / Total columns replace D3's banner.** The banner carried a comment naming this ticket as the one that deletes it; it is gone. Allocated cost is its own column, never folded into a single total, with the rule in the column header and the estimate styled apart from the measured figure. The untagged bucket is rendered below the table rather than ranked inside it. A reconciliation line prints direct plus allocated against the tenant total, summed from the rendered rows rather than read back off the allocation result, so it is a real check on what was displayed.

## The unattributed bucket participates in allocation

The most consequential decision in the ticket, so here is the reasoning.

The bucket is synthetic and is not a customer, but **untagged traffic is traffic**. On the live tenant it is over 99.99 percent of direct spend, so it is causing essentially all of the compute bill. Excluding it would divide the whole shared total across only the accounts that happen to be tagged today. Concretely, on this tenant that hands three accounts with $2.50, $1.50 and $0.0001 of direct spend about **$14,021 of compute each**. That figure is not merely unhelpful, it is false.

It also has a property no cost report may have: instrumenting one more account would redistribute the entire infrastructure bill and roughly halve every existing account's cost. A customer's cost would depend on how many *other* customers were instrumented. There is a test for exactly this (`does not let a newly tagged account change what the others cost`).

With the bucket participating, the same tenant reads honestly: the untagged row carries $42,059.46 of the $42,062.92 shared pot, the tagged accounts carry $2.16 / $1.30 / $0.0000, and the page states plainly that most infrastructure cost belongs to traffic carrying no account yet. The remedy that reading suggests, tag more spans, is the true one.

The same policy applies to `even_split` (the bucket is one participant), which keeps reconciliation identical across rules. Under even split the tagged accounts do get ~$10.5k each, which is the weaker rule doing exactly what it says on the tin; the page names the rule, so the reader can see why the number looks like that.

The bucket keeps `unattributed: true` throughout, so nothing can rank it among customers or label it as one.

## THE ACCEPTANCE TEST: reconciliation against live ClickHouse

Live `daily_account_rollup`, tenant `local-dev`, same 30-day window the tab uses:

```
account         direct        compute       egress
(untagged)      48712.154646  41883.583337  179.333335
cf0f8e1442e6         2.5             0            0
c861664f5a0b         1.5             0            0
cccccccccccc         0.000054        0            0
```

Direct $48,716.15, compute $41,883.58, egress $179.33, tenant total **$90,779.07**.

Run through the shipped `allocateAccountCosts`, in integer micro-USD (`[direct, allocated, total]`):

**pro_rata_direct** (the default)
```
[        2500000,     2158571,     4658571]
[        1500000,     1295143,     2795143]
[             54,          47,         101]
[    48712154646, 42059462911, 90771617557]   untagged
rows sum      90779071372
tenant total  90779071372   ->  exact match
```

**even_split**
```
[        2500000, 10515729168, 10518229168]
[        1500000, 10515729168, 10517229168]
[             54, 10515729168, 10515729222]
[    48712154646, 10515729168, 59227883814]   untagged
rows sum      90779071372
tenant total  90779071372   ->  exact match
```

Both reconcile to the micro-USD. Nothing lost to rounding, nothing double counted, and the page's own on-screen reconciliation line renders the non-warning branch.

One honest note about `/cost` on this local database: it reads `otel_spans` and reports $90,775.07, $4.00 less than the rollup. That gap is a stray `chat` row in `daily_account_rollup` for 2026-08-26 with no matching span, pre-existing local seed data unrelated to this branch (the ticket's own quoted tenant total, $90,779.07, is the rollup figure). Both the account table and the compute/egress figure are read from the same rollup under complementary filters, so the page is internally exact either way.

## Live gateway verification

Branch gateway on a spare port against the running Postgres:

```
GET  (name, no row)   -> {"allocation_rule":"pro_rata_direct","configured":false,...}
POST (name)           -> even_split stored, configured:true
GET  (tenant UUID)    -> even_split          # both spellings, one row, no 500
POST allocation_rule=nonsense
                      -> 422 "allocation_rule must be one of: pro_rata_direct, even_split"
```

Migration applied by hand to the running Postgres (initdb only fires on a fresh volume) and added to the compose mounts.

## Verification

- `web`: `npm run typecheck` clean, `npm run lint` clean (3 pre-existing warnings in `attribution/Live.tsx` and `useLivePoll.ts`), `npm run test` 353 passed with the 2 known pre-existing `app/api/api.test.ts` failures and no new ones.
- `infra/gateway`: `uv run --extra dev pytest -q` 537 passed, `uv run ruff check .` clean.
- Verified in a browser against live data.

## Rendered

Verified in a browser against live data (screenshot captured locally). The page renders, top to
bottom: four stat cards (Direct spend measured $48,716.15, Allocated infra estimated $42,062.92,
Total cost $90,779.07, Direct spend with no account >99.9%); the existing mostly-unattributed
notice; the new Allocated notice naming the rule and its source; the table with Account, Users,
Direct cost, Allocated (pro rata on direct spend), Total cost, Direct cost per user; the untagged
traffic panel; and the reconciliation line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
