### PR TITLE
feat(budgets): record what a tenant intends to spend on AI (CTO-205)

### DIFF
--- a/db/postgres/0026_tenant_budgets.sql
+++ b/db/postgres/0026_tenant_budgets.sql
@@ -1,0 +1,132 @@
+-- What a tenant intends to SPEND on AI, per period and per scope (CTO-205, F1).
+--
+-- WHY this table exists. Nothing in this schema has ever recorded a customer's intent. The two
+-- existing `daily_budget_usd` columns (`tenant_replay_config`, `tenant_eval_config`) are caps on
+-- what ai-tally itself is allowed to spend running replays and evals on a tenant's behalf. They
+-- are operational safety valves for our own machinery, not a statement by the customer about their
+-- own AI bill. Every "versus budget" number in the spend-forecasting epic (CTO-204) is meaningless
+-- until that intent is written down somewhere, and this is that somewhere. See
+-- docs/spend-forecasting-scope.md, "The budget model".
+--
+-- WHY money is BIGINT micro-USD and not NUMERIC dollars. Same reason as everywhere else in this
+-- system: a budget is compared against summed span costs which are already micro-USD integers, and
+-- mixing a float budget into an integer comparison reintroduces the rounding the integers exist to
+-- avoid. A budget of $30,000 is 30000000000. There is no float anywhere on this path.
+--
+-- WHY the budget is SCOPED and not just a tenant total. "The research agent gets $30k a month" is
+-- how teams actually govern AI spend, and it is the difference between a burn-down chart finance
+-- reads once a month and one a feature owner reads every day. `scope_kind` names the dimension and
+-- `scope_value` the member of it:
+--   * tenant  -> the whole bill.        scope_value = '' (the ONLY legal value, see CHECK below).
+--   * feature -> one `FeatureId`, matching the feature dimension on daily_feature_rollup.
+--   * model   -> one model id, e.g. 'gpt-4o'.
+--   * layer   -> one cost layer, e.g. 'compute', matching ALLOWED_LAYERS in tenant_connectors.
+-- The four kinds mirror the dimensions the cost queries in web/lib/clickhouse.ts already group by,
+-- so a scoped budget is always comparable against a series that actually exists.
+--
+-- WHY scope_value is '' and never NULL for a tenant-wide budget. It is part of the overlap
+-- identity below, and NULL is not equal to NULL. A NULLable scope_value would let a tenant create
+-- unlimited duplicate tenant-wide budgets for the same month, each invisible to the other. The
+-- empty string compares as an ordinary value and the CHECK constraints keep the two spellings from
+-- ever both being legal for the same row.
+--
+-- WHY OVERLAP IS REJECTED AT WRITE TIME (the central decision of this ticket).
+--
+-- Two budgets for the same scope and period whose date ranges overlap pose a question with no good
+-- answer at read time: which one is the number the burn-down is drawn against? Every tie-break
+-- available is arbitrary. Newest-wins silently disables a budget somebody deliberately set.
+-- Smallest-wins turns an accidental duplicate into a false breach alert. Summing them invents a
+-- budget nobody approved. Worse, whichever rule is chosen has to be re-implemented identically in
+-- the projection, the burn-down chart, and the future breach alerts, and the first place it drifts
+-- produces an alert that disagrees with the chart on the same screen.
+--
+-- So an overlapping write is refused, and the tenant is told which existing budget it collided
+-- with. The invariant every downstream consumer may rely on is: for a given
+-- (tenant, period, scope_kind, scope_value) and a given day, AT MOST ONE budget row applies. That
+-- makes budget resolution a lookup rather than a policy, and there is nothing to keep in sync.
+--
+-- The EXCLUDE constraint is what actually enforces it. An application-level pre-check races: two
+-- concurrent POSTs both read no conflict and both insert. The gateway still pre-checks so it can
+-- return a useful message naming the colliding budget_id, but correctness rests here, not there.
+--
+-- An open-ended budget (`ends_on IS NULL`) means "until further notice", which is the common case:
+-- a monthly budget is usually a standing figure, not a fixed-term one. It is modelled as a range
+-- ending at 'infinity', so a second open-ended budget for the same scope necessarily overlaps it
+-- and is refused. Ranges are INCLUSIVE at both ends ('[]'): a budget ending on the 31st covers the
+-- 31st, and a successor budget therefore has to start on the 1st, not on the 31st.
+--
+-- INVARIANT, and it is load-bearing for the whole epic: A TENANT WITH NO ROW HERE IS NORMAL. Every
+-- tenant on this system is in that state right now. There is no backfill, no placeholder row, and
+-- no implicit budget of zero. A zero budget is a real and different claim ("this feature may spend
+-- nothing"), and rendering an absent budget as 0 would report every tenant as infinitely over
+-- budget. Downstream renders "no budget set" and omits the variance entirely, per the
+-- honest-under-uncertainty rule: unknown is null, never 0.
+--
+-- Reads and writes go through GET/POST/DELETE /v1/tenant/budgets. The web app never touches
+-- Postgres directly, same as the rest of the control plane.
+
+-- Required for the EXCLUDE constraint below: gist needs equality operators for the scalar columns
+-- (UUID and TEXT) it combines with the range overlap test. Ships with the postgres image.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE IF NOT EXISTS tenant_budgets (
+    tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    -- Caller-supplied stable handle, so a UI can rename or re-target a budget without the row
+    -- identity moving. Not a UUID by fiat: 'research-agent-2026' is a perfectly good budget_id and
+    -- reads better in an audit than a random uuid.
+    budget_id     TEXT NOT NULL,
+    period        TEXT NOT NULL,
+    -- Micro-USD. >= 0 rather than > 0 on purpose: a deliberate zero budget for a scope that must
+    -- not spend is a legitimate and meaningful thing to record. It is the ABSENCE of a row, not a
+    -- zero, that means "no budget".
+    amount_micro  BIGINT NOT NULL,
+    scope_kind    TEXT NOT NULL,
+    scope_value   TEXT NOT NULL DEFAULT '',
+    starts_on     DATE NOT NULL,
+    -- NULL means open-ended, i.e. "until further notice". Not a sentinel far-future date: the
+    -- distinction between "runs until we say otherwise" and "ends on 2099-12-31" is real, and a
+    -- sentinel would show up in a UI as a date somebody typed.
+    ends_on       DATE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, budget_id),
+
+    CONSTRAINT tenant_budgets_period_check
+        CHECK (period IN ('month', 'quarter')),
+    CONSTRAINT tenant_budgets_amount_check
+        CHECK (amount_micro >= 0),
+    CONSTRAINT tenant_budgets_scope_kind_check
+        CHECK (scope_kind IN ('tenant', 'feature', 'model', 'layer')),
+    -- The two halves of the scope have to agree. A 'tenant' budget naming a feature would be
+    -- ambiguous about what it covers, and a 'feature' budget naming nothing could never be matched
+    -- against a series.
+    CONSTRAINT tenant_budgets_scope_value_check
+        CHECK (
+            (scope_kind = 'tenant' AND scope_value = '')
+            OR (scope_kind <> 'tenant' AND scope_value <> '')
+        ),
+    CONSTRAINT tenant_budgets_budget_id_check
+        CHECK (budget_id <> ''),
+    -- An end before the start is not a short budget, it is a typo that would silently cover no
+    -- days at all and quietly disable the burn-down.
+    CONSTRAINT tenant_budgets_dates_check
+        CHECK (ends_on IS NULL OR ends_on >= starts_on),
+
+    -- The overlap rule, enforced by the database rather than by hope. See the header.
+    CONSTRAINT tenant_budgets_no_overlap EXCLUDE USING gist (
+        tenant_id WITH =,
+        period WITH =,
+        scope_kind WITH =,
+        scope_value WITH =,
+        daterange(starts_on, COALESCE(ends_on, 'infinity'::date), '[]') WITH &&
+    )
+);
+
+-- The read pattern is "every budget this tenant has", fetched once per page render and filtered in
+-- memory against the scopes actually on screen. The primary key leads with tenant_id and serves
+-- that prefix scan; the EXCLUDE constraint's gist index covers the effective-on-a-date lookup.
+-- No further index is warranted at the row counts a budget table reaches.
+
+COMMENT ON TABLE tenant_budgets IS
+    'What a tenant intends to spend on AI, per period and scope (CTO-205). Absence of a row means '
+    'no budget set, which is a normal state and never an implicit zero.';

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -82,6 +82,9 @@ services:
       - ../db/postgres/0023_tenant_account_labels.sql:/docker-entrypoint-initdb.d/0023_tenant_account_labels.sql:ro
       - ../db/postgres/0024_tenant_allocation_config.sql:/docker-entrypoint-initdb.d/0024_tenant_allocation_config.sql:ro
       - ../db/postgres/0025_tenant_revenue_uploads.sql:/docker-entrypoint-initdb.d/0025_tenant_revenue_uploads.sql:ro
