### PR TITLE
feat(scheduler): run the cloud cost connectors daily (CTO-215)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -45,6 +45,7 @@ from gateway.account_lookup import (
 from gateway.auth import ApiKeyAuth
 from gateway.backpressure import Backpressure
 from gateway.config import get_settings
+from gateway.cost_connector_job import register_cost_connector_job
 from gateway.errors import ErrorCode
 from gateway.ingest_buffer import AsyncIngestBuffer
 from gateway.mapping import span_to_row
@@ -57,7 +58,7 @@ from gateway.protocol import (
 )
 from gateway.ratelimit import RateLimiter
 from gateway.reconciliation import ReconciliationStore
-from gateway.scheduler import build_scheduler
+from gateway.scheduler import JobRegistry, build_scheduler
 from gateway.store import ClickHouseStore
 from gateway.stripe_ingest import (
     StripeSignatureError,
@@ -314,13 +315,19 @@ async def lifespan(app: FastAPI):
     # Scheduler (CTO-213): periodic per-tenant job execution. A tick loop that asks each registered
     # job "are you due for this tenant" and answers from run history in Postgres, rather than
     # sleeping for a day and losing its place on the next redeploy. Disabled → no task at all
-    # (None), which is byte-identical to the behaviour before this landed. It registers NO jobs
-    # yet: wiring the cost connectors is CTO-215 and the ingest workers CTO-216, so an enabled
-    # scheduler currently ticks over an empty registry. Safe on multiple replicas as of CTO-214:
-    # per (job, tenant) Postgres advisory locks, so two gateways cannot run the same job at once.
+    # (None), which is byte-identical to the behaviour before this landed.
+    # Safe on multiple replicas as of CTO-214: per (job, tenant) Postgres advisory locks, so two
+    # gateways cannot run the same job at once.
+    #
+    # CTO-215 registers the first job body: the daily cloud cost connectors. Until it, a tenant
+    # could connect AWS / GCP / Vercel / Cloudflare on /connectors and nothing ever acted on that
+    # config. Enabling the scheduler now makes the Compute and Egress columns populate on their
+    # own, which CHANGES tenants' numbers (see docs/scheduler-scope.md).
     app.state.scheduler = None
     if settings.scheduler_enabled:
-        scheduler = build_scheduler(settings)
+        registry = JobRegistry()
+        register_cost_connector_job(registry, settings)  # CTO-215
+        scheduler = build_scheduler(settings, registry)
         await scheduler.start()
         app.state.scheduler = scheduler
         logger.info(

--- a/infra/gateway/src/gateway/cost_connector_job.py
+++ b/infra/gateway/src/gateway/cost_connector_job.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The daily cloud cost-connector job (CTO-215, S3): the thing that finally CALLS the connectors.
+
+WHY this exists. ``ComputeCostConnector``, ``EgressCostConnector`` and ``VercelCostConnector`` all
+shipped with a working ``run()`` and ``run_backfill()``, and the only callers were
+``scripts/backfill_*.py``, invoked by a human. CTO-176 then shipped the Connect flow, so a tenant can
+configure AWS, GCP, Vercel or Cloudflare from ``/connectors``, and that config was never acted on: a
+customer connected a cloud account and nothing happened, forever. This module is the job body the
+scheduler (CTO-213) runs once a day per tenant, and it is what makes the Compute and Egress columns
+populate on their own.
+
+It is deliberately NOT a new connector. Everything here is orchestration: read the config rows that
+CTO-176 writes, construct the connectors that already exist, run them for one day, and let them
+record their own outcome.
+
+Run recording has ONE owner per fact
+------------------------------------
+The connectors already stamp ``last_run_at`` / ``last_status`` on their own config row through the
+``RunRecorder`` protocol, and this job passes those same recorders in rather than wrapping them.
+There is no second "did the connector run" store here, because two sources of truth for one fact is
+how a dashboard ends up disagreeing with itself. The division is:
+
+* ``scheduler_runs`` answers "did the SCHEDULE fire for this tenant" (owned by the scheduler).
+* ``tenant_*_config.last_status`` answers "did the CONNECTOR work" (owned by the connector).
+
+An unconfigured tenant raises :class:`gateway.scheduler.JobSkipped` rather than returning success.
+Most tenants have no cloud account connected, and a ``skipped`` row settles the cadence window (so
+they are not re-asked every tick) while staying distinguishable from a real run, so a freshness
+surface can never read "we ran, all good" off a tenant we never had anything to do for.
+
+Which day
+---------
+Yesterday UTC, always (:func:`target_day`). Billing APIs only report a complete day once it has
+closed, so asking for today would fetch a partial number. That partial number would then be FROZEN:
+the emitter is keyed on ``(tenant, provider, operation, day)`` and skips a day that already has a
+span, so nothing would ever correct it. One day of lag is the honest choice, and it is the same
+window the backfill scripts default to.
+
+Multiple egress providers is the normal case
+--------------------------------------------
+``tenant_egress_config`` is keyed on ``(tenant_id, egress_provider)``, so a tenant can have AWS,
+Cloudflare and Vercel egress at the same time. Every configured provider gets its own run with its
+own provider-scoped recorder, because each provider produces a DISTINCT synthetic span id and the
+three only sum correctly on ``/cost`` if all three ran.
+
+Vercel double-count gate
+------------------------
+``tenant_vercel_config.emit_egress`` defaults false and exists so Vercel bandwidth reaches the
+egress layer through exactly one path (CTO-163). ``VercelCostConnector`` reads the flag itself and
+this job passes the loaded row through untouched: nothing here inspects, overrides or works around
+it. ``enabled`` is honoured the same way, as the tenant's own pause switch.
+
+Failure posture
+---------------
+A failure in one connector records ``failed`` on that connector's row, emits NO span (never a
+guessed number), and does not stop the other connectors for the same tenant. Once every unit has had
+its turn, the job raises if any of them failed, so the scheduler records ``failed`` for the tenant
+and its backoff applies. A partially failed tenant is therefore ``failed`` at the schedule level and
+the config rows say precisely which connector broke.
+
+Re-running a day inserts nothing new. The base connector checks ``span_exists`` on the deterministic
+synthetic span id before every insert, which is the backstop if the scheduler ever double-fires.
+Nothing in this module weakens that: it picks the day and calls ``run()``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from datetime import date, datetime, timedelta, timezone
+
+from gateway.config import Settings
+from gateway.connectors.base import BillingClient, RunRecorder
+from gateway.connectors.compute import ComputeCostConnector, build_billing_client
+from gateway.connectors.config_store import (
+    TenantComputeConfigStore,
+    TenantEgressConfigStore,
+    TenantVercelConfigStore,
+)
+from gateway.connectors.egress import EgressCostConnector, build_egress_client
+from gateway.connectors.vercel import (
+    VercelCostConnector,
+    VercelUsageClient,
+    build_vercel_usage_client,
+)
+from gateway.scheduler import Job, JobRegistry, JobSkipped
+from gateway.store import ClickHouseStore
+
+logger = logging.getLogger("tally.gateway.cost_connector_job")
+
+#: Persisted in ``scheduler_runs.job_name``, so it is a stable contract: renaming it orphans the
+#: history and every tenant would look like it had never run, which would trigger an immediate run
+#: for all of them.
+JOB_NAME = "cost_connectors"
+
+#: Daily. The providers themselves publish daily granularity, so a finer cadence would re-ask for a
+#: number that cannot have changed and would spend a tenant's billing-API rate limit doing it.
+DAILY_INTERVAL_S = 86400.0
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def target_day(now: datetime) -> date:
+    """The day to bill for: yesterday UTC. See the module docstring for why not today."""
+    return (now.astimezone(timezone.utc) - timedelta(days=1)).date()
+
+
+class CostConnectorRunError(RuntimeError):
+    """At least one of a tenant's connectors failed. Carries every failure, not just the first.
+
+    Raised only AFTER every configured connector has had its turn, so one broken provider never
+    costs a tenant the providers that were working.
+    """
+
+
+class CostConnectorJob:
+    """Runs every cost connector a tenant has configured, for one day. Callable as a job body.
+
+    Constructed once at startup and called with a tenant id per due tick. It holds no per-tenant
+    state: config is re-read on every call, so connecting or disconnecting a cloud account takes
+    effect on the next tick with no restart.
+
+    Every collaborator is injectable so the tests never touch Postgres, ClickHouse or a cloud
+    billing API. The defaults are the production wiring.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        compute_store: TenantComputeConfigStore | None = None,
+        egress_store: TenantEgressConfigStore | None = None,
+        vercel_store: TenantVercelConfigStore | None = None,
+        store_factory: Callable[[], ClickHouseStore] | None = None,
+        compute_client_factory: Callable[[str], BillingClient] = build_billing_client,
+        egress_client_factory: Callable[[str], BillingClient] = build_egress_client,
+        usage_client_factory: Callable[[], VercelUsageClient] = build_vercel_usage_client,
+        now: Callable[[], datetime] = _utcnow,
+    ) -> None:
+        self._settings = settings
+        self._compute_store = (
+            compute_store if compute_store is not None else TenantComputeConfigStore(settings)
+        )
+        self._egress_store = (
+            egress_store if egress_store is not None else TenantEgressConfigStore(settings)
+        )
+        self._vercel_store = (
+            vercel_store if vercel_store is not None else TenantVercelConfigStore(settings)
+        )
+        # A span sink per invocation rather than one shared with the API. These are daily runs, so a
+        # client per run costs nothing, and a job that owns its client cannot leave the request
+        # path's client in a bad state or be left in one by it.
+        self._store_factory = (
+            store_factory if store_factory is not None else lambda: ClickHouseStore(settings)
+        )
+        self._compute_client_factory = compute_client_factory
+        self._egress_client_factory = egress_client_factory
+        self._usage_client_factory = usage_client_factory
+        self._now = now
+
+    def __call__(self, tenant_id: str) -> None:
+        """Run every configured connector for ``tenant_id``. Raises if any of them failed.
+
+        Blocking by design: the scheduler calls job bodies on a worker thread precisely so they can
+        do blocking Postgres and HTTP work without touching the event loop.
+        """
+        compute_config = self._compute_store.load_config(tenant_id)
+        egress_configs = self._egress_store.load_configs(tenant_id)
+        vercel_config = self._vercel_store.load_config(tenant_id)
+        if vercel_config is not None and not vercel_config.enabled:
+            # The tenant's own pause switch. Paused is "nothing to do", not a failure, and if it is
+            # the tenant's only connector then the whole tenant is a skip.
+            vercel_config = None
+
+        if compute_config is None and not egress_configs and vercel_config is None:
+            # The normal state for most tenants. JobSkipped settles the cadence window without
+            # claiming a run happened. See the module docstring.
+            raise JobSkipped(f"tenant {tenant_id} has no cost connector configured")
+
+        day = target_day(self._now())
+        failures: list[str] = []
+        # The connectors share ONE sink, so the span_exists idempotency guard sees every insert this
+        # run makes, including the Vercel egress span whose id is identical to the CTO-144 one.
+        store = self._store_factory()
+        try:
+            if compute_config is not None:
+                provider = compute_config.cloud_provider
+                self._attempt(
+                    failures,
+                    label=f"compute/{provider}",
+                    tenant_id=tenant_id,
+                    connector_id="compute",
+                    recorder=self._compute_store,
+                    run=lambda cfg=compute_config: [
+                        ComputeCostConnector(
+                            store=store,
+                            recorder=self._compute_store,
+                            billing_client=self._compute_client_factory(cfg.cloud_provider),
+                        )
+                        .run(cfg, day=day)
+                        .status
+                    ],
+                )
+
+            for egress_config in egress_configs:
+                # `cfg` is bound per iteration on purpose: the lambda outlives the iteration that
+                # built it, and a late-bound loop variable would run the last provider N times.
+                self._attempt(
+                    failures,
+                    label=f"egress/{egress_config.cloud_provider}",
+                    tenant_id=tenant_id,
+                    connector_id="egress",
+                    recorder=self._egress_store.recorder_for(egress_config.cloud_provider),
+                    run=lambda cfg=egress_config: [
+                        EgressCostConnector(
+                            store=store,
+                            recorder=self._egress_store.recorder_for(cfg.cloud_provider),
+                            billing_client=self._egress_client_factory(cfg.cloud_provider),
+                        )
+                        .run(cfg, day=day)
+                        .status
+                    ],
+                )
+
+            if vercel_config is not None:
+                self._attempt(
+                    failures,
+                    label="vercel",
+                    tenant_id=tenant_id,
+                    connector_id="compute",
+                    recorder=self._vercel_store,
+                    # emit_egress rides on the config row and VercelCostConnector reads it itself:
+                    # the CTO-163 double-count gate is not this job's to interpret.
+                    run=lambda cfg=vercel_config: _vercel_statuses(
+                        VercelCostConnector(
+                            store=store,
+                            usage_client=self._usage_client_factory(),
+                            recorder=self._vercel_store,
+                        ).run(cfg, day=day)
+                    ),
+                )
+        finally:
+            # Closed on every path, including the raise below. A job that leaked a ClickHouse client
+            # a day would take a long time to notice and would look like a ClickHouse problem.
+            store.close()
+
+        if failures:
+            raise CostConnectorRunError(
+                f"cost connectors failed for tenant {tenant_id} on {day.isoformat()}: "
+                + "; ".join(failures)
+            )
+
+    def _attempt(
+        self,
+        failures: list[str],
+        *,
+        label: str,
+        tenant_id: str,
+        connector_id: str,
+        recorder: RunRecorder,
+        run: Callable[[], Sequence[str]],
+    ) -> None:
+        """Run one connector, collect its failure, and never let it end the tenant's other runs.
+
+        The connector's own ``_run_range`` already records ``failed`` for a failed FETCH and returns
+        a status rather than raising. This wrapper covers everything outside that: an unsupported
+        provider, a client that cannot be constructed, a ClickHouse insert that fails. Those record
+        ``failed`` here so the config row still tells the tenant their connector is broken, which is
+        what that column is for.
+        """
+        try:
+            statuses = run()
+        except Exception as exc:  # noqa: BLE001 - one broken connector must not cost the others
+            logger.warning(
+                "cost connector job: tenant=%s connector=%s raised: %s: %s",
+                tenant_id,
+                label,
+                type(exc).__name__,
+                exc,
+            )
+            self._record_failed(recorder, tenant_id, connector_id, exc)
+            failures.append(f"{label}: {type(exc).__name__}: {exc}")
+            return
+        for status in statuses:
+            if status != "success":
+                # Already recorded on the config row by the connector, with no span emitted.
+                failures.append(f"{label}: {status}")
+
+    @staticmethod
+    def _record_failed(
+        recorder: RunRecorder, tenant_id: str, connector_id: str, exc: Exception
+    ) -> None:
+        try:
+            recorder.record_run(
+                tenant_id, connector_id, "failed", error_message=f"{type(exc).__name__}: {exc}"
+            )
+        except Exception:  # noqa: BLE001 - the raise that brought us here is the real news
+            logger.warning("cost connector job: tenant=%s could not record failed status", tenant_id)
+
+
+def _vercel_statuses(result: object) -> list[str]:
+    """Both halves of a Vercel run: compute always, egress only when the gate let it run."""
+    compute = getattr(result, "compute", None)
+    egress = getattr(result, "egress", None)
+    statuses = [] if compute is None else [compute.status]
+    if egress is not None:
+        statuses.append(egress.status)
+    return statuses
+
+
+def register_cost_connector_job(
+    registry: JobRegistry,
+    settings: Settings,
+    *,
+    interval_s: float = DAILY_INTERVAL_S,
+    job: CostConnectorJob | None = None,
+) -> Job:
+    """Register the daily cost-connector job on ``registry`` (called from the gateway lifespan).
+
+    Kept here rather than inside ``build_scheduler`` so the scheduler core stays a job-free engine
+    and each job's wiring lives next to the job.
+    """
+    return registry.register(
+        JOB_NAME,
+        interval_s,
+        job if job is not None else CostConnectorJob(settings),
+    )
+
+
+__all__ = [
+    "DAILY_INTERVAL_S",
+    "JOB_NAME",
+    "CostConnectorJob",
+    "CostConnectorRunError",
+    "register_cost_connector_job",
+    "target_day",
+]

--- a/infra/gateway/tests/test_cost_connector_job.py
+++ b/infra/gateway/tests/test_cost_connector_job.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The daily cost-connector job: skip, run, fail, and stay idempotent (CTO-215).
+
+No Postgres, no ClickHouse, no cloud billing API: the three config stores are in-memory fakes with
+the same method shapes the real ones expose, the span sink is a dict keyed on the deterministic
+synthetic span id (which is exactly what ``span_exists`` checks in production), and the billing
+clients are injected.
+
+What these tests are actually asserting is the acceptance list on the ticket:
+
+* a configured tenant gets a run with nobody touching a script,
+* an unconfigured tenant is ``JobSkipped`` and not an error,
+* a failed fetch records ``failed`` and emits NO span, never a guessed number,
+* re-running a day inserts nothing new,
+* every configured egress provider runs, because a tenant with AWS plus Cloudflare plus Vercel is
+  the normal case and their totals only sum if all of them ran,
+* the ``emit_egress`` gate is respected rather than routed around.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from gateway.connectors.base import ConnectorConfig, DailyCost, synthetic_span_id
+from gateway.connectors.egress import EgressConfig
+from gateway.connectors.vercel import VercelConfig, VercelUsageClient
+from gateway.cost_connector_job import (
+    JOB_NAME,
+    CostConnectorJob,
+    CostConnectorRunError,
+    register_cost_connector_job,
+    target_day,
+)
+from gateway.scheduler import JobRegistry, JobSkipped
+
+NOW = datetime(2026, 8, 25, 4, 30, 0, tzinfo=timezone.utc)
+DAY = date(2026, 8, 24)  # yesterday, the day the job bills for
+TENANT = "11111111-1111-1111-1111-111111111111"
+
+
+class FakeSpanSink:
+    """The slice of ``ClickHouseStore`` the emitter uses, over a set of span ids."""
+
+    def __init__(self) -> None:
+        self.spans: list[tuple[object, ...]] = []
+        self.ids: set[tuple[str, str]] = set()
+        self.closed = 0
+        self.insert_error: Exception | None = None
+
+    def span_exists(self, tenant_id: str, span_id: str) -> bool:
+        return (tenant_id, span_id) in self.ids
+
+    def insert_spans(self, rows: list[tuple[object, ...]]) -> int:
+        if self.insert_error is not None:
+            raise self.insert_error
+        for row in rows:
+            self.spans.append(row)
+        return len(rows)
+
+    def close(self) -> None:
+        self.closed += 1
+
+    def remember(self, tenant_id: str, span_id: str) -> None:
+        self.ids.add((tenant_id, span_id))
+
+
+class FakeComputeStore:
+    def __init__(self, config: ConnectorConfig | None = None) -> None:
+        self.config = config
+        self.runs: list[tuple[str, str, str]] = []
+
+    def load_config(self, tenant_id: str) -> ConnectorConfig | None:
+        return self.config
+
+    def record_run(
+        self, tenant_id: str, connector_id: str, status: str, *, error_message: str | None = None
+    ) -> None:
+        self.runs.append((tenant_id, connector_id, status))
+
+
+class FakeEgressStore:
+    def __init__(self, configs: list[EgressConfig] | None = None) -> None:
+        self.configs = configs or []
+        self.runs: list[tuple[str, str, str]] = []
+
+    def load_configs(self, tenant_id: str) -> list[EgressConfig]:
+        return list(self.configs)
+
+    def recorder_for(self, provider: str) -> "FakeEgressStore._Recorder":
+        return FakeEgressStore._Recorder(self, provider)
+
+    class _Recorder:
+        def __init__(self, store: "FakeEgressStore", provider: str) -> None:
+            self._store = store
+            self._provider = provider
+
+        def record_run(
+            self,
+            tenant_id: str,
+            connector_id: str,
+            status: str,
+            *,
+            error_message: str | None = None,
+        ) -> None:
+            self._store.runs.append((tenant_id, self._provider, status))
+
+
+class FakeVercelStore:
+    def __init__(self, config: VercelConfig | None = None) -> None:
+        self.config = config
+        self.runs: list[tuple[str, str, str]] = []
+
+    def load_config(self, tenant_id: str) -> VercelConfig | None:
+        return self.config
+
+    def record_run(
+        self, tenant_id: str, connector_id: str, status: str, *, error_message: str | None = None
+    ) -> None:
+        self.runs.append((tenant_id, connector_id, status))
+
+
+class FakeBillingClient:
+    """Returns a fixed daily total, or raises to model an upstream that is down."""
+
+    def __init__(self, micro: int = 1_000_000, error: Exception | None = None) -> None:
+        self.micro = micro
+        self.error = error
+        self.calls = 0
+
+    def get_daily_costs(self, config, *, start_day: date, end_day: date) -> list[DailyCost]:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return [DailyCost(day=start_day, cost_micro_usd=self.micro)]
+
+
+def compute_config(provider: str = "aws") -> ConnectorConfig:
+    return ConnectorConfig(
+        tenant_id=TENANT, cloud_provider=provider, credentials_ref="aws-default-chain"
+    )
+
+
+def egress_config(provider: str) -> EgressConfig:
+    return EgressConfig(
+        tenant_id=TENANT,
+        cloud_provider=provider,
+        credentials_ref=f"{provider}-ref",
+        resource_id="zone-1",
+        usd_per_gb=Decimal("0.09"),
+    )
+
+
+def build_job(
+    *,
+    sink: FakeSpanSink,
+    compute_store: FakeComputeStore | None = None,
+    egress_store: FakeEgressStore | None = None,
+    vercel_store: FakeVercelStore | None = None,
+    compute_client: FakeBillingClient | None = None,
+    egress_clients: dict[str, FakeBillingClient] | None = None,
+    vercel_payload: dict | None = None,
+) -> CostConnectorJob:
+    egress_clients = egress_clients or {}
+    usage_client = VercelUsageClient(
+        http_getter=lambda config, start, end: vercel_payload or {"items": []}
+    )
+    return CostConnectorJob(
+        None,  # settings unused: every collaborator below is injected
+        compute_store=compute_store or FakeComputeStore(),
+        egress_store=egress_store or FakeEgressStore(),
+        vercel_store=vercel_store or FakeVercelStore(),
+        store_factory=lambda: sink,
+        compute_client_factory=lambda provider: compute_client or FakeBillingClient(),
+        egress_client_factory=lambda provider: egress_clients[provider],
+        usage_client_factory=lambda: usage_client,
+        now=lambda: NOW,
+    )
+
+
+def test_target_day_is_yesterday_utc():
+    # Today is incomplete at every billing provider, and the emitter would freeze the partial
+    # number in place because the day already has a span.
+    assert target_day(NOW) == DAY
+
+
+def test_unconfigured_tenant_raises_job_skipped():
+    sink = FakeSpanSink()
+    job = build_job(sink=sink)
+    with pytest.raises(JobSkipped):
+        job(TENANT)
+    assert sink.spans == []
+
+
+def test_paused_vercel_only_tenant_is_a_skip_not_a_run():
+    # `enabled=False` is the tenant's own pause switch, so there is nothing to do rather than
+    # something that failed.
+    vercel = FakeVercelStore(
+        VercelConfig(
+            tenant_id=TENANT,
+            cloud_provider="vercel",
+            credentials_ref="ref",
+            enabled=False,
+        )
+    )
+    sink = FakeSpanSink()
+    with pytest.raises(JobSkipped):
+        build_job(sink=sink, vercel_store=vercel)(TENANT)
+    assert vercel.runs == []
+
+
+def test_configured_compute_tenant_runs_and_emits_one_span():
+    sink = FakeSpanSink()
+    compute = FakeComputeStore(compute_config("aws"))
+    client = FakeBillingClient(micro=2_500_000)
+    build_job(sink=sink, compute_store=compute, compute_client=client)(TENANT)
+    assert client.calls == 1
+    assert len(sink.spans) == 1
+    # The connector owns its own run recording; the job does not shadow it.
+    assert compute.runs == [(TENANT, "compute", "success")]
+    assert sink.closed == 1
+
+
+def test_every_configured_egress_provider_runs():
+    # A tenant with AWS, Cloudflare and Vercel egress at once is normal: the composite PK allows it
+    # and the three totals only sum on /cost if all three ran.
+    sink = FakeSpanSink()
+    egress = FakeEgressStore([egress_config(p) for p in ("aws", "cloudflare", "vercel")])
+    clients = {p: FakeBillingClient() for p in ("aws", "cloudflare", "vercel")}
+    build_job(sink=sink, egress_store=egress, egress_clients=clients)(TENANT)
+    assert all(c.calls == 1 for c in clients.values())
+    assert len(sink.spans) == 3
+    assert sorted(egress.runs) == [
+        (TENANT, "aws", "success"),
+        (TENANT, "cloudflare", "success"),
+        (TENANT, "vercel", "success"),
+    ]
+
+
+def test_one_failing_provider_does_not_stop_the_others():
+    sink = FakeSpanSink()
+    egress = FakeEgressStore([egress_config("aws"), egress_config("cloudflare")])
+    clients = {
+        "aws": FakeBillingClient(error=RuntimeError("cost explorer 500")),
+        "cloudflare": FakeBillingClient(),
+    }
+    with pytest.raises(CostConnectorRunError) as excinfo:
+        build_job(sink=sink, egress_store=egress, egress_clients=clients)(TENANT)
+    assert "egress/aws" in str(excinfo.value)
+    # The healthy provider still landed its span, and only the broken one is 'failed'.
+    assert len(sink.spans) == 1
+    assert sorted(egress.runs) == [(TENANT, "aws", "failed"), (TENANT, "cloudflare", "success")]
+
+
+def test_failed_fetch_records_failed_and_emits_no_span():
+    sink = FakeSpanSink()
+    compute = FakeComputeStore(compute_config("aws"))
+    client = FakeBillingClient(error=RuntimeError("boom"))
+    with pytest.raises(CostConnectorRunError):
+        build_job(sink=sink, compute_store=compute, compute_client=client)(TENANT)
+    assert sink.spans == []  # never a guessed number
+    assert compute.runs == [(TENANT, "compute", "failed")]
+
+
+def test_failure_outside_the_fetch_still_lands_on_the_config_row():
+    # An unsupported provider (or any client that cannot be built) never reaches the connector's own
+    # error handling, so the job records it. Otherwise the tenant's row would claim the last run
+    # succeeded while nothing ran at all.
+    sink = FakeSpanSink()
+    compute = FakeComputeStore(compute_config("azure"))
+    job = CostConnectorJob(
+        None,
+        compute_store=compute,
+        egress_store=FakeEgressStore(),
+        vercel_store=FakeVercelStore(),
+        store_factory=lambda: sink,
+        compute_client_factory=lambda provider: (_ for _ in ()).throw(
+            ValueError(f"unsupported cloud_provider {provider!r}")
+        ),
+        now=lambda: NOW,
+    )
+    with pytest.raises(CostConnectorRunError):
+        job(TENANT)
+    assert compute.runs == [(TENANT, "compute", "failed")]
+    assert sink.spans == []
+    assert sink.closed == 1  # the sink is closed even on the failure path
+
+
+def test_rerunning_a_day_inserts_nothing_new():
+    sink = FakeSpanSink()
+    compute = FakeComputeStore(compute_config("aws"))
+    client = FakeBillingClient()
+    job = build_job(sink=sink, compute_store=compute, compute_client=client)
+    job(TENANT)
+    assert len(sink.spans) == 1
+    # Model what production sees on a second fire: the day's deterministic span id is now present.
+    _, span_id = synthetic_span_id(TENANT, "aws", "compute", DAY)
+    sink.remember(TENANT, span_id)
+    job(TENANT)
+    assert len(sink.spans) == 1  # the idempotency guard held
+
+
+def test_vercel_egress_gate_is_respected():
+    payload = {
+        "items": [
+            {"date": DAY.isoformat(), "type": "function_duration", "amount": "3.00"},
+            {"date": DAY.isoformat(), "type": "bandwidth", "amount": "1.00"},
+        ]
+    }
+    # Gate off (the default): compute only, so Vercel egress stays owned by the CTO-144 path.
+    sink = FakeSpanSink()
+    vercel = FakeVercelStore(
+        VercelConfig(tenant_id=TENANT, cloud_provider="vercel", credentials_ref="ref")
+    )
+    build_job(sink=sink, vercel_store=vercel, vercel_payload=payload)(TENANT)
+    assert len(sink.spans) == 1
+
+    # Gate on: compute plus egress, two spans, still one row per (provider, operation, day).
+    sink_on = FakeSpanSink()
+    vercel_on = FakeVercelStore(
+        VercelConfig(
+            tenant_id=TENANT,
+            cloud_provider="vercel",
+            credentials_ref="ref",
+            emit_egress=True,
+        )
+    )
+    build_job(sink=sink_on, vercel_store=vercel_on, vercel_payload=payload)(TENANT)
+    assert len(sink_on.spans) == 2
+
+
+def test_all_three_layers_run_for_one_tenant():
+    sink = FakeSpanSink()
+    compute = FakeComputeStore(compute_config("gcp"))
+    egress = FakeEgressStore([egress_config("cloudflare")])
+    vercel = FakeVercelStore(
+        VercelConfig(tenant_id=TENANT, cloud_provider="vercel", credentials_ref="ref")
+    )
+    build_job(
+        sink=sink,
+        compute_store=compute,
+        egress_store=egress,
+        vercel_store=vercel,
+        egress_clients={"cloudflare": FakeBillingClient()},
+        vercel_payload={
+            "items": [{"date": DAY.isoformat(), "type": "compute", "amount": "2.00"}]
+        },
+    )(TENANT)
+    assert len(sink.spans) == 3
+    assert compute.runs == [(TENANT, "compute", "success")]
+    assert egress.runs == [(TENANT, "cloudflare", "success")]
+    assert vercel.runs == [(TENANT, "compute", "success")]
+
+
+def test_registration_uses_the_stable_job_name_and_a_daily_cadence():
+    registry = JobRegistry()
+    job = register_cost_connector_job(registry, None, job=build_job(sink=FakeSpanSink()))
+    assert job.name == JOB_NAME
+    assert job.interval_s == 86400.0
+    assert len(registry) == 1


### PR DESCRIPTION
## What

CTO-215 (S3): the daily job that finally calls the cloud cost connectors.

`ComputeCostConnector`, `EgressCostConnector` and `VercelCostConnector` all shipped with working `run()` and `run_backfill()`, and the only callers were `scripts/backfill_*.py`, invoked by a human. CTO-176 then shipped the Connect flow, so a tenant could configure AWS, GCP, Vercel or Cloudflare from `/connectors`, and that config was never acted on. A customer connected a cloud account and nothing happened. This PR is what makes the Compute and Egress columns populate on their own.

New `gateway/cost_connector_job.py` plus one additive registration in the lifespan (`JobRegistry` -> `register_cost_connector_job` -> `build_scheduler`). No connector logic changed.

Design points, all argued in the module docstring:

- **Run recording keeps one owner per fact.** `scheduler_runs` answers "did the schedule fire"; `tenant_*_config.last_status` answers "did the connector work", and the connectors already write it through the `RunRecorder` they were built with. The job passes those recorders straight through and adds no second store.
- **Unconfigured tenants raise `JobSkipped`**, not success. That settles the cadence window so they are not re-asked every tick, while staying distinguishable from a real run.
- **Yesterday UTC, always.** Billing APIs only report a complete day once it has closed, and the emitter is keyed on the day, so a partial number fetched today would be frozen in place with nothing to correct it.
- **Every configured egress provider runs.** `tenant_egress_config` is keyed on `(tenant_id, egress_provider)`, each provider produces a distinct synthetic span id, and the totals only sum correctly on `/cost` if all of them ran.
- **`emit_egress` is passed through untouched.** `VercelCostConnector` reads the CTO-163 gate itself; nothing here inspects or routes around it.
- **Failure isolation within a tenant.** One broken connector records `failed` on its own row, emits no span, and does not stop the tenant's others. The job then raises so the schedule records `failed` too and the scheduler's backoff applies.
- **Idempotency unchanged.** The base connector still checks `span_exists` on the deterministic `(tenant, provider, operation, day)` id before every insert. This PR picks a day and calls `run()`; it does not touch that guard.

## Release note (this changes customers' numbers)

**Cloud cost connectors now run on their own.** Until this release, connecting AWS, GCP, Vercel or Cloudflare on the Connectors page stored the configuration but never fetched anything: the connectors only ran when someone ran a backfill script by hand. With the scheduler enabled, every tenant with a configured connector now gets a daily run, and their Compute and Egress cost layers start filling in from the day after they connected.

**Expect totals to jump.** Compute and egress are roughly 46 percent of spend on the demo tenant. A tenant who connected AWS weeks ago and has been looking at an empty Compute column will see their reported bill nearly double overnight. That increase is correct: it is spend that was always happening and was never being counted. It is not a pricing change, a double count, or a bug. Anyone who has been quoting the old AI-only figure internally should be told before they see it.

Two things that do not change: historical days are not rewritten (use `scripts/backfill_compute.py` / `backfill_egress.py` for catch-up), and a connector whose fetch fails records `failed` on the Connectors page and emits nothing at all. A missing number stays missing rather than being guessed.

## End-to-end proof (live, against the docker-compose stack)

Gateway rebuilt with `docker compose -f infra/docker-compose.yml up -d --build gateway`. A second gateway container was then run on the same network with `TALLY_SCHEDULER_ENABLED=true` and a 10s tick, and a Cloudflare egress connector was configured for the demo tenant through the dashboard API (`POST /v1/tenant/cost-connectors`). A second, deliberately unconfigured tenant was added to check the skip path.

**1. It runs with nobody touching a script.** Within one tick, `scheduler_runs` had:

```
    job_name     |  tenant  | status  | error_message
-----------------+----------+---------+---------------------------------------------------------------
 cost_connectors | 38a6c264 | failed  | CostConnectorRunError: ... compute/aws: failed;
                 |          |         | egress/cloudflare: failed; egress/vercel: failed; vercel: failed
 cost_connectors | e0709677 | skipped |
```

The unconfigured tenant is `skipped`, not an error. The configured tenant attempted all four of its connectors and each failed, which is correct here: this machine has no cloud credentials and no route to those APIs.

**2. A failing fetch records `failed` and emits NO span.** All four config rows moved to `last_status = failed`, and ClickHouse held zero `cloud-billing` spans:

```
 compute | aws        | failed  | 2026-08-26 14:55:08+00
 egress  | cloudflare | failed  | 2026-08-26 14:55:08+00
 egress  | vercel     | failed  | 2026-08-26 14:55:08+00
 vercel  | vercel     | failed  | 2026-08-26 14:55:08+00

SELECT count() FROM otel_spans WHERE ServiceName='cloud-billing'  ->  0
```

**3. Spans land and `last_status` updates.** The success path needs a billing response, which cannot be obtained without a real customer's credentials, so a tick was driven inside the gateway container with the cloud billing HTTP calls (and only those) stubbed. Everything else was the real thing: the real `Scheduler`, `SchedulerRunStore` over Postgres, the advisory lock provider, the Postgres tenant provider, the three config stores, and `ClickHouseStore`.

```
TickResult(considered=2, ran=2, succeeded=1, skipped_by_job=1, failed=0, not_due=0, lock_contended=0)

   ┌──────────d─┬─GenAiSystem─┬─GenAiOperation─┬─EstimatedCost─┬─CostSource─┬─SpanId───────────┐
   │ 2026-08-25 │ aws         │ compute        │           4.2 │ estimated  │ 1061accf313dcca7 │
   │ 2026-08-25 │ cloudflare  │ egress         │           1.1 │ estimated  │ e57972f86d4b6201 │
   │ 2026-08-25 │ vercel      │ compute        │           2.5 │ estimated  │ 59f8131fd8a5826e │
   │ 2026-08-25 │ vercel      │ egress         │           1.1 │ estimated  │ aa59e25d525d899a │
   └────────────┴─────────────┴────────────────┴───────────────┴────────────┴──────────────────┘

 compute | aws        | success | egress | cloudflare | success
 egress  | vercel     | success | vercel | vercel     | success
```

Note the day: `2026-08-25`, yesterday, while the run happened on the 26th. Note also that there is exactly ONE `vercel` egress span: the tenant has both a `tenant_vercel_config` row (with `emit_egress` at its default false) and a `tenant_egress_config` row for Vercel, and the gate kept the bandwidth on the single CTO-144 path.

**4. Re-running a day inserts nothing new.** The `scheduler_runs` rows were deleted to force the pair due again, and the same tick re-ran:

```
TickResult(considered=2, ran=2, succeeded=1, skipped_by_job=1, ...)
SELECT count(), uniqExact(SpanId) FROM otel_spans WHERE ServiceName='cloud-billing'  ->  4   4
```

Same four spans. The `span_exists` guard held.

The test tenant, the connector row added for the run, the synthetic spans and the `scheduler_runs` rows were all cleaned out of the local stack afterwards, and `last_status` was reset to null so nothing implies a real run happened.

## Verification

- `cd infra/gateway && uv run --extra dev pytest -q` -> **736 passed** (724 before, 12 new in `tests/test_cost_connector_job.py`).
- `uv run ruff check .` -> clean.
- `cd web && npm run typecheck` -> clean; `npm run test` -> 568 passed, the only failures being the 2 long-standing `app/api/api.test.ts` ones.
- `docker compose -f infra/docker-compose.yml up -d --build gateway` -> builds and comes up healthy.

## Note for CTO-216

The lifespan change is deliberately three lines at the registration point (build a `JobRegistry`, register this job, pass it to `build_scheduler`), so adding the reconciler and the ingest workers there should be a one-line addition and any conflict mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
