### PR TITLE
fix(gateway): bound the reconciler scan, size ingest timeouts per provider, add an ingest cursor

### DIFF
--- a/db/postgres/0028_tenant_ingest_cursors.sql
+++ b/db/postgres/0028_tenant_ingest_cursors.sql
@@ -1,0 +1,50 @@
+-- Incremental ingest cursors for the Segment / HubSpot / Pendo workers (CTO-219).
+--
+-- WHY this table exists. The scheduled ingest workers (CTO-216) had no cursor, so every cycle asked
+-- the provider for its whole default payload: 96 identical pulls a day for Segment and HubSpot, 48
+-- for Pendo. This table is the per-tenant per-integration watermark that turns each cycle into
+-- "give me what is new since X".
+--
+-- WHAT THIS IS NOT FIXING, precisely, because the cost was overstated when it was first written up.
+-- Re-sending the same payload did NOT corrupt data. `BusinessEventId` is the PROVIDER's stable id
+-- (Segment `messageId`, Stripe event `id`, HubSpot `eventId`; Pendo has none, so the mapper builds a
+-- deterministic (feature, hashed visitor) id), and `business_events` is
+-- `ReplacingMergeTree(IngestedAt) ORDER BY (TenantId, BusinessEventId)`, so re-insertion of the same
+-- event collapses to one row by design. The real costs are narrower and both real:
+--
+--   * Write amplification. Every cycle re-inserts every event in the provider's window, and every
+--     one of those rows is stored, merged and then discarded by the background merge.
+--   * A transient pre-merge double count. Between the insert and the merge that collapses it, a
+--     read WITHOUT `FINAL` sees the same event more than once. Only 2 of the 12 `business_events`
+--     reads in `web/lib/clickhouse.ts` use `FINAL`, so most surfaces are exposed to that window.
+--
+-- SHAPE. Follows `bq_export_watermarks` (0010), which is the existing precedent for a per-tenant
+-- incremental cursor in this control plane: one row per (tenant, source), a timestamp high-water
+-- mark, and a missing row meaning "never run". A missing row is NOT "fetch all history": the worker
+-- floors a first run at a bounded initial window (see gateway.ingest_cursors), because a tenant
+-- connecting Segment for the first time should not trigger an unbounded backfill on a 15-minute
+-- cadence.
+--
+-- The cursor is deliberately BEHIND the last event seen by a per-connector overlap (Pendo's is the
+-- largest, because its aggregation API is documented at ~5 minutes of latency). Re-fetching that
+-- overlap every cycle is safe precisely because of the ReplacingMergeTree dedup above, and losing an
+-- event that the provider had not aggregated yet would not be.
+--
+-- Migration is additive and every existing deployment has zero rows, which reads as "no tenant has
+-- ever run an incremental cycle" and is true: nothing scheduled these workers before CTO-216, and
+-- the scheduler itself is still opt-in behind TALLY_SCHEDULER_ENABLED.
+
+CREATE TABLE IF NOT EXISTS tenant_ingest_cursors (
+    tenant_id    TEXT NOT NULL CHECK (length(tenant_id) > 0),
+    connector_id TEXT NOT NULL
+                     CHECK (connector_id IN ('segment', 'hubspot', 'pendo')),
+    -- High-water mark: the next cycle asks the provider for events at or after this instant.
+    cursor_at    TIMESTAMPTZ NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, connector_id)
+);
+
+-- tenant_id is TEXT with no FK to tenants, matching scheduler_runs (0027) and reconciliation_runs
+-- (0008). A cursor that outlives its tenant row is harmless (nothing reads it), whereas a cascade
+-- during a cycle would delete the cursor out from under a run in flight and silently turn the next
+-- cycle into a full initial-window pull.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -92,6 +92,9 @@ services:
       # Scheduler run history (CTO-213). The tick loop answers "is this job due for this
       # tenant" from this table rather than from a sleeping coroutine, so it survives restarts.
       - ../db/postgres/0027_scheduler_runs.sql:/docker-entrypoint-initdb.d/0027_scheduler_runs.sql:ro
