### PR TITLE
fix(scheduler): bound shutdown, flush the buffer first, pool the read path

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -368,11 +368,18 @@ async def lifespan(app: FastAPI):
         app.state.models = []
     logger.info("gateway up (require_api_key=%s)", settings.require_api_key)
     yield
-    if app.state.scheduler is not None:
-        # Stopped before the stores close: a job in flight is holding one of them.
-        await app.state.scheduler.stop()
+    # Shutdown order matters (CTO-219). The buffer is flushed FIRST, before anything is allowed to
+    # wait on the scheduler: it holds accepted customer telemetry that is not durable anywhere yet,
+    # while the scheduler holds jobs that are re-run from recorded history on the next tick. Stopping
+    # the scheduler first meant a SIGTERM arriving mid-job blocked the flush behind that job, and the
+    # buffered spans died with the process. Nothing about the flush depends on the scheduler's state.
     if app.state.ingest_buffer is not None:
         await app.state.ingest_buffer.stop()  # flush buffered rows before closing the store
+    if app.state.scheduler is not None:
+        # Still before the stores close, because a job in flight is holding one of them. The wait is
+        # bounded (settings.scheduler_shutdown_timeout_s): a job runs on a thread that cannot be
+        # cancelled, so past the bound it is left to die with the process. See Scheduler.stop.
+        await app.state.scheduler.stop()
     app.state.store.close()
 
 

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -152,6 +152,18 @@ class Settings(BaseSettings):
     # The first failure is not delayed at all; the second waits base, and it doubles to the cap.
     scheduler_backoff_base_s: float = 300.0
     scheduler_backoff_cap_s: float = 6 * 3600.0
+    # CTO-219. How long shutdown WAITS for an in-flight tick before proceeding without it. It bounds
+    # the wait, not the job: a job runs on a worker thread that cannot be cancelled, so past this
+    # point the thread is left to die with the process and its run is not recorded (the next tick
+    # sees the pair as still due). Without a bound, one connector talking to a slow billing API held
+    # the whole deploy open, and with it the ingest buffer's flush. Long enough that a healthy tick
+    # finishes normally, short enough that a rolling deploy never waits on one tenant.
+    scheduler_shutdown_timeout_s: float = 30.0
+    # CTO-219. Idle Postgres sessions the scheduler keeps warm for its state reads, run inserts and
+    # tenant listing, which previously opened one connection per (job, tenant) per tick. Advisory
+    # locks are NOT pooled: each held lock keeps its own dedicated session, because the session is
+    # what makes the lock die with the process. See gateway/scheduler.py.
+    scheduler_db_pool_max_idle: int = 4
 
 
 _settings: Settings | None = None

--- a/infra/gateway/src/gateway/scheduler.py
+++ b/infra/gateway/src/gateway/scheduler.py
@@ -68,6 +68,25 @@ a reaper to get the same property, and a reaper is one more thing that can silen
 A lock-contention skip is NOT a ``skipped`` run and records NO row. See :class:`TickResult` for the
 argument: ``skipped`` settles the cadence window, and settling a window that another replica is at
 this second working on would quietly cost a run.
