### PR TITLE
feat(cost): scoped budgets and per-scope forecasts (CTO-211)

### DIFF
--- a/web/app/api/cost/budget/route.ts
+++ b/web/app/api/cost/budget/route.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Month-to-date actual versus budget for /cost (CTO-209, F5).
+// Month-to-date actual versus budget for /cost (CTO-209, F5), the burn-down forecast (CTO-210, F6)
+// and the per-scope roster (CTO-211, F7).
 //
 // WHY THIS IS ITS OWN ROUTE AND NOT PART OF /api/cost. The cost page live-polls /api/cost every 5
-// seconds (`useLivePoll`, NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS). This payload costs two more
+// seconds (`useLivePoll`, NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS). This payload costs several
 // ClickHouse reads plus a gateway round trip, and none of it changes at that cadence: a budget is
 // edited by a human maybe monthly, and the settled window advances once a day. Folding it into the
 // polled route would multiply that work by 720 an hour to redraw an identical section. So it is
@@ -11,20 +12,43 @@
 //
 // CTO-210 (F6) adds the burn-down section to the same payload rather than a second route. Both
 // sections are derived from ONE `querySettledCostSeries` result, so the measured month-to-date
-// figure and the projection can never be reading two different windows, and the forecast costs no
-// extra ClickHouse work at all: `burndownSection` is pure arithmetic over the series already read
-// for the comparison.
+// figure and the projection can never be reading two different windows.
 //
-// The comparison is always TENANT-WIDE, even under /cost?tag=<feature>. The budget scopes in
-// CTO-205 include 'feature', but wiring the tag filter to a feature-scoped budget is the
-// scoped-budget phase of docs/spend-forecasting-scope.md, not this ticket, and silently comparing
-// one feature's spend against the whole tenant's budget would be worse than either.
+// CTO-211 (F7) makes the forecast half scoped. Three things follow, in this order, and the order is
+// forced:
+//
+//  1. The budgets have to be read BEFORE the spend, because the budgets are what decide which
+//     scopes exist. `rosterScopes` derives the roster from the monthly budgets covering today, so a
+//     tenant with 200 feature tags gets a selector of the two or three somebody actually owns
+//     rather than 200 ClickHouse reads for scopes with nothing to be on track against.
+//
+//  2. Each scope gets its OWN `querySettledCostSeries(scope)` (CTO-207 has taken a scope argument
+//     since F3). Filtering a tenant-wide series afterwards would be cheaper and wrong: the
+//     leading-zero trim and the fourteen-day floor are counted in the scope's own settled days, and
+//     a feature introduced last week has to fail that floor on a tenant that has been running for a
+//     year. Reading per scope is what makes the guard per scope.
+//
+//  3. The measured card above stays TENANT-WIDE whatever the selector says. Rescoping it too would
+//     mean the same page had two different definitions of "month to date" one card apart, and the
+//     scoped figure is already on screen: it is in the roster table and in the forecast section's
+//     own settled line, both labelled with the scope they belong to.
+//
+// A `?scope=` naming something with no budget is not honoured silently: the payload falls back to
+// tenant-wide and carries `selectionFallbackReason`, which the card prints.
 
 import { NextResponse } from "next/server";
 
 import { budgetVsActual } from "@/lib/budgetVsActual";
 import { burndownSection } from "@/lib/burndown";
-import { querySettledCostSeries } from "@/lib/clickhouse";
+import { querySettledCostSeries, type SpendScope } from "@/lib/clickhouse";
+import { LAYERS, type Layer } from "@/lib/cost";
+import {
+  rosterScopes,
+  scopedForecast,
+  type ScopeSection,
+  type ScopedForecastPayload,
+} from "@/lib/scopedForecast";
+import { parseScopeKey, type ForecastScope } from "@/lib/spendScopes";
 import { fetchTenantBudgets } from "@/lib/tenantBudgetsClient";
 
 import type { CostBudgetPayload } from "@/app/cost/BurndownCard";
