### PR TITLE
feat(gateway): advisory locking so two replicas cannot run a job twice (CTO-214)

### DIFF
--- a/docs/scheduler-scope.md
+++ b/docs/scheduler-scope.md
@@ -46,6 +46,8 @@ Two gateway replicas would otherwise run every job twice, which for cost connect
 
 **Postgres advisory locks** (`pg_try_advisory_lock`) keyed on job plus tenant. A replica that cannot take the lock skips that tenant this tick. No new infrastructure, no leader election, and the lock dies with the connection so a crashed replica does not wedge a job forever.
 
+Shipped in CTO-214. The key is a personalised BLAKE2b digest of the length-prefixed (job, tenant) pair, truncated to a signed 64-bit integer, taken in the single-bigint lock space (which does not intersect the two-int32 space). A contended pair records **no run row at all**: `skipped` settles the cadence window, and a window settled while another replica is mid-run would silently cost that tenant a run.
+
 ## Decision 4: failure isolation
 
 One tenant's failure must never stop another tenant's job, and one job's failure must never stop the tick loop. Every job invocation is wrapped, records `failed` with a scrubbed error, and the loop continues.

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -316,8 +316,8 @@ async def lifespan(app: FastAPI):
     # sleeping for a day and losing its place on the next redeploy. Disabled → no task at all
     # (None), which is byte-identical to the behaviour before this landed. It registers NO jobs
     # yet: wiring the cost connectors is CTO-215 and the ingest workers CTO-216, so an enabled
-    # scheduler currently ticks over an empty registry. Single-replica only until advisory locking
-    # lands (phase 2 of docs/scheduler-scope.md).
+    # scheduler currently ticks over an empty registry. Safe on multiple replicas as of CTO-214:
+    # per (job, tenant) Postgres advisory locks, so two gateways cannot run the same job at once.
     app.state.scheduler = None
     if settings.scheduler_enabled:
         scheduler = build_scheduler(settings)

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -139,8 +139,10 @@ class Settings(BaseSettings):
     # today. CTO-213 registers no jobs at all (the cost connectors are CTO-215, the ingest workers
     # CTO-216), so even enabling it ticks over an empty registry until one of those lands.
     #
-    # NOT yet safe on more than one replica: advisory locking is phase 2 of
-    # docs/scheduler-scope.md, so two enabled gateways would run every job twice. Enable on one.
+    # Safe on more than one replica since CTO-214: every (job, tenant) pair is guarded by a
+    # Postgres advisory lock, and a replica that cannot take the lock leaves that tenant to the one
+    # that can and re-asks next tick. No flag of its own, because the alternative is the
+    # double-counted spend it exists to prevent. See gateway/scheduler.py.
     scheduler_enabled: bool = False
     # How often the loop wakes to ask "is anything due". This is NOT a job's cadence — cadence is
     # per job and is measured against recorded run history, so this only bounds how late a due job

--- a/infra/gateway/src/gateway/scheduler.py
+++ b/infra/gateway/src/gateway/scheduler.py
@@ -57,14 +57,23 @@ background task here: ``asyncio.create_task``, ``while not self._stop.is_set()``
 (``settings.scheduler_enabled``, default off, matching ``ingest_buffered`` and the export flags).
 With the flag off, behaviour is byte-identical to today.
 
-Not covered here, by design: multi-replica safety. Two replicas with the flag on would run every job
-twice. Advisory locking (``pg_try_advisory_lock`` keyed on job plus tenant) is phase 2 of the scope
-doc; until it lands, enable the scheduler on exactly one gateway replica.
+Multi-replica safety (CTO-214, S2). Two replicas with the flag on would otherwise run every job
+twice for every tenant, which for the cost connectors means double-counted spend. Each (job, tenant)
+pair is therefore guarded by a Postgres advisory lock (see :func:`advisory_lock_key` for the hash
+and the lock space), and a replica that cannot take the lock leaves that tenant to whoever holds it.
+Advisory locks specifically, rather than a lock table: the lock belongs to the session, so a replica
+that crashes mid-job releases it the moment its connection dies. A lock table would need a lease and
+a reaper to get the same property, and a reaper is one more thing that can silently stop.
+
+A lock-contention skip is NOT a ``skipped`` run and records NO row. See :class:`TickResult` for the
+argument: ``skipped`` settles the cadence window, and settling a window that another replica is at
+this second working on would quietly cost a run.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
 from collections.abc import Callable, Iterator, Sequence
@@ -166,6 +175,21 @@ class TickResult:
     skipped_by_job: int = 0  # invoked, raised JobSkipped
     failed: int = 0
     not_due: int = 0  # inside the cadence window or serving backoff, so never invoked
