### PR TITLE
fix(gateway): configure logging at boot so INFO lines reach container stderr (CTO-218)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -168,6 +168,41 @@ from tally.hmac_keys import HmacKeyRegistry
 
 logger = logging.getLogger("tally.gateway")
 
+# Guards _configure_logging so a re-created app (e.g. the test suite spinning up many TestClients in
+# one process) attaches the root handler exactly once and never stacks duplicates. See CTO-218.
+_logging_configured = False
+
+
+def _configure_logging(level_name: str) -> None:
+    """Install one root stderr handler so gateway INFO lines are actually visible (CTO-218).
+
+    The gateway is started with ``uvicorn gateway.app:app`` (see the Dockerfile CMD). uvicorn
+    configures its own ``uvicorn*`` loggers but leaves the ROOT logger without a handler, so Python's
+    lastResort handler applied and only WARNING and above reached stderr. Every gateway ``logger.info``
+    (the ``tally.gateway*`` namespace: startup line, ingest buffer enablement, scheduler per-tick
+    summary) was therefore silently discarded in a compose deployment.
+
+    We attach a single handler to the root logger at the configured level. uvicorn's own loggers set
+    ``propagate=False``, so their records are handled by uvicorn's handlers and never reach this one,
+    which is why gateway lines appear exactly once and uvicorn's own lines are not doubled. Idempotent
+    so it is safe to call at the very start of every ``lifespan``.
+    """
+    global _logging_configured
+    if _logging_configured:
+        return
+    level = logging.getLevelName((level_name or "INFO").upper())
+    # getLevelName returns the "Level <n>" string for an unknown name; fall back to INFO then.
+    if not isinstance(level, int):
+        level = logging.INFO
+    handler = logging.StreamHandler()  # defaults to stderr, matching uvicorn's own default handler
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    root = logging.getLogger()
+    root.addHandler(handler)
+    root.setLevel(level)
+    _logging_configured = True
+
 
 def _build_replay_blob_store(settings) -> ReplayBlobStore:
     """Select the replay blob-store backend from settings (CTO-152).
@@ -205,6 +240,9 @@ def _build_replay_blob_store(settings) -> ReplayBlobStore:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     settings = get_settings()
+    # Configure logging first so the startup INFO line below (and every other gateway logger.info)
+    # is captured rather than dropped by uvicorn's WARNING-only root (CTO-218).
+    _configure_logging(settings.log_level)
     app.state.settings = settings
     app.state.store = ClickHouseStore(settings)
     app.state.auth = ApiKeyAuth(settings)

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -10,6 +10,13 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="TALLY_", env_file=".env", extra="ignore")
 
+    # Root log level (CTO-218). The gateway never configured logging, so under uvicorn the root
+    # logger kept its WARNING-only lastResort and every gateway logger.info (startup line, ingest
+    # buffer enablement, scheduler per-tick summary) was dropped in a compose deployment. Logging is
+    # now configured once at boot at this level; raise to WARNING to quiet a noisy deployment or drop
+    # to DEBUG to trace one. See gateway.app._configure_logging.
+    log_level: str = "INFO"
+
     # ClickHouse (HTTP interface — clickhouse-connect).
     clickhouse_host: str = "localhost"
     clickhouse_port: int = 8123


### PR DESCRIPTION
## The bug

The gateway never called `logging.basicConfig` (or configured handlers any other way), so under `uvicorn gateway.app:app` (the Dockerfile CMD) the root logger kept Python's WARNING-only `lastResort` handler. Every gateway `logger.info(...)` was silently discarded in a compose deployment: the startup line, the ingest buffer enablement line, and the scheduler per-tick summary (how many tenants ran / succeeded / were skipped / failed). An operator tailing `docker compose logs gateway` saw nothing and concluded the scheduler was dead when it was working.

## The fix

- New `TALLY_LOG_LEVEL` setting on `Settings` (default `INFO`), matching the existing `TALLY_`-prefixed style.
- `_configure_logging(level)` in `app.py`, called at the very top of the FastAPI `lifespan` (right after `get_settings()`, so the startup INFO line is captured). It installs a single root stderr handler at the configured level.
- **Reconciled with uvicorn, not fighting it.** uvicorn configures only its own `uvicorn*` loggers, which set `propagate=False`, so their records are handled by uvicorn's handlers and never reach the root handler we add. Result: gateway `logger.info` lines appear exactly once, uvicorn's own lines are not doubled. Verified empirically (below).
- Idempotent via a module-level guard, so a re-created app in the test suite never stacks duplicate handlers.

The `app.py` edit is confined to the logging init at import + one call line at the top of `lifespan`. The job-registration block is untouched.

## Proof (container stderr, currently invisible on main)

Default `docker compose -f infra/docker-compose.yml up -d --build gateway`:

```
2026-08-26 17:36:13,787 INFO tally.gateway: gateway up (require_api_key=False)
```

With the scheduler enabled (`TALLY_SCHEDULER_ENABLED=true`, short tick), same image:

```
2026-08-26 17:37:16,510 INFO tally.gateway: scheduler enabled (tick=2s, jobs=5)
2026-08-26 17:37:16,510 INFO tally.gateway: gateway up (require_api_key=False)
2026-08-26 17:37:17,122 INFO tally.gateway.worker_jobs: reconciliation: tenant=... status=ok late=0 median_lag_s=0
2026-08-26 17:37:17,123 INFO tally.gateway.scheduler: scheduler tick: ran=5 ok=1 skipped=3 failed=1 contended=0 (considered=5)
```

Each gateway INFO line appears exactly once. Note the gateway lines use our formatter (`... INFO tally.gateway:`) while uvicorn's own lines keep its `INFO:` format, confirming they flow through separate handlers and are not doubled.

## Verification

- `cd infra/gateway && uv run --extra dev pytest -q` -> 794 passed.
- `uv run ruff check .` -> All checks passed.
- `docker compose -f infra/docker-compose.yml up -d --build gateway` builds and runs; logs shown above.

## Conventions

Comments explain WHY and cite CTO-218. No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)