### PR TITLE
fix(cost): derive queryCostSeries day buckets from ClickHouse's window, not the Node clock (CTO-203)

### DIFF
--- a/web/components/BurndownChart.tsx
+++ b/web/components/BurndownChart.tsx
@@ -17,10 +17,10 @@
 //      weighting can check it against the dumbest possible arithmetic without leaving the page.
 //
 // THE X AXIS IS BUILT FROM THE DATES IN `points`, WHICH CAME FROM CLICKHOUSE. There is no
-// `new Date()` in this file and there must never be one. `queryCostSeries` builds its axis from the
-// Node clock (CTO-203) and the failure mode is silence: the oldest day slides off the chart while
-// still counting toward the total printed beside it. Everything plotted here is indexed off the
-// array it was handed.
+// `new Date()` in this file and there must never be one. `queryCostSeries` once built its axis from
+// the Node clock (CTO-203, since fixed) and the failure mode was silence: the oldest day slid off
+// the chart while still counting toward the total printed beside it. Everything plotted here is
+// indexed off the array it was handed.
 //
 // This component renders a cone unconditionally, so the CALLER is responsible for not rendering it
 // at all below the minimum history. `BurndownCard` does that; `points` being empty is the belt to

--- a/web/lib/burndown.ts
+++ b/web/lib/burndown.ts
@@ -18,10 +18,11 @@
 //  2. THE TWO CLOCKS. Every date here comes from ClickHouse: `periodStart` and `windowEnd` are read
 //     off the series, `asOf` is the series' own `settledThrough`, and the period end is calendar
 //     arithmetic on `periodStart`. There is no `new Date()` anywhere in this module and none in the
-//     chart. `queryCostSeries` still builds its axis from the Node clock (CTO-203) and the failure
-//     mode is silent: the oldest day drops off the chart while still counting in the total printed
-//     beside it. `chartReconciles` below exists so that if this section ever acquires the same bug
-//     it says so on screen instead of quietly disagreeing with the card above it.
+//     chart. `queryCostSeries` used to build its axis from the Node clock, and the failure mode was
+//     silent: the oldest day dropped off the chart while still counting in the total printed beside
+//     it (CTO-203, now fixed by sourcing its day list from ClickHouse too). `chartReconciles` below
+//     exists so that if this section ever acquires the same bug it says so on screen instead of
+//     quietly disagreeing with the card above it.
 //
 //  3. TRIMMING THE PRE-ONBOARDING ZEROS, which is what makes the minimum-history guard fire at all.
 //     `querySettledCostSeries` gives every calendar day in its 30-day window a slot, and a day with

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -471,6 +471,78 @@ describe("queryExcludedInfraCost: what the per-account table leaves out (CTO-189
   });
 });
 
