### PR TITLE
feat(cost): settled daily spend series for the forecast baseline (CTO-207)

### DIFF
--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -749,3 +749,169 @@ describe("queryAccountStitching (CTO-184)", () => {
     expect(await queryAccountStitching()).toBeNull();
   });
 });
+
+// --- querySettledCostSeries (CTO-207, F3) -------------------------------------------------------
+//
+// The point of this query is which days it REFUSES to hand a forecast. Each test stubs the three
+// reads in order (bounds, money, settlement evidence) and asserts on the settled/unsettled split.
+
+describe("querySettledCostSeries — settled-day rule (CTO-207)", () => {
+  const bounds = (windowStart: string, today: string, periodStart: string, windowDays: number) =>
+    respondRows([{ windowStart, periodStart, today, windowDays }]);
+
+  const landing = (
+    day: string,
+    opts: { compute?: number; egress?: number; reconciled?: number } = {},
+  ) => ({
+    day,
+    compute: String(opts.compute ?? 0),
+    egress: String(opts.egress ?? 0),
+    reconciled: String(opts.reconciled ?? 0),
+  });
+
+  it("withholds the day in progress and any day a connector has not landed", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-08-01", "2026-08-04", "2026-08-01", 4);
+    respondRows([
+      { day: "2026-08-01", layer: "llm", cost: "10.00" },
+      { day: "2026-08-01", layer: "compute", cost: "8.00" },
+      { day: "2026-08-02", layer: "llm", cost: "10.00" },
+      { day: "2026-08-02", layer: "compute", cost: "8.00" },
+      // 08-03 is the half-reported day: LLM spans are in, the cloud bill is not.
+      { day: "2026-08-03", layer: "llm", cost: "10.00" },
+      { day: "2026-08-04", layer: "llm", cost: "3.00" },
+    ]);
+    respondRows([
+      landing("2026-08-01", { compute: 4 }),
+      landing("2026-08-02", { compute: 4 }),
+      landing("2026-08-03"),
+      landing("2026-08-04"),
+    ]);
+
+    const out = (await querySettledCostSeries())!;
+    expect(out.rule).toBe("connector-landing");
+    expect(out.connectorLayers).toEqual(["compute"]);
+    // 08-03 has money but no cloud bill; 08-04 is today. Neither may set a run-rate.
+    expect(out.baselineDays).toEqual(["2026-08-01", "2026-08-02"]);
+    expect(out.settledThrough).toBe("2026-08-02");
+    expect(out.days.find((d) => d.date === "2026-08-03")!.awaitingLayers).toEqual(["compute"]);
+    expect(out.days.find((d) => d.date === "2026-08-04")!.inProgress).toBe(true);
+    expect(out.days.find((d) => d.date === "2026-08-04")!.awaitingLayers).toEqual([]);
+  });
+
+  it("keeps the half-reported day out of the baseline total but still reports it as observed", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-08-01", "2026-08-03", "2026-08-01", 3);
+    respondRows([
+      { day: "2026-08-01", layer: "llm", cost: "10.00" },
+      { day: "2026-08-01", layer: "compute", cost: "10.00" },
+      { day: "2026-08-02", layer: "llm", cost: "10.00" }, // compute missing: half the day's money
+      { day: "2026-08-03", layer: "llm", cost: "1.00" },
+    ]);
+    respondRows([
+      landing("2026-08-01", { compute: 2 }),
+      landing("2026-08-02"),
+      landing("2026-08-03"),
+    ]);
+
+    const out = (await querySettledCostSeries())!;
+    // $20 over 1 settled day, not $31 over 3 days. The inflated divisor is the whole bug: it reads
+    // $10.33/day against a true $20/day and lands the month at half what it will be.
+    expect(out.windowSettled.totalMicroUsd).toBe(20_000_000);
+    expect(out.windowSettled.dayCount).toBe(1);
+    expect(out.windowObserved.totalMicroUsd).toBe(31_000_000);
+    expect(out.windowObserved.dayCount).toBe(3);
+    expect(out.windowSettled.byLayer.compute).toBe(10_000_000);
+  });
+
+  it("waits on nothing but the clock when the tenant has no cloud connector", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-08-01", "2026-08-03", "2026-08-01", 3);
+    respondRows([{ day: "2026-08-01", layer: "llm", cost: "5.00" }]);
+    respondRows([landing("2026-08-01"), landing("2026-08-02"), landing("2026-08-03")]);
+
+    const out = (await querySettledCostSeries())!;
+    expect(out.rule).toBe("day-complete");
+    expect(out.connectorLayers).toEqual([]);
+    expect(out.baselineDays).toEqual(["2026-08-01", "2026-08-02"]);
+  });
+
+  it("builds the day list from the ClickHouse window, never from the Node clock (CTO-203)", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    // A window nowhere near "now" in this process: if the list came from the Node clock, none of
+    // these days would have a slot and their money would vanish from the series while still
+    // counting toward the totals printed above it.
+    bounds("2021-03-01", "2021-03-03", "2021-03-01", 3);
+    respondRows([{ day: "2021-03-01", layer: "llm", cost: "2.00" }]);
+    respondRows([landing("2021-03-01"), landing("2021-03-02"), landing("2021-03-03")]);
+
+    const out = (await querySettledCostSeries())!;
+    expect(out.days.map((d) => d.date)).toEqual(["2021-03-01", "2021-03-02", "2021-03-03"]);
+    expect(out.days[0].weekday).toBe(1); // 2021-03-01 was a Monday
+    expect(out.windowObserved.totalMicroUsd).toBe(2_000_000);
+  });
+
+  it("marks trailing history apart from the period being forecast", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-07-30", "2026-08-02", "2026-08-01", 4);
+    respondRows([
+      { day: "2026-07-31", layer: "llm", cost: "4.00" },
+      { day: "2026-08-01", layer: "llm", cost: "7.00" },
+    ]);
+    respondRows([]);
+
+    const out = (await querySettledCostSeries())!;
+    expect(out.days.filter((d) => d.inPeriod).map((d) => d.date)).toEqual([
+      "2026-08-01",
+      "2026-08-02",
+    ]);
+    expect(out.periodSettled.totalMicroUsd).toBe(7_000_000); // 08-02 is today, withheld
+    expect(out.windowSettled.totalMicroUsd).toBe(11_000_000);
+  });
+
+  it("reports settledThrough and reconciledThrough as null rather than a stand-in date", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-08-04", "2026-08-04", "2026-08-01", 1);
+    respondRows([{ day: "2026-08-04", layer: "llm", cost: "9.00" }]);
+    respondRows([landing("2026-08-04", { compute: 1 })]);
+
+    const out = (await querySettledCostSeries())!;
+    expect(out.baselineDays).toEqual([]);
+    expect(out.settledThrough).toBeNull();
+    expect(out.reconciledThrough).toBeNull();
+  });
+
+  it("carries the reconciliation boundary through so estimates are not read as invoiced", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-08-01", "2026-08-03", "2026-08-01", 3);
+    respondRows([]);
+    respondRows([
+      landing("2026-08-01", { compute: 1, reconciled: 5 }),
+      landing("2026-08-02", { compute: 1 }),
+      landing("2026-08-03", { compute: 1 }),
+    ]);
+
+    const out = (await querySettledCostSeries())!;
+    expect(out.reconciledThrough).toBe("2026-08-01");
+  });
+
+  it("scopes the money without letting the scope decide whether a day settled", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    bounds("2026-08-01", "2026-08-02", "2026-08-01", 2);
+    // The feature emitted nothing on 08-01. That is a real zero for the feature, not a reason to
+    // call the day unsettled: settlement is judged on the tenant's whole data.
+    respondRows([]);
+    respondRows([landing("2026-08-01", { compute: 3 }), landing("2026-08-02", { compute: 3 })]);
+
+    const out = (await querySettledCostSeries({ kind: "feature", value: "research-agent" }))!;
+    expect(out.scope).toEqual({ kind: "feature", value: "research-agent" });
+    expect(out.baselineDays).toEqual(["2026-08-01"]);
+    expect(out.windowSettled.totalMicroUsd).toBe(0);
+  });
+
+  it("returns null when ClickHouse is unreachable, so no caller reads it as zero spend", async () => {
+    const { querySettledCostSeries } = await freshSut();
+    queryMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    expect(await querySettledCostSeries()).toBeNull();
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -326,6 +326,323 @@ export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<F
   });
 }
 
