### PR TITLE
feat(cost): month-to-date actual vs budget on /cost (CTO-209)

### DIFF
--- a/web/app/api/cost/budget/route.ts
+++ b/web/app/api/cost/budget/route.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Month-to-date actual versus budget for /cost (CTO-209, F5).
+//
+// WHY THIS IS ITS OWN ROUTE AND NOT PART OF /api/cost. The cost page live-polls /api/cost every 5
+// seconds (`useLivePoll`, NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS). This payload costs two more
+// ClickHouse reads plus a gateway round trip, and none of it changes at that cadence: a budget is
+// edited by a human maybe monthly, and the settled window advances once a day. Folding it into the
+// polled route would multiply that work by 720 an hour to redraw an identical section. So it is
+// fetched once per page render, server side, and the section states the days it covers instead of
+// pretending to be live.
+//
+// The comparison is always TENANT-WIDE, even under /cost?tag=<feature>. The budget scopes in
+// CTO-205 include 'feature', but wiring the tag filter to a feature-scoped budget is the
+// scoped-budget phase of docs/spend-forecasting-scope.md, not this ticket, and silently comparing
+// one feature's spend against the whole tenant's budget would be worse than either.
+
+import { NextResponse } from "next/server";
+
+import { budgetVsActual } from "@/lib/budgetVsActual";
+import { querySettledCostSeries } from "@/lib/clickhouse";
+import { fetchTenantBudgets } from "@/lib/tenantBudgetsClient";
+
+import type { BudgetPayload } from "@/app/cost/BudgetVsActualCard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const [series, budgets] = await Promise.all([
+    querySettledCostSeries({ kind: "tenant" }),
+    fetchTenantBudgets(),
+  ]);
+
+  // No mock fallback on this surface, unlike the rest of /cost. Everywhere else a canned series
+  // keeps a fresh clone looking alive; here it would put invented spend next to a budget somebody
+  // really set and produce a variance that is pure fiction. "We cannot read the spend" is the only
+  // honest answer, and the section renders it as a blank with this reason attached.
+  if (!series) {
+    const payload: BudgetPayload = {
+      comparison: null,
+      unavailable: "spend data is unavailable: ClickHouse is unreachable from the dashboard",
+    };
+    return NextResponse.json(payload);
+  }
+  if (!budgets.ok) {
+    const payload: BudgetPayload = {
+      comparison: null,
+      unavailable: `the budget could not be read: gateway unreachable (${budgets.error})`,
+    };
+    return NextResponse.json(payload);
+  }
+
+  const payload: BudgetPayload = {
+    comparison: budgetVsActual(series, budgets.budgets),
+    unavailable: null,
+  };
+  return NextResponse.json(payload);
+}

