### PR TITLE
fix(export): carry the account dimension into telemetry export specs

### DIFF
--- a/infra/gateway/src/gateway/bq_export.py
+++ b/infra/gateway/src/gateway/bq_export.py
@@ -126,6 +126,10 @@ SPANS_SPEC = ExportTableSpec(
     source_table="otel_spans",
     watermark_column="Timestamp",
     key_columns=("TenantId", "TraceId", "SpanId"),
+    # Derived 1:1 from the gateway insert column list, so the account dimension CTO-180 added to
+    # otel_spans (AccountIdHash + AccountIdHashKeyVersion) reaches this export automatically via
+    # _SPAN_COLUMNS. Both are FixedString(64)/LowCardinality on the source and map to STRING here,
+    # exactly like UserIdHash/UserIdHashKeyVersion. See CTO-202: a test asserts they are present.
     schema=tuple(BQField(c, _SPAN_TYPES.get(c, "STRING")) for c in _SPAN_COLUMNS),
     json_columns=("SpanAttributes",),
 )
@@ -140,6 +144,13 @@ BUSINESS_EVENTS_SPEC = ExportTableSpec(
         _s("BusinessEventId"),
         _s("EventName"),
         _s("UserIdHash"),
+        # Account dimension (CTO-202). business_events.AccountIdHash is populated by CTO-195 but
+        # was never added to this hand-written spec, so a tenant mirroring revenue events to their
+        # own warehouse got rows with no account grouping and could not rebuild cost-per-customer.
+        # Same treatment as UserIdHash: a FixedString(64) HMAC hash exported as STRING. There is no
+        # AccountIdHashKeyVersion here because business_events carries no such column (unlike
+        # otel_spans); see db/clickhouse/attribution.sql.
+        _s("AccountIdHash"),
         BQField("OccurredAt", "TIMESTAMP"),
         BQField("IngestedAt", "TIMESTAMP"),
         BQField("ValueAmountMicro", "INT64"),

--- a/infra/gateway/tests/test_athena_export.py
+++ b/infra/gateway/tests/test_athena_export.py
@@ -29,6 +29,7 @@ from gateway.athena_export import (
     run_export,
 )
 from gateway.bq_export import (
+    BUSINESS_EVENTS_SPEC,
     DAILY_ROLLUP_SPEC,
     SPANS_SPEC,
     strip_body_keys,
@@ -299,6 +300,21 @@ def test_athena_ddl_maps_shared_schema_and_partitions_by_day() -> None:
     assert "`SpanAttributes` string" in ddl  # JSON map stored as a JSON string
     # The partition column must NOT also be a data column.
     assert "`dt` " not in ddl.split("PARTITIONED BY")[0]
+
+
+def test_account_dimension_appears_in_generated_ddl() -> None:
+    # CTO-202: the widened shared specs must carry the account hash into the Athena DDL for both
+    # the span and the business-event tables, mapped as string like the user hash.
+    span_ddl = athena_create_table_ddl(
+        SPANS_SPEC, database="db", s3_location="s3://bkt/tally/otel_spans/"
+    )
+    assert "`AccountIdHash` string" in span_ddl
+    assert "`AccountIdHashKeyVersion` string" in span_ddl
+    be_ddl = athena_create_table_ddl(
+        BUSINESS_EVENTS_SPEC, database="db", s3_location="s3://bkt/tally/business_events/"
+    )
+    assert "`AccountIdHash` string" in be_ddl
+    assert "AccountIdHashKeyVersion" not in be_ddl
 
 
 def test_daily_rollup_ddl_has_date_partition_and_date_column() -> None:

--- a/infra/gateway/tests/test_bq_export.py
+++ b/infra/gateway/tests/test_bq_export.py
@@ -17,6 +17,7 @@ import pytest
 from gateway import bq_export
 from gateway.bq_export import (
     ALL_SPECS,
+    BUSINESS_EVENTS_SPEC,
     DAILY_ROLLUP_SPEC,
     SPANS_SPEC,
     BigQueryDependencyMissing,
@@ -249,6 +250,25 @@ def test_load_bigquery_sink_guards_missing_dependency() -> None:
             load_bigquery_sink("proj")
     else:  # pragma: no cover - extra installed in this env
         pytest.skip("google-cloud-bigquery is installed; lazy-import guard not exercisable")
+
+
+def test_span_spec_exports_account_dimension() -> None:
+    # CTO-202: cost/revenue per customer needs the account hash on the exported span. It maps to
+    # STRING exactly like the user hash (both are FixedString(64) on the source).
+    fields = {f.name: f for f in SPANS_SPEC.schema}
+    assert "AccountIdHash" in fields
+    assert "AccountIdHashKeyVersion" in fields
+    assert fields["AccountIdHash"].type == fields["UserIdHash"].type == "STRING"
+
+
+def test_business_events_spec_exports_account_dimension() -> None:
+    # CTO-202: business_events.AccountIdHash (populated by CTO-195) must reach the export so a
+    # tenant can group revenue events by account. No AccountIdHashKeyVersion: the source table
+    # has none, unlike otel_spans.
+    fields = {f.name: f for f in BUSINESS_EVENTS_SPEC.schema}
+    assert "AccountIdHash" in fields
+    assert fields["AccountIdHash"].type == fields["UserIdHash"].type == "STRING"
+    assert "AccountIdHashKeyVersion" not in fields
 
 
 def test_all_specs_have_consistent_schema_and_keys() -> None:


### PR DESCRIPTION
## CTO-202

CTO-180 added `AccountIdHash` / `AccountIdHashKeyVersion` to `otel_spans` and CTO-195 started populating `business_events.AccountIdHash`, but the export specs shared by the BigQuery (CTO-154) and Athena/S3 (CTO-160) sinks were never widened for `business_events`. A tenant mirroring telemetry to their own warehouse got cost and revenue rows with **no account dimension**, so once the cost-per-customer tab ships they could not rebuild that analysis against their own warehouse.

Both sinks share one `ExportTableSpec` set (`ALL_SPECS`), so this single change reaches BigQuery *and* Athena; the generated `MERGE` and `CREATE EXTERNAL TABLE` DDL both pick up the new column.

## Changes

- **`business_events`**: added `AccountIdHash` to the hand-written `BUSINESS_EVENTS_SPEC`, placed right after `UserIdHash` to mirror the DDL. Mapped to `STRING` exactly like `UserIdHash` (both are `FixedString(64)` on the source). No `AccountIdHashKeyVersion` because `business_events` has no such column (unlike `otel_spans`); see `db/clickhouse/attribution.sql`.
- **`otel_spans`**: no code change was required. `SPANS_SPEC` derives its schema 1:1 from the gateway insert column list (`mapping.COLUMNS`), which CTO-180 already widened, so `AccountIdHash` and `AccountIdHashKeyVersion` already export as `STRING`. Added a clarifying comment plus a regression test so this coverage is explicit rather than incidental.
- **Tests**: new assertions in `test_bq_export.py` (account columns present in both generated schemas, correct types) and `test_athena_export.py` (account columns present in the generated Athena DDL for both the span and business-event tables). `792 passed, 5 skipped`; `ruff check .` clean.

## Other spec drift reviewed

Per the ticket's ask, I diffed the live `db/clickhouse` schemas against every export spec:

- **`business_events`**: `AccountIdHash` was the only missing column. Fixed here.
- **`attribution_records`**: no drift. Its DDL has no account column, and `ATTRIBUTION_SPEC` matches.
- **`daily_feature_rollup`**: no drift.
- **`otel_spans`**: the span spec derives from `mapping.COLUMNS`, so it cannot drift from that insert list. `mapping.COLUMNS` itself deliberately omits some DDL columns that the gateway never writes (`ReconciledCost`, `ResolvedPromptHash`, `ResolvedContextRef`, `SpanEvents`). These are pre-existing, intentional exclusions unrelated to the account dimension. **Follow-up, not addressed here.**

### Follow-up (out of scope, noted for a separate ticket)

- `db/clickhouse/account_rollups.sql` introduces a new per-customer rollup table that has **no export spec at all**. That is a new-table gap rather than a column drift on an existing spec, so it belongs in its own ticket alongside the cost-per-customer tab work rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)