### PR TITLE
feat(gateway): scheduler core, registry, due-calculation, tick loop (CTO-213)

### DIFF
--- a/db/postgres/0027_scheduler_runs.sql
+++ b/db/postgres/0027_scheduler_runs.sql
@@ -1,0 +1,63 @@
+-- Scheduler run history (CTO-213, S1).
+--
+-- WHY this table exists. The scheduler does not remember when it last ran anything; Postgres does.
+-- That is the whole design. A daily job implemented as ``await asyncio.sleep(86400)`` drifts, and
+-- it loses its place on every restart, so a gateway that redeploys daily would never run a daily
+-- job at all. Instead a tick loop wakes every few minutes and asks each registered job "are you due
+-- for this tenant?", and the answer is a query against this table. Restart-safe and drift-free,
+-- because the state that matters is on disk rather than in a sleeping coroutine.
+--
+-- One row per invocation, per job, per tenant. ``status`` is the honest outcome:
+--
+--   success  the job ran and did its work.
+--   skipped  the job ran and decided there was nothing to do (a tenant with no config for it).
+--            Not a failure and not a success: it settles the cadence window so an unconfigured
+--            tenant is not retried every tick, but it never claims work happened.
+--   failed   the job raised. ``error_message`` carries the scrubbed reason and NOTHING was
+--            produced. The repo rule holds here: a failed run records the failure and emits no
+--            number, never a guessed one.
+--
+-- ``error_message`` is PII-scrubbed at write time by gateway.tenant_integrations.scrub_error_message
+-- before the parameter is bound, the same as tenant_integration_runs (0007) does. Job errors bubble
+-- up from third-party SDKs that sometimes echo customer emails verbatim, and that must never reach
+-- storage.
+--
+-- WHY tenant_id is TEXT and not a UUID FK to tenants, unlike 0007. Two reasons. This is an
+-- operational log that has to survive the tenant row vanishing mid-run (a cascade would delete the
+-- record of the run that was in flight when the tenant was deleted, which is exactly the history an
+-- operator wants at that moment). And the jobs this schedules key off different tenant spellings:
+-- the cost connectors take the tenants.id UUID, the reconciler takes the TenantId string used
+-- end-to-end in telemetry. TEXT holds both; reconciliation_runs (0008) made the same call.
+--
+-- Migration is additive. Existing deployments have zero rows, which reads as "nothing has ever been
+-- scheduled" and is the true state of every deployment today: the scheduler ships opt-in behind
+-- TALLY_SCHEDULER_ENABLED, defaulting to off, and CTO-213 registers no jobs at all.
+
+CREATE TABLE IF NOT EXISTS scheduler_runs (
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    job_name      TEXT NOT NULL CHECK (length(job_name) > 0 AND length(job_name) < 128),
+    tenant_id     TEXT NOT NULL CHECK (length(tenant_id) > 0),
+    started_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    status        TEXT NOT NULL CHECK (status IN ('success', 'skipped', 'failed')),
+    error_message TEXT,
+    -- A failed run must not carry a result and a successful one must not carry an error. Cheap
+    -- guard against a caller stamping a success with the last exception still in hand.
+    CONSTRAINT scheduler_runs_error_only_on_failure
+        CHECK (error_message IS NULL OR status = 'failed'),
+    CONSTRAINT scheduler_runs_finished_after_started
+        CHECK (finished_at >= started_at)
+);
+
+-- The tick loop asks "when did this job last settle for this tenant" for every (job, tenant) pair
+-- on every tick, which is the hottest query in the feature by a wide margin. This index is what
+-- makes it an index-only backwards scan rather than a growing sequential one.
+CREATE INDEX IF NOT EXISTS idx_scheduler_runs_job_tenant_finished
+    ON scheduler_runs(job_name, tenant_id, finished_at DESC);
+
+-- Same question narrowed to "last SUCCESS", which is what the freshness surfaces (phase 5 of
+-- docs/scheduler-scope.md) report and what backoff counts failures since. Partial, so it stays
+-- small even when a broken job fills the table with failures.
+CREATE INDEX IF NOT EXISTS idx_scheduler_runs_job_tenant_success
+    ON scheduler_runs(job_name, tenant_id, finished_at DESC)
+    WHERE status = 'success';

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -85,6 +85,9 @@ services:
       # What a tenant intends to SPEND on AI (CTO-205). Needs btree_gist for the no-overlap
       # EXCLUDE constraint; the extension is created by the migration itself.
       - ../db/postgres/0026_tenant_budgets.sql:/docker-entrypoint-initdb.d/0026_tenant_budgets.sql:ro
+      # Scheduler run history (CTO-213). The tick loop answers "is this job due for this
+      # tenant" from this table rather than from a sleeping coroutine, so it survives restarts.
+      - ../db/postgres/0027_scheduler_runs.sql:/docker-entrypoint-initdb.d/0027_scheduler_runs.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -57,6 +57,7 @@ from gateway.protocol import (
 )
 from gateway.ratelimit import RateLimiter
 from gateway.reconciliation import ReconciliationStore
