### PR TITLE
feat(forecast): day-of-week weighted spend projection with a narrowing band (CTO-206)

### DIFF
--- a/web/lib/forecast.test.ts
+++ b/web/lib/forecast.test.ts
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_HISTORY_DAYS,
+  type DailySpend,
+  forecastSpend,
+} from "./forecast";
+
+const MS_PER_DAY = 86_400_000;
+
+function addDays(date: string, n: number): string {
+  return new Date(Date.parse(`${date}T00:00:00Z`) + n * MS_PER_DAY).toISOString().slice(0, 10);
+}
+
+/** 0 = Sunday .. 6 = Saturday, matching the engine. */
+function dow(date: string): number {
+  return new Date(Date.parse(`${date}T00:00:00Z`)).getUTCDay();
+}
+
+/** Build `count` consecutive days starting at `start`, amounts from `amount(date, dow, index)`. */
+function series(
+  start: string,
+  count: number,
+  amount: (date: string, weekday: number, index: number) => number,
+): DailySpend[] {
+  const out: DailySpend[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const date = addDays(start, i);
+    out.push({ date, microUsd: Math.round(amount(date, dow(date), i)) });
+  }
+  return out;
+}
+
+/**
+ * Deterministic LCG. The synthetic month has to be reproducible or the "weighted beats naive"
+ * assertion becomes a coin flip that fails in CI once a quarter.
+ */
+function seededJitter(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 4_294_967_296; // [0, 1)
+  };
+}
+
+// March 2024: 31 days, starts on a Friday. Enough weekend/weekday interleaving that a flat run-rate
+// computed over a part-month lands visibly wrong.
+const PERIOD_START = "2024-03-01";
+const PERIOD_END = "2024-03-31";
+/** 28 settled days of trailing history immediately before the period. */
+const HISTORY_START = addDays(PERIOD_START, -28);
+
+const WEEKDAY_MICRO = 1_000_000;
+const WEEKEND_MICRO = 300_000; // a B2B product at roughly a third of weekday volume on a Sunday
+
+function weekendHeavy(jitterSeed: number | null): (d: string, w: number) => number {
+  const rand = jitterSeed === null ? null : seededJitter(jitterSeed);
+  return (_date, weekday) => {
+    const base = weekday === 0 || weekday === 6 ? WEEKEND_MICRO : WEEKDAY_MICRO;
+    // +/-10 percent of seeded noise, so the medians are estimates rather than an exact replay.
+    return rand ? base * (0.9 + 0.2 * rand()) : base;
+  };
+}
+
+describe("day-of-week weighted projection", () => {
+  it("beats the naive run-rate on a seeded weekend-heavy month", () => {
+    const shape = weekendHeavy(20_240_301);
+    const history = series(HISTORY_START, 28, shape);
+    const march = series(PERIOD_START, 31, shape);
+
+    // Truth: what the month actually lands at. Only the first 15 days are visible to the forecast.
+    const truth = march.reduce((s, d) => s + d.microUsd, 0);
+    const asOf = addDays(PERIOD_START, 14); // 2024-03-15, a Friday
+
+    const f = forecastSpend({
+      days: [...history, ...march.slice(0, 15)],
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf,
+    });
+
+    expect(f.status).toBe("ok");
+    expect(f.projectedMicroUsd).not.toBeNull();
+    expect(f.naiveRunRateMicroUsd).not.toBeNull();
+
+    const weightedError = Math.abs(f.projectedMicroUsd! - truth);
+    const naiveError = Math.abs(f.naiveRunRateMicroUsd! - truth);
+
+    // The two must actually disagree, and the weighted one must be the closer of the two.
+    expect(f.projectedMicroUsd).not.toBe(f.naiveRunRateMicroUsd);
+    expect(weightedError).toBeLessThan(naiveError);
+    // Weighted lands within 3 percent of truth; naive is off by more than that.
+    expect(weightedError / truth).toBeLessThan(0.03);
+    expect(naiveError / truth).toBeGreaterThan(0.03);
+  });
+
+  it("reproduces a clean periodic month exactly", () => {
+    // No jitter: the weekday medians ARE the generating pattern, so the projection should land on
+    // the true total to the micro-USD. Any drift here is a bug in the weekday walk, not noise.
+    const shape = weekendHeavy(null);
+    const history = series(HISTORY_START, 28, shape);
+    const march = series(PERIOD_START, 31, shape);
+    const truth = march.reduce((s, d) => s + d.microUsd, 0);
+
+    const f = forecastSpend({
+      days: [...history, ...march.slice(0, 10)],
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 9),
+    });
+
+    expect(f.projectedMicroUsd).toBe(truth);
+    // Sanity line still disagrees, which is the whole reason it is labelled as one.
+    expect(f.naiveRunRateMicroUsd).not.toBe(truth);
+  });
+
+  it("uses a median per weekday, so one spike day does not move the projection much", () => {
+    const flat = series(HISTORY_START, 28, () => WEEKDAY_MICRO);
+    const spiked = flat.map((d, i) =>
+      i === flat.length - 1 ? { ...d, microUsd: WEEKDAY_MICRO * 50 } : d,
+    );
+    const base = { periodStart: PERIOD_START, periodEnd: PERIOD_END, asOf: PERIOD_START };
+
+    const clean = forecastSpend({ ...base, days: flat });
+    const withSpike = forecastSpend({ ...base, days: spiked });
+
+    // A mean over 28 days would drag the projection up by ~75 percent. The median moves one
+    // weekday's estimate by nothing at all here, because 3 of its 4 observations are unchanged.
+    expect(withSpike.projectedMicroUsd).toBe(clean.projectedMicroUsd);
+  });
+
+  it("reports the trailing window it computed from", () => {
+    const days = series(HISTORY_START, 40, () => WEEKDAY_MICRO);
+    const asOf = days[days.length - 1].date;
+    const f = forecastSpend({ days, periodStart: PERIOD_START, periodEnd: PERIOD_END, asOf });
+
+    expect(f.historyDays).toBe(40);
+    expect(f.windowEnd).toBe(asOf);
+    expect(f.windowStart).toBe(addDays(asOf, -27));
+  });
+
+  it("leaves a never-observed weekday null and falls back to the overall median", () => {
+    // A caller that only has settled weekdays: Saturday and Sunday were never seen at all.
+    const days = series(HISTORY_START, 28, () => WEEKDAY_MICRO).filter(
+      (d) => dow(d.date) !== 0 && dow(d.date) !== 6,
+    );
+    const f = forecastSpend({
+      days,
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: days[days.length - 1].date,
+    });
+
+    expect(f.weekdayMedianMicroUsd[0]).toBeNull(); // Sunday: unknown, not zero
+    expect(f.weekdayMedianMicroUsd[6]).toBeNull(); // Saturday
+    expect(f.weekdayMedianMicroUsd[3]).toBe(WEEKDAY_MICRO);
+    // Fallback is the overall median, so every remaining day projects at the weekday level.
+    expect(f.projectedMicroUsd).toBe(31 * WEEKDAY_MICRO);
+  });
+});
+
+describe("the confidence band", () => {
+  it("narrows monotonically as the period elapses, and closes to nothing at period end", () => {
+    // A strictly periodic series: the trailing 28-day window is the same multiset of values on
+    // every `asOf`, so the standard deviation is constant and any change in width comes from time
+    // elapsed rather than from the data moving underneath the test.
+    const shape = weekendHeavy(null);
+    const history = series(HISTORY_START, 28, shape);
+    const march = series(PERIOD_START, 31, shape);
+
+    const widths: number[] = [];
+    for (let elapsed = 1; elapsed <= 31; elapsed += 1) {
+      const f = forecastSpend({
+        days: [...history, ...march.slice(0, elapsed)],
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        asOf: addDays(PERIOD_START, elapsed - 1),
+      });
+      expect(f.status).toBe("ok");
+      widths.push(f.highMicroUsd! - f.lowMicroUsd!);
+    }
+
+    for (let i = 1; i < widths.length; i += 1) {
+      expect(widths[i]).toBeLessThanOrEqual(widths[i - 1]);
+    }
+    // Day 2 is a genuinely fat cone; the closed period is a single number.
+    expect(widths[1]).toBeGreaterThan(widths[24]);
+    expect(widths[widths.length - 1]).toBe(0);
+  });
+
+  it("brackets the point projection and never dips below money already spent", () => {
+    const shape = weekendHeavy(7);
+    const f = forecastSpend({
+      days: [...series(HISTORY_START, 28, shape), ...series(PERIOD_START, 12, shape)],
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 11),
+    });
+
+    expect(f.lowMicroUsd!).toBeLessThanOrEqual(f.projectedMicroUsd!);
+    expect(f.projectedMicroUsd!).toBeLessThanOrEqual(f.highMicroUsd!);
+    expect(f.lowMicroUsd!).toBeGreaterThanOrEqual(f.spendToDateMicroUsd);
+  });
+
+  it("has no band at all when daily spend never varies", () => {
+    const days = series(HISTORY_START, 28, () => WEEKDAY_MICRO);
+    const f = forecastSpend({
+      days,
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: days[days.length - 1].date,
+    });
+    expect(f.dailyStdDevMicroUsd).toBe(0);
+    expect(f.lowMicroUsd).toBe(f.projectedMicroUsd);
+    expect(f.highMicroUsd).toBe(f.projectedMicroUsd);
+  });
+
+  it("widens the cone with distance from the last settled day", () => {
+    const shape = weekendHeavy(99);
+    const f = forecastSpend({
+      days: [...series(HISTORY_START, 28, shape), ...series(PERIOD_START, 5, shape)],
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 4),
+    });
+
+    const future = f.burndown.filter((p) => p.actualMicroUsd === null);
+    const widths = future.map((p) => p.highMicroUsd - p.lowMicroUsd);
+    for (let i = 1; i < widths.length; i += 1) {
+      expect(widths[i]).toBeGreaterThan(widths[i - 1]);
+    }
+    // Settled days carry no band: they are measured, not projected.
+    for (const p of f.burndown.filter((q) => q.actualMicroUsd !== null)) {
+      expect(p.lowMicroUsd).toBe(p.actualMicroUsd);
+      expect(p.highMicroUsd).toBe(p.actualMicroUsd);
+    }
+  });
+});
+
+describe("the minimum-history guard", () => {
+  it("returns null rather than a number below the floor", () => {
+    const days = series(addDays(PERIOD_START, -4), 4, () => WEEKDAY_MICRO);
+    const f = forecastSpend({
+      days,
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 3),
+      budgetMicroUsd: 1_000,
+    });
+
+    expect(f.status).toBe("insufficient_history");
+    expect(f.projectedMicroUsd).toBeNull();
+    expect(f.lowMicroUsd).toBeNull();
+    expect(f.highMicroUsd).toBeNull();
+    expect(f.naiveRunRateMicroUsd).toBeNull();
+    expect(f.dailyStdDevMicroUsd).toBeNull();
+    expect(f.windowStart).toBeNull();
+    expect(f.windowEnd).toBeNull();
+    expect(f.burndown).toEqual([]);
+    expect(f.weekdayMedianMicroUsd.every((v) => v === null)).toBe(true);
+    // Measured facts are still reported: refusing to project is not refusing to count.
+    expect(f.historyDays).toBe(4);
+    expect(f.daysInPeriod).toBe(31);
+  });
+
+  it("flips to a projection exactly at the floor", () => {
+    const build = (n: number) =>
+      forecastSpend({
+        days: series(addDays(PERIOD_START, -n), n, () => WEEKDAY_MICRO),
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        asOf: addDays(PERIOD_START, -1),
+      });
+
+    expect(build(MIN_HISTORY_DAYS - 1).status).toBe("insufficient_history");
+    expect(build(MIN_HISTORY_DAYS).status).toBe("ok");
+    expect(build(MIN_HISTORY_DAYS).projectedMicroUsd).not.toBeNull();
+  });
+
+  it("ignores days after asOf when counting history", () => {
+    // 30 days on hand but only 10 of them settled: still a refusal, not a projection built from
+    // data the caller told us it cannot vouch for yet.
+    const f = forecastSpend({
+      days: series(addDays(PERIOD_START, -10), 30, () => WEEKDAY_MICRO),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, -1),
+    });
+    expect(f.historyDays).toBe(10);
+    expect(f.status).toBe("insufficient_history");
+  });
+});
+
+describe("the breach date", () => {
+  const flatMarch = (elapsed: number) => [
+    ...series(HISTORY_START, 28, () => WEEKDAY_MICRO),
+    ...series(PERIOD_START, elapsed, () => WEEKDAY_MICRO),
+  ];
+
+  it("is exact on a series constructed to cross on a known day", () => {
+    // A flat 1 USD/day: cumulative hits 20 USD on the 20th, and not a day earlier.
+    const f = forecastSpend({
+      days: flatMarch(10),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 9),
+      budgetMicroUsd: 20 * WEEKDAY_MICRO,
+    });
+
+    expect(f.breach.outcome).toBe("breaches");
+    expect(f.breach.date).toBe("2024-03-20");
+    expect(f.breach.dayIndex).toBe(20);
+    expect(f.breach.budgetMicroUsd).toBe(20 * WEEKDAY_MICRO);
+  });
+
+  it("reports the day it already happened when the period is over budget in the past", () => {
+    const f = forecastSpend({
+      days: flatMarch(20),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 19),
+      budgetMicroUsd: 5 * WEEKDAY_MICRO,
+    });
+
+    expect(f.breach.outcome).toBe("breaches");
+    expect(f.breach.date).toBe("2024-03-05");
+    expect(f.breach.dayIndex).toBe(5);
+  });
+
+  it("distinguishes 'never breaches' from 'cannot project'", () => {
+    const never = forecastSpend({
+      days: flatMarch(10),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 9),
+      budgetMicroUsd: 500 * WEEKDAY_MICRO,
+    });
+    const cannot = forecastSpend({
+      days: series(PERIOD_START, 4, () => WEEKDAY_MICRO),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 3),
+      budgetMicroUsd: 500 * WEEKDAY_MICRO,
+    });
+
+    expect(never.breach.outcome).toBe("never");
+    expect(never.breach.date).toBeNull();
+    expect(cannot.breach.outcome).toBe("cannot_project");
+    expect(cannot.breach.date).toBeNull();
+    // Same null date, different meaning, and the caller can tell them apart without guessing.
+    expect(never.breach.outcome).not.toBe(cannot.breach.outcome);
+    // Both still echo the budget they were asked about.
+    expect(cannot.breach.budgetMicroUsd).toBe(500 * WEEKDAY_MICRO);
+  });
+
+  it("says no_budget rather than assuming a budget of zero", () => {
+    const f = forecastSpend({
+      days: flatMarch(10),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 9),
+    });
+    expect(f.breach.outcome).toBe("no_budget");
+    expect(f.breach.date).toBeNull();
+    expect(f.breach.budgetMicroUsd).toBeNull();
+    // A zero budget is a real budget, and breaches immediately. Not the same answer.
+    const zero = forecastSpend({
+      days: flatMarch(10),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 9),
+      budgetMicroUsd: 0,
+    });
+    expect(zero.breach.outcome).toBe("breaches");
+    expect(zero.breach.date).toBe(PERIOD_START);
+  });
+
+  it("puts the bad-case crossing on or before the likely one", () => {
+    const shape = weekendHeavy(4_242);
+    const f = forecastSpend({
+      days: [...series(HISTORY_START, 28, shape), ...series(PERIOD_START, 8, shape)],
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 7),
+      budgetMicroUsd: 24 * WEEKDAY_MICRO,
+    });
+
+    expect(f.breach.outcome).toBe("breaches");
+    expect(f.breach.earliestDate).not.toBeNull();
+    expect(Date.parse(f.breach.earliestDate!)).toBeLessThanOrEqual(Date.parse(f.breach.date!));
+  });
+});
+
+describe("period edges and inputs", () => {
+  it("projects nothing once the period has closed", () => {
+    const days = [
+      ...series(HISTORY_START, 28, () => WEEKDAY_MICRO),
+      ...series(PERIOD_START, 31, () => WEEKDAY_MICRO),
+    ];
+    const f = forecastSpend({
+      days,
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: "2024-04-09", // well past the end; clamped into the period
+    });
+
+    expect(f.daysElapsed).toBe(31);
+    expect(f.daysRemaining).toBe(0);
+    expect(f.spendToDateMicroUsd).toBe(31 * WEEKDAY_MICRO);
+    expect(f.projectedMicroUsd).toBe(f.spendToDateMicroUsd);
+    expect(f.lowMicroUsd).toBe(f.spendToDateMicroUsd);
+    expect(f.highMicroUsd).toBe(f.spendToDateMicroUsd);
+  });
+
+  it("projects the whole period when it has not started yet", () => {
+    const f = forecastSpend({
+      days: series(HISTORY_START, 28, () => WEEKDAY_MICRO),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, -1),
+    });
+
+    expect(f.daysElapsed).toBe(0);
+    expect(f.daysRemaining).toBe(31);
+    expect(f.spendToDateMicroUsd).toBe(0);
+    // No elapsed days means no denominator for a run-rate. Null, not Infinity, not zero.
+    expect(f.naiveRunRateMicroUsd).toBeNull();
+    expect(f.projectedMicroUsd).toBe(31 * WEEKDAY_MICRO);
+  });
+
+  it("treats an absent settled day inside the period as a zero-spend day", () => {
+    const days = [
+      ...series(HISTORY_START, 28, () => WEEKDAY_MICRO),
+      ...series(PERIOD_START, 10, () => WEEKDAY_MICRO).filter((d) => d.date !== "2024-03-04"),
+    ];
+    const f = forecastSpend({
+      days,
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 9),
+    });
+    expect(f.spendToDateMicroUsd).toBe(9 * WEEKDAY_MICRO);
+    expect(f.burndown[3].actualMicroUsd).toBe(f.burndown[2].actualMicroUsd);
+  });
+
+  it("does not care what order the days arrive in", () => {
+    const days = series(HISTORY_START, 30, weekendHeavy(11));
+    const base = { periodStart: PERIOD_START, periodEnd: PERIOD_END, asOf: addDays(PERIOD_START, 1) };
+    expect(forecastSpend({ ...base, days: [...days].reverse() })).toEqual(
+      forecastSpend({ ...base, days }),
+    );
+  });
+
+  it("carries a credit through instead of clamping it away", () => {
+    const days = series(HISTORY_START, 28, () => WEEKDAY_MICRO).concat(
+      series(PERIOD_START, 3, (_d, _w, i) => (i === 1 ? -5 * WEEKDAY_MICRO : WEEKDAY_MICRO)),
+    );
+    const f = forecastSpend({
+      days,
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 2),
+    });
+    expect(f.spendToDateMicroUsd).toBe(-3 * WEEKDAY_MICRO);
+  });
+
+  it("returns integer micro-USD everywhere", () => {
+    const f = forecastSpend({
+      days: [...series(HISTORY_START, 28, weekendHeavy(5)), ...series(PERIOD_START, 6, weekendHeavy(6))],
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: addDays(PERIOD_START, 5),
+      budgetMicroUsd: 25 * WEEKDAY_MICRO,
+    });
+
+    for (const v of [
+      f.projectedMicroUsd,
+      f.lowMicroUsd,
+      f.highMicroUsd,
+      f.naiveRunRateMicroUsd,
+      f.spendToDateMicroUsd,
+      f.dailyStdDevMicroUsd,
+    ]) {
+      expect(Number.isSafeInteger(v)).toBe(true);
+    }
+    for (const p of f.burndown) {
+      expect(Number.isSafeInteger(p.projectedMicroUsd)).toBe(true);
+      expect(Number.isSafeInteger(p.lowMicroUsd)).toBe(true);
+      expect(Number.isSafeInteger(p.highMicroUsd)).toBe(true);
+    }
+    expect(f.burndown).toHaveLength(31);
+  });
+
+  it("throws on input that would silently produce a wrong number", () => {
+    const good = {
+      days: series(HISTORY_START, 28, () => WEEKDAY_MICRO),
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      asOf: PERIOD_START,
+    };
+
+    expect(() => forecastSpend({ ...good, periodStart: "03/01/2024" })).toThrow(TypeError);
+    expect(() => forecastSpend({ ...good, periodEnd: "2024-02-01" })).toThrow(RangeError);
+    expect(() =>
+      forecastSpend({ ...good, days: [{ date: "2024-02-01", microUsd: 1.5 }] }),
+    ).toThrow(TypeError);
+    expect(() =>
+      forecastSpend({
+        ...good,
+        days: [
+          { date: "2024-02-01", microUsd: 1 },
+          { date: "2024-02-01", microUsd: 2 },
+        ],
+      }),
+    ).toThrow(/duplicate day/);
+    expect(() => forecastSpend({ ...good, budgetMicroUsd: 10.5 })).toThrow(TypeError);
+  });
+});

