### PR TITLE
Interactive design foundation for the dashboard overhaul (CTO-221)

### DIFF
--- a/web/app/api/explore/route.ts
+++ b/web/app/api/explore/route.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// The flexible cost-explore endpoint (CTO-221, D1). Reads the SAME URL query the FilterBar writes
+// (range / from / to / groupBy / feature / model / provider / layer / account) so a shared dashboard
+// link and its data request are one and the same string. The heavy lifting is queryCostExplore; this
+// handler only parses the filters and states honestly when the source is unreachable.
+//
+// Honest-under-uncertainty: when ClickHouse is unreachable queryCostExplore returns null, and we
+// return `source: "unavailable"` with a null series rather than a fabricated or zero-filled chart.
+// There is deliberately no mock fallback here (unlike /api/cost): the explorer's whole point is
+// arbitrary live slices, and a canned series would misrepresent one.
+
+import { NextResponse } from "next/server";
+
+import { queryCostExplore } from "@/lib/clickhouse";
+import { exploreParamsFromFilters } from "@/lib/explore";
+import { parseFilters } from "@/lib/filters";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  // Plain URL API (not NextRequest.nextUrl) so unit tests can pass a bare Request.
+  const sp = new URL(req.url).searchParams;
+  const state = parseFilters(sp);
+  const params = exploreParamsFromFilters(state);
+
+  const series = await queryCostExplore(params);
+  if (series === null) {
+    return NextResponse.json({ source: "unavailable", groupBy: params.groupBy, series: null });
+  }
+  return NextResponse.json({ source: "live", groupBy: params.groupBy, series });
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4,6 +4,42 @@
 
 :root {
   color-scheme: dark;
+
+  /* Chart chrome tokens (CTO-221). SVG fill/stroke cannot read Tailwind classes, so the inline-SVG
+     charts reference these variables instead of hardcoding hex. The dark values are byte-identical
+     to the palette the existing charts already inline (edge #252b37, muted #8a93a6, panel #161a22),
+     so dark mode is unchanged; the light block below lets the same charts track a light palette if
+     one is ever applied. Series/data colors (LAYER_COLORS) are intentionally NOT here: those encode
+     data identity and read in both themes. */
+  --chart-axis: #252b37;
+  --chart-muted: #8a93a6;
+  --chart-surface: #161a22;
+  --chart-surface-border: #252b37;
+  --chart-est-band: #252b37;
+  --chart-crosshair: #8a93a6;
+}
+
+/* A light palette for the same tokens. Guarded so an explicit dark choice still wins, matching the
+   theme-aware pattern; the app ships dark today, so this only engages under a light preference or an
+   explicit [data-theme="light"]. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --chart-axis: #dfe3ea;
+    --chart-muted: #5b6470;
+    --chart-surface: #ffffff;
+    --chart-surface-border: #dfe3ea;
+    --chart-est-band: #eef1f6;
+    --chart-crosshair: #5b6470;
+  }
+}
+
+:root[data-theme="light"] {
+  --chart-axis: #dfe3ea;
+  --chart-muted: #5b6470;
+  --chart-surface: #ffffff;
+  --chart-surface-border: #dfe3ea;
+  --chart-est-band: #eef1f6;
+  --chart-crosshair: #5b6470;
 }
 
 body {

--- a/web/components/FilterBar.test.tsx
+++ b/web/components/FilterBar.test.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// FilterBar + useFilters wiring (CTO-221, D1). next/navigation is mocked so the bar can be driven
+// without a router: we assert that interacting with it writes the expected URL through
+// router.replace and that it renders the state parsed back out of the query string.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const replace = vi.fn();
+let currentQuery = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/cost",
+  useSearchParams: () => new URLSearchParams(currentQuery),
+}));
+
+import { FilterBar } from "./FilterBar";
+
+afterEach(() => {
+  replace.mockClear();
+  currentQuery = "";
+});
+
+describe("<FilterBar />", () => {
+  it("defaults to the 30d preset and writes a preset change to the URL", () => {
+    render(<FilterBar />);
+    expect(screen.getByRole("button", { name: "30d" }).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "7d" }));
+    // 7d is non-default, so it lands in the query; the default group-by stays out.
+    expect(replace).toHaveBeenCalledWith("/cost?range=7d", { scroll: false });
+  });
+
+  it("returns to a clean URL when the default preset is chosen", () => {
+    currentQuery = "range=7d";
+    render(<FilterBar />);
+    fireEvent.click(screen.getByRole("button", { name: "30d" }));
+    expect(replace).toHaveBeenCalledWith("/cost", { scroll: false });
+  });
+
+  it("preserves an unrelated ?tag= when a filter changes", () => {
+    currentQuery = "tag=research_agent";
+    render(<FilterBar options={{ provider: [{ value: "openai" }, { value: "anthropic" }] }} />);
+    fireEvent.click(screen.getByRole("button", { name: /Provider/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /openai/ }));
+    expect(replace).toHaveBeenCalledTimes(1);
+    const url = replace.mock.calls[0][0] as string;
+    expect(url).toContain("tag=research_agent");
+    expect(url).toContain("provider=openai");
+  });
+
+  it("changes the group-by dimension", () => {
+    render(<FilterBar />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "provider" } });
+    expect(replace).toHaveBeenCalledWith("/cost?groupBy=provider", { scroll: false });
+  });
+
+  it("only renders filter controls for dimensions it was given options for", () => {
+    render(<FilterBar options={{ provider: [{ value: "openai" }] }} />);
+    expect(screen.getByRole("button", { name: /Provider/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Account/ })).toBeNull();
+  });
+});

--- a/web/components/FilterBar.tsx
+++ b/web/components/FilterBar.tsx
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// The shared dashboard filter toolbar (CTO-221, D1). Time range, group-by, and multi-select
+// dimension filters, all URL-synced through useFilters so the bar is stateless: it reads and writes
+// the query string and nothing else. Pages adopt it later; this ticket only builds it.
+//
+// Dimension filter OPTIONS are a prop, not something the bar fetches: which providers or models
+// exist is page data (it comes from the same query the page already runs), so a page passes the
+// values it knows and the bar renders a control only for the dimensions it was given. A dimension
+// with no options simply shows no filter, never an empty menu.
+//
+// Theme: chrome is driven by the Tailwind semantic tokens (edge / panel / muted / accent) and the
+// chart CSS variables, so it is correct in dark today and tracks a light palette if one is applied.
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  DIMENSION_LABEL,
+  DIMENSIONS,
+  type Dimension,
+  type TimeRangePreset,
+} from "@/lib/filters";
+import { useFilters } from "@/lib/useFilters";
+
+/** A selectable value for a dimension filter. `label` defaults to `value` when omitted. */
+export interface FilterOption {
+  value: string;
+  label?: string;
+}
+
+export interface FilterBarProps {
+  /** Available values per dimension. A dimension absent here renders no filter control. */
+  options?: Partial<Record<Dimension, FilterOption[]>>;
+  /** Restrict the group-by choices. Defaults to every dimension. */
+  groupByChoices?: readonly Dimension[];
+  /** Hide the group-by selector entirely (a page that groups by a fixed dimension). */
+  hideGroupBy?: boolean;
+}
+
+const RANGE_PRESETS: { preset: Exclude<TimeRangePreset, "custom">; label: string }[] = [
+  { preset: "7d", label: "7d" },
+  { preset: "30d", label: "30d" },
+  { preset: "90d", label: "90d" },
+];
+
+export function FilterBar({ options, groupByChoices = DIMENSIONS, hideGroupBy }: FilterBarProps) {
+  const {
+    state,
+    setRangePreset,
+    setCustomRange,
+    setGroupBy,
+    toggleFilter,
+    clearFilter,
+    clearAll,
+  } = useFilters();
+
+  const anyActive = DIMENSIONS.some((d) => state.filters[d].length > 0);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-xl border border-edge bg-panel px-3 py-2 text-sm">
+      {/* Time range */}
+      <div className="flex items-center gap-1" role="group" aria-label="Time range">
+        {RANGE_PRESETS.map(({ preset, label }) => (
+          <button
+            key={preset}
+            type="button"
+            aria-pressed={state.range.preset === preset}
+            onClick={() => setRangePreset(preset)}
+            className={segmentClass(state.range.preset === preset)}
+          >
+            {label}
+          </button>
+        ))}
+        <CustomRangeControl
+          active={state.range.preset === "custom"}
+          from={state.range.from}
+          to={state.range.to}
+          onApply={setCustomRange}
+        />
+      </div>
+
+      <Divider />
+
+      {!hideGroupBy && (
+        <label className="flex items-center gap-1.5 text-muted">
+          <span className="uppercase text-xs tracking-wide">Group by</span>
+          <select
+            value={state.groupBy}
+            onChange={(e) => setGroupBy(e.target.value as Dimension)}
+            className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100 focus:border-accent focus:outline-none"
+          >
+            {groupByChoices.map((dim) => (
+              <option key={dim} value={dim}>
+                {DIMENSION_LABEL[dim]}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {/* Dimension filters, one dropdown per dimension the page supplied options for. */}
+      {DIMENSIONS.filter((d) => (options?.[d]?.length ?? 0) > 0).map((dim) => (
+        <FilterDropdown
+          key={dim}
+          dim={dim}
+          options={options![dim]!}
+          selected={state.filters[dim]}
+          onToggle={(value) => toggleFilter(dim, value)}
+          onClear={() => clearFilter(dim)}
+        />
+      ))}
+
+      {anyActive && (
+        <button
+          type="button"
+          onClick={clearAll}
+          className="ml-auto rounded-md px-2 py-1 text-xs text-muted hover:text-white"
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+}
+
+function segmentClass(active: boolean): string {
+  return [
+    "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+    active ? "bg-accent text-white" : "text-muted hover:text-white",
+  ].join(" ");
+}
+
+function Divider() {
+  return <span aria-hidden className="mx-1 h-5 w-px bg-edge" />;
+}
+
+function CustomRangeControl({
+  active,
+  from,
+  to,
+  onApply,
+}: {
+  active: boolean;
+  from: string | null;
+  to: string | null;
+  onApply: (from: string, to: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // Draft dates default to today so the two inputs are never blank-then-invalid on first open.
+  const today = new Date().toISOString().slice(0, 10);
+  const [draftFrom, setDraftFrom] = useState(from ?? today);
+  const [draftTo, setDraftTo] = useState(to ?? today);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-pressed={active}
+        onClick={() => setOpen((v) => !v)}
+        className={segmentClass(active)}
+      >
+        {active && from && to ? `${from.slice(5)} – ${to.slice(5)}` : "Custom"}
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-10 mt-1 flex flex-col gap-2 rounded-lg border border-edge bg-panel p-3 shadow-lg">
+          <label className="flex items-center justify-between gap-2 text-xs text-muted">
+            From
+            <input
+              type="date"
+              value={draftFrom}
+              max={draftTo}
+              onChange={(e) => setDraftFrom(e.target.value)}
+              className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100"
+            />
+          </label>
+          <label className="flex items-center justify-between gap-2 text-xs text-muted">
+            To
+            <input
+              type="date"
+              value={draftTo}
+              min={draftFrom}
+              onChange={(e) => setDraftTo(e.target.value)}
+              className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => {
+              onApply(draftFrom, draftTo);
+              setOpen(false);
+            }}
+            className="rounded-md bg-accent px-2 py-1 text-xs font-medium text-white hover:opacity-90"
+          >
+            Apply
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterDropdown({
+  dim,
+  options,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  dim: Dimension;
+  options: FilterOption[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  onClear: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on an outside click so several dropdowns don't stack open at once.
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const count = selected.length;
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className={[
+          "flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium",
+          count > 0
+            ? "border-accent/60 bg-accent/10 text-white"
+            : "border-edge text-muted hover:text-white",
+        ].join(" ")}
+      >
+        {DIMENSION_LABEL[dim]}
+        {count > 0 && (
+          <span className="rounded-full bg-accent px-1.5 text-[10px] leading-4 text-white">
+            {count}
+          </span>
+        )}
+        <span aria-hidden className="text-[10px]">
+          ▾
+        </span>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-10 mt-1 max-h-64 w-56 overflow-y-auto rounded-lg border border-edge bg-panel p-1 shadow-lg">
+          {options.map((opt) => {
+            const checked = selected.includes(opt.value);
+            return (
+              <label
+                key={opt.value}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs text-gray-200 hover:bg-edge"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => onToggle(opt.value)}
+                  className="accent-accent"
+                />
+                <span className="truncate">{opt.label ?? opt.value}</span>
+              </label>
+            );
+          })}
+          {count > 0 && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="mt-1 w-full rounded-md px-2 py-1 text-left text-xs text-muted hover:text-white"
+            >
+              Clear {DIMENSION_LABEL[dim].toLowerCase()}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/InteractiveStackedChart.test.tsx
+++ b/web/components/InteractiveStackedChart.test.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Interaction tests for the interactive stacked chart (CTO-221, D1): the hover tooltip, legend
+// toggling, and the onDrill callback. Geometry is covered by rendering, not asserted pixel-wise.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { InteractiveStackedChart, type StackedChartDay } from "./InteractiveStackedChart";
+
+const DAYS: StackedChartDay[] = [
+  { date: "2026-06-01", byGroup: { openai: 1_000_000, anthropic: 500_000 } },
+  { date: "2026-06-02", byGroup: { openai: 2_000_000, anthropic: 250_000 } },
+];
+const GROUPS = ["openai", "anthropic"];
+
+describe("<InteractiveStackedChart />", () => {
+  it("shows a tooltip naming the group, date and value on hover", () => {
+    // Legend off so the only "openai" on screen is the tooltip's.
+    render(<InteractiveStackedChart days={DAYS} groups={GROUPS} showLegend={false} />);
+    // Each day renders one <rect> per group; hover the first day's openai segment.
+    const rects = document.querySelectorAll("rect");
+    fireEvent.mouseEnter(rects[0]);
+    // Tooltip carries the group label, the date and the formatted value.
+    expect(screen.getByText("openai")).toBeTruthy();
+    expect(screen.getByText(/2026-06-01/)).toBeTruthy();
+    expect(screen.getByText(/\$1\.00/)).toBeTruthy();
+  });
+
+  it("toggles a series off and back on from the legend", () => {
+    const { container } = render(<InteractiveStackedChart days={DAYS} groups={GROUPS} />);
+    const rectCount = () => container.querySelectorAll("svg rect").length;
+    // 2 days x 2 groups = 4 segments (plus the baseline <line>, not a rect).
+    expect(rectCount()).toBe(4);
+
+    // The legend button's accessible name is its text ("anthropic"); it starts pressed (visible).
+    const legend = screen.getByRole("button", { name: /anthropic/ });
+    expect(legend.getAttribute("aria-pressed")).toBe("true");
+
+    // Hiding anthropic drops its segments and flips aria-pressed.
+    fireEvent.click(legend);
+    expect(rectCount()).toBe(2);
+    expect(legend.getAttribute("aria-pressed")).toBe("false");
+
+    // Toggling back restores them.
+    fireEvent.click(legend);
+    expect(rectCount()).toBe(4);
+    expect(legend.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("calls onDrill with the clicked group", () => {
+    const onDrill = vi.fn();
+    render(<InteractiveStackedChart days={DAYS} groups={GROUPS} onDrill={onDrill} />);
+    const rects = document.querySelectorAll("svg rect");
+    fireEvent.click(rects[0]);
+    expect(onDrill).toHaveBeenCalledWith("openai");
+  });
+
+  it("renders an empty-state label when there are no days", () => {
+    render(<InteractiveStackedChart days={[]} groups={GROUPS} emptyLabel="nothing here" />);
+    expect(screen.getByText("nothing here")).toBeTruthy();
+  });
+});

--- a/web/components/InteractiveStackedChart.tsx
+++ b/web/components/InteractiveStackedChart.tsx
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// The interactive stacked-bar chart the dashboard overhaul is built on (CTO-221, D1).
+//
+// WHY A NEW COMPONENT rather than upgrading StackedBarChart in place: the existing chart is typed to
+// CostSeries and the six fixed cost LAYERS, and its whole shape (LAYER_COLORS, the reconciled/
+// estimated boundary band) assumes them. The explorer groups by an ARBITRARY dimension chosen at
+// runtime (feature / model / provider / account), so it needs a chart keyed on a generic group list,
+// not on Layer. Mutating the shipped /cost chart to be generic would also have restyled an existing
+// page, which this ticket forbids. So this is the interactive variant the ticket explicitly allows,
+// and the reason is recorded here and in the PR body.
+//
+// It stays in the house style: hand-rolled inline SVG, no charting library (the CSP / artifact
+// posture forbids external chart deps), deterministic, one bar per calendar day. What it adds over
+// StackedBarChart:
+//   - a hover tooltip naming the group, date and value under the cursor;
+//   - legend toggling (click a legend item to hide/show that series; the y-axis rescales to what is
+//     visible so a hidden dominant series lets the rest breathe);
+//   - an onDrill(group) callback so a page can turn a click on a bar or legend into a filter.
+//
+// Theme: axis, gridlines, crosshair, tooltip surface and the empty band read from the --chart-*
+// CSS variables (see globals.css), so the chart is correct in dark today and tracks a light palette
+// if one is applied. Series colors are data identity and are passed in by the caller.
+
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { formatUSD, type MicroUSD } from "@/lib/types";
+
+export interface StackedChartDay {
+  /** ISO yyyy-mm-dd. Supplied by the caller from a ClickHouse-derived day list, never a JS clock. */
+  date: string;
+  /** Micro-USD per group for this day. A missing group is a real zero. */
+  byGroup: Record<string, MicroUSD>;
+}
+
+export interface InteractiveStackedChartProps {
+  days: readonly StackedChartDay[];
+  /** Stacking order, bottom to top, and legend order. */
+  groups: readonly string[];
+  /** Color per group. Falls back to a built-in categorical palette by index. */
+  color?: (group: string, index: number) => string;
+  /** Human label per group. Defaults to the group key. */
+  label?: (group: string) => string;
+  /** Clicking a bar segment or legend swatch calls this (the page turns it into a filter). */
+  onDrill?: (group: string) => void;
+  /** Render the built-in interactive legend below the chart. Default true. */
+  showLegend?: boolean;
+  ariaLabel?: string;
+  emptyLabel?: string;
+  /** Formats the tooltip value. Defaults to formatUSD (micro-USD in). */
+  formatValue?: (micro: MicroUSD) => string;
+  height?: number;
+}
+
+// A brand-adjacent categorical palette for arbitrary groups. Ordered so the top few (the usual big
+// spenders) are the most distinct; it repeats past its length, which the group cap (MAX_EXPLORE_
+// GROUPS) keeps us well short of in practice.
+const PALETTE = [
+  "#5e6ad2", // accent
+  "#26b5ce",
+  "#4cb782", // good
+  "#f2c94c", // warn
+  "#bb87fc",
+  "#eb5757", // bad
+  "#5cc8ff",
+  "#f2994a",
+  "#7ed3b2",
+  "#c58af9",
+  "#9aa4b2",
+  "#e57ea8",
+];
+
+function defaultColor(_group: string, index: number): string {
+  return PALETTE[index % PALETTE.length];
+}
+
+const W = 720;
+const PAD_L = 44;
+const PAD_R = 16;
+const PAD_T = 12;
+const PAD_B = 28;
+
+export function InteractiveStackedChart({
+  days,
+  groups,
+  color = defaultColor,
+  label = (g) => g,
+  onDrill,
+  showLegend = true,
+  ariaLabel = "stacked cost over time",
+  emptyLabel = "no data for this filter yet",
+  formatValue = formatUSD,
+  height = 220,
+}: InteractiveStackedChartProps) {
+  const H = height;
+  const plotW = W - PAD_L - PAD_R;
+  const plotH = H - PAD_T - PAD_B;
+
+  // Hidden series live in component state, not the URL: this is a transient view tweak, not a
+  // shareable filter (that is what onDrill + the FilterBar are for).
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
+  const [hover, setHover] = useState<{ day: number; group: string } | null>(null);
+
+  const colorOf = useMemo(() => {
+    const m = new Map<string, string>();
+    groups.forEach((g, i) => m.set(g, color(g, i)));
+    return (g: string) => m.get(g) ?? "#8a93a6";
+  }, [groups, color]);
+
+  const visibleGroups = groups.filter((g) => !hidden.has(g));
+  const n = days.length;
+
+  const dayTotal = (d: StackedChartDay) => visibleGroups.reduce((s, g) => s + (d.byGroup[g] ?? 0), 0);
+  // Max over VISIBLE groups so hiding the dominant series rescales the rest. Max(1, …) guards the
+  // all-zero / all-hidden case, which would otherwise divide by zero and emit NaN per <rect>.
+  const maxTotal = Math.max(1, ...days.map(dayTotal));
+
+  if (n === 0) {
+    return (
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label={emptyLabel} className="w-full">
+        <text
+          x={W / 2}
+          y={H / 2}
+          fontSize="12"
+          fill="var(--chart-muted)"
+          textAnchor="middle"
+        >
+          {emptyLabel}
+        </text>
+      </svg>
+    );
+  }
+
+  const step = plotW / n;
+  const barW = step * 0.7;
+
+  const hoverDay = hover ? days[hover.day] : null;
+  const hoverValue = hover && hoverDay ? hoverDay.byGroup[hover.group] ?? 0 : 0;
+
+  return (
+    <div className="w-full">
+      <div className="relative">
+        <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label={ariaLabel} className="w-full">
+          {/* baseline */}
+          <line
+            x1={PAD_L}
+            x2={W - PAD_R}
+            y1={H - PAD_B}
+            y2={H - PAD_B}
+            stroke="var(--chart-axis)"
+          />
+          {days.map((d, i) => {
+            const cx = PAD_L + i * step + step / 2;
+            let yCursor = H - PAD_B;
+            return (
+              <g key={d.date}>
+                {visibleGroups.map((g) => {
+                  const v = d.byGroup[g] ?? 0;
+                  const h = (v / maxTotal) * plotH;
+                  yCursor -= h;
+                  const isHovered = hover?.day === i && hover?.group === g;
+                  return (
+                    <rect
+                      key={g}
+                      x={cx - barW / 2}
+                      y={yCursor}
+                      width={barW}
+                      height={h}
+                      fill={colorOf(g)}
+                      opacity={hover && !isHovered ? 0.55 : 1}
+                      cursor={onDrill ? "pointer" : "default"}
+                      onMouseEnter={() => setHover({ day: i, group: g })}
+                      onMouseLeave={() => setHover(null)}
+                      onClick={() => onDrill?.(g)}
+                    />
+                  );
+                })}
+                {i % Math.max(1, Math.ceil(n / 10)) === 0 && (
+                  <text
+                    x={cx}
+                    y={H - 10}
+                    fontSize="9"
+                    fill="var(--chart-muted)"
+                    textAnchor="middle"
+                  >
+                    {d.date.slice(5)}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+
+        {hover && hoverDay && (
+          <Tooltip
+            x={PAD_L + hover.day * step + step / 2}
+            plotW={W}
+            group={label(hover.group)}
+            swatch={colorOf(hover.group)}
+            date={hoverDay.date}
+            value={formatValue(hoverValue)}
+          />
+        )}
+      </div>
+
+      {showLegend && (
+        <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+          {groups.map((g) => {
+            const off = hidden.has(g);
+            return (
+              <li key={g}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setHidden((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(g)) next.delete(g);
+                      else next.add(g);
+                      return next;
+                    })
+                  }
+                  aria-pressed={!off}
+                  className={`flex items-center gap-1.5 hover:text-white ${off ? "opacity-40" : ""}`}
+                  title={off ? `Show ${label(g)}` : `Hide ${label(g)}`}
+                >
+                  <span
+                    aria-hidden
+                    className="inline-block h-2.5 w-2.5 rounded-sm"
+                    style={{
+                      background: colorOf(g),
+                      // A struck-through swatch reads as "off" without relying on color alone.
+                      filter: off ? "grayscale(1)" : undefined,
+                    }}
+                  />
+                  <span className={off ? "line-through" : ""}>{label(g)}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The hover tooltip. Positioned as a percentage of the chart width so it tracks the bar under the
+ * responsive SVG (which scales to its container) rather than a fixed pixel that would drift. Flips to
+ * the left of the cursor past the midpoint so it never runs off the right edge.
+ */
+function Tooltip({
+  x,
+  plotW,
+  group,
+  swatch,
+  date,
+  value,
+}: {
+  x: number;
+  plotW: number;
+  group: string;
+  swatch: string;
+  date: string;
+  value: string;
+}) {
+  const pct = (x / plotW) * 100;
+  const flip = pct > 60;
+  return (
+    <div
+      className="pointer-events-none absolute top-1 z-10 whitespace-nowrap rounded-md border px-2 py-1 text-xs shadow-lg"
+      style={{
+        left: `${pct}%`,
+        transform: flip ? "translateX(-100%) translateX(-8px)" : "translateX(8px)",
+        background: "var(--chart-surface)",
+        borderColor: "var(--chart-surface-border)",
+        color: "var(--chart-muted)",
+      }}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          aria-hidden
+          className="inline-block h-2 w-2 rounded-sm"
+          style={{ background: swatch }}
+        />
+        <span className="font-medium text-gray-100">{group}</span>
+      </div>
+      <div className="mt-0.5 tabular-nums">
+        {date} · <span className="text-gray-100">{value}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/components/PageHeader.tsx
+++ b/web/components/PageHeader.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Shared page header + toolbar wrapper for the visual refresh (CTO-221, D1). Pages adopt it later;
+// nothing is restyled here. It standardizes the top-of-page layout every workflow hand-rolls today
+// (a title row on the left, live/status badges on the right, a filter toolbar underneath) so the
+// overhaul lands one consistent header instead of ten slightly different ones.
+
+import type { ReactNode } from "react";
+
+export interface PageHeaderProps {
+  title: string;
+  /** A short line under the title (what this page measures, the window, etc.). */
+  subtitle?: ReactNode;
+  /** Right-aligned slot: LiveIndicator, stale badges, export buttons. */
+  actions?: ReactNode;
+  /** Full-width slot under the title row, for the FilterBar / a toolbar. */
+  toolbar?: ReactNode;
+}
+
+export function PageHeader({ title, subtitle, actions, toolbar }: PageHeaderProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold">{title}</h1>
+          {subtitle && <p className="mt-0.5 text-sm text-muted">{subtitle}</p>}
+        </div>
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      </div>
+      {toolbar}
+    </div>
+  );
+}

--- a/web/components/SummaryTile.test.tsx
+++ b/web/components/SummaryTile.test.tsx
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SummaryTile honesty (CTO-221, D1): an unknown value is the honest blank with a reason, never a
+// fabricated zero, and the delta is colored by whether the move is good given the tile's direction.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SummaryTile } from "./SummaryTile";
+
+describe("<SummaryTile />", () => {
+  it("renders a known value through Money", () => {
+    render(<SummaryTile label="Spend" micro={52_400_000} />);
+    expect(screen.getByText("$52.40")).toBeTruthy();
+  });
+
+  it("renders the honest blank with its reason when the value is null", () => {
+    render(<SummaryTile label="Spend" micro={null} reason="no cost data for this window" />);
+    expect(screen.getByText("No value: no cost data for this window")).toBeTruthy();
+  });
+
+  it("tints a cost increase bad and a decrease good by default", () => {
+    const { rerender } = render(<SummaryTile label="Spend" micro={100} delta={0.12} />);
+    expect(document.querySelector(".text-bad")).toBeTruthy();
+    rerender(<SummaryTile label="Spend" micro={100} delta={-0.12} />);
+    expect(document.querySelector(".text-good")).toBeTruthy();
+  });
+
+  it("flips the delta coloring when higherIsBetter", () => {
+    render(<SummaryTile label="Value" micro={100} delta={0.2} higherIsBetter />);
+    expect(document.querySelector(".text-good")).toBeTruthy();
+  });
+
+  it("shows a blank delta with a reason rather than zero when the change is unknown", () => {
+    render(<SummaryTile label="Spend" micro={100} delta={null} deltaReason="no prior period" />);
+    expect(screen.getByText("No value: no prior period")).toBeTruthy();
+  });
+});

--- a/web/components/SummaryTile.tsx
+++ b/web/components/SummaryTile.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Layout kit for the dashboard visual refresh (CTO-221, D1): a dense KPI tile and the row wrapper
+// pages lay them out in. This ticket only builds the primitives; no existing page is restyled here.
+//
+// Honesty is baked in, not optional: the value renders through <Money> and the delta through <Pct>,
+// so an unknown number is the honest blank with a reason on hover, never a fabricated or zeroed
+// figure. A tile whose `micro` can be null must pass a `reason`, exactly as the Money primitive
+// requires, so the blank is always explained.
+
+import type { ReactNode } from "react";
+
+import { Money, Pct } from "@/components/HonestValue";
+import type { MicroUSD } from "@/lib/types";
+
+export interface SummaryTileProps {
+  label: string;
+  /** The headline value in micro-USD. null renders the honest blank (reason required then). */
+  micro: MicroUSD | null;
+  /** Required when `micro` can be null: the reason shown on the blank. */
+  reason?: string;
+  /** Small caption under the value (e.g. "last 30 days"). */
+  hint?: string;
+  /** Period-over-period change as a fraction (0.12 = +12%). null renders a blank delta. */
+  delta?: number | null;
+  /** Reason for a null delta. */
+  deltaReason?: string;
+  /**
+   * Whether a rising value is good. Cost tiles leave this false, so an increase is tinted bad and a
+   * decrease good; a value or ROI tile passes true to flip the coloring. A zero delta is neutral.
+   */
+  higherIsBetter?: boolean;
+  /** Optional sparkline series in micro-USD, oldest to newest. */
+  sparkline?: readonly number[];
+}
+
+export function SummaryTile({
+  label,
+  micro,
+  reason,
+  hint,
+  delta,
+  deltaReason,
+  higherIsBetter = false,
+  sparkline,
+}: SummaryTileProps) {
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-edge bg-panel p-4">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted">{label}</span>
+      <div className="flex items-end justify-between gap-2">
+        <span className="text-2xl font-semibold tabular-nums">
+          {/* Money's type requires a reason exactly when micro is nullable; forward whatever we got. */}
+          <Money micro={micro} reason={reason ?? "no data for this period"} />
+        </span>
+        {sparkline && sparkline.length > 1 && <Sparkline values={sparkline} />}
+      </div>
+      <div className="flex items-center gap-2 text-xs">
+        {delta !== undefined && (
+          <DeltaBadge delta={delta} reason={deltaReason} higherIsBetter={higherIsBetter} />
+        )}
+        {hint && <span className="text-muted">{hint}</span>}
+      </div>
+    </div>
+  );
+}
+
+function DeltaBadge({
+  delta,
+  reason,
+  higherIsBetter,
+}: {
+  delta: number | null;
+  reason?: string;
+  higherIsBetter: boolean;
+}) {
+  if (delta === null || Number.isNaN(delta)) {
+    // Blank delta with a reason: an unknown change is not "no change".
+    return (
+      <span className="text-muted">
+        <Pct value={null} reason={reason ?? "no prior period to compare"} />
+      </span>
+    );
+  }
+  const rising = delta > 0;
+  const flat = delta === 0;
+  const good = flat ? null : rising === higherIsBetter;
+  const tone = good === null ? "text-muted" : good ? "text-good" : "text-bad";
+  const arrow = flat ? "→" : rising ? "▲" : "▼";
+  return (
+    <span className={`inline-flex items-center gap-1 tabular-nums ${tone}`}>
+      <span aria-hidden>{arrow}</span>
+      <Pct value={Math.abs(delta)} />
+    </span>
+  );
+}
+
+/** A tiny inline sparkline. No chart library; a single polyline scaled to its own min/max. */
+function Sparkline({ values }: { values: readonly number[] }) {
+  const w = 72;
+  const h = 24;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const step = values.length > 1 ? w / (values.length - 1) : w;
+  const points = values
+    .map((v, i) => `${(i * step).toFixed(1)},${(h - ((v - min) / span) * h).toFixed(1)}`)
+    .join(" ");
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      width={w}
+      height={h}
+      role="img"
+      aria-label="trend sparkline"
+      className="shrink-0"
+    >
+      <polyline points={points} fill="none" stroke="#5e6ad2" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+/** Responsive grid the tiles sit in. Defaults to a 4-up row that reflows down on narrow screens. */
+export function TileGrid({ children }: { children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">{children}</div>
+  );
+}

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -24,6 +24,18 @@ import type {
 } from "./types";
 import type { CostDayPoint, CostSeries, FeatureCostRow, HiddenCostAlert } from "./cost";
 import { LAYERS, type Layer } from "./cost";
+import {
+  type ExploreCostRow,
+  type ExploreDimension,
+  type ExploreFilters,
+  type ExploreGroupTotal,
+  type ExploreParams,
+  type ExploreSeries,
+  capGroups,
+  clampWindowDays,
+  OTHER_GROUP,
+  pivotExploreDays,
+} from "./explore";
 import type { AttributionDiagnostics, FeatureEconomics } from "./features";
 import type {
   AccountCostRow,
@@ -333,6 +345,178 @@ export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<F
       (a, b) =>
         LAYERS.reduce((s, l) => s + b.byLayer[l], 0) - LAYERS.reduce((s, l) => s + a.byLayer[l], 0),
     );
+  });
+}
+
+// --- Flexible cost explore (CTO-221, D1) --------------------------------------------------------
+//
+// The one query behind the design-foundation FilterBar: a user-selectable window grouped by any of
+// feature / model / layer / provider / account, with multi-select dimension filters. It returns a
+// time series (one point per calendar day, per group) AND the breakdown table off the same scan, so
+// the chart and the table can never disagree.
+//
+// WINDOW: user-selectable, so the day list is derived from the window ClickHouse itself reports,
+// NEVER the Node clock. This is the exact CTO-203 seam queryCostSeries / queryAccountDetail already
+// close: a JS-built day list drifts a day against the SQL predicate across a midnight boundary and
+// silently drops the oldest row while it still counts toward the totals. A single bounds SELECT
+// pins windowStart/windowEnd, every read below reuses them as bound parameters, and the day list is
+// generated from that windowStart (isoDaysFrom), so all of it lives on one clock.
+//
+// SCAN BOUND: the window is clamped to MAX_WINDOW_DAYS at the SQL boundary (preset via a
+// ClickHouse-derived start, custom via `greatest(from, to - MAX)`), so a hand-crafted range can't
+// ask for years of spans. Group cardinality is folded to the top MAX_EXPLORE_GROUPS with an honest
+// "other" bucket (capGroups). Honest failure over a wrong number: any ClickHouse error returns null
+// (via tryLive) and the route renders "source unavailable" rather than a fabricated series.
+
+/** Per-dimension SQL expression. Provider/layer reuse the exact expressions the other reads use so
+ *  the operation→layer and system→provider mappings live in one place. */
+const EXPLORE_GROUP_EXPR: Record<ExploreDimension, string> = {
+  feature: "if(FeatureTag != '', FeatureTag, 'untagged')",
+  // Response model when the provider returned one, request model otherwise; matches scopeFilter.
+  model:
+    "if(GenAiResponseModel != '', GenAiResponseModel, if(GenAiRequestModel != '', GenAiRequestModel, 'unknown'))",
+  layer: LAYER_CASE,
+  provider:
+    "coalesce(nullIf(SpanAttributes['chatbot.real_provider'], ''), nullIf(GenAiSystem, ''), 'unknown')",
+  account: "if(empty(AccountIdHash), 'unattributed', toString(AccountIdHash))",
+};
+
+/**
+ * Build the multi-select filter clauses. Each active dimension becomes `AND <expr> IN {key:Array}`
+ * with the values bound as an Array(String) parameter (never interpolated). The group-by dimension
+ * is expected to be excluded upstream (see exploreParamsFromFilters); if it is not, filtering on the
+ * grouped dimension is still a valid, if narrow, query.
+ */
+function exploreFilterClauses(filters: ExploreFilters | undefined): {
+  clause: string;
+  params: Record<string, string[]>;
+} {
+  if (!filters) return { clause: "", params: {} };
+  const clauses: string[] = [];
+  const params: Record<string, string[]> = {};
+  for (const dim of Object.keys(EXPLORE_GROUP_EXPR) as ExploreDimension[]) {
+    const values = filters[dim];
+    if (values && values.length > 0) {
+      const key = `f_${dim}`;
+      clauses.push(`AND ${EXPLORE_GROUP_EXPR[dim]} IN {${key}:Array(String)}`);
+      params[key] = values;
+    }
+  }
+  return { clause: clauses.join(" "), params };
+}
+
+/**
+ * Grouped cost time series + breakdown for the given window / dimension / filters.
+ *
+ * Returns `null` (via tryLive) when ClickHouse is unreachable, which the caller MUST NOT read as
+ * "no spend": the /api/explore route surfaces it as an unavailable source rather than an empty
+ * chart.
+ */
+export async function queryCostExplore(params: ExploreParams): Promise<ExploreSeries | null> {
+  return tryLive(async (db, tenant) => {
+    const groupExpr = EXPLORE_GROUP_EXPR[params.groupBy];
+
+    // Bounds from ClickHouse's clock, clamped to MAX_WINDOW_DAYS at the SQL boundary. Reused by
+    // every read below so the whole result sits on one window even across a midnight boundary.
+    const maxBack = clampWindowDays(Number.MAX_SAFE_INTEGER) - 1; // = MAX_WINDOW_DAYS - 1
+    let boundsRows: { windowStart: string; windowEnd: string; windowDays: number }[];
+    if (params.window.kind === "range") {
+      boundsRows = await rowsP(
+        db,
+        `WITH toDate({from:String}) AS f0,
+              least(toDate({to:String}), toDate(now())) AS t,
+              greatest(f0, t - {maxBack:UInt32}) AS f
+         SELECT toString(f) AS windowStart,
+                toString(t) AS windowEnd,
+                toUInt32(greatest(dateDiff('day', f, t) + 1, 0)) AS windowDays`,
+        { from: params.window.from, to: params.window.to, maxBack },
+      );
+    } else {
+      const back = clampWindowDays(params.window.days) - 1;
+      boundsRows = await rowsP(
+        db,
+        `WITH toDate(now()) AS td
+         SELECT toString(td - {back:UInt32}) AS windowStart,
+                toString(td) AS windowEnd,
+                toUInt32({back:UInt32} + 1) AS windowDays`,
+        { back },
+      );
+    }
+    const b = boundsRows[0];
+    const windowDays = b ? Number(b.windowDays) || 0 : 0;
+    if (!b || windowDays <= 0) return null;
+
+    const { clause: filterClause, params: filterParams } = exploreFilterClauses(params.filters);
+    // Half-open on the high end so the whole of windowEnd's calendar day is included exactly once.
+    const scope = `TenantId = {tenant:String}
+        AND Timestamp >= toDate({windowStart:String})
+        AND Timestamp < toDate({windowEnd:String}) + 1`;
+    const common = { tenant, windowStart: b.windowStart, windowEnd: b.windowEnd, ...filterParams };
+
+    // Per-group totals over the whole window. Group cardinality is inherently small (one row per
+    // distinct dimension value), so this is not the unbounded axis; the day×group read below is
+    // bounded to the kept groups.
+    const totalRows = await rowsP<{ grp: string; cost: string; spans: string }>(
+      db,
+      `SELECT ${groupExpr} AS grp, sum(EstimatedCost) AS cost, count() AS spans
+       FROM otel_spans
+       WHERE ${scope} ${filterClause}
+       GROUP BY grp
+       ORDER BY cost DESC`,
+      common,
+    );
+    const groupTotals: ExploreGroupTotal[] = totalRows.map((r) => ({
+      group: r.grp,
+      totalMicroUsd: micro(r.cost),
+      spanCount: parseInt(r.spans, 10) || 0,
+    }));
+    const capped = capGroups(groupTotals);
+    const kept = [...capped.keptGroups];
+    const hasOther = capped.truncatedGroups > 0;
+
+    // Per-day cost for the kept groups only, plus a single per-day "other" aggregate for the folded
+    // tail (grp NOT IN kept), so the stacked bars sum to each day's true spend without shipping a
+    // day×group row for every long-tail value.
+    const perDayKept =
+      kept.length > 0
+        ? await rowsP<{ day: string; grp: string; cost: string }>(
+            db,
+            `SELECT toString(toDate(Timestamp)) AS day, ${groupExpr} AS grp, sum(EstimatedCost) AS cost
+             FROM otel_spans
+             WHERE ${scope} ${filterClause} AND ${groupExpr} IN {kept:Array(String)}
+             GROUP BY day, grp`,
+            { ...common, kept },
+          )
+        : [];
+    const perDayOther = hasOther
+      ? await rowsP<{ day: string; cost: string }>(
+          db,
+          `SELECT toString(toDate(Timestamp)) AS day, sum(EstimatedCost) AS cost
+           FROM otel_spans
+           WHERE ${scope} ${filterClause} AND ${groupExpr} NOT IN {kept:Array(String)}
+           GROUP BY day`,
+          { ...common, kept },
+        )
+      : [];
+
+    const dayList = isoDaysFrom(b.windowStart, windowDays);
+    const costRows: ExploreCostRow[] = [
+      ...perDayKept.map((r) => ({ day: r.day, group: r.grp, costMicroUsd: micro(r.cost) })),
+      ...perDayOther.map((r) => ({ day: r.day, group: OTHER_GROUP, costMicroUsd: micro(r.cost) })),
+    ];
+    const days = pivotExploreDays(dayList, costRows, capped.keptGroups, hasOther);
+
+    return {
+      groupBy: params.groupBy,
+      windowStart: b.windowStart,
+      windowEnd: b.windowEnd,
+      windowDays,
+      groups: capped.orderedGroups,
+      days,
+      breakdown: capped.breakdown,
+      totalMicroUsd: capped.totalMicroUsd,
+      truncatedGroups: capped.truncatedGroups,
+    };
   });
 }
 

--- a/web/lib/explore.test.ts
+++ b/web/lib/explore.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for the pure explore transforms (CTO-221, D1): group capping, the day pivot, window
+// clamping, and the FilterState -> ExploreParams mapping. The SQL in queryCostExplore is exercised
+// live against ClickHouse (numbers in the PR body); these cover the logic that shapes its output.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_WINDOW_DAYS,
+  OTHER_GROUP,
+  type ExploreCostRow,
+  type ExploreGroupTotal,
+  capGroups,
+  clampWindowDays,
+  exploreParamsFromFilters,
+  pivotExploreDays,
+} from "./explore";
+import { defaultFilterState, toggleDimensionValue, withCustomRange, withGroupBy } from "./filters";
+
+function total(group: string, totalMicroUsd: number, spanCount = 1): ExploreGroupTotal {
+  return { group, totalMicroUsd, spanCount };
+}
+
+describe("capGroups", () => {
+  it("keeps every group and folds nothing when under the cap", () => {
+    const c = capGroups([total("a", 30), total("b", 20), total("c", 10)], 5);
+    expect(c.orderedGroups).toEqual(["a", "b", "c"]);
+    expect(c.truncatedGroups).toBe(0);
+    expect(c.totalMicroUsd).toBe(60);
+    expect(c.breakdown.some((r) => r.group === OTHER_GROUP)).toBe(false);
+  });
+
+  it("ranks by total desc, keeps the top N and folds the tail into an honest other row", () => {
+    const c = capGroups([total("a", 10), total("b", 50), total("c", 30), total("d", 5, 3)], 2);
+    // Kept: b (50), c (30). Folded: a (10) + d (5) = 15, spans 1 + 3 = 4.
+    expect(c.orderedGroups).toEqual(["b", "c", OTHER_GROUP]);
+    expect(c.truncatedGroups).toBe(2);
+    const other = c.breakdown.find((r) => r.group === OTHER_GROUP)!;
+    expect(other.totalMicroUsd).toBe(15);
+    expect(other.spanCount).toBe(4);
+    // The grand total is over ALL groups, kept and folded, so it never disagrees with the tenant.
+    expect(c.totalMicroUsd).toBe(95);
+    expect(c.keptGroups.has("b")).toBe(true);
+    expect(c.keptGroups.has("a")).toBe(false);
+  });
+
+  it("handles an empty input", () => {
+    const c = capGroups([]);
+    expect(c.orderedGroups).toEqual([]);
+    expect(c.totalMicroUsd).toBe(0);
+    expect(c.truncatedGroups).toBe(0);
+  });
+});
+
+describe("pivotExploreDays", () => {
+  const dayList = ["2026-06-01", "2026-06-02", "2026-06-03"];
+  const rows: ExploreCostRow[] = [
+    { day: "2026-06-01", group: "a", costMicroUsd: 100 },
+    { day: "2026-06-01", group: "b", costMicroUsd: 50 },
+    { day: "2026-06-02", group: "a", costMicroUsd: 200 },
+    { day: "2026-06-03", group: OTHER_GROUP, costMicroUsd: 10 },
+  ];
+
+  it("fills every day in the list, leaving a day with no rows as a real zero", () => {
+    const days = pivotExploreDays(dayList, rows, new Set(["a", "b"]), true);
+    expect(days.map((d) => d.date)).toEqual(dayList);
+    expect(days[0].byGroup).toEqual({ a: 100, b: 50 });
+    expect(days[1].byGroup).toEqual({ a: 200 });
+    expect(days[2].byGroup).toEqual({ [OTHER_GROUP]: 10 });
+  });
+
+  it("folds a group not in keptGroups into other when hasOther, and drops it otherwise", () => {
+    const folded = pivotExploreDays(
+      dayList,
+      [{ day: "2026-06-01", group: "z", costMicroUsd: 7 }],
+      new Set(["a"]),
+      true,
+    );
+    expect(folded[0].byGroup).toEqual({ [OTHER_GROUP]: 7 });
+
+    const dropped = pivotExploreDays(
+      dayList,
+      [{ day: "2026-06-01", group: "z", costMicroUsd: 7 }],
+      new Set(["a"]),
+      false,
+    );
+    expect(dropped[0].byGroup).toEqual({});
+  });
+
+  it("ignores rows whose day is not in the authoritative list rather than shifting the axis", () => {
+    const days = pivotExploreDays(
+      dayList,
+      [{ day: "2025-01-01", group: "a", costMicroUsd: 999 }],
+      new Set(["a"]),
+      false,
+    );
+    expect(days.every((d) => Object.keys(d.byGroup).length === 0)).toBe(true);
+  });
+});
+
+describe("clampWindowDays", () => {
+  it("bounds the window to [1, MAX_WINDOW_DAYS]", () => {
+    expect(clampWindowDays(30)).toBe(30);
+    expect(clampWindowDays(0)).toBe(1);
+    expect(clampWindowDays(-5)).toBe(1);
+    expect(clampWindowDays(10_000)).toBe(MAX_WINDOW_DAYS);
+    expect(clampWindowDays(Number.NaN)).toBe(1);
+    expect(clampWindowDays(30.9)).toBe(30);
+  });
+});
+
+describe("exploreParamsFromFilters", () => {
+  it("maps a preset range and excludes the group-by dimension from its own filter", () => {
+    let s = withGroupBy(defaultFilterState(), "provider");
+    s = toggleDimensionValue(s, "provider", "openai"); // filter on the grouped dim -> dropped
+    s = toggleDimensionValue(s, "model", "gpt-4o"); // filter on another dim -> kept
+    const p = exploreParamsFromFilters(s);
+    expect(p.groupBy).toBe("provider");
+    expect(p.window).toEqual({ kind: "preset", days: 30 });
+    expect(p.filters?.provider).toBeUndefined();
+    expect(p.filters?.model).toEqual(["gpt-4o"]);
+  });
+
+  it("maps a custom range to a range window", () => {
+    const s = withCustomRange(defaultFilterState(), "2026-06-01", "2026-06-15");
+    const p = exploreParamsFromFilters(s);
+    expect(p.window).toEqual({ kind: "range", from: "2026-06-01", to: "2026-06-15" });
+  });
+});

--- a/web/lib/explore.ts
+++ b/web/lib/explore.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// The flexible cost-explore contract (CTO-221, D1). Types and PURE transforms shared by the
+// ClickHouse query (`queryCostExplore` in lib/clickhouse.ts) and the /api/explore route.
+//
+// The query itself is a thin SQL shell around these helpers: ClickHouse returns raw (day, group,
+// cost) rows, and everything else — capping the group set so a high-cardinality dimension cannot
+// explode the payload, folding the long tail into a single honest "other" bucket, and pivoting the
+// flat rows into one point per calendar day — happens here, where it is unit-testable without a
+// database.
+//
+// The day list is NEVER built in this file. It is threaded in from the caller, which derives it from
+// the window ClickHouse reported (see queryCostExplore). This is the CTO-203 seam: a JS-built day
+// list drifts a day against the SQL window across a midnight boundary and silently drops the oldest
+// row while it still counts toward the totals. So `pivotExploreDays` takes the authoritative day
+// list as an argument and fills it; it does not generate one.
+
+import type { MicroUSD } from "./types";
+import { DIMENSIONS, type Dimension, type FilterState, rangeDays } from "./filters";
+
+/** The dimensions the explorer can group by. Same set as the filter dimensions (CTO-221). */
+export const EXPLORE_DIMENSIONS = DIMENSIONS;
+export type ExploreDimension = Dimension;
+
+/**
+ * Above this many distinct groups we stop returning individual series and fold the tail into
+ * {@link OTHER_GROUP}. A stacked chart past a dozen bands is unreadable, and an unbounded group set
+ * on a high-cardinality dimension (account, model) is also an unbounded payload. The kept groups are
+ * the top spenders; the fold is honest because "other" carries the exact remaining total.
+ */
+export const MAX_EXPLORE_GROUPS = 12;
+
+/** The synthetic bucket the long tail folds into. Not a real dimension value, so it is namespaced. */
+export const OTHER_GROUP = "· other";
+
+/** Hard ceiling on the window a single explore scan may cover, so a hand-crafted range can't ask
+ *  ClickHouse for years of spans. A year is plenty for the dashboard's longest view. */
+export const MAX_WINDOW_DAYS = 366;
+
+export type ExploreWindow =
+  | { kind: "preset"; days: number }
+  | { kind: "range"; from: string; to: string };
+
+export type ExploreFilters = Partial<Record<ExploreDimension, string[]>>;
+
+export interface ExploreParams {
+  window: ExploreWindow;
+  groupBy: ExploreDimension;
+  filters?: ExploreFilters;
+}
+
+export interface ExploreDayPoint {
+  /** ISO yyyy-mm-dd, from the caller's ClickHouse-derived day list. */
+  date: string;
+  /** Cost per kept group for this day, in integer micro-USD. Missing group = genuinely zero. */
+  byGroup: Record<string, MicroUSD>;
+}
+
+export interface ExploreBreakdownRow {
+  group: string;
+  totalMicroUsd: MicroUSD;
+  spanCount: number;
+}
+
+export interface ExploreSeries {
+  groupBy: ExploreDimension;
+  /** Oldest / newest day in the window, per ClickHouse. */
+  windowStart: string;
+  windowEnd: string;
+  windowDays: number;
+  /** Kept group names, ordered by total spend desc, possibly ending in {@link OTHER_GROUP}. */
+  groups: string[];
+  /** One point per calendar day in the window, oldest to newest. */
+  days: ExploreDayPoint[];
+  /** The breakdown table: one row per kept group (plus "other"), ordered by total desc. */
+  breakdown: ExploreBreakdownRow[];
+  /** Sum over every group, so the headline can never disagree with the rows beneath it. */
+  totalMicroUsd: MicroUSD;
+  /** How many real groups were folded into "other". 0 when the dimension fit under the cap. */
+  truncatedGroups: number;
+}
+
+/** A raw per-group total row as it comes back from ClickHouse before capping. */
+export interface ExploreGroupTotal {
+  group: string;
+  totalMicroUsd: MicroUSD;
+  spanCount: number;
+}
+
+/** A raw per-day-per-group cost row from ClickHouse. */
+export interface ExploreCostRow {
+  day: string;
+  group: string;
+  costMicroUsd: MicroUSD;
+}
+
+export interface CappedGroups {
+  /** Kept breakdown rows, top spenders first, with an appended "other" row when anything folded. */
+  breakdown: ExploreBreakdownRow[];
+  /** Just the kept real group names (no "other"), for fast membership tests during the pivot. */
+  keptGroups: Set<string>;
+  /** Ordered group names for the chart legend, "other" last when present. */
+  orderedGroups: string[];
+  truncatedGroups: number;
+  totalMicroUsd: MicroUSD;
+}
+
+/**
+ * Rank groups by total spend, keep the top {@link MAX_EXPLORE_GROUPS}, and fold the rest into one
+ * "other" row whose total is the exact sum of everything dropped. The returned total is over ALL
+ * groups, kept and folded alike, so it always equals the tenant's spend for the slice.
+ */
+export function capGroups(
+  totals: readonly ExploreGroupTotal[],
+  max: number = MAX_EXPLORE_GROUPS,
+): CappedGroups {
+  const sorted = [...totals].sort((a, b) => b.totalMicroUsd - a.totalMicroUsd);
+  const grandTotal = sorted.reduce((s, r) => s + r.totalMicroUsd, 0);
+
+  const kept = sorted.slice(0, Math.max(0, max));
+  const tail = sorted.slice(Math.max(0, max));
+
+  const breakdown: ExploreBreakdownRow[] = kept.map((r) => ({
+    group: r.group,
+    totalMicroUsd: r.totalMicroUsd,
+    spanCount: r.spanCount,
+  }));
+
+  if (tail.length > 0) {
+    breakdown.push({
+      group: OTHER_GROUP,
+      totalMicroUsd: tail.reduce((s, r) => s + r.totalMicroUsd, 0),
+      spanCount: tail.reduce((s, r) => s + r.spanCount, 0),
+    });
+  }
+
+  return {
+    breakdown,
+    keptGroups: new Set(kept.map((r) => r.group)),
+    orderedGroups: breakdown.map((r) => r.group),
+    truncatedGroups: tail.length,
+    totalMicroUsd: grandTotal,
+  };
+}
+
+/**
+ * Pivot flat (day, group, cost) rows onto the authoritative `dayList`, folding any group not in
+ * `keptGroups` into the "other" bucket so a day's bars still sum to that day's true spend. Every day
+ * in `dayList` gets a point even with no rows (a real zero), and rows whose day is not in the list
+ * are ignored rather than silently shifting the axis.
+ */
+export function pivotExploreDays(
+  dayList: readonly string[],
+  rows: readonly ExploreCostRow[],
+  keptGroups: ReadonlySet<string>,
+  hasOther: boolean,
+): ExploreDayPoint[] {
+  const byDay = new Map<string, ExploreDayPoint>();
+  for (const date of dayList) byDay.set(date, { date, byGroup: {} });
+
+  for (const r of rows) {
+    const point = byDay.get(r.day);
+    if (!point) continue;
+    const key = keptGroups.has(r.group) ? r.group : hasOther ? OTHER_GROUP : null;
+    if (key === null) continue;
+    point.byGroup[key] = (point.byGroup[key] ?? 0) + r.costMicroUsd;
+  }
+
+  return dayList.map((date) => byDay.get(date)!);
+}
+
+/** Clamp a requested window to `[1, MAX_WINDOW_DAYS]` so a scan can't be asked to cover forever. */
+export function clampWindowDays(days: number): number {
+  if (!Number.isFinite(days)) return 1;
+  return Math.min(MAX_WINDOW_DAYS, Math.max(1, Math.trunc(days)));
+}
+
+/**
+ * Translate the URL-driven {@link FilterState} into {@link ExploreParams}. The group-by dimension is
+ * excluded from its own dimension filter: grouping by provider AND filtering to one provider would
+ * collapse the chart to a single band, which is never what a group-by intends. Every other
+ * dimension's filter is carried through.
+ */
+export function exploreParamsFromFilters(state: FilterState): ExploreParams {
+  const filters: ExploreFilters = {};
+  for (const dim of DIMENSIONS) {
+    if (dim === state.groupBy) continue;
+    if (state.filters[dim].length > 0) filters[dim] = state.filters[dim];
+  }
+
+  const window: ExploreWindow =
+    state.range.preset === "custom" && state.range.from && state.range.to
+      ? { kind: "range", from: state.range.from, to: state.range.to }
+      : { kind: "preset", days: rangeDays(state.range) };
+
+  return { window, groupBy: state.groupBy, filters };
+}

--- a/web/lib/filters.test.ts
+++ b/web/lib/filters.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for the URL-synced filter state (CTO-221, D1). The load-bearing property is the round-trip:
+// parse(serialize(state)) === state for any normalized state, which is what makes a shared link
+// reconstruct the exact view. The other half is that serialization never clobbers ?tag= / ?scope=.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_GROUP_BY,
+  DEFAULT_RANGE_PRESET,
+  type FilterState,
+  clearAllFilters,
+  defaultFilterState,
+  filtersToSearchParams,
+  isIsoDate,
+  parseFilters,
+  parseMulti,
+  rangeDays,
+  toggleDimensionValue,
+  withCustomRange,
+  withGroupBy,
+  withRangePreset,
+} from "./filters";
+
+function sp(query: string): URLSearchParams {
+  return new URLSearchParams(query);
+}
+
+describe("parseFilters", () => {
+  it("returns the documented defaults for an empty query", () => {
+    const s = parseFilters(sp(""));
+    expect(s.range.preset).toBe(DEFAULT_RANGE_PRESET);
+    expect(s.groupBy).toBe(DEFAULT_GROUP_BY);
+    expect(s.filters).toEqual({
+      feature: [],
+      model: [],
+      layer: [],
+      provider: [],
+      account: [],
+    });
+  });
+
+  it("parses presets, group-by, and multi-select filters", () => {
+    const s = parseFilters(sp("range=90d&groupBy=provider&provider=openai,anthropic&model=gpt-4o"));
+    expect(s.range.preset).toBe("90d");
+    expect(s.groupBy).toBe("provider");
+    expect(s.filters.provider).toEqual(["openai", "anthropic"]);
+    expect(s.filters.model).toEqual(["gpt-4o"]);
+  });
+
+  it("degrades an unknown group-by and range to the defaults rather than throwing", () => {
+    const s = parseFilters(sp("range=all-time&groupBy=galaxy"));
+    expect(s.range.preset).toBe(DEFAULT_RANGE_PRESET);
+    expect(s.groupBy).toBe(DEFAULT_GROUP_BY);
+  });
+
+  it("honors a valid custom range and rejects a malformed or reversed one", () => {
+    const ok = parseFilters(sp("range=custom&from=2026-06-01&to=2026-06-30"));
+    expect(ok.range).toEqual({ preset: "custom", from: "2026-06-01", to: "2026-06-30" });
+
+    // Reversed → not a range we can honor, so it degrades to the default preset.
+    const reversed = parseFilters(sp("range=custom&from=2026-06-30&to=2026-06-01"));
+    expect(reversed.range.preset).toBe(DEFAULT_RANGE_PRESET);
+
+    // Missing / garbage end → default preset.
+    const missing = parseFilters(sp("range=custom&from=2026-06-01"));
+    expect(missing.range.preset).toBe(DEFAULT_RANGE_PRESET);
+    const garbage = parseFilters(sp("range=custom&from=2026-13-40&to=2026-06-01"));
+    expect(garbage.range.preset).toBe(DEFAULT_RANGE_PRESET);
+  });
+});
+
+describe("parseMulti", () => {
+  it("splits, trims, drops blanks and dedupes while preserving order", () => {
+    expect(parseMulti(" a , b ,,a, c ")).toEqual(["a", "b", "c"]);
+    expect(parseMulti(null)).toEqual([]);
+    expect(parseMulti("")).toEqual([]);
+  });
+});
+
+describe("isIsoDate", () => {
+  it("accepts real calendar dates and rejects impossible ones", () => {
+    expect(isIsoDate("2026-02-28")).toBe(true);
+    expect(isIsoDate("2026-02-31")).toBe(false);
+    expect(isIsoDate("2026-13-01")).toBe(false);
+    expect(isIsoDate("not-a-date")).toBe(false);
+    expect(isIsoDate(null)).toBe(false);
+  });
+});
+
+describe("filtersToSearchParams", () => {
+  it("omits every default so the canonical view has a clean URL", () => {
+    expect(filtersToSearchParams(defaultFilterState()).toString()).toBe("");
+  });
+
+  it("serializes non-default range, group-by and filters", () => {
+    let s = defaultFilterState();
+    s = withRangePreset(s, "7d");
+    s = withGroupBy(s, "provider");
+    s = toggleDimensionValue(s, "provider", "openai");
+    const out = filtersToSearchParams(s);
+    expect(out.get("range")).toBe("7d");
+    expect(out.get("groupBy")).toBe("provider");
+    expect(out.get("provider")).toBe("openai");
+  });
+
+  it("preserves ?tag= and ?scope= and any other unrelated param (never clobbers them)", () => {
+    const base = sp("tag=research_agent&scope=model:gpt-4o&debug=1");
+    let s = defaultFilterState();
+    s = withGroupBy(s, "layer");
+    s = toggleDimensionValue(s, "feature", "chatbot");
+    const out = filtersToSearchParams(s, base);
+    expect(out.get("tag")).toBe("research_agent");
+    expect(out.get("scope")).toBe("model:gpt-4o");
+    expect(out.get("debug")).toBe("1");
+    expect(out.get("feature")).toBe("chatbot");
+  });
+
+  it("rewrites its own keys without leaving stale copies from the base URL", () => {
+    // A base carrying an old provider filter must be overwritten, not appended to.
+    const base = sp("provider=stale&groupBy=account");
+    const out = filtersToSearchParams(defaultFilterState(), base);
+    expect(out.getAll("provider")).toEqual([]);
+    expect(out.get("groupBy")).toBeNull();
+  });
+});
+
+describe("round-trip parse(serialize(state)) === state", () => {
+  const cases: FilterState[] = [
+    defaultFilterState(),
+    withRangePreset(defaultFilterState(), "7d"),
+    withRangePreset(defaultFilterState(), "90d"),
+    withGroupBy(defaultFilterState(), "account"),
+    withCustomRange(defaultFilterState(), "2026-06-01", "2026-06-30"),
+    (() => {
+      let s = defaultFilterState();
+      s = withRangePreset(s, "90d");
+      s = withGroupBy(s, "model");
+      s = toggleDimensionValue(s, "provider", "openai");
+      s = toggleDimensionValue(s, "provider", "anthropic");
+      s = toggleDimensionValue(s, "feature", "chatbot");
+      return s;
+    })(),
+  ];
+
+  it.each(cases.map((c, i) => [i, c] as const))("case %i", (_i, state) => {
+    const query = filtersToSearchParams(state);
+    expect(parseFilters(query)).toEqual(state);
+  });
+
+  it("also round-trips when other params ride alongside", () => {
+    let s = defaultFilterState();
+    s = withGroupBy(s, "provider");
+    s = toggleDimensionValue(s, "model", "gpt-4o");
+    const query = filtersToSearchParams(s, sp("tag=chatbot&scope=layer:llm"));
+    // Re-parsing only reads the managed keys; tag/scope are ignored by the parser but preserved.
+    expect(parseFilters(query)).toEqual(s);
+    expect(query.get("tag")).toBe("chatbot");
+  });
+});
+
+describe("state helpers", () => {
+  it("toggleDimensionValue adds then removes", () => {
+    let s = defaultFilterState();
+    s = toggleDimensionValue(s, "layer", "llm");
+    expect(s.filters.layer).toEqual(["llm"]);
+    s = toggleDimensionValue(s, "layer", "llm");
+    expect(s.filters.layer).toEqual([]);
+  });
+
+  it("withCustomRange rejects an invalid or reversed pair", () => {
+    const s = defaultFilterState();
+    expect(withCustomRange(s, "2026-06-30", "2026-06-01")).toBe(s);
+    expect(withCustomRange(s, "garbage", "2026-06-01")).toBe(s);
+  });
+
+  it("clearAllFilters empties every dimension but keeps range and group-by", () => {
+    let s = withGroupBy(defaultFilterState(), "model");
+    s = toggleDimensionValue(s, "provider", "openai");
+    const cleared = clearAllFilters(s);
+    expect(cleared.filters.provider).toEqual([]);
+    expect(cleared.groupBy).toBe("model");
+  });
+});
+
+describe("rangeDays", () => {
+  it("returns fixed spans for presets and an inclusive count for custom", () => {
+    expect(rangeDays({ preset: "7d", from: null, to: null })).toBe(7);
+    expect(rangeDays({ preset: "30d", from: null, to: null })).toBe(30);
+    expect(rangeDays({ preset: "90d", from: null, to: null })).toBe(90);
+    expect(rangeDays({ preset: "custom", from: "2026-06-01", to: "2026-06-30" })).toBe(30);
+    expect(rangeDays({ preset: "custom", from: "2026-06-01", to: "2026-06-01" })).toBe(1);
+  });
+});

--- a/web/lib/filters.ts
+++ b/web/lib/filters.ts
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Shared dashboard filter state, URL-synced (CTO-221, D1 design foundation).
+//
+// This is the single source of truth for "what slice of spend am I looking at": a time range, a
+// group-by dimension, and multi-select dimension filters. The state lives in the URL query string
+// (parsed here, driven by `useFilters`) so a filtered view is shareable and the browser back button
+// walks the filter history rather than the page history.
+//
+// Two hard constraints shape this file:
+//
+//   1. It PRESERVES `?tag=` and `?scope=` (CTO-104 / CTO-211) and any other unrelated query param.
+//      Serialization only ever touches the keys this module owns (`MANAGED_KEYS`); everything else
+//      on the incoming URLSearchParams is carried through untouched. Clobbering `tag`/`scope` would
+//      silently change which feature the breakdown is filtered to or which budget the forecast
+//      reports on, from an unrelated filter interaction.
+//   2. It round-trips. `parseFilters(filtersToSearchParams(state, base))` yields `state` back for
+//      any normalized state, which is what makes a shared link reconstruct the exact view and what
+//      the D1 acceptance test asserts. Default values are OMITTED from the URL (a bare `/cost` is
+//      the 30-day, group-by-layer, unfiltered view) precisely so the round-trip holds at the
+//      defaults too: an empty query parses to the defaults, and the defaults serialize to empty.
+//
+// This module is deliberately pure (no React, no `next/navigation`) so the round-trip is testable
+// without a router and so both the client hook and the server route can read the same parser.
+
+/** Time-range presets. Custom carries an explicit `from`/`to`. 30 days is the historical default. */
+export type TimeRangePreset = "7d" | "30d" | "90d" | "custom";
+
+export const TIME_RANGE_PRESETS: readonly TimeRangePreset[] = ["7d", "30d", "90d", "custom"];
+
+/** Days for a fixed preset. `custom` has none: its span comes from `from`/`to`. */
+export const PRESET_DAYS: Record<Exclude<TimeRangePreset, "custom">, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+/**
+ * The dimensions a page can group by or filter on. These are also the multi-select filter keys, so
+ * the list drives both the group-by selector and the set of dimension-filter URL params.
+ */
+export const DIMENSIONS = ["feature", "model", "layer", "provider", "account"] as const;
+export type Dimension = (typeof DIMENSIONS)[number];
+
+export const DIMENSION_LABEL: Record<Dimension, string> = {
+  feature: "Feature",
+  model: "Model",
+  layer: "Layer",
+  provider: "Provider",
+  account: "Account",
+};
+
+export interface TimeRange {
+  preset: TimeRangePreset;
+  /** ISO yyyy-mm-dd, only meaningful (and only non-null) when `preset === "custom"`. */
+  from: string | null;
+  to: string | null;
+}
+
+/** One string array per dimension. Empty array = no filter on that dimension. */
+export type DimensionFilters = Record<Dimension, string[]>;
+
+export interface FilterState {
+  range: TimeRange;
+  groupBy: Dimension;
+  filters: DimensionFilters;
+}
+
+export const DEFAULT_RANGE_PRESET: TimeRangePreset = "30d";
+export const DEFAULT_GROUP_BY: Dimension = "layer";
+
+/** The URL query keys this module owns. Serialization touches ONLY these; all else is preserved. */
+export const MANAGED_KEYS: readonly string[] = ["range", "from", "to", "groupBy", ...DIMENSIONS];
+
+function emptyFilters(): DimensionFilters {
+  return { feature: [], model: [], layer: [], provider: [], account: [] };
+}
+
+export function defaultFilterState(): FilterState {
+  return {
+    range: { preset: DEFAULT_RANGE_PRESET, from: null, to: null },
+    groupBy: DEFAULT_GROUP_BY,
+    filters: emptyFilters(),
+  };
+}
+
+/** A plausible ISO calendar date `yyyy-mm-dd`. Rejects garbage so custom ranges never fabricate. */
+export function isIsoDate(s: string | null | undefined): s is string {
+  if (!s || !/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const [y, m, d] = s.split("-").map(Number);
+  if (m < 1 || m > 12 || d < 1 || d > 31) return false;
+  // Round-trip through Date to reject impossible days (2026-02-31): the UTC constructor normalizes,
+  // so a valid date comes back byte-identical.
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
+/** Normalize a comma-joined multi-select value: split, trim, drop blanks, dedupe, keep order. */
+export function parseMulti(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of raw.split(",")) {
+    const v = part.trim();
+    if (v && !seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a URL's query into a {@link FilterState}. Unknown / malformed values degrade to the default
+ * rather than throwing, so a hand-edited or stale link can never blank the page: a bad `groupBy`
+ * reads as the default dimension, a `custom` range missing a valid `from`/`to` falls back to the
+ * 30-day preset (honest-under-uncertainty: we do not invent a window).
+ */
+export function parseFilters(sp: URLSearchParams): FilterState {
+  const state = defaultFilterState();
+
+  const rawRange = sp.get("range");
+  if (rawRange && (TIME_RANGE_PRESETS as readonly string[]).includes(rawRange)) {
+    const preset = rawRange as TimeRangePreset;
+    if (preset === "custom") {
+      const from = sp.get("from");
+      const to = sp.get("to");
+      // Both ends must be real dates and ordered; otherwise it is not a range we can honor.
+      if (isIsoDate(from) && isIsoDate(to) && from <= to) {
+        state.range = { preset: "custom", from, to };
+      }
+    } else {
+      state.range = { preset, from: null, to: null };
+    }
+  }
+
+  const rawGroupBy = sp.get("groupBy");
+  if (rawGroupBy && (DIMENSIONS as readonly string[]).includes(rawGroupBy)) {
+    state.groupBy = rawGroupBy as Dimension;
+  }
+
+  for (const dim of DIMENSIONS) {
+    state.filters[dim] = parseMulti(sp.get(dim));
+  }
+
+  return state;
+}
+
+/**
+ * Write a {@link FilterState} onto a copy of `base`, preserving every param `base` carries that this
+ * module does not own (`tag`, `scope`, anything else). Defaults are omitted so the canonical view
+ * has a clean URL and the round-trip holds at the defaults.
+ */
+export function filtersToSearchParams(
+  state: FilterState,
+  base?: URLSearchParams,
+): URLSearchParams {
+  // Start from base so tag/scope/etc. survive, then clear only the keys we own before rewriting them.
+  const params = new URLSearchParams(base?.toString() ?? "");
+  for (const key of MANAGED_KEYS) params.delete(key);
+
+  if (state.range.preset !== DEFAULT_RANGE_PRESET) {
+    params.set("range", state.range.preset);
+    if (state.range.preset === "custom" && state.range.from && state.range.to) {
+      params.set("from", state.range.from);
+      params.set("to", state.range.to);
+    }
+  }
+
+  if (state.groupBy !== DEFAULT_GROUP_BY) {
+    params.set("groupBy", state.groupBy);
+  }
+
+  for (const dim of DIMENSIONS) {
+    const values = state.filters[dim];
+    if (values.length > 0) params.set(dim, values.join(","));
+  }
+
+  return params;
+}
+
+/** Convenience: the managed query string alone (no leading `?`), for building an API endpoint. */
+export function filtersToQueryString(state: FilterState, base?: URLSearchParams): string {
+  return filtersToSearchParams(state, base).toString();
+}
+
+// --- Small immutable state helpers, so the hook's setters stay one-liners ------------------------
+
+export function withRangePreset(
+  state: FilterState,
+  preset: Exclude<TimeRangePreset, "custom">,
+): FilterState {
+  return { ...state, range: { preset, from: null, to: null } };
+}
+
+/** Set an explicit custom range. Rejects an invalid or reversed pair by returning `state` unchanged. */
+export function withCustomRange(state: FilterState, from: string, to: string): FilterState {
+  if (!isIsoDate(from) || !isIsoDate(to) || from > to) return state;
+  return { ...state, range: { preset: "custom", from, to } };
+}
+
+export function withGroupBy(state: FilterState, groupBy: Dimension): FilterState {
+  return { ...state, groupBy };
+}
+
+/** Toggle one value in a dimension's multi-select (add if absent, remove if present). */
+export function toggleDimensionValue(
+  state: FilterState,
+  dim: Dimension,
+  value: string,
+): FilterState {
+  const current = state.filters[dim];
+  const next = current.includes(value)
+    ? current.filter((v) => v !== value)
+    : [...current, value];
+  return { ...state, filters: { ...state.filters, [dim]: next } };
+}
+
+export function clearDimension(state: FilterState, dim: Dimension): FilterState {
+  return { ...state, filters: { ...state.filters, [dim]: [] } };
+}
+
+export function clearAllFilters(state: FilterState): FilterState {
+  return { ...state, filters: emptyFilters() };
+}
+
+/** How many days the range spans, inclusive. Presets are fixed; custom counts `from`..`to`. */
+export function rangeDays(range: TimeRange): number {
+  // DEFAULT_RANGE_PRESET is typed as the wide TimeRangePreset (it could in principle be "custom"),
+  // so the 30-day fallback is spelled as the literal to keep it a valid PRESET_DAYS key.
+  const fallbackDays = PRESET_DAYS["30d"];
+  if (range.preset !== "custom") return PRESET_DAYS[range.preset];
+  if (!range.from || !range.to) return fallbackDays;
+  const from = Date.parse(`${range.from}T00:00:00Z`);
+  const to = Date.parse(`${range.to}T00:00:00Z`);
+  if (Number.isNaN(from) || Number.isNaN(to) || to < from) return fallbackDays;
+  return Math.round((to - from) / 86_400_000) + 1;
+}
+
+/** True when no dimension filter is active, for an empty-state / "clear all" affordance. */
+export function hasActiveFilters(state: FilterState): boolean {
+  return DIMENSIONS.some((d) => state.filters[d].length > 0);
+}

--- a/web/lib/useFilters.ts
+++ b/web/lib/useFilters.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// The single source of truth pages read for the active filter slice (CTO-221, D1).
+//
+// State lives in the URL query string, not in React state: `useSearchParams` is the read side and a
+// shallow `router.replace` is the write side, so a filtered view is shareable, the browser back
+// button walks the filter history, and two components on the same page (a chart and a toolbar) stay
+// in lockstep because they both read the URL rather than a local copy that could drift.
+//
+// `replace` (not `push`) with `scroll: false`: flipping a filter should not stack a new history
+// entry per keystroke nor jump the viewport. Every write goes through `commit`, which rebuilds the
+// query from the CURRENT params (so a concurrent `tag`/`scope` is preserved, see filters.ts) and
+// hands the setters as one-liners over the pure state helpers.
+
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+import {
+  type Dimension,
+  type FilterState,
+  type TimeRangePreset,
+  clearAllFilters,
+  clearDimension,
+  filtersToSearchParams,
+  parseFilters,
+  toggleDimensionValue,
+  withCustomRange,
+  withGroupBy,
+  withRangePreset,
+} from "./filters";
+
+export interface UseFiltersResult {
+  /** The parsed filter state, reconstructed from the URL on every navigation. */
+  state: FilterState;
+  setRangePreset: (preset: Exclude<TimeRangePreset, "custom">) => void;
+  setCustomRange: (from: string, to: string) => void;
+  setGroupBy: (dim: Dimension) => void;
+  toggleFilter: (dim: Dimension, value: string) => void;
+  clearFilter: (dim: Dimension) => void;
+  clearAll: () => void;
+  /** The managed query string for the current state (no leading `?`), for building an endpoint. */
+  queryString: string;
+}
+
+export function useFilters(): UseFiltersResult {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // A fresh URLSearchParams each render: ReadonlyURLSearchParams is not directly mutable and we must
+  // not retain a reference that a later `delete` could mutate under the parser.
+  const currentParams = useMemo(
+    () => new URLSearchParams(searchParams?.toString() ?? ""),
+    [searchParams],
+  );
+
+  const state = useMemo(() => parseFilters(currentParams), [currentParams]);
+  const queryString = useMemo(
+    () => filtersToSearchParams(state, currentParams).toString(),
+    [state, currentParams],
+  );
+
+  const commit = useCallback(
+    (next: FilterState) => {
+      const qs = filtersToSearchParams(next, currentParams).toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [router, pathname, currentParams],
+  );
+
+  const setRangePreset = useCallback(
+    (preset: Exclude<TimeRangePreset, "custom">) => commit(withRangePreset(state, preset)),
+    [commit, state],
+  );
+  const setCustomRange = useCallback(
+    (from: string, to: string) => commit(withCustomRange(state, from, to)),
+    [commit, state],
+  );
+  const setGroupBy = useCallback((dim: Dimension) => commit(withGroupBy(state, dim)), [commit, state]);
+  const toggleFilter = useCallback(
+    (dim: Dimension, value: string) => commit(toggleDimensionValue(state, dim, value)),
+    [commit, state],
+  );
+  const clearFilter = useCallback(
+    (dim: Dimension) => commit(clearDimension(state, dim)),
+    [commit, state],
+  );
+  const clearAll = useCallback(() => commit(clearAllFilters(state)), [commit, state]);
+
+  return {
+    state,
+    setRangePreset,
+    setCustomRange,
+    setGroupBy,
+    toggleFilter,
+    clearFilter,
+    clearAll,
+    queryString,
+  };
+}


### PR DESCRIPTION
## What this is

The D1 design + interactivity **foundation** for the dashboard overhaul (CTO-220). Shared, URL-synced primitives the pages will adopt in later waves. It keeps every existing feature and restyles no existing page; it only builds the kit.

## What the foundation provides

**1. `FilterBar` + `useFilters`, URL-synced** (`lib/filters.ts`, `lib/useFilters.ts`, `components/FilterBar.tsx`)
- Time range: 7 / 30 / 90 days + custom range, default 30 (matches today's hardcoded window).
- Group-by: feature / model / layer / provider / account.
- Multi-select dimension filters on all five dimensions.
- State lives in the query string via `useSearchParams` + a shallow `router.replace` (`scroll:false`), so a filtered view is shareable and the back button walks the filter history.
- **Preserves `?tag=` and `?scope=`** (and any other param): serialization only ever touches the keys it owns, and omits defaults so the canonical view has a clean URL.
- `useFilters()` is the single source of truth pages read.

**2. Interactive chart** (`components/InteractiveStackedChart.tsx`)
- Hover tooltip (group, date, value under the cursor), click-to-toggle legend (hiding a series rescales the y-axis to what's visible), and an `onDrill(group)` callback so a click can become a filter.
- Hand-rolled inline SVG, **no charting library** (CSP / house-style posture), theme-token driven via new `--chart-*` CSS vars (correct in dark today, tracks a light palette).

**Chart approach — why a new component, not an in-place `StackedBarChart` upgrade:** the explorer groups by an *arbitrary runtime dimension* (feature/model/provider/account), which the existing chart — typed to `CostSeries` and the six fixed cost `LAYER`s — cannot express. Making it generic would also have restyled the shipped `/cost` page, which this ticket forbids. So per the ticket's allowance I added an interactive variant and recorded the reason here and in the component header. `StackedBarChart` is untouched, so `/cost` is byte-identical.

**3. Flexible cost query API** (`lib/explore.ts`, `queryCostExplore` in `lib/clickhouse.ts`, `app/api/explore/route.ts`)
- `/api/explore` takes `{ window, groupBy, filters }` (read straight off the same filter URL) and returns a per-day grouped time series **plus** a breakdown table off one scan.
- Day list derived from the **ClickHouse-reported window, never the Node clock** (the CTO-203 seam; follows `queryCostSeries`/`queryAccountDetail`).
- Scan is window-clamped (`MAX_WINDOW_DAYS`), group set folds to the top N with an honest `· other` bucket, provider uses the attribution `coalesce(...)` expression and layer uses `LAYER_CASE`.
- ClickHouse error → `null` → route reports `source:"unavailable"` (honest failure over a wrong number; no mock fallback that would misrepresent an arbitrary live slice).

**4. Layout kit** (`components/SummaryTile.tsx`, `components/PageHeader.tsx`)
- `SummaryTile`: label, big value via `<Money>`, optional delta via `<Pct>` (colored by direction) and sparkline. Plus `TileGrid`, `PageHeader`.
- Honesty primitives throughout: an unknown value is the explained blank, never a fabricated zero.

## Live `queryCostExplore` numbers (tenant `local-dev`, verified against ClickHouse)

Window 2026-07-28 → 2026-08-26 (30d, ClickHouse-derived).

**Grouped by layer** — total **$94,798.70**, rows sum exactly to the headline:

| layer | cost | spans |
|---|--:|--:|
| llm | $48,712.15 | 250,678 |
| compute | $41,883.58 | 334 |
| vector | $4,023.63 | 44,707 |
| egress | $179.33 | 81 |
| tools | $0.00 | 19,798 |
| embeddings | $0.00 | 3,719 |

**Grouped by provider** — same tenant total **$94,798.70**, different split:

| provider | cost | spans |
|---|--:|--:|
| aws | $41,883.58 | 334 |
| openai | $24,670.45 | 165,983 |
| anthropic | $24,041.71 | 108,212 |
| pinecone | $4,023.63 | 44,707 |
| vercel | $179.33 | 81 |

**Filtered** (`provider IN (openai, anthropic)`, `range=7d`, `groupBy=layer`) — window narrows to the ClickHouse-derived **2026-08-20 → 2026-08-26 (7d)**, total **$13,370.75**, all `llm` (the non-LLM layers belong to aws/pinecone/vercel and are correctly excluded).

## Browser verification (screenshots captured during review)

Ran the worktree dev server on a spare port against a throwaway demo mount (reverted before build) and confirmed in Chrome:
- **FilterBar** renders the 7/30/90/Custom segmented control, the Group-by select, and per-dimension multi-select dropdowns (Provider dropdown shows aws / openai / anthropic / pinecone / vercel checkboxes).
- **Tooltip**: hovering a bar shows `2026-08-21 · <group> · $value` with the series swatch.
- **Legend toggle**: clicking `openai` strikes it through in the legend, removes its segments from every bar, and rescales the y-axis to the remaining series.
- Theme-correct in dark; chart chrome is driven by `--chart-*` vars for light.

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — clean (only pre-existing warnings in `attribution/Live.tsx` and `useLivePoll.ts`, none from new files).
- `npm run test` — 616 pass; the only failure is one long-standing `app/api/api.test.ts` "falls back to mock when ClickHouse is unreachable" case, which fails precisely because a local ClickHouse **is** running (documented known issue). No new failures.
- `npm run build` — succeeds with no dev server active (`/api/explore` registered).

New unit tests: `lib/filters.test.ts` (round-trip + tag/scope preservation), `lib/explore.test.ts` (capping/pivot/window/param mapping), `components/FilterBar.test.tsx`, `components/InteractiveStackedChart.test.tsx` (tooltip/toggle/drill), `components/SummaryTile.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
