### PR TITLE
feat(budgets): set, edit and withdraw budgets from the dashboard (CTO-208)

### DIFF
--- a/web/app/settings/budgets/BudgetManager.tsx
+++ b/web/app/settings/budgets/BudgetManager.tsx
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+// Create, edit and withdraw budgets (CTO-208, F4). The storage and every rule it enforces came from
+// CTO-205; this is the first surface that lets anyone use it without hand-writing JSON.
+//
+// THREE THINGS THIS COMPONENT IS DELIBERATE ABOUT.
+//
+// 1. The overlap 409 is treated as a normal answer, not a crash. The gateway refuses a budget that
+//    covers the same scope and period over an overlapping range and NAMES the budget it collided
+//    with. That name is shown verbatim and turned into a button that loads the colliding budget
+//    into the form, because "that overlaps with research-agent-2026" is only actionable if you can
+//    then go and change research-agent-2026.
+//
+// 2. Editing is the same POST as creating. The gateway upserts on (tenant_id, budget_id) and
+//    excludes the row from its own overlap check, so raising an amount needs no delete first. The
+//    budget_id field is therefore locked while editing: changing it would silently create a second
+//    budget rather than rename the one on screen.
+//
+// 3. An empty table says "no budget set" and nothing else. It is not an error and it is not a
+//    budget of zero. A stored zero is a separate, deliberate claim and renders as $0.00.
+
+import { useState, useTransition } from "react";
+
+import { DataTable, type Column } from "@/components/DataTable";
+import { Money } from "@/components/HonestValue";
+import { type Budget, microToDollarInput, scopeLabel } from "@/lib/budgets";
+
+import { type BudgetFormValues, deleteBudgetAction, saveBudgetAction } from "./actions";
+
+interface Props {
+  initialBudgets: Budget[];
+  /** Echoed by the gateway so this form cannot drift from the CHECK constraints in migration 0026. */
+  periods: string[];
+  scopeKinds: string[];
+  /** false when the list could not be read. The empty table then means "we could not ask", which
+   *  is a different sentence from "no budget set" and has to read as one. */
+  reachable: boolean;
+}
+
+type Status =
+  | { tone: "ok"; text: string }
+  | { tone: "err"; text: string; conflictingBudgetId?: string | null }
+  | null;
+
+function blankForm(): BudgetFormValues {
+  return {
+    budgetId: "",
+    period: "month",
+    amountDollars: "",
+    scopeKind: "tenant",
+    scopeValue: "",
+    startsOn: "",
+    endsOn: "",
+  };
+}
+
+function formFor(budget: Budget): BudgetFormValues {
+  return {
+    budgetId: budget.budgetId,
+    period: budget.period,
+    // The exact stored amount, not the display rounding: an edit-and-save must not change a number
+    // the form never showed.
+    amountDollars: microToDollarInput(budget.amountMicro),
+    scopeKind: budget.scopeKind,
+    scopeValue: budget.scopeValue,
+    startsOn: budget.startsOn,
+    endsOn: budget.endsOn ?? "",
+  };
+}
+
+export function BudgetManager({ initialBudgets, periods, scopeKinds, reachable }: Props) {
+  const [budgets, setBudgets] = useState<Budget[]>(initialBudgets);
+  const [form, setForm] = useState<BudgetFormValues | null>(null);
+  /** Non-null while editing an existing row: the budget_id is then fixed. */
+  const [editing, setEditing] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>(null);
+  const [pending, startTransition] = useTransition();
+
+  const set = (patch: Partial<BudgetFormValues>) =>
+    setForm((f) => (f ? { ...f, ...patch } : f));
+
+  const openCreate = () => {
+    setStatus(null);
+    setEditing(null);
+    setForm(blankForm());
+  };
+
+  const openEdit = (budget: Budget) => {
+    setStatus(null);
+    setEditing(budget.budgetId);
+    setForm(formFor(budget));
+  };
+
+  /** The "edit the budget you collided with" path off a 409. */
+  const openConflicting = (budgetId: string) => {
+    const target = budgets.find((b) => b.budgetId === budgetId);
+    if (target) openEdit(target);
+    else setStatus({ tone: "err", text: `budget ${budgetId} is not in this tenant's list` });
+  };
+
+  const submit = () => {
+    if (!form) return;
+    setStatus(null);
+    startTransition(async () => {
+      const res = await saveBudgetAction(form);
+      if (res.ok) {
+        if (res.budgets) setBudgets(res.budgets);
+        setStatus({ tone: "ok", text: `Saved ${form.budgetId}.` });
+        setForm(null);
+        setEditing(null);
+      } else {
+        setStatus({
+          tone: "err",
+          text: res.error ?? "the gateway refused the write",
+          conflictingBudgetId: res.conflictingBudgetId,
+        });
+      }
+    });
+  };
+
+  const remove = (budgetId: string) => {
+    setStatus(null);
+    startTransition(async () => {
+      const res = await deleteBudgetAction(budgetId);
+      setConfirmDelete(null);
+      if (res.ok) {
+        if (res.budgets) setBudgets(res.budgets);
+        setStatus({ tone: "ok", text: `Withdrew ${budgetId}. That scope has no budget set again.` });
+        if (editing === budgetId) {
+          setForm(null);
+          setEditing(null);
+        }
+      } else {
+        setStatus({ tone: "err", text: res.error ?? "the gateway refused the delete" });
+      }
+    });
+  };
+
+  // Built inline rather than memoized: the action cells close over `pending` and `confirmDelete`,
+  // and a memo whose deps have to list every one of those is a stale-button bug waiting to happen.
+  // A budget list is a handful of rows, so there is nothing here worth caching.
+  const columns: Column<Budget>[] = [
+    {
+      key: "budgetId",
+      header: "Budget",
+      sortValue: (b) => b.budgetId,
+      render: (b) => <span className="font-medium">{b.budgetId}</span>,
+    },
+    {
+      key: "scope",
+      header: "Scope",
+      sortValue: (b) => scopeLabel(b),
+      render: (b) => <span className="text-muted">{scopeLabel(b)}</span>,
+    },
+    {
+      key: "period",
+      header: "Period",
+      sortValue: (b) => b.period,
+      render: (b) => <span className="capitalize">{b.period}</span>,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      align: "right",
+      sortValue: (b) => b.amountMicro,
+      // Money, not a hand-formatted number: a stored 0 has to read as $0.00 (a real claim) and
+      // never as a blank, which in this app means "we do not know".
+      render: (b) => <Money micro={b.amountMicro} />,
+    },
+    {
+      key: "startsOn",
+      header: "Starts",
+      sortValue: (b) => b.startsOn,
+      render: (b) => <span className="tabular-nums">{b.startsOn}</span>,
+    },
+    {
+      key: "endsOn",
+      header: "Ends",
+      sortValue: (b) => b.endsOn,
+      // NOT a Blank. A Blank in this app means "we do not have this value"; an absent ends_on is
+      // a definite statement that the budget stands until somebody changes it.
+      render: (b) =>
+        b.endsOn ? (
+          <span className="tabular-nums">{b.endsOn}</span>
+        ) : (
+          <span className="text-muted">Open-ended</span>
+        ),
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      render: (b) => (
+        <div className="flex items-center justify-end gap-1.5">
+          <button
+            type="button"
+            onClick={() => openEdit(b)}
+            className="rounded-full border border-edge bg-ink/40 px-2.5 py-1 text-xs font-medium text-muted transition hover:bg-ink/60"
+          >
+            Edit
+          </button>
+          {confirmDelete === b.budgetId ? (
+            <button
+              type="button"
+              disabled={pending}
+              onClick={() => remove(b.budgetId)}
+              className="rounded-full border border-warn/50 bg-warn/15 px-2.5 py-1 text-xs font-medium text-warn transition hover:bg-warn/25 disabled:opacity-50"
+            >
+              Confirm withdraw
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(b.budgetId)}
+              className="rounded-full border border-edge bg-ink/40 px-2.5 py-1 text-xs font-medium text-muted transition hover:bg-ink/60"
+            >
+              Withdraw
+            </button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  const scopedKind = form && form.scopeKind !== "tenant";
+
+  return (
+    <div className="space-y-4">
+      <DataTable
+        columns={columns}
+        rows={budgets}
+        rowKey={(b) => b.budgetId}
+        pageSize={25}
+        initialSort={{ key: "budgetId", direction: "asc" }}
+        empty={
+          reachable ? (
+            <span>
+              No budget set. That is a normal state, not a gap: nothing here is assumed to be zero,
+              and spend surfaces show no variance until a budget exists.
+            </span>
+          ) : (
+            <span>
+              Budgets could not be read, so this table says nothing about your configuration. You
+              may well have budgets set.
+            </span>
+          )
+        }
+      />
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={openCreate}
+          className="rounded-full border border-accent/50 bg-accent/15 px-3 py-1 text-xs font-medium text-accent transition hover:bg-accent/25"
+        >
+          Set a budget
+        </button>
+        {status && (
+          <span
+            className={`text-[11px] ${status.tone === "ok" ? "text-good" : "text-warn"}`}
+            role="status"
+          >
+            {status.text}
+            {status.tone === "err" && status.conflictingBudgetId ? (
+              <button
+                type="button"
+                onClick={() => openConflicting(status.conflictingBudgetId as string)}
+                className="ml-2 rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-white"
+              >
+                Edit {status.conflictingBudgetId}
+              </button>
+            ) : null}
+          </span>
+        )}
+      </div>
+
+      {form && (
+        <div className="rounded-lg border border-edge bg-ink/60 p-4">
+          <h3 className="text-sm font-medium">
+            {editing ? `Edit ${editing}` : "New budget"}
+          </h3>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <Field
+              label="Budget id"
+              hint={
+                editing
+                  ? "Fixed while editing. A different id would create a second budget, not rename this one."
+                  : "Your own stable handle, for example research-agent-2026. It appears in overlap errors."
+              }
+            >
+              <input
+                id="budget-id"
+                type="text"
+                value={form.budgetId}
+                disabled={editing !== null}
+                placeholder="research-agent-2026"
+                onChange={(e) => set({ budgetId: e.target.value })}
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60 disabled:opacity-60"
+              />
+            </Field>
+
+            <Field label="Amount (USD)" hint="Stored as integer micro-USD. Zero is allowed and means this scope may spend nothing.">
+              <input
+                id="budget-amount"
+                type="text"
+                inputMode="decimal"
+                value={form.amountDollars}
+                placeholder="30000"
+                onChange={(e) => set({ amountDollars: e.target.value })}
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60"
+              />
+            </Field>
+
+            <Field label="Period" hint="Only the periods the forecast can evaluate a window for.">
+              <select
+                id="budget-period"
+                value={form.period}
+                onChange={(e) => set({ period: e.target.value })}
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60"
+              >
+                {periods.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            <Field label="Scope" hint="Tenant-wide is the whole bill. The other kinds name one member of a dimension the cost queries already group by.">
+              <select
+                id="budget-scope-kind"
+                value={form.scopeKind}
+                onChange={(e) =>
+                  set({
+                    scopeKind: e.target.value,
+                    // Switching to tenant-wide clears the value: a tenant budget must name nothing.
+                    scopeValue: e.target.value === "tenant" ? "" : form.scopeValue,
+                  })
+                }
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60"
+              >
+                {scopeKinds.map((k) => (
+                  <option key={k} value={k}>
+                    {k === "tenant" ? "tenant (whole bill)" : k}
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            <Field
+              label="Scope value"
+              hint={
+                scopedKind
+                  ? "A feature id, model id or cost layer, matching your telemetry exactly. Case is preserved."
+                  : "Not used for a tenant-wide budget."
+              }
+            >
+              <input
+                id="budget-scope-value"
+                type="text"
+                value={form.scopeValue}
+                disabled={!scopedKind}
+                placeholder={scopedKind ? "research-agent" : ""}
+                onChange={(e) => set({ scopeValue: e.target.value })}
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60 disabled:opacity-40"
+              />
+            </Field>
+
+            <Field label="Starts on" hint="Inclusive.">
+              <input
+                id="budget-starts-on"
+                type="date"
+                value={form.startsOn}
+                onChange={(e) => set({ startsOn: e.target.value })}
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60"
+              />
+            </Field>
+
+            <Field
+              label="Ends on (optional)"
+              hint="Leave blank for open-ended, the usual case. Inclusive: a budget ending on the 31st covers the 31st, so its successor starts on the 1st."
+            >
+              <input
+                id="budget-ends-on"
+                type="date"
+                value={form.endsOn}
+                onChange={(e) => set({ endsOn: e.target.value })}
+                className="mt-1 w-full rounded border border-edge bg-bg px-2 py-1 text-xs outline-none focus:border-accent/60"
+              />
+            </Field>
+          </div>
+
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setForm(null);
+                setEditing(null);
+              }}
+              className="rounded border border-edge px-2 py-1 text-xs text-muted hover:bg-ink/60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={pending}
+              className="rounded border border-accent/50 bg-accent/15 px-2 py-1 text-xs font-medium text-accent hover:bg-accent/25 disabled:opacity-50"
+            >
+              {pending ? "Saving…" : "Save budget"}
+            </button>
+          </div>
+
+          <p className="mt-3 max-w-prose text-[10px] leading-snug text-muted">
+            Two budgets for the same scope and period cannot cover the same day. An overlapping save
+            is refused and names the budget it collided with. Adjacent ranges are fine, and raising
+            an existing budget is an edit rather than a second row.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <span className="block text-[11px] font-medium text-muted">{label}</span>
+      {children}
+      {hint && <p className="mt-1 text-[10px] leading-snug text-muted">{hint}</p>}
+    </div>
+  );
+}

--- a/web/app/settings/budgets/actions.ts
+++ b/web/app/settings/budgets/actions.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+"use server";
+
+// Server actions behind the budget settings form (CTO-208, F4).
+//
+// Same shape as app/connectors/costConnectorActions.ts: the browser never talks to the gateway and
+// never sees the tenant header, and field validation belongs to the gateway rather than being
+// duplicated here. The one piece of validation that HAS to live on this side is the dollars to
+// micro-USD conversion, because the API only speaks micro-USD integers and a bad amount must be
+// caught before it becomes a meaningless 422.
+//
+// Every action returns the refreshed list alongside its result. The table is the user's confirmation
+// that the write landed, and re-reading it from the gateway proves that rather than assuming it: an
+// upsert that succeeded but stored something different from what the form thought it sent shows up
+// immediately instead of at the next page load.
+import { revalidatePath } from "next/cache";
+
+import {
+  type Budget,
+  deleteBudget,
+  dollarsToMicro,
+  queryBudgets,
+  saveBudget,
+} from "@/lib/budgets";
+
+export interface BudgetFormValues {
+  budgetId: string;
+  period: string;
+  /** Dollars as typed. Converted to integer micro-USD here, at the boundary. */
+  amountDollars: string;
+  scopeKind: string;
+  scopeValue: string;
+  startsOn: string;
+  /** "" means open-ended, which is sent as null. */
+  endsOn: string;
+}
+
+export interface BudgetActionResult {
+  ok: boolean;
+  /** Gateway text, verbatim. Only set when ok is false. */
+  error?: string;
+  /** Set on a 409 so the UI can offer to open the budget that was collided with. */
+  conflictingBudgetId?: string | null;
+  /** The tenant's budgets after the write. Null when we could not re-read them. */
+  budgets?: Budget[] | null;
+}
+
+/** Re-read after a write. A failure here does not undo the write, so it is reported as an absent
+ *  list rather than as a failed action. */
+async function currentBudgets(): Promise<Budget[] | null> {
+  const list = await queryBudgets();
+  return list.reachable ? list.budgets : null;
+}
+
+export async function saveBudgetAction(values: BudgetFormValues): Promise<BudgetActionResult> {
+  const amount = dollarsToMicro(values.amountDollars);
+  if (!amount.ok) return { ok: false, error: amount.error, conflictingBudgetId: null };
+
+  const result = await saveBudget({
+    budgetId: values.budgetId.trim(),
+    period: values.period,
+    amountMicro: amount.micro,
+    scopeKind: values.scopeKind,
+    // A tenant-wide budget must name nothing; the gateway rejects the pair otherwise.
+    scopeValue: values.scopeKind === "tenant" ? "" : values.scopeValue.trim(),
+    startsOn: values.startsOn.trim(),
+    endsOn: values.endsOn.trim() ? values.endsOn.trim() : null,
+  });
+  if (!result.ok) {
+    return { ok: false, error: result.error, conflictingBudgetId: result.conflictingBudgetId };
+  }
+  revalidatePath("/settings/budgets");
+  return { ok: true, budgets: await currentBudgets() };
+}
+
+export async function deleteBudgetAction(budgetId: string): Promise<BudgetActionResult> {
+  const result = await deleteBudget(budgetId);
+  if (!result.ok) {
+    return { ok: false, error: result.error, conflictingBudgetId: result.conflictingBudgetId };
+  }
+  revalidatePath("/settings/budgets");
+  return { ok: true, budgets: await currentBudgets() };
+}

--- a/web/app/settings/budgets/page.tsx
+++ b/web/app/settings/budgets/page.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Budget settings (CTO-208, F4).
+//
+// WHERE THIS LIVES AND WHY. Budgets are configuration, not a reading: a number the tenant asserts,
+// which every "versus budget" figure downstream then depends on. That puts it with the other things
+// a tenant declares about themselves rather than on a spend surface, so it is its own route under
+// /settings instead of a panel bolted onto /cost. It also keeps this out of the way of CTO-209,
+// which owns /cost and is adding the budget-vs-actual section there; that page links here by route
+// and neither page imports the other's components.
+//
+// The page separates three states that are easy to collapse into one and must not be:
+//   * budgets exist            -> the table
+//   * no budget set            -> normal, its own copy, no variance implied anywhere
+//   * the gateway is unreachable -> we could not ask, which is NOT "no budget set"
+import Link from "next/link";
+
+import { Card } from "@/components/Card";
+import { queryBudgets } from "@/lib/budgets";
+
+import { BudgetManager } from "./BudgetManager";
+
+export const dynamic = "force-dynamic";
+
+export default async function BudgetSettingsPage() {
+  const { budgets, configured, periods, scopeKinds, reachable, error } = await queryBudgets();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Settings — Budgets</h1>
+        <p className="mt-1 max-w-prose text-sm text-muted">
+          What you intend to spend on AI, per period and per scope. This is the reference every
+          &ldquo;versus budget&rdquo; figure is measured against. Until a budget exists here, spend
+          surfaces report actuals and no variance rather than assuming a budget of zero.
+        </p>
+      </div>
+
+      {!reachable && (
+        // Distinct from the empty table on purpose. "We could not ask" must never be rendered as
+        // "no budget set": one of those is a fact about the tenant, the other about our plumbing.
+        <div className="rounded-lg border border-warn/40 bg-warn/10 p-3 text-sm text-warn">
+          <span className="font-medium">Budgets could not be read.</span>{" "}
+          <span className="text-warn/90">
+            {error ?? "the gateway did not answer"}. This is not the same as having no budget set,
+            so nothing below should be taken as the current configuration.
+          </span>
+        </div>
+      )}
+
+      <Card
+        title={
+          reachable
+            ? configured
+              ? `Budgets — ${budgets.length} set`
+              : "Budgets — none set"
+            : "Budgets — unknown"
+        }
+      >
+        <p className="mb-3 max-w-prose text-xs text-muted">
+          One budget covers one scope for one period over one date range. Two budgets for the same
+          scope and period cannot cover the same day, so there is never a question about which
+          number a burn-down is drawn against. A tenant-wide budget and a feature budget for the
+          same month are independent and do not collide.
+        </p>
+        <BudgetManager
+          initialBudgets={budgets}
+          periods={periods}
+          scopeKinds={scopeKinds}
+          reachable={reachable}
+        />
+      </Card>
+
+      <p className="text-xs text-muted">
+        Spend against these budgets appears on{" "}
+        <Link href="/cost" className="text-accent hover:underline">
+          Cost
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+import Link from "next/link";
+
 import { Card } from "@/components/Card";
 import { apiGet } from "@/lib/api";
 import type { GuardrailRule } from "@/lib/guardrails";
@@ -28,6 +30,16 @@ export default async function SettingsPage() {
       <Card title="Guardrail rules">
         <GuardrailConfig initialRules={rules} />
       </Card>
+
+      {/* Budgets are their own route (CTO-208, F4) rather than another panel here: they are read
+          by the spend surfaces, so they need a URL worth linking to from elsewhere. */}
+      <p className="text-xs text-muted">
+        Looking for spending budgets?{" "}
+        <Link href="/settings/budgets" className="text-accent hover:underline">
+          Settings — Budgets
+        </Link>
+        .
+      </p>
     </div>
   );
 }

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -13,8 +13,11 @@ const NAV: { label: string; href: string }[] = [
   { label: "Cost per Customer", href: "/cost-per-customer" },
   { label: "Connectors", href: "/connectors" },
   { label: "Guardrails", href: "/guardrails" },
+  // Budgets are real, tenant-declared configuration backed by the gateway control plane
+  // (CTO-208, F4), so they are linked directly rather than hidden behind /settings.
+  { label: "Budgets", href: "/settings/budgets" },
   // Hidden from the nav until they have real signal end-to-end (pages still render at the URL):
-  //   - /settings        — empty shell, no real settings wired
+  //   - /settings        — guardrail config only, nothing else wired
   //   - /estimate        — mock fixtures (re-add when CTO-128 lands)
   //   - /data-quality    — placeholder rows (re-add when DQ follow-ups land)
 ];

--- a/web/lib/budgets.test.ts
+++ b/web/lib/budgets.test.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  deleteBudget,
+  dollarsToMicro,
+  microToDollarInput,
+  queryBudgets,
+  saveBudget,
+  scopeLabel,
+} from "./budgets";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+const WIRE_ROW = {
+  budget_id: "research-agent-2026",
+  period: "month",
+  amount_micro: 30_000_000_000,
+  scope_kind: "feature",
+  scope_value: "research-agent",
+  starts_on: "2026-01-01",
+  ends_on: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("dollarsToMicro", () => {
+  it("converts whole dollars exactly", () => {
+    expect(dollarsToMicro("30000")).toEqual({ ok: true, micro: 30_000_000_000 });
+  });
+
+  it("converts cents exactly, without going through a float", () => {
+    // 1250.5 * 1e6 is a float multiplication; these cases are the ones that drift.
+    expect(dollarsToMicro("1250.50")).toEqual({ ok: true, micro: 1_250_500_000 });
+    expect(dollarsToMicro("0.07")).toEqual({ ok: true, micro: 70_000 });
+    expect(dollarsToMicro("0.000001")).toEqual({ ok: true, micro: 1 });
+  });
+
+  it("accepts a pasted spreadsheet figure", () => {
+    expect(dollarsToMicro("$1,250.50")).toEqual({ ok: true, micro: 1_250_500_000 });
+  });
+
+  it("accepts zero, which is a deliberate claim and not 'no budget'", () => {
+    expect(dollarsToMicro("0")).toEqual({ ok: true, micro: 0 });
+  });
+
+  it("rejects blanks, negatives, text and sub-micro precision", () => {
+    for (const bad of ["", "   ", "-5", "abc", "1.2.3", "0.0000001"]) {
+      expect(dollarsToMicro(bad).ok).toBe(false);
+    }
+  });
+});
+
+describe("microToDollarInput", () => {
+  it("round-trips through dollarsToMicro", () => {
+    for (const dollars of ["30000", "1250.5", "0", "0.000001", "999999.999999"]) {
+      const parsed = dollarsToMicro(dollars);
+      expect(parsed.ok).toBe(true);
+      if (!parsed.ok) return;
+      expect(microToDollarInput(parsed.micro)).toBe(dollars);
+    }
+  });
+});
+
+describe("scopeLabel", () => {
+  it("names the dimension for a scoped budget and says 'whole tenant' otherwise", () => {
+    expect(scopeLabel({ scopeKind: "tenant", scopeValue: "" })).toBe("Whole tenant");
+    expect(scopeLabel({ scopeKind: "feature", scopeValue: "research-agent" })).toBe(
+      "feature: research-agent",
+    );
+  });
+});
+
+describe("queryBudgets", () => {
+  it("maps the wire rows and echoes the deployment's allowed periods and scopes", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            tenant_id: "t",
+            budgets: [WIRE_ROW],
+            configured: true,
+            available_periods: ["month", "quarter"],
+            available_scope_kinds: ["tenant", "feature", "model", "layer"],
+          }),
+          { status: 200 },
+        ),
+    ) as typeof fetch;
+    const result = await queryBudgets();
+    expect(result.reachable).toBe(true);
+    expect(result.configured).toBe(true);
+    expect(result.budgets[0]).toMatchObject({
+      budgetId: "research-agent-2026",
+      amountMicro: 30_000_000_000,
+      scopeValue: "research-agent",
+      endsOn: null,
+    });
+    expect(result.periods).toEqual(["month", "quarter"]);
+  });
+
+  it("reports no budgets as configured:false and reachable:true, never as an error", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ tenant_id: "t", budgets: [], configured: false }), {
+          status: 200,
+        }),
+    ) as typeof fetch;
+    const result = await queryBudgets();
+    expect(result).toMatchObject({ configured: false, reachable: true, error: null });
+    expect(result.budgets).toEqual([]);
+  });
+
+  it("keeps 'unreachable' distinct from 'no budget set'", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    const result = await queryBudgets();
+    expect(result.reachable).toBe(false);
+    expect(result.error).toBe("ECONNREFUSED");
+    // The fallback lists still render a usable form rather than an empty dropdown.
+    expect(result.periods).toEqual(["month", "quarter"]);
+  });
+});
+
+describe("saveBudget", () => {
+  it("posts integer micro-USD and a null ends_on for an open-ended budget", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ budget: WIRE_ROW }), { status: 200 }),
+    );
+    globalThis.fetch = fetchMock;
+    const result = await saveBudget({
+      budgetId: "research-agent-2026",
+      period: "month",
+      amountMicro: 30_000_000_000,
+      scopeKind: "feature",
+      scopeValue: "research-agent",
+      startsOn: "2026-01-01",
+      endsOn: null,
+    });
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.amount_micro).toBe(30_000_000_000);
+    expect(Number.isInteger(body.amount_micro)).toBe(true);
+    expect(body.ends_on).toBeNull();
+  });
+
+  it("surfaces a 409 overlap message verbatim and carries the colliding budget_id", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            detail: {
+              message:
+                "a budget already covers this scope and period over an overlapping date range: " +
+                "research-agent-2026",
+              conflicting_budget_id: "research-agent-2026",
+            },
+          }),
+          { status: 409 },
+        ),
+    ) as typeof fetch;
+    const result = await saveBudget({
+      budgetId: "another",
+      period: "month",
+      amountMicro: 1,
+      scopeKind: "feature",
+      scopeValue: "research-agent",
+      startsOn: "2026-01-01",
+      endsOn: null,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("research-agent-2026");
+    expect(result.conflictingBudgetId).toBe("research-agent-2026");
+  });
+
+  it("surfaces a 422 validation string verbatim", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: "a feature-scoped budget requires a scope_value" }), {
+          status: 422,
+        }),
+    ) as typeof fetch;
+    const result = await saveBudget({
+      budgetId: "x",
+      period: "month",
+      amountMicro: 1,
+      scopeKind: "feature",
+      scopeValue: "",
+      startsOn: "2026-01-01",
+      endsOn: null,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "a feature-scoped budget requires a scope_value",
+      conflictingBudgetId: null,
+    });
+  });
+
+  it("falls back to the status code only when the gateway said nothing useful", async () => {
+    globalThis.fetch = vi.fn(async () => new Response("boom", { status: 500 })) as typeof fetch;
+    const result = await saveBudget({
+      budgetId: "x",
+      period: "month",
+      amountMicro: 1,
+      scopeKind: "tenant",
+      scopeValue: "",
+      startsOn: "2026-01-01",
+      endsOn: null,
+    });
+    expect(result).toMatchObject({ ok: false, error: "gateway HTTP 500" });
+  });
+});
+
+describe("deleteBudget", () => {
+  it("reports removed:false for an already-absent budget rather than failing", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ removed: false }), { status: 200 }),
+    ) as typeof fetch;
+    expect(await deleteBudget("gone")).toEqual({ ok: true, removed: false });
+  });
+
+  it("passes the budget_id as a query parameter", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ removed: true }), { status: 200 }),
+    );
+    globalThis.fetch = fetchMock;
+    await deleteBudget("research agent/2026");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      "budget_id=research%20agent%2F2026",
+    );
+  });
+});