+// --- Settled daily spend, the forecast baseline (CTO-207, F3) -----------------------------------
+//
+// Cost is NOT complete when a day ends, and a run-rate that pretends otherwise is wrong in the one
+// direction that flatters the customer.
+//
+// Two sources arrive late:
+//   1. Connector-sourced `compute` (CTO-143) and `egress` (CTO-144) land as synthetic daily rows
+//      from a cloud-billing pull, and the cloud bill itself lags by hours. On the demo tenant those
+//      two layers are roughly 46 percent of spend, so a day read at midnight can carry half of what
+//      it will eventually carry, and read again at noon it has roughly doubled.
+//   2. Reconciliation (`reconciliation_runs`) replaces estimated cost with invoiced cost afterwards.
+//
+// Project the month from a window whose last day is half-reported and you systematically
+// UNDERESTIMATE month-end. So the baseline has to exclude days that are not finished yet, and it
+// has to say which days it used: a forecast that cannot state its input window is not auditable.
+//
+// THE SETTLED-DAY RULE (the one this file implements)
+//
+//   A day D is settled when BOTH hold:
+//     (a) D is strictly before today as ClickHouse reports today. Today is still accruing by
+//         definition, whatever its sources have done.
+//     (b) every connector-backed layer this tenant actually uses has landed at least one row for D.
+//         "Actually uses" is measured over the same window: a tenant with no cloud connector waits
+//         on nothing, a tenant with compute only waits on compute.
+//
+// Why landed rows and not `tenant_compute_config.last_run_at` / `queryReconcilerLastRun`: those
+// live in Postgres behind the gateway, one HTTP hop and one more clock away, and they answer
+// "did a run finish?" rather than "did the day D we are about to divide by actually arrive?" A run
+// can finish having written nothing for D. The landed row IS the completion signal for that day,
+// it is per-day rather than per-connector, and it comes back from the same read as the money, so
+// there is no window where the two disagree. `last_run_at` remains the right signal for the
+// connector health card, which is a different question.
+//
+// The fallback the ticket allows (a fixed grace period) is what condition (a) degenerates to when a
+// tenant has no connector layers at all: withhold the day in progress, trust every completed day.
+// A fixed N-hour grace on top of that would be a guess about someone else's billing pipeline; the
+// evidence is right there in the table, so we read it instead of guessing.
+//
+// Known limit, stated rather than papered over: a genuinely idle day with no connector row is
+// indistinguishable from a day the connector has not reached yet, so we withhold it. That errs
+// toward a smaller, truer baseline, which is the honest direction.
+//
+// Window: the calendar-aligned `toDate(now()) - INTERVAL 29 DAY` boundary the cost surfaces share,
+// widened to reach the start of the calendar month so month-to-date is always fully covered (on the
+// 31st a plain 30-day window would clip the 1st). A rolling `now() - INTERVAL 30 DAY` drifts by the
+// second and clips a partial day, which is why nothing here uses one.
+//
+// Clocks: every date in the result — window start, today, the day list, the day count — comes from
+// ClickHouse. None of it is generated from the Node process clock. Those are two clocks in two
+// timezones, and when they straddle midnight the JS-built list is shifted a day against the SQL
+// window, so the oldest day silently has no slot to land in while still counting toward the totals
+// (the bug `queryCostSeries` still has, CTO-203). `queryAccountDetail` does it correctly; so does
+// this.
+
+/** Trailing history for the weekday profile, on the shared calendar-aligned boundary. */
+const SETTLED_TRAILING_DAYS = 30;
+
+/** The layers that arrive from a lagging cloud-billing pull rather than from live SDK spans. */
+const CONNECTOR_LAYERS = ["compute", "egress"] as const;
+type ConnectorLayer = (typeof CONNECTOR_LAYERS)[number];
+
+/**
+ * Optional slice of spend to forecast, matching the budget scopes in CTO-205
+ * (`tenant` / `feature` / `model` / `layer`). Settlement itself is always judged on the tenant's
+ * WHOLE data, never on the slice: whether the cloud bill for Tuesday has landed is a fact about the
+ * pipeline, not about the feature you happen to be looking at, and a slice that emitted nothing on
+ * Tuesday must not read as "Tuesday is unsettled".
+ */
+export type SpendScope =
+  | { kind: "tenant" }
+  | { kind: "feature"; value: string }
+  | { kind: "model"; value: string }
+  | { kind: "layer"; value: Layer };
+
+export interface SettledDayPoint {
+  /** ISO yyyy-mm-dd, from ClickHouse. */
+  date: string;
+  /** 0 = Sunday … 6 = Saturday, UTC. Derived from `date` by arithmetic, not from the Node clock. */
+  weekday: number;
+  byLayer: SpendByLayer;
+  totalMicroUsd: number;
+  /** Inside the calendar month being forecast (i.e. month-to-date), as opposed to trailing history. */
+  inPeriod: boolean;
+  /** Safe to divide by. See the settled-day rule above. */
+  settled: boolean;
+  /** True for the day in progress: it is today per ClickHouse and still accruing. */
+  inProgress: boolean;
+  /** Connector layers with no row for this day yet. Empty when settled or when in progress. */
+  awaitingLayers: ConnectorLayer[];
+}
+
+export interface SettledSpendTotals {
+  dayCount: number;
+  byLayer: SpendByLayer;
+  totalMicroUsd: number;
+}
+
+export interface SettledSpendSeries {
+  scope: SpendScope;
+  /** Oldest day in the window, per ClickHouse. */
+  windowStart: string;
+  /** Today per ClickHouse: the day in progress, and the newest day in `days`. */
+  windowEnd: string;
+  /** First day of the calendar month being forecast. */
+  periodStart: string;
+  /** Every calendar day in the window, oldest → newest, settled and unsettled alike. */
+  days: SettledDayPoint[];
+  /**
+   * Exactly the days a forecast may compute a run-rate from, oldest → newest, so it can print its
+   * own input window. Empty means "no settled history": refuse to project rather than print a
+   * number (honest-under-uncertainty, and the minimum-history guard in the scope doc).
+   */
+  baselineDays: string[];
+  /** Newest settled day, or null when none is — never a fabricated date. */
+  settledThrough: string | null;
+  /** Which connector layers this tenant actually uses, i.e. what settlement waits on. */
+  connectorLayers: ConnectorLayer[];
+  /** `connector-landing` when the rule waited on a connector, `day-complete` when there was none. */
+  rule: "connector-landing" | "day-complete";
+  /** Window totals over settled days only. This is the baseline. */
+  windowSettled: SettledSpendTotals;
+  /** Window totals including unsettled days. Diagnostic: the gap is the late-data exposure. */
+  windowObserved: SettledSpendTotals;
+  /** Month-to-date over settled days only. */
+  periodSettled: SettledSpendTotals;
+  /** Month-to-date including unsettled days, i.e. what a naive run-rate would divide. */
+  periodObserved: SettledSpendTotals;
+  /**
+   * Newest day carrying reconciled (invoiced) cost, or null when the reconciler has never run for
+   * this window. Days after it are still estimates and can move again.
+   */
+  reconciledThrough: string | null;
+}
+
+function emptyTotals(): SettledSpendTotals {
+  return { dayCount: 0, byLayer: zeroLayers(), totalMicroUsd: 0 };
+}
+
+function addDay(into: SettledSpendTotals, point: SettledDayPoint): void {
+  into.dayCount += 1;
+  for (const l of LAYERS) into.byLayer[l] += point.byLayer[l];
+  into.totalMicroUsd += point.totalMicroUsd;
+}
+
+/** SQL predicate + bound value for a scope. The value is always a parameter, never interpolated. */
+function scopeFilter(scope: SpendScope): { clause: string; value: string } {
+  switch (scope.kind) {
+    case "feature":
+      return { clause: "AND FeatureTag = {scope:String}", value: scope.value };
+    // Response model when the provider returned one (it is the model that actually served the
+    // call), request model otherwise. Matches queryCurrentModel's resolution.
+    case "model":
+      return {
+        clause:
+          "AND if(GenAiResponseModel != '', GenAiResponseModel, GenAiRequestModel) = {scope:String}",
+        value: scope.value,
+      };
+    case "layer":
+      return { clause: `AND ${LAYER_CASE} = {scope:String}`, value: scope.value };
+    default:
+      return { clause: "", value: "" };
+  }
+}
+
+/**
+ * Daily spend for the current calendar month plus trailing history, split by cost layer, with every
+ * day marked settled or not and the settled subset named explicitly (CTO-207).
+ *
+ * This is the forecast's input, not the forecast: it deliberately projects nothing. CTO-208 builds
+ * the weekday-weighted projection on top of `baselineDays`, and CTO-209/210 put it on a page.
+ *
+ * Returns `null` (via tryLive) when ClickHouse is unreachable, which the caller must not read as
+ * "no spend".
+ */
+export async function querySettledCostSeries(
+  scope: SpendScope = { kind: "tenant" },
+): Promise<SettledSpendSeries | null> {
+  return tryLive(async (db, tenant) => {
+    // Bounds first, from ClickHouse's clock, and reused as a bound parameter by the reads below so
+    // all three see one window even if the call straddles midnight.
+    const bounds = await rowsP<{
+      windowStart: string;
+      periodStart: string;
+      today: string;
+      windowDays: number;
+    }>(
+      db,
+      // The CTE aliases are deliberately not the output names: reusing `windowStart` for both
+      // makes the SELECT resolve the alias to itself and the query fails to parse.
+      `WITH toDate(now()) AS td,
+            toStartOfMonth(td) AS ps,
+            least(td - INTERVAL ${SETTLED_TRAILING_DAYS - 1} DAY, ps) AS ws
+       SELECT toString(ws) AS windowStart,
+              toString(ps) AS periodStart,
+              toString(td) AS today,
+              toUInt32(dateDiff('day', ws, td) + 1) AS windowDays`,
+      { tenant },
+    );
+    const b = bounds[0];
+    if (!b) return null;
+    const windowDays = Number(b.windowDays) || 0;
+
+    const { clause, value } = scopeFilter(scope);
+    const params = { tenant, windowStart: b.windowStart, scope: value };
+    const inWindow = `TenantId = {tenant:String} AND Timestamp >= toDate({windowStart:String})`;
+
+    // The money, sliced by the caller's scope.
+    const costRows = await rowsP<{ day: string; layer: Layer; cost: string }>(
+      db,
+      `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
+       FROM otel_spans
+       WHERE ${inWindow} ${clause}
+       GROUP BY day, layer`,
+      params,
+    );
+
+    // The settlement evidence, deliberately UNSCOPED (see SpendScope). One row per day: did each
+    // connector layer land, and did anything reconcile. LAYER_CASE is reused rather than re-derived
+    // so there is only ever one operation→layer mapping in this file.
+    const landingRows = await rowsP<{
+      day: string;
+      compute: string;
+      egress: string;
+      reconciled: string;
+    }>(
+      db,
+      `SELECT toString(toDate(Timestamp)) AS day,
+              countIf(${LAYER_CASE} = 'compute') AS compute,
+              countIf(${LAYER_CASE} = 'egress') AS egress,
+              countIf(CostSource = 'reconciled') AS reconciled
+       FROM otel_spans
+       WHERE ${inWindow}
+       GROUP BY day`,
+      params,
+    );
+
+    const landed = new Map<string, Set<ConnectorLayer>>();
+    const usesConnector = new Set<ConnectorLayer>();
+    let reconciledThrough: string | null = null;
+    for (const r of landingRows) {
+      const present = new Set<ConnectorLayer>();
+      for (const l of CONNECTOR_LAYERS) {
+        if ((parseInt(r[l], 10) || 0) > 0) {
+          present.add(l);
+          usesConnector.add(l);
+        }
+      }
+      landed.set(r.day, present);
+      if ((parseInt(r.reconciled, 10) || 0) > 0 && (!reconciledThrough || r.day > reconciledThrough)) {
+        reconciledThrough = r.day;
+      }
+    }
+    const connectorLayers = CONNECTOR_LAYERS.filter((l) => usesConnector.has(l));
+
+    // Every calendar day gets a slot, built from the window ClickHouse reported. A day with no rows
+    // is a real zero for the scope, not a hole.
+    const byDay = new Map<string, SettledDayPoint>();
+    for (const iso of isoDaysFrom(b.windowStart, windowDays)) {
+      const inProgress = iso === b.today;
+      const present = landed.get(iso) ?? new Set<ConnectorLayer>();
+      const awaiting = inProgress ? [] : connectorLayers.filter((l) => !present.has(l));
+      byDay.set(iso, {
+        date: iso,
+        weekday: new Date(`${iso}T00:00:00Z`).getUTCDay(),
+        byLayer: zeroLayers(),
+        totalMicroUsd: 0,
+        inPeriod: iso >= b.periodStart,
+        settled: !inProgress && awaiting.length === 0,
+        inProgress,
+        awaitingLayers: awaiting,
+      });
+    }
+    for (const r of costRows) {
+      const point = byDay.get(r.day);
+      if (point && (LAYERS as readonly string[]).includes(r.layer)) {
+        const m = micro(r.cost);
+        point.byLayer[r.layer] += m;
+        point.totalMicroUsd += m;
+      }
+    }
+
+    const days = [...byDay.values()];
+    const windowSettled = emptyTotals();
+    const windowObserved = emptyTotals();
+    const periodSettled = emptyTotals();
+    const periodObserved = emptyTotals();
+    const baselineDays: string[] = [];
+    for (const point of days) {
+      addDay(windowObserved, point);
+      if (point.inPeriod) addDay(periodObserved, point);
+      if (!point.settled) continue;
+      baselineDays.push(point.date);
+      addDay(windowSettled, point);
+      if (point.inPeriod) addDay(periodSettled, point);
+    }
+
+    return {
+      scope,
+      windowStart: b.windowStart,
+      windowEnd: b.today,
+      periodStart: b.periodStart,
+      days,
+      baselineDays,
+      // null, not a stand-in date: "nothing has settled yet" is a thing we know, and a fake
+      // boundary would read as a settled day that does not exist.
+      settledThrough: baselineDays.length > 0 ? baselineDays[baselineDays.length - 1] : null,
+      connectorLayers,
+      rule: connectorLayers.length > 0 ? "connector-landing" : "day-complete",
+      windowSettled,
+      windowObserved,
+      periodSettled,
+      periodObserved,
+      reconciledThrough,
+    };
+  });
+}
+
 // --- Per-customer cost (CTO-187, D1) ------------------------------------------------------------
 //
 // These read `daily_account_rollup` (CTO-183), not `otel_spans`. AccountIdHash sits nowhere near the