--- a/web/lib/forecast.ts
+++ b/web/lib/forecast.ts
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+// Spend forecasting engine (CTO-206). Pure functions, no I/O.
+//
+// This answers a calendar question: "given what this tenant has spent so far, where does the period
+// land, and when does it cross budget?" That is NOT the question `sdk/python/src/tally/projection.py`
+// answers. That module does pre-deploy change impact (p99 cost per run over a replayed sample) and
+// none of it is reusable here. What is worth stealing is its posture: report the honest uncertain
+// thing rather than the flattering point estimate. Hence a band, a minimum-history refusal, and a
+// stated input window rather than a single confident number.
+//
+// Three decisions, all from `docs/spend-forecasting-scope.md`:
+//
+//   1. **Day-of-week weighted median**, not a flat run-rate. AI spend has strong weekday/weekend
+//      structure: a B2B product can run at a third of weekday volume on a Sunday. Projecting the
+//      remaining days from a flat mean is wrong every weekend, and wrong in a direction that flips
+//      depending on which day of the week the period happens to be paused on. The trailing profile
+//      uses a MEDIAN per weekday so one spike day does not distort the whole period.
+//      The naive run-rate is still computed and returned, but as a labelled sanity line, never as
+//      the headline.
+//
+//   2. **A band that is wide early and narrow late.** A day-2 projection genuinely is nearly
+//      meaningless and a day-25 one is nearly certain, so the width is driven both by the observed
+//      variance of daily spend and by how much of the period is still unwritten. This is the
+//      honesty mechanism of the whole feature: it is what stops a volatile day-3 number reading as
+//      a commitment.
+//
+//   3. **Refuse below a minimum history.** Under MIN_HISTORY_DAYS settled days there is no
+//      projection, no band, and no breach date, and the caller is told which of those it is. This
+//      follows the `/compare` precedent, which renders a blank rather than a noisy score below its
+//      replay floor. A forecast from four days of data must say "not enough history yet".
+//
+// Explicitly out of scope (scope Decision 1): Holt-Winters or any other time-series model. Most
+// tenants have about 30 days of history, which does not support one, and it would look
+// authoritative while being wrong.
+//
+// Money is integer micro-USD throughout (mirrors `unitEconomics.ts`, `allocation.ts` and
+// `tally.pricing`); never float dollars. Every field distinguishes unknown (null) from zero, as the
+// rest of this codebase does: a tenant that spent nothing and a tenant we cannot project for are
+// different answers and the UI renders them differently.
+//
+// Dates are `YYYY-MM-DD` strings interpreted in UTC. No `Date.now()`, no local timezone: the caller
+// supplies `asOf`, so the same input always produces the same output in tests and in CI.
+
+/** One settled day of spend, integer micro-USD. */
+export interface DailySpend {
+  /** `YYYY-MM-DD`, UTC. */
+  date: string;
+  /** Settled spend for that day, integer micro-USD. May be negative (a credit). */
+  microUsd: number;
+}
+
+/**
+ * Minimum settled days of history before this engine will project at all.
+ *
+ * Fourteen, for two reasons. It is two full weeks, so every weekday has at least two observations
+ * and a median per weekday is a median rather than a single point. And it is short enough that a
+ * tenant onboarded at the start of a month sees a forecast inside that same month, which is when
+ * the feature is worth anything. Below it the honest answer is "not enough history yet".
+ */
+export const MIN_HISTORY_DAYS = 14;
+
+/**
+ * How far back the weekday profile and the variance estimate look. Four weeks gives up to four
+ * observations per weekday, which is enough for a stable median, while still tracking a tenant
+ * whose spend stepped up a month ago rather than averaging over a level that no longer exists.
+ */
+export const TRAILING_WINDOW_DAYS = 28;
+
+/**
+ * Half-width multiplier on the standard deviation of daily spend. 1.2816 is the normal 80 percent
+ * two-sided z. The band is a heuristic, not a distributional claim, so a wide-but-not-absurd
+ * interval beats a 95 percent one that would swamp the chart on any noisy tenant.
+ */
+const CONFIDENCE_Z = 1.2816;
+
+/**
+ * Extra width applied in proportion to how much of the period is still unwritten. Variance alone
+ * (which scales with the square root of the remaining days) narrows too slowly to express how
+ * little a day-2 projection is worth, because early on the weekday profile itself is the shakiest
+ * part and that uncertainty is not in the daily variance. This term is what makes the cone visibly
+ * fat at the start of the period and pinch shut at the end.
+ */
+const EARLY_PERIOD_INFLATION = 1.5;
+
+/** Whether the engine produced a projection, and if not, why not. */
+export type ForecastStatus = "ok" | "insufficient_history";
+
+/**
+ * What happened to the budget, kept distinct on purpose.
+ *
+ * `breaches`   — the projection crosses the budget inside the period; `date` says when.
+ * `never`      — we projected, and the projection stays under budget for the whole period.
+ * `no_budget`  — no budget was configured. Not a forecast failure; render the forecast without a
+ *                variance rather than assuming a budget of zero (scope: "honest under uncertainty").
+ * `cannot_project` — below the minimum history. We are not saying it will not breach; we are saying
+ *                we do not know. A caller MUST render this differently from `never`.
+ */
+export type BreachOutcome = "breaches" | "never" | "no_budget" | "cannot_project";
+
+export interface BreachForecast {
+  outcome: BreachOutcome;
+  /** `YYYY-MM-DD` the projection crosses the budget, or null for every other outcome. */
+  date: string | null;
+  /** 1-based day index within the period for `date`, or null. Convenient for a chart x-axis. */
+  dayIndex: number | null;
+  /**
+   * The earliest crossing along the HIGH edge of the band: the bad case, not the likely one. Null
+   * when even the high edge stays under budget, or when we cannot project. Always on or before
+   * `date` when both are set.
+   */
+  earliestDate: string | null;
+  /** Echo of the budget the outcome was computed against. Null when none was configured. */
+  budgetMicroUsd: number | null;
+}
+
+/** One day of the burn-down: cumulative actual up to `asOf`, cumulative projection after it. */
+export interface BurndownPoint {
+  date: string;
+  /** Cumulative settled spend through this day, or null for days after `asOf`. */
+  actualMicroUsd: number | null;
+  /** Cumulative point projection through this day. Equals the actual on and before `asOf`. */
+  projectedMicroUsd: number;
+  /** Low edge of the cone. Equals the actual on and before `asOf` (the past has no band). */
+  lowMicroUsd: number;
+  /** High edge of the cone. */
+  highMicroUsd: number;
+}
+
+export interface SpendForecast {
+  status: ForecastStatus;
+
+  /** Projected spend for the whole period, day-of-week weighted. Null below the history floor. */
+  projectedMicroUsd: number | null;
+  /** Low edge of the band at period end. Null below the history floor. */
+  lowMicroUsd: number | null;
+  /** High edge of the band at period end. Null below the history floor. */
+  highMicroUsd: number | null;
+
+  /**
+   * `spend_so_far / days_elapsed * days_in_period`. The sanity line, shown ALONGSIDE the headline
+   * so a reader can see what the weekday weighting did. Null below the history floor as well: it is
+   * still a projection, and the point of the floor is that no projection ships from four days of
+   * data, however simple its arithmetic.
+   */
+  naiveRunRateMicroUsd: number | null;
+
+  /** Measured, not projected: settled spend inside the period through `asOf`. Never null. */
+  spendToDateMicroUsd: number;
+
+  /** Days of the period already settled (1-based count through `asOf`). */
+  daysElapsed: number;
+  /** Calendar days in the period, inclusive of both ends. */
+  daysInPeriod: number;
+  /** `daysInPeriod - daysElapsed`. Zero once the period has closed. */
+  daysRemaining: number;
+
+  /** Count of settled days fed in at or before `asOf`, whether or not they fall inside the period. */
+  historyDays: number;
+  /**
+   * The window the weekday profile and the variance were actually computed from, inclusive. Null
+   * when nothing was projected. A forecast that cannot state its input window is not auditable
+   * (scope Decision 3), and late-arriving connector data makes that a live concern here: the caller
+   * is expected to pass only SETTLED days, and this is what it can show for having done so.
+   */
+  windowStart: string | null;
+  windowEnd: string | null;
+
+  /**
+   * Trailing median spend per weekday, indexed 0 = Sunday .. 6 = Saturday. An entry is null when
+   * that weekday has no observation in the trailing window. Null (not zero) matters: a weekday we
+   * have never seen is unknown, and the projection falls back to the overall median for it.
+   */
+  weekdayMedianMicroUsd: (number | null)[];
+
+  /** Standard deviation of trailing daily spend, integer micro-USD. Null when not projected. */
+  dailyStdDevMicroUsd: number | null;
+
+  breach: BreachForecast;
+
+  /** The burn-down series. Empty when nothing was projected. */
+  burndown: BurndownPoint[];
+}
+
+export interface ForecastInput {
+  /**
+   * Settled daily spend. Order does not matter (sorted internally) but dates must be unique, and
+   * days should be SETTLED: a half-reported final day drags the whole baseline down and makes the
+   * projection systematically low (scope Decision 3). Days after `asOf` are ignored.
+   */
+  days: readonly DailySpend[];
+  /** First day of the period, `YYYY-MM-DD`, inclusive. */
+  periodStart: string;
+  /** Last day of the period, `YYYY-MM-DD`, inclusive. */
+  periodEnd: string;
+  /** Last settled day. Clamped into the period. Explicit rather than "today" so this stays pure. */
+  asOf: string;
+  /** Tenant budget for the period, integer micro-USD. Null/undefined when none is configured. */
+  budgetMicroUsd?: number | null;
+}
+
+/**
+ * Project period spend, band it, and say when it crosses budget.
+ *
+ * The method, in order:
+ *
+ *   1. Take the trailing settled window (up to TRAILING_WINDOW_DAYS ending at `asOf`) and reduce it
+ *      to a median per weekday plus a standard deviation of daily spend.
+ *   2. Project each remaining day of the period at its weekday's median, falling back to the
+ *      overall median for a weekday never observed.
+ *   3. Band the cumulative projection: half-width grows with the square root of the days ahead and
+ *      with how much of the period is still unwritten, so it is wide early and pinches shut at the
+ *      close.
+ *   4. Walk the cumulative path day by day and report the first day it crosses the budget.
+ *
+ * Below MIN_HISTORY_DAYS settled days it refuses: every projected field comes back null and the
+ * breach outcome is `cannot_project`, which the caller must not collapse into `never`.
+ *
+ * Throws only on input that would silently produce a wrong number: malformed dates, a period that
+ * ends before it starts, duplicate days, and non-integer money.
+ */
+export function forecastSpend(input: ForecastInput): SpendForecast {
+  const periodStart = parseDay(input.periodStart, "periodStart");
+  const periodEnd = parseDay(input.periodEnd, "periodEnd");
+  if (periodEnd < periodStart) {
+    throw new RangeError(
+      `forecastSpend: periodEnd ${input.periodEnd} is before periodStart ${input.periodStart}`,
+    );
+  }
+  const asOfRaw = parseDay(input.asOf, "asOf");
+  // An `asOf` past the end means the period has closed: everything is measured, nothing is left to
+  // project. An `asOf` before the start means nothing has been measured yet.
+  const asOf = Math.min(asOfRaw, periodEnd);
+
+  const budget = input.budgetMicroUsd ?? null;
+  if (budget !== null) assertMicroUsd(budget, "budgetMicroUsd");
+
+  const seen = new Set<string>();
+  const settled: { day: number; microUsd: number }[] = [];
+  for (const d of input.days) {
+    assertMicroUsd(d.microUsd, `microUsd for ${d.date}`);
+    if (seen.has(d.date)) throw new Error(`forecastSpend: duplicate day ${d.date}`);
+    seen.add(d.date);
+    const day = parseDay(d.date, "day");
+    if (day <= asOfRaw) settled.push({ day, microUsd: d.microUsd });
+  }
+  settled.sort((a, b) => a.day - b.day);
+
+  const daysInPeriod = periodEnd - periodStart + 1;
+  const daysElapsed = asOf < periodStart ? 0 : asOf - periodStart + 1;
+  const daysRemaining = daysInPeriod - daysElapsed;
+
+  const inPeriod = settled.filter((s) => s.day >= periodStart && s.day <= asOf);
+  const spendToDate = inPeriod.reduce((sum, s) => sum + s.microUsd, 0);
+
+  const historyDays = settled.length;
+
+  // The refusal. Everything projected is null, and `cannot_project` is a different answer from
+  // "never breaches" so a caller cannot mistake silence for safety.
+  if (historyDays < MIN_HISTORY_DAYS) {
+    return {
+      status: "insufficient_history",
+      projectedMicroUsd: null,
+      lowMicroUsd: null,
+      highMicroUsd: null,
+      naiveRunRateMicroUsd: null,
+      spendToDateMicroUsd: spendToDate,
+      daysElapsed,
+      daysInPeriod,
+      daysRemaining,
+      historyDays,
+      windowStart: null,
+      windowEnd: null,
+      weekdayMedianMicroUsd: emptyWeekdayProfile(),
+      dailyStdDevMicroUsd: null,
+      breach: {
+        outcome: "cannot_project",
+        date: null,
+        dayIndex: null,
+        earliestDate: null,
+        budgetMicroUsd: budget,
+      },
+      burndown: [],
+    };
+  }
+
+  const window = settled.slice(-TRAILING_WINDOW_DAYS);
+  const windowValues = window.map((s) => s.microUsd);
+
+  // Median per weekday, not mean: one spike day should move its own weekday a little, not drag the
+  // whole projection. Null for a weekday with no observation in the window.
+  const buckets: number[][] = Array.from({ length: 7 }, () => []);
+  for (const s of window) buckets[weekdayOf(s.day)].push(s.microUsd);
+  const weekdayMedian = buckets.map((b) => (b.length > 0 ? median(b) : null));
+  const overallMedian = median(windowValues);
+
+  const stdDev = Math.round(sampleStdDev(windowValues));
+
+  // Cumulative actuals for the elapsed days, then the projected tail.
+  const byDay = new Map<number, number>();
+  for (const s of inPeriod) byDay.set(s.day, s.microUsd);
+
+  const burndown: BurndownPoint[] = [];
+  let cumulative = 0;
+  for (let day = periodStart; day <= periodEnd; day += 1) {
+    if (day <= asOf) {
+      // A period day with no row is a genuine zero-spend day, not a gap: the caller passes settled
+      // days, so an absent settled day inside the period spent nothing.
+      cumulative += byDay.get(day) ?? 0;
+      burndown.push({
+        date: formatDay(day),
+        actualMicroUsd: cumulative,
+        projectedMicroUsd: cumulative,
+        lowMicroUsd: cumulative,
+        highMicroUsd: cumulative,
+      });
+      continue;
+    }
+    const expected = weekdayMedian[weekdayOf(day)] ?? overallMedian;
+    cumulative += expected;
+    const daysAhead = day - Math.max(asOf, periodStart - 1);
+    const half = bandHalfWidth(stdDev, daysAhead, daysInPeriod);
+    const point = Math.round(cumulative);
+    burndown.push({
+      date: formatDay(day),
+      actualMicroUsd: null,
+      projectedMicroUsd: point,
+      // Money already spent cannot un-spend, so the low edge never dips below spend to date.
+      lowMicroUsd: Math.min(point, Math.max(point - half, spendToDate)),
+      highMicroUsd: point + half,
+    });
+  }
+
+  const last = burndown[burndown.length - 1];
+  const projected = last ? last.projectedMicroUsd : spendToDate;
+  const low = last ? last.lowMicroUsd : spendToDate;
+  const high = last ? last.highMicroUsd : spendToDate;
+
+  const naive =
+    daysElapsed > 0 ? Math.round((spendToDate / daysElapsed) * daysInPeriod) : null;
+
+  return {
+    status: "ok",
+    projectedMicroUsd: projected,
+    lowMicroUsd: low,
+    highMicroUsd: high,
+    naiveRunRateMicroUsd: naive,
+    spendToDateMicroUsd: spendToDate,
+    daysElapsed,
+    daysInPeriod,
+    daysRemaining,
+    historyDays,
+    windowStart: formatDay(window[0].day),
+    windowEnd: formatDay(window[window.length - 1].day),
+    weekdayMedianMicroUsd: weekdayMedian,
+    dailyStdDevMicroUsd: stdDev,
+    breach: breachFrom(burndown, budget, periodStart),
+    burndown,
+  };
+}
+
+/**
+ * Band half-width `daysAhead` days past the last settled day.
+ *
+ * `sqrt(daysAhead)` is the variance of a sum of that many independent days; the second factor adds
+ * width in proportion to how much of the period is still unwritten, which is the part that makes a
+ * day-2 cone visibly wider than a day-25 one. Both factors shrink as the period elapses, so for a
+ * given tenant the end-of-period band narrows monotonically day over day, reaching zero on the day
+ * the period closes and there is nothing left to guess at.
+ */
+function bandHalfWidth(stdDev: number, daysAhead: number, daysInPeriod: number): number {
+  if (daysAhead <= 0 || stdDev <= 0) return 0;
+  const unwritten = daysInPeriod > 0 ? daysAhead / daysInPeriod : 0;
+  return Math.round(
+    CONFIDENCE_Z * stdDev * Math.sqrt(daysAhead) * (1 + EARLY_PERIOD_INFLATION * unwritten),
+  );
+}
+
+/**
+ * First day the cumulative path crosses the budget. Walks the elapsed days too, so a tenant already
+ * over budget gets the day it actually happened rather than a null that reads as "fine".
+ */
+function breachFrom(
+  burndown: readonly BurndownPoint[],
+  budget: number | null,
+  periodStart: number,
+): BreachForecast {
+  if (budget === null) {
+    return {
+      outcome: "no_budget",
+      date: null,
+      dayIndex: null,
+      earliestDate: null,
+      budgetMicroUsd: null,
+    };
+  }
+
+  let date: string | null = null;
+  let dayIndex: number | null = null;
+  let earliestDate: string | null = null;
+  for (const p of burndown) {
+    if (earliestDate === null && p.highMicroUsd >= budget) earliestDate = p.date;
+    if (p.projectedMicroUsd >= budget) {
+      date = p.date;
+      dayIndex = parseDay(p.date, "burndown") - periodStart + 1;
+      break;
+    }
+  }
+
+  return {
+    outcome: date === null ? "never" : "breaches",
+    date,
+    dayIndex,
+    earliestDate,
+    budgetMicroUsd: budget,
+  };
+}
+
+function emptyWeekdayProfile(): (number | null)[] {
+  return [null, null, null, null, null, null, null];
+}
+
+/** Median of a non-empty list, rounded to integer micro-USD. Even counts average the two middles. */
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+/** Sample standard deviation. Zero for fewer than two points: no spread is observable from one day. */
+function sampleStdDev(values: readonly number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance =
+    values.reduce((sum, v) => sum + (v - mean) * (v - mean), 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MS_PER_DAY = 86_400_000;
+
+/** `YYYY-MM-DD` to a UTC day number. UTC throughout so the result never depends on the runner's TZ. */
+function parseDay(value: string, label: string): number {
+  if (!DAY_PATTERN.test(value)) {
+    throw new TypeError(`forecastSpend: ${label} must be YYYY-MM-DD, got ${value}`);
+  }
+  const ms = Date.parse(`${value}T00:00:00Z`);
+  if (Number.isNaN(ms)) {
+    throw new RangeError(`forecastSpend: ${label} is not a real date, got ${value}`);
+  }
+  return Math.round(ms / MS_PER_DAY);
+}
+
+function formatDay(day: number): string {
+  return new Date(day * MS_PER_DAY).toISOString().slice(0, 10);
+}
+
+/** 0 = Sunday .. 6 = Saturday. 1970-01-01 was a Thursday (4). */
+function weekdayOf(day: number): number {
+  return (((day + 4) % 7) + 7) % 7;
+}
+
+function assertMicroUsd(value: number, label: string): void {
+  if (!Number.isSafeInteger(value)) {
+    // Money is integer micro-USD everywhere in this codebase (see `allocation.ts`). Accepting a
+    // float here would put fractional micro-USD into a chart and a breach date, silently.
+    throw new TypeError(`forecastSpend: ${label} must be a safe integer micro-USD, got ${value}`);
+  }
+}


### PR DESCRIPTION
Second ticket of the spend forecasting epic (CTO-204), per `docs/spend-forecasting-scope.md`.

Adds `web/lib/forecast.ts`: pure functions, no I/O, integer micro-USD throughout, matching the house
style of `web/lib/unitEconomics.ts` and `web/lib/allocation.ts`. Nothing is wired into a page; that is
CTO-209 and CTO-210.

`sdk/python/src/tally/projection.py` was read and deliberately not reused: it answers pre-deploy
change impact (p99 cost per run over a replayed sample), which is a different problem. What is
borrowed is its posture, which is to report the honest uncertain thing rather than the flattering
point estimate.

## The method

1. Take the trailing settled window (up to 28 days ending at `asOf`) and reduce it to a **median per
   weekday** plus a standard deviation of daily spend.
2. Project each remaining day of the period at its weekday's median, falling back to the overall
   median for a weekday never observed (which stays `null` in the returned profile: unknown, not zero).
3. Band the cumulative path.
4. Walk the path day by day and report the first day it crosses the budget.

Median rather than mean so one spike day cannot distort the whole month; day-of-week rather than flat
because AI spend has strong weekday/weekend structure and a naive run-rate is wrong every weekend.
The naive run-rate is still returned as `naiveRunRateMicroUsd`, a labelled sanity line, never the
headline. On the seeded synthetic month in the tests the weighted projection lands within 0.5 percent
of truth where the naive one is off by 4.2 percent.

Explicitly out of scope: Holt-Winters or any other time-series model. Most tenants have about 30 days
of history, which does not support one, and it would look authoritative while being wrong.

## Minimum history: 14 days

Below 14 settled days, `status` is `insufficient_history` and every projected field
(`projectedMicroUsd`, the band, the naive run-rate, the standard deviation, the burn-down) is `null`.
Measured facts such as spend to date and the day counts are still returned: refusing to project is not
refusing to count.

Fourteen for two reasons. It is two full weeks, so every weekday has at least two observations and a
median per weekday is a median rather than a single point. And it is short enough that a tenant
onboarded at the start of a month sees a forecast inside that same month, which is when the feature is
worth anything. This follows the `/compare` precedent of rendering a blank below its replay floor
rather than printing a noisy number.

## How the band behaves

Half-width `d` days past the last settled day:

```
z * stddev(trailing daily spend) * sqrt(d) * (1 + 1.5 * d / daysInPeriod)
```

The `sqrt(d)` term is the variance of a sum of `d` days. The second term adds width in proportion to
how much of the period is still unwritten, because early on the weekday profile itself is the shakiest
part and that uncertainty is not in the daily variance. Both factors shrink as the period elapses, so
the end-of-period band **narrows monotonically day over day** and reaches exactly zero on the day the
period closes. The low edge never dips below money already spent. Per-day cone widths in `burndown`
grow with distance from `asOf`, which is what the chart in CTO-210 will draw.

## The breach date

`breach.date` is the day the cumulative point projection crosses the budget, including days already
elapsed, so a tenant already over budget gets the day it actually happened rather than a null that
reads as fine. `breach.earliestDate` is the same crossing along the high edge of the band: the bad
case, not the likely one.

Four distinct outcomes, so a caller can never mistake silence for safety:

- `breaches` — crosses inside the period, `date` says when
- `never` — we projected, and it stays under budget
- `no_budget` — none configured; render without a variance rather than assuming a budget of zero
- `cannot_project` — below the history floor; we are not saying it will not breach, we are saying we
  do not know

## Auditability

`windowStart` / `windowEnd` state the input window the profile and variance were computed from. Late
connector data makes that a live concern (scope Decision 3): callers are expected to pass only settled
days, and this is what the UI can show for having done so.

## Tests

24 tests in `web/lib/forecast.test.ts`, covering the seeded weekend-heavy month (weighted beats naive
and is within 3 percent of truth), an exact reproduction on a clean periodic month, median robustness
to a 50x spike, monotone band narrowing across all 31 `asOf` values, the history floor and the exact
day it flips, an exact breach date, a past breach, `never` vs `cannot_project` vs `no_budget` vs a
real zero budget, period-closed and period-not-started edges, credits, input-order independence,
integer-only outputs, and throwing on malformed dates, duplicate days and float money.

## Verification

From `web/`: `npm run typecheck` clean, `npm run lint` clean (3 pre-existing warnings, none in new
files), `npm run test` 455 passed. The only failures are the 2 long-standing `app/api/api.test.ts`
ones (attribution and data-quality ClickHouse fallback) that fail against a running local ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
