### PR TITLE
fix(cost-connectors): bill from the last day billed, and stop a false green on the Vercel row

### DIFF
--- a/infra/gateway/src/gateway/cost_connector_job.py
+++ b/infra/gateway/src/gateway/cost_connector_job.py
@@ -10,15 +10,17 @@ scheduler (CTO-213) runs once a day per tenant, and it is what makes the Compute
 populate on their own.
 
 It is deliberately NOT a new connector. Everything here is orchestration: read the config rows that
-CTO-176 writes, construct the connectors that already exist, run them for one day, and let them
-record their own outcome.
+CTO-176 writes, construct the connectors that already exist, run them for the days that are owed,
+and let them record their own outcome.
 
 Run recording has ONE owner per fact
 ------------------------------------
 The connectors already stamp ``last_run_at`` / ``last_status`` on their own config row through the
-``RunRecorder`` protocol, and this job passes those same recorders in rather than wrapping them.
-There is no second "did the connector run" store here, because two sources of truth for one fact is
-how a dashboard ends up disagreeing with itself. The division is:
+``RunRecorder`` protocol, and this job passes those same recorders in. There is no second "did the
+connector run" store here, because two sources of truth for one fact is how a dashboard ends up
+disagreeing with itself. The one wrapper in this module, :class:`_WorstOfRecorder`, does not become
+a second store: it forwards to the connector's own recorder and only decides WHICH of two sub-run
+outcomes that one row ends up carrying (see "One shared config row, one status"). The division is:
 
 * ``scheduler_runs`` answers "did the SCHEDULE fire for this tenant" (owned by the scheduler).
 * ``tenant_*_config.last_status`` answers "did the CONNECTOR work" (owned by the connector).
@@ -28,13 +30,56 @@ Most tenants have no cloud account connected, and a ``skipped`` row settles the 
 they are not re-asked every tick) while staying distinguishable from a real run, so a freshness
 surface can never read "we ran, all good" off a tenant we never had anything to do for.
 
-Which day
----------
-Yesterday UTC, always (:func:`target_day`). Billing APIs only report a complete day once it has
-closed, so asking for today would fetch a partial number. That partial number would then be FROZEN:
-the emitter is keyed on ``(tenant, provider, operation, day)`` and skips a day that already has a
-span, so nothing would ever correct it. One day of lag is the honest choice, and it is the same
-window the backfill scripts default to.
+Which days
+----------
+Yesterday UTC is the NEWEST billable day (:func:`target_day`). Billing APIs only report a complete
+day once it has closed, so asking for today would fetch a partial number. That partial number would
+then be FROZEN: the emitter is keyed on ``(tenant, provider, operation, day)`` and skips a day that
+already has a span, so nothing would ever correct it. One day of lag is the honest choice, and it is
+the same window the backfill scripts default to.
+
+The OLDEST day of a run is derived from the last day actually billed, not from today's date
+(CTO-219, finding 1). CTO-215 said "run for yesterday UTC" and that is exactly what shipped, so any
+run gap spanning two UTC midnights lost a day of cloud spend permanently: the missed day was never
+asked for again, and because the emitter skips a day that already has a span it also could not be
+picked up later by widening some other run. Cadence drift towards midnight makes that routine rather
+than exotic. So the job now bills ``[last billed day + 1, yesterday]`` and catches the gap up.
+
+Where "the last day actually billed" comes from: the spans themselves. For each
+``(provider, operation)`` series the job walks back from yesterday probing the SAME deterministic
+:func:`gateway.connectors.base.synthetic_span_id` the emitter's idempotency guard checks, and the
+newest day that has a span is the last day billed. That is authoritative because the span IS the
+billing output for a day, it is cheap (tenant-scoped, bloom-filtered ``SpanId`` point lookups, the
+query the connectors already run before every insert), and it introduces no second source of truth.
+The alternative, ``tenant_*_config.last_run_at``, answers a different question: it says when a RUN
+happened, not which DAY was billed, so a run that failed, was skipped by the gate, or covered a
+different window would all read identically.
+
+Both ends of the window are bounded:
+
+* :data:`MAX_CATCHUP_DAYS` caps ONE invocation at a week of billing days. A connector broken for
+  three months must not try to bill ninety days in one run and time out. The remainder is not lost:
+  the next run reads the new last-billed day and continues from there, so a long gap closes over
+  consecutive runs rather than in one heroic one.
+* :data:`LOOKBACK_DAYS` caps the SEARCH at a fortnight of probes. If nothing was billed inside that
+  window the job bills yesterday alone and starts a fresh chain from it. That is the right answer
+  for the two cases that look identical from here: a brand new connector, which has no history and
+  should not quietly backfill one, and a long dead one, whose deep history belongs to
+  ``scripts/backfill_*.py`` (which ``docs/scheduler-scope.md`` deliberately keeps for exactly this).
+
+A multi-day window goes through ``run_backfill(config, start_day=..., end_day=...)``, which every
+connector already exposes and which fetches the whole range in ONE billing-API call, rather than
+looping ``run()`` once per day.
+
+One shared config row, one status
+---------------------------------
+``VercelCostConnector`` has two sub-runs (compute always, egress when the CTO-163 gate is on) and
+both stamp the SAME ``tenant_vercel_config`` row, so the row used to show whatever finished last: a
+failed compute sub-run followed by a successful egress sub-run left ``last_status = 'success'`` on a
+customer-facing row while no compute span had been emitted (CTO-219, finding 2). The Vercel recorder
+is therefore wrapped in :class:`_WorstOfRecorder`, which buffers the sub-run outcomes and stamps the
+row once with the WORST of them. A tenant with ``emit_egress = false`` has a single sub-run, and for
+that case the wrapper replays exactly the call the connector made.
 
 Multiple egress providers is the normal case
 --------------------------------------------