+
+Shutdown is BOUNDED (CTO-219). The paragraph above about there being no per-job timeout still
+holds: ``asyncio.wait_for`` around a ``to_thread`` cannot kill the thread, so a timeout there would
+report a lie. But "we cannot force-kill the job" is not the same claim as "shutdown must block
+until the job feels like finishing", and the second one is what the original :meth:`Scheduler.stop`
+accidentally implemented. A SIGTERM arriving while a connector is halfway through a slow third
+party held the whole deploy open, and with the old lifespan ordering it also held the ingest
+buffer's flush, so the price of one slow connector was every buffered span in the process. So
+:meth:`Scheduler.stop` now waits a bounded time and then proceeds, leaving the worker thread to die
+with the process. What that abandons is spelled out on :meth:`Scheduler.stop`.
+
+Connections are POOLED on the read path (CTO-219). The first cut opened a fresh Postgres session
+per (job, tenant) per tick for the state read, another per recorded run, and one per tick for the
+tenant list. At five jobs by a few thousand tenants the connection handshakes alone cost more than
+the tick interval, so the loop ran back to back and Postgres forked a backend for each one. The
+state reads, the run inserts and the tenant listing now share a small
+:class:`SchedulerConnectionPool`. The lock path deliberately does NOT: see that class and
+:class:`PostgresAdvisoryLockProvider` for why a pooled connection cannot be allowed anywhere near a
+session-scoped advisory lock.
 """
 
 from __future__ import annotations
@@ -75,8 +94,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Literal, Protocol
@@ -114,6 +135,16 @@ _MIN_TICK_INTERVAL_S = 1.0
 # its own once whatever broke is fixed.
 _DEFAULT_BACKOFF_BASE_S = 300.0
 _DEFAULT_BACKOFF_CAP_S = 6 * 3600.0
+
+# How long a shutdown WAITS for the tick loop before proceeding without it (CTO-219). Generous
+# enough that a healthy tick between tenants finishes normally, short enough that a deploy is never
+# held open by one slow connector. It bounds the wait, not the job: see :meth:`Scheduler.stop`.
+_DEFAULT_SHUTDOWN_TIMEOUT_S = 30.0
+
+# Idle sessions the read path keeps warm. Small on purpose: the tick loop walks (job, tenant) pairs
+# sequentially, so one connection carries almost the whole tick, and the spare capacity is only for
+# the job bodies' own recording overlapping the loop's next read.
+_DEFAULT_POOL_MAX_IDLE = 4
 
 
 def _utcnow() -> datetime:
@@ -290,15 +321,147 @@ class RunStore(Protocol):
     ) -> None: ...
 
 
+class SchedulerConnectionPool:
+    """A small thread-safe pool of Postgres sessions for the scheduler's NON-LOCK path (CTO-219).
+
+    WHY. The first cut opened a connection per call, following ``TenantIntegrationStore``. That is
+    fine for a request handler that opens one; the tick loop opens one per (job, tenant) state read,
+    a second per recorded run, and one more per tick for the tenant list. Five jobs by a few thousand
+    tenants is tens of thousands of connects per tick, and a connect (TCP, TLS, auth, backend fork)
+    costs single-digit milliseconds, so the connection overhead alone exceeded the tick interval and
+    the loop ran back to back doing almost nothing else.
+
+    WHAT THIS POOL MUST NEVER HOLD: an advisory lock. ``pg_advisory_lock`` is scoped to the SESSION,
+    so a pooled connection returned while its lock was still held would hand the next borrower a
+    session that silently owns a lock it knows nothing about, and would release that lock at a
+    moment nobody chose. Worse, it would destroy the property CTO-214 picked advisory locks FOR: the
+    lock dying with the process, with no lease and no reaper. :class:`PostgresAdvisoryLockProvider`
+    therefore keeps its own dedicated session per held lock and never touches this pool.
+
+    That separation is sound rather than merely careful, because the pooled path holds no session
+    state at all: every connection is autocommit, and the only statements run on it are a SELECT
+    aggregate, a tenant listing and a single-row INSERT. No ``SET``, no temp table, no advisory lock,
+    no open transaction between checkouts. A connection is therefore interchangeable between
+    borrowers by construction, which is exactly the thing a lock session is not.
+
+    A connection that errors is discarded rather than returned, so a server-side disconnect cannot
+    be handed to the next borrower.
+    """
+
+    __slots__ = ("_connect", "_closed", "_dsn", "_idle", "_lock", "_max_idle", "_opened")
+
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        max_idle: int = _DEFAULT_POOL_MAX_IDLE,
+        connect: Callable[..., psycopg.Connection] | None = None,
+    ) -> None:
+        self._dsn = dsn
+        self._max_idle = max(1, int(max_idle))
+        self._connect = connect if connect is not None else psycopg.connect
+        self._idle: list[psycopg.Connection] = []
+        self._lock = threading.Lock()
+        self._closed = False
+        self._opened = 0
+
+    @property
+    def opened(self) -> int:
+        """Sessions this pool has opened. The number CTO-219 is about; asserted in the tests."""
+        return self._opened
+
+    @property
+    def idle(self) -> int:
+        return len(self._idle)
+
+    @contextmanager
+    def connection(self) -> Iterator[psycopg.Connection]:
+        """Borrow a session for the length of the block. Returned on success, discarded on error."""
+        conn = self._checkout()
+        try:
+            yield conn
+        except BaseException:
+            _close_quietly(conn)
+            raise
+        self._checkin(conn)
+
+    def _checkout(self) -> psycopg.Connection:
+        while True:
+            with self._lock:
+                conn = self._idle.pop() if self._idle else None
+            if conn is None:
+                break
+            if _connection_is_usable(conn):
+                return conn
+            _close_quietly(conn)
+        # autocommit for the same reason the lock provider uses it: nothing here wants a transaction
+        # spanning statements, and an idle-in-transaction session pins the xmin horizon for nothing.
+        conn = self._connect(self._dsn, autocommit=True)
+        with self._lock:
+            self._opened += 1
+        return conn
+
+    def _checkin(self, conn: psycopg.Connection) -> None:
+        keep = False
+        if _connection_is_usable(conn):
+            with self._lock:
+                if not self._closed and len(self._idle) < self._max_idle:
+                    self._idle.append(conn)
+                    keep = True
+        if not keep:
+            _close_quietly(conn)
+
+    def close(self) -> None:
+        """Drop every idle session. Safe to call twice, and safe to call with borrows outstanding.
+
+        Deliberately NOT a hard shutdown. A bounded stop (CTO-219) can leave a job on a worker
+        thread that is still trying to record its outcome, and killing the connection under it, or
+        refusing it a new one, would turn "the run finished after we stopped waiting" into "the run
+        finished and the history lost it". So a closed pool stops REUSING sessions: a borrow still
+        gets a live connection, and it is closed on return instead of being kept warm.
+        """
+        with self._lock:
+            self._closed = True
+            idle, self._idle = self._idle, []
+        for conn in idle:
+            _close_quietly(conn)
+
+
+def _connection_is_usable(conn: psycopg.Connection) -> bool:
+    """Cheap local check only. A server that went away is caught by the statement failing."""
+    return not (getattr(conn, "closed", False) or getattr(conn, "broken", False))
+
+
+def _close_quietly(conn: psycopg.Connection) -> None:
+    try:
+        conn.close()
+    except Exception:  # noqa: BLE001 - a connection we are throwing away cannot fail usefully
+        pass
+
+
 class SchedulerRunStore:
     """Postgres-backed run history over ``scheduler_runs`` (migration 0027).
 
-    Mirrors :class:`gateway.tenant_integrations.TenantIntegrationStore`: a connection per call,
-    tenant-scoped SQL, and error strings scrubbed before the parameter is bound.
+    Tenant-scoped SQL and error strings scrubbed before the parameter is bound, as
+    :class:`gateway.tenant_integrations.TenantIntegrationStore` does. Unlike that store this one runs
+    on the tick loop's hot path, so its sessions come from a :class:`SchedulerConnectionPool` rather
+    than a fresh connect per call (CTO-219). Nothing here holds session state, which is what makes
+    the sessions interchangeable; see the pool for the full argument, and for why the advisory locks
+    are excluded from it.
     """
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(self, settings: Settings, *, pool: SchedulerConnectionPool | None = None) -> None:
         self._dsn = settings.postgres_dsn
+        # A private pool when nobody supplied one, so constructing the store directly (tests, a
+        # future worker process) still gets the pooling rather than quietly falling back to the
+        # connect-per-call behaviour this ticket removed.
+        self._pool = pool if pool is not None else SchedulerConnectionPool(self._dsn)
+        self._owns_pool = pool is None
+
+    def close(self) -> None:
+        """Release pooled sessions. Only closes a pool this store made for itself."""
+        if self._owns_pool:
+            self._pool.close()
 
     def get_state(self, job_name: str, tenant_id: str) -> JobState:
         """Everything :func:`is_due` needs for one (job, tenant) pair, in one round trip.
@@ -308,7 +471,7 @@ class SchedulerRunStore:
         clearing a counter, so there is no in-memory state to lose on restart or to drift out of
         sync with the history.
         """
-        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+        with self._pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 WITH agg AS (
@@ -357,7 +520,10 @@ class SchedulerRunStore:
     ) -> None:
         """Append one immutable row. Only a ``failed`` run may carry an error, per the CHECK."""
         scrubbed = scrub_error_message(error_message) if status == "failed" else None
-        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+        # No explicit commit: pooled sessions are autocommit, so the row is durable when execute
+        # returns. A run that is not committed before the lock is released is a run another replica
+        # would repeat, which is why record_run happens inside the lock in the first place.
+        with self._pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO scheduler_runs
@@ -366,7 +532,6 @@ class SchedulerRunStore:
                 """,
                 (job_name, tenant_id, started_at, finished_at, status, scrubbed),
             )
