### PR TITLE
fix(gateway): resolve tenant NAME to UUID in control-plane stores (CTO-201)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -781,6 +781,20 @@ def _resolve_tenant_for_control_plane(
     return x_tenant_id
 
 
+@app.exception_handler(TenantNotFoundError)
+def _tenant_not_found_handler(_request: Request, exc: TenantNotFoundError) -> JSONResponse:
+    """Map an unresolved tenant identifier onto a clean 404 (CTO-201).
+
+    Control-plane tables key on ``tenants.id`` while the dashboard and local dev identify a tenant
+    by NAME. The stores fold the name onto the UUID via ``resolve_tenant_uuid`` and raise this when
+    the name matches no row. Without this handler that raise would surface as an opaque 500 with a
+    driver-shaped body; here it becomes the same ``{"detail": ...}`` 404 the endpoints that catch it
+    inline already return. Endpoints that translate it themselves still win, so this only backstops
+    the stores whose 404 is not mapped inline.
+    """
+    return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+
 @app.get("/v1/tenant/connectors")
 def list_tenant_connectors(
     authorization: str | None = Header(default=None),

--- a/infra/gateway/src/gateway/tenant_account_labels.py
+++ b/infra/gateway/src/gateway/tenant_account_labels.py
@@ -35,12 +35,12 @@ touches Postgres directly.
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass
 
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
 
 # A label is a display string for one table cell, not a description field. The cap is generous
 # enough for any real company name and tight enough that the tab cannot be broken by pasting a
@@ -128,24 +128,19 @@ def normalize_account_id_hash(value: object) -> str:
 def _resolve_tenant_uuid(cur: psycopg.Cursor, tenant_id: str) -> str:
     """Map the caller's tenant identifier onto ``tenants.id``.
 
-    Same shape as :func:`gateway.connectors.config_admin._resolve_tenant_uuid`. This table keys on
-    the UUID because of the foreign key, but the dashboard and local dev identify a tenant by name.
-    Without this a name-based caller trips ``InvalidTextRepresentation`` deep in the driver and
-    surfaces as an opaque 503.
+    The rule now lives in :mod:`gateway.tenant_lookup` so every control-plane store shares one copy
+    (CTO-201). This wrapper only re-types the failure as this module's :class:`TenantNotFound`
+    subclass, which the endpoint above already catches, and keeps the non-quoting message this
+    module deliberately uses.
 
     Note this is the *row identity* question only. It is NOT the same question as which spelling
     hashed the account id, which is key material and cannot be folded this way. See the module
     docstring.
     """
     try:
-        return str(uuid.UUID(tenant_id))
-    except (ValueError, AttributeError, TypeError):
-        pass
-    cur.execute("SELECT id FROM tenants WHERE name = %s", (tenant_id,))
-    row = cur.fetchone()
-    if row is None:
-        raise TenantNotFound("no tenant matches the supplied identifier")
-    return str(row[0])
+        return resolve_tenant_uuid(cur, tenant_id)
+    except TenantNotFoundError as exc:
+        raise TenantNotFound("no tenant matches the supplied identifier") from exc
 
 
 def _row_to_label(row: tuple) -> AccountLabel:

--- a/infra/gateway/src/gateway/tenant_allocation.py
+++ b/infra/gateway/src/gateway/tenant_allocation.py
@@ -26,7 +26,6 @@ once, so "who changed it, when, and from what" is the first question anyone asks
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -34,6 +33,7 @@ import psycopg
 from psycopg.types.json import Json
 
 from gateway.config import Settings
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
 
 #: Every storable rule, in the same order as ``ALLOCATION_RULES`` in ``web/lib/allocation.ts``.
 #: Kept in lockstep with that list and with the CHECK constraint in migration 0024: a rule the
@@ -111,22 +111,15 @@ def normalize_updated_by(value: object) -> str | None:
 def _resolve_tenant_uuid(cur: psycopg.Cursor, tenant_id: str) -> str:
     """Map the caller's tenant identifier onto ``tenants.id``.
 
-    Same shape as :func:`gateway.tenant_account_labels._resolve_tenant_uuid` and
-    :func:`gateway.connectors.config_admin._resolve_tenant_uuid`. This table keys on the UUID
-    because of the foreign key, but the dashboard and local dev identify a tenant by NAME
-    (``local-dev``). Without this a name-based caller trips ``InvalidTextRepresentation`` deep in
-    the driver and surfaces as an opaque 503, which is the trap that has now caught three separate
-    features in this stack.
+    The rule now lives in :mod:`gateway.tenant_lookup` so every control-plane store shares one copy
+    (CTO-201). This table keys on the UUID because of the foreign key, but the dashboard and local
+    dev identify a tenant by NAME (``local-dev``). This wrapper only re-types the failure as this
+    module's :class:`TenantNotFound`, which the endpoint above catches to return a clean 404.
     """
     try:
-        return str(uuid.UUID(tenant_id))
-    except (ValueError, AttributeError, TypeError):
-        pass
-    cur.execute("SELECT id FROM tenants WHERE name = %s", (tenant_id,))
-    row = cur.fetchone()
-    if row is None:
-        raise TenantNotFound("no tenant matches the supplied identifier")
-    return str(row[0])
+        return resolve_tenant_uuid(cur, tenant_id)
+    except TenantNotFoundError as exc:
+        raise TenantNotFound("no tenant matches the supplied identifier") from exc
 
 
 def _row_to_config(row: tuple) -> AllocationConfig:

--- a/infra/gateway/src/gateway/tenant_cac.py
+++ b/infra/gateway/src/gateway/tenant_cac.py
@@ -25,6 +25,7 @@ from typing import Iterable
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 
 @dataclass(frozen=True, slots=True)
@@ -268,6 +269,9 @@ class TenantCacStore:
 
     def list(self, tenant_id: str) -> list[CacPeriod]:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: cac_periods.tenant_id is a UUID FK, but the dashboard identifies a tenant by
+            # NAME. Fold the name onto the UUID so a name-based caller does not 500.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT period_start, period_end, currency,
@@ -278,7 +282,7 @@ class TenantCacStore:
                 WHERE tenant_id = %s
                 ORDER BY period_start DESC
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             return [_row_to_period(r) for r in cur.fetchall()]
 
@@ -286,9 +290,11 @@ class TenantCacStore:
         form.sanity_check()
         period_end = _end_of_month(form.period_start)
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before any read or write.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 "SELECT closed_at FROM cac_periods WHERE tenant_id = %s AND period_start = %s",
-                (tenant_id, form.period_start),
+                (resolved, form.period_start),
             )
             existing = cur.fetchone()
             if existing and existing[0] is not None:
@@ -320,7 +326,7 @@ class TenantCacStore:
                           overhead_micro_usd, new_customers_paid, new_customers_total,
                           notes, closed_at, arpa_micro_usd, gross_margin_pct
                 """,
-                (tenant_id, form.period_start, period_end,
+                (resolved, form.period_start, period_end,
                  form.paid_spend_micro_usd, form.sales_spend_micro_usd,
                  form.content_spend_micro_usd, form.overhead_micro_usd,
                  form.new_customers_paid, form.new_customers_total, form.notes,
@@ -332,7 +338,7 @@ class TenantCacStore:
                 UPDATE cac_periods SET closed_at = now()
                  WHERE tenant_id = %s AND period_start < %s AND closed_at IS NULL
                 """,
-                (tenant_id, form.period_start),
+                (resolved, form.period_start),
             )
             conn.commit()
             return _row_to_period(row)