+from gateway.scheduler import build_scheduler
 from gateway.store import ClickHouseStore
 from gateway.stripe_ingest import (
     StripeSignatureError,
@@ -310,6 +311,23 @@ async def lifespan(app: FastAPI):
         await buffer.start()
         app.state.ingest_buffer = buffer
         logger.info("ingest buffer enabled (capacity=%d)", settings.ingest_buffer_capacity)
+    # Scheduler (CTO-213): periodic per-tenant job execution. A tick loop that asks each registered
+    # job "are you due for this tenant" and answers from run history in Postgres, rather than
+    # sleeping for a day and losing its place on the next redeploy. Disabled → no task at all
+    # (None), which is byte-identical to the behaviour before this landed. It registers NO jobs
+    # yet: wiring the cost connectors is CTO-215 and the ingest workers CTO-216, so an enabled
+    # scheduler currently ticks over an empty registry. Single-replica only until advisory locking
+    # lands (phase 2 of docs/scheduler-scope.md).
+    app.state.scheduler = None
+    if settings.scheduler_enabled:
+        scheduler = build_scheduler(settings)
+        await scheduler.start()
+        app.state.scheduler = scheduler
+        logger.info(
+            "scheduler enabled (tick=%.0fs, jobs=%d)",
+            settings.scheduler_tick_interval_s,
+            scheduler.job_count,
+        )
     # Auto-discover provider model lineups (CTO-109). Fail-soft: if both providers
     # are unreachable AND there's no cached file, we still boot — just with an empty
     # list and a WARNING. Demos read app.state.models so they don't hardcode SKUs
@@ -327,6 +345,9 @@ async def lifespan(app: FastAPI):
         app.state.models = []
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
+    if app.state.scheduler is not None:
+        # Stopped before the stores close: a job in flight is holding one of them.
+        await app.state.scheduler.stop()
     if app.state.ingest_buffer is not None:
         await app.state.ingest_buffer.stop()  # flush buffered rows before closing the store
     app.state.store.close()

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -133,6 +133,24 @@ class Settings(BaseSettings):
     # Max rows pulled from ClickHouse per (tenant, table) export pass.
     athena_export_batch_limit: int = 10_000
 
+    # Scheduler (CTO-213). Periodic per-tenant job execution, started from the FastAPI lifespan the
+    # same way the ingest buffer is. OFF by default like every other background feature here, so an
+    # upgrade changes nothing: with the flag off no task is created and behaviour is identical to
+    # today. CTO-213 registers no jobs at all (the cost connectors are CTO-215, the ingest workers
+    # CTO-216), so even enabling it ticks over an empty registry until one of those lands.
+    #
+    # NOT yet safe on more than one replica: advisory locking is phase 2 of
+    # docs/scheduler-scope.md, so two enabled gateways would run every job twice. Enable on one.
+    scheduler_enabled: bool = False
+    # How often the loop wakes to ask "is anything due". This is NOT a job's cadence — cadence is
+    # per job and is measured against recorded run history, so this only bounds how late a due job
+    # can be picked up. Minutes, because the finest useful cadence in this product is minutes.
+    scheduler_tick_interval_s: float = 300.0
+    # Backoff after repeated failure, so a permanently broken job is not retried every tick forever.
+    # The first failure is not delayed at all; the second waits base, and it doubles to the cap.
+    scheduler_backoff_base_s: float = 300.0
+    scheduler_backoff_cap_s: float = 6 * 3600.0
+
 
 _settings: Settings | None = None
 

--- a/infra/gateway/src/gateway/scheduler.py
+++ b/infra/gateway/src/gateway/scheduler.py
@@ -1,0 +1,594 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Periodic per-tenant job execution: registry, due-calculation, tick loop (CTO-213, S1).
+
+WHY this exists. Nothing in this repo schedules anything, and a pile of working, tested code is
+invoked by nobody as a result: the compute / egress / Vercel cost connectors have ``run()`` and are
+called only by ``scripts/backfill_*.py`` by hand, ``IngestWorker.run_cycle`` exists for Segment,
+HubSpot and Pendo and nothing calls it, ``run_reconciliation`` is in the same position. So the first
+job wired up here is not new value, it is switching on value that already merged. See
+``docs/scheduler-scope.md`` for the full argument.
+
+THIS MODULE IS THE ENGINE ONLY. It registers no jobs. Wiring the cost connectors is CTO-215 and the
+ingest workers CTO-216, and until one of those lands an enabled scheduler ticks over an empty
+registry and does nothing. That is deliberate: the engine lands and gets exercised on its own.
+
+The central design point: a daily job is NOT ``await asyncio.sleep(86400)``.
+----------------------------------------------------------------------------
+That spelling drifts (every cycle's own runtime is added to the next interval), and worse, it keeps
+its place in memory, so it loses it on every restart. A gateway that redeploys once a day would
+never run a daily job at all: each deploy restarts the sleep, and the sleep never finishes. The bug
+would be invisible, because a scheduler that silently does nothing looks exactly like a scheduler
+with nothing to do.
+
+Instead: a tick loop wakes every few minutes and asks each registered job "are you due for THIS
+tenant?", and the answer comes from the run history in Postgres (``scheduler_runs``, migration
+0027). Nothing is held in memory across a tick. A restart mid-window resumes exactly where it left
+off, a missed window is caught on the next tick rather than skipped, and the cadence cannot drift
+because it is measured from a recorded timestamp rather than accumulated from sleeps.
+
+Catch-up is BOUNDED by construction. :func:`is_due` returns a boolean, never a count of missed
+windows, and a tick runs each (job, tenant) pair at most once. A tenant whose connector has been
+broken for a month therefore gets ONE run on the next tick, not thirty queued. If a job ever needs
+to reprocess the days it missed, that belongs inside the job (the connectors already have
+``run_backfill``) where the range is explicit and bounded, not in the scheduler's clock.
+
+Failure isolation. One tenant's failure must never stop another tenant, and one job's failure must
+never stop the loop. Every invocation is wrapped: a raise records ``failed`` with a scrubbed error
+and the loop moves on to the next tenant. Repeated failure earns exponential backoff (see
+:func:`backoff_delay_s`) so a permanently broken job is not retried every tick forever, which would
+otherwise mean hammering a dead third-party API every few minutes indefinitely and burying the run
+history under identical failures.
+
+Nothing blocks the event loop. The jobs this will eventually call are synchronous and do blocking
+Postgres and HTTP work, and the scheduler runs in-process with the API, so every job invocation and
+every store query goes through :func:`asyncio.to_thread`. A slow job delays the next tick; it never
+delays a request. There is deliberately no per-job timeout: ``asyncio.wait_for`` around a
+``to_thread`` abandons the coroutine but cannot kill the thread, so it would report a lie ("timed
+out", while the job keeps running and writing) rather than enforce anything.
+
+The registry does NOT assume it is running inside a web process. It takes plain callables and a
+tenant provider and knows nothing about FastAPI or ``app.state``. That is the seam
+``docs/scheduler-scope.md`` commits to for extracting a worker container later: the extraction
+becomes "construct the registry somewhere else", not a rewrite.
+
+Shape follows :class:`gateway.ingest_buffer.AsyncIngestBuffer`, the existing precedent for a
+background task here: ``asyncio.create_task``, ``while not self._stop.is_set()``, ``start()`` /
+``stop()``, graceful cancellation from the FastAPI ``lifespan``, and opt-in behind a settings flag
+(``settings.scheduler_enabled``, default off, matching ``ingest_buffered`` and the export flags).
+With the flag off, behaviour is byte-identical to today.
+
+Not covered here, by design: multi-replica safety. Two replicas with the flag on would run every job
+twice. Advisory locking (``pg_try_advisory_lock`` keyed on job plus tenant) is phase 2 of the scope
+doc; until it lands, enable the scheduler on exactly one gateway replica.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal, Protocol
+
+import psycopg
+
+from gateway.config import Settings
+from gateway.tenant_integrations import scrub_error_message
+
+logger = logging.getLogger("tally.gateway.scheduler")
+
+#: Outcome of one invocation. Mirrors the CHECK constraint in ``0027_scheduler_runs.sql``.
+#:
+#: ``skipped`` is not a soft failure. It is a job saying "there is nothing to do for this tenant",
+#: which is the normal state for a tenant that has not configured the thing the job runs (most
+#: tenants, for most jobs). It settles the cadence window so the job is not re-asked every tick, and
+#: it never claims work happened.
+RunStatus = Literal["success", "skipped", "failed"]
+
+#: A job body: takes a tenant id, does its work synchronously, returns nothing. Raising means the
+#: run failed. Raising :class:`JobSkipped` means there was nothing to do.
+JobFn = Callable[[str], None]
+
+#: How the scheduler learns which tenants exist. A plain callable so the registry stays free of any
+#: assumption about where it runs; :class:`PostgresTenantProvider` is the default implementation.
+TenantProvider = Callable[[], Sequence[str]]
+
+# Tick cadence floor. The finest useful cadence in this product is minutes (everything real is
+# hourly or daily), and a sub-second tick against Postgres would be pure waste.
+_MIN_TICK_INTERVAL_S = 1.0
+
+# Backoff defaults. The first failure retries on the next tick as normal (a transient 503 should not
+# cost a whole window), and only repeated failure stretches the gap: 2 failures -> 5 min, 3 -> 10,
+# 4 -> 20, capped at 6h so a job broken for a week still retries a few times a day and recovers on
+# its own once whatever broke is fixed.
+_DEFAULT_BACKOFF_BASE_S = 300.0
+_DEFAULT_BACKOFF_CAP_S = 6 * 3600.0
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class JobSkipped(Exception):
+    """Raised by a job body to record ``skipped`` rather than ``success`` for this tenant.
+
+    The intended use is "this tenant has not configured me": the cost connectors already treat a
+    missing config row that way. It settles the cadence window without claiming work was done.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class Job:
+    """A name, a cadence, and a callable taking a tenant id. That is the whole abstraction.
+
+    ``name`` is the identity persisted in ``scheduler_runs.job_name`` and is therefore a stable
+    contract: renaming a job orphans its history and makes it look like it has never run, which
+    would trigger an immediate run for every tenant.
+    """
+
+    name: str
+    interval_s: float
+    fn: JobFn
+
+    def __post_init__(self) -> None:
+        if not self.name or len(self.name) >= 128:
+            raise ValueError("job name must be non-empty and shorter than 128 chars")
+        if self.interval_s <= 0:
+            raise ValueError("interval_s must be > 0")
+
+
+@dataclass(frozen=True, slots=True)
+class JobState:
+    """What the run history says about one (job, tenant) pair. Everything :func:`is_due` needs.
+
+    ``last_settled_at`` is the cadence anchor: the most recent run that either succeeded or was
+    skipped. ``last_success_at`` is narrower and is what a freshness surface should quote to a user,
+    because "last skipped 10 minutes ago" is not "we have current data". They are kept separate so
+    the scheduler can be efficient about unconfigured tenants without the dashboard ever being able
+    to mistake a skip for a success.
+    """
+
+    last_success_at: datetime | None = None
+    last_settled_at: datetime | None = None
+    last_attempt_at: datetime | None = None
+    consecutive_failures: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class TickResult:
+    """What one pass over the registry did. Returned for tests and logged when anything ran."""
+
+    considered: int = 0  # (job, tenant) pairs examined
+    ran: int = 0  # job bodies actually invoked
+    succeeded: int = 0
+    skipped_by_job: int = 0  # invoked, raised JobSkipped
+    failed: int = 0
+    not_due: int = 0  # inside the cadence window or serving backoff, so never invoked
+
+
+def backoff_delay_s(
+    consecutive_failures: int,
+    *,
+    base_s: float = _DEFAULT_BACKOFF_BASE_S,
+    cap_s: float = _DEFAULT_BACKOFF_CAP_S,
+) -> float:
+    """Minimum gap after ``consecutive_failures`` failures before the job may be attempted again.
+
+    Zero for a first failure: the next tick retries as usual, because most failures are a transient
+    upstream blip and making the customer wait an extra window for one 503 is worse than one wasted
+    retry. From the second failure on it doubles, capped, so a permanently broken job settles into a
+    few attempts a day instead of one every tick forever.
+    """
+    if consecutive_failures <= 1:
+        return 0.0
+    return min(cap_s, base_s * (2.0 ** (consecutive_failures - 2)))
+
+
+def is_due(
+    job: Job,
+    state: JobState,
+    now: datetime,
+    *,
+    backoff_base_s: float = _DEFAULT_BACKOFF_BASE_S,
+    backoff_cap_s: float = _DEFAULT_BACKOFF_CAP_S,
+) -> bool:
+    """Is ``job`` due for the tenant that ``state`` describes, as of ``now``? Pure, hence testable.
+
+    Three questions, in order:
+
+    1. Is the job serving backoff after repeated failures? Measured from the last ATTEMPT, so
+       backoff holds regardless of how long ago the last success was.
+    2. Has it ever settled (succeeded or skipped)? If not it is due immediately: that is a
+       newly-registered job, or a brand-new tenant.
+    3. Has a full cadence window passed since it last settled?
+
+    Note what is absent: any notion of how MANY windows were missed. That is what bounds catch-up.
+    """
+    if state.consecutive_failures > 0 and state.last_attempt_at is not None:
+        delay = backoff_delay_s(
+            state.consecutive_failures, base_s=backoff_base_s, cap_s=backoff_cap_s
+        )
+        if delay > 0 and (now - state.last_attempt_at).total_seconds() < delay:
+            return False
+    if state.last_settled_at is None:
+        return True
+    return (now - state.last_settled_at).total_seconds() >= job.interval_s
+
+
+class JobRegistry:
+    """The set of registered jobs. A plain container: no I/O, no event loop, no web framework.
+
+    Deliberately dumb, because it is the seam. Extracting a worker container later means building
+    one of these in a different process; nothing in here would change.
+    """
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, Job] = {}
+
+    def register(self, name: str, interval_s: float, fn: JobFn) -> Job:
+        """Add a job. A duplicate name is a programming error, not a silent overwrite."""
+        if name in self._jobs:
+            raise ValueError(f"job '{name}' is already registered")
+        job = Job(name=name, interval_s=float(interval_s), fn=fn)
+        self._jobs[name] = job
+        return job
+
+    def get(self, name: str) -> Job | None:
+        return self._jobs.get(name)
+
+    def jobs(self) -> tuple[Job, ...]:
+        """Registration order, so a tick is deterministic and reproducible in tests."""
+        return tuple(self._jobs.values())
+
+    def __len__(self) -> int:
+        return len(self._jobs)
+
+    def __iter__(self) -> Iterator[Job]:
+        return iter(self._jobs.values())
+
+
+class RunStore(Protocol):
+    """What the tick loop needs from run history. Synchronous; the loop calls it off-thread."""
+
+    def get_state(self, job_name: str, tenant_id: str) -> JobState: ...
+
+    def record_run(
+        self,
+        job_name: str,
+        tenant_id: str,
+        status: RunStatus,
+        *,
+        started_at: datetime,
+        finished_at: datetime,
+        error_message: str | None = None,
+    ) -> None: ...
+
+
+class SchedulerRunStore:
+    """Postgres-backed run history over ``scheduler_runs`` (migration 0027).
+
+    Mirrors :class:`gateway.tenant_integrations.TenantIntegrationStore`: a connection per call,
+    tenant-scoped SQL, and error strings scrubbed before the parameter is bound.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get_state(self, job_name: str, tenant_id: str) -> JobState:
+        """Everything :func:`is_due` needs for one (job, tenant) pair, in one round trip.
+
+        The failure count is "failures since the last settled run", which is what makes backoff
+        reset by itself: one success (or one skip) makes the count zero again without anybody
+        clearing a counter, so there is no in-memory state to lose on restart or to drift out of
+        sync with the history.
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                WITH agg AS (
+                    SELECT max(finished_at) FILTER (WHERE status = 'success')
+                               AS success_at,
+                           max(finished_at) FILTER (WHERE status IN ('success', 'skipped'))
+                               AS settled_at,
+                           max(finished_at)
+                               AS attempt_at
+                    FROM scheduler_runs
+                    WHERE job_name = %(job)s AND tenant_id = %(tenant)s
+                )
+                SELECT agg.success_at,
+                       agg.settled_at,
+                       agg.attempt_at,
+                       (SELECT count(*)
+                          FROM scheduler_runs r
+                         WHERE r.job_name = %(job)s
+                           AND r.tenant_id = %(tenant)s
+                           AND r.status = 'failed'
+                           AND r.finished_at
+                               > coalesce(agg.settled_at, '-infinity'::timestamptz))
+                FROM agg
+                """,
+                {"job": job_name, "tenant": tenant_id},
+            )
+            row = cur.fetchone()
+        if row is None:  # pragma: no cover - the aggregate always yields exactly one row
+            return JobState()
+        return JobState(
+            last_success_at=row[0],
+            last_settled_at=row[1],
+            last_attempt_at=row[2],
+            consecutive_failures=int(row[3] or 0),
+        )
+
+    def record_run(
+        self,
+        job_name: str,
+        tenant_id: str,
+        status: RunStatus,
+        *,
+        started_at: datetime,
+        finished_at: datetime,
+        error_message: str | None = None,
+    ) -> None:
+        """Append one immutable row. Only a ``failed`` run may carry an error, per the CHECK."""
+        scrubbed = scrub_error_message(error_message) if status == "failed" else None
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO scheduler_runs
+                    (job_name, tenant_id, started_at, finished_at, status, error_message)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (job_name, tenant_id, started_at, finished_at, status, scrubbed),
+            )
+            conn.commit()
+
+
+class PostgresTenantProvider:
+    """Every tenant in the control plane, which is the default population for every job.
+
+    A job that only applies to configured tenants raises :class:`JobSkipped` for the rest, rather
+    than the scheduler trying to guess who is in scope: the job is the only thing that knows what
+    "configured" means for it.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def __call__(self) -> Sequence[str]:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute("SELECT id::text FROM tenants ORDER BY id")
+            return [str(row[0]) for row in cur.fetchall()]
+
+
+class Scheduler:
+    """The tick loop: wake, ask every (job, tenant) pair whether it is due, run the due ones.
+
+    Started from the FastAPI ``lifespan`` when ``settings.scheduler_enabled`` is on, exactly as
+    :class:`~gateway.ingest_buffer.AsyncIngestBuffer` is. :meth:`tick_once` is public and performs
+    one full pass, which is what the tests drive; :meth:`start` / :meth:`stop` wrap it in the
+    background task.
+    """
+
+    def __init__(
+        self,
+        registry: JobRegistry,
+        run_store: RunStore,
+        tenant_provider: TenantProvider,
+        *,
+        tick_interval_s: float = 300.0,
+        backoff_base_s: float = _DEFAULT_BACKOFF_BASE_S,
+        backoff_cap_s: float = _DEFAULT_BACKOFF_CAP_S,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        if tick_interval_s < _MIN_TICK_INTERVAL_S:
+            raise ValueError(f"tick_interval_s must be >= {_MIN_TICK_INTERVAL_S}")
+        self._registry = registry
+        self._store = run_store
+        self._tenants = tenant_provider
+        self._tick_interval_s = float(tick_interval_s)
+        self._backoff_base_s = float(backoff_base_s)
+        self._backoff_cap_s = float(backoff_cap_s)
+        self._now = now if now is not None else _utcnow
+        self._task: asyncio.Task[None] | None = None
+        self._stop: asyncio.Event | None = None
+        self._ticks = 0
+
+    @property
+    def ticks(self) -> int:
+        """Completed passes. Useful for tests and for an "is it alive" log line."""
+        return self._ticks
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None
+
+    @property
+    def job_count(self) -> int:
+        """How many jobs are registered. Zero is the correct answer for all of CTO-213."""
+        return len(self._registry)
+
+    async def start(self) -> None:
+        """Launch the background tick loop (idempotent, like the ingest buffer's)."""
+        if self._task is not None:
+            return
+        self._stop = asyncio.Event()
+        self._task = asyncio.create_task(self._run(), name="scheduler-tick")
+
+    async def stop(self) -> None:
+        """Signal the loop and wait for the current tick to finish. Never cancels mid-job.
+
+        Waiting matters: a job is a blocking call on a worker thread that may be halfway through
+        writing spans, and killing the loop out from under it would leave a run with no recorded
+        outcome, which the next tick would read as "never ran". The tick checks the stop event
+        between tenants, so a graceful shutdown costs at most one job's runtime.
+        """
+        if self._task is None:
+            return
+        assert self._stop is not None
+        self._stop.set()
+        await self._task
+        self._task = None
+
+    async def _run(self) -> None:
+        assert self._stop is not None
+        while not self._stop.is_set():
+            started = time.monotonic()
+            try:
+                result = await self.tick_once()
+                if result.ran:
+                    logger.info(
+                        "scheduler tick: ran=%d ok=%d skipped=%d failed=%d (considered=%d)",
+                        result.ran,
+                        result.succeeded,
+                        result.skipped_by_job,
+                        result.failed,
+                        result.considered,
+                    )
+            except Exception:  # noqa: BLE001 - the loop outlives any single tick's failure
+                # Reaching here means the tenant provider itself failed (per-job and per-tenant
+                # failures are handled inside the tick). Postgres being briefly unreachable must
+                # not end scheduling for the life of the process.
+                logger.exception("scheduler tick failed; continuing")
+            # Sleep the remainder of the interval, so the cadence does not drift by the tick's own
+            # runtime, and wake immediately on stop rather than making shutdown wait out the sleep.
+            elapsed = time.monotonic() - started
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(), timeout=max(0.0, self._tick_interval_s - elapsed)
+                )
+            except asyncio.TimeoutError:
+                pass
+
+    async def tick_once(self) -> TickResult:
+        """One full pass: for each job, for each tenant, run it if due. Returns what happened.
+
+        Jobs and tenants are walked sequentially. These are hourly-or-daily jobs against
+        rate-limited third-party billing APIs, so there is nothing to gain from fanning out, and a
+        sequential walk keeps the load this puts on Postgres and on those APIs obvious.
+        """
+        tenants = await asyncio.to_thread(self._tenants)
+        considered = ran = ok = skipped = failed = not_due = 0
+        for job in self._registry.jobs():
+            for tenant_id in tenants:
+                if self._stopping:
+                    break
+                considered += 1
+                try:
+                    state = await asyncio.to_thread(self._store.get_state, job.name, tenant_id)
+                except Exception:  # noqa: BLE001 - one unreadable row must not end the tick
+                    logger.exception(
+                        "scheduler: reading state for job=%s tenant=%s failed", job.name, tenant_id
+                    )
+                    continue
+                if not is_due(
+                    job,
+                    state,
+                    self._now(),
+                    backoff_base_s=self._backoff_base_s,
+                    backoff_cap_s=self._backoff_cap_s,
+                ):
+                    not_due += 1
+                    continue
+                ran += 1
+                status = await self._invoke(job, tenant_id)
+                if status == "success":
+                    ok += 1
+                elif status == "skipped":
+                    skipped += 1
+                else:
+                    failed += 1
+        self._ticks += 1
+        return TickResult(
+            considered=considered,
+            ran=ran,
+            succeeded=ok,
+            skipped_by_job=skipped,
+            failed=failed,
+            not_due=not_due,
+        )
+
+    @property
+    def _stopping(self) -> bool:
+        return self._stop is not None and self._stop.is_set()
+
+    async def _invoke(self, job: Job, tenant_id: str) -> RunStatus:
+        """Run one job for one tenant off the event loop and record the outcome. Never raises.
+
+        This wrapper is the failure isolation: whatever the job does, the caller gets a status back
+        and the loop continues to the next tenant. The job body runs via :func:`asyncio.to_thread`
+        because the things it will call (the cost connectors, the ingest workers, the reconciler)
+        do blocking Postgres and HTTP work, and this loop shares a process with the API.
+        """
+        started_at = self._now()
+        status: RunStatus = "success"
+        error: str | None = None
+        try:
+            await asyncio.to_thread(job.fn, tenant_id)
+        except JobSkipped as exc:
+            status = "skipped"
+            logger.debug("scheduler: job=%s tenant=%s skipped (%s)", job.name, tenant_id, exc)
+        except Exception as exc:  # noqa: BLE001 - a job's failure is data, not a crash
+            status = "failed"
+            error = f"{type(exc).__name__}: {exc}"
+            # Not .exception(): a job that is broken for a tenant fails on every attempt, and a
+            # stack trace per tick per tenant drowns the log. The scrubbed reason is on the row.
+            logger.warning("scheduler: job=%s tenant=%s failed: %s", job.name, tenant_id, error)
+        finished_at = self._now()
+        try:
+            await asyncio.to_thread(
+                self._store.record_run,
+                job.name,
+                tenant_id,
+                status,
+                started_at=started_at,
+                finished_at=finished_at,
+                error_message=error,
+            )
+        except Exception:  # noqa: BLE001 - an unrecordable run must not stop the loop
+            # The run happened but the history does not know it, so the next tick will run it again.
+            # For an idempotent daily job that is a wasted repeat, which is the right way to fail.
+            logger.exception("scheduler: recording job=%s tenant=%s failed", job.name, tenant_id)
+        return status
+
+
+def build_scheduler(
+    settings: Settings,
+    registry: JobRegistry | None = None,
+    *,
+    run_store: RunStore | None = None,
+    tenant_provider: TenantProvider | None = None,
+) -> Scheduler:
+    """Construct the production scheduler from settings. Called from the gateway ``lifespan``.
+
+    Registers NO jobs (CTO-213 is the engine; CTO-215 and CTO-216 add the first bodies), so with
+    the default registry an enabled scheduler ticks over an empty set and does nothing.
+    """
+    return Scheduler(
+        registry if registry is not None else JobRegistry(),
+        run_store if run_store is not None else SchedulerRunStore(settings),
+        tenant_provider if tenant_provider is not None else PostgresTenantProvider(settings),
+        tick_interval_s=settings.scheduler_tick_interval_s,
+        backoff_base_s=settings.scheduler_backoff_base_s,
+        backoff_cap_s=settings.scheduler_backoff_cap_s,
+    )
+
+
+__all__ = [
+    "Job",
+    "JobFn",
+    "JobRegistry",
+    "JobSkipped",
+    "JobState",
+    "PostgresTenantProvider",
+    "RunStatus",
+    "RunStore",
+    "Scheduler",
+    "SchedulerRunStore",
+    "TenantProvider",
+    "TickResult",
+    "backoff_delay_s",
+    "build_scheduler",
+    "is_due",
+]

