### PR TITLE
fix: wire Home ROI snapshot to real value/payback + repair margin caveat/tests

### DIFF
--- a/web/app/cost-per-customer/AccountTable.test.tsx
+++ b/web/app/cost-per-customer/AccountTable.test.tsx
@@ -130,13 +130,19 @@ describe("AccountTable", () => {
     // The zero-revenue account: revenue $0.00, margin minus its cost. Both are real numbers.
     expect(screen.getByText("$0.00")).toBeTruthy();
     expect(screen.getByText("-$1.00")).toBeTruthy();
-    // The unknown account gets a blank that says why, and no invented margin of minus cost.
-    expect(screen.getAllByText(/No value: no revenue source wired/i).length).toBe(2);
+    // The unknown account gets a blank that says why in the Revenue column, and no invented margin
+    // of minus cost. The Revenue column is the one place that carries the full reason; the Gross
+    // margin cell defers to it rather than repeating the same sentence.
+    expect(screen.getByText(/No value: no revenue source wired/i)).toBeTruthy();
+    expect(screen.getByText(/No value: unknown while this account's revenue is unknown/i)).toBeTruthy();
   });
 
   it("distinguishes an unreadable revenue source from an unwired one", () => {
     renderTable([row(LABELLED)], {}, {}, true);
-    expect(screen.getAllByText(/No value: revenue could not be read/i).length).toBe(2);
+    // The Revenue column carries the "could not be read" reason (distinct from "unwired"); the
+    // Gross margin cell defers to it rather than restating which flavour of unknown it is.
+    expect(screen.getByText(/No value: revenue could not be read/i)).toBeTruthy();
+    expect(screen.getByText(/No value: unknown while this account's revenue is unknown/i)).toBeTruthy();
     expect(screen.queryByText(/no revenue source wired/i)).toBeNull();
   });
 

--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -376,10 +376,12 @@ export function AccountTable({
           it at all". What it still does not delegate is the ▲ mark: that flags a per-row reason,
           which no tenant-wide sentence can carry. */}
       <p className="max-w-prose text-xs text-warn">
-        Gross margin subtracts <em>direct</em> cost only. Compute and egress carry no account, so
-        they sit in the Allocated and Total columns rather than in this subtraction, which leaves
-        every margin overstated. Treat the ranking as where to look first, not what a customer
-        actually earns. A ▲ flags a further per-row caveat on hover.
+        Gross margin subtracts <em>direct</em> cost only.{" "}
+        {allocationRule
+          ? "Compute and egress carry no account, so they sit in the Allocated and Total columns rather than in this subtraction, which leaves every margin overstated."
+          : "Compute and egress carry no account and nothing could be allocated this window, so they sit outside every row and each margin is overstated by their share of the customer's cost."}{" "}
+        Treat the ranking as where to look first, not what a customer actually earns. A ▲ flags a
+        further per-row caveat on hover.
       </p>
     </div>
   );

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -218,28 +218,20 @@ export async function queryOutliers(): Promise<CostOutlier[] | null> {
 }
 
 export async function queryRoi(): Promise<FeatureRoi[] | null> {
-  return tryLive(async (db, tenant) => {
-    const out = await rows<{ feature: string; cost: string; users: string }>(
-      db,
-      `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users
-       FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
-       GROUP BY FeatureTag
-       ORDER BY cost DESC`,
-      tenant,
-    );
-    return out.map((r) => {
-      const users = Math.max(1, parseInt(r.users, 10) || 1);
-      return {
-        feature: r.feature,
-        costPerUserMicroUsd: Math.round(micro(r.cost) / users),
-        // value/payback/attribution require business-event attribution (not wired yet) → null.
-        valuePerUserMicroUsd: null,
-        paybackDays: null,
-        attributionRate: null,
-      };
-    });
-  });
+  // The Home ROI snapshot is a strict subset of the /features economics table, so it delegates
+  // rather than keeping its own copy. It used to hardcode value/payback/attribution to null with a
+  // "not wired yet" note; once the attribution stitcher started populating attribution_records
+  // (CTO-200) that note was stale and the snapshot silently disagreed with /features. One source of
+  // truth now: whatever /features shows per feature, Home shows the same for value and payback.
+  const econ = await queryFeatureEconomics();
+  if (econ === null) return null;
+  return econ.map((e) => ({
+    feature: e.feature,
+    costPerUserMicroUsd: e.costPerUserMicroUsd,
+    valuePerUserMicroUsd: e.valuePerUserMicroUsd,
+    paybackDays: e.paybackDays,
+    attributionRate: e.attributionRate,
+  }));
 }
 
 export async function queryDataQuality(): Promise<DataQuality | null> {


### PR DESCRIPTION
**Repairs the red web CI on main** (my earlier #211 merged before the web job finished) and delivers the ROI-snapshot fix.

- `queryRoi` (Home ROI snapshot) hardcoded value/payback/attribution to null. Stale since the stitcher (CTO-200) populated `attribution_records`: `/features` showed real numbers while Home showed dashes. It now delegates to `queryFeatureEconomics`, so the two agree.
- Fixed the margin caveat regression (said "Allocated and Total columns" even with no allocation) and updated the two blank tests to match the deduped margin cell.

typecheck clean; only the 2 long-standing api.test.ts ClickHouse-running failures remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)