### PR DESCRIPTION
Third ticket of the Spend forecasting epic (CTO-204). Adds `querySettledCostSeries` to `web/lib/clickhouse.ts`: daily spend for the current calendar month plus trailing history, split by cost layer, with every day marked settled or not and the settled subset named explicitly. It projects nothing. CTO-208 builds the weekday-weighted projection on top of `baselineDays`; nothing here is wired into a page (CTO-209 / CTO-210).

## The settled-day rule

A day **D is settled** when **both** hold:

1. **D is strictly before today, as ClickHouse reports today.** The day in progress is still accruing whatever its sources have done.
2. **Every connector-backed layer this tenant actually uses has landed at least one row for D.** "Actually uses" is measured over the same window, so a tenant with no cloud connector waits on nothing, and a tenant with compute only waits on compute.

Rule 2 degenerating to nothing *is* the grace-period fallback the ticket allows: with no connector layers the rule is "withhold the day in progress, trust every completed day", reported as `rule: "day-complete"` rather than `"connector-landing"` so the caller can see which one it got.

### Why landed rows rather than `last_run_at` / `queryReconcilerLastRun`

`tenant_compute_config.last_run_at` and `queryReconcilerLastRun` live in Postgres behind the gateway, one HTTP hop and one more clock away, and they answer *"did a run finish?"* rather than *"did the day D we are about to divide by actually arrive?"* A run can finish having written nothing for D. The landed row **is** the completion signal for that specific day, it is per-day instead of per-connector, and it comes back from the same read as the money, so there is no window in which the two disagree. `last_run_at` stays the right signal for the connector health card, which is a different question.