+      # Incremental ingest cursors (CTO-219). Without these every Segment / HubSpot / Pendo cycle
+      # re-pulls the provider's whole window, 96 times a day per tenant per connector.
+      - ../db/postgres/0028_tenant_ingest_cursors.sql:/docker-entrypoint-initdb.d/0028_tenant_ingest_cursors.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/hubspot_ingest.py
+++ b/infra/gateway/src/gateway/hubspot_ingest.py
@@ -37,6 +37,7 @@ from tally.wire import BusinessEvent
 
 from gateway.integration_workers import (
     IngestOutcome,
+    IngestWindow,
     IngestWorker,
     as_event_list,
     build_hasher,
@@ -137,12 +138,23 @@ class HubSpotWorker(IngestWorker):
     connector_id = "hubspot"
 
     def _ingest(
-        self, tenant_id: str, secret: IntegrationSecret, token: str
+        self, tenant_id: str, secret: IntegrationSecret, token: str, window: IngestWindow
     ) -> IngestOutcome:
         base = str(secret.config.get("base_url") or DEFAULT_HUBSPOT_BASE).rstrip("/")
         url = base + HUBSPOT_EVENTS_PATH
         headers = {"Authorization": f"Bearer {token}"}
-        payload = self._http.get_json(url, headers=headers)
+        # CTO-219: incremental. HubSpot timestamps are epoch milliseconds throughout (the mapper
+        # already reads occurredAt that way), so the window goes out in the same units. Like the
+        # endpoint path above the exact parameter spelling is a deployment detail; what this ticket
+        # pins down is that a cycle asks for a bounded window, not the provider's default payload.
+        payload = self._http.get_json(
+            url,
+            headers=headers,
+            params={
+                "occurredAfter": str(window.since_ms()),
+                "occurredBefore": str(window.until_ms()),
+            },
+        )
 
         hasher = build_hasher(self._registry, tenant_id)
         linker = self._account_linker

--- a/infra/gateway/src/gateway/ingest_cursors.py
+++ b/infra/gateway/src/gateway/ingest_cursors.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-tenant, per-integration ingest watermarks (CTO-219).
+
+WHY this exists. :meth:`gateway.integration_workers.IngestWorker.run_cycle` had no cursor, so a
+15-minute cadence asked Segment and HubSpot for the provider's whole default payload 96 times a day
+and Pendo's 48 times. This module is the watermark that makes each cycle ask only for what is new.
+
+WHAT THE COST ACTUALLY WAS, stated accurately. Re-sending the same events did not corrupt anything.
+``BusinessEventId`` is the provider's own stable id and ``business_events`` is
+``ReplacingMergeTree(IngestedAt) ORDER BY (TenantId, BusinessEventId)``, so re-insertion of an event
+already present collapses to one row by design. The genuine costs are write amplification (every
+cycle re-inserts every event in the window, and the background merge then throws the duplicates
+away) and a transient pre-merge double count on the read paths that do not use ``FINAL``, which is
+10 of the 12 ``business_events`` reads in ``web/lib/clickhouse.ts``. Both are worth fixing. Neither
+is data loss, and this module should not be described as fixing one.
+
+THE WINDOW. Each cycle asks for ``[since, until]`` where ``until`` is the moment the cycle started
+and ``since`` is the stored cursor. Afterwards the cursor advances to ``until`` minus a
+per-connector OVERLAP, never backwards. The overlap is the whole reason this is safe:
+
+* A provider that has not yet aggregated an event when we ask for it would otherwise lose that event
+  forever, because the next cycle would start after it. Pendo documents roughly five minutes of
+  aggregation latency, which is precisely the number the 30-minute Pendo cadence in
+  :mod:`gateway.worker_jobs` was chosen against, so Pendo's overlap is sized above it.
+* Re-fetching the overlap costs nothing but bandwidth, because re-insertion is idempotent (above).
+
+So the trade is deliberately asymmetric: a little duplicated fetch, never a dropped event.
+
+A FIRST RUN with no cursor is floored at :data:`INITIAL_LOOKBACK_S`, not at "all history". A tenant
+who connects Segment for the first time should get a bounded, useful initial window on a 15-minute
+cadence, not an unbounded backfill that times out and then retries every 15 minutes forever. A real
+historical backfill is a different operation with a different shape (see ``scripts/backfill_*.py``
+for the connectors' equivalent) and it does not belong on a cadence.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+import psycopg
+
+from gateway.config import Settings
+
+logger = logging.getLogger("tally.gateway.ingest_cursors")
+
+#: The connectors this table serves. Must stay in lockstep with the CHECK constraint in
+#: ``0028_tenant_ingest_cursors.sql``.
+ALLOWED_CURSOR_CONNECTORS: frozenset[str] = frozenset({"segment", "hubspot", "pendo"})
+
+#: How far back a FIRST cycle reaches when no cursor exists. Seven days: wide enough that a tenant
+#: who connects a source sees something immediately and that a gateway down for a long weekend
+#: catches up in one cycle, narrow enough that the pull is one bounded request rather than a
+#: backfill. Every subsequent cycle asks for roughly one cadence plus one overlap.
+INITIAL_LOOKBACK_S = 7 * 24 * 3600.0
+
+#: Per-connector overlap, in seconds: how far BEHIND the end of a cycle's window its cursor is left.
+#: Sized to each provider's own lateness, not to a single global guess.
+#:
+#: * ``pendo``   600s. Pendo's aggregation API is documented at roughly five minutes of latency, so
+#:   anything under that drops events that simply had not been aggregated when we asked. Ten minutes
+#:   is that documented figure with the same doubling of slack the cadence comment applies.
+#: * ``segment`` / ``hubspot``  120s. Both deliver into their event APIs promptly; two minutes
+#:   covers clock skew between us and them plus ordinary delivery jitter.
+CURSOR_OVERLAP_S: dict[str, float] = {
+    "segment": 120.0,
+    "hubspot": 120.0,
+    "pendo": 600.0,
+}
+DEFAULT_CURSOR_OVERLAP_S = 120.0
+
+
+class CursorStore(Protocol):
+    """What :class:`~gateway.integration_workers.IngestWorker` needs from a cursor store.
+
+    A Protocol so a worker can be driven in tests with an in-memory dict and no Postgres, the same
+    way every other collaborator on that class already is.
+    """
+
+    def get(self, tenant_id: str, connector_id: str) -> datetime | None: ...
+
+    def advance(self, tenant_id: str, connector_id: str, cursor_at: datetime) -> datetime: ...
+
+
+class IngestCursorStore:
+    """Postgres-backed watermark over ``tenant_ingest_cursors`` (migration 0028).
+
+    Mirrors :class:`gateway.tenant_integrations.TenantIntegrationStore`: a connection per call and
+    tenant-scoped SQL, so a buggy caller cannot cross tenants.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str, connector_id: str) -> datetime | None:
+        """The stored watermark, or ``None`` for "this pair has never run".
+
+        ``None`` is the honest first-run state and the caller floors it at
+        :data:`INITIAL_LOOKBACK_S`; it must never be read as "fetch everything".
+        """
+        if connector_id not in ALLOWED_CURSOR_CONNECTORS:
+            raise ValueError(f"unknown connector_id '{connector_id}'")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cursor_at FROM tenant_ingest_cursors
+                WHERE tenant_id = %s AND connector_id = %s
+                """,
+                (tenant_id, connector_id),
+            )
+            row = cur.fetchone()
+        return None if row is None else _as_utc(row[0])
+
+    def advance(self, tenant_id: str, connector_id: str, cursor_at: datetime) -> datetime:
+        """Move the watermark forward. Returns what the row holds AFTER the write.
+
+        MONOTONIC by construction: the upsert takes ``greatest(existing, proposed)``, so a cycle
+        that computes an earlier watermark than one already stored (a clock skew between replicas,
+        or a retry of an older window) cannot rewind the cursor and cause the next cycle to re-pull
+        a window that was already handled. Rewinding would be safe for correctness, since
+        re-insertion is idempotent, but it would silently undo the write amplification fix, which is
+        the entire point of the table.
+        """
+        if connector_id not in ALLOWED_CURSOR_CONNECTORS:
+            raise ValueError(f"unknown connector_id '{connector_id}'")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO tenant_ingest_cursors (tenant_id, connector_id, cursor_at)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (tenant_id, connector_id) DO UPDATE
+                  SET cursor_at = greatest(tenant_ingest_cursors.cursor_at, EXCLUDED.cursor_at),
+                      updated_at = now()
+                RETURNING cursor_at
+                """,
+                (tenant_id, connector_id, _as_utc(cursor_at)),
+            )
+            row = cur.fetchone()
+            conn.commit()
+        assert row is not None
+        return _as_utc(row[0])
+
+
+class NullCursorStore:
+    """The no-cursor fallback: always "never run", and every advance is dropped.
+
+    Exists so an :class:`~gateway.integration_workers.IngestWorker` constructed without a store (a
+    unit test of a mapper, say) still works. It is NOT the production path: with this store every
+    cycle re-pulls the initial window, which is the pre-CTO-219 behaviour and is why
+    :func:`gateway.worker_jobs.register_worker_jobs` builds a real
+    :class:`IngestCursorStore` by default.
+    """
+
+    __slots__ = ()
+
+    def get(self, tenant_id: str, connector_id: str) -> datetime | None:
+        return None
+
+    def advance(self, tenant_id: str, connector_id: str, cursor_at: datetime) -> datetime:
+        return cursor_at
+
+
+def overlap_for(connector_id: str) -> float:
+    """Per-connector cursor overlap in seconds. See :data:`CURSOR_OVERLAP_S`."""
+    return CURSOR_OVERLAP_S.get(connector_id, DEFAULT_CURSOR_OVERLAP_S)
+
+
+def next_cursor(connector_id: str, window_end: datetime) -> datetime:
+    """Where the cursor lands after a cycle whose window ended at ``window_end``.
+
+    ``window_end`` minus this connector's overlap, so the next cycle re-asks for the tail the
+    provider may not have aggregated yet. See the module docstring for why that is the safe
+    direction to be wrong in.
+    """
+    return _as_utc(window_end) - timedelta(seconds=overlap_for(connector_id))
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(
+        timezone.utc
+    )
+
+
+__all__ = [
+    "ALLOWED_CURSOR_CONNECTORS",
+    "CURSOR_OVERLAP_S",
+    "DEFAULT_CURSOR_OVERLAP_S",
+    "INITIAL_LOOKBACK_S",
+    "CursorStore",
+    "IngestCursorStore",
+    "NullCursorStore",
+    "next_cursor",
+    "overlap_for",
+]

--- a/infra/gateway/src/gateway/integration_workers.py
+++ b/infra/gateway/src/gateway/integration_workers.py
@@ -8,10 +8,16 @@ the outcome via :meth:`TenantIntegrationStore.record_run`.
 This module holds what all three share:
 
 * :class:`HttpClient` — the injectable transport Protocol (one ``get_json`` method).
-* :class:`IngestWorker` — the base that owns credential resolution, the ClickHouse writes' error
-  boundary, and the ``record_run`` bookkeeping (with PII-scrubbed errors and honest
-  success / partial / failed / skipped status), so each connector only describes its own fetch +
-  mapping in :meth:`IngestWorker._ingest`.
+* :class:`IngestWorker`, the base that owns credential resolution, the incremental window, the
+  ClickHouse writes' error boundary, and the ``record_run`` bookkeeping (with PII-scrubbed errors
+  and honest success / partial / failed / skipped status), so each connector only describes its own
+  fetch + mapping in :meth:`IngestWorker._ingest`.
+* :data:`CONNECTOR_TIMEOUT_S`, the per-provider HTTP timeout. One global default cannot be right
+  for both Segment (answers in milliseconds) and Pendo (documents a five-minute query timeout);
+  CTO-219 replaced it with a number per provider.
+* :class:`IngestWindow`, the ``[since, until]`` range one cycle asks for, derived from the
+  per-tenant watermark in :mod:`gateway.ingest_cursors` (CTO-219). Before that every cycle re-pulled
+  the provider's whole default window, 96 times a day per tenant per connector.
 
 Invariants enforced here (not left to each connector): no raw message bodies are ever persisted
 (only counts / mapped events / values), credentials are held only transiently as a resolved token,
@@ -25,7 +31,7 @@ import logging
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, ClassVar, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urlsplit
@@ -35,6 +41,12 @@ from tally.account_identity import AccountLinker
 from tally.hmac_keys import HmacKeyRegistry
 from tally.wire import BusinessEvent, IdentityLink
 
+from gateway.ingest_cursors import (
+    INITIAL_LOOKBACK_S,
+    CursorStore,
+    NullCursorStore,
+    next_cursor,
+)
 from gateway.store import ClickHouseStore
 from gateway.tenant_integration_secrets import (
     IntegrationSecret,
@@ -77,10 +89,22 @@ class UrllibHttpClient:
     an honest ``failed`` run. The status line, not the body, goes into the exception: a third-party
     error body is exactly where a customer email turns up, and while ``scrub_error_message`` would
     catch it on the way to storage, not putting it in the string is the cheaper guarantee.
+
+    ``timeout_s`` has NO default (CTO-219). It used to default to 30 seconds for all three
+    providers, which is a number that cannot be right for all three: see
+    :data:`CONNECTOR_TIMEOUT_S`. Making it required means a caller has to say which provider's
+    budget it is spending.
     """
 
-    def __init__(self, *, timeout_s: float = 30.0) -> None:
+    def __init__(self, *, timeout_s: float) -> None:
+        if timeout_s <= 0:
+            raise ValueError("timeout_s must be positive")
         self._timeout_s = float(timeout_s)
+
+    @property
+    def timeout_s(self) -> float:
+        """The socket timeout this client enforces, in seconds. Read-only; set at construction."""
+        return self._timeout_s
 
     def get_json(
         self,
@@ -103,6 +127,91 @@ class UrllibHttpClient:
         if not payload:
             return None
         return json.loads(payload.decode("utf-8"))
+
+
+# --- per-integration HTTP timeouts (CTO-219) ------------------------------------------------------
+#
+# One global 30-second default used to serve all three providers, and it directly contradicted the
+# cadence argument in gateway.worker_jobs: that comment justifies Pendo's 30-minute cadence partly by
+# noting Pendo's aggregation API has a DOCUMENTED FIVE-MINUTE query timeout and returns responses up
+# to 4GB. A 30-second client timeout means every Pendo tenant whose aggregation takes longer than 30
+# seconds fails on every single cycle, records `failed`, and is pushed into the scheduler's
+# exponential backoff until it is retrying at the 6-hour cap. The integration is then effectively
+# dead for exactly the tenants with enough data to be slow, which is to say the ones it matters for.
+#
+# The fix is NOT to raise the global number. A 5-minute timeout on Segment would hold a worker thread
+# on a hung connection for five minutes, and the scheduler runs every job body through
+# `asyncio.to_thread` in the gateway's own process, so those threads are not free. Each provider gets
+# the budget its own documented behaviour justifies:
+#
+#   segment   20s. Segment's Public API is a paged event read with per-minute rate limits, i.e. it is
+#             built to answer fast. Anything slower than 20s is a stuck connection, not a slow query,
+#             and the next cycle is 15 minutes away.
+#   hubspot   30s. Unchanged, and the one provider the old global default actually suited. HubSpot
+#             publishes burst limits in requests per 10 seconds, so it too is built to answer fast;
+#             30s leaves room for a large page without holding a thread pointlessly.
+#   pendo    330s. Pendo's own documented query timeout is 300s, so a client timeout at or below that
+#             makes US the thing that fails rather than Pendo, and we cannot tell a slow query from a
+#             broken one. 330s is that documented ceiling plus 30s of transfer slack for a large
+#             response body. It is affordable only because Pendo's cadence is 30 minutes: one thread
+#             held for at most 5.5 minutes out of every 30 per tenant.
+CONNECTOR_TIMEOUT_S: dict[str, float] = {
+    "segment": 20.0,
+    "hubspot": 30.0,
+    "pendo": 330.0,
+}
+
+#: Used for a connector with no entry above. Deliberately tight rather than generous: a provider
+#: nobody has sized yet should hold a worker thread for as little as possible.
+DEFAULT_CONNECTOR_TIMEOUT_S = 30.0
+
+
+def timeout_for(connector_id: str) -> float:
+    """This connector's HTTP timeout in seconds. See :data:`CONNECTOR_TIMEOUT_S`."""
+    return CONNECTOR_TIMEOUT_S.get(connector_id, DEFAULT_CONNECTOR_TIMEOUT_S)
+
+
+def build_http_client(connector_id: str) -> UrllibHttpClient:
+    """A production HTTP client sized for one connector.
+
+    One client PER connector, not one shared client, because the timeout is the thing that differs
+    and it is a property of the transport. Sharing one would put every provider back on a single
+    number, which is the bug.
+    """
+    return UrllibHttpClient(timeout_s=timeout_for(connector_id))
+
+
+@dataclass(frozen=True, slots=True)
+class IngestWindow:
+    """The half-open-ish time range one cycle asks the provider for: ``[since, until]``.
+
+    Handed to :meth:`IngestWorker._ingest` so each connector can translate it into whatever its own
+    API calls those parameters. ``is_first_run`` is carried explicitly rather than inferred from the
+    width, so a connector (or a test, or a log line) can tell "this tenant has never run" from "this
+    tenant was down for a week", which look identical from the timestamps alone.
+    """
+
+    since: datetime
+    until: datetime
+    is_first_run: bool = False
+
+    @property
+    def span_seconds(self) -> float:
+        return (self.until - self.since).total_seconds()
+
+    def since_ms(self) -> int:
+        """``since`` as epoch milliseconds, for the providers whose APIs take ms (HubSpot, Pendo)."""
+        return int(self.since.timestamp() * 1000)
+
+    def until_ms(self) -> int:
+        return int(self.until.timestamp() * 1000)
+
+    def since_iso(self) -> str:
+        """``since`` as an ISO-8601 UTC instant, for the providers whose APIs take one (Segment)."""
+        return self.since.astimezone(timezone.utc).isoformat()
+
+    def until_iso(self) -> str:
+        return self.until.astimezone(timezone.utc).isoformat()
 
 
 @dataclass(frozen=True, slots=True)
@@ -224,6 +333,7 @@ class IngestWorker:
         integrations: TenantIntegrationStore,
         registry: HmacKeyRegistry,
         account_linker: AccountLinker | None = None,
+        cursors: CursorStore | None = None,
     ) -> None:
         self._secrets = secrets
         self._resolver = resolver
@@ -231,6 +341,11 @@ class IngestWorker:
         self._store = store
         self._integrations = integrations
         self._registry = registry
+        # CTO-219: the incremental watermark. Optional and defaulted so every existing construction
+        # (and every mapper unit test) keeps working; a worker without one re-pulls the initial
+        # window every cycle, which is the pre-CTO-219 behaviour. The production wiring in
+        # gateway.worker_jobs always passes a real IngestCursorStore.
+        self._cursors: CursorStore = cursors if cursors is not None else NullCursorStore()
         # CTO-195: shared user→account map, so a connector can fill in an account for a revenue
         # event that names a person but no company. Optional and defaulted so every existing
         # construction keeps working; a worker with its own linker simply learns nothing from the
@@ -242,6 +357,12 @@ class IngestWorker:
 
         Skips silently (no ``record_run``) when the tenant hasn't connected this integration, since
         an absent row is the honest "not connected" state the dashboard already renders.
+
+        INCREMENTAL since CTO-219. The cycle asks the provider only for ``[cursor, now]`` and then
+        advances the cursor, so a 15-minute cadence stops re-pulling the provider's whole window 96
+        times a day. See :mod:`gateway.ingest_cursors` for the window, the per-connector overlap and
+        an accurate account of what re-pulling actually cost (write amplification and a transient
+        pre-merge double count, NOT corruption: re-insertion is idempotent by design).
         """
         secret = self._secrets.get(tenant_id, self.connector_id)
         if secret is None or not secret.is_active:
@@ -252,16 +373,69 @@ class IngestWorker:
         except Exception as exc:  # noqa: BLE001 — any resolver failure is an honest 'failed' cycle
             return self._finish(tenant_id, "failed", 0, f"credential resolution failed: {exc}")
 
+        window = self._window(tenant_id)
         try:
-            outcome = self._ingest(tenant_id, secret, token)
+            outcome = self._ingest(tenant_id, secret, token, window)
         except Exception as exc:  # noqa: BLE001 — a fetch / insert failure is a 'failed' cycle
+            # NO cursor advance on a failed cycle. The window has not been handled, so the next
+            # cycle must ask for it again; advancing here would silently drop every event in it.
             return self._finish(tenant_id, "failed", 0, str(exc))
 
         status: RunStatus = "partial" if outcome.partial else "success"
+        self._advance_cursor(tenant_id, window)
         return self._finish(tenant_id, status, outcome.event_count, outcome.error_message)
 
+    def _window(self, tenant_id: str) -> IngestWindow:
+        """The time range this cycle asks the provider for.
+
+        A cursor read that FAILS is not a failed cycle: it falls back to the initial window, which
+        re-pulls more than necessary and is idempotent, rather than skipping data or aborting. The
+        control plane being briefly unreachable should cost bandwidth, not events.
+        """
+        until = datetime.now(tz=timezone.utc)
+        cursor: datetime | None = None
+        try:
+            cursor = self._cursors.get(tenant_id, self.connector_id)
+        except Exception:  # noqa: BLE001 - see docstring: degrade to a wider window, never skip
+            logger.exception(
+                "cursor read failed for tenant %s connector %s; using the initial window",
+                tenant_id,
+                self.connector_id,
+            )
+        if cursor is None:
+            return IngestWindow(
+                since=until - timedelta(seconds=INITIAL_LOOKBACK_S),
+                until=until,
+                is_first_run=True,
+            )
+        # A cursor from the future (clock skew, or a replica that ran ahead) would produce an
+        # inverted window that some providers answer with an error and others with everything.
+        # Clamp it to an empty-but-valid window instead.
+        return IngestWindow(since=min(cursor, until), until=until)
+
+    def _advance_cursor(self, tenant_id: str, window: IngestWindow) -> None:
+        """Move the watermark to the end of the handled window, less this connector's overlap.
+
+        Called on ``success`` AND on ``partial``. A partial cycle is one where some records failed
+        to MAP, which is deterministic: the same bytes will fail the same way next cycle, so holding
+        the cursor back would re-pull them forever and never make progress. The failure itself is
+        not lost: ``record_run`` has the ``partial`` status and the reason.
+
+        Best-effort, like ``record_run``: a control-plane blip must not turn a cycle that already
+        wrote its data into a failure. The cost of a dropped advance is one repeated window, which
+        is idempotent.
+        """
+        try:
+            self._cursors.advance(
+                tenant_id, self.connector_id, next_cursor(self.connector_id, window.until)
+            )
+        except Exception:  # noqa: BLE001 - best-effort: a dropped advance costs a repeat, not data
+            logger.exception(
+                "cursor advance failed for tenant %s connector %s", tenant_id, self.connector_id
+            )
+
     def _ingest(
-        self, tenant_id: str, secret: IntegrationSecret, token: str
+        self, tenant_id: str, secret: IntegrationSecret, token: str, window: IngestWindow
     ) -> IngestOutcome:  # pragma: no cover - abstract
         raise NotImplementedError
 

--- a/infra/gateway/src/gateway/pendo_ingest.py
+++ b/infra/gateway/src/gateway/pendo_ingest.py
@@ -20,6 +20,7 @@ from tally.wire import BusinessEvent
 
 from gateway.integration_workers import (
     IngestOutcome,
+    IngestWindow,
     IngestWorker,
     as_event_list,
     build_hasher,
@@ -74,12 +75,24 @@ class PendoWorker(IngestWorker):
     connector_id = "pendo"
 
     def _ingest(
-        self, tenant_id: str, secret: IntegrationSecret, token: str
+        self, tenant_id: str, secret: IntegrationSecret, token: str, window: IngestWindow
     ) -> IngestOutcome:
         base = str(secret.config.get("base_url") or DEFAULT_PENDO_BASE).rstrip("/")
         url = base + PENDO_FEATURE_PATH
         headers = {"x-pendo-integration-key": token}
-        payload = self._http.get_json(url, headers=headers)
+        # CTO-219: incremental. Pendo's aggregation takes epoch-millisecond bounds, matching the
+        # `firstTime` the mapper reads back. The window is deliberately overlapped on its trailing
+        # edge (gateway.ingest_cursors sizes Pendo's overlap above Pendo's own documented ~5-minute
+        # aggregation latency), so a first-use Pendo had not aggregated when we asked is picked up
+        # next cycle rather than missed forever.
+        payload = self._http.get_json(
+            url,
+            headers=headers,
+            params={
+                "firstTimeAfter": str(window.since_ms()),
+                "firstTimeBefore": str(window.until_ms()),
+            },
+        )
 
         hasher = build_hasher(self._registry, tenant_id)
         events: list[BusinessEvent] = []

--- a/infra/gateway/src/gateway/reconciliation.py
+++ b/infra/gateway/src/gateway/reconciliation.py
@@ -208,6 +208,27 @@ class ReconciliationStore:
 DEFAULT_LOOKBACK_DAYS = 7
 DEFAULT_EVENT_CAP = 50_000
 
+# Slack on the span side of the join, in days (CTO-219). An event at the very start of the event
+# window still has to be able to find the span that preceded it, so the span window opens EARLIER
+# than the oldest event in the pass. One day is the smallest slack that is still far wider than
+# LATE_THRESHOLD_SECONDS, and otel_spans is PARTITION BY toDate(Timestamp), so a whole number of
+# days is also exactly the granularity at which part pruning happens.
+DEFAULT_SPAN_SLACK_DAYS = 1
+
+# Hard server-side ceilings on one pass (CTO-219). These are ClickHouse query settings, not Python
+# ones: they are what makes a runaway pass FAIL rather than consume the ClickHouse server, and a
+# failure here is recorded as a `failed` run with zeroed metrics, so the /features card reads
+# "ran, but errored" and never a wrong lateness figure.
+#
+# max_rows_to_read with read_overflow_mode='throw' is the load-bearing one. It bounds rows SCANNED,
+# which is the thing the old `LIMIT 50000` did NOT do: a LIMIT caps rows RETURNED, and the ASOF join
+# materialises its right-hand side in full before any limit applies. 50 million rows is roughly two
+# orders of magnitude more than a correctly-pruned pass should touch, so tripping it means the
+# pruning is broken rather than that the tenant is merely large.
+DEFAULT_MAX_ROWS_TO_READ = 50_000_000
+DEFAULT_MAX_MEMORY_BYTES = 2 * 1024**3  # 2 GiB
+DEFAULT_MAX_EXECUTION_S = 120
+
 
 class _ClickHouseEventSource(Protocol):
     """Minimal surface the orchestrator needs from a ClickHouse client.
@@ -240,11 +261,38 @@ class ClickHouseLateArrivalSource:
     preceding row per key. INNER, so an event with no preceding span for that user contributes
     nothing rather than a fabricated lag of zero — an event we cannot pair is not an event that
     arrived on time.
+
+    BOUNDING THE SCAN (CTO-219). The first cut of this query capped the EVENT side with
+    ``LIMIT 50000`` and left the span side as a flat "the last 14 days of otel_spans for this
+    tenant". That is not a bound. A ``LIMIT`` caps rows RETURNED; an ASOF join materialises its
+    right-hand side before any limit on the result can apply, so the span side was read in full
+    every hour. On a high-volume tenant that is ``MEMORY_LIMIT_EXCEEDED`` every single hour, which
+    means the diagnostics card never updates for exactly the tenants it matters most for. Three
+    things fix it, in order of how much they buy:
+
+    1. **The span window is derived from the events, not from the clock.** The span side is
+       restricted to ``[min(event OccurredAt) - slack, max(event OccurredAt)]``, read from the
+       already-capped event set via scalar subqueries. ClickHouse evaluates a scalar subquery first
+       and substitutes the constant, so these become literal bounds on ``Timestamp`` and prune parts
+       (``otel_spans`` is ``PARTITION BY toDate(Timestamp)``). This is what actually collapses the
+       scan: a busy tenant hits the 50k event cap inside a few minutes of wall clock, so the span
+       side goes from fourteen days of parts to one or two. A quiet tenant's events genuinely span
+       the whole window and it reads the whole window, which is correct and is also cheap.
+    2. **The fixed lookback is kept as a floor, not as the bound.** ``Timestamp >= subtractDays(...)``
+       stays, so if the derived bound is ever wrong the query is still no worse than it was.
+    3. **Server-side ceilings** (see :data:`DEFAULT_MAX_ROWS_TO_READ` and friends) so a pass that
+       escapes both bounds fails fast and honestly instead of taking ClickHouse, and with it the
+       gateway, down. ``run_reconciliation`` turns that raise into a ``failed`` run with zeroed
+       metrics: the card goes stale-but-labelled, and never shows a wrong lateness figure.
+
+    NOT SAMPLED, deliberately. ``SAMPLE`` on the span side would be the cheapest bound of all and it
+    would silently corrupt the answer: dropping spans makes the ASOF join match an EARLIER span than
+    the true nearest one, so every sampled pass would over-report lateness. A bound that changes the
+    number is not a bound on this query, it is a different query.
     """
 
     _SQL = """
-        SELECT e.OccurredAt, s.Timestamp
-        FROM (
+        WITH capped_events AS (
             SELECT UserIdHash, OccurredAt
             FROM business_events
             WHERE TenantId = {tenant:String}
@@ -252,13 +300,18 @@ class ClickHouseLateArrivalSource:
               AND OccurredAt >= subtractDays(now64(9), {days:UInt32})
             ORDER BY OccurredAt DESC
             LIMIT {cap:UInt32}
-        ) AS e
+        )
+        SELECT e.OccurredAt, s.Timestamp
+        FROM capped_events AS e
         ASOF INNER JOIN (
             SELECT UserIdHash, Timestamp
             FROM otel_spans
             WHERE TenantId = {tenant:String}
               AND UserIdHash != ''
               AND Timestamp >= subtractDays(now64(9), {span_days:UInt32})
+              AND Timestamp >= subtractDays(
+                      (SELECT min(OccurredAt) FROM capped_events), {span_slack_days:UInt32})
+              AND Timestamp <= (SELECT max(OccurredAt) FROM capped_events)
         ) AS s
         ON e.UserIdHash = s.UserIdHash AND e.OccurredAt >= s.Timestamp
     """
@@ -269,27 +322,56 @@ class ClickHouseLateArrivalSource:
         *,
         lookback_days: int = DEFAULT_LOOKBACK_DAYS,
         event_cap: int = DEFAULT_EVENT_CAP,
+        span_slack_days: int = DEFAULT_SPAN_SLACK_DAYS,
+        max_rows_to_read: int = DEFAULT_MAX_ROWS_TO_READ,
+        max_memory_bytes: int = DEFAULT_MAX_MEMORY_BYTES,
+        max_execution_s: int = DEFAULT_MAX_EXECUTION_S,
     ) -> None:
         if lookback_days <= 0 or event_cap <= 0:
             raise ValueError("lookback_days and event_cap must be positive")
+        if span_slack_days <= 0:
+            raise ValueError("span_slack_days must be positive")
+        if max_rows_to_read <= 0 or max_memory_bytes <= 0 or max_execution_s <= 0:
+            raise ValueError("query ceilings must be positive")
         self._store = store
         self._lookback_days = int(lookback_days)
         self._event_cap = int(event_cap)
+        self._span_slack_days = int(span_slack_days)
+        self._settings: dict[str, object] = {
+            # Rows SCANNED, not rows returned. See DEFAULT_MAX_ROWS_TO_READ.
+            "max_rows_to_read": int(max_rows_to_read),
+            "read_overflow_mode": "throw",
+            "max_memory_usage": int(max_memory_bytes),
+            # A pass that is still running after this is not going to produce a number anyone
+            # wants; the next cadence window is an hour away and will try again.
+            "max_execution_time": int(max_execution_s),
+            "timeout_overflow_mode": "throw",
+        }
+
+    @property
+    def query_settings(self) -> dict[str, object]:
+        """The ClickHouse-side ceilings this source enforces. Exposed so tests can assert on them."""
+        return dict(self._settings)
 
     def fetch_event_span_pairs(self, tenant_id: str) -> Sequence[tuple[datetime, datetime]]:
-        """One tenant-scoped round trip. Raises on a CH failure, which records a ``failed`` run."""
+        """One tenant-scoped round trip. Raises on a CH failure, which records a ``failed`` run.
+
+        ``throw`` on both overflow modes is the point: an exception here becomes a ``failed`` run,
+        which is the honest outcome. The alternative modes (``break``) would return a partial result
+        that looks exactly like a complete one, and the card would show a confidently wrong number.
+        """
         result = self._store.client.query(  # type: ignore[attr-defined]
             self._SQL,
             parameters={
                 "tenant": tenant_id,
                 "days": self._lookback_days,
-                # Spans are searched over a wider window than events, so an event at the very start
-                # of the event window can still find the span that preceded it. Without the slack
-                # the oldest events in every pass would look unmatched purely because of where the
-                # window boundary happened to fall.
-                "span_days": self._lookback_days * 2,
+                # The floor under the derived span bound, not the bound itself. See the class
+                # docstring: without a derived bound this alone read the whole window every hour.
+                "span_days": self._lookback_days + self._span_slack_days,
+                "span_slack_days": self._span_slack_days,
                 "cap": self._event_cap,
             },
+            settings=self._settings,
         )
         return [(_as_utc(row[0]), _as_utc(row[1])) for row in result.result_rows]
 
@@ -316,8 +398,11 @@ def run_reconciliation(
     scan raises (recorded with zeroed metrics so the dashboard shows "ran, but errored" rather than
     silently going stale), else ``"ok"``.
 
-    The CH query itself is intentionally simple — per-tenant scheduling and a smarter matched-span
-    join are out of scope (CTO-139); the value here is the pure compute + the run log.
+    A smarter matched-span join (real attribution) is out of scope and belongs to the stitcher
+    runner, CTO-200. What IS in scope, since CTO-219, is that the scan the source performs is
+    bounded: a pass that cannot compute a number records ``failed`` and writes zeroed metrics, so
+    the /features card goes stale-but-labelled rather than showing a lateness figure nobody
+    measured.
     """
     started_at = datetime.now(tz=timezone.utc)
     status: RunStatus = "ok"

--- a/infra/gateway/src/gateway/segment_ingest.py
+++ b/infra/gateway/src/gateway/segment_ingest.py
@@ -24,6 +24,7 @@ from tally.wire import BusinessEvent, IdentityLink
 
 from gateway.integration_workers import (
     IngestOutcome,
+    IngestWindow,
     IngestWorker,
     as_event_list,
     build_hasher,
@@ -112,12 +113,19 @@ class SegmentWorker(IngestWorker):
     connector_id = "segment"
 
     def _ingest(
-        self, tenant_id: str, secret: IntegrationSecret, token: str
+        self, tenant_id: str, secret: IntegrationSecret, token: str, window: IngestWindow
     ) -> IngestOutcome:
         base = str(secret.config.get("base_url") or DEFAULT_SEGMENT_BASE).rstrip("/")
         url = base + SEGMENT_EVENTS_PATH
         headers = {"Authorization": f"Bearer {token}"}
-        payload = self._http.get_json(url, headers=headers)
+        # CTO-219: incremental. Segment's Public API takes ISO-8601 instants; like the endpoint path
+        # above, the exact parameter spelling is a deployment detail, and what this ticket pins down
+        # is that a cycle asks for a bounded window instead of the provider's default payload.
+        payload = self._http.get_json(
+            url,
+            headers=headers,
+            params={"start": window.since_iso(), "end": window.until_iso()},
+        )
 
         hasher = build_hasher(self._registry, tenant_id)
         events: list[BusinessEvent] = []

--- a/infra/gateway/src/gateway/worker_jobs.py
+++ b/infra/gateway/src/gateway/worker_jobs.py
@@ -41,6 +41,24 @@ when"):
 * ``failed``   -> raise, so the scheduler records ``failed`` and applies its backoff.
 
 Cadences are per job and defended below, at the constants.
+
+CTO-219 REVIEW FIXES. Three things this module wires up were wrong in ways the cadences above hid:
+
+* The HTTP timeout was one global 30 seconds, which contradicted the Pendo cadence argument below in
+  its own terms (that argument leans on Pendo's documented 5-minute aggregation). Timeouts are now
+  per connector, sized to what each provider actually does. See
+  :data:`gateway.integration_workers.CONNECTOR_TIMEOUT_S`.
+* Ingest had no cursor, so each cycle re-pulled the provider's whole default payload. It does not
+  any more: see :mod:`gateway.ingest_cursors`. Be accurate about what that cost, because the first
+  write-up was not: re-insertion was already idempotent (``BusinessEventId`` is the provider's stable
+  id and ``business_events`` is a ``ReplacingMergeTree`` ordered on it), so the costs were write
+  amplification and a transient pre-merge double count on the reads that lack ``FINAL``, not
+  corruption.
+* The reconciler's ClickHouse scan was bounded only in rows RETURNED, so its ASOF join read an
+  uncapped 14 days of ``otel_spans`` every hour and blew up on the biggest tenants. See
+  :class:`gateway.reconciliation.ClickHouseLateArrivalSource`.
+
+None of that changes what is said above about /features, which stays blocked on CTO-200.
 """
 
 from __future__ import annotations
@@ -52,7 +70,8 @@ from tally.hmac_keys import HmacKeyRegistry
 
 from gateway.config import Settings
 from gateway.hubspot_ingest import HubSpotWorker
-from gateway.integration_workers import HttpClient, IngestWorker, UrllibHttpClient
+from gateway.ingest_cursors import CursorStore, IngestCursorStore
+from gateway.integration_workers import HttpClient, IngestWorker, build_http_client
 from gateway.pendo_ingest import PendoWorker
 from gateway.reconciliation import (
     ClickHouseLateArrivalSource,
@@ -98,6 +117,13 @@ INGEST_INTERVAL_S = 15 * 60.0
 #: (documented 5-minute query timeout, responses up to 4GB), so a Pendo cycle costs the provider
 #: materially more than a Segment or HubSpot pull. 30 minutes still keeps the dashboard inside a
 #: window a human would call current, and can be tightened later if a real published limit appears.
+#:
+#: The HTTP TIMEOUT has to agree with that argument, and until CTO-219 it did not: one global
+#: 30-second default meant a Pendo aggregation that took the 5 minutes Pendo itself documents was
+#: cut off by us on every cycle, recorded `failed`, and pushed into the scheduler's backoff until it
+#: was retrying at the 6-hour cap. Timeouts are per connector now
+#: (:data:`gateway.integration_workers.CONNECTOR_TIMEOUT_S`), and Pendo's 330s budget is affordable
+#: precisely BECAUSE of this cadence: at most 5.5 minutes of a worker thread out of every 30.
 PENDO_INGEST_INTERVAL_S = 30 * 60.0
 
 #: The reconciler: hourly. It hits our own ClickHouse rather than anyone else's API, so third-party
@@ -200,6 +226,7 @@ def register_worker_jobs(
     http: HttpClient | None = None,
     integrations: TenantIntegrationStore | None = None,
     reconciliation_store: ReconciliationStore | None = None,
+    cursors: CursorStore | None = None,
 ) -> tuple[Job, ...]:
     """Register the three ingest jobs and the reconciler on ``registry``. Returns what it added.
 
@@ -216,8 +243,8 @@ def register_worker_jobs(
     """
     ch_secrets = secrets if secrets is not None else TenantIntegrationSecretStore(settings)
     ch_resolver = resolver if resolver is not None else EnvSecretResolver()
-    ch_http = http if http is not None else UrllibHttpClient()
     ch_integrations = integrations if integrations is not None else TenantIntegrationStore(settings)
+    ch_cursors = cursors if cursors is not None else IngestCursorStore(settings)
     recon_store = (
         reconciliation_store if reconciliation_store is not None else ReconciliationStore(settings)
     )
@@ -225,16 +252,29 @@ def register_worker_jobs(
     common = {
         "secrets": ch_secrets,
         "resolver": ch_resolver,
-        "http": ch_http,
         "store": store,
         "integrations": ch_integrations,
         "registry": hmac_registry,
         "account_linker": account_linker,
+        # CTO-219: the incremental watermark, so a 15-minute cadence stops re-pulling the
+        # provider's whole window 96 times a day. See gateway.ingest_cursors.
+        "cursors": ch_cursors,
     }
+
+    def _http_for(connector_id: str) -> HttpClient:
+        """This connector's transport. An injected ``http`` overrides all three (tests do this).
+
+        CTO-219: otherwise ONE CLIENT PER CONNECTOR, because the socket timeout differs per provider
+        and is a property of the transport. A single shared client would put Segment, HubSpot and
+        Pendo back on one number, and there is no one number that is right: see
+        :data:`gateway.integration_workers.CONNECTOR_TIMEOUT_S` and the Pendo cadence note above.
+        """
+        return http if http is not None else build_http_client(connector_id)
+
     workers: tuple[tuple[IngestWorker, float], ...] = (
-        (SegmentWorker(**common), INGEST_INTERVAL_S),  # type: ignore[arg-type]
-        (HubSpotWorker(**common), INGEST_INTERVAL_S),  # type: ignore[arg-type]
-        (PendoWorker(**common), PENDO_INGEST_INTERVAL_S),  # type: ignore[arg-type]
+        (SegmentWorker(http=_http_for("segment"), **common), INGEST_INTERVAL_S),  # type: ignore[arg-type]
+        (HubSpotWorker(http=_http_for("hubspot"), **common), INGEST_INTERVAL_S),  # type: ignore[arg-type]
+        (PendoWorker(http=_http_for("pendo"), **common), PENDO_INGEST_INTERVAL_S),  # type: ignore[arg-type]
     )
 
     added: list[Job] = []

--- a/infra/gateway/tests/_worker_fakes.py
+++ b/infra/gateway/tests/_worker_fakes.py
@@ -6,6 +6,7 @@ worker logic (mapping, record_run bookkeeping, honest failure handling) is exerc
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from gateway.tenant_integration_secrets import IntegrationSecret
@@ -107,6 +108,30 @@ class FakeIntegrations:
             total_events_24h=event_count,
             total_events_7d=event_count,
         )
+
+
+class FakeCursorStore:
+    """In-memory ``CursorStore`` (CTO-219). Same monotonic-advance contract as the real one."""
+
+    def __init__(self, initial: dict[tuple[str, str], datetime] | None = None) -> None:
+        self.cursors: dict[tuple[str, str], datetime] = dict(initial or {})
+        self.advances: list[tuple[str, str, datetime]] = []
+        self.raise_on_get = False
+        self.raise_on_advance = False
+
+    def get(self, tenant_id: str, connector_id: str) -> datetime | None:
+        if self.raise_on_get:
+            raise RuntimeError("postgres unavailable")
+        return self.cursors.get((tenant_id, connector_id))
+
+    def advance(self, tenant_id: str, connector_id: str, cursor_at: datetime) -> datetime:
+        if self.raise_on_advance:
+            raise RuntimeError("postgres unavailable")
+        self.advances.append((tenant_id, connector_id, cursor_at))
+        key = (tenant_id, connector_id)
+        existing = self.cursors.get(key)
+        self.cursors[key] = cursor_at if existing is None else max(existing, cursor_at)
+        return self.cursors[key]
 
 
 def make_secret(connector_id: str, *, ref: str = "ref-1", **config: Any) -> IntegrationSecret:

--- a/infra/gateway/tests/test_worker_jobs.py
+++ b/infra/gateway/tests/test_worker_jobs.py
@@ -14,10 +14,17 @@ These pin the seam between two things that already work on their own: the worker
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from gateway.ingest_cursors import INITIAL_LOOKBACK_S, next_cursor, overlap_for
+from gateway.integration_workers import (
+    DEFAULT_CONNECTOR_TIMEOUT_S,
+    UrllibHttpClient,
+    build_http_client,
+    timeout_for,
+)
 from gateway.reconciliation import ClickHouseLateArrivalSource, ReconciliationRun
 from gateway.scheduler import JobRegistry, JobSkipped, Scheduler
 from gateway.worker_jobs import (
@@ -31,6 +38,7 @@ from gateway.worker_jobs import (
 
 from _worker_fakes import (
     FakeCHStore,
+    FakeCursorStore,
     FakeHttp,
     FakeIntegrations,
     FakeResolver,
@@ -92,6 +100,7 @@ def _register(
     http: FakeHttp | None = None,
     integrations: FakeIntegrations | None = None,
     registry: JobRegistry | None = None,
+    cursors: FakeCursorStore | None = None,
 ) -> tuple[JobRegistry, FakeIntegrations]:
     reg = registry if registry is not None else JobRegistry()
     ints = integrations if integrations is not None else FakeIntegrations()
@@ -106,6 +115,7 @@ def _register(
         http=http if http is not None else FakeHttp(payload={"events": []}),
         integrations=ints,  # type: ignore[arg-type]
         reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+        cursors=cursors if cursors is not None else FakeCursorStore(),  # type: ignore[arg-type]
     )
     return reg, ints
 
@@ -193,7 +203,7 @@ def test_partial_cycle_is_scheduler_success_but_still_recorded_as_partial() -> N
 
     from gateway.integration_workers import IngestOutcome
 
-    def _partial(tenant_id, secret, token):  # noqa: ANN001, ANN202
+    def _partial(tenant_id, secret, token, window):  # noqa: ANN001, ANN202
         return IngestOutcome(event_count=3, partial=True, error_message="1 of 4 pages unreadable")
 
     worker._ingest = _partial  # type: ignore[method-assign]
@@ -249,6 +259,109 @@ def test_late_arrival_source_rejects_nonsense_bounds() -> None:
         ClickHouseLateArrivalSource(FakeCHStore(), lookback_days=0)
     with pytest.raises(ValueError):
         ClickHouseLateArrivalSource(FakeCHStore(), event_cap=0)
+    with pytest.raises(ValueError):
+        ClickHouseLateArrivalSource(FakeCHStore(), span_slack_days=0)
+    with pytest.raises(ValueError):
+        ClickHouseLateArrivalSource(FakeCHStore(), max_rows_to_read=0)
+    with pytest.raises(ValueError):
+        ClickHouseLateArrivalSource(FakeCHStore(), max_memory_bytes=0)
+    with pytest.raises(ValueError):
+        ClickHouseLateArrivalSource(FakeCHStore(), max_execution_s=0)
+
+
+# --- CTO-219 finding 3: the reconciler scan is BOUNDED, not merely limited -----------------------
+
+
+class _RecordingCHClient:
+    """Captures the SQL, parameters and settings one query was issued with."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def query(self, sql: str, parameters=None, settings=None):  # noqa: ANN001, ANN202
+        self.calls.append({"sql": sql, "parameters": parameters, "settings": settings})
+
+        class _R:
+            result_rows: list[tuple[datetime, datetime]] = []
+
+        return _R()
+
+
+class _RecordingCHStore:
+    def __init__(self) -> None:
+        self.client = _RecordingCHClient()
+
+
+def test_reconciler_span_side_is_bounded_by_the_event_window_not_by_the_clock() -> None:
+    """The finding: `LIMIT 50000` caps rows RETURNED; the ASOF join materialises spans first.
+
+    So the span side must be narrowed by the events actually selected. The scalar subqueries against
+    the capped event set are what ClickHouse folds into literal `Timestamp` bounds, which is what
+    prunes parts on `otel_spans` (PARTITION BY toDate(Timestamp)).
+    """
+    store = _RecordingCHStore()
+    source = ClickHouseLateArrivalSource(store)
+    source.fetch_event_span_pairs(T)
+
+    sql = " ".join(str(store.client.calls[0]["sql"]).split())
+    assert "ASOF INNER JOIN" in sql
+    # The span side is bounded ABOVE by the newest event and BELOW by the oldest, both read from the
+    # capped event set rather than from now().
+    assert "Timestamp <= (SELECT max(OccurredAt) FROM capped_events)" in sql
+    assert "(SELECT min(OccurredAt) FROM capped_events)" in sql
+    # The fixed lookback survives only as a FLOOR under the derived bound, never as the bound.
+    assert "Timestamp >= subtractDays(now64(9), {span_days:UInt32})" in sql
+    # Both sides stay tenant-scoped: an untenanted scan is a whole-cluster scan (see otel_spans.sql).
+    assert sql.count("TenantId = {tenant:String}") == 2
+    # And it is still not sampled: sampling the span side would make the ASOF join match an EARLIER
+    # span and over-report lateness, i.e. change the answer rather than bound the work.
+    assert "SAMPLE" not in sql
+
+
+def test_reconciler_span_window_is_no_wider_than_the_event_window_plus_slack() -> None:
+    store = _RecordingCHStore()
+    source = ClickHouseLateArrivalSource(store, lookback_days=7, span_slack_days=1)
+    source.fetch_event_span_pairs(T)
+    params = store.client.calls[0]["parameters"]
+    assert isinstance(params, dict)
+    # The old query searched spans over lookback_days * 2 = 14 days, unconditionally. The floor is
+    # now the event window plus one day of slack, and the derived bound is usually far tighter.
+    assert params["days"] == 7
+    assert params["span_days"] == 8
+    assert params["span_slack_days"] == 1
+    assert params["cap"] == 50_000
+
+
+def test_reconciler_query_carries_fail_fast_server_side_ceilings() -> None:
+    """A runaway pass must fail honestly and fast, never take ClickHouse (and the gateway) with it."""
+    store = _RecordingCHStore()
+    source = ClickHouseLateArrivalSource(store)
+    source.fetch_event_span_pairs(T)
+    settings = store.client.calls[0]["settings"]
+    assert isinstance(settings, dict)
+    # Rows SCANNED, which is the bound the LIMIT never was.
+    assert settings["max_rows_to_read"] > 0
+    assert settings["max_memory_usage"] > 0
+    assert settings["max_execution_time"] > 0
+    # `throw`, never `break`: a truncated result looks exactly like a complete one, and the card
+    # would then show a confidently wrong lateness figure.
+    assert settings["read_overflow_mode"] == "throw"
+    assert settings["timeout_overflow_mode"] == "throw"
+    assert source.query_settings == settings
+
+
+def test_a_reconciler_that_blows_its_ceiling_records_failed_and_never_a_number() -> None:
+    """MEMORY_LIMIT_EXCEEDED is the exact failure this finding is about. It must be honest."""
+    from gateway.reconciliation import run_reconciliation
+
+    store = FakeReconciliationStore()
+    source = FakeLateArrivals(
+        [], error=RuntimeError("Memory limit (for query) exceeded: would use 9.31 GiB")
+    )
+    run = run_reconciliation(source, store, T)  # type: ignore[arg-type]
+    assert run.status == "failed"
+    # Zeroed metrics, not a guessed lateness. The card reads "ran, but errored".
+    assert (run.events_late, run.lag_seconds_median, run.lag_seconds_p95) == (0, 0, 0)
 
 
 # --- failure isolation, through a real tick ------------------------------------------------------
@@ -293,12 +406,13 @@ def test_one_tenants_failure_does_not_stop_another_tenants_run() -> None:
         http=FakeHttp(payload={"events": []}),
         integrations=ints,  # type: ignore[arg-type]
         reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+        cursors=FakeCursorStore(),  # type: ignore[arg-type]
     )
     job = reg.get(INGEST_JOB_NAMES["segment"])
     assert job is not None
     worker = job.fn.__closure__[0].cell_contents  # type: ignore[index, union-attr]
 
-    def _ingest(tenant_id, secret, token):  # noqa: ANN001, ANN202
+    def _ingest(tenant_id, secret, token, window):  # noqa: ANN001, ANN202
         from gateway.integration_workers import IngestOutcome
 
         if tenant_id == T:
@@ -338,6 +452,7 @@ def test_skip_and_failure_coexist_across_tenants_in_one_tick() -> None:
         http=FakeHttp(payload={"events": []}),
         integrations=ints,  # type: ignore[arg-type]
         reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+        cursors=FakeCursorStore(),  # type: ignore[arg-type]
     )
     job = reg.get(INGEST_JOB_NAMES["segment"])
     assert job is not None
@@ -351,3 +466,203 @@ def test_skip_and_failure_coexist_across_tenants_in_one_tick() -> None:
     assert result.skipped_by_job == 1
     by_tenant = {tenant: status for _, tenant, status, _ in runs.rows}
     assert by_tenant == {T: "success", OTHER: "skipped"}
+
+
+# --- CTO-219 finding 5: HTTP timeouts are per integration ----------------------------------------
+
+
+def test_timeouts_are_per_integration_and_pendo_gets_more_room_than_segment() -> None:
+    """One 30s global default contradicted this module's own Pendo cadence argument.
+
+    That argument leans on Pendo's DOCUMENTED 5-minute aggregation timeout to justify the 30-minute
+    cadence. A 30s client timeout therefore killed every slow Pendo tenant on every cycle, recorded
+    `failed`, and backed the connector off to the 6h cap: dead for exactly the tenants with the most
+    data.
+    """
+    seg = build_http_client("segment")
+    hub = build_http_client("hubspot")
+    pen = build_http_client("pendo")
+
+    assert pen.timeout_s > seg.timeout_s
+    assert pen.timeout_s > hub.timeout_s
+    # Pendo has to outlast Pendo's own documented 300s query timeout, or we cannot tell a slow
+    # aggregation from a broken one.
+    assert pen.timeout_s > 300.0
+    # And Segment and HubSpot stay TIGHT. Raising the global default instead would hold a worker
+    # thread for five minutes on a hung Segment connection, and those threads are the gateway's.
+    assert seg.timeout_s <= 30.0
+    assert hub.timeout_s <= 30.0
+    assert timeout_for("segment") == seg.timeout_s
+    # An unsized connector gets the tight default, not the generous one.
+    assert timeout_for("not-a-connector") == DEFAULT_CONNECTOR_TIMEOUT_S <= 30.0
+
+
+def test_each_registered_worker_gets_its_own_client_sized_for_its_provider() -> None:
+    """One shared client would put all three providers back on one number, which is the bug."""
+    reg = JobRegistry()
+    register_worker_jobs(
+        reg,
+        object(),
+        store=FakeCHStore(),  # type: ignore[arg-type]
+        hmac_registry=_HmacRegistryStub(),  # type: ignore[arg-type]
+        secrets=FakeSecretStore(make_secret("segment")),  # type: ignore[arg-type]
+        resolver=FakeResolver({"ref-1": "tok"}),  # type: ignore[arg-type]
+        integrations=FakeIntegrations(),  # type: ignore[arg-type]
+        reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+        cursors=FakeCursorStore(),  # type: ignore[arg-type]
+    )
+    timeouts = {}
+    for connector in ("segment", "hubspot", "pendo"):
+        job = reg.get(INGEST_JOB_NAMES[connector])
+        assert job is not None
+        worker = job.fn.__closure__[0].cell_contents  # type: ignore[index, union-attr]
+        timeouts[connector] = worker._http.timeout_s
+    assert timeouts["pendo"] > timeouts["segment"]
+    assert timeouts == {c: timeout_for(c) for c in timeouts}
+
+
+def test_a_client_with_no_timeout_is_a_construction_error() -> None:
+    """No global default to fall back into. A caller has to say whose budget it is spending."""
+    with pytest.raises(TypeError):
+        UrllibHttpClient()  # type: ignore[call-arg]
+    with pytest.raises(ValueError):
+        UrllibHttpClient(timeout_s=0)
+
+
+# --- CTO-219 finding 6: ingest is incremental ----------------------------------------------------
+#
+# Be accurate about what this fixes. Re-pulling did NOT corrupt data: BusinessEventId is the
+# provider's stable id and business_events is ReplacingMergeTree(IngestedAt) ORDER BY
+# (TenantId, BusinessEventId), so re-insertion collapses by design. What it cost was write
+# amplification and a transient pre-merge double count on the reads that lack FINAL.
+
+
+def _segment_worker(cursors: FakeCursorStore, http: FakeHttp) -> object:
+    reg = JobRegistry()
+    register_worker_jobs(
+        reg,
+        object(),
+        store=FakeCHStore(),  # type: ignore[arg-type]
+        hmac_registry=_HmacRegistryStub(),  # type: ignore[arg-type]
+        secrets=FakeSecretStore(make_secret("segment")),  # type: ignore[arg-type]
+        resolver=FakeResolver({"ref-1": "tok"}),  # type: ignore[arg-type]
+        http=http,
+        integrations=FakeIntegrations(),  # type: ignore[arg-type]
+        reconciliation_store=FakeReconciliationStore(),  # type: ignore[arg-type]
+        cursors=cursors,  # type: ignore[arg-type]
+    )
+    job = reg.get(INGEST_JOB_NAMES["segment"])
+    assert job is not None
+    return job.fn
+
+
+def test_a_first_run_with_no_cursor_works_and_is_bounded() -> None:
+    """No cursor must mean a bounded initial window, never "every event the provider ever had"."""
+    cursors = FakeCursorStore()
+    http = FakeHttp(payload={"events": []})
+    run = _segment_worker(cursors, http)
+    before = datetime.now(tz=timezone.utc)
+    run(T)  # type: ignore[operator]
+
+    params = http.calls[0]["params"]
+    assert params is not None, "a first cycle must still ask for a WINDOW, not the default payload"
+    since = datetime.fromisoformat(str(params["start"]))
+    end = datetime.fromisoformat(str(params["end"]))
+    span_s = (end - since).total_seconds()
+    assert span_s == pytest.approx(INITIAL_LOOKBACK_S, abs=5.0)
+    # Bounded means bounded: not the epoch, and not open-ended.
+    assert since > before - timedelta(seconds=INITIAL_LOOKBACK_S + 5)
+    assert end <= datetime.now(tz=timezone.utc)
+
+
+def test_a_second_cycle_asks_only_for_what_is_new() -> None:
+    """The whole point: a 15-minute cadence stops re-sending the provider's whole payload 96x/day."""
+    cursors = FakeCursorStore()
+    http = FakeHttp(payload={"events": []})
+    run = _segment_worker(cursors, http)
+
+    run(T)  # type: ignore[operator]
+    run(T)  # type: ignore[operator]
+
+    first_end = datetime.fromisoformat(str(http.calls[0]["params"]["end"]))  # type: ignore[index]
+    second_since = datetime.fromisoformat(str(http.calls[1]["params"]["start"]))  # type: ignore[index]
+    second_end = datetime.fromisoformat(str(http.calls[1]["params"]["end"]))  # type: ignore[index]
+
+    # The second window starts where the first ended, less Segment's overlap. It is therefore two
+    # orders of magnitude narrower than the first, which is the write amplification that goes away.
+    assert (second_end - second_since).total_seconds() <= overlap_for("segment") + 5
+    assert (second_end - second_since).total_seconds() < INITIAL_LOOKBACK_S / 100
+    assert (first_end - second_since).total_seconds() == pytest.approx(
+        overlap_for("segment"), abs=5.0
+    )
+
+
+def test_the_overlap_is_per_provider_and_covers_pendos_aggregation_latency() -> None:
+    """Pendo documents ~5 minutes of aggregation latency, so its overlap has to exceed that.
+
+    Without it, a first-use Pendo had not aggregated when we asked is not merely re-fetched later,
+    it is missed forever, because the next cycle starts after it.
+    """
+    assert overlap_for("pendo") > 300.0
+    assert overlap_for("segment") < overlap_for("pendo")
+    assert overlap_for("hubspot") < overlap_for("pendo")
+    end = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    assert next_cursor("pendo", end) == end - timedelta(seconds=overlap_for("pendo"))
+
+
+def test_a_failed_cycle_does_not_advance_the_cursor() -> None:
+    """The window was not handled, so the next cycle must ask for it again or the events are lost."""
+    cursors = FakeCursorStore()
+    http = FakeHttp(error=RuntimeError("HTTP 503 from api.segment.io"))
+    run = _segment_worker(cursors, http)
+    with pytest.raises(Exception):
+        run(T)  # type: ignore[operator]
+    assert cursors.advances == []
+    assert cursors.get(T, "segment") is None
+
+
+def test_a_partial_cycle_does_advance_the_cursor() -> None:
+    """Partial means records failed to MAP, which is deterministic. Holding back never progresses."""
+    cursors = FakeCursorStore()
+    # A non-dict item in the payload is exactly the "one bad record" path that yields `partial`.
+    http = FakeHttp(payload={"events": ["not-an-object"]})
+    run = _segment_worker(cursors, http)
+    run(T)  # type: ignore[operator]
+    assert len(cursors.advances) == 1
+    assert cursors.get(T, "segment") is not None
+
+
+def test_a_cursor_store_outage_widens_the_window_rather_than_dropping_events() -> None:
+    """A control-plane blip should cost bandwidth (which is idempotent), never data."""
+    cursors = FakeCursorStore()
+    http = FakeHttp(payload={"events": []})
+    run = _segment_worker(cursors, http)
+    cursors.raise_on_get = True
+    cursors.raise_on_advance = True
+    run(T)  # type: ignore[operator]  # no exception: the cycle still succeeds
+
+    params = http.calls[0]["params"]
+    since = datetime.fromisoformat(str(params["start"]))  # type: ignore[index]
+    end = datetime.fromisoformat(str(params["end"]))  # type: ignore[index]
+    assert (end - since).total_seconds() == pytest.approx(INITIAL_LOOKBACK_S, abs=5.0)
+
+
+def test_the_cursor_never_rewinds() -> None:
+    """Monotonic, so a skewed clock or a replayed older window cannot undo the fix."""
+    cursors = FakeCursorStore()
+    later = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    cursors.advance(T, "segment", later)
+    cursors.advance(T, "segment", later - timedelta(hours=6))
+    assert cursors.get(T, "segment") == later
+
+
+def test_a_cursor_from_the_future_clamps_to_an_empty_window_not_an_inverted_one() -> None:
+    now = datetime.now(tz=timezone.utc)
+    cursors = FakeCursorStore({(T, "segment"): now + timedelta(days=1)})
+    http = FakeHttp(payload={"events": []})
+    run = _segment_worker(cursors, http)
+    run(T)  # type: ignore[operator]
+    params = http.calls[0]["params"]
+    since = datetime.fromisoformat(str(params["start"]))  # type: ignore[index]
+    end = datetime.fromisoformat(str(params["end"]))  # type: ignore[index]
+    assert since <= end


### PR DESCRIPTION
Fixes review findings 3, 5 and 6 on CTO-216's scheduled worker jobs. `cost_connector_job.py` and `scheduler.py` are untouched; sibling PRs cover those.

## Finding 3: the reconciler would fall over on the tenants it matters most for

`ClickHouseLateArrivalSource.fetch_event_span_pairs` capped the **event** side of its ASOF join with `LIMIT 50000` and left the **span** side as a flat 14-day scan of `otel_spans`. A `LIMIT` caps rows *returned*, not rows *scanned*, and an ASOF join materialises its right-hand side before any limit on the result applies, so the span side was read in full every hour. On a high-volume tenant that is `MEMORY_LIMIT_EXCEEDED` every hour, which is why the `/features` diagnostics card never updated for exactly the tenants it matters most for.

**The bound I chose: derive the span window from the events, not from the clock.** The span side is restricted to `[min(event OccurredAt) - slack, max(event OccurredAt)]`, read from the already-capped event set via scalar subqueries. ClickHouse evaluates a scalar subquery first and substitutes the constant, so these become literal `Timestamp` bounds and prune parts (`otel_spans` is `PARTITION BY toDate(Timestamp)`). A busy tenant fills the 50k event cap inside a few minutes of wall clock, so its span side collapses from fourteen days of parts to one or two. A quiet tenant's events genuinely span the whole window and it reads the whole window, which is correct and is also cheap.

The other options, and why they are supporting rather than primary:

- **Keep the fixed lookback**, but as a *floor* under the derived bound rather than as the bound. If the derived bound is ever wrong the query is no worse than it was.
- **Push tenant and time predicates** so parts prune. Both sides were already tenant-scoped; the time predicate is what changed, and it is the thing that prunes.
- **Server-side ceilings.** `max_rows_to_read` (50M) with `read_overflow_mode='throw'`, `max_memory_usage` (2 GiB), `max_execution_time` (120s) with `timeout_overflow_mode='throw'`. `throw`, never `break`: a truncated result looks exactly like a complete one, and the card would then show a confidently wrong number. `max_rows_to_read` is the one that bounds rows *scanned*, which is precisely what the `LIMIT` never did.
- **Sampling: rejected.** `SAMPLE` on the span side would be the cheapest bound and it would silently corrupt the answer. Dropping spans makes the ASOF join match an *earlier* span than the true nearest one, so every sampled pass would over-report lateness. A bound that changes the number is not a bound on this query, it is a different query.

**Honest failure.** `run_reconciliation` already turns a raise into a `failed` run with zeroed metrics, so a pass that cannot compute a number leaves the card stale-but-labelled and never writes a wrong lateness figure. Verified live that tripping a ceiling does exactly that.

Measured live on a seeded high-row tenant (600k spans over 14 days, 60k events all inside the last 30 minutes):

```
OLD query (span side = flat 14 days): read_rows=660000  returned=50000
NEW query (span side derived + floor): read_rows=227252  returned=50000
--> rows SCANNED cut by 65.6%, rows RETURNED identical
```

## Finding 5: per-integration timeouts

The 30s global default contradicted this module's own cadence comment ~120 lines above, which justifies Pendo's 30-minute cadence partly by citing Pendo's **documented 5-minute** aggregation query timeout. A 30s client timeout therefore cut off every slow Pendo tenant on every cycle, recorded `failed`, and pushed the connector into the scheduler's exponential backoff until it was retrying at the 6h cap. The integration was effectively dead for the tenants with the most data.

| connector | timeout | why |
| --- | --- | --- |
| `segment` | 20s | Paged event read with per-minute rate limits, built to answer fast. Slower than 20s is a stuck connection, and the next cycle is 15 minutes away. |
| `hubspot` | 30s | Unchanged, and the one provider the old global default actually suited. Burst limits are per 10 seconds, so it too answers fast. |
| `pendo` | 330s | Must outlast Pendo's own 300s query timeout or we cannot tell a slow aggregation from a broken one, plus 30s of transfer slack for a large body. |

Not a raised global: a 5-minute timeout on Segment would hold a worker thread for five minutes on a hung connection, and the scheduler runs every job body through `asyncio.to_thread` in the gateway's own process. Pendo's 330s is affordable *because* of its 30-minute cadence: at most 5.5 minutes of a thread out of every 30 per tenant. `UrllibHttpClient` no longer has a default timeout at all, so a caller has to say whose budget it is spending, and `register_worker_jobs` builds one client per connector.

## Finding 6: incremental ingest

**Being accurate about the severity: the review called this data corruption, and that is wrong.** `BusinessEventId` is the provider's stable id (Segment `messageId`, Stripe event `id`, HubSpot `eventId`), and `business_events` is `ReplacingMergeTree(IngestedAt) ORDER BY (TenantId, BusinessEventId)`, so re-insertion of an event already present collapses to one row by design. The genuine costs are narrower and both real:

- **Write amplification.** Every cycle re-inserted every event in the provider's window; each of those rows is stored, merged, then discarded.
- **A transient pre-merge double count.** Between the insert and the merge that collapses it, a read *without* `FINAL` sees the same event more than once. Only 2 of the 12 `business_events` reads in `web/lib/clickhouse.ts` use `FINAL`.

**Cursor design.** Migration **0028** (`tenant_ingest_cursors`) adds a per-tenant per-integration watermark, following the `bq_export_watermarks` (0010) precedent already in this control plane: one row per (tenant, connector), a timestamp high-water mark, `tenant_id` as `TEXT` with no FK (matching 0027 and 0008), and the compose mount alongside it. `IngestWorker.run_cycle` reads it, hands an `IngestWindow` to `_ingest`, and each connector translates that into its own API's parameters.

- **Where the cursor lands.** At the end of the handled window minus a **per-connector overlap** sized to that provider's own lateness: `pendo` 600s (above its documented ~5-minute aggregation latency), `segment` and `hubspot` 120s. Re-fetching the overlap costs bandwidth and nothing else, because re-insertion is idempotent; losing an event the provider had not aggregated yet would be permanent. The trade is deliberately asymmetric in that direction.
- **First run.** No cursor floors at a bounded 7-day initial window, not all history. A tenant connecting Segment should get one bounded useful pull on a 15-minute cadence, not an unbounded backfill that times out and retries forever. Real historical backfill is a different operation with a different shape.
- **Monotonic.** The upsert takes `greatest(existing, proposed)`, so clock skew between replicas cannot rewind the cursor and quietly undo the fix.
- **Failure handling.** A `failed` cycle does **not** advance the cursor: the window was not handled, so the next cycle must ask for it again. A `partial` cycle **does**, because a mapping failure is deterministic and holding back would re-pull the same unparseable bytes forever without progressing. The partial-ness is not lost; `record_run` has the status and the reason. A cursor-store outage degrades to the wider initial window rather than skipping data or failing the cycle.

## What this does not change

`run_cycle` still records through `TenantIntegrationStore.record_run` with PII-scrubbed errors; `partial` still maps to scheduler `success` on purpose; `JobSkipped` is still what an unconfigured tenant gets. No parallel status path.

**This does not fix `/features`**, which stays blocked on the stitcher runner (CTO-200).

## Verification

- `cd infra/gateway && uv run --extra dev pytest -q` — **764 passed** (749 before, 15 added). `uv run ruff check .` clean.
- `cd web && npm run typecheck` clean; `npm run test` — 568 passed, only the 2 long-standing `app/api/api.test.ts` failures.
- `docker compose -f infra/docker-compose.yml up -d --build gateway` builds and comes up healthy; migration 0028 applies.
- Verified live in the container against real ClickHouse and Postgres (per CTO-218 the gateway configures no logging, so this reads tables and query summaries rather than container logs):
  - the reconciler numbers above, plus a deliberately tiny `max_rows_to_read` producing `status=failed` with `(0, 0, 0)`;
  - Segment end to end against the real `IngestCursorStore` — first window 604,800s, second window **120s** (99.98% narrower), cursor row advanced in Postgres, and unchanged after a provider 503.

New tests cover: the generated reconciler SQL is bounded by the event window and not sampled; the ceilings are sent and are `throw`; a blown ceiling records `failed` with no number; Pendo's timeout exceeds Segment's and exceeds 300s while Segment and HubSpot stay tight; each registered worker gets its own sized client; a first run with no cursor is bounded; a second cycle asks only for what is new; the overlap covers Pendo's aggregation latency; failed does not advance and partial does; the cursor never rewinds; a future cursor clamps rather than inverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
