### PR TITLE
feat(cost): burn-down chart with confidence cone and breach date (CTO-210)

### DIFF
--- a/web/app/api/cost/budget/route.ts
+++ b/web/app/api/cost/budget/route.ts
@@ -9,6 +9,12 @@
 // fetched once per page render, server side, and the section states the days it covers instead of
 // pretending to be live.
 //
+// CTO-210 (F6) adds the burn-down section to the same payload rather than a second route. Both
+// sections are derived from ONE `querySettledCostSeries` result, so the measured month-to-date
+// figure and the projection can never be reading two different windows, and the forecast costs no
+// extra ClickHouse work at all: `burndownSection` is pure arithmetic over the series already read
+// for the comparison.
+//
 // The comparison is always TENANT-WIDE, even under /cost?tag=<feature>. The budget scopes in
 // CTO-205 include 'feature', but wiring the tag filter to a feature-scoped budget is the
 // scoped-budget phase of docs/spend-forecasting-scope.md, not this ticket, and silently comparing
@@ -17,10 +23,11 @@
 import { NextResponse } from "next/server";
 
 import { budgetVsActual } from "@/lib/budgetVsActual";
+import { burndownSection } from "@/lib/burndown";
 import { querySettledCostSeries } from "@/lib/clickhouse";
 import { fetchTenantBudgets } from "@/lib/tenantBudgetsClient";
 
-import type { BudgetPayload } from "@/app/cost/BudgetVsActualCard";
+import type { CostBudgetPayload } from "@/app/cost/BurndownCard";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -35,24 +42,32 @@ export async function GET() {
   // keeps a fresh clone looking alive; here it would put invented spend next to a budget somebody
   // really set and produce a variance that is pure fiction. "We cannot read the spend" is the only
   // honest answer, and the section renders it as a blank with this reason attached.
+  // The same reason blanks both sections: a projection built on invented spend and compared against
+  // a budget somebody really set would be fiction with a date attached, which is worse here than on
+  // the measured card because a reader would act on it days in advance.
   if (!series) {
-    const payload: BudgetPayload = {
+    const reason = "spend data is unavailable: ClickHouse is unreachable from the dashboard";
+    const payload: CostBudgetPayload = {
       comparison: null,
-      unavailable: "spend data is unavailable: ClickHouse is unreachable from the dashboard",
+      unavailable: reason,
+      forecast: { section: null, unavailable: reason },
     };
     return NextResponse.json(payload);
   }
   if (!budgets.ok) {
-    const payload: BudgetPayload = {
+    const reason = `the budget could not be read: gateway unreachable (${budgets.error})`;
+    const payload: CostBudgetPayload = {
       comparison: null,
-      unavailable: `the budget could not be read: gateway unreachable (${budgets.error})`,
+      unavailable: reason,
+      forecast: { section: null, unavailable: reason },
     };
     return NextResponse.json(payload);
   }
 
-  const payload: BudgetPayload = {
+  const payload: CostBudgetPayload = {
     comparison: budgetVsActual(series, budgets.budgets),
     unavailable: null,
+    forecast: { section: burndownSection(series, budgets.budgets), unavailable: null },
   };
   return NextResponse.json(payload);
 }

--- a/web/app/cost/BurndownCard.test.tsx
+++ b/web/app/cost/BurndownCard.test.tsx
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// The four states that have to be right on this section (CTO-210): a projected breach with its
+// date, a projection that stays under, no budget configured, and not enough history to project at
+// all. Each is an honesty requirement of the ticket, and the last two are the ones that regress
+// quietly: rendering a cone below the history floor, or letting "we cannot say" read like "you are
+// fine", both look completely normal on screen.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { SettledSeriesLike, TenantBudget } from "@/lib/budgetVsActual";
+import { burndownSection } from "@/lib/burndown";
+import { LAYERS } from "@/lib/cost";
+import type { SpendByLayer } from "@/lib/types";
+
+import { BurndownCard } from "./BurndownCard";
+
+const USD = 1_000_000;
+
+function layers(over: Partial<SpendByLayer> = {}): SpendByLayer {
+  return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0, ...over };
+}
+
+function addDays(iso: string, n: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d + n)).toISOString().slice(0, 10);
+}
+
+/** One row of `SettledSeriesLike["days"]`, mutable so the fixtures can be built up in a loop. */
+type DayRow = {
+  date: string;
+  byLayer: SpendByLayer;
+  totalMicroUsd: number;
+  inPeriod: boolean;
+  settled: boolean;
+  inProgress: boolean;
+  awaitingLayers: string[];
+};
+
+/** `settledDays` complete days ending yesterday, plus today still accruing. */
+function series(settledDays: number, today = "2026-08-20"): SettledSeriesLike {
+  const perDay = 100 * USD;
+  const days: DayRow[] = [];
+  for (let i = settledDays; i >= 1; i -= 1) {
+    days.push({
+      date: addDays(today, -i),
+      byLayer: layers({ llm: 70 * USD, compute: 30 * USD }),
+      totalMicroUsd: perDay,
+      inPeriod: addDays(today, -i) >= "2026-08-01",
+      settled: true,
+      inProgress: false,
+      awaitingLayers: [],
+    });
+  }
+  days.push({
+    date: today,
+    byLayer: layers({ llm: 35 * USD, compute: 15 * USD }),
+    totalMicroUsd: 50 * USD,
+    inPeriod: true,
+    settled: false,
+    inProgress: true,
+    awaitingLayers: [],
+  });
+  const totals = (keep: (d: DayRow) => boolean) => {
+    const byLayer = layers();
+    let totalMicroUsd = 0;
+    let dayCount = 0;
+    for (const d of days.filter(keep)) {
+      dayCount += 1;
+      totalMicroUsd += d.totalMicroUsd;
+      for (const l of LAYERS) byLayer[l] += d.byLayer[l];
+    }
+    return { dayCount, byLayer, totalMicroUsd };
+  };
+  const settledDates = days.filter((d) => d.settled).map((d) => d.date);
+  return {
+    periodStart: "2026-08-01",
+    windowEnd: today,
+    settledThrough: settledDates[settledDates.length - 1] ?? null,
+    rule: "connector-landing",
+    connectorLayers: ["compute", "egress"],
+    days,
+    periodSettled: totals((d) => d.inPeriod && d.settled),
+    periodObserved: totals((d) => d.inPeriod),
+  };
+}
+
+function budget(amountUsd: number): TenantBudget {
+  return {
+    budget_id: "tenant-month",
+    period: "month",
+    amount_micro: amountUsd * USD,
+    scope_kind: "tenant",
+    scope_value: "",
+    starts_on: "2026-01-01",
+    ends_on: null,
+  };
+}
+
+function renderSection(settledDays: number, budgets: TenantBudget[]) {
+  return render(
+    <BurndownCard
+      payload={{ section: burndownSection(series(settledDays), budgets), unavailable: null }}
+    />,
+  );
+}
+
+describe("BurndownCard", () => {
+  it("labels the breach date on the chart and in the headline", () => {
+    const { container } = renderSection(20, [budget(2_400)]);
+    // In the headline, in words: the single most useful output of the feature.
+    expect(screen.getByTestId("burndown-headline").textContent).toContain(
+      "Crosses budget 2026-08-24",
+    );
+    // And on the chart itself, so it survives being screenshotted out of context.
+    expect(container.querySelector("svg")?.textContent).toContain("crosses budget 2026-08-24");
+    // The chart's own sentence names the outcome rather than describing shapes.
+    expect(container.querySelector("svg")?.getAttribute("aria-label")).toContain(
+      "crossing the",
+    );
+  });
+
+  it("says a projection that stays under budget is a projection, not a guarantee", () => {
+    const { container } = renderSection(20, [budget(100_000)]);
+    const headline = screen.getByTestId("burndown-headline").textContent ?? "";
+    expect(headline).toContain("None this period");
+    expect(headline).toContain("forecast, not a commitment");
+    // No breach marker anywhere on the chart.
+    expect(container.querySelector("svg")?.textContent).not.toContain("crosses budget");
+  });
+
+  it("renders no budget as its own state, with a way to set one and no invented variance", () => {
+    renderSection(20, []);
+    const headline = screen.getByTestId("burndown-headline").textContent ?? "";
+    expect(headline).toContain("No budget is set");
+    expect(headline).toContain("rather than compared against a budget of zero");
+    expect(screen.getByRole("link", { name: /set a monthly budget/i })).toHaveProperty("href");
+    // A projection is still shown: no budget is not a reason to withhold the forecast.
+    expect(headline).toMatch(/\$/);
+  });
+
+  it("draws NO cone below the minimum history and says it is not a claim of safety", () => {
+    const { container } = renderSection(5, [budget(2_400)]);
+    const panel = screen.getByTestId("burndown-insufficient-history").textContent ?? "";
+    expect(panel).toContain("Not enough history to project");
+    expect(panel).toContain("5 settled days");
+    expect(panel).toContain("14");
+    // The load-bearing sentence: `cannot_project` must not read like `never`.
+    expect(panel).toContain("This is not a statement that spend is under control");
+    // No chart at all. Not a faint one, not an empty frame: none.
+    expect(container.querySelector("svg")).toBeNull();
+    expect(screen.queryByTestId("burndown-headline")).toBeNull();
+  });
+
+  it("states the input window in every state, including the refusal", () => {
+    const { container: projected } = renderSection(20, [budget(2_400)]);
+    expect(projected.textContent).toContain("Projected from 20 settled days");
+    expect(projected.textContent).toContain("2026-08-19");
+    expect(projected.textContent).toContain("rule: connector-landing");
+    // The excluded in-progress day, quantified in dollars rather than merely mentioned.
+    expect(projected.textContent).toContain("2026-08-20");
+    expect(projected.textContent).toMatch(/Excludes 1 day/);
+
+    const { container: refused } = renderSection(5, [budget(2_400)]);
+    expect(refused.textContent).toContain("Projected from 5 settled days");
+    expect(refused.textContent).toContain("rule: connector-landing");
+  });
+
+  it("names the layer behind the projection rather than only the total", () => {
+    const { container } = renderSection(20, [budget(2_400)]);
+    expect(container.textContent).toContain("By layer: what the projection is made of");
+    // 70/30 llm/compute in the fixture, so LLM is the reason.
+    expect(container.textContent).toMatch(/LLM is the largest part of it/);
+    expect(container.textContent).toContain("Share of projection");
+  });
+
+  it("blanks the whole section with a reason when the data could not be read", () => {
+    render(
+      <BurndownCard
+        payload={{ section: null, unavailable: "ClickHouse is unreachable from the dashboard" }}
+      />,
+    );
+    expect(screen.getByText(/No forecast:/).textContent).toContain(
+      "ClickHouse is unreachable from the dashboard",
+    );
+  });
+});