--- a/infra/gateway/src/gateway/tenant_connectors.py
+++ b/infra/gateway/src/gateway/tenant_connectors.py
@@ -19,6 +19,7 @@ from typing import Literal
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 # The cost-layer enum mirrors the same six layers the web app and ClickHouse use.
 Layer = Literal["llm", "vector", "tools", "compute", "embeddings", "egress"]
@@ -59,6 +60,10 @@ class TenantConnectorStore:
 
     def list(self, tenant_id: str) -> list[ConnectorDeclaration]:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_connectors.tenant_id is a UUID FK, but the dashboard and local dev
+            # identify a tenant by NAME (``local-dev``). Fold the name onto the UUID via the shared
+            # helper so a name-based caller resolves instead of tripping InvalidTextRepresentation.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT layer, enabled_at, disabled_at, notes
@@ -66,7 +71,7 @@ class TenantConnectorStore:
                 WHERE tenant_id = %s
                 ORDER BY layer
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             return [
                 ConnectorDeclaration(
@@ -96,6 +101,9 @@ class TenantConnectorStore:
         if layer not in ALLOWED_LAYERS:
             raise ValueError(f"unknown layer '{layer}'")
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before the write, same as the
+            # read path. Without this the toggle 500s in any name-based environment (local dev).
+            tenant_id = resolve_tenant_uuid(cur, tenant_id)
             if enabled:
                 cur.execute(
                     """

--- a/infra/gateway/src/gateway/tenant_eval.py
+++ b/infra/gateway/src/gateway/tenant_eval.py
@@ -21,6 +21,7 @@ from decimal import Decimal
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 
 DEFAULT_JUDGE_MODEL = os.environ.get("TALLY_EVAL_JUDGE_MODEL", "claude-opus-4-8")
@@ -60,13 +61,16 @@ class TenantEvalStore:
 
     def get(self, tenant_id: str) -> EvalConfig:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_eval_config keys on the tenants.id UUID, but the dashboard identifies
+            # a tenant by NAME. Fold the name onto the UUID so a name-based caller does not 500.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT enabled, judge_model, daily_budget_usd
                 FROM tenant_eval_config
                 WHERE tenant_id = %s
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             row = cur.fetchone()
             if row is None:
@@ -98,6 +102,8 @@ class TenantEvalStore:
         if new.daily_budget_usd < 0:
             raise ValueError("daily_budget_usd must be non-negative")
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before the write.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 INSERT INTO tenant_eval_config
@@ -110,7 +116,7 @@ class TenantEvalStore:
                       updated_at       = now()
                 """,
                 (
-                    tenant_id,
+                    resolved,
                     new.enabled,
                     new.judge_model,
                     new.daily_budget_usd,

--- a/infra/gateway/src/gateway/tenant_feature_value_events.py
+++ b/infra/gateway/src/gateway/tenant_feature_value_events.py
@@ -18,6 +18,7 @@ import psycopg
 from psycopg.types.json import Json
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +86,9 @@ class TenantFeatureValueEventStore:
 
     def list(self, tenant_id: str) -> list[FeatureValueEvent]:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_feature_value_events keys on the tenants.id UUID, but the dashboard
+            # identifies a tenant by NAME. Fold the name onto the UUID so a name caller does not 500.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT feature_tag, event_name, created_at, created_by, notes
@@ -92,7 +96,7 @@ class TenantFeatureValueEventStore:
                 WHERE tenant_id = %s
                 ORDER BY feature_tag
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             return [_row_to_event(row) for row in cur.fetchall()]
 
@@ -115,7 +119,10 @@ class TenantFeatureValueEventStore:
         if not event_name:
             raise ValueError("event_name required")
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
-            before_event = self._fetch(cur, tenant_id, feature_tag)
+            # CTO-201: resolve a name-based tenant id onto the UUID FK once, and use it for the
+            # mapping row and the audit rows alike so both key on the same tenant.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            before_event = self._fetch(cur, resolved, feature_tag)
 
             cur.execute(
                 """
@@ -127,7 +134,7 @@ class TenantFeatureValueEventStore:
                 """,
                 (
                     change_id,
-                    tenant_id,
+                    resolved,
                     feature_tag,
                     actor,
                     Json(before_event.as_dict()) if before_event is not None else None,
@@ -136,7 +143,7 @@ class TenantFeatureValueEventStore:
             )
             if cur.fetchone() is None:
                 conn.commit()
-                current = self._fetch(cur, tenant_id, feature_tag)
+                current = self._fetch(cur, resolved, feature_tag)
                 if current is None:
                     raise RuntimeError(
                         "change_id reserved but mapping absent — out-of-band delete?"
@@ -153,7 +160,7 @@ class TenantFeatureValueEventStore:
                       notes = COALESCE(EXCLUDED.notes, tenant_feature_value_events.notes)
                 RETURNING feature_tag, event_name, created_at, created_by, notes
                 """,
-                (tenant_id, feature_tag, event_name, actor, notes),
+                (resolved, feature_tag, event_name, actor, notes),
             )
             row = cur.fetchone()
             assert row is not None
@@ -165,7 +172,7 @@ class TenantFeatureValueEventStore:
                 SET after = %s
                 WHERE tenant_id = %s AND change_id = %s
                 """,
-                (Json(after_event.as_dict()), tenant_id, change_id),
+                (Json(after_event.as_dict()), resolved, change_id),
             )
             conn.commit()
             return after_event
@@ -184,7 +191,9 @@ class TenantFeatureValueEventStore:
         change_id is a replay). The audit row records the removed mapping as ``before``.
         """
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
-            before_event = self._fetch(cur, tenant_id, feature_tag)
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before the delete + audit.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            before_event = self._fetch(cur, resolved, feature_tag)
 
             cur.execute(
                 """
@@ -196,7 +205,7 @@ class TenantFeatureValueEventStore:
                 """,
                 (
                     change_id,
-                    tenant_id,
+                    resolved,
                     feature_tag,
                     actor,
                     Json(before_event.as_dict()) if before_event is not None else None,
@@ -208,7 +217,7 @@ class TenantFeatureValueEventStore:
 
             cur.execute(
                 "DELETE FROM tenant_feature_value_events WHERE tenant_id = %s AND feature_tag = %s",
-                (tenant_id, feature_tag),
+                (resolved, feature_tag),
             )
             removed = cur.rowcount > 0
             conn.commit()
@@ -221,6 +230,8 @@ class TenantFeatureValueEventStore:
         limit: int = 100,
     ) -> list[FeatureValueEventChange]:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before reading the audit log.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             if feature_tag is None:
                 cur.execute(
                     """
@@ -230,7 +241,7 @@ class TenantFeatureValueEventStore:
                     ORDER BY changed_at DESC
                     LIMIT %s
                     """,
-                    (tenant_id, limit),
+                    (resolved, limit),
                 )
             else:
                 cur.execute(
@@ -241,7 +252,7 @@ class TenantFeatureValueEventStore:
                     ORDER BY changed_at DESC
                     LIMIT %s
                     """,
-                    (tenant_id, feature_tag, limit),
+                    (resolved, feature_tag, limit),
                 )
             return [
                 FeatureValueEventChange(

--- a/infra/gateway/src/gateway/tenant_guardrails.py
+++ b/infra/gateway/src/gateway/tenant_guardrails.py
@@ -19,6 +19,7 @@ import psycopg
 from psycopg.types.json import Json
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 ALLOWED_KINDS: frozenset[str] = frozenset(
     {"pii_gate", "cost_cap", "loop_limit", "model_deprecation"}
@@ -100,6 +101,10 @@ class TenantGuardrailStore:
 
     def list(self, tenant_id: str) -> list[GuardrailRule]:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_guardrails keys on the tenants.id UUID, but the dashboard identifies a
+            # tenant by NAME. Fold the name onto the UUID so a name-based caller does not 500. A
+            # UUID caller (the SDK config poll under api-key auth) passes through unchanged.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT rule_id, kind, params, state, created_at, updated_at, created_by, notes
@@ -107,7 +112,7 @@ class TenantGuardrailStore:
                 WHERE tenant_id = %s
                 ORDER BY rule_id
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             return [_row_to_rule(row) for row in cur.fetchall()]
 
@@ -134,13 +139,16 @@ class TenantGuardrailStore:
         if state not in ALLOWED_STATES:
             raise ValueError(f"unknown state '{state}'")
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK once, and use it for the rule
+            # row and the audit rows alike so both key on the same tenant.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT rule_id, kind, params, state, created_at, updated_at, created_by, notes
                 FROM tenant_guardrails
                 WHERE tenant_id = %s AND rule_id = %s
                 """,
-                (tenant_id, rule_id),
+                (resolved, rule_id),
             )
             existing_row = cur.fetchone()
             before_rule = _row_to_rule(existing_row) if existing_row else None
@@ -155,7 +163,7 @@ class TenantGuardrailStore:
                 """,
                 (
                     change_id,
-                    tenant_id,
+                    resolved,
                     rule_id,
                     actor,
                     Json(before_rule.as_dict()) if before_rule is not None else None,
@@ -173,7 +181,7 @@ class TenantGuardrailStore:
                         FROM tenant_guardrails
                         WHERE tenant_id = %s AND rule_id = %s
                         """,
-                        (tenant_id, rule_id),
+                        (resolved, rule_id),
                     )
                     row = cur.fetchone()
                     if row is None:
@@ -196,7 +204,7 @@ class TenantGuardrailStore:
                       updated_at = now()
                 RETURNING rule_id, kind, params, state, created_at, updated_at, created_by, notes
                 """,
-                (tenant_id, rule_id, kind, Json(params), state, actor, notes),
+                (resolved, rule_id, kind, Json(params), state, actor, notes),
             )
             row = cur.fetchone()
             assert row is not None
@@ -208,7 +216,7 @@ class TenantGuardrailStore:
                 SET after = %s
                 WHERE tenant_id = %s AND change_id = %s
                 """,
-                (Json(after_rule.as_dict()), tenant_id, change_id),
+                (Json(after_rule.as_dict()), resolved, change_id),
             )
             conn.commit()
             return after_rule
@@ -220,6 +228,8 @@ class TenantGuardrailStore:
         limit: int = 100,
     ) -> list[GuardrailChange]:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before reading the audit log.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             if rule_id is None:
                 cur.execute(
                     """
@@ -229,7 +239,7 @@ class TenantGuardrailStore:
                     ORDER BY changed_at DESC
                     LIMIT %s
                     """,
-                    (tenant_id, limit),
+                    (resolved, limit),
                 )
             else:
                 cur.execute(
@@ -240,7 +250,7 @@ class TenantGuardrailStore:
                     ORDER BY changed_at DESC
                     LIMIT %s
                     """,
-                    (tenant_id, rule_id, limit),
+                    (resolved, rule_id, limit),
                 )
             return [
                 GuardrailChange(

--- a/infra/gateway/src/gateway/tenant_integrations.py
+++ b/infra/gateway/src/gateway/tenant_integrations.py
@@ -26,6 +26,7 @@ from typing import Literal
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 from gateway.validation import _EMAIL_RE, _FORBIDDEN_PII_KEYS
 
 # The set of third-party integrations we track. Cost-layer connectors (llm/vector/tools/…) are
@@ -114,6 +115,9 @@ class TenantIntegrationStore:
         across the board, which is the honest first-render state for a fresh tenant.
         """
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_integration_runs keys on the tenants.id UUID, but the dashboard
+            # identifies a tenant by NAME. Fold the name onto the UUID so a name caller does not 500.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT connector_id, last_run_at, last_run_status, last_run_event_count,
@@ -122,7 +126,7 @@ class TenantIntegrationStore:
                 WHERE tenant_id = %s
                 ORDER BY connector_id
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             return [
                 IntegrationStatus(
@@ -164,6 +168,10 @@ class TenantIntegrationStore:
             raise ValueError("event_count must be non-negative")
         scrubbed = scrub_error_message(error_message)
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before the upsert. The worker
+            # and scheduler pass a UUID (passed through unchanged); the Stripe webhook can pass a
+            # NAME, which without this trips InvalidTextRepresentation and loses the run stamp.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 INSERT INTO tenant_integration_runs
@@ -186,7 +194,7 @@ class TenantIntegrationStore:
                           last_run_error_message, total_events_24h, total_events_7d
                 """,
                 (
-                    tenant_id,
+                    resolved,
                     connector_id,
                     status,
                     event_count,

--- a/infra/gateway/src/gateway/tenant_replay.py
+++ b/infra/gateway/src/gateway/tenant_replay.py
@@ -17,6 +17,7 @@ from decimal import Decimal
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 
 # Consent disclosure (CTO-125). When a tenant opts into replay, captured samples AND the candidate
@@ -66,13 +67,17 @@ class TenantReplayStore:
 
     def get(self, tenant_id: str) -> ReplayConfig:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_replay_config keys on the tenants.id UUID, but the dashboard
+            # identifies a tenant by NAME. Fold the name onto the UUID so a name-based caller does
+            # not trip InvalidTextRepresentation. A UUID caller passes through unchanged.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT enabled, sample_rate, retention_days, daily_budget_usd
                 FROM tenant_replay_config
                 WHERE tenant_id = %s
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             row = cur.fetchone()
             if row is None:
@@ -109,6 +114,8 @@ class TenantReplayStore:
         if new.daily_budget_usd < 0:
             raise ValueError("daily_budget_usd must be non-negative")
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before the write.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 INSERT INTO tenant_replay_config
@@ -122,7 +129,7 @@ class TenantReplayStore:
                       updated_at       = now()
                 """,
                 (
-                    tenant_id,
+                    resolved,
                     new.enabled,
                     new.sample_rate,
                     new.retention_days,

--- a/infra/gateway/src/gateway/tenant_stripe.py
+++ b/infra/gateway/src/gateway/tenant_stripe.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import psycopg
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,6 +57,10 @@ class TenantStripeStore:
 
     def get(self, tenant_id: str) -> StripeConfig | None:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_stripe_config keys on the tenants.id UUID, but the dashboard and the
+            # webhook can identify a tenant by NAME. Fold the name onto the UUID so a name-based
+            # caller does not 500; a UUID caller passes through unchanged.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT tenant_id, webhook_secret, stripe_account_id,
@@ -63,7 +68,7 @@ class TenantStripeStore:
                 FROM tenant_stripe_config
                 WHERE tenant_id = %s
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             row = cur.fetchone()
             if row is None:
@@ -91,9 +96,13 @@ class TenantStripeStore:
         if not webhook_secret.startswith("whsec_"):
             raise ValueError("Stripe webhook signing secrets start with 'whsec_'")
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before any read or write, and
+            # key the audit change_id on the resolved id so a name caller and a UUID caller for the
+            # same tenant converge on one idempotent change rather than two.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 "SELECT webhook_secret FROM tenant_stripe_config WHERE tenant_id = %s",
-                (tenant_id,),
+                (resolved,),
             )
             existing = cur.fetchone()
             kind = "connected"
@@ -116,13 +125,13 @@ class TenantStripeStore:
                 RETURNING tenant_id, webhook_secret, stripe_account_id,
                           connected_at, disconnected_at
                 """,
-                (tenant_id, webhook_secret, stripe_account_id),
+                (resolved, webhook_secret, stripe_account_id),
             )
             row = cur.fetchone()
             assert row is not None
             # Audit row — UUID5 keyed on (tenant, secret) so retried pastes don't duplicate.
             change_id = uuid.uuid5(
-                uuid.NAMESPACE_URL, f"stripe-change|{tenant_id}|{kind}|{webhook_secret}"
+                uuid.NAMESPACE_URL, f"stripe-change|{resolved}|{kind}|{webhook_secret}"
             )
             cur.execute(
                 """
@@ -130,7 +139,7 @@ class TenantStripeStore:
                 VALUES (%s, %s, %s, %s)
                 ON CONFLICT (change_id) DO NOTHING
                 """,
-                (str(change_id), tenant_id, kind, actor),
+                (str(change_id), resolved, kind, actor),
             )
             conn.commit()
             return StripeConfig(
@@ -143,17 +152,19 @@ class TenantStripeStore:
 
     def disconnect(self, tenant_id: str, *, actor: str | None = None) -> None:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK before the update.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 UPDATE tenant_stripe_config
                    SET disconnected_at = now()
                  WHERE tenant_id = %s AND disconnected_at IS NULL
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             change_id = uuid.uuid5(
                 uuid.NAMESPACE_URL,
-                f"stripe-change|{tenant_id}|disconnected|{conn.info.transaction_status}",
+                f"stripe-change|{resolved}|disconnected|{conn.info.transaction_status}",
             )
             cur.execute(
                 """
@@ -161,6 +172,6 @@ class TenantStripeStore:
                 VALUES (%s, %s, 'disconnected', %s)
                 ON CONFLICT (change_id) DO NOTHING
                 """,
-                (str(change_id), tenant_id, actor),
+                (str(change_id), resolved, actor),
             )
             conn.commit()

--- a/infra/gateway/src/gateway/tenant_unit_economics.py
+++ b/infra/gateway/src/gateway/tenant_unit_economics.py
@@ -22,6 +22,7 @@ import psycopg
 from psycopg.types.json import Json
 
 from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
 
 
 class UnitEconomicsConfigError(ValueError):
@@ -143,6 +144,10 @@ class TenantUnitEconomicsStore:
 
     def get(self, tenant_id: str) -> UnitEconomicsConfig | None:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: tenant_unit_economics_config keys on the tenants.id UUID, but the dashboard
+            # identifies a tenant by NAME. Fold the name onto the UUID so a name-based caller does
+            # not 500.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT ltv_cac_green_threshold, ltv_cac_yellow_threshold,
@@ -151,7 +156,7 @@ class TenantUnitEconomicsStore:
                 FROM tenant_unit_economics_config
                 WHERE tenant_id = %s
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             row = cur.fetchone()
             return _row_to_config(row) if row else None
@@ -172,6 +177,9 @@ class TenantUnitEconomicsStore:
         """
         config.sanity_check()
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # CTO-201: resolve a name-based tenant id onto the UUID FK once, and use it for the
+            # config row and the audit rows alike so both key on the same tenant.
+            resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
                 """
                 SELECT ltv_cac_green_threshold, ltv_cac_yellow_threshold,
@@ -180,7 +188,7 @@ class TenantUnitEconomicsStore:
                 FROM tenant_unit_economics_config
                 WHERE tenant_id = %s
                 """,
-                (tenant_id,),
+                (resolved,),
             )
             existing_row = cur.fetchone()
             before = _row_to_config(existing_row) if existing_row else None
@@ -195,7 +203,7 @@ class TenantUnitEconomicsStore:
                 """,
                 (
                     change_id,
-                    tenant_id,
+                    resolved,
                     actor or config.updated_by,
                     Json(before.as_dict()) if before is not None else None,
                     None,
@@ -215,7 +223,7 @@ class TenantUnitEconomicsStore:
                         FROM tenant_unit_economics_config
                         WHERE tenant_id = %s
                         """,
-                        (tenant_id,),
+                        (resolved,),
                     )
                     row = cur.fetchone()
                     if row is None:
@@ -243,7 +251,7 @@ class TenantUnitEconomicsStore:
                           created_at, updated_at, updated_by
                 """,
                 (
-                    tenant_id,
+                    resolved,
                     config.ltv_cac_green_threshold,
                     config.ltv_cac_yellow_threshold,
                     config.payback_months_green,
@@ -261,7 +269,7 @@ class TenantUnitEconomicsStore:
                 SET after = %s
                 WHERE tenant_id = %s AND change_id = %s
                 """,
-                (Json(after.as_dict()), tenant_id, change_id),
+                (Json(after.as_dict()), resolved, change_id),
             )
             conn.commit()
             return after

--- a/infra/gateway/tests/test_app_tenant_connectors.py
+++ b/infra/gateway/tests/test_app_tenant_connectors.py
@@ -10,20 +10,38 @@ from fastapi.testclient import TestClient
 
 from gateway.app import app
 from gateway.tenant_connectors import ALLOWED_LAYERS, ConnectorDeclaration
+from gateway.tenant_lookup import TenantNotFoundError
 
 T = "t-acme"
 
+# CTO-201: a tenant is addressed by NAME (``local-dev``) or by its ``tenants.id`` UUID, and both
+# spellings must fold onto one tenant the way the UUID foreign key forces.
+TENANT_NAME = "local-dev"
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+UNKNOWN_TENANT = "no-such-tenant"
+
 
 class FakeStore:
-    """In-memory stand-in for :class:`TenantConnectorStore` — no Postgres required."""
+    """In-memory stand-in for :class:`TenantConnectorStore`, no Postgres required.
+
+    Mirrors the resolution contract the store enforces (CTO-201): the name and the UUID address one
+    tenant, and an unknown name raises :class:`TenantNotFoundError` the same way the real resolver
+    does. Any other id passes through unchanged so the isolation tests keep their distinct tenants.
+    """
 
     def __init__(self) -> None:
         # (tenant_id, layer) -> ConnectorDeclaration
         self._rows: dict[tuple[str, str], ConnectorDeclaration] = {}
 
+    def _resolve(self, tenant_id: str) -> str:
+        if tenant_id == UNKNOWN_TENANT:
+            raise TenantNotFoundError(f"no tenant named '{tenant_id}'")
+        return TENANT_UUID if tenant_id in {TENANT_NAME, TENANT_UUID} else tenant_id
+
     def list(self, tenant_id: str) -> list[ConnectorDeclaration]:
+        resolved = self._resolve(tenant_id)
         return sorted(
-            [r for (t, _), r in self._rows.items() if t == tenant_id],
+            [r for (t, _), r in self._rows.items() if t == resolved],
             key=lambda r: r.layer,
         )
 
@@ -37,6 +55,7 @@ class FakeStore:
     ) -> ConnectorDeclaration:
         if layer not in ALLOWED_LAYERS:
             raise ValueError(f"unknown layer '{layer}'")
+        tenant_id = self._resolve(tenant_id)
         now = datetime.now(tz=timezone.utc).isoformat()
         existing = self._rows.get((tenant_id, layer))
         enabled_at = existing.enabled_at if existing else now
@@ -174,3 +193,38 @@ def test_tenant_isolation(client: TestClient) -> None:
     b = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": "t-b"}).json()
     assert a["enabled_layers"] == ["llm"]
     assert b["enabled_layers"] == ["vector"]
+
+
+def test_name_based_caller_does_not_500(client: TestClient) -> None:
+    """A tenant NAME and its UUID address the same connector rows (CTO-201).
+
+    ``tenant_connectors`` keys on ``tenants.id`` but the dashboard identifies a tenant as
+    ``local-dev``. Without the resolver a name-based caller trips InvalidTextRepresentation deep in
+    the driver and surfaces as an opaque 500, breaking the /connectors toggle in local dev.
+    """
+    written = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": TENANT_NAME},
+        json={"layer": "llm", "enabled": True},
+    )
+    assert written.status_code == 200, written.text
+
+    by_name = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": TENANT_NAME})
+    by_uuid = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": TENANT_UUID})
+    assert by_name.status_code == 200 and by_uuid.status_code == 200, by_uuid.text
+    # A toggle set through one spelling must be visible through the other, or the two doors would
+    # look like two different tenants.
+    assert by_name.json()["enabled_layers"] == by_uuid.json()["enabled_layers"] == ["llm"]
+
+
+def test_unknown_tenant_name_is_404_not_500(client: TestClient) -> None:
+    """An unresolvable tenant name is a clean 404, never an opaque 500 from the driver (CTO-201)."""
+    listed = client.get("/v1/tenant/connectors", headers={"X-Tenant-Id": UNKNOWN_TENANT})
+    assert listed.status_code == 404, listed.text
+
+    toggled = client.post(
+        "/v1/tenant/connectors",
+        headers={"X-Tenant-Id": UNKNOWN_TENANT},
+        json={"layer": "llm", "enabled": True},
+    )
+    assert toggled.status_code == 404, toggled.text

--- a/infra/gateway/tests/test_control_plane_name_404.py
+++ b/infra/gateway/tests/test_control_plane_name_404.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unknown-tenant-name control-plane 404s (CTO-201).
+
+Every control-plane store folds a name onto ``tenants.id`` via ``resolve_tenant_uuid`` and raises
+:class:`TenantNotFoundError` when the name resolves to no row. A name-based caller used to reach a
+UUID column and surface an opaque 500; the app-level exception handler now turns that raise into a
+clean 404 for every store whose endpoint does not translate it inline. This asserts that contract
+across each read endpoint that was made name-safe, using a stand-in store that always raises.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_lookup import TenantNotFoundError
+
+UNKNOWN_TENANT = "no-such-tenant"
+
+
+class _Raiser:
+    """A store stand-in whose every method raises :class:`TenantNotFoundError`.
+
+    Models a caller whose tenant NAME resolves to no row: the real store raises from
+    ``resolve_tenant_uuid`` before it can run any query.
+    """
+
+    def __getattr__(self, _name: str):
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise TenantNotFoundError(f"no tenant named '{UNKNOWN_TENANT}'")
+
+        return _raise
+
+
+# (app.state attribute, read endpoint) for every store made name-safe under CTO-201.
+CASES = [
+    ("tenant_connectors", "/v1/tenant/connectors"),
+    ("tenant_cac", "/v1/tenant/cac"),
+    ("tenant_guardrails", "/v1/tenant/guardrails"),
+    ("tenant_feature_value_events", "/v1/tenant/feature-value-events"),
+    ("tenant_eval", "/v1/tenant/eval/config"),
+    ("tenant_integrations", "/v1/tenant/integrations/status"),
+    ("tenant_unit_economics", "/v1/tenant/unit-economics/config"),
+    ("tenant_replay", "/v1/tenant/replay/config"),
+    ("tenant_stripe", "/v1/tenant/stripe"),
+]
+
+
+@pytest.mark.parametrize("attr,path", CASES)
+def test_unknown_tenant_name_is_404_not_500(attr: str, path: str) -> None:
+    with TestClient(app) as client:
+        # Auth off so the X-Tenant-Id header is taken as the tenant identifier (dev / dashboard).
+        app.state.settings.require_api_key = False
+        setattr(app.state, attr, _Raiser())
+        r = client.get(path, headers={"X-Tenant-Id": UNKNOWN_TENANT})
+    assert r.status_code == 404, r.text
+    assert r.json()["detail"], "the 404 body should name the failure"

--- a/infra/gateway/tests/test_tenant_lookup.py
+++ b/infra/gateway/tests/test_tenant_lookup.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the shared tenant-identifier resolver (CTO-201).
+
+Every control-plane store folds a caller's tenant identifier onto ``tenants.id`` through
+:func:`gateway.tenant_lookup.resolve_tenant_uuid`. This pins the three cases the stores rely on: a
+UUID passes through untouched, a NAME is looked up in ``tenants.name``, and an unknown identifier
+raises :class:`TenantNotFoundError` rather than reaching a UUID column and tripping the driver.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
+
+TENANT_NAME = "local-dev"
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+
+
+class FakeCursor:
+    """Stands in for a psycopg cursor, answering the resolver's single name lookup from a dict."""
+
+    def __init__(self, names_to_ids: dict[str, str]) -> None:
+        self._names = names_to_ids
+        self._last_param: str | None = None
+        self.executed: list[str] = []
+
+    def execute(self, sql: str, params: tuple) -> None:
+        self.executed.append(sql)
+        self._last_param = params[0]
+
+    def fetchone(self) -> tuple | None:
+        value = self._names.get(self._last_param)
+        return (value,) if value is not None else None
+
+
+def test_uuid_passes_through_without_a_lookup() -> None:
+    cur = FakeCursor({})
+    assert resolve_tenant_uuid(cur, TENANT_UUID) == TENANT_UUID
+    # A UUID caller must not cost a round trip to tenants.
+    assert cur.executed == []
+
+
+def test_name_is_resolved_to_its_uuid() -> None:
+    cur = FakeCursor({TENANT_NAME: TENANT_UUID})
+    assert resolve_tenant_uuid(cur, TENANT_NAME) == TENANT_UUID
+    assert cur.executed, "a name must trigger the tenants lookup"
+
+
+def test_unknown_name_raises_rather_than_reaching_a_uuid_column() -> None:
+    cur = FakeCursor({})
+    with pytest.raises(TenantNotFoundError):
+        resolve_tenant_uuid(cur, "no-such-tenant")


### PR DESCRIPTION
## CTO-201: `/v1/tenant/connectors` 500s when the tenant is named, not a UUID

`GET/POST /v1/tenant/connectors` returned HTTP 500 whenever the caller identified the tenant by NAME:

```
curl localhost:8080/v1/tenant/connectors -H 'x-tenant-id: local-dev'
-> psycopg.errors.InvalidTextRepresentation: invalid input syntax for type uuid: "local-dev"
```

`tenant_connectors.tenant_id` is a UUID FK, but the dashboard and local dev pass the tenant name. `TenantConnectorStore` handed the string straight into `WHERE tenant_id = %s`. This broke the enable/disable toggle on `/connectors` in every name-based environment, including standard local dev.

## The fix

Apply the shared `resolve_tenant_uuid` helper (`gateway.tenant_lookup`) in `TenantConnectorStore.list` and `.set`. A UUID passes through untouched; a name is folded onto `tenants.id`; an unknown name raises `TenantNotFoundError`.

A single app-level exception handler maps `TenantNotFoundError` to a clean `404 {"detail": ...}`, so an unknown name is a 404 rather than a 500 across every control-plane endpoint that does not already translate it inline. This keeps the change inside the store modules plus one handler, and leaves `app.py`'s lifespan and job-registration block untouched (another agent owns those).

## Sibling audit

The ticket noted other control-plane stores that take a tenant id from a header likely share the bug. I traced every store that runs `WHERE tenant_id = %s` on a value that can arrive as a name via `_resolve_tenant_for_control_plane`.

### Fixed (reachable by NAME, would 500 on a UUID FK column)

| Store | Notes |
|---|---|
| `tenant_connectors` | the ticket |
| `tenant_cac` | `list` + `upsert` |
| `tenant_guardrails` | `list` + `upsert` + `audit` |
| `tenant_feature_value_events` | `list` + `upsert` + `delete` + `audit` |
| `tenant_eval` | `get` + `upsert` |
| `tenant_replay` | `get` + `upsert` |
| `tenant_unit_economics` | `get` + `upsert` (config row and audit rows) |
| `tenant_integrations` | `get_status`, and the `record_run` path the Stripe webhook drives with a name |
| `tenant_stripe` | `get`/`connect`/`disconnect`; the webhook read too. `change_id` now keyed on the resolved UUID so a name caller and a UUID caller converge |

### Deduplicated onto the shared helper (already resolved via a private copy)

- `tenant_account_labels`
- `tenant_allocation`

Both kept their own `_resolve_tenant_uuid` copy (per CTO-198). Each now delegates to `resolve_tenant_uuid` and only re-types the failure as its module-local `TenantNotFound` subclass, so the existing per-endpoint 404 mapping and non-quoting error messages are unchanged.

### Deliberately left (would not 500 / does not fit)

- **`tenant_identity`** — `TenantIdentityResolver` is fail-soft, resolves in **both** directions (`id<->name`), and must **never raise** (it degrades to the given spelling). The shared name->uuid-or-raise helper does not fit that contract, and it never passes a name into a UUID column, so it has no bug to fix.
- **`tenant_bq_export`, `tenant_athena_export`** — not wired to any control-plane endpoint (only the export runners use them), and their `tenant_id` columns are `TEXT`, not UUID FKs, so a name never trips the driver.
- **`tenant_integration_secrets`** — worker/scheduler path only; the scheduler yields resolved UUIDs (`SELECT id::text FROM tenants`), so a name never reaches it.

## Tests

- `test_app_tenant_connectors.py`: name and UUID address the same rows (200), and an unknown name is a 404 on both the read and the toggle.
- `test_tenant_lookup.py`: unit test for the shared resolver (UUID passthrough with no lookup, name lookup, unknown raises).
- `test_control_plane_name_404.py`: parametrized unknown-name-404 across every store made name-safe, proving the exception handler maps the raise for each endpoint.

## Verification

`cd infra/gateway && uv run --extra dev pytest -q && uv run ruff check .` — 803 passed, 5 skipped (the 5 are pre-existing opportunistic live-Postgres scheduler tests that skip when no local Postgres is up; they were untouched), ruff clean.

Verified live against a real Postgres with the `local-dev` tenant:

```
GET  /v1/tenant/connectors  -H 'x-tenant-id: local-dev'         -> 200
POST /v1/tenant/connectors  -H 'x-tenant-id: local-dev'  {tools:on} -> 200, persists
GET  /v1/tenant/connectors  -H 'x-tenant-id: <uuid>'            -> 200 (unchanged)
GET  /v1/tenant/connectors  -H 'x-tenant-id: no-such-tenant'    -> 404 {"detail":"no tenant named 'no-such-tenant'"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