--- a/infra/gateway/tests/test_scheduler.py
+++ b/infra/gateway/tests/test_scheduler.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler core: due-calculation, bounded catch-up, failure isolation, shutdown (CTO-213).
+
+No Postgres and no event-loop plugin: the run history is an in-memory fake implementing the
+:class:`gateway.scheduler.RunStore` protocol, ``now`` is injected, and async behaviour is driven
+with ``asyncio.run``, matching ``test_ingest_buffer.py``.
+
+The point of these tests is the design claim in the module docstring: the scheduler keeps NO state
+across a tick, so every decision is a pure function of the recorded history and the clock. That is
+what makes "restart-safe" testable without restarting anything.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gateway.scheduler import (
+    Job,
+    JobRegistry,
+    JobSkipped,
+    JobState,
+    Scheduler,
+    backoff_delay_s,
+    is_due,
+)
+
+T0 = datetime(2026, 8, 25, 12, 0, 0, tzinfo=timezone.utc)
+DAY = 86400.0
+
+
+class FakeRunStore:
+    """In-memory ``scheduler_runs``. Same queries as the real store, over a list."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+        self.record_error: Exception | None = None
+        self.state_error: Exception | None = None
+        self._lock = threading.Lock()
+
+    def get_state(self, job_name: str, tenant_id: str) -> JobState:
+        if self.state_error is not None:
+            raise self.state_error
+        with self._lock:
+            mine = [r for r in self.rows if r["job"] == job_name and r["tenant"] == tenant_id]
+        if not mine:
+            return JobState()
+        successes = [r["finished_at"] for r in mine if r["status"] == "success"]
+        settled = [r["finished_at"] for r in mine if r["status"] in ("success", "skipped")]
+        last_settled = max(settled) if settled else None
+        failures_since = [
+            r
+            for r in mine
+            if r["status"] == "failed"
+            and (last_settled is None or r["finished_at"] > last_settled)
+        ]
+        return JobState(
+            last_success_at=max(successes) if successes else None,
+            last_settled_at=last_settled,
+            last_attempt_at=max(r["finished_at"] for r in mine),
+            consecutive_failures=len(failures_since),
+        )
+
+    def record_run(
+        self,
+        job_name: str,
+        tenant_id: str,
+        status: str,
+        *,
+        started_at: datetime,
+        finished_at: datetime,
+        error_message: str | None = None,
+    ) -> None:
+        if self.record_error is not None:
+            raise self.record_error
+        with self._lock:
+            self.rows.append(
+                {
+                    "job": job_name,
+                    "tenant": tenant_id,
+                    "status": status,
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                    "error": error_message,
+                }
+            )
+
+    def statuses(self, job_name: str, tenant_id: str) -> list[str]:
+        return [r["status"] for r in self.rows if r["job"] == job_name and r["tenant"] == tenant_id]
+
+
+class MovableClock:
+    """An injectable ``now`` a test can advance by hand. Nothing here ever sleeps for real."""
+
+    def __init__(self, start: datetime = T0) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now = self.now + timedelta(seconds=seconds)
+
+
+def _daily(fn) -> Job:
+    return Job(name="daily-job", interval_s=DAY, fn=fn)
+
+
+# --- due-calculation (the pure core) -----------------------------------------------------------
+
+
+def test_due_when_never_run():
+    """A job with no history at all is due immediately: a new job, or a new tenant."""
+    assert is_due(_daily(lambda t: None), JobState(), T0) is True
+
+
+def test_not_due_inside_the_window():
+    """Ran an hour ago on a daily cadence: not due. This is the common case on every tick."""
+    state = JobState(
+        last_success_at=T0 - timedelta(hours=1),
+        last_settled_at=T0 - timedelta(hours=1),
+        last_attempt_at=T0 - timedelta(hours=1),
+    )
+    assert is_due(_daily(lambda t: None), state, T0) is False
+
+
+def test_due_again_after_the_window():
+    """Exactly one interval later it is due again. The boundary is inclusive: >= not >."""
+    job = _daily(lambda t: None)
+    last = T0 - timedelta(seconds=DAY)
+    state = JobState(last_success_at=last, last_settled_at=last, last_attempt_at=last)
+    assert is_due(job, state, T0) is True
+    # One second short of the window is still inside it.
+    assert is_due(job, state, T0 - timedelta(seconds=1)) is False
+
+
+def test_a_skip_settles_the_window_but_is_not_a_success():
+    """An unconfigured tenant is not re-asked every tick, and never looks like fresh data."""
+    last = T0 - timedelta(hours=2)
+    state = JobState(last_success_at=None, last_settled_at=last, last_attempt_at=last)
+    assert is_due(_daily(lambda t: None), state, T0) is False
+    assert state.last_success_at is None
+
+
+def test_backoff_holds_a_repeatedly_failing_job_off():
+    """Second failure onwards earns a growing gap; the first failure retries at the next tick."""
+    assert backoff_delay_s(0) == 0.0
+    assert backoff_delay_s(1) == 0.0  # a single blip is retried normally
+    assert backoff_delay_s(2) == 300.0
+    assert backoff_delay_s(3) == 600.0
+    assert backoff_delay_s(20) == 6 * 3600.0  # capped, so it never stops retrying entirely
+
+    job = _daily(lambda t: None)
+    failed_at = T0 - timedelta(seconds=60)
+    state = JobState(last_attempt_at=failed_at, consecutive_failures=3)
+    # Never succeeded, so the cadence says "due", but backoff says wait.
+    assert is_due(job, state, T0) is False
+    assert is_due(job, state, T0 + timedelta(seconds=600)) is True
+
+
+# --- bounded catch-up --------------------------------------------------------------------------
+
+
+def test_bounded_catch_up_a_month_of_downtime_is_one_run():
+    """The whole reason due-calculation is a boolean rather than a count of missed windows."""
+    clock = MovableClock()
+    store = FakeRunStore()
+    calls: list[str] = []
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, lambda tenant: calls.append(tenant))
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=60.0, now=clock)
+
+    # Last ran 30 days ago. Thirty windows have elapsed.
+    store.record_run(
+        "daily-job",
+        "t1",
+        "success",
+        started_at=clock.now - timedelta(days=30),
+        finished_at=clock.now - timedelta(days=30),
+    )
+    result = asyncio.run(sched.tick_once())
+    assert result.ran == 1 and result.succeeded == 1
+    assert calls == ["t1"]
+
+    # And the very next tick is quiet, because that one run settled the window.
+    clock.advance(60)
+    assert asyncio.run(sched.tick_once()).ran == 0
+    assert calls == ["t1"]
+
+
+# --- failure isolation -------------------------------------------------------------------------
+
+
+def test_one_tenants_failure_does_not_stop_the_others():
+    """Tenant b blows up; a and c still run, and b's failure is recorded rather than raised."""
+    store = FakeRunStore()
+    seen: list[str] = []
+
+    def flaky(tenant: str) -> None:
+        seen.append(tenant)
+        if tenant == "b":
+            raise RuntimeError("cost explorer returned 500")
+
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, flaky)
+    sched = Scheduler(registry, store, lambda: ["a", "b", "c"], tick_interval_s=60.0)
+
+    result = asyncio.run(sched.tick_once())
+    assert seen == ["a", "b", "c"]
+    assert (result.ran, result.succeeded, result.failed) == (3, 2, 1)
+    assert store.statuses("daily-job", "b") == ["failed"]
+    assert store.statuses("daily-job", "a") == ["success"]
+    # A failed run records the failure and produces nothing. The reason is kept, unscrubbed here
+    # only because the fake store is standing in for the SQL layer that does the scrubbing.
+    (row,) = [r for r in store.rows if r["tenant"] == "b"]
+    assert "cost explorer returned 500" in row["error"]
+
+
+def test_one_jobs_failure_does_not_stop_the_loop():
+    """A job that fails for every tenant must not prevent the next job from running at all."""
+    store = FakeRunStore()
+    ran_second: list[str] = []
+    registry = JobRegistry()
+    registry.register("broken", DAY, lambda tenant: (_ for _ in ()).throw(ValueError("nope")))
+    registry.register("healthy", DAY, lambda tenant: ran_second.append(tenant))
+    sched = Scheduler(registry, store, lambda: ["t1", "t2"], tick_interval_s=60.0)
+
+    result = asyncio.run(sched.tick_once())
+    assert result.failed == 2
+    assert result.succeeded == 2
+    assert ran_second == ["t1", "t2"]
+
+
+def test_a_skipping_job_records_skipped_not_success():
+    """JobSkipped is the honest "nothing to do here", distinct from both success and failure."""
+    store = FakeRunStore()
+    registry = JobRegistry()
+    registry.register(
+        "daily-job", DAY, lambda tenant: (_ for _ in ()).throw(JobSkipped("not configured"))
+    )
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=60.0)
+
+    result = asyncio.run(sched.tick_once())
+    assert (result.skipped_by_job, result.succeeded, result.failed) == (1, 0, 0)
+    assert store.statuses("daily-job", "t1") == ["skipped"]
+    assert store.get_state("daily-job", "t1").last_success_at is None
+
+
+def test_an_unrecordable_run_does_not_stop_the_tick():
+    """History being unwritable costs a repeat next tick; it must not end scheduling."""
+    store = FakeRunStore()
+    store.record_error = RuntimeError("postgres gone")
+    seen: list[str] = []
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, lambda tenant: seen.append(tenant))
+    sched = Scheduler(registry, store, lambda: ["a", "b"], tick_interval_s=60.0)
+
+    result = asyncio.run(sched.tick_once())
+    assert seen == ["a", "b"]
+    assert result.ran == 2
+
+
+def test_repeated_failure_then_recovery_clears_the_backoff():
+    """Backoff comes out of the history, so one good run resets it with no counter to clear."""
+    clock = MovableClock()
+    store = FakeRunStore()
+    outcome = {"fail": True}
+
+    def job(tenant: str) -> None:
+        if outcome["fail"]:
+            raise RuntimeError("still broken")
+
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, job)
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=60.0, now=clock)
+
+    assert asyncio.run(sched.tick_once()).failed == 1  # first failure, no backoff yet
+    clock.advance(60)
+    assert asyncio.run(sched.tick_once()).failed == 1  # second failure arms 300s of backoff
+    clock.advance(60)
+    assert asyncio.run(sched.tick_once()).not_due == 1  # serving backoff, not attempted
+
+    clock.advance(300)
+    outcome["fail"] = False
+    assert asyncio.run(sched.tick_once()).succeeded == 1
+    state = store.get_state("daily-job", "t1")
+    assert state.consecutive_failures == 0
+    assert state.last_success_at == clock.now
+
+
+# --- the loop ----------------------------------------------------------------------------------
+
+
+def test_start_and_stop_cleanly():
+    """The lifespan contract: start creates the task, stop drains it and leaves nothing running."""
+    store = FakeRunStore()
+    ticked = threading.Event()
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, lambda tenant: ticked.set())
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=1.0)
+
+    async def drive() -> None:
+        await sched.start()
+        assert sched.running
+        for _ in range(200):  # up to ~2s, far more than the first tick needs
+            if ticked.is_set():
+                break
+            await asyncio.sleep(0.01)
+        await sched.stop()
+
+    asyncio.run(drive())
+    assert ticked.is_set()
+    assert not sched.running
+    assert sched.ticks >= 1
+    assert store.statuses("daily-job", "t1")[0] == "success"
+
+
+def test_stop_waits_for_an_in_flight_job_rather_than_abandoning_it():
+    """Shutdown mid-job must still record an outcome, or the run vanishes from history."""
+    store = FakeRunStore()
+    started = threading.Event()
+    registry = JobRegistry()
+
+    def slow(tenant: str) -> None:
+        started.set()
+        time.sleep(0.3)
+
+    registry.register("slow-job", DAY, slow)
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=1.0)
+
+    async def drive() -> None:
+        await sched.start()
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+        await sched.stop()  # signalled while the job is still on its worker thread
+
+    asyncio.run(drive())
+    assert store.statuses("slow-job", "t1") == ["success"]
+
+
+def test_stop_is_prompt_between_tenants():
+    """A stop signalled mid-tick skips the remaining tenants instead of finishing the whole pass."""
+    store = FakeRunStore()
+    seen: list[str] = []
+    gate = threading.Event()
+
+    def job(tenant: str) -> None:
+        seen.append(tenant)
+        if tenant == "a":
+            gate.set()
+            time.sleep(0.2)
+
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, job)
+    tenants = [f"{c}" for c in "abcdefgh"]
+    sched = Scheduler(registry, store, lambda: tenants, tick_interval_s=1.0)
+
+    async def drive() -> None:
+        await sched.start()
+        while not gate.is_set():
+            await asyncio.sleep(0.01)
+        await sched.stop()
+
+    asyncio.run(drive())
+    assert seen[0] == "a"
+    assert len(seen) < len(tenants)  # the pass was abandoned, not run to completion
+
+
+def test_a_job_does_not_block_the_event_loop():
+    """The jobs this will call do blocking Postgres and HTTP work in a shared-with-the-API process.
+
+    Asserted by keeping a coroutine ticking on the loop while a job sleeps on its worker thread: if
+    the job body ran on the loop thread, the counter would not advance.
+    """
+    store = FakeRunStore()
+    registry = JobRegistry()
+    registry.register("blocking-job", DAY, lambda tenant: time.sleep(0.25))
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=60.0)
+    beats = 0
+
+    async def heartbeat() -> None:
+        nonlocal beats
+        while True:
+            await asyncio.sleep(0.01)
+            beats += 1
+
+    async def drive() -> None:
+        beat = asyncio.create_task(heartbeat())
+        await sched.tick_once()
+        beat.cancel()
+
+    asyncio.run(drive())
+    assert beats >= 5
+
+
+# --- registry ----------------------------------------------------------------------------------
+
+
+def test_registry_rejects_duplicates_and_nonsense_cadences():
+    registry = JobRegistry()
+    registry.register("a", DAY, lambda t: None)
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("a", DAY, lambda t: None)
+    with pytest.raises(ValueError, match="interval_s"):
+        registry.register("b", 0, lambda t: None)
+    assert len(registry) == 1
+    assert registry.get("a") is not None and registry.get("zzz") is None
+
+
+def test_an_empty_registry_is_a_no_op_which_is_all_of_cto_213():
+    """CTO-213 registers no jobs. An enabled scheduler must therefore do exactly nothing."""
+    store = FakeRunStore()
+    sched = Scheduler(JobRegistry(), store, lambda: ["t1", "t2"], tick_interval_s=60.0)
+    result = asyncio.run(sched.tick_once())
+    assert (result.considered, result.ran) == (0, 0)
+    assert store.rows == []


