### PR TITLE
feat(gateway): build the attribution stitcher runner (CTO-200)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -59,6 +59,7 @@ from gateway.protocol import (
 from gateway.ratelimit import RateLimiter
 from gateway.reconciliation import ReconciliationStore
 from gateway.scheduler import JobRegistry, build_scheduler
+from gateway.stitcher_job import register_stitcher_job
 from gateway.store import ClickHouseStore
 from gateway.stripe_ingest import (
     StripeSignatureError,
@@ -364,12 +365,15 @@ async def lifespan(app: FastAPI):
     #     Cloudflare on /connectors and nothing ever acted on that config. Enabling the scheduler
     #     makes the Compute and Egress columns populate on their own, which CHANGES tenants'
     #     numbers (see docs/scheduler-scope.md).
-    #   * CTO-216, the third-party ingest workers and the reconciler. This does NOT fix /features,
-    #     which stays blocked on the stitcher runner (CTO-200).
+    #   * CTO-216, the third-party ingest workers and the reconciler.
+    #   * CTO-200, the attribution stitcher runner. This is what finally populates
+    #     attribution_records, so /features stops showing honest nulls for value, payback and
+    #     attribution rate for a tenant whose touches and value events actually overlap.
     app.state.scheduler = None
     if settings.scheduler_enabled:
         job_registry = JobRegistry()
         register_cost_connector_job(job_registry, settings)  # CTO-215
+        register_stitcher_job(job_registry, settings)  # CTO-200
         register_worker_jobs(
             job_registry,
             settings,

--- a/infra/gateway/src/gateway/stitcher_job.py
+++ b/infra/gateway/src/gateway/stitcher_job.py
@@ -1,0 +1,658 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The attribution stitcher runner (CTO-200): the thing that finally POPULATES attribution_records.
+
+WHY this exists. ``attribution_records`` has 0 rows for every tenant, so ``/features`` renders honest
+nulls for value, payback and attribution rate, and always has. The cause was never a broken stitcher:
+``sdk/python/src/tally/stitcher.py`` is a pure in-memory library with no ClickHouse-backed
+``TouchStore``, no worker calling it, and no writer of ``attribution_records``. The raw signal is
+healthy (the demo tenant has ~138k rows in ``last_touch_index``); nothing consumed it. This module is
+that missing runner. It is the third scheduled job, alongside the cost connectors (CTO-215) and the
+ingest workers / reconciler (CTO-216), and it is deliberately thin: all the attribution LOGIC already
+lives and is tested in :mod:`tally.stitcher`. What was missing was the three pieces of plumbing this
+file supplies.
+
+WHAT THIS DOES, precisely:
+
+1. :class:`ClickHouseTouchStore` implements the exact :class:`tally.stitcher.TouchStore` protocol the
+   stitcher expects ("most recent touch per (user, feature) within a window"), backed by
+   ``last_touch_index``.
+2. :class:`ClickHouseValueEventSource` reads the tenant's value events from ``business_events`` for
+   the same bounded window and maps each row to a :class:`tally.stitcher.BusinessEvent`.
+3. A default :class:`tally.stitcher.AttributionRule` set (last-touch, 30-day lookback) generated from
+   the feature tags and event names actually present for the tenant, so no per-tenant config row is
+   required for the slice to work. A per-tenant config TABLE is a follow-up (see below).
+4. :class:`ClickHouseAttributionWriter` writes the produced records back to ``attribution_records``
+   (and the unattributable ones to ``unattributed_events``), matching the DDL in
+   ``db/clickhouse/attribution.sql``.
+
+THE DEFAULT RULE, and why the rule set is a product of what is present. A
+:class:`~tally.stitcher.AttributionRule` is per ``(event_name, feature_tag)``: the stitcher, for each
+rule matching an event's name, looks up the last touch for THAT feature tag and, if one exists in the
+window, credits the conversion to it. Last-touch attribution therefore means "credit the conversion
+to every feature the converting user touched within the lookback window", which is exactly what the
+``/features`` per-feature economics query sums (and it is explicit that summing across features
+double-counts at the conversion level, spec 7.2). So the default rule set is the cartesian product of
+the value event names in ``business_events`` and the feature tags in ``last_touch_index`` for the
+tenant, each with the default 30-day window and ``last_touch_v1`` model. Both sides come from the same
+two bounded loads the job already does, so generating the rules costs no extra query.
+
+CONFIDENCE. v1 attributes on a DIRECT user-hash match only: the stitcher is handed an empty
+:class:`tally.identity.IdentityGraph`, so a converting user's identity set is just their own hash and
+every record lands as ``direct``. That is honest and it is what lights ``/features`` up for a tenant
+whose revenue connector hashes into the same ``UserIdHash`` space the SDK uses (CTO-110). Populating
+the identity graph from the ``identity_graph`` table to earn ``session_stitched`` /
+``identity_graph_stitched`` confidence is a follow-up, called out with the late-edge path below.
+
+DEFERRED, on purpose (see the PR body and CTO-200):
+
+* The LATE-EDGE RESTITCH path (:func:`tally.stitcher.restitch_on_new_edge`): re-stitching an event
+  that was unattributable on the first pass once a late identity edge reveals the converting user was
+  someone we already had a touch for. It needs the identity graph loaded and a store of the pending
+  unattributed events, and it only matters once confidence stitching exists. This job does a full
+  from-scratch pass every tick instead, which is correct but does not retroactively rescue an event
+  the moment an edge lands. Follow-up ticket.
+* A per-tenant config TABLE for the rule (model + lookback). v1 uses a sensible default that works
+  with no config row, which is the priority. If it grows, migration 0029 is next free.
+
+BOUNDING THE CLICKHOUSE WORK (the CTO-219 posture, applied up front rather than learned the hard way).
+Both loads are tenant-scoped, restricted to the lookback window, capped in rows, and run under
+server-side ``max_rows_to_read`` / ``max_memory_usage`` / ``max_execution_time`` ceilings that make a
+runaway scan FAIL rather than take ClickHouse (and with it the gateway) down. A failure raises, the
+scheduler records ``failed`` and its backoff applies, and nothing wrong is ever written. The touch
+store is loaded ONCE per run into memory and answers every ``query_last_touch`` from there, rather
+than issuing a query per (event, rule) pair, which for a tenant with thousands of events and dozens of
+feature tags would be tens of thousands of round trips an hour. It is still a ClickHouse-backed store:
+one bounded scan sources it, and it implements exactly the protocol the stitcher calls.
+
+HONESTY AND SAFETY. A tenant with no touches or no value events is a no-op that raises
+:class:`~gateway.scheduler.JobSkipped` (settles the cadence window without claiming a run happened),
+never an error. An unattributable value event is written to ``unattributed_events`` (queryable, never
+silent) and is never guessed onto a random trace. Re-running does not duplicate: ``attribution_records``
+is a ``ReplacingMergeTree`` whose sort key is ``(TenantId, BusinessEventId, FeatureTag)`` and whose
+version is ``StitchedAt``, so a second pass replaces rather than appends, and the ``/features`` read
+uses ``FINAL``. We rely on that and invent no second dedupe.
+
+CADENCE: hourly, matching the reconciler (CTO-216). The stitcher reads our own ClickHouse rather than
+anyone else's rate-limited API, and what it feeds is the ``/features`` economics that a human reads as
+"current". An hour keeps that within a window a human would call fresh without re-deriving a number
+that has barely moved every few minutes.
+
+RUNS OFF THE EVENT LOOP. The scheduler calls job bodies on a worker thread, so :meth:`StitcherJob.__call__`
+is plain synchronous blocking code. It owns its own :class:`gateway.store.ClickHouseStore` per run
+(like the cost connector job, and unlike the ingest workers) so a job on a worker thread never shares a
+``clickhouse-connect`` client with the request path.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from tally.stitcher import (
+    AttributionRecord,
+    AttributionRule,
+    BusinessEvent,
+    Stitcher,
+    Touch,
+    UnattributedRecord,
+    ValueType,
+)
+
+from gateway.config import Settings
+from gateway.scheduler import Job, JobRegistry, JobSkipped
+from gateway.store import ClickHouseStore
+
+logger = logging.getLogger("tally.gateway.stitcher_job")
+
+#: Persisted in ``scheduler_runs.job_name``, so it is a stable contract: renaming it orphans the
+#: history and every tenant would look like it had never run, triggering an immediate run for all.
+JOB_NAME = "stitcher"
+
+#: Hourly. See the module docstring for why not finer and not daily.
+HOURLY_INTERVAL_S = 3600.0
+
+#: The default attribution rule the slice runs with when a tenant has no config row (which is every
+#: tenant, since the config table is a follow-up). 30 days is the stitcher library's own default and
+#: the window the ``/features`` economics is documented against.
+DEFAULT_LOOKBACK_DAYS = 30
+DEFAULT_ATTRIBUTION_MODEL = "last_touch_v1"
+
+#: Stamped on every record so a future model change is distinguishable in the history.
+STITCHER_VERSION = "v1"
+
+#: Row caps on the two bounded loads. A tenant with more touches or events than this in the window
+#: gets the newest, which is what last-touch attribution wants anyway; the ceilings below are the
+#: hard stop that turns a runaway into a failed run rather than an OOM.
+DEFAULT_TOUCH_CAP = 1_000_000
+DEFAULT_EVENT_CAP = 200_000
+
+#: Server-side ClickHouse ceilings (CTO-219). ``max_rows_to_read`` with ``read_overflow_mode=throw``
+#: bounds rows SCANNED, which a ``LIMIT`` does not; the other two bound memory and wall time. A pass
+#: that trips any of them raises, which the scheduler records as ``failed`` and backs off, rather than
+#: taking the ClickHouse server down for every tenant after it.
+DEFAULT_MAX_ROWS_TO_READ = 200_000_000
+DEFAULT_MAX_MEMORY_BYTES = 2 * 1024**3  # 2 GiB
+DEFAULT_MAX_EXECUTION_S = 120
+
+#: Enum names permitted by the ``unattributed_events.Reason`` column in attribution.sql. The stitcher
+#: emits ``no_trace_in_window``; anything unexpected is coerced to it rather than failing the insert.
+_UNATTRIBUTED_REASONS: frozenset[str] = frozenset(
+    {"no_trace_in_window", "unknown_user", "identity_unresolved", "feature_tag_missing"}
+)
+
+
+def _query_settings(
+    *,
+    max_rows_to_read: int = DEFAULT_MAX_ROWS_TO_READ,
+    max_memory_bytes: int = DEFAULT_MAX_MEMORY_BYTES,
+    max_execution_s: int = DEFAULT_MAX_EXECUTION_S,
+) -> dict[str, object]:
+    """The CTO-219 ceilings, as a fresh dict per caller so nobody mutates a shared one."""
+    return {
+        "max_rows_to_read": int(max_rows_to_read),
+        "read_overflow_mode": "throw",
+        "max_memory_usage": int(max_memory_bytes),
+        "max_execution_time": int(max_execution_s),
+        "timeout_overflow_mode": "throw",
+    }
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """ClickHouse hands back naive UTC for a ``DateTime64`` with no timezone. Make that explicit,
+    so the comparisons the stitcher does against ``event.occurred_at`` never raise a naive/aware
+    ``TypeError``."""
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
+def _hash_str(value: object) -> str:
+    """A ``FixedString(64)`` column (``UserIdHash``) comes back from clickhouse-connect as ``bytes``,
+    and ``str(bytes)`` would yield the ``b'...'`` repr rather than the hex, which then fails to bind
+    back into a ``FixedString(64)`` and, worse, would not match a touch's hash. Decode it as ASCII
+    and strip any trailing NUL padding so both sides of the attribution join are the same 64-char
+    string they were written as."""
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("ascii", "replace").rstrip("\x00")
+    return str(value)
+
+
+def _dollars_to_micros(value: object) -> int:
+    """``last_touch_index.LastTraceCost`` is a ``Decimal64(8)`` in dollars; the stitcher's
+    :class:`~tally.stitcher.Touch` carries integer micro-USD. Convert once, at the boundary."""
+    return int(round(float(value) * 1_000_000))
+
+
+def _micros_to_dollars(micros: int) -> Decimal:
+    """Inverse of :func:`_dollars_to_micros` for the ``AttributedTraceCost`` ``Decimal64(8)`` column.
+    A Decimal (not a float) so the value binds to the decimal column without a binary-float wobble."""
+    return Decimal(int(micros)) / Decimal(1_000_000)
+
+
+def _value_type(raw: object) -> ValueType:
+    """Map the ``business_events.ValueType`` enum name back to the stitcher's :class:`ValueType`.
+    An unrecognised value falls back to ``monetary`` rather than failing the whole load."""
+    try:
+        return ValueType(str(raw))
+    except ValueError:
+        return ValueType.MONETARY
+
+
+class ClickHouseTouchStore:
+    """A :class:`tally.stitcher.TouchStore` sourced by ONE bounded load of ``last_touch_index``.
+
+    WHY bulk-load rather than a query per call. The stitcher calls ``query_last_touch`` once per
+    ``(event, rule)`` pair. A tenant with thousands of value events and dozens of feature tags is tens
+    of thousands of pairs, and one ClickHouse round trip each would be the most expensive thing the
+    gateway does every hour. So a single capped, memory- and time-bounded scan (the CTO-219 posture)
+    loads the newest touch per ``(UserIdHash, FeatureTag)`` in the window into memory, and every
+    ``query_last_touch`` is answered from there. It still IS a ClickHouse-backed store: ClickHouse
+    sources it, and it implements exactly the protocol the stitcher expects.
+
+    The load window is wider than the value-event window by one lookback: an event at the very start
+    of ``[now - lookback, now]`` still has to be able to see a touch a full lookback before IT, so the
+    touches are loaded over ``[now - 2*lookback, now]``. The precise per-event window is then enforced
+    in memory by :meth:`query_last_touch`, which the stitcher calls with ``[occurred - lookback,
+    occurred]``.
+
+    ``ReplacingMergeTree`` on ``(TenantId, UserIdHash, FeatureTag)`` means multiple physical rows can
+    exist per key before a merge, so the load collapses them with ``argMax(..., UpdatedAt)`` rather
+    than trusting the parts to be merged.
+    """
+
+    _SQL = """
+        SELECT UserIdHash,
+               FeatureTag,
+               argMax(LastTraceId, UpdatedAt)           AS trace_id,
+               argMax(LastTraceTs, UpdatedAt)           AS trace_ts,
+               argMax(LastTraceCost, UpdatedAt)         AS trace_cost,
+               argMax(UserIdHashKeyVersion, UpdatedAt)  AS key_version
+        FROM last_touch_index
+        WHERE TenantId = {tenant:String}
+          AND LastTraceTs >= subtractDays(now64(9), {days:UInt32})
+          AND LastTraceTs <= now64(9)
+        GROUP BY UserIdHash, FeatureTag
+        ORDER BY trace_ts DESC
+        LIMIT {cap:UInt32}
+    """
+
+    def __init__(
+        self,
+        store: object,
+        *,
+        touch_lookback_days: int,
+        cap: int = DEFAULT_TOUCH_CAP,
+        query_settings: dict[str, object] | None = None,
+    ) -> None:
+        if touch_lookback_days <= 0 or cap <= 0:
+            raise ValueError("touch_lookback_days and cap must be positive")
+        self._store = store
+        self._days = int(touch_lookback_days)
+        self._cap = int(cap)
+        self._settings = query_settings if query_settings is not None else _query_settings()
+        self._by_key: dict[tuple[str, str], Touch] = {}
+
+    @property
+    def query_settings(self) -> dict[str, object]:
+        """The ClickHouse-side ceilings this store enforces. Exposed so tests can assert on them."""
+        return dict(self._settings)
+
+    @property
+    def touch_count(self) -> int:
+        return len(self._by_key)
+
+    def feature_tags(self) -> set[str]:
+        """Every feature tag seen in the loaded window. Drives the default rule set, so it costs no
+        extra query."""
+        return {feature_tag for (_user, feature_tag) in self._by_key}
+
+    def load(self, tenant_id: str) -> int:
+        """Run the one bounded scan and index the result. Returns how many touches were loaded.
+
+        Raises on a ClickHouse failure (including a tripped ceiling), which the job turns into a
+        ``failed`` run: the honest outcome, never a partial index that looks complete.
+        """
+        result = self._store.client.query(  # type: ignore[attr-defined]
+            self._SQL,
+            parameters={"tenant": tenant_id, "days": self._days, "cap": self._cap},
+            settings=self._settings,
+        )
+        by_key: dict[tuple[str, str], Touch] = {}
+        for row in result.result_rows:
+            user_hash, feature_tag, trace_id, trace_ts, trace_cost, key_version = row
+            touch = Touch(
+                trace_id=str(trace_id),
+                user_hash=_hash_str(user_hash),
+                feature_tag=str(feature_tag),
+                ts=_as_utc(trace_ts),
+                cost_micro_usd=_dollars_to_micros(trace_cost),
+                key_version=str(key_version) or "v1",
+            )
+            key = (touch.user_hash, touch.feature_tag)
+            current = by_key.get(key)
+            # argMax already collapses the ReplacingMergeTree per key, so this only guards the
+            # theoretical case of two rows surviving; newest LastTraceTs wins, as last-touch wants.
+            if current is None or touch.ts > current.ts:
+                by_key[key] = touch
+        self._by_key = by_key
+        return len(by_key)
+
+    def query_last_touch(
+        self,
+        *,
+        tenant_id: str,
+        user_hashes: set[str],
+        feature_tag: str,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> Touch | None:
+        """The most recent loaded touch for any of ``user_hashes`` on ``feature_tag`` within the
+        window, or ``None``. Same shape and semantics as :class:`tally.stitcher.MemoryTouchStore`, so
+        the stitcher cannot tell the two apart. ``tenant_id`` is already fixed by :meth:`load`; it is
+        accepted to satisfy the protocol and is not re-checked."""
+        best: Touch | None = None
+        for user_hash in user_hashes:
+            touch = self._by_key.get((user_hash, feature_tag))
+            if touch is None:
+                continue
+            if touch.ts < window_start or touch.ts > window_end:
+                continue
+            if best is None or touch.ts > best.ts:
+                best = touch
+        return best
+
+
+class ClickHouseValueEventSource:
+    """Loads a tenant's recent value events from ``business_events`` as :class:`BusinessEvent`s.
+
+    ``FINAL`` collapses the ``ReplacingMergeTree`` so a re-posted event (same ``BusinessEventId``) is
+    read once, not twice, which would otherwise attribute the same conversion twice. Bounded exactly
+    like the touch load: tenant-scoped, windowed, capped and under the CTO-219 ceilings. Events with
+    an empty ``UserIdHash`` are skipped in SQL, because there is nothing to resolve them to and they
+    would only ever be unattributable.
+    """
+
+    _SQL = """
+        SELECT BusinessEventId,
+               EventName,
+               UserIdHash,
+               OccurredAt,
+               ValueAmountMicro,
+               ValueCurrency,
+               ValueType
+        FROM business_events FINAL
+        WHERE TenantId = {tenant:String}
+          AND UserIdHash != ''
+          AND OccurredAt >= subtractDays(now64(9), {days:UInt32})
+          AND OccurredAt <= now64(9)
+        ORDER BY OccurredAt DESC
+        LIMIT {cap:UInt32}
+    """
+
+    def __init__(
+        self,
+        *,
+        lookback_days: int,
+        cap: int = DEFAULT_EVENT_CAP,
+        query_settings: dict[str, object] | None = None,
+    ) -> None:
+        if lookback_days <= 0 or cap <= 0:
+            raise ValueError("lookback_days and cap must be positive")
+        self._days = int(lookback_days)
+        self._cap = int(cap)
+        self._settings = query_settings if query_settings is not None else _query_settings()
+
+    @property
+    def query_settings(self) -> dict[str, object]:
+        return dict(self._settings)
+
+    def fetch(self, store: object, tenant_id: str) -> list[BusinessEvent]:
+        """One bounded, tenant-scoped round trip. Raises on a ClickHouse failure (see the touch load)."""
+        result = store.client.query(  # type: ignore[attr-defined]
+            self._SQL,
+            parameters={"tenant": tenant_id, "days": self._days, "cap": self._cap},
+            settings=self._settings,
+        )
+        events: list[BusinessEvent] = []
+        for row in result.result_rows:
+            business_event_id, event_name, user_hash, occurred_at, value_micro, currency, vtype = row
+            events.append(
+                BusinessEvent(
+                    business_event_id=str(business_event_id),
+                    tenant_id=tenant_id,
+                    user_hash=_hash_str(user_hash),
+                    event_name=str(event_name),
+                    occurred_at=_as_utc(occurred_at),
+                    value_amount_micro=(int(value_micro) if value_micro is not None else None),
+                    value_currency=str(currency) or "USD",
+                    value_type=_value_type(vtype),
+                )
+            )
+        return events
+
+
+#: Column order for ``attribution_records``, pinned against the DDL in attribution.sql. A column added
+#: to one and not the other silently shifts every value after it, so the tests pin this list to the
+#: canonical DDL, exactly as ``store._BUSINESS_EVENT_COLS`` is pinned.
+_ATTRIBUTION_COLS = (
+    "TenantId",
+    "BusinessEventId",
+    "FeatureTag",
+    "AttributedTraceId",
+    "AttributedTraceTs",
+    "AttributedTraceCost",
+    "ValueAmountMicro",
+    "ValueCurrency",
+    "AttributionModel",
+    "AttributionConfidence",
+    "UserIdHashKeyVersion",
+    "LookbackWindowDays",
+    "StitchedAt",
+    "StitcherVersion",
+)
+
+#: Column order for ``unattributed_events``, pinned the same way.
+_UNATTRIBUTED_COLS = (
+    "TenantId",
+    "BusinessEventId",
+    "EventName",
+    "UserIdHash",
+    "OccurredAt",
+    "Reason",
+    "LastCheckedAt",
+)
+
+
+class ClickHouseAttributionWriter:
+    """Writes the stitcher's output back to ClickHouse: records to ``attribution_records``, the
+    unattributable events to ``unattributed_events``.
+
+    No dedupe of its own. ``attribution_records`` is a ``ReplacingMergeTree`` keyed on
+    ``(TenantId, BusinessEventId, FeatureTag)`` with ``StitchedAt`` as the version, so re-running the
+    job replaces rather than appends and the ``/features`` read collapses with ``FINAL``. Inventing a
+    second dedupe here would only be a way to disagree with that one.
+    """
+
+    def write(
+        self,
+        store: object,
+        records: Sequence[AttributionRecord],
+        unattributed: Sequence[UnattributedRecord],
+    ) -> tuple[int, int]:
+        """Insert both sets. Returns ``(records_written, unattributed_written)``."""
+        if records:
+            rows = [
+                (
+                    record.tenant_id,
+                    record.business_event_id,
+                    record.feature_tag,
+                    record.attributed_trace_id,
+                    record.attributed_trace_ts,
+                    _micros_to_dollars(record.attributed_trace_cost_micro_usd),
+                    record.value_amount_micro,
+                    record.value_currency,
+                    record.attribution_model,
+                    # str value of the enum, which is the ClickHouse Enum8 NAME ('direct', ...).
+                    record.confidence.value,
+                    record.user_id_hash_key_version,
+                    record.lookback_window_days,
+                    record.stitched_at,
+                    record.stitcher_version,
+                )
+                for record in records
+            ]
+            store.client.insert(  # type: ignore[attr-defined]
+                "attribution_records", rows, column_names=list(_ATTRIBUTION_COLS)
+            )
+        if unattributed:
+            urows = [
+                (
+                    u.tenant_id,
+                    u.business_event_id,
+                    u.event_name,
+                    u.user_hash,
+                    u.occurred_at,
+                    u.reason if u.reason in _UNATTRIBUTED_REASONS else "no_trace_in_window",
+                    u.last_checked_at,
+                )
+                for u in unattributed
+            ]
+            store.client.insert(  # type: ignore[attr-defined]
+                "unattributed_events", urows, column_names=list(_UNATTRIBUTED_COLS)
+            )
+        return len(records), len(unattributed)
+
+
+def _default_rules(
+    event_names: set[str], feature_tags: set[str], *, lookback_days: int
+) -> list[AttributionRule]:
+    """The default rule set: one rule per ``(event_name, feature_tag)`` actually present for the
+    tenant, at the default window and model. See the module docstring for why last-touch attribution
+    is exactly this product. Sorted so a run is deterministic and reproducible in tests."""
+    return [
+        AttributionRule(
+            event_name=event_name,
+            feature_tag=feature_tag,
+            lookback_days=lookback_days,
+            attribution_model=DEFAULT_ATTRIBUTION_MODEL,
+        )
+        for event_name in sorted(event_names)
+        for feature_tag in sorted(feature_tags)
+    ]
+
+
+class StitcherJob:
+    """Stitches a tenant's value events against its touches and writes the result. Callable as a job.
+
+    Constructed once at startup and called with a tenant id per due tick. Holds no per-tenant state:
+    everything is re-read on every call, so a tenant that starts converting today attributes on the
+    next tick with no restart.
+
+    Every collaborator is injectable so the tests never touch ClickHouse. The defaults are the
+    production wiring.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        store_factory: Callable[[], ClickHouseStore] | None = None,
+        writer: ClickHouseAttributionWriter | None = None,
+        lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+        touch_cap: int = DEFAULT_TOUCH_CAP,
+        event_cap: int = DEFAULT_EVENT_CAP,
+        query_settings: dict[str, object] | None = None,
+        now: Callable[[], datetime] = _utcnow,
+    ) -> None:
+        if lookback_days <= 0:
+            raise ValueError("lookback_days must be positive")
+        self._settings = settings
+        # Own client per run, like the cost connector job: a job on a worker thread must never share a
+        # clickhouse-connect client with the request path.
+        self._store_factory = (
+            store_factory if store_factory is not None else lambda: ClickHouseStore(settings)
+        )
+        self._writer = writer if writer is not None else ClickHouseAttributionWriter()
+        self._lookback_days = int(lookback_days)
+        self._touch_cap = int(touch_cap)
+        self._event_cap = int(event_cap)
+        self._query_settings = query_settings
+        self._now = now
+
+    def __call__(self, tenant_id: str) -> None:
+        """Run one full stitch pass for ``tenant_id``. Blocking by design (worker thread).
+
+        Skips (``JobSkipped``) when the tenant has no touches or no value events, which is a no-op that
+        settles the cadence window without claiming a run happened. Otherwise stitches every event
+        against the default rules, writes the records and the unattributable events, and returns.
+        """
+        store = self._store_factory()
+        try:
+            touches = ClickHouseTouchStore(
+                store,
+                # Load one lookback WIDER than the events, so an event at the start of the event
+                # window can still see a touch a full lookback before it. See the class docstring.
+                touch_lookback_days=self._lookback_days * 2,
+                cap=self._touch_cap,
+                query_settings=(
+                    dict(self._query_settings) if self._query_settings is not None else None
+                ),
+            )
+            touches.load(tenant_id)
+
+            event_source = ClickHouseValueEventSource(
+                lookback_days=self._lookback_days,
+                cap=self._event_cap,
+                query_settings=(
+                    dict(self._query_settings) if self._query_settings is not None else None
+                ),
+            )
+            events = event_source.fetch(store, tenant_id)
+
+            feature_tags = touches.feature_tags()
+            # No touches or no events is the normal state for most tenants and is a no-op, not an
+            # error. Nothing is written: with no touches nothing could attribute, and with no events
+            # there is nothing to attribute. See HONESTY AND SAFETY in the module docstring.
+            if not feature_tags or not events:
+                raise JobSkipped(
+                    f"tenant {tenant_id} has "
+                    f"{'no touches' if not feature_tags else 'no value events'}"
+                )
+
+            event_names = {event.event_name for event in events}
+            rules = _default_rules(
+                event_names, feature_tags, lookback_days=self._lookback_days
+            )
+
+            # Empty identity graph: v1 attributes on a direct user-hash match only. See CONFIDENCE in
+            # the module docstring. now= anchors the stitch clock; each rule's own window is measured
+            # back from the event's occurred_at inside stitch().
+            stitcher = Stitcher(touches=touches, rules=rules)
+            now = self._now()
+            for event in events:
+                stitcher.stitch(event, now=now)
+
+            records = list(stitcher.records.values())
+            attributed_ids = {record.business_event_id for record in records}
+            # Only events that attributed to NOTHING are written as unattributed. The stitcher keys
+            # its unattributed set on (tenant, event) without the feature tag, so an event that
+            # attributed to one feature but not another can leave a stale unattributed entry depending
+            # on rule order; filtering on "produced zero records" is the honest, order-independent
+            # definition of unattributable and avoids writing a row that contradicts an attribution.
+            unattributed = [
+                record
+                for (_tenant, business_event_id), record in stitcher.unattributed.items()
+                if business_event_id not in attributed_ids
+            ]
+
+            written, unattributed_written = self._writer.write(store, records, unattributed)
+            logger.info(
+                "stitcher: tenant=%s events=%d touches=%d rules=%d records=%d unattributed=%d",
+                tenant_id,
+                len(events),
+                touches.touch_count,
+                len(rules),
+                written,
+                unattributed_written,
+            )
+        finally:
+            # Closed on every path, including the JobSkipped raise. A leaked ClickHouse client per run
+            # would take a long time to notice and would look like a ClickHouse problem.
+            store.close()
+
+
+def register_stitcher_job(
+    registry: JobRegistry,
+    settings: Settings,
+    *,
+    interval_s: float = HOURLY_INTERVAL_S,
+    job: StitcherJob | None = None,
+) -> Job:
+    """Register the hourly stitcher job on ``registry`` (called from the gateway lifespan).
+
+    Kept here rather than inside ``build_scheduler`` so the scheduler core stays a job-free engine and
+    each job's wiring lives next to the job, exactly as :func:`register_cost_connector_job` and
+    :func:`register_worker_jobs` do.
+    """
+    return registry.register(
+        JOB_NAME,
+        interval_s,
+        job if job is not None else StitcherJob(settings),
+    )
+
+
+__all__ = [
+    "DEFAULT_LOOKBACK_DAYS",
+    "HOURLY_INTERVAL_S",
+    "JOB_NAME",
+    "STITCHER_VERSION",
+    "ClickHouseAttributionWriter",
+    "ClickHouseTouchStore",
+    "ClickHouseValueEventSource",
+    "StitcherJob",
+    "register_stitcher_job",
+]

--- a/infra/gateway/tests/test_stitcher_job.py
+++ b/infra/gateway/tests/test_stitcher_job.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The attribution stitcher runner: TouchStore mapping, writeback, and the skip path (CTO-200).
+
+No ClickHouse: a fake client records the SQL / parameters / settings it is queried with and returns
+canned ``result_rows``, and captures the inserts. What these tests assert is the acceptance list on
+the ticket:
+
+* the ClickHouse-backed ``TouchStore`` maps ``last_touch_index`` rows to the exact
+  :class:`tally.stitcher.Touch` shape the stitcher expects, and answers ``query_last_touch`` from that
+  one bounded load,
+* a full run for a tenant with overlapping touches and value events WRITES ``attribution_records``
+  (which is what lights /features up), and the written rows match the DDL column-for-column,
+* a value event with no touch in its window is written to ``unattributed_events``, never guessed onto
+  a trace,
+* a tenant with no value events (or no touches) raises ``JobSkipped``, not an error,
+* both ClickHouse loads are bounded: tenant-scoped, windowed, capped, and carrying the CTO-219
+  server-side ceilings.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from tally.stitcher import AttributionConfidence
+
+from gateway.scheduler import JobRegistry, JobSkipped
+from gateway.stitcher_job import (
+    JOB_NAME,
+    ClickHouseAttributionWriter,
+    ClickHouseTouchStore,
+    ClickHouseValueEventSource,
+    StitcherJob,
+    _ATTRIBUTION_COLS,
+    _UNATTRIBUTED_COLS,
+    register_stitcher_job,
+)
+
+DDL = Path(__file__).resolve().parents[3] / "db" / "clickhouse" / "attribution.sql"
+
+TENANT = "11111111-1111-1111-1111-111111111111"
+NOW = datetime(2026, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
+USER_A = "a" * 64
+USER_B = "b" * 64
+
+
+class FakeCHClient:
+    """Records queries and inserts; returns canned rows keyed by which table the SQL names."""
+
+    def __init__(
+        self,
+        *,
+        touch_rows: list[tuple] | None = None,
+        event_rows: list[tuple] | None = None,
+    ) -> None:
+        self.queries: list[dict[str, object]] = []
+        self.inserts: list[tuple[str, list, list[str]]] = []
+        self._touch_rows = touch_rows or []
+        self._event_rows = event_rows or []
+
+    def query(self, sql: str, parameters=None, settings=None):  # noqa: ANN001, ANN202
+        self.queries.append({"sql": sql, "parameters": parameters, "settings": settings})
+        rows = self._touch_rows if "last_touch_index" in sql else self._event_rows
+
+        class _R:
+            result_rows = rows
+
+        return _R()
+
+    def insert(self, table: str, rows: list, column_names: list[str]) -> None:
+        self.inserts.append((table, rows, column_names))
+
+
+class FakeStore:
+    """The slice of ``ClickHouseStore`` the job uses: a ``.client`` and a ``.close()``."""
+
+    def __init__(self, client: FakeCHClient) -> None:
+        self.client = client
+        self.closed = 0
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def _touch_row(
+    user_hash: str,
+    feature_tag: str,
+    *,
+    ts: datetime,
+    trace_id: str = "trace-1",
+    cost: Decimal = Decimal("0.50000000"),
+    key_version: str = "v1",
+) -> tuple:
+    # Matches the SELECT column order in ClickHouseTouchStore._SQL.
+    return (user_hash, feature_tag, trace_id, ts, cost, key_version)
+
+
+def _event_row(
+    business_event_id: str,
+    user_hash: str,
+    *,
+    event_name: str = "subscription_started",
+    occurred_at: datetime,
+    value_micro: int | None = 49_000_000,
+    currency: str = "USD",
+    value_type: str = "monetary",
+) -> tuple:
+    # Matches the SELECT column order in ClickHouseValueEventSource._SQL.
+    return (business_event_id, event_name, user_hash, occurred_at, value_micro, currency, value_type)
+
+
+def _job(store: FakeStore, **kw: object) -> StitcherJob:
+    kw.setdefault("now", lambda: NOW)
+    return StitcherJob(
+        settings=None,  # type: ignore[arg-type]
+        store_factory=lambda: store,
+        **kw,  # type: ignore[arg-type]
+    )
+
+
+# --- TouchStore mapping --------------------------------------------------------------------------
+
+
+def test_fixed_string_hash_bytes_are_decoded_not_repr_ed() -> None:
+    """A FixedString(64) column comes back from clickhouse-connect as bytes. str(bytes) yields the
+    b'...' repr, which is 68 chars, fails to bind back into FixedString(64), and never matches a
+    touch. So an event whose hash arrives as bytes must still attribute against a touch with the same
+    hash. This pins the boundary decode that a live run caught."""
+    hash_bytes = (USER_A).encode("ascii")
+    client = FakeCHClient(
+        touch_rows=[_touch_row(hash_bytes, "chatbot", ts=NOW - timedelta(days=2))],
+        event_rows=[_event_row("evt-b", hash_bytes, occurred_at=NOW - timedelta(days=1))],
+    )
+    store = FakeStore(client)
+    _job(store)(TENANT)
+
+    rows = {table: r for table, r, _c in client.inserts}["attribution_records"]
+    row = dict(zip(_ATTRIBUTION_COLS, rows[0]))
+    # Attributed (bytes on both sides decoded to the same 64-char hex, so they matched).
+    assert row["BusinessEventId"] == "evt-b"
+    assert row["FeatureTag"] == "chatbot"
+
+
+def test_touch_store_maps_rows_to_the_stitcher_touch_shape() -> None:
+    client = FakeCHClient(touch_rows=[_touch_row(USER_A, "chatbot", ts=NOW - timedelta(days=1))])
+    store = FakeStore(client)
+    touches = ClickHouseTouchStore(store, touch_lookback_days=60)
+    loaded = touches.load(TENANT)
+
+    assert loaded == 1
+    assert touches.feature_tags() == {"chatbot"}
+    got = touches.query_last_touch(
+        tenant_id=TENANT,
+        user_hashes={USER_A},
+        feature_tag="chatbot",
+        window_start=NOW - timedelta(days=30),
+        window_end=NOW,
+    )
+    assert got is not None
+    assert got.user_hash == USER_A
+    assert got.feature_tag == "chatbot"
+    assert got.trace_id == "trace-1"
+    # Decimal dollars -> integer micro-USD at the boundary.
+    assert got.cost_micro_usd == 500_000
+    # Naive ClickHouse DateTime64 is stamped UTC so the stitcher's aware comparisons never raise.
+    assert got.ts.tzinfo is not None
+
+
+def test_touch_store_query_respects_the_per_event_window() -> None:
+    """The bulk load is wide; the precise per-event window is enforced in memory by query_last_touch."""
+    client = FakeCHClient(touch_rows=[_touch_row(USER_A, "chatbot", ts=NOW - timedelta(days=45))])
+    store = FakeStore(client)
+    touches = ClickHouseTouchStore(store, touch_lookback_days=60)
+    touches.load(TENANT)
+
+    # Inside the load window (60d) but OUTSIDE a 30-day event window -> not a candidate.
+    assert (
+        touches.query_last_touch(
+            tenant_id=TENANT,
+            user_hashes={USER_A},
+            feature_tag="chatbot",
+            window_start=NOW - timedelta(days=30),
+            window_end=NOW,
+        )
+        is None
+    )
+
+
+def test_touch_store_load_is_bounded_and_tenant_scoped() -> None:
+    client = FakeCHClient(touch_rows=[])
+    store = FakeStore(client)
+    ClickHouseTouchStore(store, touch_lookback_days=60, cap=1234).load(TENANT)
+
+    call = client.queries[0]
+    sql = " ".join(str(call["sql"]).split())
+    assert "TenantId = {tenant:String}" in sql
+    # Newest-per-key collapse of the ReplacingMergeTree, not a trust in merges having happened.
+    assert "argMax(LastTraceTs, UpdatedAt)" in sql
+    assert "LastTraceTs >= subtractDays(now64(9), {days:UInt32})" in sql
+    params = call["parameters"]
+    assert isinstance(params, dict)
+    assert params["tenant"] == TENANT
+    assert params["days"] == 60
+    assert params["cap"] == 1234
+    settings = call["settings"]
+    assert isinstance(settings, dict)
+    assert settings["max_rows_to_read"] > 0
+    assert settings["max_memory_usage"] > 0
+    assert settings["max_execution_time"] > 0
+    assert settings["read_overflow_mode"] == "throw"
+
+
+def test_value_event_source_is_bounded_and_uses_final() -> None:
+    client = FakeCHClient(event_rows=[])
+    store = FakeStore(client)
+    ClickHouseValueEventSource(lookback_days=30, cap=999).fetch(store, TENANT)
+
+    call = client.queries[0]
+    sql = " ".join(str(call["sql"]).split())
+    # FINAL so a re-posted event (same BusinessEventId) is read once, not attributed twice.
+    assert "business_events FINAL" in sql
+    assert "TenantId = {tenant:String}" in sql
+    assert "OccurredAt >= subtractDays(now64(9), {days:UInt32})" in sql
+    params = call["parameters"]
+    assert isinstance(params, dict)
+    assert params["days"] == 30
+    assert params["cap"] == 999
+    assert isinstance(call["settings"], dict)
+
+
+# --- a full run writes attribution_records -------------------------------------------------------
+
+
+def test_a_run_with_overlapping_touch_and_event_writes_an_attribution_record() -> None:
+    client = FakeCHClient(
+        touch_rows=[_touch_row(USER_A, "chatbot", ts=NOW - timedelta(days=2))],
+        event_rows=[_event_row("evt-1", USER_A, occurred_at=NOW - timedelta(days=1))],
+    )
+    store = FakeStore(client)
+    _job(store)(TENANT)
+
+    inserts = {table: (rows, cols) for table, rows, cols in client.inserts}
+    assert "attribution_records" in inserts
+    rows, cols = inserts["attribution_records"]
+    assert cols == list(_ATTRIBUTION_COLS)
+    assert len(rows) == 1
+    row = dict(zip(cols, rows[0]))
+    assert row["TenantId"] == TENANT
+    assert row["BusinessEventId"] == "evt-1"
+    assert row["FeatureTag"] == "chatbot"
+    assert row["AttributedTraceId"] == "trace-1"
+    assert row["ValueAmountMicro"] == 49_000_000
+    # v1 attributes on a direct user-hash match -> 'direct' confidence, the Enum8 name.
+    assert row["AttributionConfidence"] == AttributionConfidence.DIRECT.value
+    assert row["AttributionModel"] == "last_touch_v1"
+    assert row["LookbackWindowDays"] == 30
+    # Decimal micro-USD -> Decimal dollars for the Decimal64(8) column.
+    assert row["AttributedTraceCost"] == Decimal("500000") / Decimal(1_000_000)
+    # The store is always closed.
+    assert store.closed == 1
+
+
+def test_the_written_columns_match_the_canonical_ddl() -> None:
+    """A column added to attribution.sql but not to _ATTRIBUTION_COLS (or vice versa) shifts every
+    value after it. Pin the insert column list against the DDL, exactly as the business_events test
+    pins its own."""
+    ddl = DDL.read_text()
+    # The CREATE TABLE body for attribution_records.
+    body = ddl.split("CREATE TABLE IF NOT EXISTS attribution_records", 1)[1].split(")\nENGINE", 1)[0]
+    for col in _ATTRIBUTION_COLS:
+        assert col in body, f"{col} missing from attribution_records DDL"
+    for col in _UNATTRIBUTED_COLS:
+        assert col in ddl
+
+
+def test_value_event_with_no_touch_in_window_is_written_unattributed_not_guessed() -> None:
+    client = FakeCHClient(
+        # A touch exists, but for a DIFFERENT user, so the converting user has no touch.
+        touch_rows=[_touch_row(USER_B, "chatbot", ts=NOW - timedelta(days=2))],
+        event_rows=[_event_row("evt-lonely", USER_A, occurred_at=NOW - timedelta(days=1))],
+    )
+    store = FakeStore(client)
+    _job(store)(TENANT)
+
+    inserts = {table: rows for table, rows, _cols in client.inserts}
+    # Nothing was attributed (no touch for USER_A), so no attribution_records insert happened.
+    assert "attribution_records" not in inserts or inserts["attribution_records"] == []
+    assert "unattributed_events" in inserts
+    urows = inserts["unattributed_events"]
+    assert len(urows) == 1
+    urow = dict(zip(_UNATTRIBUTED_COLS, urows[0]))
+    assert urow["BusinessEventId"] == "evt-lonely"
+    assert urow["UserIdHash"] == USER_A
+    assert urow["Reason"] == "no_trace_in_window"
+
+
+# --- the skip path -------------------------------------------------------------------------------
+
+
+def test_no_value_events_raises_jobskipped_not_an_error() -> None:
+    client = FakeCHClient(
+        touch_rows=[_touch_row(USER_A, "chatbot", ts=NOW - timedelta(days=2))],
+        event_rows=[],
+    )
+    store = FakeStore(client)
+    with pytest.raises(JobSkipped):
+        _job(store)(TENANT)
+    # A skip writes nothing and still closes the store.
+    assert client.inserts == []
+    assert store.closed == 1
+
+
+def test_no_touches_raises_jobskipped() -> None:
+    client = FakeCHClient(
+        touch_rows=[],
+        event_rows=[_event_row("evt-1", USER_A, occurred_at=NOW - timedelta(days=1))],
+    )
+    store = FakeStore(client)
+    with pytest.raises(JobSkipped):
+        _job(store)(TENANT)
+    assert client.inserts == []
+
+
+def test_a_clickhouse_failure_propagates_so_the_scheduler_records_failed() -> None:
+    class Boom(FakeCHClient):
+        def query(self, sql, parameters=None, settings=None):  # noqa: ANN001, ANN202
+            raise RuntimeError("max_rows_to_read exceeded")
+
+    store = FakeStore(Boom())
+    with pytest.raises(RuntimeError):
+        _job(store)(TENANT)
+    # Even on failure the client is closed rather than leaked.
+    assert store.closed == 1
+
+
+# --- writer + registration -----------------------------------------------------------------------
+
+
+def test_writer_reports_counts_and_skips_empty_inserts() -> None:
+    client = FakeCHClient()
+    store = FakeStore(client)
+    written, unattributed = ClickHouseAttributionWriter().write(store, [], [])
+    assert (written, unattributed) == (0, 0)
+    # Nothing to write means no insert call at all.
+    assert client.inserts == []
+
+
+def test_register_stitcher_job_registers_the_hourly_job() -> None:
+    registry = JobRegistry()
+    job = register_stitcher_job(registry, settings=None)  # type: ignore[arg-type]
+    assert job.name == JOB_NAME
+    assert job.interval_s == 3600.0
+    assert registry.get(JOB_NAME) is job
+
+
+def test_rerun_writes_the_same_sort_key_so_replacingmergetree_dedupes() -> None:
+    """Idempotency is the table's, not ours: two runs write the SAME (Tenant, BusinessEventId,
+    FeatureTag) sort key, and StitchedAt (the version) advances, so FINAL collapses them."""
+    rows = lambda: (  # noqa: E731
+        [_touch_row(USER_A, "chatbot", ts=NOW - timedelta(days=2))],
+        [_event_row("evt-1", USER_A, occurred_at=NOW - timedelta(days=1))],
+    )
+    first = FakeCHClient(touch_rows=rows()[0], event_rows=rows()[1])
+    store1 = FakeStore(first)
+    _job(store1)(TENANT)
+    second = FakeCHClient(touch_rows=rows()[0], event_rows=rows()[1])
+    store2 = FakeStore(second)
+    _job(store2, now=lambda: NOW + timedelta(hours=1))(TENANT)
+
+    r1 = dict(zip(_ATTRIBUTION_COLS, first.inserts[0][1][0]))
+    r2 = dict(zip(_ATTRIBUTION_COLS, second.inserts[0][1][0]))
+    key = ("TenantId", "BusinessEventId", "FeatureTag")
+    assert tuple(r1[k] for k in key) == tuple(r2[k] for k in key)
+    # The version column advances, so the later write wins on merge / FINAL.
+    assert r2["StitchedAt"] > r1["StitchedAt"]


### PR DESCRIPTION
## What and why

`attribution_records` had **0 rows for every tenant**, so `/features` rendered honest nulls for value, payback and attribution rate, and always had. The cause was never a broken stitcher: `sdk/python/src/tally/stitcher.py` is a pure in-memory library with no ClickHouse-backed `TouchStore`, no worker calling it, and no writer of `attribution_records`. `last_touch_index` is healthy (137,985 rows on the demo tenant); nothing consumed it. This PR adds the missing **runner** as the third scheduled job, alongside the cost connectors (CTO-215) and the ingest workers / reconciler (CTO-216).

The attribution logic already lived and was tested in `tally.stitcher`. This PR is the three pieces of plumbing that were missing, plus the scheduler wiring.

## What it builds

- **`ClickHouseTouchStore`** — implements the exact `tally.stitcher.TouchStore` protocol, sourced from `last_touch_index` by **one bounded scan** (row-capped, `argMax`-collapsed over the ReplacingMergeTree, under `max_rows_to_read` / `max_memory_usage` / `max_execution_time` ceilings), answering every `query_last_touch` from memory rather than issuing a query per `(event, rule)` pair. It is still ClickHouse-backed and implements the protocol exactly.
- **`ClickHouseValueEventSource`** — the tenant's value events from `business_events FINAL`, bounded the same way.
- **A default `AttributionRule` set** — `last_touch_v1`, 30-day lookback, generated from the event names and feature tags actually present for the tenant, so **no per-tenant config row is required** for the slice to work.
- **`ClickHouseAttributionWriter`** — writes records to `attribution_records` and unattributable events to `unattributed_events`, columns pinned to `db/clickhouse/attribution.sql`. **No second dedupe:** `attribution_records` is a `ReplacingMergeTree` keyed `(TenantId, BusinessEventId, FeatureTag)`, so re-running replaces on the sort key and the `/features` read uses `FINAL`.
- **`register_stitcher_job`** — one additive `register_*` call in the lifespan next to the existing two. Cadence **hourly**, matching the reconciler.

## Honesty and safety

- A tenant with no touches or no value events raises **`JobSkipped`** (settles the cadence window, not an error).
- An unattributable value event goes to `unattributed_events` (queryable), never guessed onto a random trace.
- Every ClickHouse load is tenant-scoped, windowed, row-capped and fail-fast bounded — the CTO-219 posture applied up front, so a runaway scan fails honestly rather than OOMing the server.
- v1 attributes on a **direct user-hash match** only (empty identity graph).

## Deferred (follow-ups)

- **The late-edge restitch path** (`restitch_on_new_edge`): re-stitching an event once a late identity edge reveals the converting user. It needs the identity graph loaded and only matters once confidence stitching exists; this job does a full from-scratch pass every tick instead.
- Populating the identity graph from the `identity_graph` table to earn `session_stitched` / `identity_graph_stitched` confidence.
- A per-tenant rule config table (migration 0029 is next free). v1 uses a default that works with no row.

## Verified live end to end (demo tenant `local-dev`)

`attribution_records`:

| | rows |
| --- | --- |
| **before** | **0** |
| **after** (FINAL) | **87,400** |

Job log: `stitcher: tenant=local-dev events=88004 touches=134844 rules=33 records=87398 unattributed=613`

Re-running is idempotent: the raw table doubled but `SELECT count() FROM attribution_records FINAL` stayed at 87,400 — the ReplacingMergeTree collapses re-runs on the sort key.

`/features` now shows **non-null value / payback / attribution-rate** for five features (the per-feature economics the web query computes, `AttributedTraceTs >= now() - 30d`, floor of 5 conversions):

| feature | conversions | matched users | attributed value |
| --- | --- | --- | --- |
| research_agent | 32,236 | 28,431 | $606,194.75 |
| support_triage | 18,542 | 16,407 | $344,518.70 |
| inline_writer | 12,977 | 11,566 | $228,119.24 |
| chatbot | 12,842 | 11,318 | $237,395.08 |
| smart_search | 10,740 | 9,488 | $200,791.96 |

Worked example (research_agent): cost/user ≈ $1.09 (from `otel_spans`), value/user ≈ $21.32 → **payback ≈ 2 days**, all non-null where before they were `—`.

## Tests / CI

- 14 new tests in `test_stitcher_job.py` cover the TouchStore mapping (including the FixedString-bytes hash decode a live run caught), the writeback columns pinned to the DDL, the unattributed path, both skip paths, the bounded/tenant-scoped SQL, and re-run idempotency.
- Full gateway suite: **810 passed** (was ~797), `ruff check .` clean.
- No web changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)