@@ -60,7 +105,9 @@ the config rows say precisely which connector broke.
 
 Re-running a day inserts nothing new. The base connector checks ``span_exists`` on the deterministic
 synthetic span id before every insert, which is the backstop if the scheduler ever double-fires.
-Nothing in this module weakens that: it picks the day and calls ``run()``.
+Nothing in this module weakens that: it picks the window and hands it to the connector. A widened
+window is the same guarantee applied to more days, because a day that already has a span is skipped
+whether it was reached by ``run()`` or by ``run_backfill()``.
 """
 
 from __future__ import annotations
@@ -70,7 +117,7 @@ from collections.abc import Callable, Sequence
 from datetime import date, datetime, timedelta, timezone
 
 from gateway.config import Settings
-from gateway.connectors.base import BillingClient, RunRecorder
+from gateway.connectors.base import BillingClient, RunRecorder, SpanSink, synthetic_span_id
 from gateway.connectors.compute import ComputeCostConnector, build_billing_client
 from gateway.connectors.config_store import (
     TenantComputeConfigStore,
@@ -79,6 +126,7 @@ from gateway.connectors.config_store import (
 )
 from gateway.connectors.egress import EgressCostConnector, build_egress_client
 from gateway.connectors.vercel import (
+    VERCEL_PROVIDER,
     VercelCostConnector,
     VercelUsageClient,
     build_vercel_usage_client,
@@ -97,14 +145,130 @@ JOB_NAME = "cost_connectors"
 #: number that cannot have changed and would spend a tenant's billing-API rate limit doing it.
 DAILY_INTERVAL_S = 86400.0
 
+#: The most billing days ONE invocation will cover (CTO-219). A connector that has been broken for
+#: three months must not try to bill ninety days in a single run: that is a very long billing-API
+#: call, and a job body that times out mid-window is worse than one that makes steady progress.
+#: A week is comfortably more than any realistic scheduler outage while still being one cheap range
+#: query at every provider. The remainder is NOT lost: the next run recomputes the last billed day,
+#: which has moved forward by this much, and continues from there.
+MAX_CATCHUP_DAYS = 7
+
+#: How far back the search for "the last day actually billed" will probe before giving up
+#: (CTO-219). Bounds the work of the search itself, which is one point lookup per day per
+#: (provider, operation) series. A fortnight covers the outages a daily job realistically has (a
+#: deploy freeze, a long weekend of a broken credential) and must stay LARGER than
+#: :data:`MAX_CATCHUP_DAYS`, otherwise a gap could never be seen far enough back to be caught up in
+#: instalments. Nothing billed inside the window means "start a fresh chain at yesterday": deeper
+#: history is a job for ``scripts/backfill_*.py``, which the scheduler scope keeps for that purpose.
+LOOKBACK_DAYS = 14
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
 def target_day(now: datetime) -> date:
-    """The day to bill for: yesterday UTC. See the module docstring for why not today."""
+    """The NEWEST day that can be billed: yesterday UTC. See the module docstring for why not today.
+
+    Still the end of every window. What changed in CTO-219 is that it is no longer also the start:
+    see :func:`billing_window`.
+    """
     return (now.astimezone(timezone.utc) - timedelta(days=1)).date()
+
+
+def last_billed_day(
+    store: SpanSink, tenant_id: str, provider: str, operation: str, *, newest: date
+) -> date | None:
+    """The newest day at or before ``newest`` that already has a span for this series, if any.
+
+    This is the "last day actually billed" the window is derived from (CTO-219). It asks the spans
+    rather than a config column because the span IS the billing output for a day, and it asks with
+    exactly the probe the emitter's idempotency guard uses, so the two can never disagree about what
+    counts as billed.
+
+    Returns ``None`` when nothing is billed within :data:`LOOKBACK_DAYS`, which is both a brand new
+    connector and one that has been dark for longer than the job will catch up. The caller treats
+    both as "start a fresh chain at yesterday".
+    """
+    day = newest
+    oldest = newest - timedelta(days=LOOKBACK_DAYS - 1)
+    while day >= oldest:
+        _, span_id = synthetic_span_id(tenant_id, provider, operation, day)
+        if store.span_exists(tenant_id, span_id):
+            return day
+        day -= timedelta(days=1)
+    return None
+
+
+def billing_window(
+    store: SpanSink,
+    tenant_id: str,
+    series: Sequence[tuple[str, str]],
+    *,
+    newest: date,
+) -> tuple[date, date]:
+    """The ``(start_day, end_day)`` one connector should bill, inclusive (CTO-219).
+
+    ``series`` is the ``(provider, operation)`` pairs this connector emits, which is one pair for
+    compute and egress and two for Vercel with the egress gate on. The window starts the day after
+    the OLDEST of their last-billed days, so a Vercel run whose egress half is behind does not leave
+    that half behind for good, and re-covering a day the other half already has costs nothing
+    because the emitter skips it.
+
+    The window is capped at :data:`MAX_CATCHUP_DAYS` and never extends past ``newest``. A tenant
+    that is already up to date gets ``(newest, newest)``, which is the pre-CTO-219 behaviour and the
+    common case.
+    """
+    known = [
+        billed
+        for provider, operation in series
+        if (billed := last_billed_day(store, tenant_id, provider, operation, newest=newest))
+        is not None
+    ]
+    # Nothing billed inside the lookback window: bill yesterday alone rather than inventing a
+    # backfill. See LOOKBACK_DAYS.
+    start = newest if not known else min(known) + timedelta(days=1)
+    if start > newest:
+        start = newest
+    end = min(start + timedelta(days=MAX_CATCHUP_DAYS - 1), newest)
+    return start, end
+
+
+class _WorstOfRecorder:
+    """Buffers sub-run outcomes for ONE shared config row and stamps it with the worst (CTO-219).
+
+    ``VercelCostConnector`` runs a compute sub-run and, when the CTO-163 gate is on, an egress
+    sub-run, and both record onto the single ``tenant_vercel_config`` row. Recording as they went
+    meant last-writer-wins, so a failed compute sub-run followed by a successful egress sub-run left
+    a customer-facing row reading ``success`` while no compute span existed: a tenant looking at a
+    healthy connector that was not producing data.
+
+    The rule is worst-outcome, not last-outcome. ``success`` is only stamped when every sub-run that
+    actually RAN succeeded. With the gate off there is exactly one sub-run and :meth:`flush` replays
+    precisely the call the connector made, so that case is untouched.
+    """
+
+    def __init__(self, inner: RunRecorder) -> None:
+        self._inner = inner
+        self._calls: list[tuple[str, str, str, str | None]] = []
+
+    def record_run(
+        self, tenant_id: str, connector_id: str, status: str, *, error_message: str | None = None
+    ) -> None:
+        self._calls.append((tenant_id, connector_id, status, error_message))
+
+    def flush(self) -> None:
+        """Stamp the row once. A no-op if no sub-run recorded anything, so a row is never invented."""
+        if not self._calls:
+            return
+        # The first failure, if there was one, so the message on the row names the sub-run that
+        # actually broke rather than the one that happened to finish last. All-success falls back
+        # to the FIRST call, which is the sub-run that always runs, so a gate-off tenant is stamped
+        # with exactly the call its single sub-run made.
+        worst = next((call for call in self._calls if call[2] != "success"), self._calls[0])
+        self._calls.clear()
+        tenant_id, connector_id, status, error_message = worst
+        self._inner.record_run(tenant_id, connector_id, status, error_message=error_message)
 
 
 class CostConnectorRunError(RuntimeError):
@@ -116,7 +280,7 @@ class CostConnectorRunError(RuntimeError):
 
 
 class CostConnectorJob:
-    """Runs every cost connector a tenant has configured, for one day. Callable as a job body.
+    """Runs every cost connector a tenant has configured, for the days it owes. Callable as a job.
 
     Constructed once at startup and called with a tenant id per due tick. It holds no per-tenant
     state: config is re-read on every call, so connecting or disconnecting a cloud account takes
@@ -161,7 +325,10 @@ class CostConnectorJob:
         self._now = now
 
     def __call__(self, tenant_id: str) -> None:
-        """Run every configured connector for ``tenant_id``. Raises if any of them failed.
+        """Bill every configured connector for ``tenant_id``. Raises if any of them failed.
+
+        Each connector gets its OWN window, because each has its own last-billed day: an egress
+        provider added yesterday must not be dragged over a gap that belongs to compute.
 
         Blocking by design: the scheduler calls job bodies on a worker thread precisely so they can
         do blocking Postgres and HTTP work without touching the event loop.
@@ -179,76 +346,106 @@ class CostConnectorJob:
             # claiming a run happened. See the module docstring.
             raise JobSkipped(f"tenant {tenant_id} has no cost connector configured")
 
-        day = target_day(self._now())
+        newest = target_day(self._now())
         failures: list[str] = []
+        # Only for the error message: each connector bills its own window, so there is no single
+        # day to name if they have drifted apart.
+        days: list[date] = []
         # The connectors share ONE sink, so the span_exists idempotency guard sees every insert this
         # run makes, including the Vercel egress span whose id is identical to the CTO-144 one.
         store = self._store_factory()
         try:
             if compute_config is not None:
                 provider = compute_config.cloud_provider
+                start, end = billing_window(
+                    store, tenant_id, [(provider, "compute")], newest=newest
+                )
+                days.append(end)
                 self._attempt(
                     failures,
                     label=f"compute/{provider}",
                     tenant_id=tenant_id,
                     connector_id="compute",
                     recorder=self._compute_store,
-                    run=lambda cfg=compute_config: [
+                    # run_backfill rather than a loop over run(): the connectors already fetch a
+                    # whole range in one billing-API call, and a single day is the same code path.
+                    run=lambda cfg=compute_config, s=start, e=end: [
                         ComputeCostConnector(
                             store=store,
                             recorder=self._compute_store,
                             billing_client=self._compute_client_factory(cfg.cloud_provider),
                         )
-                        .run(cfg, day=day)
+                        .run_backfill(cfg, start_day=s, end_day=e)
                         .status
                     ],
                 )
 
             for egress_config in egress_configs:
+                start, end = billing_window(
+                    store,
+                    tenant_id,
+                    [(egress_config.cloud_provider, "egress")],
+                    newest=newest,
+                )
+                days.append(end)
                 # `cfg` is bound per iteration on purpose: the lambda outlives the iteration that
-                # built it, and a late-bound loop variable would run the last provider N times.
+                # built it, and a late-bound loop variable would run the last provider N times. The
+                # window is bound the same way and for the same reason.
                 self._attempt(
                     failures,
                     label=f"egress/{egress_config.cloud_provider}",
                     tenant_id=tenant_id,
                     connector_id="egress",
                     recorder=self._egress_store.recorder_for(egress_config.cloud_provider),
-                    run=lambda cfg=egress_config: [
+                    run=lambda cfg=egress_config, s=start, e=end: [
                         EgressCostConnector(
                             store=store,
                             recorder=self._egress_store.recorder_for(cfg.cloud_provider),
                             billing_client=self._egress_client_factory(cfg.cloud_provider),
                         )
-                        .run(cfg, day=day)
+                        .run_backfill(cfg, start_day=s, end_day=e)
                         .status
                     ],
                 )
 
             if vercel_config is not None:
+                # Both halves of a Vercel run share a window, and the gate decides whether the
+                # egress series counts towards it. Reading the flag to pick the SERIES is not
+                # interpreting the CTO-163 gate: the connector still decides whether to emit.
+                series = [(VERCEL_PROVIDER, "compute")]
+                if vercel_config.emit_egress:
+                    series.append((VERCEL_PROVIDER, "egress"))
+                start, end = billing_window(store, tenant_id, series, newest=newest)
+                days.append(end)
+                # One row, two sub-runs: the recorder is wrapped so the row ends up worst-of rather
+                # than last-of (CTO-219, finding 2).
+                vercel_recorder = _WorstOfRecorder(self._vercel_store)
                 self._attempt(
                     failures,
                     label="vercel",
                     tenant_id=tenant_id,
                     connector_id="compute",
-                    recorder=self._vercel_store,
+                    recorder=vercel_recorder,
                     # emit_egress rides on the config row and VercelCostConnector reads it itself:
                     # the CTO-163 double-count gate is not this job's to interpret.
-                    run=lambda cfg=vercel_config: _vercel_statuses(
+                    run=lambda cfg=vercel_config, s=start, e=end: _vercel_statuses(
                         VercelCostConnector(
                             store=store,
                             usage_client=self._usage_client_factory(),
-                            recorder=self._vercel_store,
-                        ).run(cfg, day=day)
+                            recorder=vercel_recorder,
+                        ).run_backfill(cfg, start_day=s, end_day=e)
                     ),
                 )
+                self._flush(vercel_recorder, tenant_id)
         finally:
             # Closed on every path, including the raise below. A job that leaked a ClickHouse client
             # a day would take a long time to notice and would look like a ClickHouse problem.
             store.close()
 
         if failures:
+            through = max(days).isoformat() if days else newest.isoformat()
             raise CostConnectorRunError(
-                f"cost connectors failed for tenant {tenant_id} on {day.isoformat()}: "
+                f"cost connectors failed for tenant {tenant_id} through {through}: "
                 + "; ".join(failures)
             )
 
@@ -287,6 +484,16 @@ class CostConnectorJob:
             if status != "success":
                 # Already recorded on the config row by the connector, with no span emitted.
                 failures.append(f"{label}: {status}")
+
+    @staticmethod
+    def _flush(recorder: _WorstOfRecorder, tenant_id: str) -> None:
+        """Stamp a buffered shared row. A recorder that cannot write must not fail the whole run."""
+        try:
+            recorder.flush()
+        except Exception:  # noqa: BLE001 - the connector outcome is already in `failures`
+            logger.warning(
+                "cost connector job: tenant=%s could not record vercel status", tenant_id
+            )
 
     @staticmethod
     def _record_failed(
@@ -332,8 +539,12 @@ def register_cost_connector_job(
 __all__ = [
     "DAILY_INTERVAL_S",
     "JOB_NAME",
+    "LOOKBACK_DAYS",
+    "MAX_CATCHUP_DAYS",
     "CostConnectorJob",
     "CostConnectorRunError",
+    "billing_window",
+    "last_billed_day",
     "register_cost_connector_job",
     "target_day",
 ]

--- a/infra/gateway/tests/test_cost_connector_job.py
+++ b/infra/gateway/tests/test_cost_connector_job.py
@@ -12,6 +12,10 @@ What these tests are actually asserting is the acceptance list on the ticket:
 * an unconfigured tenant is ``JobSkipped`` and not an error,
 * a failed fetch records ``failed`` and emits NO span, never a guessed number,
 * re-running a day inserts nothing new,
+* a run gap spanning several UTC midnights bills every missed day rather than losing them, in
+  capped instalments (CTO-219, finding 1),
+* a Vercel row never reads 'success' off the egress sub-run when the compute sub-run failed
+  (CTO-219, finding 2),
 * every configured egress provider runs, because a tenant with AWS plus Cloudflare plus Vercel is
   the normal case and their totals only sum if all of them ran,
 * the ``emit_egress`` gate is respected rather than routed around.
@@ -19,7 +23,7 @@ What these tests are actually asserting is the acceptance list on the ticket:
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -29,8 +33,12 @@ from gateway.connectors.egress import EgressConfig
 from gateway.connectors.vercel import VercelConfig, VercelUsageClient
 from gateway.cost_connector_job import (
     JOB_NAME,
+    LOOKBACK_DAYS,
+    MAX_CATCHUP_DAYS,
     CostConnectorJob,
     CostConnectorRunError,
+    billing_window,
+    last_billed_day,
     register_cost_connector_job,
     target_day,
 )
@@ -65,6 +73,20 @@ class FakeSpanSink:
 
     def remember(self, tenant_id: str, span_id: str) -> None:
         self.ids.add((tenant_id, span_id))
+
+    def remember_days(self, provider: str, operation: str, days) -> None:
+        """Model days that have already been billed: the span ids production would find."""
+        for day in days:
+            _, span_id = synthetic_span_id(TENANT, provider, operation, day)
+            self.remember(TENANT, span_id)
+
+
+def days_between(start: date, end: date) -> list[date]:
+    out, day = [], start
+    while day <= end:
+        out.append(day)
+        day += timedelta(days=1)
+    return out
 
 
 class FakeComputeStore:
@@ -135,6 +157,25 @@ class FakeBillingClient:
         if self.error is not None:
             raise self.error
         return [DailyCost(day=start_day, cost_micro_usd=self.micro)]
+
+
+class RangeBillingClient:
+    """Bills every day in the requested window, and remembers the windows it was asked for.
+
+    A real billing API returns one row per day in the range from a single call, which is why the
+    job hands a window to ``run_backfill`` instead of looping ``run()``.
+    """
+
+    def __init__(self, micro: int = 1_000_000) -> None:
+        self.micro = micro
+        self.windows: list[tuple[date, date]] = []
+
+    def get_daily_costs(self, config, *, start_day: date, end_day: date) -> list[DailyCost]:
+        self.windows.append((start_day, end_day))
+        return [
+            DailyCost(day=day, cost_micro_usd=self.micro)
+            for day in days_between(start_day, end_day)
+        ]
 
 
 def compute_config(provider: str = "aws") -> ConnectorConfig:
@@ -352,6 +393,237 @@ def test_all_three_layers_run_for_one_tenant():
     assert compute.runs == [(TENANT, "compute", "success")]
     assert egress.runs == [(TENANT, "cloudflare", "success")]
     assert vercel.runs == [(TENANT, "compute", "success")]
+
+
+def vercel_config_with_gate(emit_egress: bool) -> VercelConfig:
+    return VercelConfig(
+        tenant_id=TENANT,
+        cloud_provider="vercel",
+        credentials_ref="ref",
+        emit_egress=emit_egress,
+    )
+
+
+# --- which days a run covers (CTO-219, finding 1) -----------------------------------------------
+
+
+def test_window_is_yesterday_alone_when_nothing_has_ever_been_billed():
+    # A brand new connector has no last-billed day, so there is no gap to catch up and the job must
+    # not invent a backfill. Deep history stays a job for scripts/backfill_*.py.
+    sink = FakeSpanSink()
+    assert billing_window(sink, TENANT, [("aws", "compute")], newest=DAY) == (DAY, DAY)
+    assert last_billed_day(sink, TENANT, "aws", "compute", newest=DAY) is None
+
+
+def test_window_starts_the_day_after_the_last_day_actually_billed():
+    sink = FakeSpanSink()
+    sink.remember_days("aws", "compute", [DAY - timedelta(days=5)])
+    assert last_billed_day(sink, TENANT, "aws", "compute", newest=DAY) == DAY - timedelta(days=5)
+    assert billing_window(sink, TENANT, [("aws", "compute")], newest=DAY) == (
+        DAY - timedelta(days=4),
+        DAY,
+    )
+
+
+def test_window_takes_the_oldest_last_billed_day_across_a_connectors_series():
+    # Vercel with the gate on emits two series onto one config row; the half that is behind sets
+    # the start, and the half that is ahead just re-covers days the emitter already skips.
+    sink = FakeSpanSink()
+    sink.remember_days("vercel", "compute", [DAY - timedelta(days=1)])
+    sink.remember_days("vercel", "egress", [DAY - timedelta(days=4)])
+    assert billing_window(
+        sink, TENANT, [("vercel", "compute"), ("vercel", "egress")], newest=DAY
+    ) == (DAY - timedelta(days=3), DAY)
+
+
+def test_window_is_capped_at_max_catchup_days():
+    sink = FakeSpanSink()
+    sink.remember_days("aws", "compute", [DAY - timedelta(days=10)])
+    start, end = billing_window(sink, TENANT, [("aws", "compute")], newest=DAY)
+    assert start == DAY - timedelta(days=9)
+    assert len(days_between(start, end)) == MAX_CATCHUP_DAYS
+
+
+def test_a_gap_older_than_the_lookback_window_restarts_at_yesterday():
+    # Dark for longer than the search looks back: bill yesterday and start a fresh chain, rather
+    # than probing unboundedly or trying to bill a quarter of history in one invocation.
+    sink = FakeSpanSink()
+    sink.remember_days("aws", "compute", [DAY - timedelta(days=LOOKBACK_DAYS + 5)])
+    assert billing_window(sink, TENANT, [("aws", "compute")], newest=DAY) == (DAY, DAY)
+
+
+def test_a_gap_over_several_midnights_bills_every_missed_day():
+    # The CTO-215 bug: a run gap spanning two UTC midnights skipped a day forever, because the day
+    # was never asked for again and span_exists means a later run cannot backfill it.
+    sink = FakeSpanSink()
+    sink.remember_days("aws", "compute", [DAY - timedelta(days=5)])
+    compute = FakeComputeStore(compute_config("aws"))
+    client = RangeBillingClient()
+    build_job(sink=sink, compute_store=compute, compute_client=client)(TENANT)
+    # One billing-API call for the whole window, not one per day.
+    assert client.windows == [(DAY - timedelta(days=4), DAY)]
+    assert len(sink.spans) == 5
+    assert compute.runs == [(TENANT, "compute", "success")]
+
+
+def test_a_long_gap_is_capped_and_the_remainder_is_taken_on_the_next_run():
+    sink = FakeSpanSink()
+    sink.remember_days("aws", "compute", [DAY - timedelta(days=10)])
+    compute = FakeComputeStore(compute_config("aws"))
+    client = RangeBillingClient()
+    job = build_job(sink=sink, compute_store=compute, compute_client=client)
+
+    job(TENANT)
+    first_start, first_end = client.windows[0]
+    assert first_start == DAY - timedelta(days=9)
+    assert len(days_between(first_start, first_end)) == MAX_CATCHUP_DAYS
+    assert len(sink.spans) == MAX_CATCHUP_DAYS
+
+    # Production now sees those days as billed; the next run picks up from the new last-billed day
+    # rather than losing the remainder.
+    sink.remember_days("aws", "compute", days_between(first_start, first_end))
+    job(TENANT)
+    assert client.windows[1] == (first_end + timedelta(days=1), DAY)
+    assert len(sink.spans) == 10  # every day of the gap billed exactly once
+
+    # And a third run, fully caught up, asks only for yesterday and inserts nothing new.
+    sink.remember_days("aws", "compute", days_between(first_end + timedelta(days=1), DAY))
+    job(TENANT)
+    assert client.windows[2] == (DAY, DAY)
+    assert len(sink.spans) == 10
+
+
+def test_each_connector_gets_its_own_window():
+    # An egress provider connected yesterday must not be dragged over compute's gap, and vice
+    # versa: each series has its own last-billed day.
+    sink = FakeSpanSink()
+    sink.remember_days("aws", "compute", [DAY - timedelta(days=3)])
+    sink.remember_days("cloudflare", "egress", [DAY - timedelta(days=1)])
+    compute_client = RangeBillingClient()
+    egress_client = RangeBillingClient()
+    build_job(
+        sink=sink,
+        compute_store=FakeComputeStore(compute_config("aws")),
+        egress_store=FakeEgressStore([egress_config("cloudflare")]),
+        compute_client=compute_client,
+        egress_clients={"cloudflare": egress_client},
+    )(TENANT)
+    assert compute_client.windows == [(DAY - timedelta(days=2), DAY)]
+    assert egress_client.windows == [(DAY, DAY)]
+
+
+def test_catch_up_stays_idempotent_over_days_already_billed():
+    # A widened window is the same guarantee applied to more days: the emitter skips any day that
+    # already has a span. Vercel with the gate on is where this actually bites, because its egress
+    # half can be behind its compute half, so the shared window re-covers days compute already has.
+    days = [DAY - timedelta(days=2), DAY - timedelta(days=1), DAY]
+    payload = {
+        "items": [
+            item
+            for day in days
+            for item in (
+                {"date": day.isoformat(), "type": "compute", "amount": "2.00"},
+                {"date": day.isoformat(), "type": "bandwidth", "amount": "1.00"},
+            )
+        ]
+    }
+    sink = FakeSpanSink()
+    sink.remember_days("vercel", "compute", [DAY - timedelta(days=1)])
+    sink.remember_days("vercel", "egress", [DAY - timedelta(days=3)])
+    vercel = FakeVercelStore(vercel_config_with_gate(True))
+    build_job(sink=sink, vercel_store=vercel, vercel_payload=payload)(TENANT)
+    # Six day-slots in the window across the two series, one of which was already billed.
+    assert len(sink.spans) == 5
+
+
+# --- one shared row, one status (CTO-219, finding 2) --------------------------------------------
+
+
+def test_failed_compute_sub_run_does_not_leave_the_vercel_row_reading_success():
+    # The compute sub-run fails and the egress sub-run then succeeds onto the SAME
+    # tenant_vercel_config row. Before CTO-219 the row read 'success' while no compute span had
+    # been emitted: a tenant looking at a healthy connector that was not producing data.
+    calls: list[int] = []
+
+    def flaky(config, start, end):
+        calls.append(1)
+        if len(calls) == 1:  # the compute half fetches first
+            raise RuntimeError("vercel usage 503")
+        return {"items": [{"date": DAY.isoformat(), "type": "bandwidth", "amount": "1.00"}]}
+
+    sink = FakeSpanSink()
+    vercel = FakeVercelStore(vercel_config_with_gate(True))
+    job = CostConnectorJob(
+        None,
+        compute_store=FakeComputeStore(),
+        egress_store=FakeEgressStore(),
+        vercel_store=vercel,
+        store_factory=lambda: sink,
+        usage_client_factory=lambda: VercelUsageClient(http_getter=flaky),
+        now=lambda: NOW,
+    )
+    with pytest.raises(CostConnectorRunError):
+        job(TENANT)
+
+    statuses = [status for _, _, status in vercel.runs]
+    assert "success" not in statuses
+    assert statuses == ["failed"]  # stamped once, with the worst outcome, not the last one
+
+
+def test_failed_egress_sub_run_also_lands_on_the_vercel_row():
+    # The mirror image: compute succeeds, egress fails. The row must still not read success.
+    calls: list[int] = []
+
+    def flaky(config, start, end):
+        calls.append(1)
+        if len(calls) == 1:
+            return {"items": [{"date": DAY.isoformat(), "type": "compute", "amount": "2.00"}]}
+        raise RuntimeError("vercel usage 503")
+
+    sink = FakeSpanSink()
+    vercel = FakeVercelStore(vercel_config_with_gate(True))
+    job = CostConnectorJob(
+        None,
+        compute_store=FakeComputeStore(),
+        egress_store=FakeEgressStore(),
+        vercel_store=vercel,
+        store_factory=lambda: sink,
+        usage_client_factory=lambda: VercelUsageClient(http_getter=flaky),
+        now=lambda: NOW,
+    )
+    with pytest.raises(CostConnectorRunError):
+        job(TENANT)
+    assert [status for _, _, status in vercel.runs] == ["failed"]
+    assert len(sink.spans) == 1  # the compute half still landed
+
+
+def test_gate_off_records_exactly_one_status_as_before():
+    # A tenant with emit_egress=false has only a compute sub-run, and that case is unchanged: one
+    # record_run, with the connector's own outcome.
+    sink = FakeSpanSink()
+    vercel = FakeVercelStore(vercel_config_with_gate(False))
+    build_job(
+        sink=sink,
+        vercel_store=vercel,
+        vercel_payload={
+            "items": [{"date": DAY.isoformat(), "type": "compute", "amount": "2.00"}]
+        },
+    )(TENANT)
+    assert vercel.runs == [(TENANT, "compute", "success")]
+
+
+def test_both_vercel_sub_runs_succeeding_still_records_success_once():
+    payload = {
+        "items": [
+            {"date": DAY.isoformat(), "type": "compute", "amount": "2.00"},
+            {"date": DAY.isoformat(), "type": "bandwidth", "amount": "1.00"},
+        ]
+    }
+    sink = FakeSpanSink()
+    vercel = FakeVercelStore(vercel_config_with_gate(True))
+    build_job(sink=sink, vercel_store=vercel, vercel_payload=payload)(TENANT)
+    assert vercel.runs == [(TENANT, "compute", "success")]
+    assert len(sink.spans) == 2
 
 
 def test_registration_uses_the_stable_job_name_and_a_daily_cadence():


### PR DESCRIPTION
Fixes findings 1 and 2 of the CTO-219 review, both in `infra/gateway/src/gateway/cost_connector_job.py`. Nothing else in the repo is touched; the sibling fixes to `worker_jobs.py` and `scheduler.py` land separately.

## Finding 1: the job stopped losing a day of spend on every run gap

`target_day()` derived the billing day from the wall clock, so a run gap spanning two UTC midnights skipped a day of cloud spend **permanently**. The missed day was never asked for again, and because spans are keyed on `synthetic_span_id(tenant, provider, operation, day)` behind a `span_exists` guard, no later run could backfill what was never fetched. Cadence drift towards midnight makes that routine rather than exotic. The root cause is the wording of CTO-215, not the code that implemented it.

**The new rule.** One invocation bills `[last day actually billed + 1, yesterday]`, inclusive.

Yesterday is still the newest billable day, unchanged and for the original reason: a billing API only reports a day once it has closed, and writing today would freeze a partial number in place under the same idempotency guard.

**Where "the last day actually billed" comes from: the spans.** For each `(provider, operation)` series the job walks back from yesterday, probing the same deterministic `synthetic_span_id` the emitter's guard already checks, and the newest day with a span is the last day billed.

That source was chosen over `tenant_*_config.last_run_at` because:

* it is **authoritative for the question being asked**. The span *is* the billing output for a day: a day with one is billed, a day without one is not. `last_run_at` answers a different question, namely when a RUN happened. A run that failed, was skipped by the `enabled` switch, or covered some other window all stamp it identically, so a day could be marked "handled" that was never billed, which is the exact class of bug this PR is fixing.
* it is **cheap**. Each probe is the tenant-scoped, bloom-filtered `SpanId` point lookup the connectors already run before every insert, at most `LOOKBACK_DAYS` of them per series per day.
* it introduces **no second source of truth**. The job reads the same fact the emitter writes, so the two cannot drift apart. The run-recording ownership split the module was built on (`scheduler_runs` owns "did the schedule fire", `tenant_*_config.last_status` owns "did the connector work") is untouched.

Per-connector windows, not one window for the tenant: an egress provider connected yesterday must not be dragged over a gap that belongs to compute.

**The cap** (`MAX_CATCHUP_DAYS = 7`, documented at the constant and in the module docstring). One invocation covers at most a week of billing days, so a connector broken for three months does not try to bill ninety days in one run and time out. The remainder is not lost: the next run recomputes the last-billed day, which has moved forward by a week, and continues from there, so a long gap closes over consecutive runs. This deliberately does not fight the scheduler, whose `is_due` stays a bool and bounds catch-up at the *schedule* level; the cap is about how many *billing days* one invocation covers.

**The search is bounded too** (`LOOKBACK_DAYS = 14`). Nothing billed within a fortnight means "bill yesterday alone and start a fresh chain", which is the right answer for the two cases indistinguishable from here: a brand new connector, which has no history and should not quietly backfill one, and a long dead one, whose deep history belongs to `scripts/backfill_*.py` that `docs/scheduler-scope.md` keeps for exactly this. It must stay larger than the cap so a gap can be seen far enough back to be closed in instalments.

A multi-day window goes through the connectors' existing `run_backfill(config, start_day, end_day)`, so a gap costs **one** billing-API call, not one per day.

## Finding 2: no more false green on the Vercel row

The Vercel egress sub-run stamped the shared `tenant_vercel_config` row after a **failed** compute sub-run, leaving `last_status = 'success'` on a customer-facing row while no compute span had been emitted. The tenant saw a healthy connector that was not producing data.

The Vercel recorder is now wrapped in `_WorstOfRecorder`: it buffers the sub-run outcomes and stamps the row **once**, with the worst of them, carrying the error message of the sub-run that actually broke rather than of whichever finished last. `success` is only written when every sub-run that actually ran succeeded.

The existing intent is preserved: a tenant with `emit_egress = false` has exactly one sub-run, and the wrapper replays precisely the call that sub-run made, so that path is byte-for-byte unchanged. The wrapper is not a second source of truth either: it forwards to the connector's own recorder and only decides which of two outcomes the one row carries.

## Not weakened

* Idempotency: re-running a day still inserts nothing. A widened window is the same guarantee applied to more days, since the emitter skips any day that already has a span.
* The `emit_egress` double-count gate: still default false, still read by `VercelCostConnector` itself. The job reads the flag only to decide which span *series* to date the window from, never whether to emit.
* One run and one provider-scoped recorder per configured egress provider.
* `JobSkipped` for an unconfigured tenant, and for a paused Vercel-only one.
* A failed fetch records `failed` and emits no span. Never a guessed number.

## Tests

13 new tests in `tests/test_cost_connector_job.py` (762 pass in the gateway suite, up from 749; `ruff check` clean). They cover: a gap over several UTC midnights billing every missed day in one range call; the cap enforced and the remainder taken on the next run; the fresh connector and the older-than-lookback connector both starting at yesterday; per-connector windows; the oldest-of rule across a two-series Vercel run; idempotency across a widened window; a failed compute sub-run leaving the Vercel row not reading `success`, and the mirror case; the gate-off tenant recording exactly one status as before.

## Verified live

On the local docker stack, against real ClickHouse, real Postgres config rows and recorders, and the real scheduler engine with its real advisory locks. The cloud billing API is the only fake, since this machine has no cloud account. Verified from the tables rather than the logs, per CTO-218.

* Second container with `TALLY_SCHEDULER_ENABLED=true` and a 5 second tick: `scheduler_runs` gets `cost_connectors` rows on cadence.
* One scheduler tick with a five day gap seeded (last billed `2026-08-21`, newest billable `2026-08-25`) asked the billing API for exactly `(2026-08-22, 2026-08-25)` and landed all four missed days. Before this change that tick would have billed `2026-08-25` alone and the other three would have been unrecoverable.
* A thirteen day gap billed `2026-08-13..2026-08-19` on the first run and `2026-08-20..2026-08-25` on the second: cap enforced, remainder taken, every day billed exactly once.
* A caught-up tenant asked only for `(2026-08-25, 2026-08-25)` and inserted nothing new.
* A Vercel run whose compute sub-run failed and whose egress sub-run then succeeded left `tenant_vercel_config.last_status = 'failed'` where the row had read `success` beforehand, with the egress span present and no compute span.

`cd web && npm run typecheck && npm run test` is clean apart from the two long-standing `app/api/api.test.ts` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
