### PR TITLE
feat(scheduler): run the ingest workers and the reconciler on a cadence (CTO-216)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -71,6 +71,10 @@ services:
       - ../db/postgres/0011_tenant_compute_config.sql:/docker-entrypoint-initdb.d/0011_tenant_compute_config.sql:ro
       - ../db/postgres/0012_tenant_egress_config.sql:/docker-entrypoint-initdb.d/0012_tenant_egress_config.sql:ro
       - ../db/postgres/0013_cac_revenue_fields.sql:/docker-entrypoint-initdb.d/0013_cac_revenue_fields.sql:ro
+      # Credentials-by-reference for the Segment / HubSpot / Pendo workers (CTO-127). Mounted as of
+      # CTO-216, which is what first made the gateway read this table on its own: before the
+      # scheduler ran the ingest workers, nothing in a local stack ever touched it.
+      - ../db/postgres/0018_tenant_integration_secrets.sql:/docker-entrypoint-initdb.d/0018_tenant_integration_secrets.sql:ro
       - ../db/postgres/0019_tenant_unit_economics_config.sql:/docker-entrypoint-initdb.d/0019_tenant_unit_economics_config.sql:ro
       - ../db/postgres/0014_tenant_feature_value_events.sql:/docker-entrypoint-initdb.d/0014_tenant_feature_value_events.sql:ro
       - ../db/postgres/0015_tenant_compute_config_gcp.sql:/docker-entrypoint-initdb.d/0015_tenant_compute_config_gcp.sql:ro

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -57,7 +57,7 @@ from gateway.protocol import (
 )
 from gateway.ratelimit import RateLimiter
 from gateway.reconciliation import ReconciliationStore
