### PR TITLE
Refresh app shell + Connectors/Guardrails on the design foundation (CTO-225)

### DIFF
--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { PageHeader } from "@/components/PageHeader";
 import { apiGet } from "@/lib/api";
 import {
   type ConnectorCategory,
@@ -66,20 +67,23 @@ export default async function ConnectorsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">Connectors</h1>
-        <span className="text-sm text-muted">
-          {connected} of {totalLive} sources connected
-          {totalSoon > 0 ? ` · ${totalSoon} coming soon` : ""}
-        </span>
-      </div>
-
-      <p className="max-w-prose text-sm text-muted">
-        Pluggable cost sources. Each normalizes one provider into the shared cost model. Connect a
-        source here by pointing it at a credential reference; sync schedules run in the backend
-        connector runner. A source shows <span className="text-good">Connected</span> once it has
-        produced data.
-      </p>
+      <PageHeader
+        title="Connectors"
+        subtitle={
+          <span className="block max-w-prose">
+            Pluggable cost sources. Each normalizes one provider into the shared cost model. Connect
+            a source here by pointing it at a credential reference; sync schedules run in the backend
+            connector runner. A source shows <span className="text-good">Connected</span> once it
+            has produced data.
+          </span>
+        }
+        actions={
+          <span className="rounded-full border border-edge bg-panel px-3 py-1 text-sm text-muted">
+            {connected} of {totalLive} sources connected
+            {totalSoon > 0 ? ` · ${totalSoon} coming soon` : ""}
+          </span>
+        }
+      />
 
       {live ? body : <SyntheticPreviewBanner workflow="Connectors">{body}</SyntheticPreviewBanner>}
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -44,4 +44,24 @@
 
 body {
   @apply bg-ink text-gray-100;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Additive shell chrome (CTO-225): a thin, token-tinted scrollbar so the sidebar's overflow does not
+   render the OS default heavy bar over the panel surface. Purely cosmetic and opt-in via the class;
+   it adds no new color, reusing the existing edge/panel tokens. */
+.app-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: theme("colors.edge") transparent;
+}
+.app-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+.app-scroll::-webkit-scrollbar-thumb {
+  background-color: theme("colors.edge");
+  border-radius: 9999px;
+}
+.app-scroll::-webkit-scrollbar-track {
+  background: transparent;
 }

--- a/web/app/guardrails/page.tsx
+++ b/web/app/guardrails/page.tsx
@@ -6,6 +6,7 @@
 // idempotent change_id to the gateway; the SDK picks the change up on its next config-refresh window.
 
 import { Card } from "@/components/Card";
+import { PageHeader } from "@/components/PageHeader";
 import { apiGet } from "@/lib/api";
 import {
   type GuardrailRule,
@@ -19,41 +20,43 @@ interface GuardrailsPayload {
   configRefreshSeconds: number;
 }
 
+// A count stat rendered in the kit's tile shell (CTO-225). These are integer counts, not money, so
+// they intentionally do not go through SummaryTile/<Money>; there is no honest-blank case for a
+// count of rules the page already holds in memory.
+function CountTile({ label, value, accent }: { label: string; value: number; accent?: boolean }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-edge bg-panel p-4">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted">{label}</span>
+      <span className={`text-2xl font-semibold tabular-nums ${accent ? "text-accent" : ""}`}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
 export default async function GuardrailsPage() {
   const { rules, configRefreshSeconds } = await apiGet<GuardrailsPayload>("/api/guardrails");
   const summary = summarize(rules);
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold">Guardrails</h1>
-        <p className="mt-1 text-sm text-muted">
-          Per-tenant cost / step caps. Rules start in observe-only and graduate to enforcement with
-          confidence. Mode changes take effect on the SDK within the {configRefreshSeconds}s
-          config-refresh window.
-        </p>
-      </div>
+      <PageHeader
+        title="Guardrails"
+        subtitle={
+          <>
+            Per-tenant cost / step caps. Rules start in observe-only and graduate to enforcement
+            with confidence. Mode changes take effect on the SDK within the {configRefreshSeconds}s
+            config-refresh window.
+          </>
+        }
+      />
 
-      <Card title="Summary">
-        <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-muted">Rules</dt>
-            <dd className="mt-0.5 text-2xl font-semibold">{summary.total}</dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-muted">Enforcing</dt>
-            <dd className="mt-0.5 text-2xl font-semibold">{summary.enforcing}</dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-muted">Observing</dt>
-            <dd className="mt-0.5 text-2xl font-semibold">{summary.observing}</dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-muted">Ready to enforce</dt>
-            <dd className="mt-0.5 text-2xl font-semibold text-accent">{summary.readyToGraduate}</dd>
-          </div>
-        </dl>
-      </Card>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <CountTile label="Rules" value={summary.total} />
+        <CountTile label="Enforcing" value={summary.enforcing} />
+        <CountTile label="Observing" value={summary.observing} />
+        <CountTile label="Ready to enforce" value={summary.readyToGraduate} accent />
+      </div>
 
       <Card title="Rules">
         <div className="overflow-x-auto">

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -1,49 +1,124 @@
 // SPDX-License-Identifier: Apache-2.0
+// The global app shell: sidebar nav + main content frame (CTO-225, D5, building on the CTO-221
+// design foundation). This is DESIGN only. Every route and every nav link is preserved exactly;
+// the refresh adds grouping captions, active-route highlighting, and token-driven spacing so the
+// app reads as one coherent surface instead of a flat list of links.
+//
+// It is a client component so it can highlight the active route via `usePathname`. Children are
+// still server-rendered in layout.tsx and passed through as an opaque node, so no page loses its
+// server rendering by living under this shell.
+
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
-const NAV: { label: string; href: string }[] = [
-  { label: "Home", href: "/" },
-  { label: "Cost", href: "/cost" },
-  { label: "Features", href: "/features" },
-  { label: "Agents", href: "/agents" },
-  { label: "Compare", href: "/compare" },
-  { label: "Attribution", href: "/attribution" },
-  { label: "Unit Economics", href: "/unit-economics" },
-  { label: "Cost per Customer", href: "/cost-per-customer" },
-  { label: "Connectors", href: "/connectors" },
-  { label: "Guardrails", href: "/guardrails" },
-  // Budgets are real, tenant-declared configuration backed by the gateway control plane
-  // (CTO-208, F4), so they are linked directly rather than hidden behind /settings.
-  { label: "Budgets", href: "/settings/budgets" },
-  // Hidden from the nav until they have real signal end-to-end (pages still render at the URL):
-  //   - /settings        — guardrail config only, nothing else wired
-  //   - /estimate        — mock fixtures (re-add when CTO-128 lands)
-  //   - /data-quality    — placeholder rows (re-add when DQ follow-ups land)
+interface NavItem {
+  label: string;
+  href: string;
+}
+
+// Links are grouped only for visual grouping; the set and order of routes is unchanged from the
+// flat list this shell shipped before. Budgets stays linked directly (real tenant-declared config
+// backed by the gateway control plane, CTO-208 F4) rather than hidden behind /settings.
+//
+// Hidden from the nav until they have real signal end-to-end (pages still render at the URL):
+//   - /settings        — guardrail config only, nothing else wired
+//   - /estimate        — mock fixtures (re-add when CTO-128 lands)
+//   - /data-quality    — placeholder rows (re-add when DQ follow-ups land)
+const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
+  {
+    caption: "Overview",
+    items: [{ label: "Home", href: "/" }],
+  },
+  {
+    caption: "Analyze",
+    items: [
+      { label: "Cost", href: "/cost" },
+      { label: "Features", href: "/features" },
+      { label: "Agents", href: "/agents" },
+      { label: "Compare", href: "/compare" },
+      { label: "Attribution", href: "/attribution" },
+      { label: "Unit Economics", href: "/unit-economics" },
+      { label: "Cost per Customer", href: "/cost-per-customer" },
+    ],
+  },
+  {
+    caption: "Configure",
+    items: [
+      { label: "Connectors", href: "/connectors" },
+      { label: "Guardrails", href: "/guardrails" },
+      { label: "Budgets", href: "/settings/budgets" },
+    ],
+  },
 ];
 
+// Active when the path is the link or nested under it. "/" matches only itself so it does not light
+// up for every route; the `href + "/"` guard keeps "/cost" from claiming "/cost-per-customer".
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
 export function Shell({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? "/";
+
   return (
     <div className="flex min-h-screen">
-      <aside className="w-56 shrink-0 border-r border-edge bg-panel px-3 py-4">
-        <div className="px-2 pb-5 text-lg font-semibold tracking-tight">
+      <aside className="sticky top-0 flex h-screen w-60 shrink-0 flex-col border-r border-edge bg-panel">
+        <div className="flex items-center gap-2 px-5 py-5 text-lg font-semibold tracking-tight">
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-sm bg-accent"
+          />
           ai-<span className="text-accent">tally</span>
         </div>
-        <nav className="space-y-0.5">
-          {NAV.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="block rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-edge hover:text-white"
-            >
-              {item.label}
-            </Link>
+
+        <nav className="app-scroll flex-1 space-y-6 overflow-y-auto px-3 pb-6" aria-label="Primary">
+          {NAV_GROUPS.map((group) => (
+            <div key={group.caption} className="space-y-1">
+              <div className="px-3 text-[11px] font-medium uppercase tracking-wider text-muted">
+                {group.caption}
+              </div>
+              <div className="space-y-0.5">
+                {group.items.map((item) => {
+                  const active = isActive(pathname, item.href);
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      aria-current={active ? "page" : undefined}
+                      className={[
+                        "relative block rounded-md px-3 py-2 text-sm transition-colors",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                        active
+                          ? "bg-edge font-medium text-white"
+                          : "text-gray-300 hover:bg-edge/60 hover:text-white",
+                      ].join(" ")}
+                    >
+                      {active && (
+                        <span
+                          aria-hidden
+                          className="absolute inset-y-1.5 left-0 w-0.5 rounded-full bg-accent"
+                        />
+                      )}
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
           ))}
         </nav>
+
+        <div className="border-t border-edge px-5 py-3 text-[11px] text-muted">
+          Cost-and-value observability
+        </div>
       </aside>
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <main className="min-w-0 flex-1 p-6">{children}</main>
+        <main className="mx-auto w-full min-w-0 max-w-7xl flex-1 p-6 lg:p-8">{children}</main>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

D5 of the dashboard overhaul (CTO-225 / CTO-220), building on the CTO-221 interactive design foundation. **DESIGN only** — every route, nav link, connector control, guardrail affordance, and control-plane gateway call behaves exactly as before.

### Global shell (`web/components/Shell.tsx`)
- Nav grouped under **Overview / Analyze / Configure** captions. Every existing link and route is preserved (Home, Cost, Features, Agents, Compare, Attribution, Unit Economics, Cost per Customer, Connectors, Guardrails, Budgets), and the hidden-route note is kept verbatim.
- Active-route highlighting via `usePathname` (`aria-current="page"` + an accent indicator bar). The match logic distinguishes `/cost` from `/cost-per-customer` and lights `/settings/budgets`.
- Sticky, full-height, token-driven sidebar with a thin scrollbar and a max-width content frame. Shell is now a client component so the active state works while page children stay server-rendered.

### Connectors (`web/app/connectors/page.tsx`)
- Adopts the shared `PageHeader`; the "X of Y sources connected" summary moves into the header actions slot as a pill. Connect flow, provider list, Connected/coming-soon status computation, and every gateway call are untouched.

### Guardrails (`web/app/guardrails/page.tsx`)
- Adopts `PageHeader`; the summary is now rendered as kit-consistent tiles. Counts intentionally do not route through `SummaryTile`/`<Money>` (they are integer counts, not money, with no honest-blank case). Rules table, mode/cap/audit affordances, and POSTs are unchanged.

### globals.css
- Additive only: body font smoothing and an opt-in `.app-scroll` thin scrollbar that reuses the existing `edge`/`panel` tokens. No existing token or class was changed or removed.

### FilterBar
- Not mounted on either page: neither Connectors nor Guardrails has a time-series/dimension data source here, so a FilterBar would be non-functional. Restyle only, per the ticket.

## Theme
The app ships a single fixed dark Tailwind palette (as the CTO-221 foundation documents). These changes use only existing semantic tokens, so both `prefers-color-scheme` values render the same coherent surface with no regression. Labels, focus-visible rings, `sr-only`/aria attributes, and the honest-blank `—` glyphs are all preserved.

## Verify
- `npm run typecheck` — clean
- `npm run lint` — clean (only pre-existing warnings in untouched files)
- `npm run test` — 616 pass; only the known `app/api/api.test.ts` ClickHouse-running failure
- `npm run build` (clean `.next`, no dev server) — succeeds

Screenshots (refreshed shell + Connectors + Guardrails) captured via a worktree dev server on a spare port, then stopped before build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)