--- a/web/lib/budgets.ts
+++ b/web/lib/budgets.ts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Typed client for the tenant budget control plane (CTO-208, F4).
+//
+// CTO-205 built the storage and the rules (`db/postgres/0026_tenant_budgets.sql`,
+// `gateway/tenant_budgets.py`); until now the only way to record what a tenant intends to spend was
+// to POST JSON by hand. This module is the dashboard's half of that API. Same rule as
+// lib/costConnectors.ts and lib/tenant.ts: the web app never touches Postgres, every read and write
+// goes through the gateway, and the gateway owns validation.
+//
+// TWO THINGS THIS MODULE REFUSES TO BLUR.
+//
+// 1. "No budget set" is not "we could not ask". The gateway answers 200 with `configured: false`
+//    for a tenant who has set nothing, which is the normal state of every tenant on this system.
+//    An unreachable gateway is a different fact, so `queryBudgets` reports `reachable` separately
+//    and never lets a network failure render as "no budget set" (or, worse, as a budget of zero).
+//
+// 2. Gateway validation text reaches the user verbatim. A 409 overlap names the budget it collided
+//    with, and that name is the whole value of the error: "that overlaps with research-agent-q1"
+//    tells the user which row to edit, "something went wrong" sends them hunting. The
+//    `conflictingBudgetId` is carried out separately as well so the UI can offer to open that row.
+
+import type { MicroUSD } from "./types";
+
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+/** Mirrors gateway.tenant_budgets.BUDGET_PERIODS. The gateway echoes its own list; this is the
+ *  fallback used when it is unreachable, so the form still renders something truthful. */
+export const BUDGET_PERIODS = ["month", "quarter"] as const;
+export type BudgetPeriod = (typeof BUDGET_PERIODS)[number];
+
+/** Mirrors gateway.tenant_budgets.BUDGET_SCOPE_KINDS. */
+export const BUDGET_SCOPE_KINDS = ["tenant", "feature", "model", "layer"] as const;
+export type BudgetScopeKind = (typeof BUDGET_SCOPE_KINDS)[number];
+
+/** The scope kind that covers the whole bill and therefore names nothing. */
+export const TENANT_SCOPE_KIND: BudgetScopeKind = "tenant";
+
+export interface Budget {
+  budgetId: string;
+  period: string;
+  amountMicro: MicroUSD;
+  scopeKind: string;
+  /** Always a string, '' for a tenant-wide budget. Never null: see the gateway's as_dict(). */
+  scopeValue: string;
+  /** ISO YYYY-MM-DD. */
+  startsOn: string;
+  /** null means open-ended ("until further notice"), not unknown and not a sentinel date. */
+  endsOn: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+interface BudgetWire {
+  budget_id: string;
+  period: string;
+  amount_micro: number;
+  scope_kind: string;
+  scope_value: string;
+  starts_on: string;
+  ends_on: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface BudgetList {
+  budgets: Budget[];
+  /** false when the tenant has set no budget at all. A normal state, not an error. */
+  configured: boolean;
+  /** What this deployment can store, echoed by the gateway so the form cannot drift from the
+   *  CHECK constraints. Falls back to the constants above when the gateway is unreachable. */
+  periods: string[];
+  scopeKinds: string[];
+  /** false when we could not reach the gateway. Deliberately distinct from `configured`: a page
+   *  must not tell a user "no budget set" when the truth is "we could not ask". */
+  reachable: boolean;
+  /** Verbatim failure text when `reachable` is false. */
+  error: string | null;
+}
+
+export function budgetFromWire(w: BudgetWire): Budget {
+  return {
+    budgetId: w.budget_id,
+    period: w.period,
+    amountMicro: w.amount_micro,
+    scopeKind: w.scope_kind,
+    scopeValue: w.scope_value ?? "",
+    startsOn: w.starts_on,
+    endsOn: w.ends_on,
+    createdAt: w.created_at,
+    updatedAt: w.updated_at,
+  };
+}
+
+/** How a budget reads in a table cell: "Whole tenant", or "feature: research-agent". */
+export function scopeLabel(budget: Pick<Budget, "scopeKind" | "scopeValue">): string {
+  if (budget.scopeKind === TENANT_SCOPE_KIND) return "Whole tenant";
+  return `${budget.scopeKind}: ${budget.scopeValue}`;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Money. Dollars in the form, integer micro-USD on the wire, and no float in between.
+// ---------------------------------------------------------------------------------------------
+
+/** Micro-USD per dollar. The gateway rejects a float amount outright, so the conversion has to be
+ *  exact, not merely close. */
+const MICRO_PER_USD = 1_000_000;
+
+export type DollarParse = { ok: true; micro: MicroUSD } | { ok: false; error: string };
+
+/**
+ * Parse a dollars-and-cents string into integer micro-USD, by STRING SURGERY rather than
+ * arithmetic on a float.
+ *
+ * `Math.round(Number("30000.07") * 1e6)` looks fine and is fine for most inputs, which is exactly
+ * why it is dangerous: it fails on a small, unpredictable subset (0.1 + 0.2 territory) and a budget
+ * that is one micro-dollar off is a variance figure that never quite reconciles. Splitting on the
+ * decimal point and padding the fraction to six digits is exact for every input the form accepts.
+ *
+ * Zero is accepted. A budget of zero is a real claim ("this scope may spend nothing"), and it is
+ * the ABSENCE of a budget, not a zero, that means "no budget set".
+ */
+export function dollarsToMicro(input: string): DollarParse {
+  // Commas and a leading $ are what people paste out of a spreadsheet. Accepting them is not
+  // guessing at intent, it is reading the same number.
+  const cleaned = input.trim().replace(/^\$/, "").replace(/,/g, "");
+  if (!cleaned) return { ok: false, error: "amount is required, in dollars (for example 30000)" };
+  if (!/^\d+(\.\d{1,6})?$/.test(cleaned)) {
+    return {
+      ok: false,
+      error:
+        "amount must be a positive dollar figure with at most 6 decimal places " +
+        "(for example 30000 or 1250.50)",
+    };
+  }
+  const [whole, fraction = ""] = cleaned.split(".");
+  const micro = Number(whole) * MICRO_PER_USD + Number(fraction.padEnd(6, "0"));
+  if (!Number.isSafeInteger(micro)) {
+    return { ok: false, error: "amount is too large to record" };
+  }
+  return { ok: true, micro };
+}
+
+/**
+ * Micro-USD back to the exact dollar string the edit form should start from.
+ *
+ * Not `formatUSD`: that one is for display and rounds to a readable number of decimals, so feeding
+ * it back into an input would let an edit-and-save silently change an amount it never showed the
+ * user. This is the round-trip inverse of `dollarsToMicro` and nothing else.
+ */
+export function microToDollarInput(micro: MicroUSD): string {
+  const negative = micro < 0;
+  const abs = Math.abs(Math.trunc(micro));
+  const whole = Math.floor(abs / MICRO_PER_USD);
+  const fraction = String(abs % MICRO_PER_USD).padStart(6, "0").replace(/0+$/, "");
+  const body = fraction ? `${whole}.${fraction}` : String(whole);
+  return negative ? `-${body}` : body;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------------------------
+
+export interface GatewayFailure {
+  ok: false;
+  /** The gateway's own words wherever it gave us any. Never reduced to a status code. */
+  error: string;
+  /** Set on a 409, naming the budget the write collided with, so the UI can offer to edit it. */
+  conflictingBudgetId: string | null;
+}
+
+export type SaveResult = { ok: true; budget: Budget } | GatewayFailure;
+export type DeleteResult = { ok: true; removed: boolean } | GatewayFailure;
+
+/**
+ * Pull the caller-facing message out of a failed response.
+ *
+ * FastAPI's `detail` is a string for the 422s and an object for the 409, because the overlap error
+ * carries the colliding budget_id alongside its message. Both shapes are handled here so no call
+ * site has to know which endpoint returns which.
+ */
+async function readFailure(res: Response): Promise<GatewayFailure> {
+  let detail: unknown;
+  try {
+    detail = ((await res.json()) as { detail?: unknown })?.detail;
+  } catch {
+    detail = undefined;
+  }
+  if (typeof detail === "string" && detail) {
+    return { ok: false, error: detail, conflictingBudgetId: null };
+  }
+  if (detail && typeof detail === "object") {
+    const d = detail as { message?: unknown; conflicting_budget_id?: unknown };
+    const message = typeof d.message === "string" && d.message ? d.message : null;
+    const conflicting =
+      typeof d.conflicting_budget_id === "string" ? d.conflicting_budget_id : null;
+    if (message) return { ok: false, error: message, conflictingBudgetId: conflicting };
+  }
+  return { ok: false, error: `gateway HTTP ${res.status}`, conflictingBudgetId: null };
+}
+
+/** Every budget this tenant has set. Never throws: an unreachable gateway is reported, not raised,
+ *  because the page still has to render the difference between "nothing set" and "could not ask". */
+export async function queryBudgets(): Promise<BudgetList> {
+  const fallback: Omit<BudgetList, "reachable" | "error"> = {
+    budgets: [],
+    configured: false,
+    periods: [...BUDGET_PERIODS],
+    scopeKinds: [...BUDGET_SCOPE_KINDS],
+  };
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) {
+      const failure = await readFailure(res);
+      return { ...fallback, reachable: false, error: failure.error };
+    }
+    const body = (await res.json()) as {
+      budgets?: BudgetWire[];
+      configured?: boolean;
+      available_periods?: string[];
+      available_scope_kinds?: string[];
+    };
+    return {
+      budgets: (body.budgets ?? []).map(budgetFromWire),
+      configured: Boolean(body.configured),
+      periods: body.available_periods?.length ? body.available_periods : [...BUDGET_PERIODS],
+      scopeKinds: body.available_scope_kinds?.length
+        ? body.available_scope_kinds
+        : [...BUDGET_SCOPE_KINDS],
+      reachable: true,
+      error: null,
+    };
+  } catch (err) {
+    return { ...fallback, reachable: false, error: (err as Error).message };
+  }
+}
+
+export interface BudgetInput {
+  budgetId: string;
+  period: string;
+  amountMicro: MicroUSD;
+  scopeKind: string;
+  scopeValue: string;
+  startsOn: string;
+  endsOn: string | null;
+}
+
+/**
+ * Create or edit one budget. Creating and editing are the same call, an upsert on
+ * `(tenant_id, budget_id)`, which is also why editing an existing budget in place does not trip the
+ * overlap check: the gateway excludes the row from its own comparison.
+ */
+export async function saveBudget(input: BudgetInput): Promise<SaveResult> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      body: JSON.stringify({
+        budget_id: input.budgetId,
+        period: input.period,
+        // Integer micro-USD. The gateway rejects a float, including a whole-valued one.
+        amount_micro: input.amountMicro,
+        scope_kind: input.scopeKind,
+        scope_value: input.scopeValue,
+        starts_on: input.startsOn,
+        // null, not "", not a far-future date. Open-ended is a statement.
+        ends_on: input.endsOn,
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return await readFailure(res);
+    const body = (await res.json()) as { budget: BudgetWire };
+    return { ok: true, budget: budgetFromWire(body.budget) };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message, conflictingBudgetId: null };
+  }
+}
+
+/** Withdraw one budget, returning that scope to the "no budget set" state. Idempotent: deleting an
+ *  absent budget is 200 with `removed: false`, so a double-click is not an error. */
+export async function deleteBudget(budgetId: string): Promise<DeleteResult> {
+  try {
+    const res = await fetch(
+      `${GATEWAY_URL}/v1/tenant/budgets?budget_id=${encodeURIComponent(budgetId)}`,
+      {
+        method: "DELETE",
+        headers: { "x-tenant-id": TENANT },
+        cache: "no-store",
+        signal: AbortSignal.timeout(5000),
+      },
+    );
+    if (!res.ok) return await readFailure(res);
+    const body = (await res.json()) as { removed?: boolean };
+    return { ok: true, removed: Boolean(body.removed) };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message, conflictingBudgetId: null };
+  }
+}