-            conn.commit()
 
 
 class PostgresTenantProvider:
@@ -377,11 +542,19 @@ class PostgresTenantProvider:
     "configured" means for it.
     """
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(self, settings: Settings, *, pool: SchedulerConnectionPool | None = None) -> None:
         self._dsn = settings.postgres_dsn
+        # Shares the run store's pool in production (CTO-219). One listing per tick is not the
+        # expensive part, but there is no reason for it to open a session of its own either.
+        self._pool = pool if pool is not None else SchedulerConnectionPool(self._dsn)
+        self._owns_pool = pool is None
+
+    def close(self) -> None:
+        if self._owns_pool:
+            self._pool.close()
 
     def __call__(self) -> Sequence[str]:
-        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+        with self._pool.connection() as conn, conn.cursor() as cur:
             cur.execute("SELECT id::text FROM tenants ORDER BY id")
             return [str(row[0]) for row in cur.fetchall()]
 
@@ -554,6 +727,8 @@ class Scheduler:
         tick_interval_s: float = 300.0,
         backoff_base_s: float = _DEFAULT_BACKOFF_BASE_S,
         backoff_cap_s: float = _DEFAULT_BACKOFF_CAP_S,
+        shutdown_timeout_s: float = _DEFAULT_SHUTDOWN_TIMEOUT_S,
+        db_pool: SchedulerConnectionPool | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         if tick_interval_s < _MIN_TICK_INTERVAL_S:
@@ -565,10 +740,17 @@ class Scheduler:
         self._tick_interval_s = float(tick_interval_s)
         self._backoff_base_s = float(backoff_base_s)
         self._backoff_cap_s = float(backoff_cap_s)
+        self._shutdown_timeout_s = float(shutdown_timeout_s)
+        # Owned by the scheduler only so that :meth:`stop` can drop its idle sessions; the loop
+        # itself never touches it. The stores hold the same pool and are the ones that use it.
+        self._db_pool = db_pool
         self._now = now if now is not None else _utcnow
         self._task: asyncio.Task[None] | None = None
         self._stop: asyncio.Event | None = None
         self._ticks = 0
+        # A tick loop that outlived the shutdown bound. Held so it is not garbage collected into a
+        # confusing "Task was destroyed but it is pending" at interpreter exit (CTO-219).
+        self._abandoned: asyncio.Task[None] | None = None
 
     @property
     def ticks(self) -> int:
@@ -578,6 +760,11 @@ class Scheduler:
     @property
     def running(self) -> bool:
         return self._task is not None
+
+    @property
+    def abandoned(self) -> bool:
+        """Did the last :meth:`stop` give up waiting on a tick? See that method for the cost."""
+        return self._abandoned is not None
 
     @property
     def job_count(self) -> int:
@@ -591,20 +778,71 @@ class Scheduler:
         self._stop = asyncio.Event()
         self._task = asyncio.create_task(self._run(), name="scheduler-tick")
 
-    async def stop(self) -> None:
-        """Signal the loop and wait for the current tick to finish. Never cancels mid-job.
+    async def stop(self, *, timeout_s: float | None = None) -> None:
+        """Signal the loop and wait, for a BOUNDED time, for the current tick to finish.
 
-        Waiting matters: a job is a blocking call on a worker thread that may be halfway through
-        writing spans, and killing the loop out from under it would leave a run with no recorded
-        outcome, which the next tick would read as "never ran". The tick checks the stop event
-        between tenants, so a graceful shutdown costs at most one job's runtime.
+        Waiting at all matters: a job is a blocking call on a worker thread that may be halfway
+        through writing spans, and abandoning it leaves a run with no recorded outcome, which the
+        next tick reads as "never ran". The tick checks the stop event between tenants, so a healthy
+        shutdown costs at most one job's runtime and this returns normally.
+
+        Waiting FOREVER is the bug this fixes (CTO-219). The module docstring is right that
+        ``asyncio.wait_for`` around a ``to_thread`` cannot kill the thread, so a per-job timeout
+        would report a lie. That argument bounds what a timeout can ENFORCE; it does not license
+        holding a deploy open because one connector is talking to a slow billing API. So the wait is
+        bounded and shutdown then proceeds without the loop.
+
+        WHAT AN ABANDONED JOB LEAVES BEHIND, precisely:
+
+        * The worker thread keeps running. Nothing interrupts it, and it dies with the process, so
+          whatever it was part-way through (an HTTP call, an insert) is simply cut off at exit.
+        * Its ``scheduler_runs`` row is most likely never written: recording happens back on the
+          event loop, which stops with the process. The pair therefore keeps its previous history,
+          stays due, and the next replica or the next boot runs it again. For the idempotent daily
+          jobs this schedules that is a repeat, not a corruption, and it is the same failure mode
+          the loop already accepts when ``record_run`` itself fails.
+        * ``record_run`` is a single INSERT, so a job cut off mid-record either committed that row
+          or did not. There is no half-written run.
+        * Its advisory lock releases itself. The lock lives on a dedicated session (see
+          :class:`PostgresAdvisoryLockProvider`) and Postgres drops it when the process dies and the
+          connection goes with it. That is exactly the property CTO-214 chose advisory locks for,
+          and it is why abandoning a job here does not wedge that (job, tenant) pair for anyone.
+
+        The bound is on the WAIT, never on the job. Nothing here claims the job stopped.
         """
-        if self._task is None:
+        task = self._task
+        if task is None:
+            self._close_pool()
             return
         assert self._stop is not None
         self._stop.set()
-        await self._task
+        bound = self._shutdown_timeout_s if timeout_s is None else float(timeout_s)
+        done, _pending = await asyncio.wait({task}, timeout=bound if bound > 0 else None)
         self._task = None
+        if task in done:
+            self._abandoned = None
+            await task  # re-raise anything the loop failed with, as awaiting it always did
+        else:
+            self._abandoned = task
+            # Not logger.exception, and deliberately plain: the gateway configures no logging
+            # (CTO-218), so this is for a future log setup and for a human reading the code. The
+            # observable evidence is the shutdown returning on time and the missing run row.
+            logger.warning(
+                "scheduler: a tick was still running after %.1fs of shutdown; leaving it to die "
+                "with the process. Its run is not recorded, its advisory lock releases with the "
+                "connection, and the next tick will consider the pair due again.",
+                bound,
+            )
+        self._close_pool()
+
+    def _close_pool(self) -> None:
+        """Drop pooled sessions on the way out. Never raises: shutdown has nothing better to do."""
+        if self._db_pool is None:
+            return
+        try:
+            self._db_pool.close()
+        except Exception:  # noqa: BLE001 - a pool we are discarding cannot fail usefully
+            logger.debug("scheduler: closing the connection pool failed")
 
     async def _run(self) -> None:
         assert self._stop is not None