+      # What a tenant intends to SPEND on AI (CTO-205). Needs btree_gist for the no-overlap
+      # EXCLUDE constraint; the extension is created by the migration itself.
+      - ../db/postgres/0026_tenant_budgets.sql:/docker-entrypoint-initdb.d/0026_tenant_budgets.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -116,6 +116,15 @@ from gateway.tenant_allocation import (
     normalize_rule,
     normalize_updated_by,
 )
+from gateway.tenant_budgets import (
+    BUDGET_PERIODS,
+    BUDGET_SCOPE_KINDS,
+    BudgetError,
+    BudgetOverlapError,
+    TenantBudgetStore,
+    TenantNotFound as BudgetTenantNotFound,
+    normalize_budget_id,
+)
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
@@ -260,6 +269,10 @@ async def lifespan(app: FastAPI):
     # across accounts on /cost-per-customer, which is roughly half of every figure on that page.
     # A tenant with no row gets pro_rata_direct and the page says the rule is the default.
     app.state.tenant_allocation = TenantAllocationStore(settings)
+    # What the tenant intends to SPEND on AI (CTO-205). The first thing in this system to record a
+    # customer's intent rather than our own metering, and every "versus budget" number in the
+    # forecasting epic reads from it. No row is the normal state and means "no budget set".
+    app.state.tenant_budgets = TenantBudgetStore(settings)
     # In-process dedup set for Stripe webhook redeliveries. ClickHouse's ReplacingMergeTree
     # will collapse late duplicates at merge time, but this short-circuits the second insert
     # so the 200 stays well under Stripe's 30s timeout window.
@@ -1450,6 +1463,152 @@ async def upsert_tenant_allocation_config(
             "available_rules": list(ALLOCATION_RULES),
             "config": config.as_dict(),
         },