--- a/web/app/cost/BurndownCard.tsx
+++ b/web/app/cost/BurndownCard.tsx
@@ -1,0 +1,526 @@
+// SPDX-License-Identifier: Apache-2.0
+// The burn-down section of /cost (CTO-210, F6): projection, confidence cone, breach date.
+//
+// It sits directly under the month-to-date card (CTO-209) because the two answer halves of one
+// question. That card is everything that has already happened; this one is the only thing on the
+// page that talks about the future, and the seam between them has to be obvious.
+//
+// THE BREACH DATE IS THE PRODUCT. "You cross budget on the 22nd" beats any percentage and arrives
+// days before a threshold alert would, so it is the largest thing in the section and it is printed
+// in words as well as marked on the chart. Everything else here exists to let a reader decide
+// whether to believe it.
+//
+// FOUR HONESTY REQUIREMENTS, all load-bearing, each of which this file would fail silently without:
+//
+//  1. NO CONE BELOW THE HISTORY FLOOR. `forecastSpend` returns `insufficient_history` and this card
+//     renders no chart at all, states how many settled days it has out of the fourteen it needs,
+//     and says explicitly that this is not the same as "you are fine". A day-2 projection is nearly
+//     meaningless and drawing one anyway is the fastest way to lose a customer's trust for good.
+//     Note what is NOT done here: there is no "preview" cone, no greyed-out chart, no reaching past
+//     the status into `burndown` (which is empty in that state anyway). The refusal is the feature.
+//
+//  2. THE INPUT WINDOW IS STATED. Which days fed the projection, how many there were, that
+//     unsettled days were excluded, and what those excluded days carry in dollars. On live data the
+//     settled window differs from the naive one by 10 to 11 percent, which is far too large to be a
+//     footnote: without this line the projection silently disagrees with the 30-day total further
+//     up the page and the reader concludes the page is broken.
+//
+//  3. IT SAYS IT IS A FORECAST. Once finance sees this number it becomes something people are
+//     measured against, so the section says out loud that it is a projection and not a commitment,
+//     next to the number rather than in a tooltip.
+//
+//  4. THE FOUR BREACH OUTCOMES RENDER DIFFERENTLY. `never` ("we projected, and it stays under") and
+//     `cannot_project` ("we did not project, so we are not claiming anything") are opposite
+//     statements and collapsing them into one calm green line would be a lie by layout.
+//
+// The chart's day axis is built from ClickHouse's dates, never the Node clock (CTO-203). The card
+// checks that the chart's own days still sum to the settled figure printed beside them and says so
+// on screen when they do not, the way the account detail view does with its allocation rows.
+
+import Link from "next/link";
+
+import { BurndownChart, BurndownLegend } from "@/components/BurndownChart";
+import { Card } from "@/components/Card";
+import { DataTable, type Column } from "@/components/DataTable";
+import { Blank, Money, Pct } from "@/components/HonestValue";
+import type { BurndownSection, ForecastPayload, LayerProjection } from "@/lib/burndown";
+import { LAYER_LABEL } from "@/lib/cost";
+
+import type { BudgetPayload } from "./BudgetVsActualCard";
+
+export type { ForecastPayload };
+
+/**
+ * The whole payload `/api/cost/budget` returns. One route, one ClickHouse read of the settled
+ * series, both sections: the month-to-date comparison (CTO-209) and this forecast (CTO-210) are
+ * computed from the SAME `querySettledCostSeries` result on purpose, so the measured figure and the
+ * projected one can never be reading two different windows.
+ */
+export interface CostBudgetPayload extends BudgetPayload {
+  forecast: ForecastPayload;
+}
+
+/** Where a budget is set. Same path the month-to-date card links to; CTO-208 owns that surface. */
+const BUDGET_SETTINGS_PATH = "/settings/budgets";
+
+export function BurndownCard({ payload }: { payload: ForecastPayload }) {
+  const section = payload.section;
+  if (!section) {
+    return (
+      <Card title="Projected month-end spend">
+        <div className="text-sm text-muted">
+          <Blank reason={payload.unavailable ?? "this forecast could not be computed"} /> No
+          forecast: {payload.unavailable ?? "this forecast could not be computed"}.
+        </div>
+      </Card>
+    );
+  }
+
+  const { forecast } = section;
+
+  return (
+    <Card title="Projected month-end spend">
+      {forecast.status === "insufficient_history" ? (
+        <InsufficientHistory section={section} />
+      ) : (
+        <>
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+            <Headline section={section} />
+            <Figures section={section} />
+          </div>
+
+          <div className="mt-5">
+            <BurndownChart
+              points={forecast.burndown}
+              budgetMicroUsd={section.budget ? section.budget.amountMicroUsd : null}
+              breach={forecast.breach}
+              naiveRunRateMicroUsd={forecast.naiveRunRateMicroUsd}
+              asOf={section.period.asOf}
+            />
+            <BurndownLegend hasBudget={section.budget !== null} />
+          </div>
+
+          <LayerSplit section={section} />
+        </>
+      )}
+
+      <Provenance section={section} />
+    </Card>
+  );
+}
+
+/**
+ * The refusal. No chart, no cone, no number, and a reason that names the floor and the shortfall.
+ *
+ * The last sentence is the important one. Refusing to project is not a claim of safety, and a
+ * reader who takes "no forecast" as "no problem" has been misled by us just as badly as one who
+ * took a day-2 number seriously.
+ */
+function InsufficientHistory({ section }: { section: BurndownSection }) {
+  const { window, period } = section;
+  const short = Math.max(0, window.requiredDays - window.dayCount);
+  return (
+    <div data-testid="burndown-insufficient-history">
+      <div className="text-2xl font-semibold text-muted">
+        <Blank reason={`only ${window.dayCount} settled days of history, ${window.requiredDays} are needed`} />{" "}
+        Not enough history to project
+      </div>
+      <p className="mt-2 max-w-prose text-sm text-muted">
+        This tenant has {window.dayCount} settled{" "}
+        {window.dayCount === 1 ? "day" : "days"} of history, and a projection needs{" "}
+        {window.requiredDays}.
+        {window.trimmedLeadingDays > 0 && window.firstObservedDay !== null ? (
+          <>
+            {" "}
+            Spend was first seen on {window.firstObservedDay}, so the {window.trimmedLeadingDays}{" "}
+            earlier {window.trimmedLeadingDays === 1 ? "day" : "days"} in the window are not counted
+            as history: they are days before this tenant was sending anything, not days it spent
+            nothing.
+          </>
+        ) : null} {short > 0 ? `${short} more ${short === 1 ? "day" : "days"} ` : "More history "}
+        will settle it. Fourteen days is two full weeks, which is the point: below that every weekday
+        has at most one observation and the day-of-week profile the projection rests on is a single
+        data point per weekday rather than a median.
+      </p>
+      <p className="mt-2 max-w-prose text-sm text-muted">
+        No cone is drawn here on purpose. A projection from this much data would be volatile enough
+        to be actively misleading, and drawing it faintly would still put a number on screen that
+        somebody would repeat in a meeting.
+      </p>
+      <p className="mt-2 max-w-prose text-sm text-warn">
+        This is not a statement that spend is under control. We are saying we do not know, which is
+        a different thing from &ldquo;this will not breach&rdquo;. Month to date is{" "}
+        <Money micro={section.settledPeriodMicroUsd} /> across days {period.start} to{" "}
+        {period.asOf ?? period.start}
+        {section.budget ? (
+          <>
+            {" "}
+            against a <Money micro={section.budget.amountMicroUsd} /> budget
+          </>
+        ) : null}
+        .
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The breach date, or the specific reason there is not one. Four outcomes, four different shapes.
+ */
+function Headline({ section }: { section: BurndownSection }) {
+  const { breach } = section.forecast;
+  const { budget, varianceMicroUsd, variancePct, period } = section;
+
+  if (breach.outcome === "no_budget") {
+    return (
+      <div data-testid="burndown-headline">
+        <div className="text-3xl font-semibold tabular-nums">
+          <Money micro={section.forecast.projectedMicroUsd} reason="nothing was projected" />
+        </div>
+        <div className="mt-1 text-sm text-muted">
+          projected for {period.start.slice(0, 7)}, a forecast and not a commitment
+        </div>
+        <p className="mt-3 max-w-prose text-sm text-muted">
+          <Blank reason={section.noBudgetReason ?? "no budget set"} /> No budget is set, so there is
+          no breach date and no variance: the projection is drawn without a reference line rather
+          than compared against a budget of zero.{" "}
+          <Link href={BUDGET_SETTINGS_PATH} className="text-accent underline">
+            Set a monthly budget
+          </Link>{" "}
+          to get one.
+        </p>
+      </div>
+    );
+  }
+
+  if (breach.outcome === "breaches" && breach.date !== null) {
+    return (
+      <div data-testid="burndown-headline">
+        <div className="text-xs uppercase tracking-wide text-muted">Forecast breach date</div>
+        <div className="mt-1 text-3xl font-semibold text-bad tabular-nums">
+          Crosses budget {breach.date}
+        </div>
+        <p className="mt-2 max-w-prose text-sm">
+          <span className="text-bad">
+            {varianceMicroUsd !== null && varianceMicroUsd > 0 ? "+" : ""}
+            <Money micro={varianceMicroUsd} reason="no budget to compare against" /> over
+          </span>
+          {variancePct === null ? null : (
+            <>
+              {" "}
+              (<Pct value={variancePct} />)
+            </>
+          )}{" "}
+          by {period.end}, on day {breach.dayIndex} of {section.forecast.daysInPeriod}. This is a
+          forecast, not a commitment: it is what the last {section.window.dayCount} settled days
+          imply, not a number anyone has agreed to.
+        </p>
+        {breach.earliestDate !== null && breach.earliestDate !== breach.date ? (
+          <p className="mt-2 max-w-prose text-sm text-muted">
+            The high edge of the band crosses as early as {breach.earliestDate}. That is the bad
+            case, not the likely one.
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  // `never`: we DID project, and it stays under. Said in those words, because the contrast with
+  // `cannot_project` (which never reaches this component) is the whole point of keeping them apart.
+  return (
+    <div data-testid="burndown-headline">
+      <div className="text-xs uppercase tracking-wide text-muted">Forecast breach date</div>
+      <div className="mt-1 text-3xl font-semibold text-good">None this period</div>
+      <p className="mt-2 max-w-prose text-sm">
+        <span className="text-good">
+          <Money micro={varianceMicroUsd === null ? null : Math.abs(varianceMicroUsd)} reason="no budget to compare against" />{" "}
+          under
+        </span>
+        {variancePct === null ? null : (
+          <>
+            {" "}
+            (<Pct value={Math.abs(variancePct)} />)
+          </>
+        )}{" "}
+        the <Money micro={budget?.amountMicroUsd ?? null} reason="no budget set" /> budget by{" "}
+        {period.end}. The projection stays under budget for every remaining day. This is a forecast,
+        not a commitment.
+      </p>
+      {breach.earliestDate !== null ? (
+        <p className="mt-2 max-w-prose text-sm text-warn">
+          The high edge of the band does cross, on {breach.earliestDate}. The likely path stays
+          under; the bad case does not.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** The supporting numbers, including the naive run-rate the chart draws as its sanity line. */
+function Figures({ section }: { section: BurndownSection }) {
+  const { forecast, budget } = section;
+  return (
+    <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
+      <Stat label="Projected month end">
+        <Money micro={forecast.projectedMicroUsd} reason="nothing was projected" />
+      </Stat>
+      <Stat label="Range (80% band)">
+        <span className="tabular-nums">
+          <Money micro={forecast.lowMicroUsd} reason="nothing was projected" /> to{" "}
+          <Money micro={forecast.highMicroUsd} reason="nothing was projected" />
+        </span>
+      </Stat>
+      <Stat label="Budget (month)">
+        <Money
+          micro={budget ? budget.amountMicroUsd : null}
+          reason={section.noBudgetReason ?? "no budget set"}
+        />
+      </Stat>
+      <Stat label="Settled month to date">
+        <Money micro={forecast.spendToDateMicroUsd} />
+      </Stat>
+      <Stat label="Naive run-rate">
+        {/* The dumb sanity line, printed as well as drawn: a reader who distrusts the weekday
+            weighting can compare the two without leaving the page. It is deliberately NOT the
+            headline, per scope Decision 1. */}
+        <Money micro={forecast.naiveRunRateMicroUsd} reason="nothing was projected" />
+      </Stat>
+      <Stat label="Days settled">
+        <span className="tabular-nums">
+          {forecast.daysElapsed} of {forecast.daysInPeriod}
+        </span>
+        <span className="ml-2 text-sm text-muted">{forecast.daysRemaining} to go</span>
+      </Stat>
+    </dl>
+  );
+}
+
+/**
+ * The layer split: the actionable half. A total says how bad; this says what to change.
+ *
+ * Each layer is projected independently by the same engine, so the rows do NOT have to sum to the
+ * headline, and the note below says so with the actual difference in dollars rather than letting a
+ * reader discover it by adding the column up.
+ */
+function LayerSplit({ section }: { section: BurndownSection }) {
+  const { layers, largestLayer, layerSumMicroUsd, forecast } = section;
+  const largest = layers.find((l) => l.layer === largestLayer) ?? null;
+  const over = section.varianceMicroUsd !== null && section.varianceMicroUsd > 0;
+  const gap =
+    layerSumMicroUsd === null || forecast.projectedMicroUsd === null
+      ? null
+      : layerSumMicroUsd - forecast.projectedMicroUsd;
+
+  return (
+    <div className="mt-5">
+      <h3 className="mb-2 text-xs uppercase tracking-wide text-muted">
+        By layer: what the projection is made of
+      </h3>
+      {largest && largest.projectedMicroUsd !== null ? (
+        <p className="mb-2 max-w-prose text-sm">
+          {over ? (
+            <>
+              You are projected to land{" "}
+              <span className="text-bad">
+                <Pct value={section.variancePct ?? 0} /> over
+              </span>
+              , and {LAYER_LABEL[largest.layer]} is the largest part of it:{" "}
+            </>
+          ) : (
+            <>The largest projected layer is {LAYER_LABEL[largest.layer]}: </>
+          )}
+          <Money micro={largest.projectedMicroUsd} />
+          {largest.shareOfProjected === null ? null : (
+            <>
+              , <Pct value={largest.shareOfProjected} /> of projected spend
+            </>
+          )}
+          , up from <Money micro={largest.settledMicroUsd} /> settled so far this month.
+        </p>
+      ) : null}
+      <DataTable
+        columns={layerColumns(section)}
+        rows={layers}
+        rowKey={(r) => r.layer}
+        pageSize={0}
+        empty="No layer spend in this period."
+      />
+      <p className="mt-2 max-w-prose text-xs text-muted">
+        Each layer is projected from its own settled history with its own day-of-week profile, so
+        these rows are six independent projections rather than a split of the headline. Independent
+        medians do not add: they sum to{" "}
+        <Money micro={layerSumMicroUsd} reason="no layer could be projected" />
+        {gap === null || gap === 0 ? (
+          ", which happens to match the projection above exactly."
+        ) : (
+          <>
+            , <Money micro={Math.abs(gap)} /> {gap > 0 ? "more" : "less"} than the{" "}
+            <Money micro={forecast.projectedMicroUsd} reason="nothing was projected" /> projected
+            above. That difference is the method, not a bug.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function layerColumns(section: BurndownSection): Column<LayerProjection>[] {
+  const hasLayerBudgets = section.layers.some((l) => l.budgetMicroUsd !== null);
+  const columns: Column<LayerProjection>[] = [
+    {
+      key: "layer",
+      header: "Layer",
+      render: (r) => LAYER_LABEL[r.layer],
+      sortValue: (r) => LAYER_LABEL[r.layer],
+    },
+    {
+      key: "settled",
+      header: "Settled to date",
+      align: "right",
+      render: (r) => <Money micro={r.settledMicroUsd} />,
+      sortValue: (r) => r.settledMicroUsd,
+    },
+    {
+      key: "projected",
+      header: "Projected month end",
+      align: "right",
+      render: (r) => (
+        <Money
+          micro={r.projectedMicroUsd}
+          reason="this layer has too little settled history of its own to project"
+        />
+      ),
+      sortValue: (r) => r.projectedMicroUsd,
+    },
+    {
+      key: "share",
+      header: "Share of projection",
+      align: "right",
+      render: (r) =>
+        r.shareOfProjected === null ? (
+          <Blank reason="nothing was projected for this layer, so it has no share" />
+        ) : (
+          <Pct value={r.shareOfProjected} />
+        ),
+      sortValue: (r) => r.shareOfProjected,
+    },
+  ];
+  if (!hasLayerBudgets) return columns;
+  return [
+    ...columns,
+    {
+      key: "layerBudget",
+      header: "Layer budget",
+      align: "right",
+      render: (r) => (
+        <Money micro={r.budgetMicroUsd} reason="no budget is set for this layer specifically" />
+      ),
+      sortValue: (r) => r.budgetMicroUsd,
+    },
+    {
+      key: "layerVariance",
+      header: "Projected variance",
+      align: "right",
+      render: (r) =>
+        r.varianceMicroUsd === null ? (
+          <Blank reason="no budget is set for this layer specifically" />
+        ) : (
+          <span className={r.varianceMicroUsd > 0 ? "text-bad" : "text-good"}>
+            {r.varianceMicroUsd > 0 ? "+" : r.varianceMicroUsd < 0 ? "−" : ""}
+            <Money micro={Math.abs(r.varianceMicroUsd)} />
+          </span>
+        ),
+      sortValue: (r) => r.varianceMicroUsd,
+    },
+  ];
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-muted">{label}</dt>
+      <dd className="mt-0.5 text-base font-medium tabular-nums">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * The audit trail: exactly which days fed the projection and which were withheld.
+ *
+ * This is requirement 2 at the top of the file. It is rendered in EVERY state, including the
+ * refusal, because "we have 11 of 14 days" is the whole content of the refusal and because a reader
+ * comparing this section against the 30-day headline higher up the page needs the same explanation
+ * either way.
+ */
+function Provenance({ section }: { section: BurndownSection }) {
+  const { window, period, forecast } = section;
+  const waiting = window.waitsOn.length > 0 ? window.waitsOn.join(" and ") : null;
+  return (
+    <div className="mt-4 space-y-1 border-t border-edge pt-3 text-xs text-muted">
+      <p>
+        {window.dayCount === 0 ? (
+          <>
+            No day has settled yet, so nothing has fed a projection. A day counts once it is complete
+            {waiting ? ` and ${waiting} have landed for it` : ""} (rule: {window.rule}).
+          </>
+        ) : (
+          <>
+            Projected from {window.dayCount} settled {window.dayCount === 1 ? "day" : "days"},{" "}
+            {forecast.windowStart ?? window.from} through {forecast.windowEnd ?? window.through}
+            {window.contiguous ? "" : " (with gaps)"}. A day counts once it is complete
+            {waiting ? ` and ${waiting} have landed for it` : ""} (rule: {window.rule}). Unsettled
+            days are excluded from the baseline: a half-reported day drags the run-rate down and
+            makes the projection systematically low.
+            {window.trimmedLeadingDays > 0 && window.firstObservedDay !== null ? (
+              <>
+                {" "}
+                {window.trimmedLeadingDays} earlier{" "}
+                {window.trimmedLeadingDays === 1 ? "day" : "days"} in the window {" "}
+                {window.trimmedLeadingDays === 1 ? "was" : "were"} dropped: nothing was seen from
+                this tenant before {window.firstObservedDay}, and a day it did not yet exist for is
+                not evidence that it spends nothing.
+              </>
+            ) : null}
+          </>
+        )}
+      </p>
+      {window.excludedDays.length > 0 ? (
+        <p>
+          Excludes {window.excludedDays.length}{" "}
+          {window.excludedDays.length === 1 ? "day" : "days"} of this month (
+          {window.excludedDays.join(", ")}) carrying <Money micro={window.excludedMicroUsd} /> so far
+          {window.excludedShareOfObserved === null ? null : (
+            <>
+              , <Pct value={window.excludedShareOfObserved} /> of observed month to date
+            </>
+          )}
+          . Those days are why the figures here need not match the 30-day total above.
+        </p>
+      ) : (
+        <p>Every day of the month to date has settled; nothing is excluded from the baseline.</p>
+      )}
+      <p>
+        Period {period.start} to {period.end}, measured through {period.asOf ?? "no settled day yet"}
+        ; today is {period.today} per the warehouse clock. The chart&rsquo;s day axis is built from
+        those dates, not from this server&rsquo;s clock.
+      </p>
+      {/* The chart's days against the figure printed beside them. Normally dead code, kept for the
+          same reason the account detail view keeps its reconciliation line: a silent disagreement
+          here is exactly the CTO-203 failure mode, and admitting it beats hiding it. */}
+      {section.chartReconciles ? null : (
+        <p className="text-warn">
+          The days plotted above sum to{" "}
+          <Money micro={section.chartActualMicroUsd} reason="the chart plots no actual" />, but
+          settled month to date is <Money micro={section.settledPeriodMicroUsd} />. That gap is a bug
+          in this chart rather than a fact about your spend.
+        </p>
+      )}
+      {section.budget && !section.budget.coversPeriodToDate ? (
+        <p className="text-warn">
+          This budget starts {section.budget.startsOn}, after the period began on {period.start}, so
+          the projection covers spend from before the budget applied.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -26,7 +26,8 @@ import {
 import { formatUSD, type SpendByLayer } from "@/lib/types";
 import { useLivePoll } from "@/lib/useLivePoll";
 
-import { BudgetVsActualCard, type BudgetPayload } from "./BudgetVsActualCard";
+import { BudgetVsActualCard } from "./BudgetVsActualCard";
+import { BurndownCard, type CostBudgetPayload } from "./BurndownCard";
 
 export interface CostPayload {
   series: CostSeries;
@@ -47,10 +48,10 @@ export function CostLive({
   endpoint: string;
   initialData: CostPayload;
   enabledLayers: readonly Layer[];
-  // Not part of the polled payload (CTO-209): a budget changes about monthly and the settled
+  // Not part of the polled payload (CTO-209/210): a budget changes about monthly and the settled
   // window advances once a day, so re-reading both every 5 seconds would be pure waste. See the
   // comment at the top of app/api/cost/budget/route.ts.
-  budget: BudgetPayload;
+  budget: CostBudgetPayload;
 }) {
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
   const { series: costSeries, featureRows, alerts: hiddenCostAlerts } = data;
@@ -92,6 +93,11 @@ export function CostLive({
           than that total, and the two only reconcile once you have read the coverage line saying
           which days it counted. Putting them far apart is how the page starts looking broken. */}
       <BudgetVsActualCard payload={budget} />
+
+      {/* Immediately after the measured card (CTO-210). The order is the argument: what happened,
+          then where it lands. Putting the projection first would let a reader take a forecast as a
+          fact, and the two cards share a settled window that only makes sense read in that order. */}
+      <BurndownCard payload={budget.forecast} />
 
       {hiddenCostAlerts.map((a) => (
         <div

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { apiGet } from "@/lib/api";
 import { queryEnabledConnectors } from "@/lib/tenant";
-import type { BudgetPayload } from "./BudgetVsActualCard";
+import type { CostBudgetPayload } from "./BurndownCard";
 import { CostLive, type CostPayload } from "./Live";
 
 export default async function CostPage({
@@ -13,13 +13,14 @@ export default async function CostPage({
   const sp = (await searchParams) ?? {};
   const query = sp.tag ? `?tag=${encodeURIComponent(sp.tag)}` : "";
   const endpoint = `/api/cost${query}`;
-  // The budget comparison (CTO-209) is fetched once per render rather than joining the live poll:
-  // it is tenant-wide, so the ?tag= filter does not apply to it, and it changes on a human/daily
-  // cadence rather than a 5-second one.
+  // The budget comparison (CTO-209) and the burn-down forecast (CTO-210) are fetched once per
+  // render rather than joining the live poll: both are tenant-wide, so the ?tag= filter does not
+  // apply to them, and they change on a human/daily cadence rather than a 5-second one. A forecast
+  // that flickered every 5 seconds would also read as far less trustworthy than it is.
   const [initialData, enabledLayers, budget] = await Promise.all([
     apiGet<CostPayload>(endpoint),
     queryEnabledConnectors(),
-    apiGet<BudgetPayload>("/api/cost/budget"),
+    apiGet<CostBudgetPayload>("/api/cost/budget"),
   ]);
   return (
     <CostLive

--- a/web/components/BurndownChart.tsx
+++ b/web/components/BurndownChart.tsx
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// The burn-down chart (CTO-210, F6). Hand-rolled inline SVG, no chart library, same house style as
+// `StackedBarChart.tsx` and `Histogram.tsx`: deterministic, server-renderable, theme tokens only.
+//
+// WHAT IT DRAWS, in the order the eye should pick it up:
+//
+//   1. The cone. Everything after the last settled day, between the low and high edges of the
+//      band. It is wide early and pinches shut on the closing day because that is genuinely how
+//      much we know, and it is drawn FIRST so the lines sit on top of it rather than inside it.
+//   2. Cumulative settled spend, solid. Measured, and it stops dead at the last settled day.
+//   3. The point projection, dashed, continuing from where the actual stops.
+//   4. The budget, a flat reference line.
+//   5. The breach date, where the projection crosses the budget, labelled ON THE CHART. This is
+//      the single most useful output of the whole feature, so it gets a marker, a rule and a date
+//      in words rather than being left for the reader to eyeball off two intersecting lines.
+//   6. The naive run-rate, faint, as the sanity line. A reader who does not trust the weekday
+//      weighting can check it against the dumbest possible arithmetic without leaving the page.
+//
+// THE X AXIS IS BUILT FROM THE DATES IN `points`, WHICH CAME FROM CLICKHOUSE. There is no
+// `new Date()` in this file and there must never be one. `queryCostSeries` builds its axis from the
+// Node clock (CTO-203) and the failure mode is silence: the oldest day slides off the chart while
+// still counting toward the total printed beside it. Everything plotted here is indexed off the
+// array it was handed.
+//
+// This component renders a cone unconditionally, so the CALLER is responsible for not rendering it
+// at all below the minimum history. `BurndownCard` does that; `points` being empty is the belt to
+// its braces and produces an explicit "nothing plotted" frame rather than an empty box.
+
+import type { BreachForecast, BurndownPoint } from "@/lib/forecast";
+import { formatUSD } from "@/lib/types";
+
+const W = 720;
+const H = 260;
+// Wide enough for a formatted six-figure dollar tick ("$122,588.12") at 9px without clipping it
+// against the left edge, which a narrower gutter silently does on any tenant spending six figures.
+const PAD_L = 82;
+const PAD_R = 16;
+const PAD_T = 16;
+const PAD_B = 34;
+const PLOT_W = W - PAD_L - PAD_R;
+const PLOT_H = H - PAD_T - PAD_B;
+
+/** Theme tokens, inlined because SVG `fill`/`stroke` cannot read Tailwind classes. */
+const COLOR = {
+  actual: "#5e6ad2", // accent
+  projection: "#26b5ce",
+  cone: "#26b5ce",
+  budget: "#f2c94c", // warn
+  breach: "#eb5757", // bad
+  naive: "#8a93a6", // muted
+  axis: "#252b37", // edge
+  text: "#8a93a6",
+};
+
+export interface BurndownChartProps {
+  /** The cone series from `forecastSpend`, oldest to newest. One point per calendar day. */
+  points: readonly BurndownPoint[];
+  /** Budget for the period, or null when none is set: then no reference line is drawn. */
+  budgetMicroUsd: number | null;
+  /** The engine's breach verdict. Only `breaches` puts a marker on the chart. */
+  breach: BreachForecast;
+  /** `spend_so_far / days_elapsed * days_in_period`, the sanity line. Null hides it. */
+  naiveRunRateMicroUsd: number | null;
+  /** Last settled day: where the solid line stops and the cone starts. */
+  asOf: string | null;
+}
+
+export function BurndownChart({
+  points,
+  budgetMicroUsd,
+  breach,
+  naiveRunRateMicroUsd,
+  asOf,
+}: BurndownChartProps) {
+  if (points.length === 0) {
+    return (
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="no burn-down to plot" className="w-full">
+        <text x={W / 2} y={H / 2} fontSize="12" fill={COLOR.text} textAnchor="middle">
+          nothing to plot for this period yet
+        </text>
+      </svg>
+    );
+  }
+
+  const n = points.length;
+  // One column per calendar day, first day at the left edge and last day at the right edge, so the
+  // period boundaries are the plot boundaries and "the 22nd" lands where a reader expects it.
+  const x = (i: number) => PAD_L + (n === 1 ? PLOT_W / 2 : (i / (n - 1)) * PLOT_W);
+
+  const candidates = [
+    ...points.map((p) => p.highMicroUsd),
+    ...points.map((p) => p.projectedMicroUsd),
+    ...points.map((p) => p.actualMicroUsd ?? 0),
+  ];
+  if (budgetMicroUsd !== null) candidates.push(budgetMicroUsd);
+  if (naiveRunRateMicroUsd !== null) candidates.push(naiveRunRateMicroUsd);
+  // 1.06 headroom keeps the budget line and its label off the top edge. Max(1, …) guards the
+  // all-zero case, which would otherwise divide by zero and emit NaN into every coordinate.
+  const yMax = Math.max(1, ...candidates) * 1.06;
+  const y = (v: number) => PAD_T + PLOT_H - (v / yMax) * PLOT_H;
+
+  // The measured span. `asOf` is a date rather than an index because it arrives from ClickHouse;
+  // this is the one place the two are related, and it is a lookup, never arithmetic on a clock.
+  const asOfIdx = asOf === null ? -1 : points.findIndex((p) => p.date === asOf);
+  const lastActualIdx = points.reduce(
+    (acc, p, i) => (p.actualMicroUsd !== null ? i : acc),
+    -1,
+  );
+  const boundaryIdx = asOfIdx >= 0 ? asOfIdx : lastActualIdx;
+
+  const actual = points
+    .map((p, i) => (p.actualMicroUsd === null ? null : `${x(i)},${y(p.actualMicroUsd)}`))
+    .filter((s): s is string => s !== null)
+    .join(" ");
+
+  // The cone and the dashed projection both start at the boundary so they visibly continue the
+  // solid line rather than floating away from it.
+  const coneFrom = Math.max(boundaryIdx, 0);
+  const coneIdx = points.map((_, i) => i).filter((i) => i >= coneFrom);
+  const conePath =
+    coneIdx.length > 1
+      ? [
+          ...coneIdx.map((i) => `${x(i)},${y(points[i].highMicroUsd)}`),
+          ...[...coneIdx].reverse().map((i) => `${x(i)},${y(points[i].lowMicroUsd)}`),
+        ].join(" ")
+      : null;
+  const projection =
+    coneIdx.length > 1
+      ? coneIdx.map((i) => `${x(i)},${y(points[i].projectedMicroUsd)}`).join(" ")
+      : null;
+
+  const budgetY = budgetMicroUsd === null ? null : y(budgetMicroUsd);
+
+  // Only a real crossing gets a marker. `never`, `no_budget` and `cannot_project` each mean
+  // something different and none of them is "a line to draw here"; the card states them in words.
+  const breachIdx =
+    breach.outcome === "breaches" && breach.date !== null
+      ? points.findIndex((p) => p.date === breach.date)
+      : -1;
+
+  const naiveFrom = boundaryIdx >= 0 ? boundaryIdx : 0;
+  const naiveLine =
+    naiveRunRateMicroUsd !== null && naiveFrom < n - 1
+      ? {
+          x1: x(naiveFrom),
+          y1: y(points[naiveFrom].projectedMicroUsd),
+          x2: x(n - 1),
+          y2: y(naiveRunRateMicroUsd),
+        }
+      : null;
+
+  // Roughly six gridlines, on round dollar steps of the y range.
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map((f) => f * yMax);
+  const labelEvery = Math.max(1, Math.ceil(n / 8));
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={chartLabel(points, breach, budgetMicroUsd)}
+      className="w-full"
+    >
+      {ticks.map((t) => (
+        <g key={t}>
+          <line x1={PAD_L} x2={W - PAD_R} y1={y(t)} y2={y(t)} stroke={COLOR.axis} />
+          <text x={PAD_L - 6} y={y(t) + 3} fontSize="9" fill={COLOR.text} textAnchor="end">
+            {formatUSD(t)}
+          </text>
+        </g>
+      ))}
+
+      {conePath && (
+        <polygon points={conePath} fill={COLOR.cone} opacity="0.16">
+          <title>
+            {`80% band: it is widest just after the last settled day and closes to nothing on ${points[n - 1].date}`}
+          </title>
+        </polygon>
+      )}
+
+      {/* The settled/projected boundary, same idiom as the reconciled/estimated line on the
+          stacked chart, so the two charts on this page read the same way. */}
+      {boundaryIdx >= 0 && boundaryIdx < n - 1 && (
+        <g>
+          <line
+            x1={x(boundaryIdx)}
+            x2={x(boundaryIdx)}
+            y1={PAD_T}
+            y2={H - PAD_B}
+            stroke={COLOR.text}
+            strokeDasharray="4 3"
+          />
+          <text x={x(boundaryIdx) + 4} y={PAD_T + 10} fontSize="9" fill={COLOR.text}>
+            ← settled · projected →
+          </text>
+        </g>
+      )}
+
+      {naiveLine && (
+        <line
+          x1={naiveLine.x1}
+          y1={naiveLine.y1}
+          x2={naiveLine.x2}
+          y2={naiveLine.y2}
+          stroke={COLOR.naive}
+          strokeWidth="1.5"
+          strokeDasharray="1 4"
+        >
+          <title>
+            {`Naive run-rate, the sanity line: ${formatUSD(naiveRunRateMicroUsd ?? 0)} by ${points[n - 1].date}. Spend to date divided by days elapsed, with no weekday weighting.`}
+          </title>
+        </line>
+      )}
+
+      {projection && (
+        <polyline
+          points={projection}
+          fill="none"
+          stroke={COLOR.projection}
+          strokeWidth="2"
+          strokeDasharray="5 4"
+        >
+          <title>
+            {`Day-of-week weighted projection: ${formatUSD(points[n - 1].projectedMicroUsd)} by ${points[n - 1].date}`}
+          </title>
+        </polyline>
+      )}
+
+      {actual && (
+        <polyline points={actual} fill="none" stroke={COLOR.actual} strokeWidth="2.5">
+          <title>
+            {lastActualIdx >= 0
+              ? `Cumulative settled spend: ${formatUSD(points[lastActualIdx].actualMicroUsd ?? 0)} through ${points[lastActualIdx].date}`
+              : "Cumulative settled spend"}
+          </title>
+        </polyline>
+      )}
+
+      {budgetY !== null && (
+        <g>
+          <line
+            x1={PAD_L}
+            x2={W - PAD_R}
+            y1={budgetY}
+            y2={budgetY}
+            stroke={COLOR.budget}
+            strokeWidth="1.5"
+            strokeDasharray="6 4"
+          />
+          <text x={PAD_L + 4} y={budgetY - 5} fontSize="10" fill={COLOR.budget}>
+            budget {formatUSD(budgetMicroUsd ?? 0)}
+          </text>
+        </g>
+      )}
+
+      {/* THE BREACH DATE. The one number a reader should be able to take away without reading a
+          word of the card, so it is a rule, a dot and a date, not an intersection to squint at. */}
+      {breachIdx >= 0 && budgetY !== null && (
+        <g>
+          <line
+            x1={x(breachIdx)}
+            x2={x(breachIdx)}
+            y1={PAD_T}
+            y2={H - PAD_B}
+            stroke={COLOR.breach}
+            strokeWidth="1.5"
+          />
+          <circle cx={x(breachIdx)} cy={budgetY} r="4" fill={COLOR.breach} />
+          <text
+            x={breachIdx > n * 0.6 ? x(breachIdx) - 6 : x(breachIdx) + 6}
+            // Below the settled/projected boundary caption rather than beside it: on a late-month
+            // breach the two labels sit at the same x and would otherwise overprint each other.
+            y={PAD_T + 44}
+            fontSize="11"
+            fontWeight="600"
+            fill={COLOR.breach}
+            textAnchor={breachIdx > n * 0.6 ? "end" : "start"}
+          >
+            crosses budget {points[breachIdx].date}
+          </text>
+        </g>
+      )}
+
+      {points.map((p, i) =>
+        // The last day always gets a label (it is the period end); the tick before it is dropped
+        // when it would collide, which on a 31-day month it otherwise does.
+        (i % labelEvery === 0 && i < n - 2) || i === n - 1 ? (
+          <text
+            key={p.date}
+            x={x(i)}
+            y={H - 12}
+            fontSize="9"
+            fill={COLOR.text}
+            textAnchor={i === 0 ? "start" : i === n - 1 ? "end" : "middle"}
+          >
+            {p.date.slice(5)}
+          </text>
+        ) : null,
+      )}
+    </svg>
+  );
+}
+
+/**
+ * The chart's own sentence, for a reader who cannot see it. It says the breach outcome rather than
+ * describing the shapes, because the outcome is the content and "a line chart with a shaded region"
+ * is not.
+ */
+function chartLabel(
+  points: readonly BurndownPoint[],
+  breach: BreachForecast,
+  budgetMicroUsd: number | null,
+): string {
+  const end = points[points.length - 1];
+  const head = `Cumulative spend burn-down through ${end.date}, projected to ${formatUSD(end.projectedMicroUsd)}`;
+  switch (breach.outcome) {
+    case "breaches":
+      return `${head}, crossing the ${formatUSD(budgetMicroUsd ?? 0)} budget on ${breach.date}.`;
+    case "never":
+      return `${head}, staying under the ${formatUSD(budgetMicroUsd ?? 0)} budget for the whole period.`;
+    case "no_budget":
+      return `${head}. No budget is set, so no reference line is drawn.`;
+    default:
+      return `${head}.`;
+  }
+}
+
+/** The key. Separate from the SVG so it wraps as text and stays readable at any width. */
+export function BurndownLegend({ hasBudget }: { hasBudget: boolean }) {
+  const items: { color: string; label: string; dash?: string }[] = [
+    { color: COLOR.actual, label: "Settled spend to date" },
+    { color: COLOR.projection, label: "Weighted projection", dash: "dashed" },
+    { color: COLOR.cone, label: "80% confidence band" },
+    { color: COLOR.naive, label: "Naive run-rate (sanity line)", dash: "dotted" },
+  ];
+  if (hasBudget) items.push({ color: COLOR.budget, label: "Budget", dash: "dashed" });
+  return (
+    <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+      {items.map((it) => (
+        <li key={it.label} className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-sm"
+            style={{ background: it.color }}
+          />
+          {it.label}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/lib/burndown.test.ts
+++ b/web/lib/burndown.test.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// The burn-down view model (CTO-210). Every test here is one of the ticket's honesty requirements,
+// because each of them fails SILENTLY if it regresses: a cone drawn from four days looks exactly
+// like a cone drawn from forty, and an axis built from the wrong clock looks exactly like one built
+// from the right one until you count the days.
+
+import { describe, expect, it } from "vitest";
+
+import { burndownSection } from "./burndown";
+import type { SettledSeriesLike, TenantBudget } from "./budgetVsActual";
+import { LAYERS } from "./cost";
+import { MIN_HISTORY_DAYS } from "./forecast";
+import type { SpendByLayer } from "./types";
+
+const USD = 1_000_000;
+
+function layers(over: Partial<SpendByLayer> = {}): SpendByLayer {
+  return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0, ...over };
+}
+
+function addDays(iso: string, n: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d + n)).toISOString().slice(0, 10);
+}
+
+/** One row of `SettledSeriesLike["days"]`, mutable so the fixtures can be built up in a loop. */
+type DayRow = {
+  date: string;
+  byLayer: SpendByLayer;
+  totalMicroUsd: number;
+  inPeriod: boolean;
+  settled: boolean;
+  inProgress: boolean;
+  awaitingLayers: string[];
+};
+
+interface SeriesOptions {
+  /** Days of settled history ending the day before `today`. */
+  settledDays: number;
+  /** Per-day spend in whole dollars, split 70/30 between llm and compute. */
+  perDayUsd?: number;
+  /** First day of the calendar month. */
+  periodStart?: string;
+  /** Today per ClickHouse. Always unsettled: it is the day in progress. */
+  today?: string;
+}
+
+/**
+ * A settled series shaped like `querySettledCostSeries`' output: `settledDays` complete days ending
+ * yesterday, plus today still accruing and therefore excluded.
+ */
+function series(opts: SeriesOptions): SettledSeriesLike {
+  const periodStart = opts.periodStart ?? "2026-08-01";
+  const today = opts.today ?? "2026-08-20";
+  const perDay = (opts.perDayUsd ?? 100) * USD;
+  const days: DayRow[] = [];
+  for (let i = opts.settledDays; i >= 1; i -= 1) {
+    const date = addDays(today, -i);
+    days.push({
+      date,
+      byLayer: layers({ llm: Math.round(perDay * 0.7), compute: Math.round(perDay * 0.3) }),
+      totalMicroUsd: perDay,
+      inPeriod: date >= periodStart,
+      settled: true,
+      inProgress: false,
+      awaitingLayers: [],
+    });
+  }
+  days.push({
+    date: today,
+    byLayer: layers({ llm: Math.round(perDay * 0.35), compute: Math.round(perDay * 0.15) }),
+    totalMicroUsd: Math.round(perDay * 0.5),
+    inPeriod: today >= periodStart,
+    settled: false,
+    inProgress: true,
+    awaitingLayers: [],
+  });
+
+  const totals = (keep: (d: DayRow) => boolean) => {
+    const byLayer = layers();
+    let totalMicroUsd = 0;
+    let dayCount = 0;
+    for (const d of days.filter(keep)) {
+      dayCount += 1;
+      totalMicroUsd += d.totalMicroUsd;
+      for (const l of LAYERS) byLayer[l] += d.byLayer[l];
+    }
+    return { dayCount, byLayer, totalMicroUsd };
+  };
+
+  const settledDates = days.filter((d) => d.settled).map((d) => d.date);
+  return {
+    periodStart,
+    windowEnd: today,
+    settledThrough: settledDates[settledDates.length - 1] ?? null,
+    rule: "connector-landing",
+    connectorLayers: ["compute", "egress"],
+    days,
+    periodSettled: totals((d) => d.inPeriod && d.settled),
+    periodObserved: totals((d) => d.inPeriod),
+  };
+}
+
+function budget(amountUsd: number, over: Partial<TenantBudget> = {}): TenantBudget {
+  return {
+    budget_id: "tenant-month",
+    period: "month",
+    amount_micro: amountUsd * USD,
+    scope_kind: "tenant",
+    scope_value: "",
+    starts_on: "2026-01-01",
+    ends_on: null,
+    ...over,
+  };
+}
+
+describe("burndownSection", () => {
+  it("refuses to project below the minimum history, and says so as `cannot_project`", () => {
+    // Four days is the scope doc's own example of a forecast that must not ship.
+    const s = burndownSection(series({ settledDays: 4 }), [budget(1_000)]);
+    expect(s.forecast.status).toBe("insufficient_history");
+    expect(s.forecast.projectedMicroUsd).toBeNull();
+    // The cone must be EMPTY, not merely small: the card renders no chart off this.
+    expect(s.forecast.burndown).toEqual([]);
+    expect(s.forecast.breach.outcome).toBe("cannot_project");
+    expect(s.forecast.breach.date).toBeNull();
+    // The refusal still has to say how far off it is.
+    expect(s.window.dayCount).toBe(4);
+    expect(s.window.requiredDays).toBe(MIN_HISTORY_DAYS);
+  });
+
+  it("projects at exactly the minimum history and not one day below it", () => {
+    const below = burndownSection(series({ settledDays: MIN_HISTORY_DAYS - 1 }), []);
+    const at = burndownSection(series({ settledDays: MIN_HISTORY_DAYS }), []);
+    expect(below.forecast.status).toBe("insufficient_history");
+    expect(at.forecast.status).toBe("ok");
+    expect(at.forecast.burndown.length).toBeGreaterThan(0);
+  });
+
+  it("states the input window it actually used, and excludes the in-progress day", () => {
+    const s = burndownSection(series({ settledDays: 20, today: "2026-08-20" }), []);
+    expect(s.window.through).toBe("2026-08-19");
+    expect(s.window.dayCount).toBe(20);
+    expect(s.window.contiguous).toBe(true);
+    expect(s.window.rule).toBe("connector-landing");
+    expect(s.window.waitsOn).toEqual(["compute", "egress"]);
+    // Today is inside the period, unsettled, and carries half a day of spend.
+    expect(s.window.excludedDays).toEqual(["2026-08-20"]);
+    expect(s.window.excludedMicroUsd).toBe(50 * USD);
+    expect(s.window.excludedShareOfObserved).toBeGreaterThan(0);
+    // And the engine agrees about the window it was fed.
+    expect(s.forecast.windowEnd).toBe("2026-08-19");
+  });
+
+  it("reports a breach date on the day the projection crosses the budget", () => {
+    // 100/day settled through the 19th is 1,900 so far; a 2,400 budget is crossed a few days later.
+    const s = burndownSection(series({ settledDays: 20, perDayUsd: 100 }), [budget(2_400)]);
+    expect(s.forecast.breach.outcome).toBe("breaches");
+    expect(s.forecast.breach.date).toBe("2026-08-24");
+    expect(s.forecast.breach.dayIndex).toBe(24);
+    expect(s.varianceMicroUsd).toBeGreaterThan(0);
+    expect(s.variancePct).toBeGreaterThan(0);
+    // The breach day must exist on the axis the chart draws, or the marker lands nowhere.
+    expect(s.forecast.burndown.map((p) => p.date)).toContain("2026-08-24");
+  });
+
+  it("distinguishes `never` from `cannot_project`: one projected, the other did not", () => {
+    const never = burndownSection(series({ settledDays: 20, perDayUsd: 100 }), [budget(100_000)]);
+    expect(never.forecast.breach.outcome).toBe("never");
+    expect(never.forecast.projectedMicroUsd).not.toBeNull();
+    expect(never.varianceMicroUsd).toBeLessThan(0);
+
+    const cannot = burndownSection(series({ settledDays: 3 }), [budget(100_000)]);
+    expect(cannot.forecast.breach.outcome).toBe("cannot_project");
+    expect(cannot.forecast.projectedMicroUsd).toBeNull();
+    // Not a variance of zero, and not a reassuring negative one: no claim at all.
+    expect(cannot.varianceMicroUsd).toBeNull();
+  });
+
+  it("renders no budget as its own outcome, never as a budget of zero", () => {
+    const s = burndownSection(series({ settledDays: 20 }), []);
+    expect(s.forecast.breach.outcome).toBe("no_budget");
+    expect(s.budget).toBeNull();
+    expect(s.varianceMicroUsd).toBeNull();
+    expect(s.variancePct).toBeNull();
+    expect(s.noBudgetReason).toContain("no monthly tenant-wide budget");
+    // A zero budget would have made this "breaches on day 1", which is the trap.
+    expect(s.forecast.breach.date).toBeNull();
+  });
+
+  it("keeps the naive run-rate as a separate labelled line rather than the headline", () => {
+    const s = burndownSection(series({ settledDays: 20, perDayUsd: 100 }), []);
+    expect(s.forecast.naiveRunRateMicroUsd).not.toBeNull();
+    expect(s.forecast.projectedMicroUsd).not.toBeNull();
+  });
+
+  it("projects every layer independently and reports the sum against the headline", () => {
+    const s = burndownSection(series({ settledDays: 20, perDayUsd: 100 }), []);
+    expect(s.layers).toHaveLength(LAYERS.length);
+    // 70/30 llm/compute, so llm leads and is "the reason".
+    expect(s.largestLayer).toBe("llm");
+    expect(s.layers[0].layer).toBe("llm");
+    expect(s.layers[0].shareOfProjected).toBeCloseTo(0.7, 2);
+    // The sum is computed and exposed whether or not it matches, so the card can print the gap.
+    expect(s.layerSumMicroUsd).not.toBeNull();
+    const gap = Math.abs((s.layerSumMicroUsd ?? 0) - (s.forecast.projectedMicroUsd ?? 0));
+    expect(s.layersReconcile).toBe(gap === 0);
+  });
+
+  it("attaches layer-scoped budgets to their own rows only", () => {
+    const s = burndownSection(series({ settledDays: 20, perDayUsd: 100 }), [
+      budget(5_000),
+      budget(1_000, { budget_id: "compute", scope_kind: "layer", scope_value: "compute" }),
+    ]);
+    const compute = s.layers.find((l) => l.layer === "compute");
+    const llm = s.layers.find((l) => l.layer === "llm");
+    expect(compute?.budgetMicroUsd).toBe(1_000 * USD);
+    expect(compute?.varianceMicroUsd).not.toBeNull();
+    expect(llm?.budgetMicroUsd).toBeNull();
+    expect(llm?.varianceMicroUsd).toBeNull();
+  });
+
+  it("builds the axis from ClickHouse's dates, not from this machine's clock", () => {
+    // A month nowhere near today. If any part of this pipeline consulted `Date.now()` the axis
+    // would be a different month, which is the CTO-203 failure mode exactly.
+    const s = burndownSection(
+      series({ settledDays: 20, periodStart: "2031-02-01", today: "2031-02-20" }),
+      [],
+    );
+    expect(s.period.start).toBe("2031-02-01");
+    // February 2031 is not a leap year: 28 days, by arithmetic on ClickHouse's own periodStart.
+    expect(s.period.end).toBe("2031-02-28");
+    expect(s.forecast.burndown).toHaveLength(28);
+    expect(s.forecast.burndown[0].date).toBe("2031-02-01");
+    expect(s.forecast.burndown[27].date).toBe("2031-02-28");
+    expect(s.period.today).toBe("2031-02-20");
+  });
+
+  it("checks the chart's own days against the settled figure printed beside them", () => {
+    const s = burndownSection(series({ settledDays: 20, perDayUsd: 100 }), []);
+    // 19 settled days inside August (the 1st through the 19th) at 100 each.
+    expect(s.settledPeriodMicroUsd).toBe(1_900 * USD);
+    expect(s.chartActualMicroUsd).toBe(1_900 * USD);
+    expect(s.chartReconciles).toBe(true);
+  });
+
+  it("still reconciles when a mid-month day is withheld, because it is never plotted", () => {
+    const s = series({ settledDays: 20, perDayUsd: 100 });
+    // A connector has not landed for the 10th: it drops out of both the baseline and the chart.
+    const days = s.days.map((d) =>
+      d.date === "2026-08-10" ? { ...d, settled: false, awaitingLayers: ["compute"] } : d,
+    );
+    const rebuilt: SettledSeriesLike = {
+      ...s,
+      days,
+      settledThrough: "2026-08-19",
+      periodSettled: {
+        dayCount: 18,
+        byLayer: layers({ llm: 18 * 70 * USD, compute: 18 * 30 * USD }),
+        totalMicroUsd: 1_800 * USD,
+      },
+    };
+    const section = burndownSection(rebuilt, []);
+    expect(section.window.contiguous).toBe(false);
+    expect(section.window.excludedDays).toContain("2026-08-10");
+    expect(section.chartActualMicroUsd).toBe(1_800 * USD);
+    expect(section.chartReconciles).toBe(true);
+  });
+
+  it("does not count days before the tenant was ever seen spending as history", () => {
+    // The live shape this defends against: `querySettledCostSeries` gives every calendar day in its
+    // 30-day window a slot, so a tenant onboarded six days ago arrives with 29 "settled" days, 23 of
+    // which are zeros meaning "did not exist yet". Counting those would sail past the history floor
+    // on a tenant that has been sending data for less than a week.
+    const s = series({ settledDays: 25, perDayUsd: 100 });
+    // Settled history runs 2026-07-26 to 2026-08-19 (today, the 20th, is still accruing). Zero
+    // everything before the 14th and six settled days are left.
+    const firstReal = "2026-08-14";
+    const days = s.days.map((d) =>
+      d.date < firstReal
+        ? { ...d, byLayer: layers(), totalMicroUsd: 0 }
+        : d,
+    );
+    const section = burndownSection({ ...s, days }, []);
+    expect(section.window.firstObservedDay).toBe(firstReal);
+    expect(section.window.trimmedLeadingDays).toBeGreaterThan(0);
+    // Six settled days, below the floor, so no cone.
+    expect(section.window.dayCount).toBe(6);
+    expect(section.forecast.status).toBe("insufficient_history");
+    expect(section.forecast.burndown).toEqual([]);
+  });
+
+  it("counts a genuine zero-spend day inside a live tenant's history", () => {
+    // The other half of the same rule: once the tenant HAS been seen, a later zero day is real and
+    // must stay in the baseline, or a quiet weekend would silently shorten the input window.
+    const s = series({ settledDays: 20, perDayUsd: 100 });
+    const days = s.days.map((d) =>
+      d.date === "2026-08-15" ? { ...d, byLayer: layers(), totalMicroUsd: 0 } : d,
+    );
+    const section = burndownSection({ ...s, days }, []);
+    expect(section.window.trimmedLeadingDays).toBe(0);
+    expect(section.window.dayCount).toBe(20);
+    expect(section.forecast.status).toBe("ok");
+  });
+
+  it("makes no reconciliation claim about a chart it did not draw", () => {
+    // Below the floor the burn-down is empty by design, so "the days plotted sum to nothing but
+    // month to date is $1.50" would be a bug report about a chart that was never rendered.
+    const s = series({ settledDays: 25, perDayUsd: 100 });
+    const days = s.days.map((d) =>
+      d.date < "2026-08-14" ? { ...d, byLayer: layers(), totalMicroUsd: 0 } : d,
+    );
+    const section = burndownSection({ ...s, days }, []);
+    expect(section.forecast.status).toBe("insufficient_history");
+    expect(section.chartActualMicroUsd).toBeNull();
+    expect(section.settledPeriodMicroUsd).toBeGreaterThan(0);
+    expect(section.chartReconciles).toBe(true);
+  });
+
+  it("refuses rather than projecting when nothing has settled at all", () => {
+    const s = series({ settledDays: 0 });
+    const section = burndownSection(s, [budget(1_000)]);
+    expect(section.period.asOf).toBeNull();
+    expect(section.forecast.status).toBe("insufficient_history");
+    expect(section.chartActualMicroUsd).toBeNull();
+    expect(section.chartReconciles).toBe(true);
+  });
+});

--- a/web/lib/burndown.ts
+++ b/web/lib/burndown.ts
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0
+// The burn-down view model (CTO-210, F6). Pure functions, no I/O, no clock.
+//
+// This is the payoff of the spend-forecasting epic: the projection from `forecast.ts` (CTO-206) fed
+// with the settled series from `querySettledCostSeries` (CTO-207) and the budget from CTO-205, in
+// the shape the chart and the card need. It COMPUTES NO FORECAST OF ITS OWN. `forecastSpend`
+// already built the cone, the band and the breach date for this ticket, so re-deriving any of them
+// here would produce a second answer to the same question and the two would drift.
+//
+// WHAT THIS FILE IS ACTUALLY FOR, given that:
+//
+//  1. Choosing the engine's inputs honestly. Only SETTLED days go in (CTO-207's rule), and the
+//     window those days form is carried out again as `window` so the section can print it. A
+//     forecast that cannot state what it measured is not auditable, and on live data the settled
+//     window is around 10 percent smaller than the observed one, which is far too big a gap to
+//     leave as a footnote (scope Decision 3).
+//
+//  2. THE TWO CLOCKS. Every date here comes from ClickHouse: `periodStart` and `windowEnd` are read
+//     off the series, `asOf` is the series' own `settledThrough`, and the period end is calendar
+//     arithmetic on `periodStart`. There is no `new Date()` anywhere in this module and none in the
+//     chart. `queryCostSeries` still builds its axis from the Node clock (CTO-203) and the failure
+//     mode is silent: the oldest day drops off the chart while still counting in the total printed
+//     beside it. `chartReconciles` below exists so that if this section ever acquires the same bug
+//     it says so on screen instead of quietly disagreeing with the card above it.
+//
+//  3. TRIMMING THE PRE-ONBOARDING ZEROS, which is what makes the minimum-history guard fire at all.
+//     `querySettledCostSeries` gives every calendar day in its 30-day window a slot, and a day with
+//     no rows is a real zero for the scope rather than a hole. That is right for the measured card:
+//     a day a tenant spent nothing did cost nothing. It is WRONG as forecast history. A tenant
+//     onboarded six days ago comes back with 29 settled days, 23 of which are zeros that mean "this
+//     tenant did not exist yet", and the engine would happily project from them: past the history
+//     floor, and with a weekday profile whose medians are mostly zero. That is precisely the
+//     day-2 projection the floor exists to refuse, wearing a full month of fake history. So the
+//     baseline starts at the first day the tenant was observed spending ANYTHING, and everything
+//     before that is dropped rather than counted as evidence. `trimmedLeadingDays` reports how many
+//     went, so the card can say so rather than silently shortening its own input window.
+//
+//  4. The layer split, which is what makes the forecast actionable. "You will land 12 percent over"
+//     is a fact; "and compute is the reason" is something a reader can do something about. Each
+//     layer is projected by the SAME engine over that layer's own settled history, so a layer with
+//     a different weekday shape than the tenant total gets its own shape rather than a share of the
+//     total. The cost of that choice is that independent medians do not add up: the layer
+//     projections need not sum to the tenant projection, so `layersReconcile` is computed and the
+//     card prints the difference rather than hiding it.
+//
+// Money is integer micro-USD. Dates are `YYYY-MM-DD` UTC strings.
+
+import {
+  daysBetweenInclusive,
+  endOfMonth,
+  selectBudget,
+  type AppliedBudget,
+  type SettledSeriesLike,
+  type TenantBudget,
+} from "./budgetVsActual";
+import { LAYERS, type Layer } from "./cost";
+import {
+  forecastSpend,
+  MIN_HISTORY_DAYS,
+  type ForecastStatus,
+  type SpendForecast,
+} from "./forecast";
+import type { MicroUSD } from "./types";
+
+/**
+ * Which days fed the projection, and which days inside the period it refused to use.
+ *
+ * All of it is restated from the series rather than recomputed from the forecast, because the point
+ * of the line is to describe the INPUT. `dayCount` is the count the engine's minimum-history guard
+ * is compared against, so `requiredDays` travels with it: "11 of the 14 days needed" is a readable
+ * refusal, "not enough history" is not.
+ */
+export interface ForecastInputWindow {
+  /** Oldest settled day fed in, or null when none has settled. */
+  from: string | null;
+  /** Newest settled day fed in, or null when none has settled. This is also `asOf`. */
+  through: string | null;
+  /** How many settled days fed in. Not `through - from`: a mid-window day can be withheld. */
+  dayCount: number;
+  /** False when a day inside the fed range was withheld, which is more surprising than a lagging tail. */
+  contiguous: boolean;
+  /** Which settled rule applied, verbatim from CTO-207. */
+  rule: "connector-landing" | "day-complete";
+  /** Connector layers settlement waits on. Empty under the `day-complete` rule. */
+  waitsOn: readonly string[];
+  /** Days inside the period that were excluded because they have not settled. */
+  excludedDays: string[];
+  /** Dollars those excluded days carry so far. Quantified, never merely asserted. */
+  excludedMicroUsd: MicroUSD;
+  /** Share of observed month-to-date withheld by settlement, or null when nothing was observed. */
+  excludedShareOfObserved: number | null;
+  /** `MIN_HISTORY_DAYS`, echoed so the UI never hard-codes the floor it is explaining. */
+  requiredDays: number;
+  /**
+   * Days dropped from the front of the window because the tenant had not been observed spending
+   * anything yet. See note 3 at the top of this file: these are almost always pre-onboarding, and
+   * counting them as evidence is how a six-day-old tenant gets a month-long forecast.
+   */
+  trimmedLeadingDays: number;
+  /** First day the tenant was observed spending anything, or null when it never was. */
+  firstObservedDay: string | null;
+}
+
+/** One layer's own projection for the period. */
+export interface LayerProjection {
+  layer: Layer;
+  /** Settled month-to-date spend for this layer. Measured. */
+  settledMicroUsd: MicroUSD;
+  /** Projected period total for this layer, or null when its own history is too short. */
+  projectedMicroUsd: MicroUSD | null;
+  /** This layer's share of the summed layer projections, or null when that sum is zero/unknown. */
+  shareOfProjected: number | null;
+  /** A layer-scoped budget when one is configured (CTO-205 `scope_kind='layer'`), else null. */
+  budgetMicroUsd: MicroUSD | null;
+  /** Projected minus layer budget. Positive is over. Null without a layer budget or a projection. */
+  varianceMicroUsd: MicroUSD | null;
+  /** Per-layer, because a quiet layer can fall below the history floor while the tenant does not. */
+  status: ForecastStatus;
+}
+
+export interface BurndownSection {
+  /** Every date here is ClickHouse's, never the Node clock's. See note 2 at the top of this file. */
+  period: {
+    /** First day of the calendar month, from the series. */
+    start: string;
+    /** Last day of that month, by arithmetic on `start`. */
+    end: string;
+    /** Last SETTLED day: where the actual line stops and the cone begins. Null when none settled. */
+    asOf: string | null;
+    /** Today per ClickHouse. Later than `asOf` whenever settlement is lagging, which is normal. */
+    today: string;
+  };
+  /** The engine's answer, untouched. The cone, the band and the breach date all live in here. */
+  forecast: SpendForecast;
+  /** The one monthly tenant-wide budget covering today, or null when none is set. */
+  budget: AppliedBudget | null;
+  /** Non-null exactly when `budget` is null. A real sentence, for `<Blank reason>`. */
+  noBudgetReason: string | null;
+  /** Projected period spend minus budget. Positive is over. Null without both. */
+  varianceMicroUsd: MicroUSD | null;
+  /** As a fraction of budget. Null without a budget, and null when the budget is zero. */
+  variancePct: number | null;
+  window: ForecastInputWindow;
+  /** Every layer, ordered by projected spend descending (settled spend when nothing projected). */
+  layers: LayerProjection[];
+  /** Sum of the layer projections, or null when no layer projected. */
+  layerSumMicroUsd: MicroUSD | null;
+  /**
+   * True when the layer projections sum to the tenant projection. Usually FALSE by construction:
+   * independent per-layer medians do not add. The card prints the gap rather than implying the
+   * rows decompose the headline exactly.
+   */
+  layersReconcile: boolean;
+  /**
+   * The largest layer by projection: the "and compute is the reason" half of the answer. Null when
+   * nothing projected.
+   */
+  largestLayer: Layer | null;
+  /**
+   * Cumulative actual at the last plotted actual point, i.e. what the CHART says was spent. Null
+   * when no day of the period has settled and the chart therefore plots no actual at all.
+   */
+  chartActualMicroUsd: MicroUSD | null;
+  /** Settled month-to-date from the series: what the card beside the chart prints. */
+  settledPeriodMicroUsd: MicroUSD;
+  /**
+   * Whether the chart's own days sum to the figure printed next to it. The two-clocks bug (CTO-203)
+   * makes these disagree silently by dropping a day off the axis, so the section states it out loud
+   * the way the account detail view states its reconciliation.
+   */
+  chartReconciles: boolean;
+}
+
+function ratio(part: number, whole: number): number | null {
+  // Zero denominator is undefined, not infinite and not zero. Callers render a blank.
+  return whole === 0 ? null : part / whole;
+}
+
+/**
+ * Build the burn-down section from a settled series and this tenant's budgets.
+ *
+ * The caller handles ClickHouse being unreachable (`series === null`) before getting here: there is
+ * no honest projection from no data, and inventing one next to a real budget is the single worst
+ * thing this surface could do.
+ */
+export function burndownSection(
+  series: SettledSeriesLike,
+  budgets: readonly TenantBudget[],
+): BurndownSection {
+  const periodStart = series.periodStart;
+  const periodEnd = endOfMonth(periodStart);
+  const today = series.windowEnd;
+
+  // The last settled day is where the measured line stops. When nothing has settled we still have
+  // to hand the engine an `asOf`; today is the honest one (nothing is measured through today), and
+  // with an empty day list the engine refuses on the history floor anyway.
+  const asOf = series.settledThrough;
+  const asOfForEngine = asOf ?? today;
+
+  // Note 3: history starts where the tenant does. Any observed spend counts, settled or not, so a
+  // still-unsettled first day does not push the start of history a day later than it really is.
+  const firstObservedDay = series.days.find((d) => d.totalMicroUsd !== 0)?.date ?? null;
+  const allSettled = series.days.filter((d) => d.settled);
+  const settled =
+    firstObservedDay === null ? [] : allSettled.filter((d) => d.date >= firstObservedDay);
+  const trimmedLeadingDays = allSettled.length - settled.length;
+  const inPeriod = series.days.filter((d) => d.inPeriod);
+  const settledInPeriod = inPeriod.filter((d) => d.settled);
+  const excluded = inPeriod.filter((d) => !d.settled);
+
+  const observedMicroUsd = series.periodObserved.totalMicroUsd;
+  const settledPeriodMicroUsd = series.periodSettled.totalMicroUsd;
+  const excludedMicroUsd = observedMicroUsd - settledPeriodMicroUsd;
+
+  const from = settled[0]?.date ?? null;
+  const through = settled[settled.length - 1]?.date ?? null;
+  const window: ForecastInputWindow = {
+    from,
+    through,
+    dayCount: settled.length,
+    contiguous:
+      from === null || through === null
+        ? true
+        : daysBetweenInclusive(from, through) === settled.length,
+    rule: series.rule,
+    waitsOn: series.connectorLayers,
+    excludedDays: excluded.map((d) => d.date),
+    excludedMicroUsd,
+    excludedShareOfObserved: ratio(excludedMicroUsd, observedMicroUsd),
+    requiredDays: MIN_HISTORY_DAYS,
+    trimmedLeadingDays,
+    firstObservedDay,
+  };
+
+  const tenantBudget = selectBudget(budgets, "tenant", "", today);
+  const budget: AppliedBudget | null = tenantBudget
+    ? {
+        budgetId: tenantBudget.budget_id,
+        amountMicroUsd: tenantBudget.amount_micro,
+        startsOn: tenantBudget.starts_on,
+        endsOn: tenantBudget.ends_on,
+        coversPeriodToDate: tenantBudget.starts_on <= periodStart,
+      }
+    : null;
+
+  const forecast = forecastSpend({
+    // Settled days only, and every settled day in the trailing window, not just this month's: the
+    // weekday profile wants four weeks and the period is only as old as the month is.
+    days: settled.map((d) => ({ date: d.date, microUsd: d.totalMicroUsd })),
+    periodStart,
+    periodEnd,
+    asOf: asOfForEngine,
+    budgetMicroUsd: budget ? budget.amountMicroUsd : null,
+  });
+
+  const layers = LAYERS.map((layer) => {
+    const layerForecast = forecastSpend({
+      days: settled.map((d) => ({ date: d.date, microUsd: d.byLayer[layer] })),
+      periodStart,
+      periodEnd,
+      asOf: asOfForEngine,
+      // Layer budgets are compared below rather than passed in: the engine's breach date for a
+      // layer is not rendered anywhere, and passing a budget here would compute a breach nothing
+      // reads. The variance is what the split needs.
+      budgetMicroUsd: null,
+    });
+    const layerBudget = selectBudget(budgets, "layer", layer, today);
+    const projected = layerForecast.projectedMicroUsd;
+    return {
+      layer,
+      settledMicroUsd: series.periodSettled.byLayer[layer],
+      projectedMicroUsd: projected,
+      // Filled in below: the denominator is the sum of all the layer projections.
+      shareOfProjected: null as number | null,
+      budgetMicroUsd: layerBudget ? layerBudget.amount_micro : null,
+      varianceMicroUsd:
+        layerBudget && projected !== null ? projected - layerBudget.amount_micro : null,
+      status: layerForecast.status,
+    };
+  });
+
+  const projectedLayers = layers.filter((l) => l.projectedMicroUsd !== null);
+  const layerSumMicroUsd =
+    projectedLayers.length > 0
+      ? projectedLayers.reduce((sum, l) => sum + (l.projectedMicroUsd ?? 0), 0)
+      : null;
+  for (const l of layers) {
+    l.shareOfProjected =
+      l.projectedMicroUsd === null || layerSumMicroUsd === null
+        ? null
+        : ratio(l.projectedMicroUsd, layerSumMicroUsd);
+  }
+  // Projected first, because that is what the section is about; settled spend breaks ties and
+  // orders the rows sensibly when nothing projected at all.
+  layers.sort(
+    (a, b) =>
+      (b.projectedMicroUsd ?? -1) - (a.projectedMicroUsd ?? -1) ||
+      b.settledMicroUsd - a.settledMicroUsd,
+  );
+
+  const projected = forecast.projectedMicroUsd;
+  const varianceMicroUsd =
+    budget && projected !== null ? projected - budget.amountMicroUsd : null;
+
+  // What the chart itself plots as spent: the last burn-down point that carries an actual.
+  const plottedActuals = forecast.burndown.filter((p) => p.actualMicroUsd !== null);
+  const chartActualMicroUsd =
+    plottedActuals.length > 0
+      ? (plottedActuals[plottedActuals.length - 1].actualMicroUsd as number)
+      : null;
+
+  return {
+    period: { start: periodStart, end: periodEnd, asOf, today },
+    forecast,
+    budget,
+    noBudgetReason: budget
+      ? null
+      : "no monthly tenant-wide budget is set, so there is nothing to project against",
+    varianceMicroUsd,
+    variancePct:
+      budget && varianceMicroUsd !== null ? ratio(varianceMicroUsd, budget.amountMicroUsd) : null,
+    window,
+    layers,
+    layerSumMicroUsd,
+    layersReconcile: projected === null || layerSumMicroUsd === null
+      ? true
+      : layerSumMicroUsd === projected,
+    largestLayer: layers.find((l) => l.projectedMicroUsd !== null)?.layer ?? null,
+    chartActualMicroUsd,
+    settledPeriodMicroUsd,
+    // Only a chart that exists can disagree with the figure beside it. Below the history floor the
+    // burn-down is empty on purpose and the card draws nothing, so there is no claim to reconcile;
+    // asserting a mismatch there would print a bug report about a chart nobody rendered. Otherwise
+    // "nothing plotted" agrees with "nothing settled" only when the settled total is zero too.
+    chartReconciles:
+      forecast.burndown.length === 0
+        ? true
+        : chartActualMicroUsd === null
+          ? settledInPeriod.length === 0
+          : chartActualMicroUsd === settledPeriodMicroUsd,
+  };
+}
+
+/** What the section carries over the wire. Exactly one of the two fields is non-null. */
+export interface ForecastPayload {
+  section: BurndownSection | null;
+  /** Why there is no section: ClickHouse or the gateway could not be read. Never "no budget". */
+  unavailable: string | null;
+}


### PR DESCRIPTION
Closes CTO-210 (F6), the payoff of the spend-forecasting epic. `/cost` now says **when** this tenant crosses budget, not only how much it has spent.

The section sits directly under CTO-209's measured card and is served by the same route off the same `querySettledCostSeries` read, so the measured figure and the projection can never be reading two different windows. `forecastSpend` (CTO-206) already built the cone; nothing here recomputes it.

## What is on screen

- Cumulative settled spend as a solid line, stopping dead at the last settled day.
- The day-of-week weighted projection as a dashed line, with the 80 percent band as a cone that is fat just past the last settled day and pinches shut on the closing day.
- Budget as a flat reference line.
- **The breach date labelled on the chart** with a rule, a dot and the date in words, and repeated as the section headline.
- The naive run-rate drawn faintly as the sanity line, and printed as a figure, so a reader can check the weighted projection against the dumbest possible arithmetic without leaving the page.
- A layer split projected per layer by the same engine, so the answer is "you land 15.8 percent over, and LLM is the largest part of it".

## States rendered, all against live local data

Gateway path: Docker Hub is unreachable from this machine and the running `ai-tally-gateway` container predates CTO-205, so it 404s on `/v1/tenant/budgets`. The gateway was run **from source with uvicorn** on port 8081 against the same Postgres and ClickHouse, as the last three agents did. The worktree's dev server ran on port 3101 (and 3102 for the second tenant); the `web` launch config serves the main checkout and was left alone. All servers shut down afterwards.

### 1. Healthy forecast, under budget

Budget $150,000.00, created through the F1 endpoint and deleted afterwards.

- Headline: **None this period**, $43,507.69 under (29.0%) by 2026-08-31.
- Projected month end $106,492.31, band $97,335.46 to $115,649.17.
- Cone, projection, naive line and budget line all drawn; no breach marker.

### 2. Projected breach, date labelled

Budget $92,000.00, created through the F1 endpoint to force the state (the live tenant will not naturally breach) and deleted afterwards.

- Headline: **Crosses budget 2026-08-27**, +$14,492.31 over (15.8%) by 2026-08-31, on day 27 of 31.
- On the chart: red rule at 2026-08-27, dot on the budget line, and the label "crosses budget 2026-08-27".
- "The high edge of the band crosses as early as 2026-08-26. That is the bad case, not the likely one."
- Layer split: "You are projected to land 15.8% over, and LLM is the largest part of it: $55,871.02, 53.1% of projected spend, up from $44,704.83 settled so far this month."

### 3. No budget configured

- Projection still shown ($106,492.31): no budget is not a reason to withhold the forecast.
- No reference line, no breach date, no variance, and the copy says explicitly that the projection is drawn without a reference line rather than compared against a budget of zero, with a link to set one.

### 4. Insufficient history

A second local tenant with six days of real spans ingested through the gateway, on port 3102. Both the tenant and its spans were deleted afterwards.

- **No chart at all.** Not faint, not greyed out: none.
- "This tenant has 6 settled days of history, and a projection needs 14. Spend was first seen on 2026-08-20, so the 23 earlier days in the window are not counted as history."
- "This is not a statement that spend is under control. We are saying we do not know, which is a different thing from 'this will not breach'."

## Live figures and the input window the forecast used

| | |
|---|---|
| Period | 2026-08-01 to 2026-08-31, measured through **2026-08-23** |
| Today per the warehouse clock | 2026-08-26 |
| Input window | **27 settled days, 2026-07-28 through 2026-08-23**, rule `connector-landing` |
| Excluded | 3 days (2026-08-24, 2026-08-25, 2026-08-26) carrying $0.0001, 0.0% of observed month to date |
| Settled month to date | $81,827.49 |
| Projected month end | $106,492.31 |
| 80% band | $97,335.46 to $115,649.17 |
| Naive run-rate | $110,289.23 |
| Layer projections | LLM $55,871.02 (53.1%), Compute $49,165.38 (46.7%), Egress $196.00 (0.2%) |
| Layer sum vs headline | $105,232.39, $1,259.92 less than the projection, stated on screen as the method rather than a bug |

The layer rows are six independent projections, each from that layer's own settled history and its own weekday profile. Independent medians do not add, so the difference is printed rather than hidden.

## The bug this found

The minimum-history guard could not fire on live data before this change.

`querySettledCostSeries` gives every calendar day in its 30-day window a slot and treats a day with no rows as a genuine zero. That is correct for the measured card and wrong as forecast history: the six-day-old tenant in state 4 arrived with **29 "settled" days, 23 of them zeros meaning "did not exist yet"**, cleared the 14-day floor, and would have been handed a month-long forecast off a weekday profile of mostly zeros. That is exactly the day-2 projection the floor exists to refuse, wearing a full month of fake history.

The baseline now starts at the first day the tenant was seen spending anything, and the card states how many leading days it dropped and why. A zero day after that first sighting stays in the baseline, because a quiet weekend is real evidence; there is a test for each half.

## Two clocks (CTO-203)

Every date comes from ClickHouse. `periodStart` and `today` are read off the series, `asOf` is its own `settledThrough`, the period end is arithmetic on `periodStart`, and the chart's x axis is indexed off the array it was handed. There is no `new Date()` in the view model or the chart, and a test projects a month in **2031** to prove nothing consults the Node clock.

The section also checks that the days it plotted still sum to the settled figure printed beside them and says so on screen if they ever stop, the way the account detail view does with its allocation rows. It makes no such claim in the refusal state, where there is no chart to reconcile.

## Verification

From `web/`:

- `npm run typecheck` clean.
- `npm run lint` clean (three pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`, untouched by this branch).
- `npm run test`: **538 passing**, up from 535. The only failures are the 2 long-standing `app/api/api.test.ts` ones (attribution and data-quality "falls back to mock when ClickHouse is unreachable") that fail because a local ClickHouse is running.

22 new tests: 15 in `lib/burndown.test.ts` and 7 in `app/cost/BurndownCard.test.tsx`, one per honesty requirement, because each of these regresses silently. A cone drawn from four days looks exactly like a cone drawn from forty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