A fixed N-hour grace period on top of that would be a guess about someone else's billing pipeline. The evidence is in the table, so the query reads it.

**Known limit, stated rather than papered over:** a genuinely idle day with no connector row is indistinguishable from a day the connector has not reached yet, so the query withholds it. That errs toward a smaller, truer baseline, which is the honest direction.

## Live numbers (tenant `local-dev`, ClickHouse `now()` = 2026-08-26)

```
window        2026-07-28 -> 2026-08-26   (30 days, period starts 2026-08-01)
rule          connector-landing
waits on      compute, egress
settledThrough      2026-08-23
reconciledThrough   null   (reconciler has never run in this window)
baseline      27 days, 2026-07-28 -> 2026-08-23
```

Withheld days, and why:

| day | total | why withheld |
|---|---|---|
| 2026-08-24 | $0.00 | awaiting compute, egress |
| 2026-08-25 | $0.00 | awaiting compute, egress |
| 2026-08-26 | $0.00 | in progress (today) |

**With and without the unsettled days:**

| | days | total | run-rate / day |
|---|---|---|---|
| Window, **with** unsettled | 30 | $90,775.07 | $3,025.84 |
| Window, **without** (baseline) | 27 | $90,775.07 | **$3,362.04** |
| Month-to-date, **with** unsettled | 26 | $81,827.49 | $3,147.21 |
| Month-to-date, **without** (baseline) | 23 | $81,827.49 | **$3,557.72** |