@@ -815,17 +1053,32 @@ def build_scheduler(
     Advisory locking is always on in this path (CTO-214). It needs no flag of its own: it uses the
     same Postgres the run history already requires, and a deployment that wanted it off would be
     asking for the double-counted spend it prevents.
+
+    The run store and the tenant provider share ONE :class:`SchedulerConnectionPool` (CTO-219), so a
+    tick costs a handful of sessions rather than one per (job, tenant) pair. The lock provider is
+    handed no pool at all, on purpose: its sessions are the locks.
     """
+    pool: SchedulerConnectionPool | None = None
+    if run_store is None or tenant_provider is None:
+        pool = SchedulerConnectionPool(
+            settings.postgres_dsn, max_idle=settings.scheduler_db_pool_max_idle
+        )
     return Scheduler(
         registry if registry is not None else JobRegistry(),
-        run_store if run_store is not None else SchedulerRunStore(settings),
-        tenant_provider if tenant_provider is not None else PostgresTenantProvider(settings),
+        run_store if run_store is not None else SchedulerRunStore(settings, pool=pool),
+        (
+            tenant_provider
+            if tenant_provider is not None
+            else PostgresTenantProvider(settings, pool=pool)
+        ),
         lock_provider=(
             lock_provider if lock_provider is not None else PostgresAdvisoryLockProvider(settings)
         ),
         tick_interval_s=settings.scheduler_tick_interval_s,
         backoff_base_s=settings.scheduler_backoff_base_s,
         backoff_cap_s=settings.scheduler_backoff_cap_s,
+        shutdown_timeout_s=settings.scheduler_shutdown_timeout_s,
+        db_pool=pool,
     )
 
 
@@ -843,6 +1096,7 @@ __all__ = [
     "RunStatus",
     "RunStore",
     "Scheduler",
+    "SchedulerConnectionPool",
     "SchedulerRunStore",
     "TenantProvider",
     "TickResult",

--- a/infra/gateway/tests/test_app_shutdown.py
+++ b/infra/gateway/tests/test_app_shutdown.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lifespan shutdown ordering: the ingest buffer is flushed first, whatever the scheduler is doing.
+
+The finding (CTO-219, review item 4a): ``lifespan`` stopped the scheduler BEFORE flushing the
+ingest buffer. A job that was mid-run when SIGTERM arrived held shutdown open, and the buffered
+spans behind it died with the process. The buffer holds accepted customer telemetry that is not
+durable anywhere yet; the scheduler holds work that the next tick re-derives from recorded history.
+So the buffer goes first, and its flush must not be able to queue behind a job at all.
+
+These drive the real ``lifespan`` through ``TestClient`` and substitute the two background objects
+it stops, because what is under test is the ORDER app.py stops things in, not what those two do
+(``test_ingest_buffer.py`` and ``test_scheduler.py`` cover that). The store is faked so no
+ClickHouse is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+from gateway import app as app_module
+from gateway.app import app
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@contextmanager
+def _client(store: FakeStore) -> Iterator[TestClient]:
+    orig_factory = app_module.ClickHouseStore
+    app_module.ClickHouseStore = lambda _settings: store  # type: ignore[assignment]
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app_module.ClickHouseStore = orig_factory  # type: ignore[assignment]
+
+
+class SlowScheduler:
+    """A scheduler with a job in flight: its stop takes a while, exactly as a real one may."""
+
+    def __init__(self, order: list[str], *, delay_s: float = 0.2) -> None:
+        self._order = order
+        self._delay_s = delay_s
+
+    async def stop(self) -> None:
+        self._order.append("scheduler-stop-entered")
+        await asyncio.sleep(self._delay_s)
+        self._order.append("scheduler-stopped")
+
+
+class WedgedScheduler:
+    """A scheduler whose stop never returns. Stands in for one whose bound has been reached."""
+
+    def __init__(self, order: list[str]) -> None:
+        self._order = order
+
+    async def stop(self) -> None:
+        self._order.append("scheduler-stop-entered")
+        await asyncio.sleep(3600)
+
+
+class RecordingBuffer:
+    def __init__(self, order: list[str]) -> None:
+        self._order = order
+        self.flushed = False
+
+    async def stop(self) -> None:
+        self._order.append("buffer-flushed")
+        self.flushed = True
+
+
+def test_the_buffer_is_flushed_before_the_scheduler_is_waited_on():
+    """Ordering, plainly: nothing about the flush is allowed to queue behind a running job."""
+    order: list[str] = []
+    store = FakeStore()
+    buffer = RecordingBuffer(order)
+
+    with _client(store):
+        app.state.scheduler = SlowScheduler(order)
+        app.state.ingest_buffer = buffer
+
+    assert order[0] == "buffer-flushed", f"buffer flushed after the scheduler: {order}"
+    assert order == ["buffer-flushed", "scheduler-stop-entered", "scheduler-stopped"]
+    assert buffer.flushed
+    assert store.closed  # and the store still closes last, after both
+
+
+def test_the_buffer_is_flushed_even_when_the_scheduler_never_stops():
+    """A stop that never returns must not cost the buffered spans. The wedged case, end to end.
+
+    ``WedgedScheduler.stop`` sleeps for an hour, which is what the OLD ordering did to shutdown for
+    real whenever a job was mid-run. The lifespan is driven directly here (rather than through
+    ``TestClient``, which would wait out that hour) with a ceiling on the whole shutdown, and the
+    assertion is that the flush is already done by the time anything waits on the scheduler.
+    """
+    order: list[str] = []
+    store = FakeStore()
+    buffer = RecordingBuffer(order)
+
+    async def run_lifespan() -> None:
+        orig_factory = app_module.ClickHouseStore
+        app_module.ClickHouseStore = lambda _settings: store  # type: ignore[assignment]
+        try:
+            ctx = app_module.lifespan(app)
+            await ctx.__aenter__()
+            app.state.scheduler = WedgedScheduler(order)
+            app.state.ingest_buffer = buffer
+            try:
+                await asyncio.wait_for(ctx.__aexit__(None, None, None), timeout=2.0)
+            except asyncio.TimeoutError:
+                pass  # the wedged scheduler, exactly as intended
+        finally:
+            app_module.ClickHouseStore = orig_factory  # type: ignore[assignment]
+            app.state.scheduler = None
+            app.state.ingest_buffer = None
+
+    asyncio.run(run_lifespan())
+
+    assert buffer.flushed, "the buffer was not flushed while the scheduler was wedged"
+    assert order == ["buffer-flushed", "scheduler-stop-entered"]
+
+
+def test_the_real_scheduler_does_not_hold_the_lifespan_open(monkeypatch):
+    """4a and 4b together: buffer flushed, and shutdown bounded, with a real job mid-run.
+
+    A job wedged on an event is the connector stuck on a slow billing API. The lifespan must exit
+    anyway, and the telemetry must already be safe when it does.
+    """
+    from gateway.scheduler import JobRegistry, JobState, Scheduler
+
+    class MemoryRunStore:
+        def __init__(self) -> None:
+            self.rows: list[tuple[str, str, str]] = []
+
+        def get_state(self, job_name: str, tenant_id: str) -> JobState:
+            return JobState()  # never run, therefore due
+
+        def record_run(self, job_name, tenant_id, status, **kwargs) -> None:
+            self.rows.append((job_name, tenant_id, status))
+
+    order: list[str] = []
+    store = FakeStore()
+    buffer = RecordingBuffer(order)
+    running = threading.Event()
+    release = threading.Event()
+
+    def wedged(_tenant: str) -> None:
+        running.set()
+        # Bounded only so the orphaned thread cannot outlive the test; the scheduler never ends it.
+        release.wait(timeout=10.0)
+
+    registry = JobRegistry()
+    registry.register("wedged-job", 86400.0, wedged)
+    run_store = MemoryRunStore()
+    sched = Scheduler(
+        registry, run_store, lambda: ["t1"], tick_interval_s=1.0, shutdown_timeout_s=0.2
+    )
+
+    async def run_lifespan() -> float:
+        orig_factory = app_module.ClickHouseStore
+        app_module.ClickHouseStore = lambda _settings: store  # type: ignore[assignment]
+        try:
+            ctx = app_module.lifespan(app)
+            await ctx.__aenter__()
+            app.state.scheduler = sched
+            app.state.ingest_buffer = buffer
+            await sched.start()
+            while not running.is_set():
+                await asyncio.sleep(0.01)
+            began = time.monotonic()
+            await ctx.__aexit__(None, None, None)
+            elapsed = time.monotonic() - began
+            release.set()  # let the orphan finish rather than leaving it to the test runner
+            return elapsed
+        finally:
+            app_module.ClickHouseStore = orig_factory  # type: ignore[assignment]
+            app.state.scheduler = None
+            app.state.ingest_buffer = None
+
+    elapsed = asyncio.run(run_lifespan())
+
+    assert elapsed < 5.0, "a job mid-run held the lifespan open"
+    assert buffer.flushed and order[0] == "buffer-flushed"
+    assert sched.abandoned
+    assert run_store.rows == []  # the abandoned run recorded nothing, so the pair stays due
+    assert store.closed

--- a/infra/gateway/tests/test_scheduler.py
+++ b/infra/gateway/tests/test_scheduler.py
@@ -418,3 +418,85 @@ def test_an_empty_registry_is_a_no_op_which_is_all_of_cto_213():
     result = asyncio.run(sched.tick_once())
     assert (result.considered, result.ran) == (0, 0)
     assert store.rows == []
+
+
+# --- bounded shutdown (CTO-219) -------------------------------------------------------------------
+
+
+def test_stop_still_waits_when_the_job_finishes_inside_the_bound():
+    """The bound does not make shutdown impatient. A normal job is waited for and recorded."""
+    store = FakeRunStore()
+    started = threading.Event()
+    registry = JobRegistry()
+
+    def slow(tenant: str) -> None:
+        started.set()
+        time.sleep(0.3)
+
+    registry.register("slow-job", DAY, slow)
+    sched = Scheduler(
+        registry, store, lambda: ["t1"], tick_interval_s=1.0, shutdown_timeout_s=10.0
+    )
+
+    async def drive() -> None:
+        await sched.start()
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+        await sched.stop()
+
+    asyncio.run(drive())
+    assert store.statuses("slow-job", "t1") == ["success"]
+    assert not sched.abandoned  # waited it out, nothing orphaned
+    assert not sched.running
+
+
+def test_stop_is_bounded_when_a_job_will_not_finish():
+    """A SIGTERM must not wait forever on an uncancellable job. THE acceptance case for CTO-219.
+
+    The job here is wedged on an event, standing in for a connector waiting on a slow third-party
+    billing API. ``asyncio.wait_for`` around the ``to_thread`` could not kill that thread and would
+    only report a lie, which is why there is still no per-job timeout. What is bounded is how long
+    SHUTDOWN waits before proceeding without it: the deploy finishes, and the thread dies with the
+    process.
+
+    Note what is asserted about the abandoned run: at the moment stop returns there is no row for
+    the pair. That is the honest cost, and it is safe in the direction that matters, because a pair
+    with no row is a pair the next tick considers due again.
+    """
+    store = FakeRunStore()
+    started = threading.Event()
+    release = threading.Event()
+    registry = JobRegistry()
+
+    def wedged(tenant: str) -> None:
+        started.set()
+        release.wait(timeout=30.0)  # released by the test, never by the scheduler
+
+    registry.register("wedged-job", DAY, wedged)
+    sched = Scheduler(registry, store, lambda: ["t1"], tick_interval_s=1.0, shutdown_timeout_s=0.2)
+
+    async def drive() -> tuple[float, list[str]]:
+        await sched.start()
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+        began = time.monotonic()
+        await sched.stop()
+        elapsed = time.monotonic() - began
+        rows_at_stop = store.statuses("wedged-job", "t1")
+        # Only now, so the orphaned worker thread does not outlive the test process.
+        release.set()
+        return elapsed, rows_at_stop
+
+    elapsed, rows_at_stop = asyncio.run(drive())
+
+    assert elapsed < 5.0, "shutdown waited on a job that was never going to finish"
+    assert sched.abandoned
+    assert not sched.running
+    assert rows_at_stop == []  # the abandoned run is not recorded, so the pair stays due
+
+
+def test_stop_on_a_scheduler_that_never_started_is_a_no_op():
+    store = FakeRunStore()
+    sched = Scheduler(JobRegistry(), store, lambda: ["t1"], tick_interval_s=1.0)
+    asyncio.run(sched.stop())
+    assert not sched.running and not sched.abandoned

--- a/infra/gateway/tests/test_scheduler_pooling.py
+++ b/infra/gateway/tests/test_scheduler_pooling.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Connection pooling on the scheduler's read path, and the lock path staying out of it (CTO-219).
+
+The finding: the scheduler opened one fresh Postgres session per (job, tenant) per tick for the
+state read, another per recorded run, and one per tick for the tenant list. At five jobs by a few
+thousand tenants the connection handshakes alone cost more than the tick interval.
+
+These tests measure that directly rather than asserting on an implementation detail. Every
+connection is opened through a counting factory, so "how many sessions did a tick cost" is a number
+the test can read, and the load-bearing claim is that the number does NOT grow with the tenant
+count.
+
+The second half is the constraint that makes pooling safe to do at all: an advisory lock is scoped
+to its SESSION, so a lock connection can never come from, or go back to, a pool. Those tests pin
+that the lock provider still opens its own dedicated connection per held lock and that the pool
+never sees one.
+
+Most of this needs no Postgres: the connections are fakes that answer the three statements the
+scheduler runs. The last test does, and is skipped without one, exactly as
+``test_scheduler_locking.py`` does: it counts real ``psycopg.connect`` calls against a real server
+for a real tick, because a fake connection cannot prove anything about connection cost. The two
+live tests that matter most to this change are over there and are untouched by it: two runners still
+run a job once, and a lock still dies with its connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from gateway import scheduler as scheduler_module
+from gateway.scheduler import (
+    JobRegistry,
+    PostgresAdvisoryLockProvider,
+    PostgresTenantProvider,
+    Scheduler,
+    SchedulerConnectionPool,
+    SchedulerRunStore,
+)
+
+DAY = 86400.0
+DSN = "postgresql://tally:tally@localhost:5432/tally"
+
+
+class _Settings:
+    """Only what these classes actually read off Settings."""
+
+    postgres_dsn = DSN
+
+
+# --- fake connections ----------------------------------------------------------------------------
+
+
+class FakeCursor:
+    def __init__(self, conn: "FakeConn") -> None:
+        self._conn = conn
+        self._last = ""
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: object = None) -> None:
+        self._last = sql
+        self._conn.factory.statements.append(sql)
+
+    def fetchone(self):
+        if "pg_try_advisory_lock" in self._last:
+            return (self._conn.factory.grant_locks,)
+        if "pg_advisory_unlock" in self._last:
+            return (True,)
+        return (None, None, None, 0)  # never-run state: due immediately
+
+    def fetchall(self):
+        return [(t,) for t in self._conn.factory.tenants]
+
+
+class FakeConn:
+    def __init__(self, factory: "CountingConnect") -> None:
+        self.factory = factory
+        self.closed = False
+        self.broken = False
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def close(self) -> None:
+        self.closed = True
+        self.factory.closed += 1
+
+
+class CountingConnect:
+    """Stands in for ``psycopg.connect`` and counts the sessions actually opened."""
+
+    def __init__(self, tenants: tuple[str, ...] = ("t1",), *, grant_locks: bool = True) -> None:
+        self.opened = 0
+        self.closed = 0
+        self.live: list[FakeConn] = []
+        self.statements: list[str] = []
+        self.tenants = tenants
+        self.grant_locks = grant_locks
+        self._lock = threading.Lock()
+
+    def __call__(self, dsn: str, **kwargs: object) -> FakeConn:
+        with self._lock:
+            self.opened += 1
+        conn = FakeConn(self)
+        self.live.append(conn)
+        return conn
+
+
+def _tick(tenants: tuple[str, ...], *, jobs: int = 2, max_idle: int = 4) -> CountingConnect:
+    """One full tick over ``jobs`` x ``tenants`` with everything pooled. Returns the counter."""
+    connect = CountingConnect(tenants)
+    pool = SchedulerConnectionPool(DSN, max_idle=max_idle, connect=connect)
+    registry = JobRegistry()
+    for i in range(jobs):
+        registry.register(f"job-{i}", DAY, lambda _tenant: None)
+    sched = Scheduler(
+        registry,
+        SchedulerRunStore(_Settings(), pool=pool),
+        PostgresTenantProvider(_Settings(), pool=pool),
+        tick_interval_s=60.0,
+        db_pool=pool,
+    )
+    result = asyncio.run(sched.tick_once())
+    assert result.ran == jobs * len(tenants), "the tick did not do the work being measured"
+    return connect
+
+
+# --- how many sessions a tick costs ---------------------------------------------------------------
+
+
+def test_a_tick_does_not_open_a_connection_per_job_per_tenant():
+    """The finding, measured: 100 pairs used to mean hundreds of connects. Now it is a handful."""
+    tenants = tuple(f"t{i}" for i in range(50))
+    connect = _tick(tenants, jobs=2)
+
+    # 100 pairs: a state read, a re-read under the lock, and a recorded run each, plus the listing.
+    assert len(connect.statements) >= 300, "expected the per-pair queries to have actually run"
+    assert connect.opened <= 4, f"a tick opened {connect.opened} sessions for 100 pairs"
+
+
+def test_connection_count_does_not_grow_with_the_tenant_count():
+    """The property that matters. Ten tenants and four hundred cost the same in sessions.
+
+    This is what makes the tick interval a real interval again: connection overhead no longer
+    scales with the population, so the loop is not spending its whole cadence on handshakes.
+    """
+    small = _tick(tuple(f"t{i}" for i in range(10)))
+    large = _tick(tuple(f"t{i}" for i in range(200)))
+
+    assert large.opened == small.opened
+    assert len(large.statements) > 20 * small.opened  # the work grew; the sessions did not
+
+
+def test_a_pooled_session_is_reused_rather_than_reopened():
+    connect = CountingConnect()
+    pool = SchedulerConnectionPool(DSN, connect=connect)
+    store = SchedulerRunStore(_Settings(), pool=pool)
+
+    for _ in range(25):
+        store.get_state("job-a", "t1")
+
+    assert connect.opened == 1
+    assert pool.idle == 1
+
+
+# --- the pool's hygiene ---------------------------------------------------------------------------
+
+
+def test_a_broken_session_is_discarded_not_handed_on():
+    """A server-side disconnect must not become the next borrower's problem."""
+    connect = CountingConnect()
+    pool = SchedulerConnectionPool(DSN, connect=connect)
+
+    with pool.connection() as conn:
+        first = conn
+    first.broken = True  # the server went away while it sat idle
+
+    with pool.connection() as conn:
+        assert conn is not first
+    assert connect.opened == 2
+    assert first.closed
+
+
+def test_a_failed_statement_discards_its_session():
+    connect = CountingConnect()
+    pool = SchedulerConnectionPool(DSN, connect=connect)
+
+    with pytest.raises(RuntimeError):
+        with pool.connection() as conn:
+            borrowed = conn
+            raise RuntimeError("query blew up")
+
+    assert borrowed.closed
+    assert pool.idle == 0
+
+
+def test_a_closed_pool_still_serves_a_borrow_but_keeps_nothing_warm():
+    """Shutdown closes the pool while an abandoned job may still be recording its run (CTO-219).
+
+    Refusing that borrow would turn "the run finished after we stopped waiting" into "the run
+    finished and the history lost it", so a closed pool only stops REUSING sessions.
+    """
+    connect = CountingConnect()
+    pool = SchedulerConnectionPool(DSN, connect=connect)
+    with pool.connection():
+        pass
+    assert pool.idle == 1
+
+    pool.close()
+    assert pool.idle == 0
+    pool.close()  # idempotent
+
+    with pool.connection() as conn:
+        late = conn
+        assert not late.closed, "a closed pool refused a borrow an in-flight job still needed"
+    assert late.closed, "a closed pool kept the session alive after the borrow"
+    assert pool.idle == 0, "a closed pool kept a session warm"
+
+
+def test_stopping_the_scheduler_closes_its_pool():
+    connect = CountingConnect()
+    pool = SchedulerConnectionPool(DSN, connect=connect)
+    store = SchedulerRunStore(_Settings(), pool=pool)
+    store.get_state("job-a", "t1")
+    assert pool.idle == 1
+
+    sched = Scheduler(
+        JobRegistry(), store, lambda: ["t1"], tick_interval_s=60.0, db_pool=pool
+    )
+    asyncio.run(sched.stop())  # never started: still tidies up the sessions
+
+    assert pool.idle == 0
+    assert connect.closed >= 1
+
+
+# --- the constraint: locks are never pooled --------------------------------------------------------
+
+
+def test_the_lock_provider_opens_its_own_session_per_lock(monkeypatch):
+    """NOT NEGOTIABLE. The lock is the session, so it can never come from a pool.
+
+    A pooled connection returned while its advisory lock was still held would hand the next
+    borrower a session silently owning a lock, and would release that lock at a moment nobody
+    chose. It would also destroy the reason CTO-214 chose advisory locks: the lock dying with the
+    process, no lease, no reaper. So the provider connects for itself, every time.
+    """
+    connect = CountingConnect()
+    monkeypatch.setattr(scheduler_module.psycopg, "connect", connect)
+    pool = SchedulerConnectionPool(DSN, connect=CountingConnect())
+    provider = PostgresAdvisoryLockProvider(_Settings())
+
+    handles = [provider.acquire("job-a", f"t{i}") for i in range(3)]
+
+    assert all(h is not None for h in handles)
+    assert connect.opened == 3, "held locks shared a session"
+    assert pool.opened == 0, "a lock session came from the read pool"
+    assert len({id(h._conn) for h in handles}) == 3  # noqa: SLF001 - the point of the assertion
+
+    for handle in handles:
+        handle.release()
+    assert connect.closed == 3, "a lock session outlived its lock instead of being closed"
+
+
+def test_a_released_lock_session_is_not_returned_to_the_pool(monkeypatch):
+    """Release closes the session outright. Nothing about a lock ever reaches the pool's idle list."""
+    connect = CountingConnect()
+    monkeypatch.setattr(scheduler_module.psycopg, "connect", connect)
+    pool = SchedulerConnectionPool(DSN, connect=connect)
+    provider = PostgresAdvisoryLockProvider(_Settings())
+
+    handle = provider.acquire("job-a", "t1")
+    assert handle is not None
+    handle.release()
+
+    assert pool.idle == 0
+    assert connect.live[0].closed
+
+
+def test_a_contended_lock_closes_its_session_immediately(monkeypatch):
+    """A refused lock must not leak the session it asked with, pooled or otherwise."""
+    connect = CountingConnect(grant_locks=False)
+    monkeypatch.setattr(scheduler_module.psycopg, "connect", connect)
+    provider = PostgresAdvisoryLockProvider(_Settings())
+
+    assert provider.acquire("job-a", "t1") is None
+    assert connect.closed == 1
+
+
+# --- against a real Postgres ----------------------------------------------------------------------
+
+
+def _live_dsn_or_skip() -> str:
+    """The live DSN, or skip. Same posture as ``test_scheduler_locking.py``: CI has no Postgres."""
+    import os
+
+    dsn = os.environ.get("TALLY_TEST_POSTGRES_DSN", DSN)
+    psycopg = pytest.importorskip("psycopg")
+    try:
+        with psycopg.connect(dsn, connect_timeout=2) as conn, conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('scheduler_runs')")
+            row = cur.fetchone()
+    except Exception as exc:  # noqa: BLE001 - no database here is a skip, not a failure
+        pytest.skip(f"no Postgres at {dsn}: {type(exc).__name__}: {exc}")
+    if row is None or row[0] is None:
+        pytest.skip("scheduler_runs is missing; apply db/postgres/0027_scheduler_runs.sql")
+    return dsn
+
+
+class _LiveSettings:
+    def __init__(self, dsn: str) -> None:
+        self.postgres_dsn = dsn
+
+
+def test_live_a_tick_over_many_tenants_opens_a_handful_of_sessions():
+    """The measurement that matters, against a real server: real connects, counted.
+
+    Twenty-five tenants means twenty-five state reads, twenty-five re-reads under the lock and
+    twenty-five recorded runs on the pooled path. Before CTO-219 that was seventy-five connects
+    (plus one per lock). The pool's own counter is the instrument, and it counts real
+    ``psycopg.connect`` calls to a real Postgres.
+
+    The advisory-lock sessions are NOT in this number, and must not be: they are still one dedicated
+    session per held lock, which is what makes a lock die with the process.
+    """
+    import uuid
+
+    import psycopg
+
+    dsn = _live_dsn_or_skip()
+    job_name = f"test-pool-{uuid.uuid4().hex[:12]}"
+    tenants = [f"tenant-{uuid.uuid4().hex[:8]}" for _ in range(25)]
+    pool = SchedulerConnectionPool(dsn, max_idle=4)
+    registry = JobRegistry()
+    registry.register(job_name, DAY, lambda _tenant: None)
+    sched = Scheduler(
+        registry,
+        SchedulerRunStore(_LiveSettings(dsn), pool=pool),
+        lambda: list(tenants),
+        lock_provider=PostgresAdvisoryLockProvider(_LiveSettings(dsn)),
+        tick_interval_s=60.0,
+        db_pool=pool,
+    )
+    try:
+        result = asyncio.run(sched.tick_once())
+        assert result.ran == 25 and result.succeeded == 25
+        assert pool.opened <= 4, f"{pool.opened} sessions for 25 tenants; pooling is not working"
+
+        with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM scheduler_runs WHERE job_name = %s", (job_name,))
+            recorded = cur.fetchone()[0]
+        assert recorded == 25, "pooled autocommit sessions did not durably record every run"
+    finally:
+        pool.close()
+        with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute("DELETE FROM scheduler_runs WHERE job_name = %s", (job_name,))
+            conn.commit()


### PR DESCRIPTION
Review findings 4 and 7 on the scheduler (CTO-219). Two problems, one theme: a SIGTERM used to cost more than it should, and a tick used to cost more than it should.

## Finding 4a: the buffer flush queued behind a running job

`lifespan` stopped the scheduler before flushing the ingest buffer, so a job that was mid-run when SIGTERM arrived held shutdown open and the buffered spans went with the process.

The two things being stopped are not equally recoverable. The ingest buffer holds accepted customer telemetry that is not durable anywhere yet; the scheduler holds work that the next tick re-derives from recorded history. So the buffer is flushed first, and nothing about that flush now depends on what the scheduler is doing. The store still closes last, after both.

## Finding 4b: the shutdown wait was unbounded

`Scheduler.stop()` waited without a bound on a job running inside `asyncio.to_thread`.

The module's existing reasoning from S1 is correct and is untouched: `wait_for` around a `to_thread` abandons the coroutine but cannot kill the thread, so a per-job timeout would report "timed out" while the job kept running and writing. There is still no per-job timeout.

What that argument bounds is what a timeout can *enforce*. It never licensed holding a deploy open. So the WAIT is bounded (`scheduler_shutdown_timeout_s`, default 30s): past it, shutdown proceeds and the thread is left to die with the process, with a plain log line saying so.

### What an abandoned job leaves behind

- **A worker thread**, still running. Nothing interrupts it; whatever it was part-way through is cut off at process exit.
- **No `scheduler_runs` row**, in the usual case. Recording happens back on the event loop, which stops with the process. The pair keeps its previous history, stays due, and is run again on the next tick or the next boot. For the idempotent daily jobs this schedules that is a repeat, not a corruption, and it is the same failure mode the loop already accepts when `record_run` itself fails. It fails in the safe direction: a pair with no row is a pair someone runs again, never a window silently settled.
- **No half-written run.** `record_run` is a single INSERT, so a job cut off mid-record either committed that row or did not.
- **No stuck lock.** The advisory lock lives on a dedicated session, and Postgres drops it when the process dies and the connection goes with it. No lease, no reaper, nothing to notice the death. That is precisely the property CTO-214 chose advisory locks for, and it is why abandoning a job here does not wedge that (job, tenant) pair for the other replicas.

## Finding 7: a connection per (job, tenant) per tick

The tick opened a fresh Postgres session per (job, tenant) for the state read, another per recorded run, and one per tick for the tenant list. At five jobs by a few thousand tenants the handshakes alone cost more than the tick interval, so the loop ran back to back and Postgres forked a backend for each one.

The state reads, run inserts and tenant listing now share a small `SchedulerConnectionPool`.

### How this keeps the lock session property

It keeps it by never going near it. `PostgresAdvisoryLockProvider` still opens its own dedicated connection per held lock and does not touch the pool. A pooled connection returned while its lock was still held would hand the next borrower a session that silently owns a lock, would release that lock at a moment nobody chose, and would turn "the lock dies with the process" into "the lock dies whenever the pool feels like it".

The separation is sound rather than merely careful, because the pooled path holds no session state at all: autocommit, and the only statements on it are one SELECT aggregate, one tenant listing and one single-row INSERT. No `SET`, no temp table, no advisory lock, no transaction spanning checkouts. Those sessions are interchangeable between borrowers by construction, which is exactly the thing a lock session is not. A connection that errors is discarded rather than returned.

`JobRegistry` and the job callables are untouched and stay free of FastAPI and `app.state`; the pool lives in `scheduler.py` and is constructed in `build_scheduler`, so the worker-extraction seam is intact.

## Not weakened

`is_due` and `backoff_delay_s` are still pure functions of recorded history plus the clock with nothing surviving a tick in memory; the lock key is still the BLAKE2b personalised, length-prefixed, single-bigint hash (the `pg_locks.objsubid = 1` test still pins it); still read state, take lock, re-read state, run; still `record_run` before release; contention still writes a counter and no row; still the three statuses with `skipped` settling the window.

## Verification

- `uv run --extra dev pytest -q` in `infra/gateway`: 765 passed (749 before, plus 16 new). `ruff check .` clean.
- The S2 live locking tests still pass against a real Postgres, including two runners running the job exactly once and a lock dying with a terminated backend.
- **Connection count, measured live.** A real tick over 25 tenants against a real Postgres opens at most 4 sessions where it previously opened 75, and all 25 runs are recorded. Unit tests with a counting connect factory show a 100-pair tick opening at most 4 sessions, and that the count does not grow between 10 tenants and 200.
- **Shutdown, measured live.** A real gateway process with the scheduler on and a deliberately wedged job (registered without touching `cost_connector_job.py` or `worker_jobs.py`), SIGTERMed with 200 buffered spans in memory: shutdown completed in **5.32s against a 5.0s bound**, and all 200 spans were in ClickHouse afterwards.
- `web`: `npm run typecheck` clean, `npm run test` has only the 2 long-standing `app/api/api.test.ts` failures.
- Per CTO-218 the gateway configures no logging, so the live checks above were read from timings and from the `otel_spans` / `scheduler_runs` tables, not from container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
