### PR TITLE
feat(web): rebuild Home and Cost on the interactive design foundation (CTO-222)

### DIFF
--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -1,5 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
-// Client-side live wrapper for the home dashboard (CTO-108).
+// Client-side live wrapper for the home dashboard (CTO-108, restyled onto the D1 design foundation
+// in CTO-222/D2).
+//
+// The visual pass keeps every figure and every honest-blank rule the shipped page had: the four
+// headline numbers (spend, estimated, reconciled, hidden cost) move into SummaryTiles WITHOUT
+// changing what they read, the outlier / ROI / per-provider cards are untouched, and the data-state
+// banners, LiveIndicator and StaleBadge all stay exactly where they were.
+//
+// FilterBar sits under the title via PageHeader. Home has no time-parameterised endpoint (its
+// summary is the fixed 30-day roll-up), so the dimension multi-selects filter the rows the page
+// already holds rather than re-querying: selecting a feature narrows the ROI snapshot, selecting a
+// provider narrows the per-provider conversion table. That is an honest hide of rows, never a
+// fabricated slice. Group-by is hidden here because Home has no grouped chart to re-key (see the
+// interactive chart on /cost for the grouped case).
 
 "use client";
 
@@ -9,12 +22,16 @@ import {
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
+import { FilterBar, type FilterOption } from "@/components/FilterBar";
 import { LiveIndicator } from "@/components/LiveIndicator";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
+import type { ProviderAttribution } from "@/lib/attribution";
 import { LAYERS, type Layer } from "@/lib/cost";
 import { allZero, asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
-import type { ProviderAttribution } from "@/lib/attribution";
 import type { CostOutlier, FeatureRoi, SpendSummary } from "@/lib/types";
 import { formatUSD } from "@/lib/types";
+import { useFilters } from "@/lib/useFilters";
 import { useLivePoll } from "@/lib/useLivePoll";
 
 export interface HomePayload {
@@ -36,7 +53,25 @@ export function HomeLive({
   const { data, updatedAt } = useLivePoll<HomePayload>(endpoint, initialData);
   const { spend: s, outliers, roi, perProviderConversion } = data;
 
-  const hidden = s.byLayer.vector + s.byLayer.tools + s.byLayer.compute + s.byLayer.embeddings + s.byLayer.egress;
+  // Same URL-synced filter state the FilterBar writes. Home reads it to narrow the tables it holds.
+  const { state: filterState } = useFilters();
+  const featureFilter = filterState.filters.feature;
+  const providerFilter = filterState.filters.provider;
+
+  const featureOptions: FilterOption[] = roi.map((r) => ({ value: r.feature }));
+  const providerOptions: FilterOption[] = perProviderConversion.map((p) => ({ value: p.provider }));
+
+  const visibleRoi =
+    featureFilter.length > 0 ? roi.filter((r) => featureFilter.includes(r.feature)) : roi;
+  const visibleProviders =
+    providerFilter.length > 0
+      ? perProviderConversion.filter((p) => providerFilter.includes(p.provider))
+      : perProviderConversion;
+
+  // Hidden cost is every non-LLM layer: the "all-in" story the tile makes explicit. The percentage
+  // and its zero-when-empty behaviour are carried over verbatim (CTO-222 keeps the meaning as-is).
+  const hidden =
+    s.byLayer.vector + s.byLayer.tools + s.byLayer.compute + s.byLayer.embeddings + s.byLayer.egress;
   const hiddenPct = s.totalMicroUsd === 0 ? 0 : Math.round((hidden / s.totalMicroUsd) * 100);
 
   const layers: Record<string, number> = { ...s.byLayer };
@@ -54,22 +89,27 @@ export function HomeLive({
     reconciledThrough: s.reconciledThrough,
   });
   const asOf = asOfLabel(s.reconciledThrough);
+  const hasReconciledDate = s.reconciledThrough > "1970-01-01";
+
+  const tiles = (
+    <TileGrid>
+      <SummaryTile label="Spend" micro={s.totalMicroUsd} hint="last 30 days" higherIsBetter={false} />
+      <SummaryTile label="Estimated" micro={s.estimatedMicroUsd} hint="not yet reconciled" />
+      <SummaryTile
+        label="Reconciled"
+        micro={s.reconciledMicroUsd}
+        hint={hasReconciledDate ? `through ${s.reconciledThrough}` : "invoiced spend"}
+      />
+      <SummaryTile
+        label="Hidden cost"
+        micro={hidden}
+        hint={`${hiddenPct}% of spend · vector + tools + compute`}
+      />
+    </TileGrid>
+  );
 
   const grid = (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <Card title="Spend — last 30 days">
-        <div className="text-3xl font-semibold">{formatUSD(s.totalMicroUsd)}</div>
-        <div className="mt-2 text-sm text-muted">
-          estimated {formatUSD(s.estimatedMicroUsd)} · reconciled {formatUSD(s.reconciledMicroUsd)}
-          {s.reconciledThrough > "1970-01-01" ? (
-            <span className="ml-1 text-xs">(through {s.reconciledThrough})</span>
-          ) : null}
-        </div>
-        <div className="mt-3 text-sm text-warn">
-          Hidden cost: {formatUSD(hidden)} ({hiddenPct}%) — vector + tools + compute
-        </div>
-      </Card>
-
       <Card title="Top cost outliers (30d)">
         <ul className="space-y-2 text-sm">
           {outliers.map((o) => (
@@ -95,7 +135,7 @@ export function HomeLive({
             </tr>
           </thead>
           <tbody>
-            {roi.map((r) => (
+            {visibleRoi.map((r) => (
               <tr key={r.feature} className="border-t border-edge">
                 <td className="py-1.5">{r.feature}</td>
                 <td className="py-1.5 text-right">{formatUSD(r.costPerUserMicroUsd)}</td>
@@ -140,7 +180,7 @@ export function HomeLive({
               </tr>
             </thead>
             <tbody>
-              {perProviderConversion.map((p) => (
+              {visibleProviders.map((p) => (
                 <tr key={p.provider} className="border-t border-edge">
                   <td className="py-1.5 font-mono">{p.provider}</td>
                   <td className="py-1.5 text-right tabular-nums">
@@ -163,30 +203,48 @@ export function HomeLive({
           </table>
         )}
       </Card>
+    </div>
+  );
 
+  const body = (
+    <div className="space-y-6">
+      {tiles}
+      {grid}
     </div>
   );
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">Home</h1>
-        <div className="flex items-center gap-2">
-          <LiveIndicator updatedAt={updatedAt} />
-          {state !== "empty" && asOf && (
-            <StaleBadge asOf={asOf} age={relativeAge(s.reconciledThrough)} stale={state === "stale"} />
-          )}
-        </div>
-      </div>
+      <PageHeader
+        title="Home"
+        subtitle="What your AI costs, and whether it pays for itself"
+        actions={
+          <>
+            <LiveIndicator updatedAt={updatedAt} />
+            {state !== "empty" && asOf && (
+              <StaleBadge
+                asOf={asOf}
+                age={relativeAge(s.reconciledThrough)}
+                stale={state === "stale"}
+              />
+            )}
+          </>
+        }
+        toolbar={
+          <FilterBar
+            options={{ feature: featureOptions, provider: providerOptions }}
+            hideGroupBy
+          />
+        }
+      />
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
       {state === "empty" ? (
-        <SyntheticPreviewBanner workflow="Home">{grid}</SyntheticPreviewBanner>
+        <SyntheticPreviewBanner workflow="Home">{body}</SyntheticPreviewBanner>
       ) : (
-        grid
+        body
       )}
     </div>
   );
 }
-

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -1,18 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
-// Client-side live wrapper for /cost (CTO-108).
+// Client-side live wrapper for /cost (CTO-108, restyled onto the D1 design foundation in
+// CTO-222/D2).
+//
+// WHAT THE DESIGN PASS KEEPS: every figure, column, banner and honest-blank the shipped page had.
+// The three headline numbers (total, reconciled, estimated) move into SummaryTiles without changing
+// what they read; the budget-vs-actual card, the burn-down forecast, the hidden-cost alerts and the
+// by-feature table with its footer row are all still here, unchanged.
+//
+// WHAT IT ADDS:
+//   - A FilterBar under the title (via PageHeader), URL-synced through useFilters.
+//   - The static StackedBarChart is replaced by the interactive chart (tooltip, legend toggle,
+//     click-to-drill). Click-to-drill adds a dimension filter through useFilters.
+//
+// FILTER-APPLICATION PATH (stated for the PR): the interactive chart honours the FULL filter set
+// (window, group-by, dimension filters) through the /api/explore endpoint the foundation built for
+// exactly this. At the DEFAULT slice (30 days, grouped by layer, no dimension filter) the chart is
+// drawn from the existing /api/cost `series` payload, so the shipped per-layer numbers and the
+// reconciled/estimated split are byte-for-byte what they were; any non-default slice fetches
+// /api/explore and states honestly when the live source is unreachable rather than drawing a
+// fabricated or zero-filled chart. The by-feature table honours the `feature` multi-select by hiding
+// unselected rows (its footer re-totals over what is visible) — an honest hide, never a re-query
+// against an endpoint that cannot take these filters. The three tiles stay the 30-day payload
+// headline and are labelled as such.
 
 "use client";
 
-import { Card } from "@/components/Card";
+import { useEffect, useState } from "react";
+
 import {
   PartialDataBanner,
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
+import { Card } from "@/components/Card";
+import { FilterBar, type FilterOption } from "@/components/FilterBar";
+import { InteractiveStackedChart, type StackedChartDay } from "@/components/InteractiveStackedChart";
 import { LiveIndicator } from "@/components/LiveIndicator";
-import { Legend, StackedBarChart } from "@/components/StackedBarChart";
-import { asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import {
+  LAYER_COLORS,
   LAYER_LABEL,
   LAYERS,
   type CostSeries,
@@ -23,7 +50,17 @@ import {
   reconciledTotal,
   totalRange,
 } from "@/lib/cost";
+import { asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
+import type { ExploreSeries } from "@/lib/explore";
+import { OTHER_GROUP } from "@/lib/explore";
+import {
+  DEFAULT_GROUP_BY,
+  DEFAULT_RANGE_PRESET,
+  DIMENSION_LABEL,
+  hasActiveFilters,
+} from "@/lib/filters";
 import { formatUSD, type SpendByLayer } from "@/lib/types";
+import { useFilters } from "@/lib/useFilters";
 import { useLivePoll } from "@/lib/useLivePoll";
 
 import { BudgetVsActualCard } from "./BudgetVsActualCard";
@@ -37,6 +74,14 @@ export interface CostPayload {
 
 function sumLayer(rows: FeatureCostRow[], layer: Layer) {
   return rows.reduce((s, r) => s + r.byLayer[layer], 0);
+}
+
+/** The live slice fetched from /api/explore for any non-default filter state. */
+interface ExploreState {
+  loading: boolean;
+  /** "live" when a series came back, "unavailable" when ClickHouse could not be read, null when idle. */
+  source: "live" | "unavailable" | null;
+  series: ExploreSeries | null;
 }
 
 export function CostLive({
@@ -59,9 +104,46 @@ export function CostLive({
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
   const { series: costSeries, featureRows, alerts: hiddenCostAlerts } = data;
 
+  const { state: filterState, toggleFilter, queryString } = useFilters();
+  const featureFilter = filterState.filters.feature;
+
+  // The default slice is drawn from the shipped payload; anything else goes through /api/explore.
+  const isDefaultSlice =
+    filterState.range.preset === DEFAULT_RANGE_PRESET &&
+    filterState.groupBy === DEFAULT_GROUP_BY &&
+    !hasActiveFilters(filterState);
+
+  const [explore, setExplore] = useState<ExploreState>({
+    loading: false,
+    source: null,
+    series: null,
+  });
+
+  useEffect(() => {
+    if (isDefaultSlice) {
+      setExplore({ loading: false, source: null, series: null });
+      return;
+    }
+    const ctrl = new AbortController();
+    setExplore((e) => ({ ...e, loading: true }));
+    fetch(`/api/explore?${queryString}`, { signal: ctrl.signal, cache: "no-store" })
+      .then((r) => r.json())
+      .then((j: { source: "live" | "unavailable"; series: ExploreSeries | null }) => {
+        setExplore({ loading: false, source: j.source, series: j.series });
+      })
+      .catch((err: unknown) => {
+        // An abort is expected on a fast filter change; keep the last state instead of flashing.
+        if (err instanceof Error && err.name === "AbortError") return;
+        // Honest-under-uncertainty: a failed fetch is "unavailable", never a zero-filled chart.
+        setExplore({ loading: false, source: "unavailable", series: null });
+      });
+    return () => ctrl.abort();
+  }, [isDefaultSlice, queryString]);
+
   const total = totalRange(costSeries);
   const reconciled = reconciledTotal(costSeries);
   const estimated = estimatedTotal(costSeries);
+  const hasReconciledDate = costSeries.reconciledThrough > "1970-01-01";
 
   const layerTotals = LAYERS.reduce<Record<Layer, number>>(
     (acc, l) => {
@@ -78,18 +160,46 @@ export function CostLive({
   });
   const asOf = asOfLabel(costSeries.reconciledThrough);
 
+  // Feature options for the FilterBar come from the payload the page already holds; layer options
+  // are the fixed cost layers. The other dimensions (model/provider/account) are not known to
+  // /api/cost, so the bar simply shows no control for them (never an empty menu), while group-by can
+  // still key the interactive chart on them through /api/explore.
+  const featureOptions: FilterOption[] = featureRows.map((r) => ({ value: r.feature }));
+  const layerOptions: FilterOption[] = LAYERS.map((l) => ({ value: l, label: LAYER_LABEL[l] }));
+
+  const visibleFeatureRows =
+    featureFilter.length > 0
+      ? featureRows.filter((r) => featureFilter.includes(r.feature))
+      : featureRows;
+
+  const chartTitle = isDefaultSlice
+    ? "Cost by layer — last 30 days"
+    : `Cost by ${DIMENSION_LABEL[filterState.groupBy].toLowerCase()} — ${sliceLabel(filterState.range.preset)}`;
+
   const body = (
     <div className="space-y-6">
-      <Card title="Cost by layer — last 30 days">
-        <div className="mb-2 flex items-baseline gap-3 text-sm">
-          <span className="text-2xl font-semibold">{formatUSD(total)}</span>
-          <span className="text-muted">
-            reconciled {formatUSD(reconciled)}
-            {costSeries.reconciledThrough > "1970-01-01" ? ` (through ${costSeries.reconciledThrough})` : ""} · estimated {formatUSD(estimated)}
-          </span>
-        </div>
-        <StackedBarChart series={costSeries} />
-        <Legend />
+      <TileGrid>
+        <SummaryTile label="Total" micro={total} hint="last 30 days" />
+        <SummaryTile
+          label="Reconciled"
+          micro={reconciled}
+          hint={hasReconciledDate ? `through ${costSeries.reconciledThrough}` : "invoiced spend"}
+        />
+        <SummaryTile label="Estimated" micro={estimated} hint="not yet reconciled" />
+      </TileGrid>
+
+      <Card title={chartTitle}>
+        <CostChart
+          isDefaultSlice={isDefaultSlice}
+          costSeries={costSeries}
+          explore={explore}
+          onDrillLayer={(g) => toggleFilter("layer", g)}
+          onDrillGroup={(g) => {
+            // The synthetic "other" fold is not a real dimension value, so it is not a filter.
+            if (g === OTHER_GROUP) return;
+            toggleFilter(filterState.groupBy, g);
+          }}
+        />
       </Card>
 
       {/* Directly under the 30-day headline on purpose (CTO-209): this card's figure is smaller
@@ -137,7 +247,7 @@ export function CostLive({
               </tr>
             </thead>
             <tbody>
-              {featureRows.map((r) => {
+              {visibleFeatureRows.map((r) => {
                 const t = LAYERS.reduce((s, l) => s + r.byLayer[l], 0);
                 return (
                   <tr key={r.feature} className="border-t border-edge">
@@ -151,7 +261,7 @@ export function CostLive({
                   </tr>
                 );
               })}
-              <FooterRow rows={featureRows} />
+              <FooterRow rows={visibleFeatureRows} />
             </tbody>
           </table>
         </div>
@@ -161,19 +271,23 @@ export function CostLive({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">Cost</h1>
-        <div className="flex items-center gap-2">
-          <LiveIndicator updatedAt={updatedAt} />
-          {state !== "empty" && asOf && (
-            <StaleBadge
-              asOf={asOf}
-              age={relativeAge(costSeries.reconciledThrough)}
-              stale={state === "stale"}
-            />
-          )}
-        </div>
-      </div>
+      <PageHeader
+        title="Cost"
+        subtitle="Where the spend goes, by layer and by feature"
+        actions={
+          <>
+            <LiveIndicator updatedAt={updatedAt} />
+            {state !== "empty" && asOf && (
+              <StaleBadge
+                asOf={asOf}
+                age={relativeAge(costSeries.reconciledThrough)}
+                stale={state === "stale"}
+              />
+            )}
+          </>
+        }
+        toolbar={<FilterBar options={{ feature: featureOptions, layer: layerOptions }} />}
+      />
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
@@ -183,6 +297,81 @@ export function CostLive({
         body
       )}
     </div>
+  );
+}
+
+/** A short human label for the active window preset, used in the chart card title. */
+function sliceLabel(preset: string): string {
+  switch (preset) {
+    case "7d":
+      return "last 7 days";
+    case "90d":
+      return "last 90 days";
+    case "custom":
+      return "custom range";
+    default:
+      return "last 30 days";
+  }
+}
+
+/**
+ * The interactive chart. Two data sources, one component: the default slice maps the shipped
+ * CostSeries onto the generic chart keyed by layer (colours and labels unchanged), any other slice
+ * renders the explore series or states honestly that the live source is unavailable.
+ */
+function CostChart({
+  isDefaultSlice,
+  costSeries,
+  explore,
+  onDrillLayer,
+  onDrillGroup,
+}: {
+  isDefaultSlice: boolean;
+  costSeries: CostSeries;
+  explore: ExploreState;
+  onDrillLayer: (group: string) => void;
+  onDrillGroup: (group: string) => void;
+}) {
+  if (isDefaultSlice) {
+    const days: StackedChartDay[] = costSeries.days.map((d) => ({
+      date: d.date,
+      byGroup: { ...d.byLayer },
+    }));
+    return (
+      <InteractiveStackedChart
+        days={days}
+        groups={LAYERS}
+        color={(g) => LAYER_COLORS[g as Layer] ?? "#8a93a6"}
+        label={(g) => LAYER_LABEL[g as Layer] ?? g}
+        onDrill={onDrillLayer}
+        ariaLabel="stacked cost by layer over time"
+      />
+    );
+  }
+
+  if (explore.loading && explore.series === null) {
+    return <p className="py-8 text-center text-sm text-muted">Loading this slice…</p>;
+  }
+
+  if (explore.source === "unavailable" || explore.series === null) {
+    // Honest-under-uncertainty: a live slice we cannot read is stated, never zero-filled.
+    return (
+      <p className="py-8 text-center text-sm text-muted">
+        This slice is served live and the telemetry source could not be reached, so no chart is
+        drawn. The default 30-day view above works without it.
+      </p>
+    );
+  }
+
+  const series = explore.series;
+  const days: StackedChartDay[] = series.days.map((d) => ({ date: d.date, byGroup: d.byGroup }));
+  return (
+    <InteractiveStackedChart
+      days={days}
+      groups={series.groups}
+      onDrill={onDrillGroup}
+      ariaLabel="stacked cost by selected dimension over time"
+    />
   );
 }
 


### PR DESCRIPTION
## What this is

D2 of the dashboard overhaul (CTO-222): the **Home** and **Cost** pages are rebuilt on the CTO-221 interactive design foundation (PageHeader + FilterBar, SummaryTile/TileGrid, InteractiveStackedChart). This is a design + interactivity pass only. Every existing feature, card, column, number and honest-blank is kept. No product change, nothing removed, no charting library.

## Home (`web/app/Live.tsx`)

- `PageHeader` carries the title, the `LiveIndicator` + `StaleBadge`, and a `FilterBar` toolbar.
- The four headline numbers (Spend, Estimated, Reconciled, Hidden cost) move into `SummaryTile`s. The hidden-cost percentage and the muted `—` spans keep their meaning verbatim, including the existing zero-when-empty percentage.
- The outlier, ROI-snapshot and per-provider-conversion cards are otherwise untouched.
- Group-by is hidden (Home has no grouped chart), so the FilterBar carries the time range plus Feature and Provider multi-selects.

## Cost (`web/app/cost/Live.tsx`)

- `PageHeader` + `FilterBar`; total / reconciled / estimated move into `SummaryTile`s with the same numbers and the reconciled-through caption.
- The static `StackedBarChart` is replaced by `InteractiveStackedChart`: hover tooltip, legend toggle, and click-to-drill wired to add a dimension filter via `useFilters` (the synthetic `· other` fold is never turned into a filter).
- `BudgetVsActualCard`, `BurndownCard`, the hidden-cost alerts, the by-feature table with its footer row, and the `?tag=` / `?scope=` wiring are all unchanged. (Those two cards already sat on the token system and honest-blank primitives, so they needed no change.)

## Filter-application path (the choice you asked me to state)

The interactive chart honours the **full** filter set (window, group-by, dimension filters) through the **`/api/explore`** endpoint the foundation built for exactly this. At the **default slice** (30 days, grouped by layer, no dimension filter) the chart is drawn from the existing `/api/cost` `series` payload, so the shipped per-layer numbers and the reconciled/estimated split are byte-for-byte what they were; **any non-default slice fetches `/api/explore`** and states honestly when the live telemetry source is unreachable rather than drawing a zero-filled chart. The by-feature table and the Home tables honour the `feature`/`provider` multi-selects by **hiding unselected rows** (footers re-total over what is visible) — an honest hide, never a re-query against an endpoint that cannot take these filters. The three Cost tiles and the four Home tiles stay the 30-day payload headline and are labelled as such (`/api/home` and `/api/cost` take no window parameter).

## Light / dark

The app ships a fixed dark chrome (`globals.css` sets `color-scheme: dark`; the `ink`/`panel`/`edge` semantic tokens are dark hex app-wide). Both rebuilt pages use only those semantic tokens plus the foundation's `--chart-*` variables, so nothing new is theme-locked: the chart chrome (axis, tooltip surface, muted labels) tracks the light `--chart-*` palette under a light preference, and the data-identity colours (`LAYER_COLORS` / the categorical explore palette) read in both. No hardcoded theme-wrong colours were introduced.

Screenshots captured against a local dev server (live ClickHouse, so `reconciled` reads `$0.00` and `estimated` equals the total on this tenant):
- **Home** — PageHeader + FilterBar, four SummaryTiles (Spend / Estimated / Reconciled / Hidden cost 49% of spend), outliers + ROI cards below, ROI `—` blanks preserved.
- **Cost, default** — `COST BY LAYER — LAST 30 DAYS` interactive chart with the six-layer legend, three tiles, group-by = Layer; budget-vs-actual, burndown and by-feature cards all present below with their honest blanks.
- **Cost, `?groupBy=feature`** — chart re-renders from `/api/explore` as `COST BY FEATURE — LAST 30 DAYS` with the per-feature categorical legend, confirming the non-default explore path.
- Verified again under an emulated light `prefers-color-scheme`; chart chrome tracks the light `--chart-*` tokens and no surface renders incorrectly.

## Verification (from `web/`)

- `npm run typecheck` — clean.
- `npm run lint` — clean (only the pre-existing warnings in `app/attribution/Live.tsx` and `lib/useLivePoll.ts`; none from the changed files).
- `npm run test` — 616 pass; the single failure is the long-standing `app/api/api.test.ts` "falls back to mock when ClickHouse is unreachable" case (fails only because a local ClickHouse is running), which is the documented exemption. No new failures.
- `npm run build` — succeeds with no dev server active (`.next` cleared first); `/` and `/cost` render dynamically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)