### PR DESCRIPTION
S1 of `docs/scheduler-scope.md`: the scheduler engine. **No jobs are registered.** Wiring the cost connectors is CTO-215, the ingest workers CTO-216. Off by default behind `TALLY_SCHEDULER_ENABLED`, so with the flag off behaviour is identical to today.

## Why

All of this code is merged, tested, and invoked by nothing: `ComputeCostConnector` / `EgressCostConnector` / `VercelCostConnector` (`run()`, called only by `scripts/backfill_*.py` by hand), `IngestWorker.run_cycle`, `run_reconciliation`. Five features are blocked on a timer existing.

## The due-calculation

A daily job is **not** `await asyncio.sleep(86400)`. That drifts, and it keeps its place in memory, so it loses it on every restart: a gateway that redeploys daily would never run a daily job at all, and the failure is invisible because a scheduler doing nothing looks like a scheduler with nothing to do.

Instead a tick loop wakes every few minutes (`scheduler_tick_interval_s`, default 300) and asks each registered job "are you due for THIS tenant". `is_due()` is a pure function of the run history in Postgres plus the clock:

1. Serving backoff after repeated failures? Not due. Measured from the last **attempt**.
2. Never settled (no success and no skip)? Due immediately: a new job, or a new tenant.
3. Otherwise due once a full `interval_s` has passed since it last settled.