Including the unsettled days understates the daily run-rate by **10.0%** on the 30-day window and by **11.5%** month-to-date. Carried to a 31-day month, that is a projection of **$97,563 instead of $110,289**, a **$12,726** shortfall, and it shortfalls in the direction that tells the customer they are fine.

On this dataset the unsettled days carry $0.00, so the entire error is the divisor: three days that have not reported are dividing a total they contributed nothing to. That is exactly the failure the ticket describes, and it is the failure that is silent, because the total above the chart still looks right.

Settled totals by layer (the reason a single number is not enough):

| layer | settled total | share |
|---|---|---|
| llm | $48,712.15 | 53.7% |
| compute | $41,883.58 | 46.1% |
| egress | $179.33 | 0.2% |

Compute alone is 46% of the baseline, and it is the half that arrives late.

Scoped reads verified live against the same window: `layer=llm` $48,712.15, `layer=compute` $41,883.58, `feature=chatbot` $7,703.51, each over the same 27 settled days.

## The three traps

1. **Two clocks.** Window start, today, the day count and the whole day list come from one ClickHouse read and are passed to the following reads as a bound parameter, so the day list cannot shift a day against the SQL window and silently drop its oldest point. `queryCostSeries` still has that bug (CTO-203); `queryAccountDetail` does it right, and so does this. There is a test that pins a window in 2021 so a Node-clock day list would produce no matching slots at all.
2. **`FixedString(64)` NUL padding.** No FixedString column is compared or returned here; the scope filters run against `FeatureTag`, the model columns and `LAYER_CASE`, all plain / LowCardinality strings.
3. **`uniq` states.** Only money is summed. No distinct-user count is merged across layers.