### PR DESCRIPTION
Implements CTO-208 (F4): create, edit and withdraw budgets from the dashboard, against the control plane CTO-205 shipped. Until now the only way to record what a tenant intends to spend was to POST JSON by hand.

## Where the surface lives, and why

**Its own route, `/settings/budgets`.** A budget is configuration the tenant asserts, not a reading derived from telemetry, so it belongs with the other things a tenant declares about themselves rather than bolted onto a spend page. `/settings` already existed as a near-empty shell, which made it the natural home.

That also keeps this clear of CTO-209 (F5), which owns `/cost` and is adding budget-vs-actual there. Nothing in `web/app/cost/` is touched. The two surfaces link by route path only: this page links to `/cost` at the bottom, and `/cost` can link here whenever F5 wants to, with neither importing the other's components.

A `Budgets` nav entry was added, since these are real wired configuration rather than the placeholder pages the nav comment excludes.

## What is in the change

- `web/lib/budgets.ts` — typed client over `GET/POST/DELETE /v1/tenant/budgets`, plus the dollars/micro-USD conversion. The web app never touches Postgres, same rule as `lib/costConnectors.ts`.
- `web/app/settings/budgets/{page,actions,BudgetManager}.tsx` — server page, server actions, client form, following `app/connectors/ConnectForm.tsx`.
- `web/lib/budgets.test.ts` — 16 tests over the money conversion and the error surfacing.
- Uses the shared `DataTable` and the `Money` primitive rather than hand-rolled markup.