+    # Due, but another replica holds the (job, tenant) advisory lock, so this replica did not run it
+    # (CTO-214). Counted here and NOWHERE ELSE: contention writes no ``scheduler_runs`` row, and is
+    # deliberately not a fourth status.
+    #
+    # WHY no row. ``skipped`` means "the job ran and there was nothing to do", and it settles the
+    # cadence window so an unconfigured tenant is not re-asked every tick. Contention is the
+    # opposite situation: the work is happening right now, on another replica, and this replica
+    # must re-ask on the next tick. Recording anything that settles the window would mean a lock
+    # collision silently costs a run, and a daily job would quietly become an every-other-day job
+    # with nothing in the history to show for it. A fourth status would need a migration to the
+    # 0027 CHECK constraint and would put a row in front of every future freshness surface that
+    # means "no work was attempted", which is exactly the sort of thing that gets miscounted. The
+    # honest record of "we tried and someone else had it" is a counter and a log line, not history:
+    # nothing was invoked, so there is no invocation to log.
+    lock_contended: int = 0
 
 
 def backoff_delay_s(
@@ -362,6 +386,150 @@ class PostgresTenantProvider:
             return [str(row[0]) for row in cur.fetchall()]
 
 
+# --- Advisory locking (CTO-214, S2) ------------------------------------------------------------
+
+# Personalisation for the key hash, mixed into the digest so this feature's keys are its own. It is
+# a blake2b ``person``, which is capped at 16 bytes. Changing it changes every key, which would let
+# an old replica and a new one both run the same job during a rolling deploy, so it is a constant.
+_LOCK_KEY_PERSON = b"tally-sched-v1"
+
+
+def advisory_lock_key(job_name: str, tenant_id: str) -> int:
+    """The bigint ``pg_try_advisory_lock`` key for one (job, tenant) pair. Deterministic, stable.
+
+    THE HASH. ``blake2b``, personalised with ``tally-sched-v1``, over the string
+    ``f"{len(job_name)}\\x00{job_name}\\x00{tenant_id}"`` encoded UTF-8, digest truncated to 8
+    bytes and read big-endian as a SIGNED integer, because a Postgres ``bigint`` is signed and an
+    unsigned reading would overflow it for half of all inputs.
+
+    The length prefix is not decoration. Without it, job ``"a"`` with tenant ``"b\\x00c"`` and job
+    ``"a\\x00b"`` with tenant ``"c"`` would hash identically, and two unrelated jobs would
+    serialise against each other for no reason a reader could ever guess.
+
+    THE LOCK SPACE. Postgres has TWO advisory-lock spaces and they do NOT interact: the single
+    ``bigint`` form ``pg_try_advisory_lock(bigint)`` and the two ``int32`` form
+    ``pg_try_advisory_lock(int, int)``. Key ``0`` in the first is a different lock from ``(0, 0)``
+    in the second. This code uses the SINGLE-BIGINT space, exclusively and deliberately: all 64 bits
+    go to the hash, where the two-int form would spend 32 of them on a namespace field that buys
+    nothing here. Anything else in this deployment that wants an advisory lock should take it in the
+    two-int32 space, or go through this function.
+
+    Collisions are possible in principle (64 bits, birthday bound: with ten thousand live (job,
+    tenant) pairs the chance is about 3e-12). The consequence is bounded and safe in the direction
+    that matters: two unrelated pairs would take turns, so one of them waits for the next tick.
+    Never a double run, which is the property this ticket exists to buy.
+    """
+    digest = hashlib.blake2b(
+        f"{len(job_name)}\x00{job_name}\x00{tenant_id}".encode(),
+        digest_size=8,
+        person=_LOCK_KEY_PERSON,
+    ).digest()
+    return int.from_bytes(digest, "big", signed=True)
+
+
+class LockHandle(Protocol):
+    """A held lock. :meth:`release` must be safe to call exactly once, and must never raise."""
+
+    def release(self) -> None: ...
+
+
+class LockProvider(Protocol):
+    """Exclusion for one (job, tenant) pair across replicas.
+
+    ``acquire`` returns a handle when this process now holds the pair, or ``None`` when somebody
+    else does. It never blocks waiting for the lock: a replica that waited would just be running the
+    job late and twice in a row, and the whole point of the tick loop is that the next tick asks
+    again anyway.
+    """
+
+    def acquire(self, job_name: str, tenant_id: str) -> LockHandle | None: ...
+
+
+class _NullLock:
+    """The handle used when no provider is configured. Releasing it is a no-op."""
+
+    __slots__ = ()
+
+    def release(self) -> None:
+        return None
+
+
+_NO_LOCK = _NullLock()
+
+
+class PostgresAdvisoryLock:
+    """A held session-scoped advisory lock, owning the connection whose session holds it.
+
+    The connection is the lock. That is the whole reason for advisory locks over a lock table: if
+    this process is SIGKILLed, or the container is evicted, or the network drops, Postgres tears the
+    session down and the lock goes with it. Nothing has to notice the death and clean up, so there
+    is no lease to tune and no reaper to forget to run.
+    """
+
+    __slots__ = ("_conn", "_key")
+
+    def __init__(self, conn: psycopg.Connection, key: int) -> None:
+        self._conn = conn
+        self._key = key
+
+    @property
+    def key(self) -> int:
+        return self._key
+
+    def release(self) -> None:
+        """Unlock and close. Never raises: a caller in a ``finally`` has nothing useful to do here.
+
+        The explicit unlock is politeness for a pooled future; closing the connection is what
+        actually guarantees the release, which is why the close is in the ``finally``.
+        """
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(%s)", (self._key,))
+        except Exception:  # noqa: BLE001 - closing below releases it regardless
+            logger.debug("scheduler: advisory unlock failed for key=%d; closing session", self._key)
+        finally:
+            try:
+                self._conn.close()
+            except Exception:  # noqa: BLE001 - a dead connection is already an unlocked one
+                pass
+
+
+class PostgresAdvisoryLockProvider:
+    """``pg_try_advisory_lock`` keyed on job plus tenant, one dedicated session per held lock.
+
+    Dedicated because the lock is scoped to the SESSION: it has to outlive the statement that took
+    it and stay held for the whole run, and every other Postgres user in this module opens a
+    connection per call and closes it. Borrowing one of those would release the lock the moment the
+    query that took it finished, which is the failure mode that looks like locking works right up
+    until two replicas overlap.
+
+    One extra connection per job invocation is affordable here precisely because these are hourly
+    and daily jobs: a tick that runs nothing opens none at all.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def acquire(self, job_name: str, tenant_id: str) -> PostgresAdvisoryLock | None:
+        """Try, once, without waiting. ``None`` means another session holds this pair."""
+        key = advisory_lock_key(job_name, tenant_id)
+        # autocommit: session-level advisory locks are not transactional, and leaving an idle
+        # transaction open for the length of a job would pin the xmin horizon for no reason.
+        conn = psycopg.connect(self._dsn, autocommit=True)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_try_advisory_lock(%s)", (key,))
+                row = cur.fetchone()
+            acquired = bool(row and row[0])
+        except Exception:
+            conn.close()
+            raise
+        if not acquired:
+            conn.close()
+            return None
+        return PostgresAdvisoryLock(conn, key)
+
+
 class Scheduler:
     """The tick loop: wake, ask every (job, tenant) pair whether it is due, run the due ones.
 
@@ -369,6 +537,11 @@ class Scheduler:
     :class:`~gateway.ingest_buffer.AsyncIngestBuffer` is. :meth:`tick_once` is public and performs
     one full pass, which is what the tests drive; :meth:`start` / :meth:`stop` wrap it in the
     background task.
+
+    ``lock_provider`` (CTO-214) is what makes more than one replica safe. It is optional so the
+    engine stays independent of Postgres for tests, and :func:`build_scheduler` always supplies the
+    real one. With a single replica the outcome is identical either way: there is nobody to contend
+    with, so every acquire succeeds and every pass does exactly what S1 did.
     """
 
     def __init__(
@@ -377,6 +550,7 @@ class Scheduler:
         run_store: RunStore,
         tenant_provider: TenantProvider,
         *,
+        lock_provider: LockProvider | None = None,
         tick_interval_s: float = 300.0,
         backoff_base_s: float = _DEFAULT_BACKOFF_BASE_S,
         backoff_cap_s: float = _DEFAULT_BACKOFF_CAP_S,
@@ -387,6 +561,7 @@ class Scheduler:
         self._registry = registry
         self._store = run_store
         self._tenants = tenant_provider
+        self._locks = lock_provider
         self._tick_interval_s = float(tick_interval_s)
         self._backoff_base_s = float(backoff_base_s)
         self._backoff_cap_s = float(backoff_cap_s)
@@ -437,13 +612,15 @@ class Scheduler:
             started = time.monotonic()
             try:
                 result = await self.tick_once()
-                if result.ran:
+                if result.ran or result.lock_contended:
                     logger.info(
-                        "scheduler tick: ran=%d ok=%d skipped=%d failed=%d (considered=%d)",
+                        "scheduler tick: ran=%d ok=%d skipped=%d failed=%d "
+                        "contended=%d (considered=%d)",
                         result.ran,
                         result.succeeded,
                         result.skipped_by_job,
                         result.failed,
+                        result.lock_contended,
                         result.considered,
                     )
             except Exception:  # noqa: BLE001 - the loop outlives any single tick's failure
@@ -469,36 +646,49 @@ class Scheduler:
         sequential walk keeps the load this puts on Postgres and on those APIs obvious.
         """
         tenants = await asyncio.to_thread(self._tenants)
-        considered = ran = ok = skipped = failed = not_due = 0
+        considered = ran = ok = skipped = failed = not_due = contended = 0
         for job in self._registry.jobs():
             for tenant_id in tenants:
                 if self._stopping:
                     break
                 considered += 1
-                try:
-                    state = await asyncio.to_thread(self._store.get_state, job.name, tenant_id)
-                except Exception:  # noqa: BLE001 - one unreadable row must not end the tick
-                    logger.exception(
-                        "scheduler: reading state for job=%s tenant=%s failed", job.name, tenant_id
-                    )
+                state = await self._read_state(job, tenant_id)
+                if state is None:
                     continue
-                if not is_due(
-                    job,
-                    state,
-                    self._now(),
-                    backoff_base_s=self._backoff_base_s,
-                    backoff_cap_s=self._backoff_cap_s,
-                ):
+                if not self._due(job, state):
                     not_due += 1
                     continue
-                ran += 1
-                status = await self._invoke(job, tenant_id)
-                if status == "success":
-                    ok += 1
-                elif status == "skipped":
-                    skipped += 1
-                else:
-                    failed += 1
+                # Due as far as this replica can tell. Take the lock BEFORE running anything: the
+                # cheap read above is what keeps a tick from opening a lock session per tenant per
+                # tick, and this is what keeps two replicas from both running the job (CTO-214).
+                lock = await self._acquire(job, tenant_id)
+                if lock is None:
+                    contended += 1
+                    continue
+                try:
+                    # Ask again, now that the pair is ours. Between the read above and the acquire,
+                    # the replica that held the lock may have finished the very run we are about to
+                    # repeat, and its row is committed before it releases. Without this second read
+                    # the lock would prevent overlap but not duplication, which for a cost connector
+                    # is the same double-counted spend by a slower route.
+                    fresh = await self._read_state(job, tenant_id)
+                    if fresh is None:
+                        continue
+                    if not self._due(job, fresh):
+                        not_due += 1
+                        continue
+                    ran += 1
+                    status = await self._invoke(job, tenant_id)
+                    if status == "success":
+                        ok += 1
+                    elif status == "skipped":
+                        skipped += 1
+                    else:
+                        failed += 1
+                finally:
+                    # After :meth:`_invoke`, which means after the row is written. Releasing first
+                    # would open exactly the window the re-read above closes, on every single run.
+                    await self._release(job, tenant_id, lock)
         self._ticks += 1
         return TickResult(
             considered=considered,
@@ -507,7 +697,63 @@ class Scheduler:
             skipped_by_job=skipped,
             failed=failed,
             not_due=not_due,
+            lock_contended=contended,
         )
+
+    async def _read_state(self, job: Job, tenant_id: str) -> JobState | None:
+        """Run history for one pair, or ``None`` if unreadable. One bad row must not end a tick."""
+        try:
+            return await asyncio.to_thread(self._store.get_state, job.name, tenant_id)
+        except Exception:  # noqa: BLE001 - one unreadable row must not end the tick
+            logger.exception(
+                "scheduler: reading state for job=%s tenant=%s failed", job.name, tenant_id
+            )
+            return None
+
+    def _due(self, job: Job, state: JobState) -> bool:
+        return is_due(
+            job,
+            state,
+            self._now(),
+            backoff_base_s=self._backoff_base_s,
+            backoff_cap_s=self._backoff_cap_s,
+        )
+
+    async def _acquire(self, job: Job, tenant_id: str) -> LockHandle | None:
+        """Claim this (job, tenant) pair for this replica, or ``None`` to leave it alone.
+
+        Fails CLOSED. If the lock cannot be taken for any reason, including Postgres refusing the
+        connection, this replica does not run the job: without a held lock there is no way to rule
+        out another replica running it right now, and the cost of not running is one tick's delay
+        while the cost of running anyway is the double-counted spend this ticket exists to prevent.
+        """
+        if self._locks is None:
+            return _NO_LOCK
+        try:
+            return await asyncio.to_thread(self._locks.acquire, job.name, tenant_id)
+        except Exception as exc:  # noqa: BLE001 - an unavailable lock is a skip, not a crash
+            logger.warning(
+                "scheduler: could not take lock for job=%s tenant=%s, leaving it: %s: %s",
+                job.name,
+                tenant_id,
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    async def _release(self, job: Job, tenant_id: str, lock: LockHandle) -> None:
+        """Release on every path out of the run, success and failure alike.
+
+        A release that fails is survivable rather than fatal, which is the advisory-lock property
+        again: the session holding it dies with this process, so the worst case is that one (job,
+        tenant) pair is unavailable to the other replicas until then, not forever.
+        """
+        try:
+            await asyncio.to_thread(lock.release)
+        except Exception:  # noqa: BLE001 - see docstring
+            logger.exception(
+                "scheduler: releasing lock for job=%s tenant=%s failed", job.name, tenant_id
+            )
 
     @property
     def _stopping(self) -> bool:
@@ -559,16 +805,24 @@ def build_scheduler(
     *,
     run_store: RunStore | None = None,
     tenant_provider: TenantProvider | None = None,
+    lock_provider: LockProvider | None = None,
 ) -> Scheduler:
     """Construct the production scheduler from settings. Called from the gateway ``lifespan``.
 
     Registers NO jobs (CTO-213 is the engine; CTO-215 and CTO-216 add the first bodies), so with
     the default registry an enabled scheduler ticks over an empty set and does nothing.
+
+    Advisory locking is always on in this path (CTO-214). It needs no flag of its own: it uses the
+    same Postgres the run history already requires, and a deployment that wanted it off would be
+    asking for the double-counted spend it prevents.
     """
     return Scheduler(
         registry if registry is not None else JobRegistry(),
         run_store if run_store is not None else SchedulerRunStore(settings),
         tenant_provider if tenant_provider is not None else PostgresTenantProvider(settings),
+        lock_provider=(
+            lock_provider if lock_provider is not None else PostgresAdvisoryLockProvider(settings)
+        ),
         tick_interval_s=settings.scheduler_tick_interval_s,
         backoff_base_s=settings.scheduler_backoff_base_s,
         backoff_cap_s=settings.scheduler_backoff_cap_s,
@@ -581,6 +835,10 @@ __all__ = [
     "JobRegistry",
     "JobSkipped",
     "JobState",
+    "LockHandle",
+    "LockProvider",
+    "PostgresAdvisoryLock",
+    "PostgresAdvisoryLockProvider",
     "PostgresTenantProvider",
     "RunStatus",
     "RunStore",
@@ -588,6 +846,7 @@ __all__ = [
     "SchedulerRunStore",
     "TenantProvider",
     "TickResult",
+    "advisory_lock_key",
     "backoff_delay_s",
     "build_scheduler",
     "is_due",

--- a/infra/gateway/tests/test_scheduler_locking.py
+++ b/infra/gateway/tests/test_scheduler_locking.py
@@ -1,0 +1,547 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Advisory locking: two replicas, one run (CTO-214, S2).
+
+Two parts, and the split is deliberate.
+
+The first part is fakes: the key hash, and what the tick loop does with a provider that hands out
+or withholds locks. Those pin the DECISIONS (contention writes no row, the lock is released on the
+success path and the failure path alike, a lock that cannot be taken means the job is not run).
+
+The second part talks to a REAL Postgres, because the claim this ticket is actually making is about
+Postgres, not about our code's opinion of Postgres. A mocked lock proves nothing about whether
+``pg_try_advisory_lock`` excludes a second session, and it proves nothing at all about the property
+we are buying the advisory lock FOR: that a replica which dies mid-job releases its lock. So those
+two run against a live database, and are skipped when there is not one (CI has no Postgres; a
+laptop with ``docker compose up`` does). ``TALLY_TEST_POSTGRES_DSN`` overrides the DSN.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from gateway.scheduler import (
+    JobRegistry,
+    JobSkipped,
+    JobState,
+    PostgresAdvisoryLockProvider,
+    Scheduler,
+    SchedulerRunStore,
+    advisory_lock_key,
+)
+
+T0 = datetime(2026, 8, 25, 12, 0, 0, tzinfo=timezone.utc)
+DAY = 86400.0
+
+DEFAULT_DSN = "postgresql://tally:tally@localhost:5432/tally"
+
+
+# --- the key hash ------------------------------------------------------------------------------
+
+
+def test_key_is_deterministic():
+    """Same pair, same key, forever. A key that moved would let two replicas both run a job."""
+    assert advisory_lock_key("cost-connectors", "t1") == advisory_lock_key("cost-connectors", "t1")
+
+
+def test_key_fits_a_signed_bigint():
+    """The single-bigint lock space is signed 64-bit; an unsigned reading would not fit."""
+    for job in ("a", "cost-connectors", "x" * 127):
+        for tenant in ("t", str(uuid.uuid4()), "local-dev"):
+            key = advisory_lock_key(job, tenant)
+            assert -(2**63) <= key < 2**63
+
+
+def test_key_separates_jobs_and_tenants():
+    """Different job, or different tenant, means a different lock. Otherwise it over-serialises."""
+    assert advisory_lock_key("job-a", "t1") != advisory_lock_key("job-b", "t1")
+    assert advisory_lock_key("job-a", "t1") != advisory_lock_key("job-a", "t2")
+
+
+def test_key_is_not_confusable_across_the_delimiter():
+    """The length prefix earns its keep: ("a", "b\\x00c") must not collide with ("a\\x00b", "c").
+
+    A plain ``job + "\\x00" + tenant`` hash collides on exactly this pair, and the resulting bug
+    would be two unrelated jobs mysteriously taking turns.
+    """
+    assert advisory_lock_key("a", "b\x00c") != advisory_lock_key("a\x00b", "c")
+
+
+# --- what the tick loop does with locks (fakes) --------------------------------------------------
+
+
+class FakeRunStore:
+    """Minimal in-memory ``scheduler_runs``, same shape as the one in test_scheduler.py."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+        self._lock = threading.Lock()
+
+    def get_state(self, job_name: str, tenant_id: str) -> JobState:
+        with self._lock:
+            mine = [r for r in self.rows if r["job"] == job_name and r["tenant"] == tenant_id]
+        if not mine:
+            return JobState()
+        settled = [r["finished_at"] for r in mine if r["status"] in ("success", "skipped")]
+        last_settled = max(settled) if settled else None
+        return JobState(
+            last_success_at=max(
+                (r["finished_at"] for r in mine if r["status"] == "success"), default=None
+            ),
+            last_settled_at=last_settled,
+            last_attempt_at=max(r["finished_at"] for r in mine),
+            consecutive_failures=sum(
+                1
+                for r in mine
+                if r["status"] == "failed"
+                and (last_settled is None or r["finished_at"] > last_settled)
+            ),
+        )
+
+    def record_run(
+        self,
+        job_name: str,
+        tenant_id: str,
+        status: str,
+        *,
+        started_at: datetime,
+        finished_at: datetime,
+        error_message: str | None = None,
+    ) -> None:
+        with self._lock:
+            self.rows.append(
+                {
+                    "job": job_name,
+                    "tenant": tenant_id,
+                    "status": status,
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                    "error": error_message,
+                }
+            )
+
+
+class FakeLock:
+    def __init__(self, owner: "FakeLockProvider", pair: tuple[str, str]) -> None:
+        self._owner = owner
+        self._pair = pair
+
+    def release(self) -> None:
+        self._owner.released.append(self._pair)
+        self._owner.held.discard(self._pair)
+
+
+class FakeLockProvider:
+    """Hands out locks unless told otherwise. Records every acquire and every release."""
+
+    def __init__(self, *, grant: bool = True, error: Exception | None = None) -> None:
+        self.grant = grant
+        self.error = error
+        self.acquired: list[tuple[str, str]] = []
+        self.released: list[tuple[str, str]] = []
+        self.held: set[tuple[str, str]] = set()
+
+    def acquire(self, job_name: str, tenant_id: str) -> FakeLock | None:
+        pair = (job_name, tenant_id)
+        self.acquired.append(pair)
+        if self.error is not None:
+            raise self.error
+        if not self.grant:
+            return None
+        self.held.add(pair)
+        return FakeLock(self, pair)
+
+
+def _scheduler(store, locks, fn, *, tenants=("t1",), name="daily-job"):
+    registry = JobRegistry()
+    registry.register(name, DAY, fn)
+    return Scheduler(
+        registry,
+        store,
+        lambda: list(tenants),
+        lock_provider=locks,
+        tick_interval_s=60.0,
+        now=lambda: T0,
+    )
+
+
+def test_lock_held_by_someone_else_does_not_run_and_records_nothing():
+    """THE judgement call of this ticket: contention is not a ``skipped`` run.
+
+    ``skipped`` settles the cadence window. If a lock collision settled it, the tenant would be
+    told "your daily job ran today" when what actually happened is that nobody on this replica ran
+    it. Whether the other replica finished is not this replica's business, so it writes nothing and
+    the next tick asks again from the same history.
+    """
+    store = FakeRunStore()
+    calls: list[str] = []
+    locks = FakeLockProvider(grant=False)
+    sched = _scheduler(store, locks, calls.append)
+
+    result = asyncio.run(sched.tick_once())
+
+    assert calls == []
+    assert store.rows == []  # nothing settled, nothing claimed, no history invented
+    assert result.lock_contended == 1
+    assert result.ran == 0
+    assert result.skipped_by_job == 0  # NOT conflated with a job saying "nothing to do"
+    assert result.not_due == 0  # NOT conflated with being inside the cadence window either
+
+
+def test_contention_leaves_the_job_due_on_the_next_tick():
+    """The point of writing no row: the very next tick still considers the pair due."""
+    store = FakeRunStore()
+    calls: list[str] = []
+    locks = FakeLockProvider(grant=False)
+    sched = _scheduler(store, locks, calls.append)
+
+    asyncio.run(sched.tick_once())
+    locks.grant = True  # the other replica finished and let go
+    result = asyncio.run(sched.tick_once())
+
+    assert calls == ["t1"]
+    assert result.ran == 1 and result.succeeded == 1
+
+
+def test_lock_released_after_success():
+    store = FakeRunStore()
+    locks = FakeLockProvider()
+    sched = _scheduler(store, locks, lambda t: None)
+
+    asyncio.run(sched.tick_once())
+
+    assert locks.released == [("daily-job", "t1")]
+    assert locks.held == set()
+
+
+def test_lock_released_after_failure():
+    """The failure path releases too, or one broken job would wedge that tenant on every replica."""
+
+    def boom(_tenant: str) -> None:
+        raise RuntimeError("upstream 500")
+
+    store = FakeRunStore()
+    locks = FakeLockProvider()
+    sched = _scheduler(store, locks, boom)
+
+    result = asyncio.run(sched.tick_once())
+
+    assert result.failed == 1
+    assert locks.released == [("daily-job", "t1")]
+    assert locks.held == set()
+
+
+def test_lock_released_after_a_job_skip():
+    def nothing_to_do(_tenant: str) -> None:
+        raise JobSkipped("tenant has no connector configured")
+
+    store = FakeRunStore()
+    locks = FakeLockProvider()
+    sched = _scheduler(store, locks, nothing_to_do)
+
+    result = asyncio.run(sched.tick_once())
+
+    assert result.skipped_by_job == 1
+    assert locks.released == [("daily-job", "t1")]
+
+
+def test_lock_released_before_the_next_tenant_is_locked():
+    """Locks are per (job, tenant) and are not held across tenants, so one slow tenant blocks one."""
+    store = FakeRunStore()
+    locks = FakeLockProvider()
+    sched = _scheduler(store, locks, lambda t: None, tenants=("t1", "t2", "t3"))
+
+    asyncio.run(sched.tick_once())
+
+    assert locks.acquired == [("daily-job", "t1"), ("daily-job", "t2"), ("daily-job", "t3")]
+    assert locks.released == locks.acquired
+    assert locks.held == set()
+
+
+def test_lock_provider_failure_fails_closed():
+    """Postgres unreachable for the lock means the job does NOT run. Not running is the safe half.
+
+    A run without a confirmed lock could be the second one for that tenant today, and a second run
+    of a cost connector is double-counted spend. A run delayed by a tick is a run delayed by a tick.
+    """
+    store = FakeRunStore()
+    calls: list[str] = []
+    locks = FakeLockProvider(error=RuntimeError("connection refused"))
+    sched = _scheduler(store, locks, calls.append)
+
+    result = asyncio.run(sched.tick_once())
+
+    assert calls == []
+    assert store.rows == []
+    assert result.lock_contended == 1 and result.ran == 0
+
+
+def test_state_is_reread_under_the_lock():
+    """The lock closes the overlap window; this re-read closes the hand-off window.
+
+    Replica B reads history, sees "due", and waits on the lock A holds. A finishes, commits its
+    row, releases. If B then ran without asking again it would run the job a second time, having
+    obeyed the lock perfectly the whole way. So B asks again with the pair in hand.
+    """
+    store = FakeRunStore()
+    calls: list[str] = []
+
+    class LateWriter(FakeLockProvider):
+        def acquire(self, job_name: str, tenant_id: str):
+            # Stand in for the other replica finishing between our read and our acquire.
+            store.record_run(
+                job_name, tenant_id, "success", started_at=T0, finished_at=T0
+            )
+            return super().acquire(job_name, tenant_id)
+
+    locks = LateWriter()
+    sched = _scheduler(store, locks, calls.append)
+
+    result = asyncio.run(sched.tick_once())
+
+    assert calls == []  # the other replica's run counts; we do not repeat it
+    assert result.ran == 0 and result.not_due == 1
+    assert locks.released == [("daily-job", "t1")]  # and we still let go
+    assert len(store.rows) == 1  # exactly one run recorded for the pair
+
+
+def test_no_lock_provider_is_s1_behaviour():
+    """The provider is optional, and without one the loop is exactly what CTO-213 shipped."""
+    store = FakeRunStore()
+    calls: list[str] = []
+    registry = JobRegistry()
+    registry.register("daily-job", DAY, calls.append)
+    sched = Scheduler(registry, store, lambda: ["t1", "t2"], now=lambda: T0)
+
+    result = asyncio.run(sched.tick_once())
+
+    assert calls == ["t1", "t2"]
+    assert result.ran == 2 and result.succeeded == 2 and result.lock_contended == 0
+
+
+# --- against a real Postgres ---------------------------------------------------------------------
+
+
+def _dsn_or_skip() -> str:
+    """The live DSN, or skip. A missing database must never turn CI red for a local-only test."""
+    dsn = os.environ.get("TALLY_TEST_POSTGRES_DSN", DEFAULT_DSN)
+    psycopg = pytest.importorskip("psycopg")
+    try:
+        with psycopg.connect(dsn, connect_timeout=2) as conn, conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('scheduler_runs')")
+            row = cur.fetchone()
+    except Exception as exc:  # noqa: BLE001 - no database here is a skip, not a failure
+        pytest.skip(f"no Postgres at {dsn}: {type(exc).__name__}: {exc}")
+    if row is None or row[0] is None:
+        pytest.skip("scheduler_runs is missing; apply db/postgres/0027_scheduler_runs.sql")
+    return dsn
+
+
+def _key_components(key: int) -> tuple[int, int]:
+    """Split a signed bigint lock key the way ``pg_locks`` reports it: high 32 bits, low 32 bits.
+
+    Done in Python rather than SQL because reassembling the halves in SQL overflows ``bigint`` for
+    any key with the high bit set, which is half of them.
+    """
+    unsigned = key & 0xFFFFFFFFFFFFFFFF
+    return unsigned >> 32, unsigned & 0xFFFFFFFF
+
+
+class _LiveSettings:
+    def __init__(self, dsn: str) -> None:
+        self.postgres_dsn = dsn
+
+
+@pytest.fixture
+def live_dsn():
+    return _dsn_or_skip()
+
+
+@pytest.fixture
+def live_job(live_dsn):
+    """A job name nothing else uses, cleaned up afterwards, so runs cannot collide or accumulate."""
+    import psycopg
+
+    name = f"test-lock-{uuid.uuid4().hex[:12]}"
+    yield name
+    with psycopg.connect(live_dsn) as conn, conn.cursor() as cur:
+        cur.execute("DELETE FROM scheduler_runs WHERE job_name = %s", (name,))
+        conn.commit()
+
+
+def test_live_two_runners_exactly_one_executes(live_dsn, live_job):
+    """THE acceptance test. Two schedulers, one Postgres, one tenant, one due job. One run.
+
+    Both are real: real ``SchedulerRunStore``, real ``PostgresAdvisoryLockProvider``, real
+    ``pg_try_advisory_lock``. The job body blocks on an event so the two ticks genuinely overlap,
+    which is the situation two gateway replicas are in every few minutes.
+    """
+    tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+    settings = _LiveSettings(live_dsn)
+    invocations: list[str] = []
+    inside = threading.Event()
+    may_finish = threading.Event()
+    lock = threading.Lock()
+
+    def body(tenant_id: str) -> None:
+        with lock:
+            invocations.append(tenant_id)
+        inside.set()
+        # Hold the run open until the other runner has had its turn at the lock.
+        may_finish.wait(timeout=10.0)
+
+    def build() -> Scheduler:
+        registry = JobRegistry()
+        registry.register(live_job, DAY, body)
+        return Scheduler(
+            registry,
+            SchedulerRunStore(settings),
+            lambda: [tenant],
+            lock_provider=PostgresAdvisoryLockProvider(settings),
+            tick_interval_s=60.0,
+        )
+
+    async def drive():
+        first = asyncio.create_task(build().tick_once())
+        # Wait until a job body is genuinely running (and therefore genuinely holding the lock)
+        # before the second runner ticks. This is the overlap, not a simulation of one.
+        await asyncio.to_thread(inside.wait, 10.0)
+        second = await build().tick_once()
+        may_finish.set()
+        return await first, second
+
+    winner, loser = asyncio.run(drive())
+
+    assert invocations == [tenant], "the job body ran more than once across two runners"
+    assert winner.ran == 1 and winner.succeeded == 1
+    assert loser.ran == 0, "the second runner executed a job another runner was holding"
+    assert loser.lock_contended == 1
+    assert loser.skipped_by_job == 0  # contention is not a skip
+
+    import psycopg
+
+    with psycopg.connect(live_dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT status FROM scheduler_runs WHERE job_name = %s AND tenant_id = %s",
+            (live_job, tenant),
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == ["success"], "contention wrote a row, or the job ran twice"
+
+
+def test_live_lock_dies_with_the_connection(live_dsn, live_job):
+    """The reason this is an advisory lock and not a lock table.
+
+    A replica is killed mid-job. Nothing runs a cleanup, nothing renews a lease, nothing reaps. The
+    session ends and Postgres drops the lock, so the next replica can pick the tenant straight up.
+    Here the kill is ``pg_terminate_backend`` from another session, which is as close to a SIGKILL
+    as a test can get without one.
+    """
+    import psycopg
+
+    tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+    settings = _LiveSettings(live_dsn)
+    provider = PostgresAdvisoryLockProvider(settings)
+    key = advisory_lock_key(live_job, tenant)
+
+    held = provider.acquire(live_job, tenant)
+    assert held is not None
+    assert held.key == key
+    # Contended while it is held, as expected.
+    assert provider.acquire(live_job, tenant) is None
+
+    classid, objid = _key_components(key)
+    with psycopg.connect(live_dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_terminate_backend(l.pid)
+            FROM pg_locks l
+            WHERE l.locktype = 'advisory'
+              AND l.classid::bigint = %s
+              AND l.objid::bigint = %s
+              AND l.objsubid = 1
+              AND l.pid <> pg_backend_pid()
+            """,
+            (classid, objid),
+        )
+        killed = cur.fetchall()
+        conn.commit()
+    assert killed, "expected to find and kill the session holding the lock"
+
+    # No cleanup, no lease expiry, no reaper: the lock is simply gone with the session.
+    deadline = time.monotonic() + 5.0
+    recovered = None
+    while time.monotonic() < deadline:
+        recovered = provider.acquire(live_job, tenant)
+        if recovered is not None:
+            break
+        time.sleep(0.05)
+    assert recovered is not None, "a dead session's advisory lock was not released"
+    recovered.release()
+
+    # And the original handle can still be released without raising, which is what the tick loop's
+    # ``finally`` depends on: a crashed connection must not turn into an exception on the way out.
+    held.release()
+
+
+def test_live_single_runner_is_unchanged(live_dsn, live_job):
+    """One replica with locking on behaves exactly as S1 did: due job runs, run is recorded."""
+    tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+    settings = _LiveSettings(live_dsn)
+    calls: list[str] = []
+    registry = JobRegistry()
+    registry.register(live_job, DAY, calls.append)
+    sched = Scheduler(
+        registry,
+        SchedulerRunStore(settings),
+        lambda: [tenant],
+        lock_provider=PostgresAdvisoryLockProvider(settings),
+        tick_interval_s=60.0,
+    )
+
+    first = asyncio.run(sched.tick_once())
+    second = asyncio.run(sched.tick_once())  # inside the cadence window now
+
+    assert calls == [tenant]
+    assert first.ran == 1 and first.succeeded == 1 and first.lock_contended == 0
+    assert second.ran == 0 and second.not_due == 1 and second.lock_contended == 0
+
+
+def test_live_lock_is_taken_in_the_single_bigint_space(live_dsn, live_job):
+    """Pin the lock space, because the two forms do NOT exclude each other.
+
+    ``pg_locks`` reports a single-bigint lock with ``classid`` holding the high 32 bits and
+    ``objid`` the low ones, and ``objsubid = 1``; the two-int32 form reports ``objsubid = 2``.
+    Anything that changed this code to the two-int form would silently stop excluding replicas
+    still running the other spelling, and this assertion is what would catch it.
+    """
+    import psycopg
+
+    tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+    provider = PostgresAdvisoryLockProvider(_LiveSettings(live_dsn))
+    key = advisory_lock_key(live_job, tenant)
+    handle = provider.acquire(live_job, tenant)
+    assert handle is not None
+    try:
+        with psycopg.connect(live_dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT objsubid
+                FROM pg_locks
+                WHERE locktype = 'advisory'
+                  AND classid::bigint = %s
+                  AND objid::bigint = %s
+                """,
+                _key_components(key),
+            )
+            rows = cur.fetchall()
+        assert rows, "the advisory lock is not visible under its documented bigint key"
+        assert all(r[0] == 1 for r in rows), "expected the single-bigint space (objsubid = 1)"
+    finally:
+        handle.release()


### PR DESCRIPTION
S2 of the scheduler (CTO-214), on top of S1 (#198). Makes it safe to run the scheduler on more than one gateway replica.

## Why

S1's scheduler is restart-safe but not replica-safe. Two gateways with `TALLY_SCHEDULER_ENABLED` on would run every job for every tenant twice. For the cost connectors that is double-counted spend. The compute and egress emitter happens to survive it, because its spans are keyed on `synthetic_span_id(tenant, provider, operation, day)` and it checks `span_exists` before inserting, but that is one job's downstream dedupe, not a design. The ingest workers and the reconciler have no such guard.

## The lock

`pg_try_advisory_lock` on every (job, tenant) pair, taken before the job body runs and released after the run is recorded. `try`, never the blocking form: a replica that waited would just run the job late and back-to-back with the other one, and the tick loop asks again in a few minutes anyway.

Advisory locks specifically, rather than a lock table, because the lock belongs to the **session**. A replica that is SIGKILLed, evicted, or partitioned mid-job releases its lock the instant Postgres tears the connection down. A lock table would need a lease and a reaper to get the same property, and a reaper is one more moving part that can silently stop, in a feature whose headline risk is silently stopping.

### The hash

```
blake2b(f"{len(job_name)}\x00{job_name}\x00{tenant_id}".encode(),
        digest_size=8, person=b"tally-sched-v1")
```

then `int.from_bytes(digest, "big", signed=True)`.

- **Signed**, because a Postgres `bigint` is signed; reading the digest unsigned would overflow it for half of all inputs.
- **Length-prefixed**, because a plain `job + "\x00" + tenant` hash collides on job `"a"` + tenant `"b\x00c"` versus job `"a\x00b"` + tenant `"c"`, and the resulting bug would be two unrelated jobs mysteriously taking turns. There is a test for exactly that pair.
- **Personalised** with a constant. Changing it changes every key, which during a rolling deploy would let an old and a new replica both run the same job, so it is not a knob.
- Collisions are possible in principle (64 bits; about 3e-12 with ten thousand live pairs) and the consequence is bounded in the safe direction: two unrelated pairs take turns, so one waits a tick. Never a double run.

### The lock space

Postgres has **two advisory-lock spaces and they do not interact**: the single-`bigint` `pg_try_advisory_lock(bigint)` and the two-`int32` `pg_try_advisory_lock(int, int)`. Key `0` in the first is a different lock from `(0, 0)` in the second.

This uses the **single-bigint space, exclusively**. All 64 bits go to the hash; the two-int form would spend 32 of them on a namespace field that buys nothing here. Anything else in this deployment that wants an advisory lock should take it in the two-int32 space or go through `advisory_lock_key()`. `test_live_lock_is_taken_in_the_single_bigint_space` pins it by asserting `pg_locks.objsubid = 1` (the two-int form reports `2`), so a change of spelling cannot pass silently while it stops excluding replicas still running the old one.

## Lock contention versus a cadence skip

**A contended pair records no row at all.** It is counted in `TickResult.lock_contended` and logged, and that is the whole record.

S1 gave `skipped` a precise meaning: the job ran, there was nothing to do for this tenant, and the **cadence window is settled** so the tenant is not re-asked every tick. Contention is not that. The other replica is running the job at this second, and this replica's honest position is "I did not run it, and I do not know how it goes". Settling the window on that would mean a lock collision silently costs a run: a daily job quietly becomes an every-other-day job with nothing in the history to show for it. That is exactly the class of silent-wrongness this codebase keeps guarding against.

A fourth status was the alternative and was rejected: it needs a migration to the 0027 CHECK constraint, and it puts a row that means "no work was attempted" in front of every future freshness surface (phase 5), where it is one `IN (...)` away from being miscounted as an attempt. Nothing was invoked, so there is no invocation to log. `test_contention_leaves_the_job_due_on_the_next_tick` pins the consequence: the pair is still due on the very next tick.

Two related details:

- **The state is re-read once the lock is held.** Between this replica's "is it due" read and its acquire, the replica that held the lock may have finished the very run we were about to repeat and committed its row. The lock alone prevents overlap, not duplication, which for a cost connector is the same double-counted spend by a slower route.
- **The lock is released after `record_run`, not before**, on the success path and the failure path alike (a `finally` around the invocation). Releasing first would open that same window on every single run.

`_acquire` **fails closed**: if the lock cannot be taken for any reason, including Postgres refusing the connection, the job does not run. Not running costs one tick; running without a confirmed lock costs the double count.

## The two-runner proof

Real Postgres, real `pg_try_advisory_lock`, no mocked lock anywhere.

1. **`test_live_two_runners_exactly_one_executes`** (in `tests/test_scheduler_locking.py`): two `Scheduler`s, two `PostgresAdvisoryLockProvider`s, one live database, one due job, one tenant. The job body blocks until the second runner has had its turn at the lock, so the ticks genuinely overlap. Asserts the body ran once, the loser reports `lock_contended == 1` and `skipped_by_job == 0`, and `scheduler_runs` holds exactly one row, `success`.
2. **Negative control.** Removing the lock provider from that test makes it fail with `job body ran more than once across two runners` and two rows. The test bites.
3. **Two OS-level replicas**, run live outside pytest so nothing can be an artefact of one interpreter: two spawned processes ticking the same due job, A holding it for four seconds while B ticks. A ran, B reported contention, one `success` row.
4. **Death mid-job.** `test_live_lock_dies_with_the_connection` takes a lock, confirms a second acquire is refused, then `pg_terminate_backend`s the holder and confirms the lock becomes available with no cleanup, no lease, no reaper. Separately verified with a real `SIGKILL` of a holder process: same result.
5. **One replica is unchanged.** `test_live_single_runner_is_unchanged` plus `test_no_lock_provider_is_s1_behaviour`: due job runs, second tick is `not_due`, `lock_contended == 0`.

The live tests skip cleanly when there is no Postgres (CI), and use `TALLY_TEST_POSTGRES_DSN` or the local compose DSN, a unique job name per test, and delete their rows afterwards.

## Verification

- `cd infra/gateway && uv run --extra dev pytest -q` — **724 passed** (707 before, 17 new). `ruff check .` clean.
- `cd web && npm run typecheck` clean; `npm run test` — 568 passed, the only failures being the 2 long-standing `app/api/api.test.ts` ones that fail with a local ClickHouse running.
- No schema change: 0027 is untouched, because contention deliberately writes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