Nothing is held in memory across a tick, so a restart mid-window resumes exactly where it left off and the cadence cannot drift.

**Bounded catch-up** falls out of that: `is_due` returns a boolean, never a count of missed windows, and a tick runs each (job, tenant) pair at most once. A tenant whose connector has been broken for a month gets ONE run, not thirty queued. Reprocessing missed days belongs inside a job, where the range is explicit (`run_backfill` already exists).

`scheduler_runs` (migration **0027**, compose mount added) records one row per invocation with `success` / `skipped` / `failed` and a scrubbed error. `skipped` means the job said "nothing to do for this tenant" (an unconfigured tenant): it settles the cadence window so the job is not re-asked every tick, but it is kept distinct from `success`, so a freshness surface can never mistake a skip for current data. `tenant_id` is TEXT with no FK, like `reconciliation_runs`: the run log should survive the tenant row vanishing mid-run, and different job families key on different tenant spellings.

## The backoff policy

`backoff_delay_s(consecutive_failures)`: 0 for the first failure (most failures are a transient upstream blip; making a customer wait another window for one 503 is worse than one wasted retry), then 5 min doubling to a 6 h cap. Capped rather than terminal, so a job broken for a week still retries a few times a day and recovers on its own.

`consecutive_failures` is computed as "failed runs since the last settled run", so **one success or skip resets it** with no counter to clear, nothing in memory to lose on restart, and nothing to drift out of sync with the history.