@@ -32,8 +56,40 @@ import type { CostBudgetPayload } from "@/app/cost/BurndownCard";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
-  const [series, budgets] = await Promise.all([
+/**
+ * A roster scope as `querySettledCostSeries` wants it, or null when this deployment cannot query it.
+ *
+ * The only way to get a null here is a `scope_kind='layer'` budget naming a layer this build does
+ * not have, which the gateway does not police. Dropping it from the roster is better than querying
+ * a layer name that matches nothing and rendering a confident zero for it.
+ */
+function toSpendScope(scope: ForecastScope): SpendScope | null {
+  switch (scope.kind) {
+    case "tenant":
+      return { kind: "tenant" };
+    case "feature":
+      return { kind: "feature", value: scope.value };
+    case "model":
+      return { kind: "model", value: scope.value };
+    case "layer":
+      return (LAYERS as readonly string[]).includes(scope.value)
+        ? { kind: "layer", value: scope.value as Layer }
+        : null;
+  }
+}
+
+export async function GET(request: Request) {
+  const requestedKey = new URL(request.url).searchParams.get("scope");
+  const requested = parseScopeKey(requestedKey);
+  const requestedReason =
+    requestedKey && !requested
+      ? `"${requestedKey}" does not name a scope this dashboard can forecast, so the tenant-wide ` +
+        "forecast is shown instead"
+      : null;
+
+  // Budgets first: they decide the roster (note 1 above). The tenant-wide series is read alongside
+  // them because it is needed in every branch, including the fallback.
+  const [tenantSeries, budgets] = await Promise.all([
     querySettledCostSeries({ kind: "tenant" }),
     fetchTenantBudgets(),
   ]);
@@ -42,32 +98,66 @@ export async function GET() {
   // keeps a fresh clone looking alive; here it would put invented spend next to a budget somebody
   // really set and produce a variance that is pure fiction. "We cannot read the spend" is the only
   // honest answer, and the section renders it as a blank with this reason attached.
-  // The same reason blanks both sections: a projection built on invented spend and compared against
+  // The same reason blanks every section: a projection built on invented spend and compared against
   // a budget somebody really set would be fiction with a date attached, which is worse here than on
   // the measured card because a reader would act on it days in advance.
-  if (!series) {
-    const reason = "spend data is unavailable: ClickHouse is unreachable from the dashboard";
-    const payload: CostBudgetPayload = {
-      comparison: null,
-      unavailable: reason,
-      forecast: { section: null, unavailable: reason },
-    };
-    return NextResponse.json(payload);
+  if (!tenantSeries) {
+    return NextResponse.json(unavailable("spend data is unavailable: ClickHouse is unreachable from the dashboard"));
   }
   if (!budgets.ok) {
-    const reason = `the budget could not be read: gateway unreachable (${budgets.error})`;
-    const payload: CostBudgetPayload = {
-      comparison: null,
-      unavailable: reason,
-      forecast: { section: null, unavailable: reason },
-    };
-    return NextResponse.json(payload);
+    return NextResponse.json(
+      unavailable(`the budget could not be read: gateway unreachable (${budgets.error})`),
+    );
   }
 
+  // Today per ClickHouse, never the Node clock: the roster's "covering today" test has to agree
+  // with the one `selectBudget` applies inside each section (CTO-203).
+  const roster = rosterScopes(budgets.budgets, tenantSeries.windowEnd);
+
+  const sections: ScopeSection[] = [
+    { scope: { kind: "tenant", value: "" }, section: burndownSection(tenantSeries, budgets.budgets) },
+  ];
+  const scoped = roster.filter((s) => s.kind !== "tenant");
+  const scopedSeries = await Promise.all(
+    scoped.map(async (scope) => {
+      const spendScope = toSpendScope(scope);
+      // Each scope reads its own series (note 2). A scope whose read fails is dropped from the
+      // roster rather than shown with tenant numbers under its name.
+      const series = spendScope ? await querySettledCostSeries(spendScope) : null;
+      return { scope, series };
+    }),
+  );
+  for (const { scope, series } of scopedSeries) {
+    if (!series) continue;
+    sections.push({ scope, section: burndownSection(series, budgets.budgets, scope) });
+  }
+
+  const result = scopedForecast({
+    sections,
+    requested,
+    requestedReason,
+    budgets: budgets.budgets,
+  });
+
   const payload: CostBudgetPayload = {
-    comparison: budgetVsActual(series, budgets.budgets),
+    // Tenant-wide whatever the selector says (note 3).
+    comparison: budgetVsActual(tenantSeries, budgets.budgets),
     unavailable: null,
-    forecast: { section: burndownSection(series, budgets.budgets), unavailable: null },
+    // The selected scope's section, so `BurndownCard` renders one section and never has to decide
+    // between two sources for it. With no `?scope=` this is the tenant-wide section, byte for byte
+    // what CTO-210 shipped.
+    forecast: { section: result.section, unavailable: null },
+    scoped: { scoped: result, unavailable: null },
   };
   return NextResponse.json(payload);
+}
+
+function unavailable(reason: string): CostBudgetPayload {
+  const scoped: ScopedForecastPayload = { scoped: null, unavailable: reason };
+  return {
+    comparison: null,
+    unavailable: reason,
+    forecast: { section: null, unavailable: reason },
+    scoped,
+  };
 }

--- a/web/app/cost/BurndownCard.test.tsx
+++ b/web/app/cost/BurndownCard.test.tsx
@@ -11,6 +11,8 @@ import { describe, expect, it } from "vitest";
 import type { SettledSeriesLike, TenantBudget } from "@/lib/budgetVsActual";
 import { burndownSection } from "@/lib/burndown";
 import { LAYERS } from "@/lib/cost";
+import { scopedForecast, type ScopeSection } from "@/lib/scopedForecast";
+import { TENANT_SCOPE, type ForecastScope } from "@/lib/spendScopes";
 import type { SpendByLayer } from "@/lib/types";
 
 import { BurndownCard } from "./BurndownCard";
@@ -38,13 +40,16 @@ type DayRow = {
 };
 
 /** `settledDays` complete days ending yesterday, plus today still accruing. */
-function series(settledDays: number, today = "2026-08-20"): SettledSeriesLike {
-  const perDay = 100 * USD;
+function series(settledDays: number, today = "2026-08-20", perDayUsd = 100): SettledSeriesLike {
+  const perDay = perDayUsd * USD;
   const days: DayRow[] = [];
   for (let i = settledDays; i >= 1; i -= 1) {
     days.push({
       date: addDays(today, -i),
-      byLayer: layers({ llm: 70 * USD, compute: 30 * USD }),
+      byLayer: layers({
+        llm: Math.round(perDay * 0.7),
+        compute: perDay - Math.round(perDay * 0.7),
+      }),
       totalMicroUsd: perDay,
       inPeriod: addDays(today, -i) >= "2026-08-01",
       settled: true,
@@ -54,8 +59,11 @@ function series(settledDays: number, today = "2026-08-20"): SettledSeriesLike {
   }
   days.push({
     date: today,
-    byLayer: layers({ llm: 35 * USD, compute: 15 * USD }),
-    totalMicroUsd: 50 * USD,
+    byLayer: layers({
+      llm: Math.round(perDay * 0.35),
+      compute: Math.round(perDay * 0.5) - Math.round(perDay * 0.35),
+    }),
+    totalMicroUsd: Math.round(perDay * 0.5),
     inPeriod: true,
     settled: false,
     inProgress: true,
@@ -183,5 +191,132 @@ describe("BurndownCard", () => {
     expect(screen.getByText(/No forecast:/).textContent).toContain(
       "ClickHouse is unreachable from the dashboard",
     );
+  });
+});
+
+// CTO-211 (F7). The states that have to be distinguishable on screen when several budgets exist:
+// one on track, one projected to breach, one with too little history of its own, and the two
+// reconciliation registers (spend is a bug when it does not add up, budgets are not).
+describe("BurndownCard, scoped (CTO-211)", () => {
+  function scopedBudget(
+    budgetId: string,
+    amountUsd: number,
+    scopeKind: string,
+    scopeValue: string,
+  ): TenantBudget {
+    return {
+      budget_id: budgetId,
+      period: "month",
+      amount_micro: amountUsd * USD,
+      scope_kind: scopeKind,
+      scope_value: scopeValue,
+      starts_on: "2026-01-01",
+      ends_on: null,
+    };
+  }
+
+  // The tenant spends 100/day; the three features spend 30, 25 and 10, so the scoped spend adds up
+  // to less than the tenant's, which is the only way it is allowed to add up.
+  const budgets = [
+    budget(4_000),
+    scopedBudget("healthy", 2_000, "feature", "research-agent"),
+    // 25/day lands near 775 by month end, over a 700 budget but not over it yet.
+    scopedBudget("tight", 700, "feature", "support-bot"),
+    scopedBudget("new", 900, "feature", "brand-new"),
+  ];
+
+  function scopedPayload(requested: ForecastScope | null) {
+    const sections: ScopeSection[] = [
+      { scope: TENANT_SCOPE, section: burndownSection(series(20), budgets) },
+      {
+        scope: { kind: "feature", value: "research-agent" },
+        section: burndownSection(series(20, "2026-08-20", 30), budgets, {
+          kind: "feature",
+          value: "research-agent",
+        }),
+      },
+      {
+        scope: { kind: "feature", value: "support-bot" },
+        section: burndownSection(series(20, "2026-08-20", 25), budgets, {
+          kind: "feature",
+          value: "support-bot",
+        }),
+      },
+      {
+        // Five settled days of its own: the feature introduced last week on a mature tenant.
+        scope: { kind: "feature", value: "brand-new" },
+        section: burndownSection(series(5, "2026-08-20", 10), budgets, {
+          kind: "feature",
+          value: "brand-new",
+        }),
+      },
+    ];
+    return scopedForecast({ sections, requested, budgets });
+  }
+
+  function renderScoped(requested: ForecastScope | null) {
+    const result = scopedPayload(requested);
+    return render(
+      <BurndownCard
+        payload={{ section: result.section, unavailable: null }}
+        scoped={{ scoped: result, unavailable: null }}
+      />,
+    );
+  }
+
+  it("offers every budgeted scope, defaulting to tenant-wide", () => {
+    const { container } = renderScoped(null);
+    const selector = screen.getByTestId("forecast-scope-selector");
+    expect(selector.textContent).toContain("Whole tenant");
+    expect(selector.textContent).toContain("feature: research-agent");
+    expect(selector.textContent).toContain("feature: brand-new");
+    expect(selector.querySelector('[aria-current="page"]')?.textContent).toContain("Whole tenant");
+    // Tenant-wide is the default, so the section reads exactly as it did before this ticket.
+    expect(container.querySelector('[data-testid="forecast-scope-heading"]')).toBeNull();
+  });
+
+  it("shows on track, projected breach and cannot-say as three different standings", () => {
+    const { container } = renderScoped(null);
+    const table = container.querySelector('[data-testid="forecast-scope-roster"]');
+    expect(table?.textContent).toContain("On track");
+    expect(table?.textContent).toContain("Projected breach");
+    // Not "On track" and not green: refusing to project is not a clean bill of health.
+    expect(table?.textContent).toContain("Cannot say");
+  });
+
+  it("blanks the variance for a scope with too little history, saying which it is", () => {
+    const { container } = renderScoped(null);
+    const table = container.querySelector('[data-testid="forecast-scope-roster"]');
+    const reasons = [...(table?.querySelectorAll("span[title]") ?? [])].map((n) =>
+      n.getAttribute("title"),
+    );
+    expect(reasons.join(" ")).toContain("settled days of its own history");
+    expect(reasons.join(" ")).toContain("no crossing date is claimed either way");
+  });
+
+  it("renders the selected scope's own section and says the card above is tenant-wide", () => {
+    const { container } = renderScoped({ kind: "feature", value: "support-bot" });
+    const heading = container.querySelector('[data-testid="forecast-scope-heading"]');
+    expect(heading?.textContent).toContain("feature: support-bot");
+    expect(heading?.textContent).toContain("month-to-date card above stays tenant-wide");
+  });
+
+  it("renders the per-scope refusal for a feature introduced last week", () => {
+    const { container } = renderScoped({ kind: "feature", value: "brand-new" });
+    const refusal = container.querySelector('[data-testid="burndown-insufficient-history"]');
+    expect(refusal?.textContent).toContain("feature: brand-new has 5 settled days of history");
+    expect(refusal?.textContent).toContain("not a statement that spend is under control");
+    // No cone, per requirement 1, and per scope now.
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("states over-allocated budgets neutrally and never as a warning", () => {
+    const { container } = renderScoped(null);
+    const alloc = container.querySelector('[data-testid="forecast-budget-allocation"]');
+    // 2000 + 700 + 900 against a 4000 tenant budget is under; the wording is still the neutral one.
+    expect(alloc?.textContent).toContain("budgets need not add up");
+    expect(alloc?.textContent).toContain("The spend below does");
+    // The spend does reconcile here, so no warning is rendered at all.
+    expect(container.textContent).not.toContain("bug on this page");
   });
 });

--- a/web/app/cost/BurndownCard.tsx
+++ b/web/app/cost/BurndownCard.tsx
@@ -36,6 +36,20 @@
 // The chart's day axis is built from ClickHouse's dates, never the Node clock (CTO-203). The card
 // checks that the chart's own days still sum to the settled figure printed beside them and says so
 // on screen when they do not, the way the account detail view does with its allocation rows.
+//
+// CTO-211 (F7) adds the scope selector and the roster above the headline, and everything below the
+// selector is then the SELECTED scope's section rather than the tenant's. Two rules that section
+// inherits and this file must not break:
+//
+//  * A scope with no budget shows its forecast with no variance. Never a variance against zero, and
+//    never a variance against the tenant-wide budget, which covers different dollars.
+//  * A scope below its own history floor shows requirement 1's refusal, per scope. A feature
+//    introduced last week hits it on a tenant that has been running for a year, which is the case
+//    the guard exists for.
+//
+// The roster's arithmetic is not this file's: `lib/scopedForecast.ts` decides what may be summed
+// (spend, within one kind) and what may not (spend across kinds; budgets, ever). This file renders
+// what that module concluded and prints its reasons verbatim.
 
 import Link from "next/link";
 
@@ -45,6 +59,13 @@ import { DataTable, type Column } from "@/components/DataTable";
 import { Blank, Money, Pct } from "@/components/HonestValue";
 import type { BurndownSection, ForecastPayload, LayerProjection } from "@/lib/burndown";
 import { LAYER_LABEL } from "@/lib/cost";
+import type {
+  ScopedForecast,
+  ScopedForecastPayload,
+  ScopeLine,
+  ScopeStanding,
+} from "@/lib/scopedForecast";
+import { isTenantScope, scopeLabel } from "@/lib/spendScopes";
 
 import type { BudgetPayload } from "./BudgetVsActualCard";
 
@@ -58,12 +79,29 @@ export type { ForecastPayload };
  */
 export interface CostBudgetPayload extends BudgetPayload {
   forecast: ForecastPayload;
+  /** The roster, the selection and the reconciliation (CTO-211). `forecast` holds the selected
+   *  scope's section, so this never has to be consulted to know what is being drawn. */
+  scoped: ScopedForecastPayload;
 }
 
 /** Where a budget is set. Same path the month-to-date card links to; CTO-208 owns that surface. */
 const BUDGET_SETTINGS_PATH = "/settings/budgets";
 
-export function BurndownCard({ payload }: { payload: ForecastPayload }) {
+/** Default scope link. Overridden by `/cost` so the `?tag=` breakdown filter survives a scope change. */
+function defaultScopeHref(key: string): string {
+  return `/cost?scope=${encodeURIComponent(key)}`;
+}
+
+export function BurndownCard({
+  payload,
+  scoped,
+  scopeHref = defaultScopeHref,
+}: {
+  payload: ForecastPayload;
+  /** Optional: without it the card renders exactly the tenant-wide section CTO-210 shipped. */
+  scoped?: ScopedForecastPayload;
+  scopeHref?: (key: string) => string;
+}) {
   const section = payload.section;
   if (!section) {
     return (
@@ -77,9 +115,13 @@ export function BurndownCard({ payload }: { payload: ForecastPayload }) {
   }
 
   const { forecast } = section;
+  const roster = scoped?.scoped ?? null;
 
   return (
     <Card title="Projected month-end spend">
+      {roster ? <ScopeSelector roster={roster} scopeHref={scopeHref} /> : null}
+      {roster ? <ScopeHeading section={section} /> : null}
+
       {forecast.status === "insufficient_history" ? (
         <InsufficientHistory section={section} />
       ) : (
@@ -104,6 +146,8 @@ export function BurndownCard({ payload }: { payload: ForecastPayload }) {
         </>
       )}
 
+      {roster ? <ScopeRoster roster={roster} scopeHref={scopeHref} /> : null}
+
       <Provenance section={section} />
     </Card>
   );
@@ -119,6 +163,9 @@ export function BurndownCard({ payload }: { payload: ForecastPayload }) {
 function InsufficientHistory({ section }: { section: BurndownSection }) {
   const { window, period } = section;
   const short = Math.max(0, window.requiredDays - window.dayCount);
+  // Per scope (CTO-211): a feature introduced last week fails this floor on a tenant that has been
+  // running for a year, and the sentence has to name what it is short of history about.
+  const subject = isTenantScope(section.scope) ? "This tenant" : scopeLabel(section.scope);
   return (
     <div data-testid="burndown-insufficient-history">
       <div className="text-2xl font-semibold text-muted">
@@ -126,7 +173,7 @@ function InsufficientHistory({ section }: { section: BurndownSection }) {
         Not enough history to project
       </div>
       <p className="mt-2 max-w-prose text-sm text-muted">
-        This tenant has {window.dayCount} settled{" "}
+        {subject} has {window.dayCount} settled{" "}
         {window.dayCount === 1 ? "day" : "days"} of history, and a projection needs{" "}
         {window.requiredDays}.
         {window.trimmedLeadingDays > 0 && window.firstObservedDay !== null ? (
@@ -134,8 +181,9 @@ function InsufficientHistory({ section }: { section: BurndownSection }) {
             {" "}
             Spend was first seen on {window.firstObservedDay}, so the {window.trimmedLeadingDays}{" "}
             earlier {window.trimmedLeadingDays === 1 ? "day" : "days"} in the window are not counted
-            as history: they are days before this tenant was sending anything, not days it spent
-            nothing.
+            as history: they are days before this{" "}
+            {isTenantScope(section.scope) ? "tenant" : section.scope.kind} was sending anything, not
+            days it spent nothing.
           </>
         ) : null} {short > 0 ? `${short} more ${short === 1 ? "day" : "days"} ` : "More history "}
         will settle it. Fourteen days is two full weeks, which is the point: below that every weekday
@@ -181,9 +229,14 @@ function Headline({ section }: { section: BurndownSection }) {
           projected for {period.start.slice(0, 7)}, a forecast and not a commitment
         </div>
         <p className="mt-3 max-w-prose text-sm text-muted">
-          <Blank reason={section.noBudgetReason ?? "no budget set"} /> No budget is set, so there is
-          no breach date and no variance: the projection is drawn without a reference line rather
-          than compared against a budget of zero.{" "}
+          <Blank reason={section.noBudgetReason ?? "no budget set"} /> No budget is set
+          {isTenantScope(section.scope) ? "" : ` for ${scopeLabel(section.scope)}`}, so there is no
+          breach date and no variance: the projection is drawn without a reference line rather than
+          compared against a budget of zero
+          {isTenantScope(section.scope)
+            ? ""
+            : ", and not against the tenant-wide budget, which covers all spend rather than this slice"}
+          .{" "}
           <Link href={BUDGET_SETTINGS_PATH} className="text-accent underline">
             Set a monthly budget
           </Link>{" "}
@@ -360,8 +413,289 @@ function LayerSplit({ section }: { section: BurndownSection }) {
           </>
         )}
       </p>
+      {section.layerBudgetReason === null ? null : (
+        <p className="mt-2 max-w-prose text-xs text-muted">
+          <Blank reason={section.layerBudgetReason} /> No layer-budget column here:{" "}
+          {section.layerBudgetReason}.
+        </p>
+      )}
     </div>
   );
+}
+
+// --- The scope selector, the heading and the roster (CTO-211, F7) --------------------------------
+
+const STANDING_LABEL: Record<ScopeStanding, string> = {
+  on_track: "On track",
+  projected_breach: "Projected breach",
+  already_over: "Already over",
+  no_budget: "No budget",
+  unknown: "Cannot say",
+};
+
+/**
+ * Colour carries meaning here, so it is spent carefully. Red is reserved for the two states that
+ * are actually bad. `unknown` is deliberately NOT green: refusing to project is not a clean bill of
+ * health, and the whole epic's failure mode is a reader taking silence for safety.
+ */
+const STANDING_CLASS: Record<ScopeStanding, string> = {
+  on_track: "text-good",
+  projected_breach: "text-bad",
+  already_over: "text-bad",
+  no_budget: "text-muted",
+  unknown: "text-warn",
+};
+
+function Standing({ line }: { line: ScopeLine }) {
+  return (
+    <span className={STANDING_CLASS[line.standing]} title={line.standingReason}>
+      {STANDING_LABEL[line.standing]}
+      <span className="sr-only"> ({line.standingReason})</span>
+    </span>
+  );
+}
+
+/**
+ * The selector. Links rather than client state: the scope is a server-side query
+ * (`querySettledCostSeries(scope)`), so a `?scope=` in the URL is both the mechanism and a
+ * shareable address for one feature owner's view. Every entry carries its standing, so an owner
+ * finds their own line without reading anyone else's numbers.
+ */
+function ScopeSelector({
+  roster,
+  scopeHref,
+}: {
+  roster: ScopedForecast;
+  scopeHref: (key: string) => string;
+}) {
+  return (
+    <div className="mb-4" data-testid="forecast-scope-selector">
+      <div className="mb-1 text-xs uppercase tracking-wide text-muted">Forecast scope</div>
+      <div className="flex flex-wrap gap-2">
+        {roster.lines.map((line) => (
+          <Link
+            key={line.key}
+            href={scopeHref(line.key)}
+            aria-current={line.selected ? "page" : undefined}
+            title={line.standingReason}
+            className={`rounded-full border px-3 py-1 text-sm ${
+              line.selected
+                ? "border-accent bg-accent/10 text-accent"
+                : "border-edge text-muted hover:text-fg"
+            }`}
+          >
+            {line.label}{" "}
+            <span className={`ml-1 text-xs ${STANDING_CLASS[line.standing]}`}>
+              {STANDING_LABEL[line.standing]}
+            </span>
+          </Link>
+        ))}
+      </div>
+      {roster.lines.length === 1 ? (
+        <p className="mt-2 max-w-prose text-xs text-muted">
+          Only the tenant-wide forecast is offered because no scoped monthly budget covers today. A
+          budget is what says somebody owns a slice, so{" "}
+          <Link href={BUDGET_SETTINGS_PATH} className="text-accent underline">
+            set a scoped budget
+          </Link>{" "}
+          to get a line here for a feature, model or layer.
+        </p>
+      ) : null}
+      {roster.selectionFallbackReason === null ? null : (
+        <p className="mt-2 max-w-prose text-sm text-warn" data-testid="forecast-scope-fallback">
+          {roster.selectionFallbackReason}.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Names the slice everything below belongs to, and where it does not agree with the card above. */
+function ScopeHeading({ section }: { section: BurndownSection }) {
+  if (isTenantScope(section.scope)) return null;
+  return (
+    <p className="mb-3 max-w-prose text-sm" data-testid="forecast-scope-heading">
+      Everything below is <span className="font-medium">{scopeLabel(section.scope)}</span> only,
+      projected from that {section.scope.kind}&rsquo;s own settled history.{" "}
+      <span className="text-muted">
+        The month-to-date card above stays tenant-wide: one page with two definitions of &ldquo;month
+        to date&rdquo; would be worse than one that says which is which.
+      </span>
+    </p>
+  );
+}
+
+/**
+ * The roster: every budgeted scope on one line, and the reconciliation underneath.
+ *
+ * The reconciliation is the correctness question of this ticket, rendered in two visually different
+ * registers on purpose. Spend that fails to reconcile is a BUG and is shown as a warning. Budgets
+ * that do not reconcile are NORMAL and are shown as a neutral note. See `lib/scopedForecast.ts`.
+ */
+function ScopeRoster({
+  roster,
+  scopeHref,
+}: {
+  roster: ScopedForecast;
+  scopeHref: (key: string) => string;
+}) {
+  const { reconciliation } = roster;
+  if (roster.lines.length <= 1) return null;
+  return (
+    <div className="mt-5" data-testid="forecast-scope-roster">
+      <h3 className="mb-2 text-xs uppercase tracking-wide text-muted">
+        Every budgeted scope: what is on track and what is projected to breach
+      </h3>
+      <DataTable
+        columns={rosterColumns(scopeHref)}
+        rows={roster.lines}
+        rowKey={(r) => r.key}
+        pageSize={0}
+        empty="No scope has a monthly budget covering today."
+      />
+
+      {reconciliation.groups.map((g) => (
+        <p key={g.kind} className="mt-2 max-w-prose text-xs text-muted">
+          The budgeted {g.kind} scopes account for <Money micro={g.settledMicroUsd} /> of the{" "}
+          <Money micro={reconciliation.tenantSettledMicroUsd} /> settled this month; the remaining{" "}
+          <Money micro={g.residualMicroUsd} /> is spend no budgeted {g.kind} covers. Scopes of one
+          kind are disjoint, so those two add up to the whole bill exactly.
+        </p>
+      ))}
+
+      {reconciliation.mixesKinds ? (
+        <p className="mt-2 max-w-prose text-xs text-muted">
+          Budgets are set across more than one kind of scope, and those overlap by construction: the
+          same dollar is both a feature&rsquo;s and a model&rsquo;s. So the rows above are never
+          added together across kinds, and there is no roster-wide total on this page.
+        </p>
+      ) : null}
+
+      {reconciliation.spendReconciles ? null : (
+        <div className="mt-2 max-w-prose space-y-1 text-sm text-warn">
+          {reconciliation.spendWarnings.map((w) => (
+            <p key={w}>{w}</p>
+          ))}
+        </div>
+      )}
+
+      {reconciliation.budgetAllocation.note === null ? null : (
+        <p className="mt-2 max-w-prose text-xs text-muted" data-testid="forecast-budget-allocation">
+          {reconciliation.budgetAllocation.perKind.map((k) => (
+            <span key={k.kind}>
+              {k.count} {k.kind} {k.count === 1 ? "budget" : "budgets"} summing to{" "}
+              <Money micro={k.budgetMicroUsd} />
+              {". "}
+            </span>
+          ))}
+          Tenant-wide budget:{" "}
+          <Money
+            micro={reconciliation.budgetAllocation.tenantBudgetMicroUsd}
+            reason="no monthly tenant-wide budget is set"
+          />
+          . {reconciliation.budgetAllocation.note}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function rosterColumns(scopeHref: (key: string) => string): Column<ScopeLine>[] {
+  return [
+    {
+      key: "scope",
+      header: "Scope",
+      render: (r) =>
+        r.selected ? (
+          <span className="font-medium">{r.label}</span>
+        ) : (
+          <Link href={scopeHref(r.key)} className="text-accent underline">
+            {r.label}
+          </Link>
+        ),
+      sortValue: (r) => r.label,
+    },
+    {
+      key: "settled",
+      header: "Settled to date",
+      align: "right",
+      render: (r) => <Money micro={r.settledMicroUsd} />,
+      sortValue: (r) => r.settledMicroUsd,
+    },
+    {
+      key: "projected",
+      header: "Projected month end",
+      align: "right",
+      render: (r) => (
+        <Money
+          micro={r.projectedMicroUsd}
+          reason={`${r.label} has ${r.historyDays} settled days of its own history and ${r.requiredDays} are needed`}
+        />
+      ),
+      sortValue: (r) => r.projectedMicroUsd,
+    },
+    {
+      key: "budget",
+      header: "Budget (month)",
+      align: "right",
+      render: (r) => (
+        <Money micro={r.budgetMicroUsd} reason={r.noBudgetReason ?? "no monthly budget is set"} />
+      ),
+      sortValue: (r) => r.budgetMicroUsd,
+    },
+    {
+      key: "variance",
+      header: "Projected variance",
+      align: "right",
+      // Null here has two very different causes and each gets its own reason: no budget (normal,
+      // and never a variance against zero) and no projection (the per-scope history floor).
+      render: (r) =>
+        r.varianceMicroUsd === null ? (
+          <Blank
+            reason={
+              r.budgetMicroUsd === null
+                ? (r.noBudgetReason ?? "no monthly budget is set for this scope")
+                : `nothing was projected for ${r.label}, so there is no projected variance`
+            }
+          />
+        ) : (
+          <span className={r.varianceMicroUsd > 0 ? "text-bad" : "text-good"}>
+            {r.varianceMicroUsd > 0 ? "+" : r.varianceMicroUsd < 0 ? "−" : ""}
+            <Money micro={Math.abs(r.varianceMicroUsd)} />
+            {r.variancePct === null ? null : (
+              <>
+                {" "}
+                (<Pct value={Math.abs(r.variancePct)} />)
+              </>
+            )}
+          </span>
+        ),
+      sortValue: (r) => r.varianceMicroUsd,
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      render: (r) => <Standing line={r} />,
+      sortValue: (r) => r.standing,
+    },
+    {
+      key: "breach",
+      header: "Crosses budget",
+      render: (r) =>
+        r.breachDate ?? (
+          <Blank
+            reason={
+              r.standing === "unknown"
+                ? `nothing was projected for ${r.label}, so no crossing date is claimed either way`
+                : r.standing === "no_budget"
+                  ? (r.noBudgetReason ?? "no monthly budget is set for this scope")
+                  : `${r.label} is not projected to cross its budget this period`
+            }
+          />
+        ),
+      sortValue: (r) => r.breachDate,
+    },
+  ];
 }
 
 function layerColumns(section: BurndownSection): Column<LayerProjection>[] {

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -44,6 +44,7 @@ export function CostLive({
   initialData,
   enabledLayers,
   budget,
+  tag = null,
 }: {
   endpoint: string;
   initialData: CostPayload;
@@ -52,6 +53,8 @@ export function CostLive({
   // window advances once a day, so re-reading both every 5 seconds would be pure waste. See the
   // comment at the top of app/api/cost/budget/route.ts.
   budget: CostBudgetPayload;
+  /** The active ?tag= breakdown filter, carried so a scope change does not silently drop it. */
+  tag?: string | null;
 }) {
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
   const { series: costSeries, featureRows, alerts: hiddenCostAlerts } = data;
@@ -97,7 +100,13 @@ export function CostLive({
       {/* Immediately after the measured card (CTO-210). The order is the argument: what happened,
           then where it lands. Putting the projection first would let a reader take a forecast as a
           fact, and the two cards share a settled window that only makes sense read in that order. */}
-      <BurndownCard payload={budget.forecast} />
+      <BurndownCard
+        payload={budget.forecast}
+        scoped={budget.scoped}
+        scopeHref={(key) =>
+          `/cost?${new URLSearchParams(tag ? { tag, scope: key } : { scope: key }).toString()}`
+        }
+      />
 
       {hiddenCostAlerts.map((a) => (
         <div

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -7,20 +7,26 @@ import { CostLive, type CostPayload } from "./Live";
 export default async function CostPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ tag?: string }>;
+  searchParams?: Promise<{ tag?: string; scope?: string }>;
 }) {
   // Forward ?tag= to the API so the breakdown is pre-filtered to one feature (CTO-104).
   const sp = (await searchParams) ?? {};
   const query = sp.tag ? `?tag=${encodeURIComponent(sp.tag)}` : "";
   const endpoint = `/api/cost${query}`;
-  // The budget comparison (CTO-209) and the burn-down forecast (CTO-210) are fetched once per
-  // render rather than joining the live poll: both are tenant-wide, so the ?tag= filter does not
-  // apply to them, and they change on a human/daily cadence rather than a 5-second one. A forecast
-  // that flickered every 5 seconds would also read as far less trustworthy than it is.
+  // The budget comparison (CTO-209) and the burn-down forecast (CTO-210/211) are fetched once per
+  // render rather than joining the live poll: they change on a human/daily cadence rather than a
+  // 5-second one, and a forecast that flickered every 5 seconds would read as far less trustworthy
+  // than it is.
+  //
+  // ?scope= (CTO-211) is a SEPARATE parameter from ?tag= even though both can name a feature, and
+  // deliberately so. ?tag= filters the 30-day breakdown; ?scope= chooses which budget the forecast
+  // is measured against, and it can also name a model or a layer. Collapsing them would mean
+  // clicking a feature in the breakdown silently swapped which budget the page reports on.
+  const budgetQuery = sp.scope ? `?scope=${encodeURIComponent(sp.scope)}` : "";
   const [initialData, enabledLayers, budget] = await Promise.all([
     apiGet<CostPayload>(endpoint),
     queryEnabledConnectors(),
-    apiGet<CostBudgetPayload>("/api/cost/budget"),
+    apiGet<CostBudgetPayload>(`/api/cost/budget${budgetQuery}`),
   ]);
   return (
     <CostLive
@@ -28,6 +34,7 @@ export default async function CostPage({
       initialData={initialData}
       enabledLayers={enabledLayers}
       budget={budget}
+      tag={sp.tag ?? null}
     />
   );
 }

--- a/web/lib/burndown.test.ts
+++ b/web/lib/burndown.test.ts
@@ -326,3 +326,53 @@ describe("burndownSection", () => {
     expect(section.chartReconciles).toBe(true);
   });
 });
+
+// CTO-211 (F7): the same view model built for a slice rather than the whole bill. The series handed
+// in is the SCOPE's own (`querySettledCostSeries(scope)`), so everything above already applies per
+// scope; what is tested here is the three things the scope argument itself changes.
+describe("burndownSection, scoped (CTO-211)", () => {
+  const feature = { kind: "feature" as const, value: "research-agent" };
+
+  it("selects that scope's budget and not the tenant-wide one", () => {
+    const budgets = [
+      budget(1_000),
+      budget(300, { budget_id: "f", scope_kind: "feature", scope_value: "research-agent" }),
+    ];
+    const scoped = burndownSection(series({ settledDays: 20 }), budgets, feature);
+    expect(scoped.scope).toEqual(feature);
+    expect(scoped.budget?.budgetId).toBe("f");
+    expect(scoped.budget?.amountMicroUsd).toBe(300 * USD);
+    // Default is unchanged: still the tenant-wide row, exactly what F6 shipped.
+    expect(burndownSection(series({ settledDays: 20 }), budgets).budget?.budgetId).toBe(
+      "tenant-month",
+    );
+  });
+
+  it("does not fall back to the tenant budget for a scope that has none", () => {
+    // A feature with no budget of its own is a normal state, and it is emphatically not covered by
+    // the tenant-wide budget: that one is compared against tenant-wide spend.
+    const scoped = burndownSection(series({ settledDays: 20 }), [budget(1_000)], feature);
+    expect(scoped.budget).toBeNull();
+    expect(scoped.varianceMicroUsd).toBeNull();
+    expect(scoped.forecast.breach.outcome).toBe("no_budget");
+    expect(scoped.noBudgetReason).toContain("feature: research-agent");
+    expect(scoped.noBudgetReason).toContain("not measured against the tenant-wide budget");
+  });
+
+  it("suppresses layer budgets off tenant-wide scope, with a reason", () => {
+    // A layer budget covers that layer across the WHOLE tenant. Comparing one feature's compute
+    // projection against it would report a feature as over a budget it does not own.
+    const budgets = [
+      budget(1_000),
+      budget(200, { budget_id: "compute", scope_kind: "layer", scope_value: "compute" }),
+    ];
+    const tenant = burndownSection(series({ settledDays: 20 }), budgets);
+    expect(tenant.layerBudgetReason).toBeNull();
+    expect(tenant.layers.find((l) => l.layer === "compute")?.budgetMicroUsd).toBe(200 * USD);
+
+    const scoped = burndownSection(series({ settledDays: 20 }), budgets, feature);
+    expect(scoped.layerBudgetReason).toContain("whole tenant");
+    expect(scoped.layers.every((l) => l.budgetMicroUsd === null)).toBe(true);
+    expect(scoped.layers.every((l) => l.varianceMicroUsd === null)).toBe(true);
+  });
+});

--- a/web/lib/burndown.ts
+++ b/web/lib/burndown.ts
@@ -43,6 +43,21 @@
 //     projections need not sum to the tenant projection, so `layersReconcile` is computed and the
 //     card prints the difference rather than hiding it.
 //
+//  5. NAMING THE SLICE (CTO-211, F7). The section now carries the `scope` it was built for, and the
+//     `series` handed in is expected to be `querySettledCostSeries(scope)`'s, not the tenant's.
+//     Everything downstream of that is already per-scope for free, including the two guards that
+//     matter most: the leading-zero trim in note 3 starts history at the first day THIS SCOPE was
+//     seen spending, and the minimum-history floor is then counted in that scope's own days. That is
+//     the point of doing it here rather than filtering a tenant series afterwards. A feature
+//     introduced last week has almost no history on a tenant that has been running for a year, and a
+//     tenant-wide history count would wave it straight past the floor and project a month of spend
+//     for it from a weekday profile of zeros.
+//
+//     The one thing that does NOT generalise is the layer budget column. A `scope_kind='layer'`
+//     budget governs that layer across the WHOLE tenant, so comparing one feature's compute
+//     projection against it would report a feature as over a budget it does not own. Off tenant-wide
+//     the column is suppressed, with `layerBudgetReason` saying why rather than rendering nulls.
+//
 // Money is integer micro-USD. Dates are `YYYY-MM-DD` UTC strings.
 
 import {
@@ -60,6 +75,12 @@ import {
   type ForecastStatus,
   type SpendForecast,
 } from "./forecast";
+import {
+  isTenantScope,
+  scopeLabel,
+  TENANT_SCOPE,
+  type ForecastScope,
+} from "./spendScopes";
 import type { MicroUSD } from "./types";
 
 /**
@@ -119,6 +140,12 @@ export interface LayerProjection {
 }
 
 export interface BurndownSection {
+  /**
+   * The slice of spend every figure below describes (CTO-211). Tenant-wide unless the caller asked
+   * for something narrower, and echoed so a card can never label a feature's projection as the
+   * tenant's.
+   */
+  scope: ForecastScope;
   /** Every date here is ClickHouse's, never the Node clock's. See note 2 at the top of this file. */
   period: {
     /** First day of the calendar month, from the series. */
@@ -143,6 +170,11 @@ export interface BurndownSection {
   window: ForecastInputWindow;
   /** Every layer, ordered by projected spend descending (settled spend when nothing projected). */
   layers: LayerProjection[];
+  /**
+   * Why the layer-budget columns are not shown, or null when they are. Non-null exactly off
+   * tenant-wide scope: see note 5. A reason rather than a boolean so the card prints a sentence.
+   */
+  layerBudgetReason: string | null;
   /** Sum of the layer projections, or null when no layer projected. */
   layerSumMicroUsd: MicroUSD | null;
   /**
@@ -182,10 +214,16 @@ function ratio(part: number, whole: number): number | null {
  * The caller handles ClickHouse being unreachable (`series === null`) before getting here: there is
  * no honest projection from no data, and inventing one next to a real budget is the single worst
  * thing this surface could do.
+ *
+ * `scope` (CTO-211) names the slice `series` was read for. It selects the budget and words the
+ * blanks; it does NOT filter anything, because filtering a tenant series after the fact would keep
+ * tenant-wide history days and defeat the per-scope minimum-history guard. Pass
+ * `querySettledCostSeries(scope)`'s own result.
  */
 export function burndownSection(
   series: SettledSeriesLike,
   budgets: readonly TenantBudget[],
+  scope: ForecastScope = TENANT_SCOPE,
 ): BurndownSection {
   const periodStart = series.periodStart;
   const periodEnd = endOfMonth(periodStart);
@@ -197,8 +235,11 @@ export function burndownSection(
   const asOf = series.settledThrough;
   const asOfForEngine = asOf ?? today;
 
-  // Note 3: history starts where the tenant does. Any observed spend counts, settled or not, so a
-  // still-unsettled first day does not push the start of history a day later than it really is.
+  // Note 3: history starts where the SCOPE does. `series` is already sliced, so "the first day
+  // anything was seen" is the first day this feature/model/layer was seen, which is exactly the
+  // question the per-scope history guard needs answered (note 5). Any observed spend counts,
+  // settled or not, so a still-unsettled first day does not push the start of history a day later
+  // than it really is.
   const firstObservedDay = series.days.find((d) => d.totalMicroUsd !== 0)?.date ?? null;
   const allSettled = series.days.filter((d) => d.settled);
   const settled =
@@ -232,16 +273,23 @@ export function burndownSection(
     firstObservedDay,
   };
 
-  const tenantBudget = selectBudget(budgets, "tenant", "", today);
-  const budget: AppliedBudget | null = tenantBudget
+  const scopeBudget = selectBudget(budgets, scope.kind, scope.value, today);
+  const budget: AppliedBudget | null = scopeBudget
     ? {
-        budgetId: tenantBudget.budget_id,
-        amountMicroUsd: tenantBudget.amount_micro,
-        startsOn: tenantBudget.starts_on,
-        endsOn: tenantBudget.ends_on,
-        coversPeriodToDate: tenantBudget.starts_on <= periodStart,
+        budgetId: scopeBudget.budget_id,
+        amountMicroUsd: scopeBudget.amount_micro,
+        startsOn: scopeBudget.starts_on,
+        endsOn: scopeBudget.ends_on,
+        coversPeriodToDate: scopeBudget.starts_on <= periodStart,
       }
     : null;
+
+  // Off tenant-wide, a `scope_kind='layer'` budget is somebody else's number: it covers that layer
+  // across the whole tenant, not this feature's share of it. Suppressed with a reason (note 5).
+  const layerBudgetReason = isTenantScope(scope)
+    ? null
+    : `layer budgets cover a layer across the whole tenant, not ${scopeLabel(scope)}, so they are ` +
+      "not compared against this slice";
 
   const forecast = forecastSpend({
     // Settled days only, and every settled day in the trailing window, not just this month's: the
@@ -264,7 +312,9 @@ export function burndownSection(
       // reads. The variance is what the split needs.
       budgetMicroUsd: null,
     });
-    const layerBudget = selectBudget(budgets, "layer", layer, today);
+    const layerBudget = layerBudgetReason === null
+      ? selectBudget(budgets, "layer", layer, today)
+      : null;
     const projected = layerForecast.projectedMicroUsd;
     return {
       layer,
@@ -310,17 +360,26 @@ export function burndownSection(
       : null;
 
   return {
+    scope,
     period: { start: periodStart, end: periodEnd, asOf, today },
     forecast,
     budget,
+    // Named per scope, because "no budget is set" is only actionable if the reader knows WHICH
+    // budget is missing. A feature with no budget of its own is a normal state, and it is not
+    // covered by the tenant-wide budget either: that one is compared against tenant-wide spend.
     noBudgetReason: budget
       ? null
-      : "no monthly tenant-wide budget is set, so there is nothing to project against",
+      : isTenantScope(scope)
+        ? "no monthly tenant-wide budget is set, so there is nothing to project against"
+        : `no monthly budget is set for ${scopeLabel(scope)}, so this projection has nothing to ` +
+          "compare against; it is not measured against the tenant-wide budget, which covers all " +
+          "spend rather than this slice",
     varianceMicroUsd,
     variancePct:
       budget && varianceMicroUsd !== null ? ratio(varianceMicroUsd, budget.amountMicroUsd) : null,
     window,
     layers,
+    layerBudgetReason,
     layerSumMicroUsd,
     layersReconcile: projected === null || layerSumMicroUsd === null
       ? true

--- a/web/lib/scopedForecast.test.ts
+++ b/web/lib/scopedForecast.test.ts
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+// Scoped budgets and per-scope forecasts (CTO-211). Every test here is one of the ticket's
+// correctness or honesty requirements, and all of them fail SILENTLY if they regress: a scope
+// projected from tenant-wide history looks exactly like one projected from its own, and a roster
+// that double counts adds up to a number that looks perfectly plausible.
+
+import { describe, expect, it } from "vitest";
+
+import type { SettledSeriesLike, TenantBudget } from "./budgetVsActual";
+import { burndownSection } from "./burndown";
+import { LAYERS } from "./cost";
+import { rosterScopes, scopedForecast, type ScopeSection } from "./scopedForecast";
+import { TENANT_SCOPE, type ForecastScope } from "./spendScopes";
+import type { SpendByLayer } from "./types";
+
+const USD = 1_000_000;
+const TODAY = "2026-08-20";
+const PERIOD_START = "2026-08-01";
+
+function layers(over: Partial<SpendByLayer> = {}): SpendByLayer {
+  return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0, ...over };
+}
+
+function addDays(iso: string, n: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d + n)).toISOString().slice(0, 10);
+}
+
+type DayRow = {
+  date: string;
+  byLayer: SpendByLayer;
+  totalMicroUsd: number;
+  inPeriod: boolean;
+  settled: boolean;
+  inProgress: boolean;
+  awaitingLayers: string[];
+};
+
+/**
+ * A settled series the way `querySettledCostSeries(scope)` returns one: a 30-day window ending
+ * today, every day before today settled, and a day with no rows carrying a genuine zero.
+ *
+ * `firstSpendDay` is the fixture that matters. Days before it are zero-but-settled, which is
+ * exactly the shape a scope introduced mid-window arrives in, and exactly what CTO-210's
+ * leading-zero trim exists to refuse to count as history.
+ */
+function series(opts: { perDayUsd: number; firstSpendDay?: string }): SettledSeriesLike {
+  const windowStart = addDays(TODAY, -29);
+  const first = opts.firstSpendDay ?? windowStart;
+  const perDay = opts.perDayUsd * USD;
+  const days: DayRow[] = [];
+  for (let i = 29; i >= 0; i -= 1) {
+    const date = addDays(TODAY, -i);
+    const inProgress = date === TODAY;
+    const spending = date >= first;
+    const amount = spending ? (inProgress ? Math.round(perDay * 0.5) : perDay) : 0;
+    days.push({
+      date,
+      byLayer: layers({ llm: Math.round(amount * 0.7), compute: amount - Math.round(amount * 0.7) }),
+      totalMicroUsd: amount,
+      inPeriod: date >= PERIOD_START,
+      settled: !inProgress,
+      inProgress,
+      awaitingLayers: [],
+    });
+  }
+
+  const totals = (keep: (d: DayRow) => boolean) => {
+    const byLayer = layers();
+    let totalMicroUsd = 0;
+    let dayCount = 0;
+    for (const d of days.filter(keep)) {
+      dayCount += 1;
+      totalMicroUsd += d.totalMicroUsd;
+      for (const l of LAYERS) byLayer[l] += d.byLayer[l];
+    }
+    return { dayCount, byLayer, totalMicroUsd };
+  };
+
+  return {
+    periodStart: PERIOD_START,
+    windowEnd: TODAY,
+    settledThrough: addDays(TODAY, -1),
+    rule: "day-complete",
+    connectorLayers: [],
+    days,
+    periodSettled: totals((d) => d.inPeriod && d.settled),
+    periodObserved: totals((d) => d.inPeriod),
+  };
+}
+
+function budget(over: Partial<TenantBudget> = {}): TenantBudget {
+  return {
+    budget_id: "b",
+    period: "month",
+    amount_micro: 10_000 * USD,
+    scope_kind: "tenant",
+    scope_value: "",
+    starts_on: PERIOD_START,
+    ends_on: null,
+    ...over,
+  };
+}
+
+function section(
+  scope: ForecastScope,
+  budgets: readonly TenantBudget[],
+  opts: { perDayUsd: number; firstSpendDay?: string },
+): ScopeSection {
+  return { scope, section: burndownSection(series(opts), budgets, scope) };
+}
+
+const FEATURE_A: ForecastScope = { kind: "feature", value: "research-agent" };
+const FEATURE_B: ForecastScope = { kind: "feature", value: "support-bot" };
+
+describe("rosterScopes", () => {
+  it("always offers tenant-wide first, even with no budget at all", () => {
+    expect(rosterScopes([], TODAY)).toEqual([TENANT_SCOPE]);
+  });
+
+  it("offers every scope with a monthly budget covering today, ordered by kind then value", () => {
+    const roster = rosterScopes(
+      [
+        budget({ budget_id: "m", scope_kind: "model", scope_value: "gpt-4o" }),
+        budget({ budget_id: "b", scope_kind: "feature", scope_value: "support-bot" }),
+        budget({ budget_id: "a", scope_kind: "feature", scope_value: "research-agent" }),
+      ],
+      TODAY,
+    );
+    expect(roster.map((s) => `${s.kind}:${s.value}`)).toEqual([
+      "tenant:",
+      "feature:research-agent",
+      "feature:support-bot",
+      "model:gpt-4o",
+    ]);
+  });
+
+  it("skips budgets that do not govern this month", () => {
+    const roster = rosterScopes(
+      [
+        // A quarter's dollars against a month of spend reports everyone as comfortably under.
+        budget({ budget_id: "q", period: "quarter", scope_kind: "feature", scope_value: "q" }),
+        // Ended before today, and starting after it.
+        budget({ budget_id: "old", scope_kind: "feature", scope_value: "old", ends_on: "2026-07-31" }),
+        budget({ budget_id: "new", scope_kind: "feature", scope_value: "new", starts_on: "2026-09-01" }),
+      ],
+      TODAY,
+    );
+    expect(roster).toEqual([TENANT_SCOPE]);
+  });
+});
+
+describe("scopedForecast: the per-scope history guard", () => {
+  // The whole reason this ticket reads a series per scope instead of filtering a tenant one.
+  it("refuses to project a feature introduced last week on a mature tenant", () => {
+    const budgets = [
+      budget({ budget_id: "t" }),
+      budget({ budget_id: "f", scope_kind: "feature", scope_value: FEATURE_A.value, amount_micro: 500 * USD }),
+    ];
+    const result = scopedForecast({
+      sections: [
+        section(TENANT_SCOPE, budgets, { perDayUsd: 100 }),
+        // Five days old: seen spending from the 15th, and today is the 20th.
+        section(FEATURE_A, budgets, { perDayUsd: 20, firstSpendDay: "2026-08-15" }),
+      ],
+      requested: null,
+      budgets,
+    });
+
+    const tenant = result.lines.find((l) => l.scope.kind === "tenant");
+    const feature = result.lines.find((l) => l.scope.kind === "feature");
+    // The tenant is mature and projects fine, which is exactly the trap: a tenant-wide day count
+    // would have waved the feature through the floor.
+    expect(tenant?.status).toBe("ok");
+    expect(tenant?.projectedMicroUsd).not.toBeNull();
+
+    expect(feature?.status).toBe("insufficient_history");
+    expect(feature?.projectedMicroUsd).toBeNull();
+    expect(feature?.historyDays).toBe(5);
+    expect(feature?.trimmedLeadingDays).toBe(24);
+    expect(feature?.firstObservedDay).toBe("2026-08-15");
+    // "We cannot say" is not "on track", and the enum is what stops those collapsing.
+    expect(feature?.standing).toBe("unknown");
+    expect(feature?.standingReason).toContain("not a statement that it is on track");
+    // A budget exists, but no projection does, so there is no projected variance to report.
+    expect(feature?.budgetMicroUsd).toBe(500 * USD);
+    expect(feature?.varianceMicroUsd).toBeNull();
+    expect(feature?.breachDate).toBeNull();
+  });
+
+  it("gives a scope with no budget a forecast and no variance, never a variance against zero", () => {
+    const budgets = [budget({ budget_id: "t" })];
+    const result = scopedForecast({
+      sections: [
+        section(TENANT_SCOPE, budgets, { perDayUsd: 100 }),
+        section(FEATURE_A, budgets, { perDayUsd: 30 }),
+      ],
+      requested: FEATURE_A,
+      budgets,
+    });
+    const feature = result.lines.find((l) => l.scope.kind === "feature");
+    expect(feature?.projectedMicroUsd).toBeGreaterThan(0);
+    expect(feature?.budgetMicroUsd).toBeNull();
+    expect(feature?.varianceMicroUsd).toBeNull();
+    expect(feature?.variancePct).toBeNull();
+    expect(feature?.standing).toBe("no_budget");
+    // And explicitly not measured against the tenant-wide budget, which covers other dollars too.
+    expect(feature?.noBudgetReason).toContain("not measured against the tenant-wide budget");
+  });
+});
+
+describe("scopedForecast: standings", () => {
+  const budgets = [
+    budget({ budget_id: "t", amount_micro: 5_000 * USD }),
+    // 30/day for 31 days lands near 930; a 2000 budget is comfortably clear.
+    budget({ budget_id: "a", scope_kind: "feature", scope_value: FEATURE_A.value, amount_micro: 2_000 * USD }),
+    // 30/day against 100 is over before the month is out, and already over month to date.
+    budget({ budget_id: "b", scope_kind: "feature", scope_value: FEATURE_B.value, amount_micro: 100 * USD }),
+  ];
+
+  const result = scopedForecast({
+    sections: [
+      section(TENANT_SCOPE, budgets, { perDayUsd: 100 }),
+      section(FEATURE_A, budgets, { perDayUsd: 30 }),
+      section(FEATURE_B, budgets, { perDayUsd: 30 }),
+    ],
+    requested: null,
+    budgets,
+  });
+
+  it("separates on track from projected breach from already over", () => {
+    const byKey = new Map(result.lines.map((l) => [l.key, l]));
+    expect(byKey.get("feature:research-agent")?.standing).toBe("on_track");
+    // Settled month to date already exceeds a 100 budget, which is measured rather than projected
+    // and outranks any forecast.
+    expect(byKey.get("feature:support-bot")?.standing).toBe("already_over");
+    expect(byKey.get("feature:support-bot")?.standingReason).toContain("measured, not projected");
+  });
+
+  it("puts tenant-wide first and then orders by settled spend so an owner finds their own line", () => {
+    expect(result.lines[0].scope.kind).toBe("tenant");
+    const rest = result.lines.slice(1);
+    expect(rest.map((l) => l.settledMicroUsd)).toEqual(
+      [...rest.map((l) => l.settledMicroUsd)].sort((a, b) => b - a),
+    );
+  });
+
+  it("reports a projected breach with its date", () => {
+    const tight = [
+      budget({ budget_id: "t", amount_micro: 5_000 * USD }),
+      budget({
+        budget_id: "a",
+        scope_kind: "feature",
+        scope_value: FEATURE_A.value,
+        // Above month to date (about 570 by the 19th) but below the month-end projection.
+        amount_micro: 700 * USD,
+      }),
+    ];
+    const tightResult = scopedForecast({
+      sections: [
+        section(TENANT_SCOPE, tight, { perDayUsd: 100 }),
+        section(FEATURE_A, tight, { perDayUsd: 30 }),
+      ],
+      requested: null,
+      budgets: tight,
+    });
+    const line = tightResult.lines.find((l) => l.scope.kind === "feature");
+    expect(line?.standing).toBe("projected_breach");
+    expect(line?.breachDate).toMatch(/^2026-08-\d\d$/);
+    expect(line?.varianceMicroUsd).toBeGreaterThan(0);
+  });
+});
+
+describe("scopedForecast: the spend must reconcile, the budgets need not", () => {
+  const budgets = [
+    budget({ budget_id: "t", amount_micro: 1_000 * USD }),
+    budget({ budget_id: "a", scope_kind: "feature", scope_value: FEATURE_A.value, amount_micro: 900 * USD }),
+    budget({ budget_id: "b", scope_kind: "feature", scope_value: FEATURE_B.value, amount_micro: 900 * USD }),
+  ];
+  const result = scopedForecast({
+    sections: [
+      section(TENANT_SCOPE, budgets, { perDayUsd: 100 }),
+      section(FEATURE_A, budgets, { perDayUsd: 30 }),
+      section(FEATURE_B, budgets, { perDayUsd: 20 }),
+    ],
+    requested: null,
+    budgets,
+  });
+
+  it("sums spend only within a kind, and states the residual rather than implying the rows are the bill", () => {
+    const { reconciliation } = result;
+    expect(reconciliation.groups).toHaveLength(1);
+    const group = reconciliation.groups[0];
+    expect(group.kind).toBe("feature");
+    expect(group.settledMicroUsd + group.residualMicroUsd).toBe(
+      reconciliation.tenantSettledMicroUsd,
+    );
+    expect(group.residualMicroUsd).toBeGreaterThan(0);
+    expect(reconciliation.spendReconciles).toBe(true);
+    expect(reconciliation.spendWarnings).toEqual([]);
+  });
+
+  it("treats feature budgets summing above the tenant budget as normal, not as a warning", () => {
+    // 900 + 900 against a 1000 tenant budget. Deliberate over-allocation is a management posture.
+    const alloc = result.reconciliation.budgetAllocation;
+    expect(alloc.tenantBudgetMicroUsd).toBe(1_000 * USD);
+    expect(alloc.perKind).toEqual([{ kind: "feature", budgetMicroUsd: 1_800 * USD, count: 2 }]);
+    expect(alloc.overAllocated).toBe(true);
+    expect(alloc.note).toContain("allowed and often deliberate");
+    // The load-bearing assertion: over-allocated budgets do NOT make the page report a problem.
+    expect(result.reconciliation.spendReconciles).toBe(true);
+    expect(result.reconciliation.spendWarnings).toEqual([]);
+  });
+
+  it("calls scoped spend above the tenant total a bug on the page", () => {
+    // Only reachable through a bug (a mis-scoped query, a stale series), which is exactly why it is
+    // checked: it would otherwise render as a perfectly plausible number.
+    const impossible = scopedForecast({
+      sections: [
+        section(TENANT_SCOPE, budgets, { perDayUsd: 10 }),
+        section(FEATURE_A, budgets, { perDayUsd: 30 }),
+      ],
+      requested: null,
+      budgets,
+    });
+    expect(impossible.reconciliation.spendReconciles).toBe(false);
+    expect(impossible.reconciliation.spendWarnings.join(" ")).toContain("bug on this page");
+    expect(impossible.lines.find((l) => l.scope.kind === "feature")?.exceedsTenantSettled).toBe(
+      true,
+    );
+  });
+
+  it("never adds spend across kinds, and says why", () => {
+    const mixed = [
+      budget({ budget_id: "t", amount_micro: 5_000 * USD }),
+      budget({ budget_id: "a", scope_kind: "feature", scope_value: FEATURE_A.value }),
+      budget({ budget_id: "m", scope_kind: "model", scope_value: "gpt-4o" }),
+    ];
+    const mixedResult = scopedForecast({
+      sections: [
+        section(TENANT_SCOPE, mixed, { perDayUsd: 100 }),
+        section(FEATURE_A, mixed, { perDayUsd: 30 }),
+        section({ kind: "model", value: "gpt-4o" }, mixed, { perDayUsd: 80 }),
+      ],
+      requested: null,
+      budgets: mixed,
+    });
+    // 30 + 80 exceeds neither the tenant total nor anything else, because the two are never added:
+    // the same dollar is both this feature's and this model's.
+    expect(mixedResult.reconciliation.mixesKinds).toBe(true);
+    expect(mixedResult.reconciliation.groups.map((g) => g.kind)).toEqual(["feature", "model"]);
+    expect(mixedResult.reconciliation.spendReconciles).toBe(true);
+  });
+});
+
+describe("scopedForecast: selection", () => {
+  const budgets = [
+    budget({ budget_id: "t" }),
+    budget({ budget_id: "a", scope_kind: "feature", scope_value: FEATURE_A.value }),
+  ];
+  const sections = [
+    section(TENANT_SCOPE, budgets, { perDayUsd: 100 }),
+    section(FEATURE_A, budgets, { perDayUsd: 30 }),
+  ];
+
+  it("defaults to tenant-wide with no fallback reason", () => {
+    const result = scopedForecast({ sections, requested: null, budgets });
+    expect(result.selected).toEqual(TENANT_SCOPE);
+    expect(result.selectionFallbackReason).toBeNull();
+    expect(result.section.scope.kind).toBe("tenant");
+  });
+
+  it("shows the requested scope's own section", () => {
+    const result = scopedForecast({ sections, requested: FEATURE_A, budgets });
+    expect(result.section.scope).toEqual(FEATURE_A);
+    expect(result.lines.find((l) => l.selected)?.key).toBe("feature:research-agent");
+  });
+
+  it("falls back to tenant-wide out loud when the requested scope is not on the roster", () => {
+    const result = scopedForecast({ sections, requested: FEATURE_B, budgets });
+    expect(result.selected).toEqual(TENANT_SCOPE);
+    expect(result.selectionFallbackReason).toContain("support-bot");
+    expect(result.selectionFallbackReason).toContain("tenant-wide forecast is shown instead");
+  });
+
+  it("refuses to assemble anything without the tenant-wide section", () => {
+    // It is the denominator of every share and the total every group is checked against.
+    expect(() =>
+      scopedForecast({ sections: [sections[1]], requested: null, budgets }),
+    ).toThrow(/tenant-wide section is required/);
+  });
+});

--- a/web/lib/scopedForecast.ts
+++ b/web/lib/scopedForecast.ts
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: Apache-2.0
+// Scoped budgets and per-scope forecasts (CTO-211, F7). Pure functions, no I/O, no clock.
+//
+// This is the last ticket of the spend-forecasting epic and it computes NO forecast of its own.
+// CTO-206 owns the projection, CTO-210 owns the burn-down view model, CTO-207 owns the settled
+// series and already takes a scope argument. What was missing was the layer above all three: a
+// tenant with five budgets has five forecasts, and somebody has to decide which of them the page
+// shows, how they line up against each other, and which ones are allowed to be added together.
+//
+// THE CORRECTNESS QUESTION THIS FILE EXISTS TO ANSWER
+//
+// Per-scope budgets can sum to more or less than the tenant-wide budget, and both are legitimate.
+// The spend and the budgets behave completely differently and conflating them is the failure this
+// epic has been guarding against, so they are modelled separately and rendered differently:
+//
+//   SPEND MUST RECONCILE. It is one bill, sliced. A slice cannot exceed the whole, and two slices
+//   of the same KIND cannot overlap, because a span carries exactly one feature tag, one model and
+//   one layer. So within a kind the scoped totals are summed, checked against the tenant total, and
+//   the leftover is reported as an explicit residual row rather than left for a reader to compute.
+//   A slice above the tenant total, or a kind summing above it, is a BUG in this page and it is
+//   labelled as one (`spendWarnings`), never quietly rendered.
+//
+//   SPEND IS NEVER SUMMED ACROSS KINDS. A feature budget and a model budget describe the same
+//   dollars from two directions: `research-agent` spend and `gpt-4o` spend overlap by construction.
+//   Adding them is double counting, so `groups` is keyed by kind and there is no cross-kind total
+//   anywhere in this module. When a tenant budgets across more than one kind, `mixesKinds` says so
+//   and the card prints the caveat instead of a number nobody can interpret.
+//
+//   BUDGETS NEED NOT RECONCILE, AND OVER-ALLOCATION IS NOT A WARNING. Three feature owners each
+//   given $30k against a $70k tenant budget is a deliberate, common and correct arrangement: not
+//   every team spends its allocation, and finance over-allocates on purpose the same way an airline
+//   overbooks. Flagging it red would train readers to ignore red on the one page where red has to
+//   mean something. So `budgetAllocation` is INFORMATIONAL: it states the sum, the tenant budget and
+//   the headroom or over-allocation, in neutral words, and the only thing it actually asserts is
+//   arithmetic. The genuinely alarming case is not "budgets sum high", it is "the FORECASTS sum
+//   above the tenant budget", which is a statement about spend, and that is what `standing` on each
+//   line and the tenant line's own breach date already say.
+//
+// PER-SCOPE HISTORY IS THE OTHER HALF. CTO-210 found that `querySettledCostSeries` treats a day with
+// no rows as a genuine zero, which is right for a measured card and wrong as forecast history: a
+// six-day-old tenant arrived with 29 "settled" days, 23 of them meaning "did not exist yet". That
+// bites harder per scope, because a feature introduced last week has almost no history even on a
+// mature tenant. The fix is not repeated here: every line is built from `burndownSection` over that
+// scope's OWN series, so the leading-zero trim and the fourteen-day floor apply per scope for free.
+// What this module adds is that `standing` keeps `unknown` apart from `on_track`, so a scope that
+// could not be projected can never be listed among the ones that are fine.
+//
+// Money is integer micro-USD. Dates are `YYYY-MM-DD` UTC strings, all of them ClickHouse's.
+
+import { selectBudget, COMPARED_PERIOD, type TenantBudget } from "./budgetVsActual";
+import type { BurndownSection } from "./burndown";
+import type { ForecastStatus } from "./forecast";
+import {
+  isTenantScope,
+  sameScope,
+  scopeKey,
+  scopeLabel,
+  scopeOfBudget,
+  SCOPE_KINDS,
+  TENANT_SCOPE,
+  type ForecastScope,
+  type ScopeKind,
+} from "./spendScopes";
+import type { MicroUSD } from "./types";
+
+/**
+ * Where one scope stands. Five values, and the two that look alike are the point of the type.
+ *
+ * `on_track`:         projected, and the projection stays under this scope's own budget.
+ * `projected_breach`: projected, and it crosses. `breachDate` says when.
+ * `already_over`:     settled spend to date is ALREADY above the budget. Not a forecast at all, and
+ *                     a strictly worse thing to be told than "you will cross on the 22nd".
+ * `no_budget`:        this scope has no budget. Its forecast still renders; its variance does not.
+ * `unknown`:          too little history for THIS scope. We are not saying it is fine. Keeping this
+ *                     apart from `on_track` is the whole reason this is an enum and not a boolean.
+ */
+export type ScopeStanding =
+  | "on_track"
+  | "projected_breach"
+  | "already_over"
+  | "no_budget"
+  | "unknown";
+
+/** One row of the roster: a scope, its budget, its forecast, and where that leaves it. */
+export interface ScopeLine {
+  scope: ForecastScope;
+  /** `scopeKey(scope)`. The selector's URL value and the row key. */
+  key: string;
+  /** `scopeLabel(scope)`. "Whole tenant", or "feature: research-agent". */
+  label: string;
+  /** True for the scope the page is currently showing in full. */
+  selected: boolean;
+
+  /** This scope's own monthly budget, or null when it has none. Never an implicit zero. */
+  budgetMicroUsd: MicroUSD | null;
+  /** Non-null exactly when `budgetMicroUsd` is null. A real sentence, for `<Blank reason>`. */
+  noBudgetReason: string | null;
+
+  /** Settled month-to-date spend for this scope. Measured, never projected. */
+  settledMicroUsd: MicroUSD;
+  /** Projected month-end spend for this scope, or null below its own history floor. */
+  projectedMicroUsd: MicroUSD | null;
+  /** Projected minus budget. Positive is over. Null without both a budget and a projection. */
+  varianceMicroUsd: MicroUSD | null;
+  /** As a fraction of budget. Null without both, and null when the budget is zero. */
+  variancePct: number | null;
+
+  status: ForecastStatus;
+  standing: ScopeStanding;
+  /** Why `standing` is what it is, in words, so a blank or a badge is never unexplained. */
+  standingReason: string;
+  /** `YYYY-MM-DD` the projection crosses this scope's budget, or null. */
+  breachDate: string | null;
+
+  /** Settled days of history for THIS scope, after the leading-zero trim. */
+  historyDays: number;
+  /** The floor `historyDays` is compared against, echoed so no UI hard-codes fourteen. */
+  requiredDays: number;
+  /** Leading days dropped because this scope had not been seen spending yet (CTO-210 note 3). */
+  trimmedLeadingDays: number;
+  /** First day this scope was seen spending anything, or null when it never was. */
+  firstObservedDay: string | null;
+
+  /** This scope's settled spend as a share of the tenant's, or null when the tenant total is zero. */
+  shareOfTenantSettled: number | null;
+  /** True when this scope's settled spend exceeds the tenant's, which is arithmetically impossible. */
+  exceedsTenantSettled: boolean;
+}
+
+/** The scoped lines of one kind, which is the only grouping in which summing is legitimate. */
+export interface ScopeKindGroup {
+  kind: ScopeKind;
+  keys: string[];
+  /** Sum of settled month-to-date across this kind's budgeted scopes. Disjoint, so this is real. */
+  settledMicroUsd: MicroUSD;
+  /**
+   * Tenant settled minus the above: spend of this month that no budgeted scope of this kind covers.
+   * Shown as its own row, because the alternative is a reader silently assuming the rows are the
+   * whole bill. Never negative unless something is wrong, and `spendReconciles` catches that.
+   */
+  residualMicroUsd: MicroUSD;
+  /** Sum of the budgets of this kind. Informational: budgets need not reconcile. */
+  budgetMicroUsd: MicroUSD;
+  /** How many of this kind's scopes actually carry a budget. */
+  budgetedCount: number;
+}
+
+/**
+ * Budgets against budgets. INFORMATIONAL BY DESIGN, see the header: over-allocation is a normal
+ * management posture and this structure deliberately carries no severity.
+ */
+export interface BudgetAllocation {
+  /** The tenant-wide monthly budget, or null when none is set. */
+  tenantBudgetMicroUsd: MicroUSD | null;
+  /** Sum of the scoped budgets, per kind. Never summed across kinds: that would double count. */
+  perKind: { kind: ScopeKind; budgetMicroUsd: MicroUSD; count: number }[];
+  /**
+   * True when some kind's budgets sum ABOVE the tenant budget. A neutral fact, not a warning: teams
+   * over-allocate on purpose. Null when there is no tenant budget to compare against.
+   */
+  overAllocated: boolean | null;
+  /** A sentence stating the arithmetic, or null when there is nothing to state. */
+  note: string | null;
+}
+
+export interface ScopeReconciliation {
+  /** Settled month-to-date for the whole tenant. The denominator of every share on this page. */
+  tenantSettledMicroUsd: MicroUSD;
+  groups: ScopeKindGroup[];
+  /** True when more than one kind is budgeted, so no roster-wide sum of spend is meaningful. */
+  mixesKinds: boolean;
+  /**
+   * True when the spend reconciles: no scope above the tenant, no kind summing above it. Spend, not
+   * budgets. False is a bug in this page, and the card says so on screen.
+   */
+  spendReconciles: boolean;
+  /** One sentence per violation, empty when `spendReconciles`. */
+  spendWarnings: string[];
+  budgetAllocation: BudgetAllocation;
+}
+
+export interface ScopedForecast {
+  /** The scope shown in full. Tenant-wide unless the reader chose otherwise. */
+  selected: ForecastScope;
+  /** Non-null when the requested scope could not be honoured, saying what was shown instead. */
+  selectionFallbackReason: string | null;
+  /** The full burn-down section for `selected`: chart, cone, breach date, layer split. */
+  section: BurndownSection;
+  /** Every scope on the roster, tenant-wide first, then by settled spend descending. */
+  lines: ScopeLine[];
+  reconciliation: ScopeReconciliation;
+}
+
+/** One scope's already-computed section, as the route hands them in. */
+export interface ScopeSection {
+  scope: ForecastScope;
+  section: BurndownSection;
+}
+
+function ratio(part: number, whole: number): number | null {
+  // Zero denominator is undefined, not infinite and not zero. Callers render a blank.
+  return whole === 0 ? null : part / whole;
+}
+
+/**
+ * Which scopes the page should offer, given this tenant's budgets.
+ *
+ * Tenant-wide always, first, whether or not it has a budget: it is the default view and the
+ * denominator everything else is checked against. Then every scope carrying a MONTHLY budget that
+ * covers today, deduplicated and ordered by kind then value so the selector does not reshuffle
+ * between renders.
+ *
+ * Deliberately NOT every feature the tenant has ever emitted. A tenant with 200 feature tags would
+ * get a 200-entry selector and 200 ClickHouse reads, and 195 of those scopes have no budget and
+ * therefore nothing to be on track against. A budget is the statement that somebody owns this slice.
+ */
+export function rosterScopes(
+  budgets: readonly TenantBudget[],
+  today: string,
+): ForecastScope[] {
+  const byKey = new Map<string, ForecastScope>();
+  byKey.set(scopeKey(TENANT_SCOPE), TENANT_SCOPE);
+  for (const b of budgets) {
+    // Same filter as `selectBudget`: a quarterly budget is not offered on a month-scoped page,
+    // because comparing a quarter's dollars against a month of spend reports everyone as fine.
+    if (b.period !== COMPARED_PERIOD) continue;
+    if (b.starts_on > today) continue;
+    if (b.ends_on !== null && b.ends_on < today) continue;
+    const scope = scopeOfBudget(b);
+    if (!scope) continue;
+    byKey.set(scopeKey(scope), scope);
+  }
+  const all = [...byKey.values()];
+  return all.sort((a, b) => {
+    if (a.kind !== b.kind) return SCOPE_KINDS.indexOf(a.kind) - SCOPE_KINDS.indexOf(b.kind);
+    return a.value.localeCompare(b.value);
+  });
+}
+
+function standingOf(
+  section: BurndownSection,
+  budgetMicroUsd: MicroUSD | null,
+  label: string,
+): { standing: ScopeStanding; reason: string } {
+  const { forecast, settledPeriodMicroUsd } = section;
+  if (forecast.status === "insufficient_history") {
+    return {
+      standing: "unknown",
+      reason:
+        `${label} has ${section.window.dayCount} settled ${section.window.dayCount === 1 ? "day" : "days"} ` +
+        `of its own history and ${section.window.requiredDays} are needed, so nothing was projected. ` +
+        "This is not a statement that it is on track.",
+    };
+  }
+  if (budgetMicroUsd === null) {
+    return {
+      standing: "no_budget",
+      reason: section.noBudgetReason ?? `no monthly budget is set for ${label}`,
+    };
+  }
+  // Already over is checked before the projection: it is a measured fact and it outranks a forecast.
+  if (settledPeriodMicroUsd > budgetMicroUsd) {
+    return {
+      standing: "already_over",
+      reason: `${label} has already spent more than its monthly budget; this is measured, not projected`,
+    };
+  }
+  const projected = section.forecast.projectedMicroUsd;
+  if (projected !== null && projected > budgetMicroUsd) {
+    return {
+      standing: "projected_breach",
+      reason:
+        section.forecast.breach.date !== null
+          ? `${label} is projected to cross its budget on ${section.forecast.breach.date}`
+          : `${label} is projected to end the month over its budget`,
+    };
+  }
+  return {
+    standing: "on_track",
+    reason: `${label} is projected to end the month within its budget`,
+  };
+}
+
+function lineFrom(
+  entry: ScopeSection,
+  selected: ForecastScope,
+  tenantSettledMicroUsd: MicroUSD,
+): ScopeLine {
+  const { scope, section } = entry;
+  const label = scopeLabel(scope);
+  const budgetMicroUsd = section.budget ? section.budget.amountMicroUsd : null;
+  const { standing, reason } = standingOf(section, budgetMicroUsd, label);
+  const settledMicroUsd = section.settledPeriodMicroUsd;
+  return {
+    scope,
+    key: scopeKey(scope),
+    label,
+    selected: sameScope(scope, selected),
+    budgetMicroUsd,
+    noBudgetReason: budgetMicroUsd === null ? section.noBudgetReason : null,
+    settledMicroUsd,
+    projectedMicroUsd: section.forecast.projectedMicroUsd,
+    varianceMicroUsd: section.varianceMicroUsd,
+    variancePct: section.variancePct,
+    status: section.forecast.status,
+    standing,
+    standingReason: reason,
+    breachDate: section.forecast.breach.outcome === "breaches" ? section.forecast.breach.date : null,
+    historyDays: section.window.dayCount,
+    requiredDays: section.window.requiredDays,
+    trimmedLeadingDays: section.window.trimmedLeadingDays,
+    firstObservedDay: section.window.firstObservedDay,
+    // The tenant's own share is 100 percent by definition; it is still computed the same way so the
+    // column has no special case in it.
+    shareOfTenantSettled: ratio(settledMicroUsd, tenantSettledMicroUsd),
+    exceedsTenantSettled: !isTenantScope(scope) && settledMicroUsd > tenantSettledMicroUsd,
+  };
+}
+
+/**
+ * Assemble the roster, the selection and the reconciliation from per-scope sections.
+ *
+ * `sections` must contain the tenant-wide scope: it is the denominator of every share and the total
+ * every group is checked against, and there is no honest version of this page without it. Each
+ * section must have been built from ITS OWN `querySettledCostSeries(scope)` result, not from a
+ * filtered tenant series, or the per-scope history guard is not actually per scope.
+ */
+export function scopedForecast(input: {
+  sections: readonly ScopeSection[];
+  /** What the reader asked for. Falls back to tenant-wide, saying so, when it is not on the roster. */
+  requested: ForecastScope | null;
+  /** Why the request could not be honoured, when the caller already knows (an unparsable `?scope=`). */
+  requestedReason?: string | null;
+  budgets: readonly TenantBudget[];
+}): ScopedForecast {
+  const tenantEntry = input.sections.find((s) => isTenantScope(s.scope));
+  if (!tenantEntry) {
+    throw new Error("scopedForecast: the tenant-wide section is required and was not supplied");
+  }
+
+  const requested = input.requested;
+  const match = requested ? input.sections.find((s) => sameScope(s.scope, requested)) : null;
+  const chosen = match ?? tenantEntry;
+  const selectionFallbackReason =
+    match || (!requested && !input.requestedReason)
+      ? null
+      : requested
+        ? `${scopeLabel(requested)} has no monthly budget covering today, so the tenant-wide ` +
+          "forecast is shown instead"
+        : (input.requestedReason ??
+          "the requested scope could not be read, so the tenant-wide forecast is shown instead");
+
+  const tenantSettled = tenantEntry.section.settledPeriodMicroUsd;
+  const lines = input.sections.map((s) => lineFrom(s, chosen.scope, tenantSettled));
+
+  // Tenant-wide first because it is the total, then by settled spend so a feature owner scanning for
+  // their own line finds the biggest ones where they expect them.
+  lines.sort((a, b) => {
+    if (a.scope.kind === "tenant") return -1;
+    if (b.scope.kind === "tenant") return 1;
+    return b.settledMicroUsd - a.settledMicroUsd || a.label.localeCompare(b.label);
+  });
+
+  const scoped = lines.filter((l) => l.scope.kind !== "tenant");
+  const kinds = SCOPE_KINDS.filter(
+    (k) => k !== "tenant" && scoped.some((l) => l.scope.kind === k),
+  );
+  const groups: ScopeKindGroup[] = kinds.map((kind) => {
+    const members = scoped.filter((l) => l.scope.kind === kind);
+    // Legitimate ONLY within a kind: a span carries one feature tag, one model and one layer, so
+    // two scopes of the same kind cannot both claim the same dollar.
+    const settledMicroUsd = members.reduce((sum, l) => sum + l.settledMicroUsd, 0);
+    const budgeted = members.filter((l) => l.budgetMicroUsd !== null);
+    return {
+      kind,
+      keys: members.map((l) => l.key),
+      settledMicroUsd,
+      residualMicroUsd: tenantSettled - settledMicroUsd,
+      budgetMicroUsd: budgeted.reduce((sum, l) => sum + (l.budgetMicroUsd ?? 0), 0),
+      budgetedCount: budgeted.length,
+    };
+  });
+
+  const spendWarnings: string[] = [];
+  for (const l of scoped) {
+    if (l.exceedsTenantSettled) {
+      spendWarnings.push(
+        `${l.label} shows more settled spend this month than the whole tenant does. A slice cannot ` +
+          "exceed the bill, so that is a bug on this page rather than a fact about your spend.",
+      );
+    }
+  }
+  for (const g of groups) {
+    if (g.residualMicroUsd < 0) {
+      spendWarnings.push(
+        `The budgeted ${g.kind} scopes sum to more settled spend this month than the whole tenant ` +
+          "does. Scopes of one kind are disjoint, so they cannot double count; that gap is a bug on " +
+          "this page.",
+      );
+    }
+  }
+
+  const tenantBudgetRow = selectBudget(
+    input.budgets,
+    "tenant",
+    "",
+    tenantEntry.section.period.today,
+  );
+  const tenantBudgetMicroUsd = tenantBudgetRow ? tenantBudgetRow.amount_micro : null;
+  const perKind = groups
+    .filter((g) => g.budgetedCount > 0)
+    .map((g) => ({ kind: g.kind, budgetMicroUsd: g.budgetMicroUsd, count: g.budgetedCount }));
+  const overAllocated =
+    tenantBudgetMicroUsd === null || perKind.length === 0
+      ? null
+      : perKind.some((k) => k.budgetMicroUsd > tenantBudgetMicroUsd);
+
+  return {
+    selected: chosen.scope,
+    selectionFallbackReason,
+    section: chosen.section,
+    lines,
+    reconciliation: {
+      tenantSettledMicroUsd: tenantSettled,
+      groups,
+      mixesKinds: kinds.length > 1,
+      spendReconciles: spendWarnings.length === 0,
+      spendWarnings,
+      budgetAllocation: {
+        tenantBudgetMicroUsd,
+        perKind,
+        overAllocated,
+        note: allocationNote(tenantBudgetMicroUsd, perKind, overAllocated),
+      },
+    },
+  };
+}
+
+/**
+ * The one sentence the allocation summary is allowed to say.
+ *
+ * Neutral on purpose, per the header. It states the arithmetic and names over-allocation as a
+ * deliberate posture rather than a problem, because the alternative trains readers to ignore the
+ * page's actual warnings.
+ */
+function allocationNote(
+  tenantBudgetMicroUsd: MicroUSD | null,
+  perKind: { kind: ScopeKind; budgetMicroUsd: MicroUSD; count: number }[],
+  overAllocated: boolean | null,
+): string | null {
+  if (perKind.length === 0) return null;
+  if (tenantBudgetMicroUsd === null) {
+    return (
+      "Scoped budgets are set but no tenant-wide budget is, so there is nothing to allocate " +
+      "against. That is a normal state: a scoped budget stands on its own."
+    );
+  }
+  if (overAllocated) {
+    return (
+      "The scoped budgets sum to more than the tenant-wide budget. That is allowed and often " +
+      "deliberate: an owner is given a ceiling they are not expected to reach, the same way a " +
+      "flight is overbooked. Budgets are statements of intent per owner and need not add up. The " +
+      "SPEND below does add up, and that is what is checked."
+    );
+  }
+  return (
+    "The scoped budgets sum to less than the tenant-wide budget, leaving headroom that no scope " +
+    "owns. Also normal: budgets need not add up. The spend below does, and that is what is checked."
+  );
+}
+
+/** What the scoped section carries over the wire. Exactly one of the two fields is non-null. */
+export interface ScopedForecastPayload {
+  scoped: ScopedForecast | null;
+  /** Why there is no scoped forecast: ClickHouse or the gateway could not be read. Never "no budget". */
+  unavailable: string | null;
+}

--- a/web/lib/spendScopes.test.ts
+++ b/web/lib/spendScopes.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// The scope vocabulary (CTO-211). Short file, but the key round trip is load-bearing: it is what a
+// `?scope=` in the URL means, and getting it wrong selects a different slice of spend than the one
+// the heading names.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parseScopeKey,
+  scopeKey,
+  scopeLabel,
+  scopeOfBudget,
+  TENANT_SCOPE,
+} from "./spendScopes";
+
+describe("scopeKey / parseScopeKey", () => {
+  it("round trips every kind", () => {
+    for (const scope of [
+      TENANT_SCOPE,
+      { kind: "feature" as const, value: "research-agent" },
+      { kind: "model" as const, value: "gpt-4o" },
+      { kind: "layer" as const, value: "compute" },
+    ]) {
+      expect(parseScopeKey(scopeKey(scope))).toEqual(scope);
+    }
+  });
+
+  it("splits on the FIRST colon only, so a model id keeps its own colons", () => {
+    // Splitting on all of them would silently truncate the scope to a prefix, which selects a
+    // different slice of spend than the URL names.
+    const scope = { kind: "model" as const, value: "bedrock:anthropic.claude-3" };
+    expect(scopeKey(scope)).toBe("model:bedrock:anthropic.claude-3");
+    expect(parseScopeKey("model:bedrock:anthropic.claude-3")).toEqual(scope);
+  });
+
+  it("returns null rather than falling back to tenant-wide for anything it cannot parse", () => {
+    // Null, so the caller falls back explicitly and says it did. A silent swap to tenant-wide puts
+    // whole-tenant numbers under a heading naming one feature.
+    for (const bad of ["", "  ", "feature", "feature:", ":x", "provider:openai", "tenant:x", null]) {
+      expect(parseScopeKey(bad)).toBeNull();
+    }
+  });
+});
+
+describe("scopeLabel", () => {
+  it("names the whole tenant rather than an empty value", () => {
+    expect(scopeLabel(TENANT_SCOPE)).toBe("Whole tenant");
+    expect(scopeLabel({ kind: "feature", value: "research-agent" })).toBe(
+      "feature: research-agent",
+    );
+  });
+});
+
+describe("scopeOfBudget", () => {
+  it("reads a budget row's scope, and rejects rows this dashboard cannot forecast", () => {
+    expect(scopeOfBudget({ scope_kind: "tenant", scope_value: "" })).toEqual(TENANT_SCOPE);
+    expect(scopeOfBudget({ scope_kind: "feature", scope_value: "a" })).toEqual({
+      kind: "feature",
+      value: "a",
+    });
+    // A scoped budget naming nothing is not a scope; it is a row that should never have been
+    // written, and forecasting it as tenant-wide would report the wrong dollars against it.
+    expect(scopeOfBudget({ scope_kind: "feature", scope_value: "" })).toBeNull();
+    expect(scopeOfBudget({ scope_kind: "provider", scope_value: "openai" })).toBeNull();
+  });
+});

--- a/web/lib/spendScopes.ts
+++ b/web/lib/spendScopes.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// The scope vocabulary shared by the scoped forecast (CTO-211, F7). Pure, no I/O, no clock.
+//
+// CTO-205 gave `tenant_budgets` a `(scope_kind, scope_value)` pair and CTO-207 gave
+// `querySettledCostSeries` a matching `SpendScope` argument. Both already speak the same four kinds.
+// What did not exist was one place that turns that pair into the three things a UI needs: a stable
+// key for a URL, a label a human reads, and the parse back. Writing those inline in the route and
+// again in the card is how the selector and the API end up disagreeing about what
+// `feature:research-agent` means.
+//
+// WHY THIS IS ITS OWN MODULE and not part of `burndown.ts` or `scopedForecast.ts`: `burndown.ts`
+// needs the type to select the right budget, `scopedForecast.ts` needs the whole vocabulary, and the
+// two already depend on each other in one direction. A shared leaf module keeps that acyclic and
+// keeps this file importable from a client component (nothing here touches the server).
+//
+// The key format is `kind` for tenant-wide and `kind:value` otherwise. Only the FIRST colon splits,
+// because a model id legitimately contains colons (`bedrock:anthropic.claude-3`) and splitting on
+// all of them would silently truncate the scope to a prefix, i.e. select a different slice of spend
+// than the one named in the URL.
+
+/** The four scope kinds CTO-205 stores and CTO-207 can query. Kept in this order for the selector. */
+export const SCOPE_KINDS = ["tenant", "feature", "model", "layer"] as const;
+export type ScopeKind = (typeof SCOPE_KINDS)[number];
+
+/**
+ * One slice of spend to forecast.
+ *
+ * `value` is `''` exactly when `kind` is `tenant`, mirroring the storage: CTO-205 writes `''` rather
+ * than NULL for a tenant-wide budget so its exclusion constraint has something to compare.
+ */
+export interface ForecastScope {
+  kind: ScopeKind;
+  value: string;
+}
+
+/** The whole bill. The default everywhere: a reader who has not chosen a scope means "all of it". */
+export const TENANT_SCOPE: ForecastScope = { kind: "tenant", value: "" };
+
+export function isTenantScope(scope: ForecastScope): boolean {
+  return scope.kind === "tenant";
+}
+
+/** Stable identity for a scope: a URL query value, a React key, a map key. */
+export function scopeKey(scope: ForecastScope): string {
+  return scope.kind === "tenant" ? "tenant" : `${scope.kind}:${scope.value}`;
+}
+
+/** How a scope reads in a heading or a table cell. */
+export function scopeLabel(scope: ForecastScope): string {
+  return scope.kind === "tenant" ? "Whole tenant" : `${scope.kind}: ${scope.value}`;
+}
+
+/** Just the noun, for sentences like "this feature has too little history". */
+export function scopeNoun(scope: ForecastScope): string {
+  return scope.kind === "tenant" ? "tenant" : scope.kind;
+}
+
+export function sameScope(a: ForecastScope, b: ForecastScope): boolean {
+  return a.kind === b.kind && a.value === b.value;
+}
+
+/**
+ * Parse a key back into a scope, or null when it names nothing this deployment can forecast.
+ *
+ * Null rather than a fallback to tenant-wide on purpose. A `?scope=` the server cannot parse means
+ * the reader asked for something specific and got something else, and silently swapping in the
+ * tenant total would put whole-tenant numbers under a heading naming one feature. The caller falls
+ * back explicitly and says it did.
+ */
+export function parseScopeKey(key: string | null | undefined): ForecastScope | null {
+  if (!key) return null;
+  if (key === "tenant") return TENANT_SCOPE;
+  const colon = key.indexOf(":");
+  if (colon <= 0) return null;
+  const kind = key.slice(0, colon);
+  const value = key.slice(colon + 1);
+  if (!value) return null;
+  // `tenant:something` is not a scope: tenant-wide names nothing by construction.
+  if (kind === "tenant") return null;
+  if (!(SCOPE_KINDS as readonly string[]).includes(kind)) return null;
+  return { kind: kind as ScopeKind, value };
+}
+
+/** The scope a budget row governs. Snake case in, camel case out; `scope_value` is never null. */
+export function scopeOfBudget(budget: { scope_kind: string; scope_value: string }): ForecastScope | null {
+  if (!(SCOPE_KINDS as readonly string[]).includes(budget.scope_kind)) return null;
+  const kind = budget.scope_kind as ScopeKind;
+  if (kind === "tenant") return TENANT_SCOPE;
+  if (!budget.scope_value) return null;
+  return { kind, value: budget.scope_value };
+}


### PR DESCRIPTION
Last ticket of the spend-forecasting epic (CTO-204). CTO-205 stored `scope_kind` / `scope_value`, CTO-207 taught `querySettledCostSeries` to take a scope, CTO-208 let people create scoped budgets. Until now nothing on `/cost` honoured any of it: every forecast number was tenant-wide. This makes the forecast, the variance and the burn-down all answer for a chosen scope.

## What you get

* A **scope selector** on the `/cost` forecast section, defaulting to tenant-wide. Every budgeted scope is a chip carrying its standing, so a feature owner spots their own line without reading anyone else's.
* Forecast, variance and burn-down computed **for the selected scope**, reusing F2's engine and F3's scope argument. `?scope=feature:support_triage` is a shareable address for one owner's view.
* A **roster table** of every budgeted scope: settled to date, projected month end, budget, projected variance, standing, and the date it crosses.

`?scope=` is deliberately separate from `?tag=`. `?tag=` filters the 30-day breakdown; `?scope=` chooses which budget the forecast is measured against, and it can name a model or a layer as well as a feature. Collapsing them would mean clicking a feature in the breakdown silently swapped which budget the page reports on. The selector preserves an active `?tag=`.

## The correctness question: spend must reconcile, budgets need not

Per-scope budgets can sum to more or less than the tenant-wide budget and both are legitimate. Spend and budgets therefore behave differently, and the page renders them in two different registers on purpose.

**Spend must reconcile, and is checked.** It is one bill, sliced. A slice cannot exceed the whole, and two scopes **of the same kind** cannot overlap, because a span carries exactly one feature tag, one model and one layer. So within a kind the scoped totals are summed, checked against the tenant total, and the leftover is printed as an explicit residual: "the budgeted feature scopes account for $59,831.03 of the $81,827.49 settled this month; the remaining $21,996.46 is spend no budgeted feature covers." A slice above the tenant total, or a kind summing above it, is arithmetically impossible, so it is labelled a bug on the page rather than rendered as a plausible number.

**Spend is never summed across kinds.** A feature budget and a model budget describe the same dollars from two directions: `research_agent` spend and `gpt-4o` spend overlap by construction. Adding them double counts. There is no roster-wide spend total anywhere in this change, and when a tenant budgets across more than one kind the card says why.

**Budgets need not reconcile, and over-allocation is a normal state, not a warning.** This is the question the ticket asked to justify. Three feature owners each given $30k against a $70k tenant budget is a deliberate and common arrangement: not every team spends its allocation, and finance over-allocates the way an airline overbooks. Rendering that red would be wrong twice over. It would report a management decision as a defect, and it would spend the page's only alarm colour on something nobody should act on, which trains readers to ignore red on the one page where red has to mean something. So the allocation line is informational and neutrally worded, and the only thing it asserts is arithmetic:

> 3 feature budgets summing to $122,500.00. 1 model budget summing to $40,000.00. Tenant-wide budget: $120,000.00. The scoped budgets sum to more than the tenant-wide budget. That is allowed and often deliberate: an owner is given a ceiling they are not expected to reach, the same way a flight is overbooked. Budgets are statements of intent per owner and need not add up. The SPEND below does add up, and that is what is checked.

The genuinely alarming case is not "budgets sum high", it is "the **forecasts** sum above the tenant budget", which is a statement about spend. That is already said, per scope, by each line's standing and by the tenant line's own breach date.

One consequence worth naming: a `scope_kind='layer'` budget covers that layer across the **whole tenant**, so off tenant-wide scope the layer-budget column is suppressed with a reason rather than comparing one feature's compute projection against a budget it does not own.

## The per-scope history guard works

F6 found that `querySettledCostSeries` treats a day with no rows as a genuine zero, which is right for the measured card and wrong as forecast history. It fixed it by starting the baseline at the first day the tenant was seen spending anything. That bites harder per scope, so the fix had to become per scope, and the way it becomes per scope is that **each scope reads its own series**. Filtering a tenant-wide series afterwards would be cheaper and would keep tenant-wide history days, defeating the guard entirely.

Verified live. On a tenant with 27 settled days of history, a feature first seen today renders:

> feature: cto182-e2e has 0 settled days of history, and a projection needs 14. Spend was first seen on 2026-08-26, so the 27 earlier days in the window are not counted as history: they are days before this feature was sending anything, not days it spent nothing.
>
> No cone is drawn here on purpose.
>
> This is not a statement that spend is under control. We are saying we do not know, which is a different thing from "this will not breach".

No chart, no number, and `standing: unknown` in the roster with its own badge ("Cannot say"), coloured warn rather than green. The tenant line on the same page projects fine, which is exactly the trap: a tenant-wide day count would have waved this feature straight past the floor.

## Every state, seen in a browser

Local ClickHouse plus the gateway on `:8080`, with five budgets created through `/v1/tenant/budgets` and deleted afterwards.

| Scope | Settled MTD | Projected | Budget | Standing |
| --- | --- | --- | --- | --- |
| Whole tenant | $81,827.49 | $106,492.31 | $120,000 | On track |
| feature: research_agent | $48,911.67 | $63,033.40 | $110,000 | On track |
| model: gpt-4o | $22,203.88 | $27,775.58 | $40,000 | On track |
| feature: support_triage | $10,919.36 | $14,252.41 | $12,000 | **Projected breach, crosses 2026-08-26** |
| feature: cto182-e2e | $0.00 | blank | $500 | **Cannot say** (0 of 14 settled days) |

Also exercised: selecting `feature: support_triage` renders its own cone, its own breach marker on the chart, and the note that the month-to-date card above stays tenant-wide; an unknown `?scope=` falls back to tenant-wide out loud ("feature: nope has no monthly budget covering today, so the tenant-wide forecast is shown instead") rather than silently showing tenant numbers under a feature's name.

## Honesty requirements

* A scope with **no budget** shows its forecast and no variance. Never a variance against zero, and never against the tenant-wide budget: `noBudgetReason` says so in the blank.
* A scope with **too little history** shows F6's refusal, per scope, and `unknown` is kept apart from `on_track` in the type, in the colour and in the words.
* Every blank uses `<Blank reason>`. The roster's variance column has two different reasons behind the same dash (no budget, versus nothing projected) and picks the right one.

## Verification

`npm run typecheck`, `npm run lint`, `npm run test` from `web/`. 568 passing, up from 538: 30 new tests across `lib/scopedForecast.test.ts`, `lib/spendScopes.test.ts`, `lib/burndown.test.ts` and `app/cost/BurndownCard.test.tsx`. The only failures are the 2 long-standing `app/api/api.test.ts` ones that fail when a local ClickHouse is running. Lint is clean apart from the pre-existing warnings on `app/attribution/Live.tsx` and `lib/useLivePoll.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