### Gateway text reaches the user verbatim

An overlapping write is a 409 naming the budget it collided with, and that name is the point of the error. It is rendered as written and turned into an `Edit <budget_id>` button that loads the colliding budget into the form, so "that overlaps with cto208-verify-tenant" is something you can act on rather than something you have to go hunting for. 422 validation strings from the gateway are surfaced the same way. Only a response that carried no message at all falls back to a status code.

### Money never round-trips through a float

Amounts are typed in dollars and stored as integer micro-USD. The conversion splits on the decimal point and pads the fraction to six digits rather than multiplying a float by 1e6, so it is exact for every input the form accepts. The edit form starts from the exact stored amount, not from `formatUSD`'s display rounding, so an edit-and-save cannot silently change a number the form never showed. `$1,250.50` typed with the spreadsheet comma stored as exactly `1250500000`.

### Three states that must not collapse into one

- **Budgets exist** — the table.
- **No budget set** — normal, with its own copy, never an implicit zero, and the card reads "Budgets — none set". A stored zero is a separate deliberate claim and renders as `$0.00` through `Money`.
- **The gateway could not be reached** — a banner saying so, the card reads "Budgets — unknown", and the empty table says it is not a statement about your configuration. "We could not ask" is not "you have no budget".

An absent `ends_on` renders as "Open-ended", not as a `Blank`: a blank in this app means "we do not know", and open-ended is a definite claim.