## Failure isolation and the event loop

Every invocation is wrapped: a raise records `failed` with the scrubbed reason, produces nothing (never a guessed value), and the loop moves to the next tenant. A job that fails for every tenant does not stop the next job. A tick that fails outright (the tenant provider) does not end the loop. An unrecordable run costs a repeat next tick rather than stopping anything.

Job bodies and store queries run via `asyncio.to_thread`, because the connector / worker code they will call does blocking Postgres and HTTP work and this runs in-process with the API. There is deliberately **no per-job timeout**: `wait_for` around a `to_thread` abandons the coroutine but cannot kill the thread, so it would report a lie rather than enforce anything.

Shape follows `AsyncIngestBuffer` throughout: `create_task`, `while not self._stop.is_set()`, `start()` / `stop()`, started and stopped from `lifespan` around the `yield`. `stop()` waits for the in-flight job rather than cancelling it (a killed job leaves a run with no recorded outcome, which the next tick reads as "never ran"); the tick checks the stop event between tenants, so shutdown costs at most one job's runtime.

Multi-replica safety is deliberately out: advisory locking is phase 2 of the scope doc. Until it lands, enable on one gateway replica. The settings comment says so.

## Verification

- `uv run --extra dev pytest -q`: **707 passed** (690 before, 17 new), `ruff check .` clean. Tests cover due when never run, not due inside the window, due again after the window (including the `>=` boundary), bounded catch-up, backoff arming and self-clearing on recovery, one tenant's failure not stopping the others, one job's failure not stopping the loop, an unrecordable run not stopping the tick, skip semantics, clean start/stop, stop waiting for an in-flight job, stop being prompt between tenants, and a blocking job not stalling the event loop.
- `npm run typecheck` clean; `npm run test` 568 passed, only the 2 long-standing `app/api/api.test.ts` failures that trip when a local ClickHouse is running.
- **Live**: rebuilt the gateway image and applied 0027 to the running Postgres by hand (initdb only fires on a first boot against an empty volume). With the flag off the gateway boots exactly as before and logs nothing about a scheduler. With `TALLY_SCHEDULER_ENABLED=true` and a 2 s tick against the compose stack: `scheduler enabled (tick=2s, jobs=0)` at startup, 3 ticks in 5 s, and `running == False` after the lifespan exits, with no warnings or orphaned tasks. Then drove the real `SchedulerRunStore` and `PostgresTenantProvider` against Postgres with a probe job over three tenants: tick 1 gave `ran=3 succeeded=1 skipped=1 failed=1`, tick 2 gave `ran=1 not_due=2` (the failure retried on the next tick and succeeded, the two settled tenants stood down), the skipped tenant read back `settled` with `success=None`, and the failed row landed as `RuntimeError: upstream 500 for [redacted-email]`. Probe rows deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