+        status_code=200,
+    )
+
+
+@app.get("/v1/tenant/budgets")
+def list_tenant_budgets(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Every budget this tenant has set (CTO-205, F1).
+
+    The response separates "what is stored" from "is anything stored":
+
+    * ``budgets``: the rows, each with ``amount_micro`` as integer micro-USD. Never dollars.
+    * ``configured``: false when the tenant has no budget at all. THIS IS THE NORMAL STATE and
+      every tenant on this system is in it today. It is not an error and it is not a budget of
+      zero: downstream must render "no budget set" and omit the variance rather than reporting the
+      tenant as infinitely over. A stored ``amount_micro`` of 0 is a different, deliberate claim.
+    * ``available_periods`` / ``available_scope_kinds``: what this deployment can store, so a
+      settings UI does not hardcode the lists and drift from the CHECK constraints.
+
+    An unknown tenant is 404 rather than an empty list. A misrouted request is not a tenant who has
+    set no budgets, and answering "no budget set" for a tenant we do not know would hide the bug.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    store: TenantBudgetStore = app.state.tenant_budgets
+    try:
+        budgets = store.list(tenant_id)
+    except BudgetTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return JSONResponse(
+        {
+            "tenant_id": tenant_id,
+            "budgets": [b.as_dict() for b in budgets],
+            "configured": bool(budgets),
+            "available_periods": list(BUDGET_PERIODS),
+            "available_scope_kinds": list(BUDGET_SCOPE_KINDS),
+        },
+        status_code=200,
+    )
+
+
+@app.post("/v1/tenant/budgets")
+async def upsert_tenant_budget(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Create or edit one budget (CTO-205, F1).
+
+    Body: ``{"budget_id": "research-agent-2026", "period": "month", "amount_micro": 30000000000,
+    "scope_kind": "feature", "scope_value": "research-agent", "starts_on": "2026-01-01",
+    "ends_on": null}``.
+
+    Creating and editing are the same call, an upsert on ``(tenant_id, budget_id)``. There is no
+    ``change_id`` idempotency token here, unlike the allocation-config control plane, because there
+    is no audit log to append to and the write is last-write-wins by nature: replaying the same
+    body is already a no-op beyond ``updated_at``.
+
+    ``amount_micro`` is an INTEGER of micro-USD and a float is a 422, not a rounding. $30,000 is
+    ``30000000000``. Every cost figure this budget will be compared against is already an integer
+    of micro-USD, and admitting dollars-as-float at the boundary is how the two stop reconciling.
+
+    **Overlap is a 409.** A budget that covers the same scope and period over an overlapping date
+    range as an existing one is refused, and the response names the budget it collided with in
+    ``conflicting_budget_id``. The alternative, resolving the ambiguity at read time, has no
+    principled tie-break and would have to be reimplemented identically in the projection, the
+    burn-down and the future breach alerts. See ``db/postgres/0026_tenant_budgets.sql``. To replace
+    a budget, either POST the same ``budget_id`` (which edits in place) or close the old one by
+    setting its ``ends_on`` first.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail="body is not valid JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="body must be a JSON object")
+
+    store: TenantBudgetStore = app.state.tenant_budgets
+    try:
+        budget = store.upsert(
+            tenant_id,
+            budget_id=body.get("budget_id"),
+            period=body.get("period"),
+            amount_micro=body.get("amount_micro"),
+            scope_kind=body.get("scope_kind"),
+            scope_value=body.get("scope_value", ""),
+            starts_on=body.get("starts_on"),
+            ends_on=body.get("ends_on"),
+        )
+    except BudgetTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except BudgetOverlapError as exc:
+        # 409 rather than 422: the body is well-formed, it conflicts with state. The distinction
+        # matters to a UI, which should offer to edit the colliding budget rather than re-validate
+        # the form the user just filled in correctly.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": str(exc),
+                "conflicting_budget_id": exc.conflicting_budget_id,
+            },
+        ) from exc
+    except BudgetError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse({"tenant_id": tenant_id, "budget": budget.as_dict()}, status_code=200)
+
+
+@app.delete("/v1/tenant/budgets")
+async def delete_tenant_budget(
+    request: Request,
+    budget_id: str | None = None,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Withdraw one budget, returning that scope to "no budget set" (CTO-205, F1).
+
+    Takes ``budget_id`` as a query parameter or in a JSON body, because DELETE-with-a-body is
+    awkward from several HTTP clients and this endpoint addresses a single named row.
+
+    A real DELETE. A budget is the tenant's own statement of intent, so withdrawing it must not
+    leave a row behind still claiming they intend it.
+
+    Deleting an absent budget returns 200 with ``removed: false`` rather than 404, same as the
+    account-labels control plane: the end state the caller asked for is the end state they get, and
+    a double-click is not an error.
+    """
+    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    if budget_id is None:
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001 - an absent body is normal when the query param was used
+            body = None
+        if isinstance(body, dict):
+            budget_id = body.get("budget_id")
+    store: TenantBudgetStore = app.state.tenant_budgets
+    try:
+        target = normalize_budget_id(budget_id)
+        removed = store.delete(tenant_id, target)
+    except BudgetTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except BudgetError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(
+        {"tenant_id": tenant_id, "budget_id": target, "removed": removed},
         status_code=200,
     )
 

--- a/infra/gateway/src/gateway/tenant_budgets.py
+++ b/infra/gateway/src/gateway/tenant_budgets.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: Apache-2.0
+"""What a tenant intends to spend on AI, per period and per scope (CTO-205, F1).
+
+WHY this exists. Nothing in this system has ever recorded a customer's spending intent. The two
+``daily_budget_usd`` columns already in the schema (``tenant_replay_config``, ``tenant_eval_config``)
+cap what ai-tally itself spends running replays and evals; they say nothing about the customer's own
+AI bill. Every "versus budget" figure in the spend-forecasting epic (CTO-204) depends on this table,
+so it is the first thing that has to exist. See ``db/postgres/0026_tenant_budgets.sql`` for the full
+rationale and ``docs/spend-forecasting-scope.md`` for where it is heading.
+
+THE RULE OF THIS MODULE: a tenant with no budget row is a normal state, not missing config, and
+never an implicit zero. :meth:`TenantBudgetStore.list` returning ``[]`` is the state every tenant on
+this system is in today. Downstream renders "no budget set" and omits the variance entirely rather
+than reporting a tenant as infinitely over a budget of zero. A stored zero is a different and real
+claim ("this scope may spend nothing"), which is why ``amount_micro >= 0`` rather than ``> 0``.
+
+WHY overlapping budgets are refused at write time. Two budgets covering the same scope, period and
+day leave the burn-down with no principled answer about which number to draw the line at, and every
+tie-break is arbitrary: newest-wins silently disables a budget somebody set, smallest-wins turns a
+duplicate into a false breach, summing invents a budget nobody approved. Worse, whichever rule were
+chosen would have to be reimplemented identically in the projection, the chart and the future breach
+alerts, and the first drift between them puts an alert and a chart that disagree on one screen. So
+the write is refused and the caller is told which budget it collided with. Downstream may rely on:
+for one ``(tenant, period, scope_kind, scope_value)`` and one day, AT MOST ONE budget applies.
+
+The pre-check in :meth:`TenantBudgetStore.upsert` exists for the error MESSAGE, not for correctness.
+Two concurrent POSTs would both find no conflict and both insert; the EXCLUDE constraint in
+migration 0026 is what actually holds the invariant, and this module translates its violation into
+the same 409 the pre-check produces.
+
+Money is integer micro-USD throughout, as everywhere in this codebase. There is no float on this
+path, and the API neither accepts nor emits dollars.
+
+Reads and writes go through ``GET/POST/DELETE /v1/tenant/budgets``. The web app never touches
+Postgres directly, same rule as :mod:`gateway.tenant_account_labels` and
+:mod:`gateway.tenant_allocation`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+
+import psycopg
+from psycopg import errors as pg_errors
+
+from gateway.config import Settings
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
+
+#: Budget periods, matching the CHECK constraint in migration 0026. Deliberately only the two the
+#: forecast can actually evaluate: a period the projection cannot compute a window for would be a
+#: budget that never renders. ``year`` is absent for that reason, not by oversight.
+BUDGET_PERIODS: tuple[str, ...] = ("month", "quarter")
+
+#: What a budget applies to. Each kind names a dimension the cost queries in
+#: ``web/lib/clickhouse.ts`` already group by, so a scoped budget is always comparable against a
+#: series that exists. ``tenant`` is the whole bill and takes an empty ``scope_value``.
+BUDGET_SCOPE_KINDS: tuple[str, ...] = ("tenant", "feature", "model", "layer")
+
+#: The scope kind that covers everything and therefore names nothing.
+TENANT_SCOPE_KIND = "tenant"
+
+#: A budget_id is a handle in a URL and an audit line, not a description.
+MAX_BUDGET_ID_CHARS = 120
+
+#: A scope value is a FeatureId, a model id or a layer name. All are short identifiers.
+MAX_SCOPE_VALUE_CHARS = 200
+
+#: Ceiling on a stored budget: 1e15 micro-USD is one billion dollars. Not a business rule, a typo
+#: guard. A budget is a BIGINT and an accidental extra six zeros would otherwise sail through and
+#: make every variance downstream meaningless while looking like a real number.
+MAX_AMOUNT_MICRO = 1_000_000_000_000_000
+
+
+class BudgetError(ValueError):
+    """Caller-facing validation error. Surfaces as HTTP 422."""
+
+
+#: The caller's tenant identifier matches no ``tenants`` row. Re-exported from
+#: :mod:`gateway.tenant_lookup` rather than redefined, so a caller catching a budget-store failure
+#: catches one name and the endpoint can map it to 404 without knowing which module raised it. This
+#: module deliberately does NOT add a fifth private copy of the name-vs-UUID resolver: CTO-201
+#: tracks folding the remaining copies in :mod:`gateway.tenant_identity` and
+#: :mod:`gateway.tenant_account_labels` onto this one, and that consolidation is not this ticket.
+TenantNotFound = TenantNotFoundError
+
+
+class BudgetOverlapError(BudgetError):
+    """A budget already covers this scope, period and date range. Surfaces as HTTP 409.
+
+    Carries ``conflicting_budget_id`` when we know it, because "that overlaps" is not actionable
+    and "that overlaps with research-agent-q1" is. The constraint-violation path does not know it,
+    so the field is optional and the caller must handle it being None.
+    """
+
+    def __init__(self, message: str, conflicting_budget_id: str | None = None) -> None:
+        super().__init__(message)
+        self.conflicting_budget_id = conflicting_budget_id
+
+
+@dataclass(frozen=True, slots=True)
+class Budget:
+    """One stored budget row."""
+
+    budget_id: str
+    period: str
+    amount_micro: int
+    scope_kind: str
+    scope_value: str
+    starts_on: date
+    ends_on: date | None
+    created_at: datetime | None
+    updated_at: datetime | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "budget_id": self.budget_id,
+            "period": self.period,
+            "amount_micro": self.amount_micro,
+            "scope_kind": self.scope_kind,
+            # Always present, always a string, '' for a tenant-wide budget. A consumer that has to
+            # branch on null vs '' for the same concept will eventually get it wrong.
+            "scope_value": self.scope_value,
+            "starts_on": self.starts_on.isoformat(),
+            # null means open-ended, not unknown. The one nullable field here, and it is a real
+            # statement rather than missing data.
+            "ends_on": self.ends_on.isoformat() if self.ends_on else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+def normalize_budget_id(value: object) -> str:
+    """Validate the caller's stable handle for a budget.
+
+    Trim only, no case folding: it is the caller's own identifier and it is the primary key, so
+    rewriting it would mean a caller could not address the row it just created.
+    """
+    if not isinstance(value, str):
+        raise BudgetError("budget_id must be a string")
+    trimmed = value.strip()
+    if not trimmed:
+        raise BudgetError("budget_id must be non-empty")
+    if len(trimmed) > MAX_BUDGET_ID_CHARS:
+        raise BudgetError(f"budget_id must be at most {MAX_BUDGET_ID_CHARS} characters")
+    return trimmed
+
+
+def normalize_period(value: object) -> str:
+    """Validate a period against :data:`BUDGET_PERIODS`.
+
+    An unknown period is rejected rather than coerced to 'month'. Storing one period and evaluating
+    another would draw a burn-down over the wrong window and label it with the right one.
+    """
+    if not isinstance(value, str):
+        raise BudgetError("period must be a string")
+    trimmed = value.strip().lower()
+    if trimmed not in BUDGET_PERIODS:
+        raise BudgetError("period must be one of: " + ", ".join(BUDGET_PERIODS))
+    return trimmed
+
+
+def normalize_amount_micro(value: object) -> int:
+    """Validate a budget amount in micro-USD.
+
+    Rejects floats outright, including whole-valued ones. Accepting ``30000.0`` would advertise
+    that dollars-as-float is a supported input shape, and the next caller passes ``30000.5`` and
+    silently loses half a cent per budget. Money in this system is an integer of micro-USD, and the
+    boundary is the right place to say so.
+
+    Zero is accepted: a scope that may spend nothing is a real budget. Absence of a row, not a
+    zero, is what means "no budget set".
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise BudgetError("amount_micro must be an integer of micro-USD (no floats, no dollars)")
+    if value < 0:
+        raise BudgetError("amount_micro must be >= 0")
+    if value > MAX_AMOUNT_MICRO:
+        raise BudgetError(
+            f"amount_micro must be at most {MAX_AMOUNT_MICRO} "
+            "(1e15 micro-USD = $1B); check for a misplaced decimal"
+        )
+    return value
+
+
+def normalize_scope(scope_kind: object, scope_value: object) -> tuple[str, str]:
+    """Validate the two halves of a scope together, because they constrain each other.
+
+    A ``tenant`` budget must name nothing and every other kind must name something. Validating them
+    separately would admit 'tenant'/'checkout' (ambiguous about what it covers) and 'feature'/''
+    (never matchable against a series), both of which the CHECK constraint would then reject as an
+    opaque 503.
+    """
+    if not isinstance(scope_kind, str):
+        raise BudgetError("scope_kind must be a string")
+    kind = scope_kind.strip().lower()
+    if kind not in BUDGET_SCOPE_KINDS:
+        raise BudgetError("scope_kind must be one of: " + ", ".join(BUDGET_SCOPE_KINDS))
+
+    if scope_value is None:
+        value = ""
+    elif isinstance(scope_value, str):
+        value = scope_value.strip()
+    else:
+        raise BudgetError("scope_value must be a string when provided")
+
+    if kind == TENANT_SCOPE_KIND:
+        if value:
+            raise BudgetError("a tenant-wide budget must not name a scope_value")
+        return kind, ""
+    if not value:
+        raise BudgetError(f"a {kind}-scoped budget requires a scope_value")
+    if len(value) > MAX_SCOPE_VALUE_CHARS:
+        raise BudgetError(f"scope_value must be at most {MAX_SCOPE_VALUE_CHARS} characters")
+    # No case folding. A FeatureId or a model id is compared against telemetry that preserves case,
+    # so lowercasing here would produce a budget that matches nothing.
+    return kind, value
+
+
+def normalize_date(value: object, *, field: str) -> date:
+    """Parse an ISO ``YYYY-MM-DD`` date."""
+    if isinstance(value, datetime):
+        raise BudgetError(f"{field} must be a date (YYYY-MM-DD), not a timestamp")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise BudgetError(f"{field} must be an ISO date string (YYYY-MM-DD)")
+    try:
+        return date.fromisoformat(value.strip())
+    except ValueError as exc:
+        raise BudgetError(f"{field} must be an ISO date string (YYYY-MM-DD)") from exc
+
+
+def normalize_optional_date(value: object, *, field: str) -> date | None:
+    """Parse an optional end date. ``None`` means open-ended, which is the common case.
+
+    Open-ended is not "unknown". A monthly budget is usually a standing figure that runs until
+    somebody changes it, so absence here is a statement rather than missing data.
+    """
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return None
+    return normalize_date(value, field=field)
+
+
+_COLUMNS = (
+    "budget_id, period, amount_micro, scope_kind, scope_value, "
+    "starts_on, ends_on, created_at, updated_at"
+)
+
+
+def _row_to_budget(row: tuple) -> Budget:
+    return Budget(
+        budget_id=str(row[0]),
+        period=str(row[1]),
+        amount_micro=int(row[2]),
+        scope_kind=str(row[3]),
+        scope_value=str(row[4]),
+        starts_on=row[5],
+        ends_on=row[6],
+        created_at=row[7],
+        updated_at=row[8],
+    )
+
+
+class TenantBudgetStore:
+    """Postgres-backed CRUD over ``tenant_budgets``.
+
+    Every method takes the ``tenant_id`` resolved by upstream auth and folds it onto ``tenants.id``,
+    so the SQL never crosses tenants.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def list(self, tenant_id: str) -> list[Budget]:
+        """Every budget this tenant has set.
+
+        An empty list is the normal answer for every tenant on this system today. It means "no
+        budget set", and the caller must render that rather than substituting zero.
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                f"SELECT {_COLUMNS} FROM tenant_budgets WHERE tenant_id = %s "
+                "ORDER BY scope_kind, scope_value, starts_on, budget_id",
+                (resolved,),
+            )
+            return [_row_to_budget(row) for row in cur.fetchall()]
+
+    def get(self, tenant_id: str, budget_id: str) -> Budget | None:
+        """One budget, or ``None`` when the tenant has not set it. ``None`` is not an error."""
+        budget_id = normalize_budget_id(budget_id)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                f"SELECT {_COLUMNS} FROM tenant_budgets "
+                "WHERE tenant_id = %s AND budget_id = %s",
+                (resolved, budget_id),
+            )
+            row = cur.fetchone()
+            return _row_to_budget(row) if row else None
+
+    def upsert(
+        self,
+        tenant_id: str,
+        *,
+        budget_id: str,
+        period: str,
+        amount_micro: int,
+        scope_kind: str,
+        starts_on: object,
+        scope_value: object = "",
+        ends_on: object = None,
+    ) -> Budget:
+        """Create or replace one budget. Refuses an overlapping one.
+
+        Setting and editing are the same call: the write is an upsert on
+        ``(tenant_id, budget_id)``, so a caller correcting an amount does not have to know whether
+        the row exists, and two concurrent writers cannot produce two rows for one budget_id.
+
+        Overlap is checked twice, and the two checks are not redundant. The SELECT below produces
+        the useful error (it names the budget it collided with) but cannot be relied on for
+        correctness, because two concurrent inserts both pass it. The EXCLUDE constraint in
+        migration 0026 is the actual guarantee, and its violation is translated into the same
+        :class:`BudgetOverlapError` so the caller sees one behaviour whichever path caught it.
+
+        The self-exclusion in the pre-check (``budget_id <> %s``) is what makes editing a budget in
+        place work at all: a budget always overlaps itself, so without it no budget could ever be
+        updated.
+        """
+        budget_id = normalize_budget_id(budget_id)
+        period = normalize_period(period)
+        amount_micro = normalize_amount_micro(amount_micro)
+        scope_kind, scope_value = normalize_scope(scope_kind, scope_value)
+        start = normalize_date(starts_on, field="starts_on")
+        end = normalize_optional_date(ends_on, field="ends_on")
+        if end is not None and end < start:
+            raise BudgetError("ends_on must be on or after starts_on")
+
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                """
+                SELECT budget_id FROM tenant_budgets
+                WHERE tenant_id = %s
+                  AND period = %s
+                  AND scope_kind = %s
+                  AND scope_value = %s
+                  AND budget_id <> %s
+                  AND daterange(starts_on, COALESCE(ends_on, 'infinity'::date), '[]')
+                      && daterange(%s, COALESCE(%s, 'infinity'::date), '[]')
+                LIMIT 1
+                """,
+                (resolved, period, scope_kind, scope_value, budget_id, start, end),
+            )
+            clash = cur.fetchone()
+            if clash is not None:
+                raise BudgetOverlapError(
+                    "a budget already covers this scope and period over an overlapping date "
+                    f"range: {clash[0]}",
+                    conflicting_budget_id=str(clash[0]),
+                )
+            try:
+                cur.execute(
+                    f"""
+                    INSERT INTO tenant_budgets
+                        (tenant_id, budget_id, period, amount_micro,
+                         scope_kind, scope_value, starts_on, ends_on)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (tenant_id, budget_id) DO UPDATE
+                      SET period       = EXCLUDED.period,
+                          amount_micro = EXCLUDED.amount_micro,
+                          scope_kind   = EXCLUDED.scope_kind,
+                          scope_value  = EXCLUDED.scope_value,
+                          starts_on    = EXCLUDED.starts_on,
+                          ends_on      = EXCLUDED.ends_on,
+                          updated_at   = now()
+                    RETURNING {_COLUMNS}
+                    """,
+                    (
+                        resolved,
+                        budget_id,
+                        period,
+                        amount_micro,
+                        scope_kind,
+                        scope_value,
+                        start,
+                        end,
+                    ),
+                )
+            except pg_errors.ExclusionViolation as exc:
+                # Lost the race against a concurrent writer. Same answer as the pre-check, minus
+                # the colliding budget_id, which the constraint does not hand us.
+                conn.rollback()
+                raise BudgetOverlapError(
+                    "a budget already covers this scope and period over an overlapping date range"
+                ) from exc
+            row = cur.fetchone()
+            assert row is not None  # RETURNING on an upsert that cannot no-op
+            conn.commit()
+            return _row_to_budget(row)
+
+    def delete(self, tenant_id: str, budget_id: str) -> bool:
+        """Remove one budget, returning that scope to the "no budget set" state.
+
+        A real DELETE. A budget is the tenant's own statement of intent, and withdrawing it should
+        leave nothing behind claiming they still intend it.
+
+        Returns True if this call removed a row, False if it was already absent. Deleting an absent
+        budget is not an error, so a double-click cannot produce a 404.
+        """
+        budget_id = normalize_budget_id(budget_id)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                "DELETE FROM tenant_budgets WHERE tenant_id = %s AND budget_id = %s",
+                (resolved, budget_id),
+            )
+            removed = cur.rowcount > 0
+            conn.commit()
+            return removed

--- a/infra/gateway/tests/test_app_tenant_budgets.py
+++ b/infra/gateway/tests/test_app_tenant_budgets.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GET/POST/DELETE /v1/tenant/budgets: what a tenant intends to spend (CTO-205, F1).
+
+Four tests carry the acceptance criteria:
+
+* :func:`test_tenant_with_no_budget_is_a_normal_state`: the state every tenant is in today. It must
+  answer 200 with an empty list and ``configured: false``, never a 404 and never an implicit zero.
+* :func:`test_scoped_budgets_round_trip`: feature, model and layer budgets, which are how teams
+  actually govern spend and what makes the later burn-down useful to a feature owner.
+* :func:`test_overlapping_budget_is_rejected_at_write_time`: the decision of this ticket. Two
+  budgets covering one scope on one day would leave the burn-down with no principled answer.
+* :func:`test_name_based_caller_does_not_500`: the tenant name-vs-UUID trap (CTO-201). The table
+  keys on ``tenants.id`` but the dashboard sends ``local-dev``.
+
+The rest guard the money contract (integer micro-USD, never float dollars) and the normalizers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date, datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_budgets import (
+    BUDGET_PERIODS,
+    BUDGET_SCOPE_KINDS,
+    Budget,
+    BudgetError,
+    BudgetOverlapError,
+    TenantNotFound,
+    normalize_amount_micro,
+    normalize_budget_id,
+    normalize_date,
+    normalize_optional_date,
+    normalize_period,
+    normalize_scope,
+)
+
+TENANT_NAME = "local-dev"
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+UNKNOWN_TENANT = "no-such-tenant"
+
+# $30,000 in micro-USD. Spelled out once here so the tests read as money rather than as a
+# suspiciously long integer.
+THIRTY_K_MICRO = 30_000_000_000
+
+
+def _overlaps(
+    a_start: date, a_end: date | None, b_start: date, b_end: date | None
+) -> bool:
+    """Inclusive date-range overlap, mirroring the ``daterange(..., '[]')`` in migration 0026.
+
+    ``None`` is 'infinity', i.e. open-ended, so two open-ended budgets always overlap.
+    """
+    if a_end is not None and a_end < b_start:
+        return False
+    if b_end is not None and b_end < a_start:
+        return False
+    return True
+
+
+class FakeStore:
+    """In-memory stand-in for :class:`TenantBudgetStore`, so no Postgres is needed.
+
+    Mirrors the contract the endpoints depend on: a name and a UUID fold onto ONE tenant the way
+    the foreign key forces, absence of a row is a normal empty answer, and an overlapping write is
+    refused with the colliding budget_id the way the EXCLUDE constraint plus pre-check do.
+    """
+
+    def __init__(self, known_tenants: set[str] | None = None) -> None:
+        self._rows: dict[tuple[str, str], Budget] = {}
+        self._known = (
+            known_tenants if known_tenants is not None else {TENANT_NAME, TENANT_UUID}
+        )
+
+    def _resolve(self, tenant_id: str) -> str:
+        if tenant_id not in self._known:
+            raise TenantNotFound("no tenant matches the supplied identifier")
+        return TENANT_UUID
+
+    def list(self, tenant_id: str) -> list[Budget]:
+        resolved = self._resolve(tenant_id)
+        rows = [b for (t, _), b in self._rows.items() if t == resolved]
+        return sorted(
+            rows, key=lambda b: (b.scope_kind, b.scope_value, b.starts_on, b.budget_id)
+        )
+
+    def get(self, tenant_id: str, budget_id: str) -> Budget | None:
+        return self._rows.get((self._resolve(tenant_id), normalize_budget_id(budget_id)))
+
+    def upsert(
+        self,
+        tenant_id: str,
+        *,
+        budget_id: str,
+        period: str,
+        amount_micro: int,
+        scope_kind: str,
+        starts_on: object,
+        scope_value: object = "",
+        ends_on: object = None,
+    ) -> Budget:
+        budget_id = normalize_budget_id(budget_id)
+        period = normalize_period(period)
+        amount_micro = normalize_amount_micro(amount_micro)
+        scope_kind, scope_value = normalize_scope(scope_kind, scope_value)
+        start = normalize_date(starts_on, field="starts_on")
+        end = normalize_optional_date(ends_on, field="ends_on")
+        if end is not None and end < start:
+            raise BudgetError("ends_on must be on or after starts_on")
+        resolved = self._resolve(tenant_id)
+
+        for (t, bid), other in self._rows.items():
+            if t != resolved or bid == budget_id:
+                continue
+            same_scope = (
+                other.period == period
+                and other.scope_kind == scope_kind
+                and other.scope_value == scope_value
+            )
+            if same_scope and _overlaps(other.starts_on, other.ends_on, start, end):
+                raise BudgetOverlapError(
+                    "a budget already covers this scope and period over an overlapping date "
+                    f"range: {bid}",
+                    conflicting_budget_id=bid,
+                )
+
+        now = datetime.now(tz=timezone.utc)
+        existing = self._rows.get((resolved, budget_id))
+        row = Budget(
+            budget_id=budget_id,
+            period=period,
+            amount_micro=amount_micro,
+            scope_kind=scope_kind,
+            scope_value=scope_value,
+            starts_on=start,
+            ends_on=end,
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+        self._rows[(resolved, budget_id)] = row
+        return row
+
+    def delete(self, tenant_id: str, budget_id: str) -> bool:
+        resolved = self._resolve(tenant_id)
+        return self._rows.pop((resolved, normalize_budget_id(budget_id)), None) is not None
+
+
+@pytest.fixture
+def store() -> FakeStore:
+    return FakeStore()
+
+
+@pytest.fixture
+def client(store: FakeStore) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        app.state.tenant_budgets = store
+        yield c
+
+
+def _get(client: TestClient, tenant: str = TENANT_NAME):
+    return client.get("/v1/tenant/budgets", headers={"X-Tenant-Id": tenant})
+
+
+def _post(client: TestClient, body: dict, tenant: str = TENANT_NAME):
+    return client.post(
+        "/v1/tenant/budgets", headers={"X-Tenant-Id": tenant}, json=body
+    )
+
+
+def _delete(client: TestClient, budget_id: str, tenant: str = TENANT_NAME):
+    return client.request(
+        "DELETE",
+        "/v1/tenant/budgets",
+        headers={"X-Tenant-Id": tenant},
+        json={"budget_id": budget_id},
+    )
+
+
+def _tenant_wide(**over: object) -> dict:
+    body: dict = {
+        "budget_id": "company-monthly",
+        "period": "month",
+        "amount_micro": THIRTY_K_MICRO,
+        "scope_kind": "tenant",
+        "starts_on": "2026-01-01",
+    }
+    body.update(over)
+    return body
+
+
+# --- the acceptance paths -------------------------------------------------------------------
+
+
+def test_tenant_with_no_budget_is_a_normal_state(client: TestClient) -> None:
+    """No budget row is a supported state, not an error and not a budget of zero.
+
+    Every tenant on this system is in this state right now. A 404 here, or an ``amount_micro`` of
+    0 invented to fill the gap, would make the whole forecasting epic report every tenant as
+    infinitely over budget the moment they spend a cent.
+    """
+    res = _get(client)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["budgets"] == []
+    assert body["configured"] is False
+    assert body["available_periods"] == list(BUDGET_PERIODS)
+    assert body["available_scope_kinds"] == list(BUDGET_SCOPE_KINDS)
+
+
+def test_a_stored_zero_is_not_the_same_as_no_budget(client: TestClient) -> None:
+    """Zero is a real budget ("this scope may spend nothing"), absence is not.
+
+    The two have to stay distinguishable or the honest-under-uncertainty rule collapses: unknown
+    renders null, never 0.
+    """
+    res = _post(client, _tenant_wide(amount_micro=0))
+    assert res.status_code == 200, res.text
+    assert res.json()["budget"]["amount_micro"] == 0
+    read = _get(client).json()
+    assert read["configured"] is True
+    assert read["budgets"][0]["amount_micro"] == 0
+
+
+@pytest.mark.parametrize(
+    ("scope_kind", "scope_value"),
+    [("feature", "research-agent"), ("model", "gpt-4o"), ("layer", "compute")],
+)
+def test_scoped_budgets_round_trip(
+    client: TestClient, scope_kind: str, scope_value: str
+) -> None:
+    """A budget can name a feature, a model or a layer, not just the whole bill.
+
+    "The research agent gets $30k a month" is how teams actually govern AI spend, and it is what
+    makes the later burn-down useful to a feature owner rather than only to finance.
+    """
+    res = _post(
+        client,
+        _tenant_wide(
+            budget_id=f"{scope_kind}-budget",
+            scope_kind=scope_kind,
+            scope_value=scope_value,
+        ),
+    )
+    assert res.status_code == 200, res.text
+    budget = res.json()["budget"]
+    assert budget["scope_kind"] == scope_kind
+    assert budget["scope_value"] == scope_value
+    assert budget["amount_micro"] == THIRTY_K_MICRO
+    assert budget["ends_on"] is None, "an absent end date means open-ended, not unknown"
+
+
+def test_scoped_budgets_are_independent_of_the_tenant_wide_one(
+    client: TestClient,
+) -> None:
+    """A feature budget and a tenant-wide budget for the same month do not collide.
+
+    They are different scopes, so both apply and neither is ambiguous. If overlap rejection were
+    keyed on the period alone, a tenant could never budget a feature and the company at once, which
+    is the single most common thing they will want to do.
+    """
+    assert _post(client, _tenant_wide()).status_code == 200
+    scoped = _post(
+        client,
+        _tenant_wide(
+            budget_id="research-agent",
+            scope_kind="feature",
+            scope_value="research-agent",
+        ),
+    )
+    assert scoped.status_code == 200, scoped.text
+    assert len(_get(client).json()["budgets"]) == 2
+
+
+def test_overlapping_budget_is_rejected_at_write_time(client: TestClient) -> None:
+    """Two budgets for one scope, period and day are refused, and the response names the clash.
+
+    Resolving the ambiguity at read time has no principled tie-break (newest-wins silently
+    disables a budget somebody set, smallest-wins turns a duplicate into a false breach, summing
+    invents a budget nobody approved) and would have to be reimplemented identically in the
+    projection, the chart and the future alerts.
+    """
+    assert _post(client, _tenant_wide(budget_id="q1", ends_on="2026-03-31")).status_code == 200
+
+    clash = _post(
+        client, _tenant_wide(budget_id="also-q1", starts_on="2026-02-01", ends_on="2026-04-30")
+    )
+    assert clash.status_code == 409, clash.text
+    assert clash.json()["detail"]["conflicting_budget_id"] == "q1"
+    assert len(_get(client).json()["budgets"]) == 1, "the refused write must store nothing"
+
+
+def test_adjacent_budgets_are_allowed(client: TestClient) -> None:
+    """A successor starting the day after the incumbent ends is not an overlap.
+
+    Ranges are inclusive at both ends, so a budget ending on the 31st covers the 31st and its
+    successor starts on the 1st. This is the ordinary "we raised the budget for Q2" path and it
+    must not need a delete first.
+    """
+    assert _post(client, _tenant_wide(budget_id="q1", ends_on="2026-03-31")).status_code == 200
+    q2 = _post(
+        client, _tenant_wide(budget_id="q2", starts_on="2026-04-01", ends_on="2026-06-30")
+    )
+    assert q2.status_code == 200, q2.text
+    assert len(_get(client).json()["budgets"]) == 2
+
+
+def test_editing_a_budget_in_place_does_not_collide_with_itself(
+    client: TestClient,
+) -> None:
+    """A budget always overlaps itself, so an edit has to be exempt from its own overlap check.
+
+    Without the self-exclusion no budget could ever be corrected, which would make a typo in an
+    amount permanent short of a delete.
+    """
+    assert _post(client, _tenant_wide()).status_code == 200
+    edited = _post(client, _tenant_wide(amount_micro=45_000_000_000))
+    assert edited.status_code == 200, edited.text
+    assert edited.json()["budget"]["amount_micro"] == 45_000_000_000
+    assert len(_get(client).json()["budgets"]) == 1
+
+
+def test_two_open_ended_budgets_for_one_scope_collide(client: TestClient) -> None:
+    """Open-ended means 'until further notice', so a second one necessarily overlaps the first."""
+    assert _post(client, _tenant_wide(budget_id="standing")).status_code == 200
+    second = _post(client, _tenant_wide(budget_id="standing-2", starts_on="2027-01-01"))
+    assert second.status_code == 409, second.text
+
+
+def test_name_based_caller_does_not_500(client: TestClient) -> None:
+    """A tenant NAME and its UUID address the same rows.
+
+    ``tenant_budgets`` keys on ``tenants.id`` but the dashboard identifies a tenant as
+    ``local-dev``. Without the resolver a name-based caller trips InvalidTextRepresentation deep in
+    the driver and surfaces as an opaque 503, which is the trap CTO-201 was filed over.
+    """
+    written = _post(client, _tenant_wide(), tenant=TENANT_NAME)
+    assert written.status_code == 200, written.text
+
+    by_name = _get(client, TENANT_NAME)
+    by_uuid = _get(client, TENANT_UUID)
+    assert by_name.status_code == 200 and by_uuid.status_code == 200, by_uuid.text
+    assert by_name.json()["budgets"] == by_uuid.json()["budgets"], (
+        "both spellings must address one tenant, or a budget set through one door is invisible "
+        "through the other"
+    )
+
+
+def test_overlap_is_detected_across_tenant_spellings(client: TestClient) -> None:
+    """A budget written by name must collide with an overlapping one written by UUID.
+
+    If the resolver only worked on the read path, the two spellings would be two tenants for the
+    purposes of the overlap check and the invariant would quietly not hold.
+    """
+    assert _post(client, _tenant_wide(budget_id="by-name"), tenant=TENANT_NAME).status_code == 200
+    clash = _post(client, _tenant_wide(budget_id="by-uuid"), tenant=TENANT_UUID)
+    assert clash.status_code == 409, clash.text
+
+
+# --- the money contract ---------------------------------------------------------------------
+
+
+def test_float_dollars_are_rejected(client: TestClient) -> None:
+    """Money is an integer of micro-USD at the boundary, and a float is a 422 rather than a round.
+
+    Accepting ``30000.0`` would advertise dollars-as-float as a supported shape, and the next
+    caller passes ``30000.5`` and silently loses half a cent per budget against cost figures that
+    are already integers.
+    """
+    res = _post(client, _tenant_wide(amount_micro=30000.5))
+    assert res.status_code == 422, res.text
+    assert "micro-USD" in res.json()["detail"]
+
+
+def test_negative_amount_is_rejected(client: TestClient) -> None:
+    assert _post(client, _tenant_wide(amount_micro=-1)).status_code == 422
+
+
+def test_implausible_amount_is_rejected(client: TestClient) -> None:
+    """A misplaced decimal produces a number that looks real and makes every variance nonsense."""
+    res = _post(client, _tenant_wide(amount_micro=10**18))
+    assert res.status_code == 422
+    assert "decimal" in res.json()["detail"]
+
+
+# --- validation and lifecycle ----------------------------------------------------------------
+
+
+def test_unknown_period_is_rejected(client: TestClient) -> None:
+    res = _post(client, _tenant_wide(period="fortnight"))
+    assert res.status_code == 422
+    assert "month" in res.json()["detail"]
+
+
+def test_tenant_scope_must_not_name_a_value(client: TestClient) -> None:
+    """'tenant'/'checkout' is ambiguous about what it actually covers."""
+    res = _post(client, _tenant_wide(scope_kind="tenant", scope_value="checkout"))
+    assert res.status_code == 422
+
+
+def test_scoped_budget_requires_a_value(client: TestClient) -> None:
+    """'feature'/'' could never be matched against a cost series, so it is not storable."""
+    res = _post(client, _tenant_wide(scope_kind="feature", scope_value=""))
+    assert res.status_code == 422
+
+
+def test_end_before_start_is_rejected(client: TestClient) -> None:
+    res = _post(client, _tenant_wide(starts_on="2026-03-01", ends_on="2026-02-01"))
+    assert res.status_code == 422
+
+
+def test_bad_date_is_rejected(client: TestClient) -> None:
+    res = _post(client, _tenant_wide(starts_on="March 2026"))
+    assert res.status_code == 422
+
+
+def test_delete_removes_the_budget(client: TestClient) -> None:
+    assert _post(client, _tenant_wide()).status_code == 200
+    removed = _delete(client, "company-monthly")
+    assert removed.status_code == 200, removed.text
+    assert removed.json()["removed"] is True
+    assert _get(client).json()["configured"] is False
+
+
+def test_delete_of_an_absent_budget_is_not_an_error(client: TestClient) -> None:
+    """The end state the caller asked for is the end state they get. A double-click is not a 404."""
+    res = _delete(client, "never-existed")
+    assert res.status_code == 200, res.text
+    assert res.json()["removed"] is False
+
+
+def test_delete_accepts_a_query_parameter(client: TestClient) -> None:
+    """DELETE-with-a-body is awkward from several HTTP clients, so the query param works too."""
+    assert _post(client, _tenant_wide()).status_code == 200
+    res = client.request(
+        "DELETE",
+        "/v1/tenant/budgets?budget_id=company-monthly",
+        headers={"X-Tenant-Id": TENANT_NAME},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["removed"] is True
+
+
+def test_delete_without_a_budget_id_is_422(client: TestClient) -> None:
+    res = client.request(
+        "DELETE", "/v1/tenant/budgets", headers={"X-Tenant-Id": TENANT_NAME}
+    )
+    assert res.status_code == 422
+
+
+def test_unknown_tenant_is_404_not_an_empty_list(client: TestClient) -> None:
+    """A misrouted request is not a tenant who has set no budgets."""
+    assert _get(client, UNKNOWN_TENANT).status_code == 404
+
+
+def test_list_is_ordered_by_scope_then_start(client: TestClient) -> None:
+    """A settings UI renders this list directly, so the order has to be stable across reads."""
+    assert _post(client, _tenant_wide(budget_id="b")).status_code == 200
+    assert _post(
+        client,
+        _tenant_wide(budget_id="a", scope_kind="feature", scope_value="research-agent"),
+    ).status_code == 200
+    kinds = [b["scope_kind"] for b in _get(client).json()["budgets"]]
+    assert kinds == ["feature", "tenant"]
+
+
+# --- normalizers ------------------------------------------------------------------------------
+
+
+def test_normalize_budget_id_trims_but_does_not_case_fold() -> None:
+    """It is the primary key, so rewriting it would leave a caller unable to address its own row."""
+    assert normalize_budget_id("  Research-Agent  ") == "Research-Agent"
+
+
+@pytest.mark.parametrize("bad", [None, 42, "", "   ", "x" * 500])
+def test_normalize_budget_id_rejects(bad: object) -> None:
+    with pytest.raises(BudgetError):
+        normalize_budget_id(bad)
+
+
+def test_normalize_period_trims_and_lowercases() -> None:
+    assert normalize_period("  Month ") == "month"
+
+
+@pytest.mark.parametrize("bad", [None, 42, "", "year", "weekly"])
+def test_normalize_period_rejects(bad: object) -> None:
+    with pytest.raises(BudgetError):
+        normalize_period(bad)
+
+
+def test_normalize_amount_rejects_bool() -> None:
+    """``True`` is an int in Python, and a budget of True is not a budget."""
+    with pytest.raises(BudgetError):
+        normalize_amount_micro(True)
+
+
+def test_normalize_scope_preserves_case_of_the_value() -> None:
+    """A model id or FeatureId is compared against telemetry that preserves case."""
+    assert normalize_scope("Model", "GPT-4o") == ("model", "GPT-4o")
+
+
+def test_normalize_scope_treats_none_as_empty() -> None:
+    assert normalize_scope("tenant", None) == ("tenant", "")
+
+
+@pytest.mark.parametrize("bad_kind", [None, 42, "", "account", "team"])
+def test_normalize_scope_rejects_unknown_kind(bad_kind: object) -> None:
+    with pytest.raises(BudgetError):
+        normalize_scope(bad_kind, "x")
+
+
+def test_normalize_optional_date_blank_is_open_ended() -> None:
+    assert normalize_optional_date(None, field="ends_on") is None
+    assert normalize_optional_date("   ", field="ends_on") is None
+
+
+def test_normalize_date_accepts_a_date_object() -> None:
+    assert normalize_date(date(2026, 1, 1), field="starts_on") == date(2026, 1, 1)
+
+
+def test_normalize_date_rejects_a_timestamp() -> None:
+    """A budget boundary is a calendar day. A timestamp would silently drop its time component."""
+    with pytest.raises(BudgetError):
+        normalize_date(datetime(2026, 1, 1, 12, 0), field="starts_on")


### PR DESCRIPTION
First ticket of the spend forecasting epic (CTO-204). Scope doc: `docs/spend-forecasting-scope.md`.

## Why

There is no tenant budget concept in this codebase. The two existing `daily_budget_usd` fields (`tenant_replay_config`, `tenant_eval_config`) cap what ai-tally itself spends running replays and evals on a tenant's behalf. Nothing records what a customer intends to spend on their own AI. Every "versus budget" figure in the epic (the projection, the burn-down, the breach date, the forecast alerts) is meaningless until that intent is written down, so this is F1.

## Schema

`db/postgres/0026_tenant_budgets.sql`. Note the number: the brief said 0025, but PR #182 took `0025_tenant_revenue_uploads.sql` while this was in flight, so this is **0026**. Mounted in `infra/docker-compose.yml`; migrations 0022 through 0026 are each mounted exactly once.

```
tenant_budgets (
  tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
  budget_id     TEXT NOT NULL,
  period        TEXT NOT NULL CHECK (period IN ('month','quarter')),
  amount_micro  BIGINT NOT NULL CHECK (amount_micro >= 0),
  scope_kind    TEXT NOT NULL CHECK (scope_kind IN ('tenant','feature','model','layer')),
  scope_value   TEXT NOT NULL DEFAULT '',
  starts_on     DATE NOT NULL,
  ends_on       DATE,
  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
  PRIMARY KEY (tenant_id, budget_id)
)
```

Additions beyond the brief's sketch, each with a reason in the migration header:

- **`updated_at`**, so an edited amount does not keep reporting the timestamp of the original setting.
- **A CHECK tying the two halves of the scope together**: a `tenant` budget must have `scope_value = ''` and every other kind must have a non-empty one. Without it `'tenant'/'checkout'` (ambiguous about what it covers) and `'feature'/''` (never matchable against a series) are both storable.
- **`scope_value` is `''` and never NULL** for tenant-wide. It is part of the overlap identity and NULL is not equal to NULL, so a nullable column would let a tenant create unlimited duplicate tenant-wide budgets, each invisible to the other.
- **`ends_on IS NULL` means open-ended**, not a sentinel far-future date. "Runs until we say otherwise" and "ends on 2099-12-31" are different statements, and a sentinel shows up in a UI as a date somebody typed.

Money is integer micro-USD. A float `amount_micro` is a 422 rather than a rounding: every cost figure a budget is compared against is already an integer of micro-USD, and accepting `30000.0` advertises dollars-as-float as a supported shape, after which the next caller sends `30000.5`.

## Scoped budgets

`scope_kind` is one of `tenant`, `feature`, `model`, `layer`, each naming a dimension the cost queries in `web/lib/clickhouse.ts` already group by, so a scoped budget is always comparable against a series that actually exists. "The research agent gets $30k a month" is how teams actually govern AI spend, and it is what makes the later burn-down useful to a feature owner rather than only to finance.

A feature budget and a tenant-wide budget for the same month do not collide: they are different scopes, both apply, and neither is ambiguous. Tested explicitly, because keying the overlap check on the period alone would make budgeting a feature and the company at once impossible, which is the first thing anyone will want.

## The overlap decision: rejected at write time

**Overlapping budgets for the same scope and period are refused with a 409 naming the budget they collided with.**

Resolving the ambiguity at read time was the alternative, and it is worse in three ways:

1. **Every tie-break is arbitrary.** Newest-wins silently disables a budget somebody deliberately set. Smallest-wins turns an accidental duplicate into a false breach alert. Largest-wins hides a cut. Summing invents a budget nobody approved. There is no rule here that is defensible to a finance reader asking why their number moved.
2. **The rule would have to be reimplemented three times.** The projection, the burn-down chart and the future breach alerts each need to resolve "the budget for this scope". The first place those drift produces an alert and a chart that disagree on the same screen, and that bug is nearly invisible in review.
3. **Rejecting makes budget resolution a lookup rather than a policy.** Downstream may now rely on the invariant: for one `(tenant, period, scope_kind, scope_value)` and one day, at most one budget applies. Nothing to keep in sync.

Enforcement is a gist `EXCLUDE` constraint over `(tenant_id, period, scope_kind, scope_value, daterange(starts_on, COALESCE(ends_on,'infinity'), '[]'))`, requiring `btree_gist` (created by the migration, ships with the postgres image). The store also pre-checks with a SELECT, but **only for the error message**: two concurrent POSTs both pass a pre-check, so the constraint is the actual guarantee and its violation is translated into the same `BudgetOverlapError`. Verified below by issuing an overlapping INSERT directly in psql.

Consequences worth knowing:

- Ranges are **inclusive at both ends**, so a budget ending on the 31st covers the 31st and a successor starts on the 1st. Adjacent budgets are allowed; this is the ordinary "we raised the budget for Q2" path and it does not need a delete first.
- Editing a budget in place works because the pre-check excludes the row being written (`budget_id <> %s`). A budget always overlaps itself, so without that no budget could ever be corrected.
- Two open-ended budgets for one scope necessarily overlap, and the second is refused.

## No budget set is a normal state

Every tenant on the system is in this state right now. `GET` answers 200 with an empty list and `configured: false`. It is never a 404 and never an implicit zero: rendering an absent budget as 0 would report every tenant as infinitely over budget the moment they spend a cent. A stored zero is a different and deliberate claim ("this scope may spend nothing"), which is why the constraint is `amount_micro >= 0` rather than `> 0`, and both cases are tested.

An unknown *tenant* is still a 404, because a misrouted request is not a tenant who has set no budgets.

## Tenant resolution

Reuses the shared `gateway/tenant_lookup.py`, which `connectors/config_admin.py` has converged onto. No fifth copy of the resolver is added here. A caller passing a tenant NAME (`local-dev`) rather than a UUID resolves instead of tripping `InvalidTextRepresentation` deep in the driver, which is the CTO-201 trap. Folding the remaining copies in `tenant_identity.py` and `tenant_account_labels.py` onto the shared one is CTO-201's job and is deliberately not done here.

Tested both that a name-based caller works and that overlap detection spans the two spellings, since a resolver applied only on the read path would make the two spellings two tenants for overlap purposes and quietly break the invariant.

## API

`GET/POST/DELETE /v1/tenant/budgets` in `infra/gateway/src/gateway/app.py`, store in `infra/gateway/src/gateway/tenant_budgets.py`. The web app never touches Postgres directly.

`POST` creates and edits (upsert on `(tenant_id, budget_id)`). No `change_id` idempotency token, unlike the allocation-config control plane, because there is no audit log to append to and the write is last-write-wins by nature. `DELETE` takes `budget_id` as a query param or in a body, and deleting an absent budget is 200 `removed: false` rather than 404, matching the account-labels control plane.

## Verification

`cd infra/gateway && uv run --extra dev pytest -q && uv run ruff check .` gives **690 passed**, ruff clean. 49 of those are new (`tests/test_app_tenant_budgets.py`), covering all four scope kinds, the overlap paths, the money contract and a name-based caller.

`cd web && npm ci && npm run typecheck && npm run test` gives typecheck clean, **476 passed, 2 failed**. The 2 are the long-standing `app/api/api.test.ts` failures (attribution + data-quality) that fail when a local ClickHouse is running, and are untouched by this change.

**Live**, against the running Postgres with the migration applied by hand (`docker-entrypoint-initdb.d` only runs on a first boot against an empty volume):

| # | Case | Result |
|---|---|---|
| 1 | `GET` with no budgets, caller uses NAME `local-dev` | 200, `configured: false`, empty list |
| 2 | `POST` tenant-wide $30k/month | 200 |
| 3 | `POST` feature-scoped, alongside the tenant-wide one | 200, both stored, no collision |
| 4 | `POST` overlapping tenant-wide | **409**, `conflicting_budget_id: company-monthly` |
| 5 | `POST` model-scoped and layer-scoped | 200 |
| 6 | `POST` adjacent quarter starting 2026-04-01 | 200, allowed |
| 7 | `POST` same `budget_id`, new amount | 200, `created_at` preserved, `updated_at` bumped |
| 8 | `POST` `amount_micro: 30000.5` | 422 |
| 9 | `GET` addressing the same tenant by UUID | 200, identical 5 rows |
| 10-12 | `DELETE` by query param, again, then by body | 200 `removed: true` / `false` / `true` |
| 13 | `GET` unknown tenant | 404 |
| 14 | Overlapping `INSERT` issued directly in psql | rejected by `tenant_budgets_no_overlap` |

Re-verified end to end through the rebuilt gateway container itself (`docker compose -f infra/docker-compose.yml up -d --build gateway`, then the same calls against `:8080`): the no-budget state with a name-based caller, tenant-wide and feature-scoped writes, the 409 naming the colliding budget, the float rejection, the UUID spelling seeing the same rows, idempotent DELETE, and the 404 for an unknown tenant. Test rows were cleaned up afterwards and `tenant_budgets` is empty.

## Not in this PR

Settings UI to enter a budget (phase 1's other half), and everything from phase 2 on: month-to-date versus budget, the projection, the burn-down cone, the breach date. This is the model and its control plane only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