--- a/web/app/cost/BudgetVsActualCard.test.tsx
+++ b/web/app/cost/BudgetVsActualCard.test.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// The three states that have to be right on this card (CTO-209): no budget configured, a budget
+// with an over-variance, and the comparison being unreadable. Each is an honesty requirement of the
+// ticket, and each is a state that fails silently rather than loudly if it regresses.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BLANK } from "@/components/HonestValue";
+import type { BudgetVsActual } from "@/lib/budgetVsActual";
+import { budgetVsActual, type SettledSeriesLike, type TenantBudget } from "@/lib/budgetVsActual";
+import { LAYERS } from "@/lib/cost";
+import type { SpendByLayer } from "@/lib/types";
+
+import { BudgetVsActualCard } from "./BudgetVsActualCard";
+
+const USD = 1_000_000;
+
+function layers(over: Partial<SpendByLayer> = {}): SpendByLayer {
+  return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0, ...over };
+}
+
+/** Two settled days (600 total) plus one unsettled day (100) inside the month. */
+function testSeries(): SettledSeriesLike {
+  const days = [
+    { date: "2026-08-01", byLayer: layers({ llm: 200 * USD, compute: 100 * USD }), settled: true },
+    { date: "2026-08-02", byLayer: layers({ llm: 200 * USD, compute: 100 * USD }), settled: true },
+    { date: "2026-08-03", byLayer: layers({ llm: 100 * USD }), settled: false },
+  ].map((d) => ({
+    ...d,
+    totalMicroUsd: LAYERS.reduce((s, l) => s + d.byLayer[l], 0),
+    inPeriod: true,
+    inProgress: d.date === "2026-08-03",
+    awaitingLayers: [] as string[],
+  }));
+  const totals = (keep: (d: (typeof days)[number]) => boolean) => {
+    const byLayer = layers();
+    let totalMicroUsd = 0;
+    let dayCount = 0;
+    for (const d of days.filter(keep)) {
+      dayCount += 1;
+      totalMicroUsd += d.totalMicroUsd;
+      for (const l of LAYERS) byLayer[l] += d.byLayer[l];
+    }
+    return { dayCount, byLayer, totalMicroUsd };
+  };
+  return {
+    periodStart: "2026-08-01",
+    windowEnd: "2026-08-03",
+    settledThrough: "2026-08-02",
+    rule: "connector-landing",
+    connectorLayers: ["compute", "egress"],
+    days,
+    periodSettled: totals((d) => d.settled),
+    periodObserved: totals(() => true),
+  };
+}
+
+const BUDGET: TenantBudget = {
+  budget_id: "tenant-month",
+  period: "month",
+  amount_micro: 500 * USD,
+  scope_kind: "tenant",
+  scope_value: "",
+  starts_on: "2026-01-01",
+  ends_on: null,
+};
+
+function comparison(budgets: TenantBudget[]): BudgetVsActual {
+  return budgetVsActual(testSeries(), budgets);
+}
+
+describe("BudgetVsActualCard", () => {
+  it("shows the actual and a blank variance, not a variance against zero, with no budget set", () => {
+    render(<BudgetVsActualCard payload={{ comparison: comparison([]), unavailable: null }} />);
+
+    expect(screen.getAllByText("$600.00").length).toBeGreaterThan(0);
+    // The reason is on the blank itself, so a reader can find out why the cell is empty.
+    const blanks = screen.getAllByText(BLANK);
+    expect(blanks.length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/No value: no monthly tenant-wide budget is set/).length,
+    ).toBeGreaterThan(0);
+    // No fabricated over/under language: the headline is the blank itself.
+    expect(screen.getByTestId("budget-variance-headline").textContent).toContain(BLANK);
+    // And a way to fix it.
+    const link = screen.getByRole("link", { name: /set a monthly budget/i });
+    expect(link.getAttribute("href")).toBe("/settings/budgets");
+  });
+
+  it("leads with the variance sign, in words as well as colour", () => {
+    render(<BudgetVsActualCard payload={{ comparison: comparison([BUDGET]), unavailable: null }} />);
+
+    // 600 settled against a 500 budget: 100 over, 20 percent.
+    const headline = screen.getByTestId("budget-variance-headline");
+    expect(headline.textContent).toBe("+$100.00 over");
+    expect(headline.className).toContain("text-bad");
+    expect(screen.getAllByText(/20.0/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$500.00").length).toBeGreaterThan(0);
+  });
+
+  it("states the days it covers and the days it excludes", () => {
+    render(<BudgetVsActualCard payload={{ comparison: comparison([BUDGET]), unavailable: null }} />);
+
+    const covers = screen.getByText(/Counts 2 settled days/);
+    expect(covers.textContent).toContain("2026-08-01");
+    expect(covers.textContent).toContain("2026-08-02");
+    expect(covers.textContent).toContain("connector-landing");
+    // The exclusion has to be quantified: without it this $600 contradicts the 30-day headline
+    // directly above it on the same page.
+    const excludes = screen.getByText(/Excludes 1 day/);
+    expect(excludes.textContent).toContain("2026-08-03");
+    expect(excludes.textContent).toContain("$100.00");
+  });
+
+  it("says it could not read the comparison rather than showing a zero", () => {
+    render(
+      <BudgetVsActualCard
+        payload={{ comparison: null, unavailable: "ClickHouse is unreachable" }}
+      />,
+    );
+    expect(screen.getAllByText(/ClickHouse is unreachable/).length).toBeGreaterThan(0);
+    expect(screen.queryByText("$0.00")).toBeNull();
+  });
+});

--- a/web/app/cost/BudgetVsActualCard.tsx
+++ b/web/app/cost/BudgetVsActualCard.tsx
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+// The month-to-date-versus-budget section of /cost (CTO-209, F5).
+//
+// A section on this page rather than a /forecast tab, per docs/spend-forecasting-scope.md: it is
+// the same question the reader already came to /cost with, and a separate tab for one comparison is
+// premature.
+//
+// THE VARIANCE SIGN IS THE POINT, so it is the largest thing here and it is stated in words
+// ("over" / "under") as well as by sign and colour. Colour alone fails for a colourblind reader and
+// a leading minus is easy to miss in a wall of dollars.
+//
+// NO PROJECTION HERE. Everything on this card already happened. The elapsed figure sits next to the
+// variance precisely so "under budget" on day 3 cannot be misread as "on track": that judgement
+// needs the day-of-week weighted projection and its confidence band, which is CTO-210.
+//
+// Three things this card must never do, each of which it would be easy to do by accident:
+//   - compare against a budget of zero when none is set. `Blank` with the store's own reason, and a
+//     link to where a budget is set, instead.
+//   - print a figure without saying which days it covers. The actual is settled days only
+//     (CTO-207), and the coverage line names them, counts them and names the rule that chose them.
+//   - hide the excluded days. Settled month-to-date can be much smaller than observed
+//     month-to-date, by around 10 percent on a tenant whose cloud connectors are still landing, so
+//     without the exclusion line this figure contradicts the 30-day headline directly above it and
+//     the page reads as broken. The gap is printed in dollars rather than asserted, because on some
+//     tenants it is pennies and the copy must not claim a size it does not know.
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Card } from "@/components/Card";
+import { DataTable, type Column } from "@/components/DataTable";
+import { Blank, Money, Pct } from "@/components/HonestValue";
+import type { BudgetVsActual, LayerLine } from "@/lib/budgetVsActual";
+import { LAYER_LABEL } from "@/lib/cost";
+
+/** What `/api/cost/budget` returns. Exactly one of the two fields is non-null. */
+export interface BudgetPayload {
+  comparison: BudgetVsActual | null;
+  /** Why there is no comparison: ClickHouse or the gateway could not be read. Never "no budget". */
+  unavailable: string | null;
+}
+
+/**
+ * Where a budget is set. A plain path, deliberately: CTO-208 owns that surface and is landing in
+ * parallel, so this file imports nothing from it and the two tickets cannot collide. "No budget
+ * set" without a way to set one is a dead end, which is why the blank always ships with this link.
+ */
+const BUDGET_SETTINGS_PATH = "/settings/budgets";
+
+export function BudgetVsActualCard({ payload }: { payload: BudgetPayload }) {
+  const c = payload.comparison;
+  if (!c) {
+    return (
+      <Card title="Month to date vs budget">
+        {/* A blank with the real reason, never a zero and never "no budget set": not being able
+            to read the spend or the budget is a different state from not having one. */}
+        <div className="text-sm text-muted">
+          <Blank reason={payload.unavailable ?? "this comparison could not be computed"} /> No
+          comparison: {payload.unavailable ?? "this comparison could not be computed"}.
+        </div>
+      </Card>
+    );
+  }
+
+  const { budget, period } = c;
+  const over = c.varianceMicroUsd !== null && c.varianceMicroUsd > 0;
+
+  return (
+    <Card title="Month to date vs budget">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+        <div>
+          <Variance comparison={c} />
+          {budget === null ? (
+            <p className="mt-2 text-sm text-muted">
+              Month to date is {" "}
+              <span className="font-medium text-white">
+                <Money micro={c.actualMicroUsd} />
+              </span>
+              .{" "}
+              <Link href={BUDGET_SETTINGS_PATH} className="text-accent underline">
+                Set a monthly budget
+              </Link>{" "}
+              to see a variance here.
+            </p>
+          ) : null}
+        </div>
+
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
+          <Stat label="Month to date">
+            <Money micro={c.actualMicroUsd} />
+          </Stat>
+          <Stat label="Budget (month)">
+            {budget ? (
+              <Money micro={budget.amountMicroUsd} />
+            ) : (
+              <Blank reason={c.noBudgetReason ?? "no budget set"} />
+            )}
+          </Stat>
+          <Stat label="Budget consumed">
+            {c.consumedFraction === null ? (
+              <Blank
+                reason={
+                  budget === null
+                    ? (c.noBudgetReason ?? "no budget set")
+                    : "the budget is zero, so a percentage of it is undefined"
+                }
+              />
+            ) : (
+              <Pct value={c.consumedFraction} />
+            )}
+          </Stat>
+          <Stat label="Period elapsed">
+            <span className="tabular-nums">
+              day {period.daysElapsed} of {period.daysInPeriod}
+            </span>
+            <span className="ml-2 text-sm text-muted">
+              <Pct value={period.elapsedFraction} digits={0} />
+            </span>
+          </Stat>
+        </dl>
+      </div>
+
+      <Provenance comparison={c} />
+
+      {budget && !budget.coversPeriodToDate ? (
+        <p className="mt-3 rounded-lg border border-warn/40 bg-warn/10 p-3 text-sm text-warn">
+          This budget starts {budget.startsOn}, after the period began on {period.start}. The actual
+          above covers the whole month to date, so it includes spend from before the budget applied.
+        </p>
+      ) : null}
+
+      <div className="mt-5">
+        <h3 className="mb-2 text-xs uppercase tracking-wide text-muted">
+          By layer{over ? ": where the overage is" : ""}
+        </h3>
+        <DataTable
+          columns={layerColumns(c)}
+          rows={c.layers}
+          rowKey={(r) => r.layer}
+          pageSize={0}
+          empty="No layer spend in this period."
+        />
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * The headline. Magnitude, direction in words, and percent, or a blank with a reason and nothing
+ * invented when no budget is set.
+ */
+function Variance({ comparison }: { comparison: BudgetVsActual }) {
+  const { varianceMicroUsd, variancePct, budget, noBudgetReason } = comparison;
+  if (varianceMicroUsd === null) {
+    return (
+      <div>
+        <div data-testid="budget-variance-headline" className="text-3xl font-semibold">
+          <Blank reason={noBudgetReason ?? "no budget set"} />
+        </div>
+        <div className="mt-1 text-sm text-muted">No budget to compare against</div>
+      </div>
+    );
+  }
+  // Exact zero is its own answer and reads oddly as either "over" or "under".
+  const direction = varianceMicroUsd === 0 ? "on budget" : varianceMicroUsd > 0 ? "over" : "under";
+  const tone =
+    varianceMicroUsd > 0 ? "text-bad" : varianceMicroUsd < 0 ? "text-good" : "text-muted";
+  const sign = varianceMicroUsd > 0 ? "+" : varianceMicroUsd < 0 ? "−" : "";
+  return (
+    <div>
+      {/* Test hook: the variance sign is the load-bearing thing on this card, and it is assembled
+          from several nodes, so the test asserts on this element rather than on a text fragment. */}
+      <div
+        data-testid="budget-variance-headline"
+        className={`text-3xl font-semibold tabular-nums ${tone}`}
+      >
+        {direction === "on budget" ? (
+          "Exactly on budget"
+        ) : (
+          <>
+            {sign}
+            <Money micro={Math.abs(varianceMicroUsd)} /> {direction}
+          </>
+        )}
+      </div>
+      <div className="mt-1 text-sm text-muted">
+        {variancePct === null ? (
+          <>
+            <Blank reason="the budget is zero, so a percentage variance is undefined" /> of a{" "}
+            <Money micro={budget?.amountMicroUsd ?? 0} /> budget
+          </>
+        ) : (
+          <>
+            <span className={tone}>
+              {sign}
+              <Pct value={Math.abs(variancePct)} />
+            </span>{" "}
+            of the month budget, measured, not projected
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Which days the actual covers and which it does not. This is the audit trail: without it the
+ * figure above is a number with no stated input window, and it will not reconcile with the 30-day
+ * total on the same page.
+ */
+function Provenance({ comparison }: { comparison: BudgetVsActual }) {
+  const { coverage, excluded, period } = comparison;
+  const waiting = coverage.waitsOn.length > 0 ? coverage.waitsOn.join(" and ") : null;
+  const gapDays = excluded.days.filter((d) => !d.inProgress);
+  return (
+    <div className="mt-4 space-y-1 border-t border-edge pt-3 text-xs text-muted">
+      <p>
+        {coverage.dayCount === 0 ? (
+          <>
+            No day of {period.start.slice(0, 7)} has settled yet, so the month-to-date figure above
+            is <Money micro={0} /> over zero days.
+          </>
+        ) : (
+          <>
+            Counts {coverage.dayCount} settled {coverage.dayCount === 1 ? "day" : "days"},{" "}
+            {coverage.from} through {coverage.through}
+            {coverage.contiguous ? "" : " (with gaps, see below)"}. A day counts once it is complete
+            {waiting ? ` and ${waiting} have landed for it` : ""} (rule: {coverage.rule}).
+          </>
+        )}
+      </p>
+      {excluded.days.length > 0 ? (
+        <p>
+          Excludes {excluded.days.length} {excluded.days.length === 1 ? "day" : "days"} (
+          {excluded.days.map((d) => d.date).join(", ")}) carrying{" "}
+          <Money micro={excluded.microUsd} /> so far
+          {excluded.shareOfObserved === null ? (
+            ""
+          ) : (
+            <>
+              , <Pct value={excluded.shareOfObserved} /> of observed month to date
+            </>
+          )}
+          {gapDays.length > 0 && waiting ? `, still waiting on ${waiting}` : ""}.{" "}
+          {/* Says the excluded days are the reason the two figures can differ, without claiming a
+              size for the gap: on this tenant it is currently pennies and on another it is a tenth
+              of the month. The dollars are printed just above, so the reader can see which. */}
+          Those days are why this figure need not match the 30-day total above.
+        </p>
+      ) : (
+        <p>Every day of the month to date has settled; nothing is excluded.</p>
+      )}
+      <p>
+        Observed month to date, settled and unsettled together, is{" "}
+        <Money micro={comparison.observedMicroUsd} />.
+      </p>
+    </div>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-muted">{label}</dt>
+      <dd className="mt-0.5 text-base font-medium tabular-nums">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * The layer split, which is what makes this actionable: "12 percent over and compute is the reason"
+ * is something a reader can act on, a single total is not.
+ *
+ * "Share of budget" is each layer's month-to-date spend as a fraction of the TENANT budget, so the
+ * rows read as a decomposition of the consumed figure above. The last two columns appear only when
+ * layer-scoped budgets (CTO-205 `scope_kind='layer'`) exist, because six columns of blanks would
+ * bury the two that carry the answer.
+ */
+function layerColumns(comparison: BudgetVsActual): Column<LayerLine>[] {
+  const hasLayerBudgets = comparison.layers.some((l) => l.budgetMicroUsd !== null);
+  const noBudget = comparison.noBudgetReason ?? "no budget set";
+  const columns: Column<LayerLine>[] = [
+    {
+      key: "layer",
+      header: "Layer",
+      render: (r) => LAYER_LABEL[r.layer],
+      sortValue: (r) => LAYER_LABEL[r.layer],
+    },
+    {
+      key: "actual",
+      header: "Month to date",
+      align: "right",
+      render: (r) => <Money micro={r.actualMicroUsd} />,
+      sortValue: (r) => r.actualMicroUsd,
+    },
+    {
+      key: "share",
+      header: "Share of spend",
+      align: "right",
+      render: (r) =>
+        r.shareOfActual === null ? (
+          <Blank reason="nothing has settled this month, so there is no total to take a share of" />
+        ) : (
+          <Pct value={r.shareOfActual} />
+        ),
+      sortValue: (r) => r.shareOfActual,
+    },
+    {
+      key: "shareOfBudget",
+      header: "Share of budget",
+      align: "right",
+      render: (r) =>
+        r.shareOfTenantBudget === null ? (
+          <Blank
+            reason={
+              comparison.budget === null
+                ? noBudget
+                : "the budget is zero, so a percentage of it is undefined"
+            }
+          />
+        ) : (
+          <Pct value={r.shareOfTenantBudget} />
+        ),
+      sortValue: (r) => r.shareOfTenantBudget,
+    },
+  ];
+  if (!hasLayerBudgets) return columns;
+  return [
+    ...columns,
+    {
+      key: "layerBudget",
+      header: "Layer budget",
+      align: "right",
+      render: (r) => (
+        <Money
+          micro={r.budgetMicroUsd}
+          reason="no budget is set for this layer specifically"
+        />
+      ),
+      sortValue: (r) => r.budgetMicroUsd,
+    },
+    {
+      key: "layerVariance",
+      header: "Variance",
+      align: "right",
+      render: (r) =>
+        r.varianceMicroUsd === null ? (
+          <Blank reason="no budget is set for this layer specifically" />
+        ) : (
+          <span className={r.varianceMicroUsd > 0 ? "text-bad" : "text-good"}>
+            {r.varianceMicroUsd > 0 ? "+" : r.varianceMicroUsd < 0 ? "−" : ""}
+            <Money micro={Math.abs(r.varianceMicroUsd)} />
+          </span>
+        ),
+      sortValue: (r) => r.varianceMicroUsd,
+    },
+  ];
+}

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -26,6 +26,8 @@ import {
 import { formatUSD, type SpendByLayer } from "@/lib/types";
 import { useLivePoll } from "@/lib/useLivePoll";
 
+import { BudgetVsActualCard, type BudgetPayload } from "./BudgetVsActualCard";
+
 export interface CostPayload {
   series: CostSeries;
   featureRows: FeatureCostRow[];
@@ -40,10 +42,15 @@ export function CostLive({
   endpoint,
   initialData,
   enabledLayers,
+  budget,
 }: {
   endpoint: string;
   initialData: CostPayload;
   enabledLayers: readonly Layer[];
+  // Not part of the polled payload (CTO-209): a budget changes about monthly and the settled
+  // window advances once a day, so re-reading both every 5 seconds would be pure waste. See the
+  // comment at the top of app/api/cost/budget/route.ts.
+  budget: BudgetPayload;
 }) {
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
   const { series: costSeries, featureRows, alerts: hiddenCostAlerts } = data;
@@ -80,6 +87,11 @@ export function CostLive({
         <StackedBarChart series={costSeries} />
         <Legend />
       </Card>
+
+      {/* Directly under the 30-day headline on purpose (CTO-209): this card's figure is smaller
+          than that total, and the two only reconcile once you have read the coverage line saying
+          which days it counted. Putting them far apart is how the page starts looking broken. */}
+      <BudgetVsActualCard payload={budget} />
 
       {hiddenCostAlerts.map((a) => (
         <div

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { apiGet } from "@/lib/api";
 import { queryEnabledConnectors } from "@/lib/tenant";
+import type { BudgetPayload } from "./BudgetVsActualCard";
 import { CostLive, type CostPayload } from "./Live";
 
 export default async function CostPage({
@@ -12,11 +13,20 @@ export default async function CostPage({
   const sp = (await searchParams) ?? {};
   const query = sp.tag ? `?tag=${encodeURIComponent(sp.tag)}` : "";
   const endpoint = `/api/cost${query}`;
-  const [initialData, enabledLayers] = await Promise.all([
+  // The budget comparison (CTO-209) is fetched once per render rather than joining the live poll:
+  // it is tenant-wide, so the ?tag= filter does not apply to it, and it changes on a human/daily
+  // cadence rather than a 5-second one.
+  const [initialData, enabledLayers, budget] = await Promise.all([
     apiGet<CostPayload>(endpoint),
     queryEnabledConnectors(),
+    apiGet<BudgetPayload>("/api/cost/budget"),
   ]);
   return (
-    <CostLive endpoint={endpoint} initialData={initialData} enabledLayers={enabledLayers} />
+    <CostLive
+      endpoint={endpoint}
+      initialData={initialData}
+      enabledLayers={enabledLayers}
+      budget={budget}
+    />
   );
 }

--- a/web/lib/budgetVsActual.test.ts
+++ b/web/lib/budgetVsActual.test.ts
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import {
+  budgetVsActual,
+  daysBetweenInclusive,
+  endOfMonth,
+  periodProgress,
+  selectBudget,
+  type SettledSeriesLike,
+  type TenantBudget,
+} from "./budgetVsActual";
+import { LAYERS, type Layer } from "./cost";
+import type { SpendByLayer } from "./types";
+
+const USD = 1_000_000;
+
+function layers(over: Partial<SpendByLayer> = {}): SpendByLayer {
+  return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0, ...over };
+}
+
+function sumLayers(byLayer: SpendByLayer): number {
+  return LAYERS.reduce((s, l) => s + byLayer[l], 0);
+}
+
+interface DaySpec {
+  date: string;
+  byLayer: SpendByLayer;
+  inPeriod?: boolean;
+  settled?: boolean;
+  inProgress?: boolean;
+  awaitingLayers?: Layer[];
+}
+
+/**
+ * Build a `SettledSpendSeries`-shaped input, with the period totals DERIVED from the days rather
+ * than stated separately. Hand-written totals would let a test assert a consistency the production
+ * query is not actually giving us.
+ */
+function series(spec: {
+  periodStart: string;
+  windowEnd: string;
+  days: DaySpec[];
+  rule?: "connector-landing" | "day-complete";
+  connectorLayers?: string[];
+}): SettledSeriesLike {
+  const days = spec.days.map((d) => ({
+    date: d.date,
+    byLayer: d.byLayer,
+    totalMicroUsd: sumLayers(d.byLayer),
+    inPeriod: d.inPeriod ?? d.date >= spec.periodStart,
+    settled: d.settled ?? true,
+    inProgress: d.inProgress ?? false,
+    awaitingLayers: d.awaitingLayers ?? [],
+  }));
+  const totals = (keep: (d: (typeof days)[number]) => boolean) => {
+    const byLayer = layers();
+    let total = 0;
+    let dayCount = 0;
+    for (const d of days.filter(keep)) {
+      dayCount += 1;
+      total += d.totalMicroUsd;
+      for (const l of LAYERS) byLayer[l] += d.byLayer[l];
+    }
+    return { dayCount, byLayer, totalMicroUsd: total };
+  };
+  const settledInPeriod = days.filter((d) => d.inPeriod && d.settled);
+  return {
+    periodStart: spec.periodStart,
+    windowEnd: spec.windowEnd,
+    settledThrough: settledInPeriod.at(-1)?.date ?? null,
+    rule: spec.rule ?? "connector-landing",
+    connectorLayers: spec.connectorLayers ?? ["compute", "egress"],
+    days,
+    periodSettled: totals((d) => d.inPeriod && d.settled),
+    periodObserved: totals((d) => d.inPeriod),
+  };
+}
+
+function monthBudget(over: Partial<TenantBudget> = {}): TenantBudget {
+  return {
+    budget_id: "tenant-month",
+    period: "month",
+    amount_micro: 1000 * USD,
+    scope_kind: "tenant",
+    scope_value: "",
+    starts_on: "2026-01-01",
+    ends_on: null,
+    ...over,
+  };
+}
+
+/** Three settled days plus today in progress, one of them still awaiting a connector. */
+function demoSeries(): SettledSeriesLike {
+  return series({
+    periodStart: "2026-08-01",
+    windowEnd: "2026-08-05",
+    days: [
+      { date: "2026-08-01", byLayer: layers({ llm: 100 * USD, compute: 50 * USD }) },
+      { date: "2026-08-02", byLayer: layers({ llm: 200 * USD, compute: 100 * USD }) },
+      { date: "2026-08-03", byLayer: layers({ llm: 150 * USD, compute: 100 * USD }) },
+      {
+        date: "2026-08-04",
+        byLayer: layers({ llm: 90 * USD }),
+        settled: false,
+        awaitingLayers: ["compute"],
+      },
+      {
+        date: "2026-08-05",
+        byLayer: layers({ llm: 40 * USD }),
+        settled: false,
+        inProgress: true,
+      },
+    ],
+  });
+}
+
+describe("date helpers", () => {
+  it("counts inclusive days and finds the end of the month, leap year included", () => {
+    expect(daysBetweenInclusive("2026-08-01", "2026-08-01")).toBe(1);
+    expect(daysBetweenInclusive("2026-08-01", "2026-08-26")).toBe(26);
+    expect(endOfMonth("2026-08-01")).toBe("2026-08-31");
+    expect(endOfMonth("2026-02-01")).toBe("2026-02-28");
+    expect(endOfMonth("2028-02-10")).toBe("2028-02-29");
+  });
+
+  it("counts today as the day in progress and clamps at the period end", () => {
+    const p = periodProgress("2026-08-01", "2026-08-26");
+    expect(p).toMatchObject({ end: "2026-08-31", daysInPeriod: 31, daysElapsed: 26 });
+    expect(p.elapsedFraction).toBeCloseTo(26 / 31);
+    expect(periodProgress("2026-08-01", "2026-08-31").elapsedFraction).toBe(1);
+  });
+});
+
+describe("selectBudget", () => {
+  const onDate = "2026-08-26";
+
+  it("finds the monthly tenant-wide budget covering the date", () => {
+    const b = monthBudget();
+    expect(selectBudget([b], "tenant", "", onDate)).toBe(b);
+  });
+
+  it("ignores budgets for another period, scope or date range", () => {
+    const cases: TenantBudget[] = [
+      // A quarterly budget's dollars would be compared against a month of spend, reporting every
+      // tenant as comfortably under.
+      monthBudget({ budget_id: "q", period: "quarter" }),
+      monthBudget({ budget_id: "f", scope_kind: "feature", scope_value: "research-agent" }),
+      monthBudget({ budget_id: "future", starts_on: "2026-09-01" }),
+      monthBudget({ budget_id: "closed", ends_on: "2026-07-31" }),
+    ];
+    for (const b of cases) expect(selectBudget([b], "tenant", "", onDate)).toBeNull();
+  });
+
+  it("includes the boundary days of the range", () => {
+    const b = monthBudget({ starts_on: onDate, ends_on: onDate });
+    expect(selectBudget([b], "tenant", "", onDate)).toBe(b);
+  });
+
+  it("is deterministic if the no-overlap invariant is ever broken", () => {
+    // CTO-205's EXCLUDE constraint should make this impossible; the point is that a bad backfill
+    // produces one stable answer rather than a section that flickers between two budgets.
+    const older = monthBudget({ budget_id: "a", starts_on: "2026-01-01" });
+    const newer = monthBudget({ budget_id: "b", starts_on: "2026-08-01" });
+    expect(selectBudget([older, newer], "tenant", "", onDate)).toBe(newer);
+    expect(selectBudget([newer, older], "tenant", "", onDate)).toBe(newer);
+  });
+});
+
+describe("budgetVsActual", () => {
+  it("sums the actual over settled days only and says which ones", () => {
+    const c = budgetVsActual(demoSeries(), []);
+    expect(c.actualMicroUsd).toBe(700 * USD);
+    expect(c.observedMicroUsd).toBe(830 * USD);
+    expect(c.coverage).toMatchObject({
+      from: "2026-08-01",
+      through: "2026-08-03",
+      dayCount: 3,
+      contiguous: true,
+      rule: "connector-landing",
+    });
+  });
+
+  it("quantifies the excluded days rather than only mentioning them", () => {
+    const c = budgetVsActual(demoSeries(), []);
+    expect(c.excluded.days.map((d) => d.date)).toEqual(["2026-08-04", "2026-08-05"]);
+    expect(c.excluded.microUsd).toBe(130 * USD);
+    expect(c.excluded.shareOfObserved).toBeCloseTo(130 / 830);
+    // The gap between settled and observed is what stops this figure contradicting the 30-day
+    // headline on the same page, so it has to be a real number, not a caveat.
+    expect(c.actualMicroUsd + c.excluded.microUsd).toBe(c.observedMicroUsd);
+    expect(c.excluded.days[0].awaitingLayers).toEqual(["compute"]);
+    expect(c.excluded.days[1].inProgress).toBe(true);
+  });
+
+  it("flags a withheld day inside the counted range as non-contiguous", () => {
+    const s = series({
+      periodStart: "2026-08-01",
+      windowEnd: "2026-08-03",
+      days: [
+        { date: "2026-08-01", byLayer: layers({ llm: 10 * USD }) },
+        { date: "2026-08-02", byLayer: layers({ llm: 10 * USD }), settled: false },
+        { date: "2026-08-03", byLayer: layers({ llm: 10 * USD }) },
+      ],
+    });
+    expect(budgetVsActual(s, []).coverage).toMatchObject({
+      from: "2026-08-01",
+      through: "2026-08-03",
+      dayCount: 2,
+      contiguous: false,
+    });
+  });
+
+  it("reports no variance at all when no budget is set, never a variance against zero", () => {
+    const c = budgetVsActual(demoSeries(), []);
+    expect(c.budget).toBeNull();
+    expect(c.varianceMicroUsd).toBeNull();
+    expect(c.variancePct).toBeNull();
+    expect(c.consumedFraction).toBeNull();
+    // The reason is what the UI puts in <Blank reason>, so it has to be a real sentence.
+    expect(c.noBudgetReason).toMatch(/no monthly tenant-wide budget/);
+    // The actual still renders: the spend is known even when the intent is not.
+    expect(c.actualMicroUsd).toBe(700 * USD);
+    for (const l of c.layers) expect(l.shareOfTenantBudget).toBeNull();
+  });
+
+  it("ignores a feature-scoped budget for the tenant headline", () => {
+    const featureOnly = monthBudget({ scope_kind: "feature", scope_value: "research-agent" });
+    expect(budgetVsActual(demoSeries(), [featureOnly]).budget).toBeNull();
+  });
+
+  it("reports a positive variance when over budget", () => {
+    const c = budgetVsActual(demoSeries(), [monthBudget({ amount_micro: 500 * USD })]);
+    expect(c.budget).toMatchObject({ budgetId: "tenant-month", amountMicroUsd: 500 * USD });
+    expect(c.varianceMicroUsd).toBe(200 * USD);
+    expect(c.variancePct).toBeCloseTo(0.4);
+    expect(c.consumedFraction).toBeCloseTo(1.4);
+  });
+
+  it("reports a negative variance when under budget", () => {
+    const c = budgetVsActual(demoSeries(), [monthBudget({ amount_micro: 1000 * USD })]);
+    expect(c.varianceMicroUsd).toBe(-300 * USD);
+    expect(c.variancePct).toBeCloseTo(-0.3);
+  });
+
+  it("compares a stored zero budget in dollars but not in percent", () => {
+    // A stored zero is a real claim ("this scope may spend nothing"), unlike an absent row. The
+    // dollar variance is meaningful; the percentage is undefined rather than infinite.
+    const c = budgetVsActual(demoSeries(), [monthBudget({ amount_micro: 0 })]);
+    expect(c.budget?.amountMicroUsd).toBe(0);
+    expect(c.varianceMicroUsd).toBe(700 * USD);
+    expect(c.variancePct).toBeNull();
+    expect(c.consumedFraction).toBeNull();
+  });
+
+  it("flags a budget that started after the period did", () => {
+    const mid = monthBudget({ starts_on: "2026-08-03" });
+    expect(budgetVsActual(demoSeries(), [mid]).budget?.coversPeriodToDate).toBe(false);
+    expect(budgetVsActual(demoSeries(), [monthBudget()]).budget?.coversPeriodToDate).toBe(true);
+  });
+
+  it("splits by layer, ordered by spend, so the variance is attributable", () => {
+    const c = budgetVsActual(demoSeries(), [monthBudget({ amount_micro: 500 * USD })]);
+    expect(c.layers.map((l) => l.layer)).toEqual([
+      "llm",
+      "compute",
+      "vector",
+      "tools",
+      "embeddings",
+      "egress",
+    ]);
+    const [llm, compute] = c.layers;
+    expect(llm.actualMicroUsd).toBe(450 * USD);
+    expect(compute.actualMicroUsd).toBe(250 * USD);
+    expect(compute.shareOfActual).toBeCloseTo(250 / 700);
+    // "Half the budget went on compute" is the actionable half of this section.
+    expect(compute.shareOfTenantBudget).toBeCloseTo(0.5);
+    // The layer split adds up to the headline actual.
+    expect(c.layers.reduce((s, l) => s + l.actualMicroUsd, 0)).toBe(c.actualMicroUsd);
+    // No layer-scoped budget configured: blanks, not zeros.
+    expect(c.layers.every((l) => l.budgetMicroUsd === null && l.varianceMicroUsd === null)).toBe(
+      true,
+    );
+  });
+
+  it("uses a layer-scoped budget when one is configured", () => {
+    const budgets = [
+      monthBudget({ amount_micro: 500 * USD }),
+      monthBudget({
+        budget_id: "compute-month",
+        scope_kind: "layer",
+        scope_value: "compute",
+        amount_micro: 200 * USD,
+      }),
+    ];
+    const c = budgetVsActual(demoSeries(), budgets);
+    const compute = c.layers.find((l) => l.layer === "compute");
+    expect(compute?.budgetMicroUsd).toBe(200 * USD);
+    expect(compute?.varianceMicroUsd).toBe(50 * USD);
+    expect(compute?.variancePct).toBeCloseTo(0.25);
+    // Other layers stay blank rather than inheriting the tenant budget.
+    expect(c.layers.find((l) => l.layer === "llm")?.budgetMicroUsd).toBeNull();
+  });
+
+  it("holds up when nothing has settled yet", () => {
+    const s = series({
+      periodStart: "2026-08-01",
+      windowEnd: "2026-08-01",
+      days: [
+        {
+          date: "2026-08-01",
+          byLayer: layers({ llm: 5 * USD }),
+          settled: false,
+          inProgress: true,
+        },
+      ],
+    });
+    const c = budgetVsActual(s, [monthBudget({ amount_micro: 500 * USD })]);
+    expect(c.actualMicroUsd).toBe(0);
+    expect(c.coverage).toMatchObject({ from: null, through: null, dayCount: 0, contiguous: true });
+    // A zero actual against a real budget is a real variance: the tenant has spent nothing that
+    // has settled. What must NOT happen is a share-of-total computed by dividing by zero.
+    expect(c.varianceMicroUsd).toBe(-500 * USD);
+    expect(c.layers.every((l) => l.shareOfActual === null)).toBe(true);
+    expect(c.excluded.microUsd).toBe(5 * USD);
+  });
+
+  it("does not project: the variance is actual minus the full budget, never pro-rated", () => {
+    // Day 3 of a 31-day month, 700 spent against a 1000 budget. A pro-rated comparison would call
+    // this wildly over; the measured one is 300 under, and the elapsed fraction is what tells the
+    // reader how little that means yet. CTO-210 owns the projection.
+    const c = budgetVsActual(demoSeries(), [monthBudget({ amount_micro: 1000 * USD })]);
+    expect(c.varianceMicroUsd).toBe(700 * USD - 1000 * USD);
+    expect(c.period.daysElapsed).toBe(5);
+    expect(c.period.daysInPeriod).toBe(31);
+  });
+});

--- a/web/lib/budgetVsActual.ts
+++ b/web/lib/budgetVsActual.ts
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+// Month-to-date actual versus budget (CTO-209, F5). Pure functions, no I/O, no clock.
+//
+// This is the MEASURED half of the spend-forecasting epic and deliberately nothing more. It ships
+// before the projection (CTO-210) because it is useful immediately and cannot be wrong about the
+// future: every number here is something that already happened. It also puts the budget somebody
+// entered in CTO-205 in front of them, so they find out whether that number is right before a
+// forecast starts depending on it.
+//
+// NOTHING IN THIS FILE PROJECTS. There is no run-rate, no pro-rating of the budget by elapsed days,
+// no month-end estimate. A pro-rated "expected spend so far" looks measured but is a flat-run-rate
+// projection wearing a disguise, and the scope doc is explicit that the projection is a separate,
+// day-of-week weighted thing with a confidence band. So the variance here is exactly
+// `month-to-date actual - full-period budget`, and the elapsed fraction is reported ALONGSIDE it so
+// a reader can see that "under budget" on day 3 means very little. See `web/lib/forecast.ts` and
+// docs/spend-forecasting-scope.md for the half that does project.
+//
+// THE THREE HONESTY RULES THIS MODULE ENFORCES
+//
+//  1. No budget row is a normal state, never an implicit zero. `budget` comes back null and every
+//     variance field comes back null with `noBudgetReason` set, so the UI renders the actual spend
+//     and a blank instead of reporting the tenant as infinitely over a budget of zero. This mirrors
+//     the rule stated in `gateway/tenant_budgets.py`.
+//
+//  2. The figure states which days it covers. The actual is summed over SETTLED days only (the
+//     rule from CTO-207, see `querySettledCostSeries`), and `coverage` names the first and last of
+//     them and how many there are. A figure that cannot say what it measured is not auditable.
+//
+//  3. The excluded days are quantified, not just mentioned. `excluded` carries the dollars and the
+//     share of observed month-to-date that settlement withheld. Without it this number silently
+//     disagrees with the 30-day headline higher up the same page and the page looks broken. On the
+//     demo tenant the gap is ~10 percent, which is far too big to leave unexplained.
+//
+// A stored budget of zero is a real claim ("this scope may spend nothing"), so it is compared
+// normally in dollars; only the PERCENT variance is null, because dividing by it is undefined
+// rather than infinite. Absence of a row is the thing that means "no budget".
+//
+// Money is integer micro-USD throughout. Dates are `YYYY-MM-DD` UTC strings supplied by the caller
+// (ClickHouse's clock, via the series), never generated here: same input, same output, in tests and
+// in CI.
+
+import { LAYERS, type Layer } from "./cost";
+import type { MicroUSD, SpendByLayer } from "./types";
+
+/** Period we compare over. The series' period window is a calendar month, so this section is
+ * month-only; a quarterly budget is not silently compared against a month of spend. */
+export const COMPARED_PERIOD = "month";
+
+/** One budget row as `GET /v1/tenant/budgets` returns it (CTO-205). Snake case is the wire shape. */
+export interface TenantBudget {
+  budget_id: string;
+  period: string;
+  amount_micro: number;
+  scope_kind: string;
+  scope_value: string;
+  starts_on: string;
+  ends_on: string | null;
+}
+
+/**
+ * The fields of `SettledSpendSeries` (CTO-207) this comparison needs, restated structurally so this
+ * module imports nothing from `clickhouse.ts` and stays trivially testable. A real
+ * `SettledSpendSeries` satisfies it.
+ */
+export interface SettledSeriesLike {
+  periodStart: string;
+  windowEnd: string;
+  settledThrough: string | null;
+  rule: "connector-landing" | "day-complete";
+  connectorLayers: readonly string[];
+  days: readonly {
+    date: string;
+    byLayer: SpendByLayer;
+    totalMicroUsd: MicroUSD;
+    inPeriod: boolean;
+    settled: boolean;
+    inProgress: boolean;
+    awaitingLayers: readonly string[];
+  }[];
+  periodSettled: { dayCount: number; byLayer: SpendByLayer; totalMicroUsd: MicroUSD };
+  periodObserved: { dayCount: number; byLayer: SpendByLayer; totalMicroUsd: MicroUSD };
+}
+
+/** Which days the actual was summed over. Days may be non-contiguous, hence a count as well. */
+export interface CoverageWindow {
+  /** Oldest settled day inside the period, or null when none has settled yet. */
+  from: string | null;
+  /** Newest settled day inside the period, or null when none has settled yet. */
+  through: string | null;
+  /** How many days were counted. Not `through - from`: a mid-month day can be withheld. */
+  dayCount: number;
+  /** True when the counted days run without a gap. False means a day inside the range was withheld. */
+  contiguous: boolean;
+  /** Which settled rule applied, verbatim from CTO-207. */
+  rule: "connector-landing" | "day-complete";
+  /** Connector layers settlement waits on. Empty under the `day-complete` rule. */
+  waitsOn: readonly string[];
+}
+
+/** A day inside the period that the actual does NOT include, and why. */
+export interface ExcludedDay {
+  date: string;
+  /** What has landed for it so far. Shown so the exclusion is quantified rather than asserted. */
+  observedMicroUsd: MicroUSD;
+  /** True for today, which is still accruing by definition. */
+  inProgress: boolean;
+  /** Connector layers with no row for this day yet. Empty when `inProgress`. */
+  awaitingLayers: readonly string[];
+}
+
+export interface ExcludedSummary {
+  days: ExcludedDay[];
+  /** Dollars withheld: observed month-to-date minus settled month-to-date. */
+  microUsd: MicroUSD;
+  /** Share of OBSERVED month-to-date that is withheld, or null when nothing has been observed. */
+  shareOfObserved: number | null;
+}
+
+/** Calendar progress through the period. Measured, not projected. */
+export interface PeriodProgress {
+  /** First day of the calendar month. */
+  start: string;
+  /** Last day of the calendar month. */
+  end: string;
+  /** Today per ClickHouse. */
+  today: string;
+  daysInPeriod: number;
+  /** Days from `start` through `today` INCLUSIVE, so today counts as the day in progress. */
+  daysElapsed: number;
+  /** `daysElapsed / daysInPeriod`, 0..1. */
+  elapsedFraction: number;
+}
+
+/** One cost layer's line in the split. */
+export interface LayerLine {
+  layer: Layer;
+  /** Settled month-to-date spend for this layer. */
+  actualMicroUsd: MicroUSD;
+  /** This layer's share of settled month-to-date spend, or null when the total is zero. */
+  shareOfActual: number | null;
+  /** This layer's spend as a share of the TENANT budget, or null when no tenant budget applies. */
+  shareOfTenantBudget: number | null;
+  /** A layer-scoped budget when one is configured (CTO-205 scope_kind='layer'), else null. */
+  budgetMicroUsd: MicroUSD | null;
+  /** Positive = over this layer's own budget. Null when no layer budget is configured. */
+  varianceMicroUsd: MicroUSD | null;
+  /** Null when no layer budget applies, or when that budget is zero (undefined, not infinite). */
+  variancePct: number | null;
+}
+
+export interface AppliedBudget {
+  budgetId: string;
+  amountMicroUsd: MicroUSD;
+  startsOn: string;
+  endsOn: string | null;
+  /**
+   * True when the budget covered the whole month-to-date span. False means it started mid-period,
+   * so a full-period budget is being compared against spend from before it existed, and the UI has
+   * to say so rather than quietly report the variance.
+   */
+  coversPeriodToDate: boolean;
+}
+
+export interface BudgetVsActual {
+  period: PeriodProgress;
+  /** Settled month-to-date spend. THE actual: every other figure hangs off it. */
+  actualMicroUsd: MicroUSD;
+  /** Month-to-date including unsettled days. Diagnostic, never the headline. */
+  observedMicroUsd: MicroUSD;
+  coverage: CoverageWindow;
+  excluded: ExcludedSummary;
+  /** The one monthly tenant-wide budget covering today, or null when none is set. */
+  budget: AppliedBudget | null;
+  /** Non-null exactly when `budget` is null. A real sentence, for `<Blank reason>`. */
+  noBudgetReason: string | null;
+  /** Positive = over budget. Null when no budget applies. The sign is the point of this section. */
+  varianceMicroUsd: MicroUSD | null;
+  /** Variance as a fraction of budget. Null with no budget, and null when the budget is zero. */
+  variancePct: number | null;
+  /** Fraction of budget consumed so far. Null with no budget, and null when the budget is zero. */
+  consumedFraction: number | null;
+  /** Every layer, ordered by settled spend descending. Zero layers are kept: a real zero. */
+  layers: LayerLine[];
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function utc(date: string): number {
+  return Date.parse(`${date}T00:00:00Z`);
+}
+
+/** Inclusive day count from `from` through `to`. Both are `YYYY-MM-DD` UTC. */
+export function daysBetweenInclusive(from: string, to: string): number {
+  return Math.round((utc(to) - utc(from)) / MS_PER_DAY) + 1;
+}
+
+/** Last calendar day of the month containing `date`. */
+export function endOfMonth(date: string): string {
+  const [y, m] = date.split("-").map(Number);
+  // Day 0 of the next month is the last day of this one.
+  return new Date(Date.UTC(y, m, 0)).toISOString().slice(0, 10);
+}
+
+/**
+ * Calendar progress through the period. `today` counts as elapsed: it is the day in progress, and
+ * "day 26 of 31" is how a reader thinks about it. The UI states the day numbers next to the
+ * fraction so nobody has to guess whether the in-progress day was counted.
+ */
+export function periodProgress(periodStart: string, today: string): PeriodProgress {
+  const end = endOfMonth(periodStart);
+  const daysInPeriod = daysBetweenInclusive(periodStart, end);
+  const daysElapsed = Math.min(Math.max(daysBetweenInclusive(periodStart, today), 0), daysInPeriod);
+  return {
+    start: periodStart,
+    end,
+    today,
+    daysInPeriod,
+    daysElapsed,
+    elapsedFraction: daysInPeriod > 0 ? daysElapsed / daysInPeriod : 0,
+  };
+}
+
+/**
+ * The one budget covering `onDate` for a scope, or null.
+ *
+ * CTO-205 refuses overlapping budgets at write time with a gist EXCLUDE constraint, so at most one
+ * row can match. The sort is not a tie-break policy, then: it is only there so that if that
+ * invariant is ever broken (a bad backfill, a dropped constraint) this renders deterministically
+ * instead of flickering between two budgets on alternate polls. Newest start wins because it is the
+ * most recent statement of intent.
+ *
+ * Only `period === 'month'` is considered. The series' period window is a calendar month, so
+ * comparing a quarterly budget here would put a quarter's dollars against a month of spend and
+ * report every tenant as comfortably under.
+ */
+export function selectBudget(
+  budgets: readonly TenantBudget[],
+  scopeKind: string,
+  scopeValue: string,
+  onDate: string,
+): TenantBudget | null {
+  const matches = budgets
+    .filter(
+      (b) =>
+        b.period === COMPARED_PERIOD &&
+        b.scope_kind === scopeKind &&
+        b.scope_value === scopeValue &&
+        b.starts_on <= onDate &&
+        (b.ends_on === null || b.ends_on >= onDate),
+    )
+    .sort((a, b) =>
+      a.starts_on === b.starts_on
+        ? a.budget_id.localeCompare(b.budget_id)
+        : b.starts_on.localeCompare(a.starts_on),
+    );
+  return matches[0] ?? null;
+}
+
+function ratio(part: number, whole: number): number | null {
+  // Zero denominator is undefined, not infinite, and not zero. Callers render a blank.
+  return whole === 0 ? null : part / whole;
+}
+
+/**
+ * Month-to-date actual versus budget, split by layer.
+ *
+ * `series` is `querySettledCostSeries()`'s result and `budgets` is `GET /v1/tenant/budgets`. The
+ * caller handles the ClickHouse-unreachable case (`series === null`) before getting here: this
+ * function has no way to render "we do not know" and must not invent a zero for it.
+ */
+export function budgetVsActual(
+  series: SettledSeriesLike,
+  budgets: readonly TenantBudget[],
+): BudgetVsActual {
+  const period = periodProgress(series.periodStart, series.windowEnd);
+
+  const inPeriod = series.days.filter((d) => d.inPeriod);
+  const settledDays = inPeriod.filter((d) => d.settled).map((d) => d.date);
+  const excludedDays: ExcludedDay[] = inPeriod
+    .filter((d) => !d.settled)
+    .map((d) => ({
+      date: d.date,
+      observedMicroUsd: d.totalMicroUsd,
+      inProgress: d.inProgress,
+      awaitingLayers: d.awaitingLayers,
+    }));
+
+  const actualMicroUsd = series.periodSettled.totalMicroUsd;
+  const observedMicroUsd = series.periodObserved.totalMicroUsd;
+  const excludedMicroUsd = observedMicroUsd - actualMicroUsd;
+
+  const from = settledDays[0] ?? null;
+  const through = settledDays[settledDays.length - 1] ?? null;
+  const coverage: CoverageWindow = {
+    from,
+    through,
+    dayCount: settledDays.length,
+    // Non-contiguous means a day INSIDE the counted range was withheld, which is a different and
+    // more surprising statement than "the last day or two have not landed".
+    contiguous:
+      from === null || through === null
+        ? true
+        : daysBetweenInclusive(from, through) === settledDays.length,
+    rule: series.rule,
+    waitsOn: series.connectorLayers,
+  };
+
+  const tenantBudget = selectBudget(budgets, "tenant", "", period.today);
+  const budget: AppliedBudget | null = tenantBudget
+    ? {
+        budgetId: tenantBudget.budget_id,
+        amountMicroUsd: tenantBudget.amount_micro,
+        startsOn: tenantBudget.starts_on,
+        endsOn: tenantBudget.ends_on,
+        coversPeriodToDate: tenantBudget.starts_on <= period.start,
+      }
+    : null;
+
+  const layers: LayerLine[] = LAYERS.map((layer) => {
+    const layerActual = series.periodSettled.byLayer[layer];
+    const layerBudget = selectBudget(budgets, "layer", layer, period.today);
+    return {
+      layer,
+      actualMicroUsd: layerActual,
+      shareOfActual: ratio(layerActual, actualMicroUsd),
+      shareOfTenantBudget: budget ? ratio(layerActual, budget.amountMicroUsd) : null,
+      budgetMicroUsd: layerBudget ? layerBudget.amount_micro : null,
+      varianceMicroUsd: layerBudget ? layerActual - layerBudget.amount_micro : null,
+      variancePct: layerBudget
+        ? ratio(layerActual - layerBudget.amount_micro, layerBudget.amount_micro)
+        : null,
+    };
+  }).sort((a, b) => b.actualMicroUsd - a.actualMicroUsd);
+
+  return {
+    period,
+    actualMicroUsd,
+    observedMicroUsd,
+    coverage,
+    excluded: {
+      days: excludedDays,
+      microUsd: excludedMicroUsd,
+      shareOfObserved: ratio(excludedMicroUsd, observedMicroUsd),
+    },
+    budget,
+    noBudgetReason: budget
+      ? null
+      : "no monthly tenant-wide budget is set, so there is nothing to compare this against",
+    varianceMicroUsd: budget ? actualMicroUsd - budget.amountMicroUsd : null,
+    variancePct: budget ? ratio(actualMicroUsd - budget.amountMicroUsd, budget.amountMicroUsd) : null,
+    consumedFraction: budget ? ratio(actualMicroUsd, budget.amountMicroUsd) : null,
+    layers,
+  };
+}

--- a/web/lib/tenantBudgetsClient.ts
+++ b/web/lib/tenantBudgetsClient.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Read this tenant's budgets from the gateway (CTO-209, F5; endpoint from CTO-205, F1).
+//
+// Server-only, imported by Route Handlers. The dashboard never touches Postgres directly, same rule
+// as `lib/tenant.ts` and `lib/allocationConfig.ts`; the gateway owns the control plane.
+//
+// WHY THIS DOES NOT FALL BACK TO AN EMPTY LIST. `lib/tenant.ts` degrades to `["llm"]` when the
+// gateway is unreachable, and that is right for it: the worst case is a banner that stays quiet.
+// Here the same move is a lie. "No budget is set" and "we could not ask" produce very different
+// screens: the first is a real state with a call to action, the second must render a blank saying
+// the control plane is unreachable. Returning `[]` on a timeout would tell a tenant who has a
+// budget that they have none, and would hide a broken gateway behind a plausible screen. So the
+// result is a discriminated union and the caller has to handle both.
+
+import type { TenantBudget } from "./budgetVsActual";
+
+const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+/** A slow control plane must not hold a page render open. Matches `lib/tenant.ts`. */
+const TIMEOUT_MS = 2000;
+
+interface TenantBudgetsResponse {
+  tenant_id: string;
+  budgets: TenantBudget[];
+  configured: boolean;
+}
+
+export type TenantBudgetsResult =
+  /** The gateway answered. `budgets` may be empty, which is a real "no budget set". */
+  | { ok: true; budgets: TenantBudget[] }
+  /** We could not ask. NOT the same as an empty list; the caller renders a blank, not a zero. */
+  | { ok: false; error: string };
+
+export async function fetchTenantBudgets(): Promise<TenantBudgetsResult> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
+      headers: { "x-tenant-id": TENANT },
+      cache: "no-store",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      // A 404 here means the gateway does not know this tenant, which is a misconfiguration and
+      // emphatically not "this tenant set no budgets". Both are surfaced as an error for that
+      // reason: the screen should say we could not read the budget, not invent a state.
+      return { ok: false, error: `gateway HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as TenantBudgetsResponse;
+    return { ok: true, budgets: Array.isArray(body.budgets) ? body.budgets : [] };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}


### PR DESCRIPTION
## What

A **Month to date vs budget** section on `/cost` (CTO-209, F5): month-to-date actual, the budget, the variance in dollars and percent, how much of the period has elapsed, and a split by cost layer.

Not a new tab. It is the same question a reader already came to `/cost` with, per `docs/spend-forecasting-scope.md`.

**No projection.** That is CTO-210. In particular the budget is **not pro-rated** by elapsed days: a pro-rated "expected spend so far" is a flat run-rate projection wearing a disguise. The variance here is `month-to-date actual - full-period budget`, with the elapsed fraction printed beside it so "under budget" on day 3 cannot read as "on track".

## Both states, live, against the local demo tenant

Verified in a browser on 2026-08-26 against the real stack: ClickHouse and Postgres from `docker compose`, and the gateway run directly with `uvicorn` on port 8081 against the same Postgres and ClickHouse (the running gateway container predates CTO-205 and 404s on `/v1/tenant/budgets`; Docker Hub is unreachable from this machine so the image could not be rebuilt). Web dev server on port 3218 from this worktree.

### 1. No budget configured (the state every tenant is in today)

```
MONTH TO DATE VS BUDGET
—                       MONTH TO DATE   BUDGET (MONTH)
No budget to compare      $81,827.49        —
against
                        BUDGET CONSUMED  PERIOD ELAPSED
Month to date is             —            day 26 of 31  84%
$81,827.49. Set a
monthly budget to see
a variance here.
```

The actual renders. The variance does not exist rather than being computed against zero. The blank carries its reason on hover and to a screen reader (`no monthly tenant-wide budget is set, so there is nothing to compare this against`) and links to `/settings/budgets`, which CTO-208 owns.

### 2. Budget configured

Created through the F1 endpoint (`POST /v1/tenant/budgets`, `amount_micro: 75000000000` tenant-wide plus `30000000000` scoped to the compute layer, both for 2026-08), and **deleted again afterwards**; `tenant_budgets` is back to 0 rows.

```
MONTH TO DATE VS BUDGET
+$6,827.49 over          MONTH TO DATE   BUDGET (MONTH)
+9.1% of the month         $81,827.49      $75,000.00
budget, measured,
not projected            BUDGET CONSUMED  PERIOD ELAPSED
                           109.1%         day 26 of 31  84%

BY LAYER: WHERE THE OVERAGE IS
LAYER        MONTH TO DATE  SHARE OF SPEND  SHARE OF BUDGET  LAYER BUDGET  VARIANCE
LLM             $44,704.83          54.6%            59.6%         —          —
Compute         $36,975.33          45.2%            49.3%  $30,000.00  +$6,975.33
Egress             $147.33           0.2%             0.2%         —          —
Vector DB            $0.00           0.0%             0.0%         —          —
Tool calls           $0.00           0.0%             0.0%         —          —
Embeddings           $0.00           0.0%             0.0%         —          —
```

The tenant is 9.1 percent over and compute is the reason: it is $6,975.33 over its own layer budget, which is more than the whole tenant overage. That is the case the layer split exists for. The last two columns appear only when layer-scoped budgets exist, so a tenant without them does not get six columns of blanks.

## Which days were counted

Verbatim from the card, on live data:

> Counts 23 settled days, 2026-08-01 through 2026-08-23. A day counts once it is complete and compute and egress have landed for it (rule: connector-landing).
> Excludes 3 days (2026-08-24, 2026-08-25, 2026-08-26) carrying $0.0001 so far, 0.0% of observed month to date, still waiting on compute and egress. Those days are why this figure need not match the 30-day total above.
> Observed month to date, settled and unsettled together, is $81,827.49.

So: **23 of the 26 elapsed days**, 2026-08-01 through 2026-08-23, chosen by CTO-207's `connector-landing` rule. The three excluded days carry essentially nothing on this tenant right now, which is why the copy states the gap in dollars rather than claiming a size for it. On a tenant whose cloud connectors are mid-flight the same line reports a real double-digit-percent gap, which is the case that would otherwise make this figure look like it disagrees with the 30-day headline directly above it.

## Honesty rules, each with a test

- **No budget is not zero.** Actual renders, variance is `null` everywhere, `<Blank reason>` carries a real sentence, and the link offers a way out. A **stored** zero is a different, deliberate claim and is compared normally in dollars; only its percentage is blank, because dividing by it is undefined rather than infinite.
- **The figure states its input window**, including when the settled days are non-contiguous.
- **The excluded days are quantified**, not merely mentioned.
- **Unreadable is not empty.** If ClickHouse or the gateway cannot be reached the card says so and shows nothing. There is no mock fallback on this surface, unlike the rest of `/cost`: invented spend next to a real budget would produce a fictional variance. The gateway client returns a discriminated union for the same reason and never degrades a timeout into "no budget set".
- A budget that starts mid-period is flagged, since the actual covers the whole month to date.

## Files

- `web/lib/budgetVsActual.ts` — pure, no I/O, no clock; every date comes from ClickHouse via the F3 series. 19 unit tests.
- `web/lib/tenantBudgetsClient.ts` — reads `GET /v1/tenant/budgets`.
- `web/app/api/cost/budget/route.ts` — always tenant-wide, even under `?tag=`.
- `web/app/cost/BudgetVsActualCard.tsx` — the section, using `DataTable` and `Money` / `Pct` / `Blank`. 4 render tests.
- `web/app/cost/{page,Live}.tsx` — fetch once per render and place the card under the 30-day headline.

Fetched once per render rather than joining the 5-second live poll: a budget changes about monthly and the settled window advances once a day, so polling it would multiply two ClickHouse reads and a gateway round trip by 720 an hour to redraw an identical section.

## Checks

From `web/`: `npm run typecheck` clean, `npm run lint` clean (only the two pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`), `npm run test` **499 passed**, up from 476, with only the two long-standing `app/api/api.test.ts` failures (attribution and data-quality "falls back to mock when ClickHouse is unreachable") that fail when a local ClickHouse is running.

## Coordination

CTO-208 (F4) is landing in parallel and owns `/settings/budgets`. This PR touches nothing under `web/app/settings/`, imports nothing from it, and links to that route by path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