## Other decisions

- **Window:** the shared calendar-aligned `toDate(now()) - INTERVAL 29 DAY`, widened to reach `toStartOfMonth` so month-to-date is always fully covered (on the 31st a plain 30-day window clips the 1st). Not a rolling `now() - INTERVAL 30 DAY`, which drifts by the second and clips a partial day.
- **Layer mapping:** reuses the existing `LAYER_CASE` for both the money and the settlement evidence, so there is only ever one operation-to-layer mapping in the file.
- **Scoping** (`tenant` / `feature` / `model` / `layer`) matches the budget scopes in CTO-205. Settlement is judged on the tenant's **whole** data, never on the slice: whether Tuesday's cloud bill landed is a fact about the pipeline, not about the feature you happen to be looking at, and a feature that emitted nothing on Tuesday must not make Tuesday read as unsettled. There is a test for that.
- **Honest under uncertainty:** `settledThrough` and `reconciledThrough` are `null` when unknown, never a stand-in date. `baselineDays` empty means "no settled history", and the caller must refuse to project rather than print a number. An unreachable ClickHouse is `null` via `tryLive`, never zero spend.

## Verification

From `web/`:

- `npm run typecheck` clean.
- `npm run lint` clean (the 3 pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`, untouched).
- `npm run test`: **440 passing**, up from 431 (9 new tests). The only failures are the 2 long-standing `app/api/api.test.ts` ones (attribution + data-quality "falls back to mock when ClickHouse is unreachable") that fail whenever a local ClickHouse is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