-from gateway.scheduler import build_scheduler
+from gateway.scheduler import JobRegistry, build_scheduler
 from gateway.store import ClickHouseStore
 from gateway.stripe_ingest import (
     StripeSignatureError,
@@ -160,6 +160,7 @@ from gateway.tenant_unit_economics import (
     UnitEconomicsConfigInput,
 )
 from gateway.validation import SpanValidator, span_item_id
+from gateway.worker_jobs import register_worker_jobs
 
 from tally.cdp_connectors import RevenuePayloadError, WebhookIngestor
 from tally.hmac_keys import HmacKeyRegistry
@@ -314,13 +315,28 @@ async def lifespan(app: FastAPI):
     # Scheduler (CTO-213): periodic per-tenant job execution. A tick loop that asks each registered
     # job "are you due for this tenant" and answers from run history in Postgres, rather than
     # sleeping for a day and losing its place on the next redeploy. Disabled → no task at all
-    # (None), which is byte-identical to the behaviour before this landed. It registers NO jobs
-    # yet: wiring the cost connectors is CTO-215 and the ingest workers CTO-216, so an enabled
-    # scheduler currently ticks over an empty registry. Safe on multiple replicas as of CTO-214:
+    # (None), which is byte-identical to the behaviour before this landed. The registered jobs are
+    # built by register_worker_jobs (CTO-216); the cloud cost connectors are CTO-215.
+    # Safe on multiple replicas as of CTO-214:
     # per (job, tenant) Postgres advisory locks, so two gateways cannot run the same job at once.
     app.state.scheduler = None
     if settings.scheduler_enabled:
-        scheduler = build_scheduler(settings)
+        job_registry = JobRegistry()
+        # CTO-216: the third-party ingest workers (Segment / HubSpot / Pendo) and the reconciler.
+        # Both were written, tested and called by nobody; this is what switches them on. It does
+        # NOT fix /features, which stays blocked on the stitcher runner (CTO-200).
+        register_worker_jobs(
+            job_registry,
+            settings,
+            store=app.state.store,
+            # Shared with the request path on purpose: a second HMAC registry would write into a
+            # different UserIdHash space, and a second linker would learn nothing. See worker_jobs.
+            hmac_registry=app.state.hmac_registry,
+            account_linker=app.state.account_linker,
+            integrations=app.state.tenant_integrations,
+            reconciliation_store=app.state.reconciliation,
+        )
+        scheduler = build_scheduler(settings, job_registry)
         await scheduler.start()
         app.state.scheduler = scheduler
         logger.info(

--- a/infra/gateway/src/gateway/integration_workers.py
+++ b/infra/gateway/src/gateway/integration_workers.py
@@ -20,12 +20,16 @@ and every error string routed to storage goes through :func:`scrub_error_message
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, ClassVar, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import Request, urlopen
 
 from tally.account_identity import AccountLinker
 from tally.hmac_keys import HmacKeyRegistry
@@ -57,6 +61,48 @@ class HttpClient(Protocol):
         headers: Mapping[str, str] | None = None,
         params: Mapping[str, str] | None = None,
     ) -> Any: ...
+
+
+class UrllibHttpClient:
+    """The production :class:`HttpClient`. stdlib ``urllib`` only, so the base install stays slim.
+
+    WHY this exists (CTO-216). The Protocol above has always had exactly one implementation, the
+    test fake, because nothing ever ran a cycle outside a test. Scheduling the workers is what makes
+    a real transport necessary, and the docstring on :class:`HttpClient` already named
+    ``urllib / httpx`` as the intended shape. ``urllib`` wins because ``requests`` is not a declared
+    dependency of this package (the Vercel and egress connectors lazy-import it), and one GET every
+    few minutes does not justify adding one.
+
+    Raises on any non-2xx, which is the contract :meth:`IngestWorker.run_cycle` relies on to record
+    an honest ``failed`` run. The status line, not the body, goes into the exception: a third-party
+    error body is exactly where a customer email turns up, and while ``scrub_error_message`` would
+    catch it on the way to storage, not putting it in the string is the cheaper guarantee.
+    """
+
+    def __init__(self, *, timeout_s: float = 30.0) -> None:
+        self._timeout_s = float(timeout_s)
+
+    def get_json(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, str] | None = None,
+    ) -> Any:
+        target = url
+        if params:
+            target = f"{url}{'&' if urlsplit(url).query else '?'}{urlencode(dict(params))}"
+        request = Request(target, headers=dict(headers or {}), method="GET")  # noqa: S310
+        try:
+            with urlopen(request, timeout=self._timeout_s) as response:  # noqa: S310
+                payload = response.read()
+        except HTTPError as exc:  # non-2xx: surface the code, never the body
+            raise RuntimeError(f"HTTP {exc.code} from {urlsplit(url).netloc}") from None
+        except URLError as exc:
+            raise RuntimeError(f"could not reach {urlsplit(url).netloc}: {exc.reason}") from None
+        if not payload:
+            return None
+        return json.loads(payload.decode("utf-8"))
 
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/src/gateway/reconciliation.py
+++ b/infra/gateway/src/gateway/reconciliation.py
@@ -13,8 +13,14 @@ pipeline:
   :mod:`gateway.tenant_integrations` — ``record_run`` stamps the outcome of one pass, ``get_latest``
   reads the most recent for the dashboard.
 * :func:`run_reconciliation` is a thin orchestrator: it queries ClickHouse for recent events + their
-  matched span timestamps, calls the pure compute, and records the run. Per-tenant scheduling / a
-  running daemon is out of scope (CTO-139) — a callable orchestrator is enough.
+  matched span timestamps, calls the pure compute, and records the run.
+* :class:`ClickHouseLateArrivalSource` is that CH scan (CTO-216). CTO-139 shipped the orchestrator
+  with no real source because nothing ran the reconciler; the scheduled job needs one to record
+  anything other than zeros. It is last-touch pairing at read time, NOT attribution: it writes
+  nothing to ``attribution_records`` and credits no feature with any value.
+
+Per-tenant scheduling is CTO-216: the scheduler registers ``reconciliation`` as a job and calls
+:func:`run_reconciliation` per tenant on a cadence.
 
 Why a separate table from ``tenant_integration_runs`` — that's a *third-party integration* run log
 ("Stripe last fired 12s ago"). This is the *reconciler* run log ("we re-checked attribution and 180
@@ -194,6 +200,15 @@ class ReconciliationStore:
             )
 
 
+# How far back one reconciliation pass looks, and the ceiling on how many events it examines.
+# Both exist to bound the scan: this runs on a cadence now (CTO-216) rather than by hand, so an
+# unbounded "every event this tenant ever sent" query would get slower every day until it was the
+# most expensive thing the gateway does. Seven days is wider than the one-hour lateness threshold by
+# a large margin, so nothing a pass could sensibly call "late" falls outside it.
+DEFAULT_LOOKBACK_DAYS = 7
+DEFAULT_EVENT_CAP = 50_000
+
+
 class _ClickHouseEventSource(Protocol):
     """Minimal surface the orchestrator needs from a ClickHouse client.
 
@@ -205,6 +220,88 @@ class _ClickHouseEventSource(Protocol):
     def fetch_event_span_pairs(
         self, tenant_id: str
     ) -> Sequence[tuple[datetime, datetime]]: ...
+
+
+class ClickHouseLateArrivalSource:
+    """The real :class:`_ClickHouseEventSource`: pairs each value event with the span it followed.
+
+    WHY this exists (CTO-216). CTO-139 shipped the pure compute, the run log and the orchestrator,
+    and left the CH scan to whoever first ran the reconciler on a schedule. That is this ticket, so
+    the scan has to exist for the job to record anything but zeros.
+
+    WHAT "the span it matched" means here, precisely, because the honest answer is narrow: the most
+    recent span for the SAME hashed user at or before the event. That is last-touch, evaluated at
+    read time, and it is deliberately NOT attribution. Nothing is written to ``attribution_records``
+    and no feature is credited with any value. Real attribution needs the stitcher runner (CTO-200),
+    which does not exist; this query answers only the much smaller question the /features
+    diagnostics card actually asks, which is "how long after the work did the value show up".
+
+    The ``ASOF INNER JOIN`` is what expresses "at or before": ClickHouse resolves it to the nearest
+    preceding row per key. INNER, so an event with no preceding span for that user contributes
+    nothing rather than a fabricated lag of zero — an event we cannot pair is not an event that
+    arrived on time.
+    """
+
+    _SQL = """
+        SELECT e.OccurredAt, s.Timestamp
+        FROM (
+            SELECT UserIdHash, OccurredAt
+            FROM business_events
+            WHERE TenantId = {tenant:String}
+              AND UserIdHash != ''
+              AND OccurredAt >= subtractDays(now64(9), {days:UInt32})
+            ORDER BY OccurredAt DESC
+            LIMIT {cap:UInt32}
+        ) AS e
+        ASOF INNER JOIN (
+            SELECT UserIdHash, Timestamp
+            FROM otel_spans
+            WHERE TenantId = {tenant:String}
+              AND UserIdHash != ''
+              AND Timestamp >= subtractDays(now64(9), {span_days:UInt32})
+        ) AS s
+        ON e.UserIdHash = s.UserIdHash AND e.OccurredAt >= s.Timestamp
+    """
+
+    def __init__(
+        self,
+        store: object,
+        *,
+        lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+        event_cap: int = DEFAULT_EVENT_CAP,
+    ) -> None:
+        if lookback_days <= 0 or event_cap <= 0:
+            raise ValueError("lookback_days and event_cap must be positive")
+        self._store = store
+        self._lookback_days = int(lookback_days)
+        self._event_cap = int(event_cap)
+
+    def fetch_event_span_pairs(self, tenant_id: str) -> Sequence[tuple[datetime, datetime]]:
+        """One tenant-scoped round trip. Raises on a CH failure, which records a ``failed`` run."""
+        result = self._store.client.query(  # type: ignore[attr-defined]
+            self._SQL,
+            parameters={
+                "tenant": tenant_id,
+                "days": self._lookback_days,
+                # Spans are searched over a wider window than events, so an event at the very start
+                # of the event window can still find the span that preceded it. Without the slack
+                # the oldest events in every pass would look unmatched purely because of where the
+                # window boundary happened to fall.
+                "span_days": self._lookback_days * 2,
+                "cap": self._event_cap,
+            },
+        )
+        return [(_as_utc(row[0]), _as_utc(row[1])) for row in result.result_rows]
+
+
+def _as_utc(value: datetime) -> datetime:
+    """ClickHouse hands back naive UTC for a ``DateTime64`` with no timezone. Make that explicit.
+
+    Both halves of a pair come from the same query and are therefore always both naive or both
+    aware, so the subtraction in :func:`compute_late_arrivals` would work either way. Stamping UTC
+    keeps a caller that mixes these with a Python-side timestamp from getting a TypeError.
+    """
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
 
 
 def run_reconciliation(

--- a/infra/gateway/src/gateway/worker_jobs.py
+++ b/infra/gateway/src/gateway/worker_jobs.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduled jobs for the third-party ingest workers and the reconciler (CTO-216, S4).
+
+WHY this exists. Two pieces of working, tested code in this repo were invoked by nobody.
+:meth:`gateway.integration_workers.IngestWorker.run_cycle` backs Segment, HubSpot and Pendo and had
+no caller; :func:`gateway.reconciliation.run_reconciliation` had no caller either, which is why the
+/features attribution diagnostics card reads "last reconciled" from a run that never happened. The
+scheduler engine (CTO-213) and its multi-replica locking (CTO-214) landed with an empty registry
+precisely so that a ticket like this one could fill it. This module is the filling: it builds the
+workers and turns each one into a :class:`~gateway.scheduler.Job`.
+
+WHAT THIS DOES NOT FIX. ``attribution_records`` stays empty and /features keeps showing honest nulls
+for value, payback and attribution rate. That needs the stitcher RUNNER, which does not exist at all
+(CTO-200): ``sdk/python/src/tally/stitcher.py`` is a pure in-memory library with no ClickHouse-backed
+``TouchStore`` and no writer, so there is nothing here to schedule. Scheduling the reconciler is a
+different thing from scheduling the stitcher, and nothing in this module should be read as the
+latter.
+
+STATUS MAPPING, and specifically ``partial``. ``run_cycle`` already records its own outcome through
+:meth:`gateway.tenant_integrations.TenantIntegrationStore.record_run`, with PII-scrubbed errors and
+an honest ``success`` / ``partial`` / ``failed`` / ``skipped`` status. That is the source of truth
+for "how is this tenant's Segment connector doing", it is what the dashboard already reads, and this
+module does not duplicate it. What the job body does is translate that outcome into the scheduler's
+own three-value vocabulary, which exists to answer a different question ("should this run again, and
+when"):
+
+* ``skipped``  -> :class:`~gateway.scheduler.JobSkipped`. The tenant has not connected this
+  integration, which is most tenants for most connectors. It settles the cadence window so they are
+  not re-asked every tick, and it is not a success, so a freshness surface cannot mistake it for
+  current data.
+* ``success``  -> return normally.
+* ``partial``  -> ALSO return normally, i.e. scheduler ``success``. The scheduler has no ``partial``
+  and should not grow one. A partial cycle DID write data, so the cadence window is genuinely
+  satisfied and the next run belongs one interval away, not immediately. Mapping it to ``failed``
+  would be worse in both directions: it would put a chronically-partial connector (one malformed
+  record per batch is enough) into exponential backoff and starve the tenant of the good data it
+  does get, and it would make the pair look broken in the run history when it is not. The
+  partial-ness is not lost by this: ``record_run`` has already written ``partial`` and the reason
+  onto the ``tenant_integration_runs`` row that the integrations status surface reads, which is the
+  surface that is actually about connector health.
+* ``failed``   -> raise, so the scheduler records ``failed`` and applies its backoff.
+
+Cadences are per job and defended below, at the constants.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tally.account_identity import AccountLinker
+from tally.hmac_keys import HmacKeyRegistry
+
+from gateway.config import Settings
+from gateway.hubspot_ingest import HubSpotWorker
+from gateway.integration_workers import HttpClient, IngestWorker, UrllibHttpClient
+from gateway.pendo_ingest import PendoWorker
+from gateway.reconciliation import (
+    ClickHouseLateArrivalSource,
+    ReconciliationStore,
+    run_reconciliation,
+)
+from gateway.scheduler import Job, JobFn, JobRegistry, JobSkipped
+from gateway.segment_ingest import SegmentWorker
+from gateway.store import ClickHouseStore
+from gateway.tenant_integration_secrets import (
+    EnvSecretResolver,
+    SecretResolver,
+    TenantIntegrationSecretStore,
+)
+from gateway.tenant_integrations import TenantIntegrationStore
+
+logger = logging.getLogger("tally.gateway.worker_jobs")
+
+# --- cadences ------------------------------------------------------------------------------------
+#
+# These are not daily. The dashboard reads what these workers write, so a daily cycle would mean a
+# conversion recorded this morning does not appear until tomorrow, and the number a customer is
+# looking at would be up to 24 hours old with nothing on the page admitting it. Against that,
+# every cycle is a call to somebody else's rate-limited API, so "as often as possible" is not the
+# answer either. Each of these is one GET per tenant per cycle.
+
+#: Segment and HubSpot: every 15 minutes. 96 cycles per tenant per day, per connector.
+#:
+#: HubSpot documents the tightest published ceilings of the three and 15 minutes clears them by
+#: orders of magnitude: the burst limit is 100 requests per 10 seconds (190 on Professional and
+#: Enterprise) and the daily cap is 250,000 requests (625,000 / 1,000,000 on the paid tiers), shared
+#: across every app on the account. At 96 calls a day we would need well over two thousand tenants
+#: on one HubSpot account before the daily cap was even in view, and the burst limit is unreachable
+#: by construction because the tick loop walks tenants sequentially.
+#:
+#: Segment's Public API publishes per-endpoint limits in requests per MINUTE, the tightest of the
+#: documented ones being 25/min. One call per tenant per 15 minutes is nowhere near it.
+INGEST_INTERVAL_S = 15 * 60.0
+
+#: Pendo: every 30 minutes. Deliberately half the frequency of the other two, for one reason: Pendo
+#: does not publish numeric rate limits at all, so there is no ceiling to check ourselves against
+#: and the honest posture is caution. Its aggregation API is also the heavyweight of the three
+#: (documented 5-minute query timeout, responses up to 4GB), so a Pendo cycle costs the provider
+#: materially more than a Segment or HubSpot pull. 30 minutes still keeps the dashboard inside a
+#: window a human would call current, and can be tightened later if a real published limit appears.
+PENDO_INGEST_INTERVAL_S = 30 * 60.0
+
+#: The reconciler: hourly. It hits our own ClickHouse rather than anyone else's API, so third-party
+#: limits do not apply, but the scan is a join over a tenant's recent events and spans and there is
+#: no point paying for it every few minutes. What it feeds is the /features diagnostics card, whose
+#: whole job is to say how stale the picture is; an hour is fine granularity for that, and it lines
+#: up with the one-hour lateness threshold the card is documented against, so a pass can never be
+#: more than one threshold-width behind the events it is measuring.
+RECONCILIATION_INTERVAL_S = 3600.0
+
+INGEST_JOB_NAMES: dict[str, str] = {
+    "segment": "ingest.segment",
+    "hubspot": "ingest.hubspot",
+    "pendo": "ingest.pendo",
+}
+RECONCILIATION_JOB_NAME = "reconciliation"
+
+
+class IngestCycleFailed(RuntimeError):
+    """A cycle that :meth:`IngestWorker.run_cycle` reported as ``failed``.
+
+    Raised purely so the scheduler sees a failure and applies its backoff. It carries no state the
+    ``tenant_integration_runs`` row does not already have.
+    """
+
+
+class ReconciliationFailed(RuntimeError):
+    """A reconciliation pass whose ClickHouse scan failed. Same purpose as :class:`IngestCycleFailed`."""
+
+
+def _ingest_job_body(worker: IngestWorker) -> JobFn:
+    """Wrap one worker as a scheduler job body: tenant id in, nothing out, exceptions for status."""
+
+    def _run(tenant_id: str) -> None:
+        result = worker.run_cycle(tenant_id)
+        if result.status == "skipped":
+            # The tenant has not connected this integration. Not an error, and not a success.
+            raise JobSkipped(f"{worker.connector_id} not connected for tenant")
+        if result.status == "failed":
+            # record_run already holds the scrubbed reason (unless it too failed, hence
+            # `recorded`). The scheduler scrubs this string again on its way to scheduler_runs, and
+            # a message that already had an address redacted collapses to the coarse
+            # "[redacted: contained PII key]" marker on that second pass. That is acceptable: it is
+            # coarser, never leakier, and the precise reason is on the tenant_integration_runs row.
+            raise IngestCycleFailed(
+                f"{worker.connector_id} cycle failed"
+                f" (recorded={result.recorded}): {result.error_message or 'no detail reported'}"
+            )
+        # success or partial. See the module docstring for why partial lands here.
+        logger.info(
+            "ingest cycle: connector=%s tenant=%s status=%s events=%d",
+            worker.connector_id,
+            tenant_id,
+            result.status,
+            result.event_count,
+        )
+
+    return _run
+
+
+def _reconciliation_job_body(
+    source: ClickHouseLateArrivalSource, store: ReconciliationStore
+) -> JobFn:
+    """Wrap one reconciliation pass as a scheduler job body.
+
+    :func:`run_reconciliation` never raises: a failed CH scan is recorded as a ``failed`` run with
+    zeroed metrics, so the card can say "ran, but errored" instead of silently going stale. That is
+    the right behaviour for the reconciler's own log and the wrong signal for the scheduler, which
+    would otherwise read the pass as a success, settle the window and retry a broken scan on the
+    full cadence forever. So the status is re-read and re-raised here.
+
+    No :class:`JobSkipped` path. Every tenant is in scope for the reconciler: there is nothing to
+    configure, and a tenant with no events yields an honest zero rather than "nothing to do".
+    """
+
+    def _run(tenant_id: str) -> None:
+        run = run_reconciliation(source, store, tenant_id)
+        if run.status == "failed":
+            raise ReconciliationFailed("reconciliation scan failed; see reconciliation_runs")
+        logger.info(
+            "reconciliation: tenant=%s status=%s late=%d median_lag_s=%d",
+            tenant_id,
+            run.status,
+            run.events_late,
+            run.lag_seconds_median,
+        )
+
+    return _run
+
+
+def register_worker_jobs(
+    registry: JobRegistry,
+    settings: Settings,
+    *,
+    store: ClickHouseStore,
+    hmac_registry: HmacKeyRegistry,
+    account_linker: AccountLinker | None = None,
+    secrets: TenantIntegrationSecretStore | None = None,
+    resolver: SecretResolver | None = None,
+    http: HttpClient | None = None,
+    integrations: TenantIntegrationStore | None = None,
+    reconciliation_store: ReconciliationStore | None = None,
+) -> tuple[Job, ...]:
+    """Register the three ingest jobs and the reconciler on ``registry``. Returns what it added.
+
+    Every collaborator is injectable and defaults to the production one built from ``settings``,
+    which is the same shape :func:`gateway.scheduler.build_scheduler` uses, and is what lets the
+    tests drive a full tick with fakes and no Postgres, ClickHouse or network.
+
+    ``hmac_registry`` and ``account_linker`` are passed in rather than constructed because they hold
+    process-local state that must be SHARED with the request path: the HMAC registry provisions the
+    per-tenant key that decides which ``UserIdHash`` space a worker writes into, and the account
+    linker learns user-to-account edges from every connector in the process. A second instance of
+    either would not error, it would quietly write into a different hash space or fail to learn, and
+    the symptom would be an attribution join that lights up for some rows and not others.
+    """
+    ch_secrets = secrets if secrets is not None else TenantIntegrationSecretStore(settings)
+    ch_resolver = resolver if resolver is not None else EnvSecretResolver()
+    ch_http = http if http is not None else UrllibHttpClient()
+    ch_integrations = integrations if integrations is not None else TenantIntegrationStore(settings)
+    recon_store = (
+        reconciliation_store if reconciliation_store is not None else ReconciliationStore(settings)
+    )
+
+    common = {
+        "secrets": ch_secrets,
+        "resolver": ch_resolver,
+        "http": ch_http,
+        "store": store,
+        "integrations": ch_integrations,
+        "registry": hmac_registry,
+        "account_linker": account_linker,
+    }
+    workers: tuple[tuple[IngestWorker, float], ...] = (
+        (SegmentWorker(**common), INGEST_INTERVAL_S),  # type: ignore[arg-type]
+        (HubSpotWorker(**common), INGEST_INTERVAL_S),  # type: ignore[arg-type]
+        (PendoWorker(**common), PENDO_INGEST_INTERVAL_S),  # type: ignore[arg-type]
+    )
+
+    added: list[Job] = []
+    for worker, interval_s in workers:
+        added.append(
+            registry.register(
+                INGEST_JOB_NAMES[worker.connector_id],
+                interval_s,
+                _ingest_job_body(worker),
+            )
+        )
+    added.append(
+        registry.register(
+            RECONCILIATION_JOB_NAME,
+            RECONCILIATION_INTERVAL_S,
+            _reconciliation_job_body(ClickHouseLateArrivalSource(store), recon_store),
+        )
+    )
+    return tuple(added)
+
+
+__all__ = [
+    "INGEST_INTERVAL_S",
+    "INGEST_JOB_NAMES",
+    "PENDO_INGEST_INTERVAL_S",
+    "RECONCILIATION_INTERVAL_S",
+    "RECONCILIATION_JOB_NAME",
+    "IngestCycleFailed",
+    "ReconciliationFailed",
+    "register_worker_jobs",
+]

--- a/infra/gateway/tests/test_worker_jobs.py
+++ b/infra/gateway/tests/test_worker_jobs.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduled ingest + reconciliation jobs (CTO-216).
+
+These pin the seam between two things that already work on their own: the workers' honest
+``success`` / ``partial`` / ``failed`` / ``skipped`` cycle status, and the scheduler's
+``success`` / ``skipped`` / ``failed`` run history. Specifically:
+
+* an unconfigured tenant raises ``JobSkipped`` (settles the window, never looks like fresh data),
+* ``partial`` maps to scheduler success rather than failure, and ``record_run`` still records it,
+* a failed cycle raises so the scheduler records ``failed`` with a scrubbed error,
+* one tenant's failure does not stop another tenant's run, driven through a real ``tick_once``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from gateway.reconciliation import ClickHouseLateArrivalSource, ReconciliationRun
+from gateway.scheduler import JobRegistry, JobSkipped, Scheduler
+from gateway.worker_jobs import (
+    INGEST_INTERVAL_S,
+    INGEST_JOB_NAMES,
+    PENDO_INGEST_INTERVAL_S,
+    RECONCILIATION_INTERVAL_S,
+    RECONCILIATION_JOB_NAME,
+    register_worker_jobs,
+)
+
+from _worker_fakes import (
+    FakeCHStore,
+    FakeHttp,
+    FakeIntegrations,
+    FakeResolver,
+    FakeSecretStore,
+    make_secret,
+)
+
+T = "t-acme"
+OTHER = "t-globex"
+
+
+class FakeReconciliationStore:
+    """Captures reconciliation ``record_run`` calls and hands back the row it would have written."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def record_run(self, tenant_id: str, **kwargs: object) -> ReconciliationRun:
+        self.calls.append({"tenant_id": tenant_id, **kwargs})
+        return ReconciliationRun(
+            started_at="2026-06-01T00:00:00+00:00",
+            finished_at="2026-06-01T00:00:01+00:00",
+            events_late=int(kwargs["events_late"]),  # type: ignore[arg-type]
+            lag_seconds_median=int(kwargs["lag_seconds_median"]),  # type: ignore[arg-type]
+            lag_seconds_p95=int(kwargs["lag_seconds_p95"]),  # type: ignore[arg-type]
+            status=kwargs["status"],  # type: ignore[arg-type]
+        )
+
+
+class FakeLateArrivals:
+    """A ``_ClickHouseEventSource`` that returns canned pairs or raises like a broken CH scan."""
+
+    def __init__(self, pairs: list[tuple[datetime, datetime]], error: Exception | None = None):
+        self._pairs = pairs
+        self._error = error
+
+    def fetch_event_span_pairs(self, tenant_id: str) -> list[tuple[datetime, datetime]]:
+        if self._error is not None:
+            raise self._error
+        return self._pairs
+
+
+class _HmacRegistryStub:
+    """Enough of ``HmacKeyRegistry`` for the workers' ``build_hasher``."""
+
+    def provision(self, tenant_id: str) -> None:
+        return None
+
+    def hash(self, tenant_id: str, value: str):  # noqa: ANN201 - shape matches HmacKeyRegistry
+        class _H:
+            value = "f" * 64
+
+        return _H()
+
+
+def _register(
+    *,
+    secret_for: str | None = "segment",
+    http: FakeHttp | None = None,
+    integrations: FakeIntegrations | None = None,
+    registry: JobRegistry | None = None,
+) -> tuple[JobRegistry, FakeIntegrations]:
+    reg = registry if registry is not None else JobRegistry()
+    ints = integrations if integrations is not None else FakeIntegrations()
+    secret = make_secret(secret_for) if secret_for else None
+    register_worker_jobs(
+        reg,
+        object(),  # settings: never touched, every collaborator below is injected
+        store=FakeCHStore(),  # type: ignore[arg-type]
+        hmac_registry=_HmacRegistryStub(),  # type: ignore[arg-type]
+        secrets=FakeSecretStore(secret),  # type: ignore[arg-type]
+        resolver=FakeResolver({"ref-1": "tok"}),  # type: ignore[arg-type]
+        http=http if http is not None else FakeHttp(payload={"events": []}),
+        integrations=ints,  # type: ignore[arg-type]
+        reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+    )
+    return reg, ints
+
+
+# --- registration --------------------------------------------------------------------------------
+
+
+def test_registers_three_ingest_jobs_and_the_reconciler() -> None:
+    reg, _ = _register()
+    names = [job.name for job in reg.jobs()]
+    assert names == [
+        INGEST_JOB_NAMES["segment"],
+        INGEST_JOB_NAMES["hubspot"],
+        INGEST_JOB_NAMES["pendo"],
+        RECONCILIATION_JOB_NAME,
+    ]
+
+
+def test_cadences_are_the_documented_ones() -> None:
+    reg, _ = _register()
+    by_name = {job.name: job.interval_s for job in reg.jobs()}
+    assert by_name[INGEST_JOB_NAMES["segment"]] == INGEST_INTERVAL_S == 900.0
+    assert by_name[INGEST_JOB_NAMES["hubspot"]] == INGEST_INTERVAL_S
+    # Pendo is deliberately slower: it publishes no rate limits at all.
+    assert by_name[INGEST_JOB_NAMES["pendo"]] == PENDO_INGEST_INTERVAL_S == 1800.0
+    assert by_name[RECONCILIATION_JOB_NAME] == RECONCILIATION_INTERVAL_S == 3600.0
+
+
+def test_registering_twice_on_one_registry_is_an_error_not_a_silent_overwrite() -> None:
+    reg, _ = _register()
+    with pytest.raises(ValueError):
+        _register(registry=reg)
+
+
+# --- status mapping ------------------------------------------------------------------------------
+
+
+def test_unconfigured_tenant_raises_job_skipped_and_records_nothing() -> None:
+    reg, ints = _register(secret_for=None)
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    with pytest.raises(JobSkipped):
+        job.fn(T)
+    # An unconnected integration is not a run: run_cycle deliberately writes no row for it.
+    assert ints.calls == []
+
+
+def test_successful_cycle_returns_and_records_through_the_existing_path() -> None:
+    payload = {
+        "events": [
+            {
+                "type": "track",
+                "messageId": "m-1",
+                "event": "signup",
+                "userId": "u-1",
+                "timestamp": "2026-06-01T00:00:00Z",
+            }
+        ]
+    }
+    reg, ints = _register(http=FakeHttp(payload=payload))
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    assert job.fn(T) is None  # no exception: scheduler records `success`
+    assert [c["status"] for c in ints.calls] == ["success"]
+    assert ints.calls[0]["event_count"] == 1
+
+
+def test_failed_cycle_raises_so_the_scheduler_records_failed() -> None:
+    reg, ints = _register(http=FakeHttp(error=RuntimeError("HTTP 503 from api.segment.io")))
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    with pytest.raises(Exception) as excinfo:
+        job.fn(T)
+    assert not isinstance(excinfo.value, JobSkipped)
+    # The existing status path still recorded the failure itself; the raise is only for the scheduler.
+    assert [c["status"] for c in ints.calls] == ["failed"]
+
+
+def test_partial_cycle_is_scheduler_success_but_still_recorded_as_partial() -> None:
+    """The one mapping with no scheduler equivalent. See worker_jobs' module docstring."""
+    reg, ints = _register()
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    worker = job.fn.__closure__[0].cell_contents  # type: ignore[index, union-attr]
+
+    from gateway.integration_workers import IngestOutcome
+
+    def _partial(tenant_id, secret, token):  # noqa: ANN001, ANN202
+        return IngestOutcome(event_count=3, partial=True, error_message="1 of 4 pages unreadable")
+
+    worker._ingest = _partial  # type: ignore[method-assign]
+    assert job.fn(T) is None  # partial does NOT raise: the window is genuinely satisfied
+    assert [c["status"] for c in ints.calls] == ["partial"]
+    assert ints.calls[0]["event_count"] == 3
+
+
+# --- error scrubbing -----------------------------------------------------------------------------
+
+
+def test_recorded_error_is_scrubbed_of_pii() -> None:
+    reg, ints = _register(http=FakeHttp(error=RuntimeError("rejected for alice@example.com")))
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    with pytest.raises(Exception):
+        job.fn(T)
+    recorded = str(ints.calls[0]["error_message"])
+    assert "alice@example.com" not in recorded
+    assert "redacted" in recorded
+
+
+# --- reconciliation ------------------------------------------------------------------------------
+
+
+def test_reconciliation_records_a_run_and_does_not_skip_any_tenant() -> None:
+    store = FakeReconciliationStore()
+    span_ts = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    late = span_ts.replace(hour=18)
+    from gateway.worker_jobs import _reconciliation_job_body
+
+    body = _reconciliation_job_body(FakeLateArrivals([(late, span_ts)]), store)  # type: ignore[arg-type]
+    assert body(T) is None
+    assert store.calls[0]["status"] == "ok"
+    assert store.calls[0]["events_late"] == 1
+
+
+def test_reconciliation_scan_failure_raises_so_backoff_applies() -> None:
+    store = FakeReconciliationStore()
+    from gateway.worker_jobs import ReconciliationFailed, _reconciliation_job_body
+
+    body = _reconciliation_job_body(  # type: ignore[arg-type]
+        FakeLateArrivals([], error=RuntimeError("clickhouse unreachable")), store
+    )
+    with pytest.raises(ReconciliationFailed):
+        body(T)
+    # run_reconciliation still recorded its own failed row: the raise is only the scheduler signal.
+    assert store.calls[0]["status"] == "failed"
+
+
+def test_late_arrival_source_rejects_nonsense_bounds() -> None:
+    with pytest.raises(ValueError):
+        ClickHouseLateArrivalSource(FakeCHStore(), lookback_days=0)
+    with pytest.raises(ValueError):
+        ClickHouseLateArrivalSource(FakeCHStore(), event_cap=0)
+
+
+# --- failure isolation, through a real tick ------------------------------------------------------
+
+
+class _MemoryRunStore:
+    """In-memory ``RunStore``: enough for one tick, and records every row the scheduler writes."""
+
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str, str, str | None]] = []
+
+    def get_state(self, job_name: str, tenant_id: str):  # noqa: ANN201
+        from gateway.scheduler import JobState
+
+        return JobState()  # never run: everything is due
+
+    def record_run(  # noqa: ANN001, ANN201
+        self,
+        job_name,
+        tenant_id,
+        status,
+        *,
+        started_at,
+        finished_at,
+        error_message=None,
+    ):
+        self.rows.append((job_name, tenant_id, status, error_message))
+
+
+def test_one_tenants_failure_does_not_stop_another_tenants_run() -> None:
+    # The worker resolves the tenant from run_cycle's argument, not the URL, so the split is driven
+    # through the worker's own _ingest: tenant T raises, tenant OTHER succeeds.
+    reg = JobRegistry()
+    ints = FakeIntegrations()
+    register_worker_jobs(
+        reg,
+        object(),
+        store=FakeCHStore(),  # type: ignore[arg-type]
+        hmac_registry=_HmacRegistryStub(),  # type: ignore[arg-type]
+        secrets=FakeSecretStore(make_secret("segment")),  # type: ignore[arg-type]
+        resolver=FakeResolver({"ref-1": "tok"}),  # type: ignore[arg-type]
+        http=FakeHttp(payload={"events": []}),
+        integrations=ints,  # type: ignore[arg-type]
+        reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+    )
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    worker = job.fn.__closure__[0].cell_contents  # type: ignore[index, union-attr]
+
+    def _ingest(tenant_id, secret, token):  # noqa: ANN001, ANN202
+        from gateway.integration_workers import IngestOutcome
+
+        if tenant_id == T:
+            raise RuntimeError("segment 500")
+        return IngestOutcome(event_count=2)
+
+    worker._ingest = _ingest  # type: ignore[method-assign]
+
+    single = JobRegistry()
+    single.register(job.name, job.interval_s, job.fn)
+    runs = _MemoryRunStore()
+    scheduler = Scheduler(single, runs, lambda: [T, OTHER], tick_interval_s=1.0)
+    result = asyncio.run(scheduler.tick_once())
+
+    assert result.ran == 2
+    assert result.failed == 1
+    assert result.succeeded == 1
+    by_tenant = {tenant: status for _, tenant, status, _ in runs.rows}
+    assert by_tenant == {T: "failed", OTHER: "success"}
+
+
+def test_skip_and_failure_coexist_across_tenants_in_one_tick() -> None:
+    reg = JobRegistry()
+    ints = FakeIntegrations()
+
+    class _SecretForOneTenant:
+        def get(self, tenant_id: str, connector_id: str):  # noqa: ANN201
+            return make_secret("segment") if tenant_id == T else None
+
+    register_worker_jobs(
+        reg,
+        object(),
+        store=FakeCHStore(),  # type: ignore[arg-type]
+        hmac_registry=_HmacRegistryStub(),  # type: ignore[arg-type]
+        secrets=_SecretForOneTenant(),  # type: ignore[arg-type]
+        resolver=FakeResolver({"ref-1": "tok"}),  # type: ignore[arg-type]
+        http=FakeHttp(payload={"events": []}),
+        integrations=ints,  # type: ignore[arg-type]
+        reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+    )
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    single = JobRegistry()
+    single.register(job.name, job.interval_s, job.fn)
+    runs = _MemoryRunStore()
+    scheduler = Scheduler(single, runs, lambda: [T, OTHER], tick_interval_s=1.0)
+    result = asyncio.run(scheduler.tick_once())
+
+    assert result.succeeded == 1
+    assert result.skipped_by_job == 1
+    by_tenant = {tenant: status for _, tenant, status, _ in runs.rows}
+    assert by_tenant == {T: "success", OTHER: "skipped"}


### PR DESCRIPTION
## What

Registers the four jobs the scheduler was built for. `gateway/worker_jobs.py` turns
`IngestWorker.run_cycle` into a scheduled job per connector (Segment, HubSpot, Pendo) and
`run_reconciliation` into one more, and `lifespan` hands the registry to `build_scheduler`.

None of this is new value. All of it is switching on value that already merged: `run_cycle` was
written, tested and invoked by nobody, and so was `run_reconciliation`, which is why the /features
attribution diagnostics card has always read "last reconciled" off a run that never happened.

A tenant with a configured integration now gets cycles without anyone running a script. A tenant
without one raises `JobSkipped`. A failure records through the existing `record_run` path with a
scrubbed error and does not stop any other tenant.

## Cadence, per job

These are not daily. The dashboard reads what these workers write, so a daily cycle means a
conversion recorded this morning does not show up until tomorrow, with nothing on the page admitting
it. Against that, every cycle is a call to somebody else's rate-limited API. Each job is one GET per
tenant per cycle, and the tick loop walks tenants sequentially, so a burst limit is unreachable by
construction.

**`ingest.segment` and `ingest.hubspot`: every 15 minutes** (96 cycles per tenant per day).
HubSpot publishes the tightest ceilings of the three and 15 minutes clears them by orders of
magnitude: 100 requests per 10 seconds burst (190 on Professional and Enterprise), and a daily cap
of 250,000 requests (625,000 / 1,000,000 on the paid tiers) shared across every app on the account.
At 96 calls a day it would take well over two thousand tenants on one HubSpot account for the daily
cap to come into view. Segment's Public API publishes per-endpoint limits in requests per **minute**,
the tightest documented one being 25/min; one call per tenant per 15 minutes is nowhere near it.

**`ingest.pendo`: every 30 minutes.** Deliberately half the frequency of the other two, for one
reason: Pendo does not publish numeric rate limits at all, so there is no ceiling to check ourselves
against and the honest posture is caution. Its aggregation API is also the heavyweight of the three
(documented 5-minute query timeout, responses up to 4GB), so a Pendo cycle costs the provider
materially more. 30 minutes is still inside any window a human would call current, and it can be
tightened if a real published limit ever appears.

**`reconciliation`: hourly.** It hits our own ClickHouse, so third-party limits do not apply, but
the scan is a join over a tenant's recent events and spans and there is no point paying for it every
few minutes. It feeds the /features diagnostics card, whose whole job is to say how stale the
picture is, and an hour lines up with the one-hour lateness threshold the card is documented
against, so a pass can never be more than one threshold-width behind the events it measures.

## The `partial` mapping

`run_cycle` already records its own outcome through `TenantIntegrationStore.record_run` with
PII-scrubbed errors and an honest `success` / `partial` / `failed` / `skipped` status. That is the
source of truth for connector health, it is what the dashboard already reads, and this PR does not
duplicate it. The job bodies only translate that outcome into the scheduler's three-value
vocabulary, which answers a different question: "should this run again, and when".

`partial` has no scheduler equivalent, and **it maps to scheduler `success`**. A partial cycle DID
write data, so the cadence window is genuinely satisfied and the next run belongs one interval away.
Mapping it to `failed` would be worse in both directions: it would put a chronically-partial
connector (one malformed record per batch is enough) into exponential backoff and starve the tenant
of the good data it does get, and it would make a working pair look broken in the run history. The
partial-ness is not lost by this, because `record_run` has already written `partial` and the reason
onto the `tenant_integration_runs` row that the integrations status surface reads. The scheduler
should not grow a fourth status for this: that means a migration to the 0027 CHECK constraint and a
value in front of every future freshness surface, to record something another table already says
better.

The other three: `skipped` raises `JobSkipped`, which settles the window so an unconnected tenant is
not re-asked every tick while staying distinct from success, so a freshness surface cannot mistake
it for current data. `success` returns. `failed` raises, so the scheduler records `failed` and backs
off.

## Two Protocols that had no production implementation

Both existed only as a Protocol plus a test fake, because nothing ever ran a cycle outside a test.

- `UrllibHttpClient`: the production `HttpClient`. stdlib only, since `requests` is not a declared
  dependency of this package and one GET every few minutes does not justify adding one. Raises on
  any non-2xx carrying the status line, never the body, because a third-party error body is exactly
  where a customer email turns up.
- `ClickHouseLateArrivalSource`: the reconciler's CH scan, which CTO-139 left to whoever first ran
  the reconciler on a schedule. An `ASOF INNER JOIN` pairing each value event with the most recent
  span for the same hashed user at or before it, bounded by a lookback window and a row cap.
  `INNER`, so an event with no preceding span contributes nothing rather than a fabricated lag of
  zero.

## What this does NOT fix

**/features is still blocked on CTO-200.** `attribution_records` is still empty for every tenant and
/features still shows honest nulls for value, payback and attribution rate. Nothing in this PR
changes that, and nothing in it should be read as claiming otherwise.

Scheduling the reconciler is a different thing from scheduling the stitcher. The reconciler measures
how late value events arrived; the stitcher is what would credit a feature with that value. The
reconciler merely lacked a caller, which is fixable here. The stitcher has no runner at all:
`sdk/python/src/tally/stitcher.py` is a pure in-memory library with no ClickHouse-backed `TouchStore`
and no writer, so there is nothing to schedule. `ClickHouseLateArrivalSource` writes nothing to
`attribution_records` and credits no feature with any value, on purpose.

## Also

Mounts `0018_tenant_integration_secrets.sql` in the local compose stack. It was never mounted
because nothing in a local gateway read that table until the scheduler started running these
workers.

## Verification

- `infra/gateway`: 737 passed (724 before, 13 new), `ruff check` clean.
- `web`: `npm run typecheck` clean; `npm run test` 568 passed with only the 2 long-standing
  `app/api/api.test.ts` failures.
- `docker compose -f infra/docker-compose.yml up -d --build gateway` builds and comes up healthy.
- **Live, end to end.** With `TALLY_SCHEDULER_ENABLED=true` against the local stack and three
  tenants, one tick produced exactly this in `scheduler_runs`, with nobody running a script:

  | job | tenant | status |
  | --- | --- | --- |
  | `ingest.segment` | configured | `success` (3 events + 1 identity link into ClickHouse, `tenant_integration_runs` says `success`, count 3) |
  | `ingest.segment` | broken endpoint | `failed`, `HTTP 404 from ...`, no host body, no PII |
  | `ingest.segment` | unconfigured | `skipped` |
  | `ingest.hubspot` / `ingest.pendo` | all three | `skipped` |
  | `reconciliation` | all three | `success` (the ASOF scan runs against real ClickHouse) |

  The failing tenant did not stop the other two in the same tick, and it retried on the next tick
  rather than backing off, which is the documented first-failure behaviour. Note the gateway
  configures no logging (CTO-218), so this was confirmed from the tables rather than from container
  logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