+describe("queryCostSeries day buckets (CTO-203)", () => {
+  // The chart draws one stacked bar per day and prints a headline total above it. Those two numbers
+  // are read from the SAME `days` array, so they can only disagree if a day the query returned has
+  // no bucket to land in. That is exactly what happened while the bucket list was built from the
+  // Node clock: whenever the Node timezone and ClickHouse straddle midnight, the JS list shifted a
+  // day against the SQL window and the oldest returned row was silently dropped.
+  //
+  // `respondSeries` mirrors queryCostSeries' two reads in order: the grouped cost rows, then the
+  // one-row window-start boundary select.
+  function respondSeries(costRows: RowShape[], windowStart: string) {
+    respondRows(costRows);
+    respondRows([{ windowStart }]);
+  }
+
+  // CostDayPoint.byLayer is a fixed-key SpendByLayer (no string index signature), so read it as a
+  // plain object of numbers rather than Record<string, number>.
+  const sumDays = (days: ReadonlyArray<{ byLayer: object }>) =>
+    days.reduce(
+      (s, d) => s + Object.values(d.byLayer).reduce((a: number, b) => a + (b as number), 0),
+      0,
+    );
+
+  it("anchors buckets on ClickHouse's reported window, not the Node clock", async () => {
+    const { queryCostSeries } = await freshSut();
+    // A 2021 boundary the Node clock (today is 2026-08-26) would NEVER produce, so if the bucket list
+    // still came from `new Date()` the oldest row below would find no slot and be dropped. Both ends
+    // of the returned window must instead track this ClickHouse-sourced date.
+    const WINDOW_START = "2021-03-01";
+    respondSeries(
+      [
+        { day: "2021-03-01", layer: "llm", cost: "12.75" }, // the oldest day, the one at risk
+        { day: "2021-03-30", layer: "tools", cost: "3.25" }, // today per this window
+      ],
+      WINDOW_START,
+    );
+    const out = await queryCostSeries();
+    expect(out!.days).toHaveLength(30);
+    expect(out!.days[0].date).toBe("2021-03-01");
+    expect(out!.days[29].date).toBe("2021-03-30");
+    // The oldest row landed rather than being dropped.
+    expect(out!.days[0].byLayer.llm).toBe(12_750_000);
+    // Gaps are real zeroes, not missing data.
+    expect(out!.days[1].byLayer.llm).toBe(0);
+    // And nothing fell out: the rendered days sum to the same total the headline is computed from
+    // (every returned row), so the chart and its own total cannot disagree.
+    expect(sumDays(out!.days)).toBe(16_000_000);
+  });
+
+  it("keeps the calendar-aligned window boundary in the SQL, not a rolling one", async () => {
+    const { queryCostSeries } = await freshSut();
+    respondSeries([{ day: "2026-08-26", layer: "llm", cost: "1" }], "2026-07-28");
+    await queryCostSeries();
+    const costSql = (queryMock.mock.calls[0][0] as { query: string }).query;
+    const boundarySql = (queryMock.mock.calls[1][0] as { query: string }).query;
+    // The window predicate stays calendar-aligned so /cost and Home agree to the penny.
+    expect(costSql).toContain("Timestamp >= toDate(now()) - INTERVAL 29 DAY");
+    expect(costSql).not.toContain("now() - INTERVAL 30 DAY");
+    // The bucket list is sourced from a value ClickHouse computes, on that same boundary.
+    expect(boundarySql).toContain("toDate(now()) - INTERVAL 29 DAY");
+  });
+
+  it("renders 30 zero days when the tenant has no spend in the window", async () => {
+    const { queryCostSeries } = await freshSut();
+    respondSeries([], "2026-07-28");
+    const out = await queryCostSeries();
+    expect(out!.days).toHaveLength(30);
+    expect(out!.days[0].date).toBe("2026-07-28");
+    expect(out!.days[29].date).toBe("2026-08-26");
+    expect(sumDays(out!.days)).toBe(0);
+  });
+});
+
 describe("queryAccountDetail (CTO-187)", () => {
   const WINDOW_START = "2026-07-28";
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -264,6 +264,11 @@ export async function queryDataQuality(): Promise<DataQuality | null> {
 
 // --- Cost workflow ------------------------------------------------------------------------------
 
+// The cost chart spans `toDate(now()) - INTERVAL 29 DAY` through today inclusive, i.e. 30 calendar
+// days. The window boundary stays this calendar-aligned form (not a rolling `now() - INTERVAL 30
+// DAY`) so /cost and Home agree to the penny; see CTO-203.
+const COST_SERIES_WINDOW_DAYS = 30;
+
 export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSeries | null> {
   return tryLive(async (db, tenant) => {
     const tag = filter?.tag ?? "";
@@ -277,12 +282,25 @@ export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSe
        ORDER BY day`,
       { tenant, tag },
     );
-    // Pivot into one CostDayPoint per calendar day (fill gaps with zero layers).
+    // CTO-203: the day-bucket LIST must come from the window ClickHouse actually reports, not from
+    // the Node process clock. The two live in different timezones, and when they straddle midnight
+    // the JS-built list shifts a day against the SQL window: the oldest returned row then finds no
+    // bucket, the pivot drops it, and that point vanishes from the stacked chart while STILL counting
+    // toward the headline total above it, so the chart and its own total silently disagree. This is
+    // the exact seam queryAccountDetail (CTO-187) already closes by anchoring its trend on a
+    // ClickHouse-sourced window start; we follow that pattern rather than inventing a new mechanism.
+    // A dedicated one-row select keeps the boundary available even when `out` is empty (a tenant with
+    // no spend in the window still renders 30 zero days).
+    const boundary = await rowsP<{ windowStart: string }>(
+      db,
+      `SELECT toString(toDate(now()) - INTERVAL 29 DAY) AS windowStart`,
+      {},
+    );
+    const windowStart = boundary[0].windowStart;
+    // Pivot into one CostDayPoint per calendar day (fill gaps with zero layers). Both ends of the
+    // list now come from the same ClickHouse clock as the window predicate above.
     const byDay = new Map<string, CostDayPoint>();
-    for (let i = 29; i >= 0; i--) {
-      const d = new Date();
-      d.setUTCDate(d.getUTCDate() - i);
-      const iso = d.toISOString().slice(0, 10);
+    for (const iso of isoDaysFrom(windowStart, COST_SERIES_WINDOW_DAYS)) {
       byDay.set(iso, { date: iso, byLayer: zeroLayers() });
     }
     for (const r of out) {
@@ -376,9 +394,9 @@ export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<F
 // Clocks: every date in the result — window start, today, the day list, the day count — comes from
 // ClickHouse. None of it is generated from the Node process clock. Those are two clocks in two
 // timezones, and when they straddle midnight the JS-built list is shifted a day against the SQL
-// window, so the oldest day silently has no slot to land in while still counting toward the totals
-// (the bug `queryCostSeries` still has, CTO-203). `queryAccountDetail` does it correctly; so does
-// this.
+// window, so the oldest day silently has no slot to land in while still counting toward the totals.
+// This is the seam CTO-203 fixed in `queryCostSeries`; `queryAccountDetail` does it correctly, and
+// so does this.
 
 /** Trailing history for the weekday profile, on the shared calendar-aligned boundary. */
 const SETTLED_TRAILING_DAYS = 30;


### PR DESCRIPTION
## The bug (CTO-203)

`queryCostSeries` in `web/lib/clickhouse.ts` filtered on ClickHouse's clock (`Timestamp >= toDate(now()) - INTERVAL 29 DAY`) but pre-filled its 30 day buckets from Node's clock via `new Date()`. Two clocks, two answers.

When the Node server and ClickHouse straddle midnight in different timezones, the JS day list shifts a day against the SQL window: the oldest returned row finds no matching bucket, the pivot drops it, and that point vanishes from the stacked chart while **still counting toward the headline total above it**. The chart and its own total silently disagree, and only in a narrow window each day, which is why it stayed hidden.

## The fix

Derive the day list from the window ClickHouse actually reports, following the pattern `queryAccountDetail` already uses (CTO-187). A dedicated one-row select returns the window start (`toDate(now()) - INTERVAL 29 DAY`) and `isoDaysFrom` builds the 30 buckets from it, so both ends of the list share the same clock as the window predicate. No new mechanism invented.

The window boundary itself is unchanged and stays calendar-aligned, so `/cost` and Home still agree to the penny. Only where the bucket **list** comes from moves off the Node clock.

## Tests

Adds tests that pin the behaviour when the Node clock and the ClickHouse-reported window disagree: a 2021-dated window a Node-clock list would never match proves no bucket is dropped and the rendered days sum to the same total the headline uses. Also covers the empty-window case (30 zero days) and asserts the SQL keeps the calendar-aligned boundary.

Comments in `burndown.ts` and `BurndownChart.tsx` that described the bug as still present are refreshed.

## Verification

From `web/`: `npm run typecheck` clean, `npm run lint` clean (only pre-existing warnings), `npm run test` = 571 passed. The only 2 failures are the long-standing `app/api/api.test.ts` ones (attribution + data-quality falling back to mock) that fail when a local ClickHouse is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)