## Verification

`npm run typecheck`, `npm run lint` and `npm run test` from `web/`: typecheck and lint clean, **492 passing**. The only failures are the two long-standing `app/api/api.test.ts` cases (attribution and data-quality ClickHouse fallback) that fail whenever a local ClickHouse is running; they fail identically on `main`.

**Live create / edit / delete / 409 exercised against a running gateway.** Docker Hub was unreachable from this machine, so per the known-issue note the gateway was **run directly with uvicorn** from the repo checkout against the same Postgres (the container image on :8080 predates CTO-205 and 404s on `/v1/tenant/budgets`). Migration 0026 was already applied. The worktree's dev server ran on a spare port pointed at that gateway.

| Step | Result |
| --- | --- |
| Create `cto208-verify-tenant`, tenant-wide, month, $30,000, starts 2026-09-01, open-ended | Row appears, card reads "Budgets — 1 set", Ends reads "Open-ended" |
| Create `cto208-verify-overlap`, tenant-wide, month, starts 2026-09-15 | **409 refused**, shown verbatim: `a budget already covers this scope and period over an overlapping date range: cto208-verify-tenant`, with an `Edit cto208-verify-tenant` button beside it |
| Click that button, change the amount to `45000.50`, save | Edits in place, still one row, `$45,000.50`. API reports `amount_micro: 45000500000` exactly, `updated_at` moved |
| Create `cto208-verify-feature`, feature `research-agent`, month, `1,250.50`, 2026-09-01 to 2026-09-30 | Accepted, coexists with the tenant-wide budget for the same month, `$1,250.50` |
| Withdraw both (two-step confirm) | Both removed, table returns to the "No budget set" copy |
| Stop the gateway, reload | Banner "Budgets could not be read. fetch failed. This is not the same as having no budget set", card "Budgets — unknown" |

`tenant_budgets` is back to 0 rows; the test rows were cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
