### PR TITLE
Rebuild Agents, Compare, Features, Unit Economics on the interactive foundation (CTO-224)

### DIFF
--- a/web/app/agents/Live.tsx
+++ b/web/app/agents/Live.tsx
@@ -1,21 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
-// Client-side live wrapper for /agents (CTO-108).
+// Client-side live wrapper for /agents (CTO-108), rebuilt on the interactive design foundation
+// (CTO-224, on the CTO-221 / CTO-220 primitives).
 //
 // The server component owns the first render: it fetches the payload, derives state, and renders
 // the page. We then re-render the body block + StaleBadge using poll-updated data so users don't
 // have to manually reload after each Aider response.
+//
+// CTO-224 additions, all design/interactivity only (no figure or honest-blank changed):
+//   - PageHeader hosts the FilterBar (time range + group-by feature/model/provider + a feature
+//     filter listing the agents), so a filtered view is shareable and the live chart honours it.
+//   - SummaryTiles surface the money headlines the table used to bury (all-agent cost/day, the
+//     priciest agent, the top outlier run, total flagged-outlier spend). Each is an aggregate of
+//     figures already on the page, rendered through the honest Money primitive.
+//   - ExploreChartCard adds the interactive cost-over-time-by-agent chart (tooltip, legend toggle,
+//     click-to-drill) the page never had.
+// The reconciled distribution table and pathological-runs list are preserved verbatim.
 
 "use client";
 
 import Link from "next/link";
+import { Suspense } from "react";
+
 import { Card } from "@/components/Card";
 import {
   PartialDataBanner,
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
+import { ExploreChartCard } from "@/components/ExploreChartCard";
+import { FilterBar } from "@/components/FilterBar";
 import { Histogram } from "@/components/Histogram";
 import { LiveIndicator } from "@/components/LiveIndicator";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import { type AgentRun, type AgentSummary, p99Ratio } from "@/lib/agents";
 import {
   asOfLabel,
@@ -23,7 +40,7 @@ import {
   deriveDataState,
   relativeAge,
 } from "@/lib/dataState";
-import { formatUSD } from "@/lib/types";
+import { formatUSD, type MicroUSD } from "@/lib/types";
 import { useLivePoll } from "@/lib/useLivePoll";
 
 export interface AgentsPayload {
@@ -32,6 +49,18 @@ export interface AgentsPayload {
   // Real reconciler last-run in minutes (CTO-169), or null when the reconciler has never run /
   // the source is unavailable — rendered as `—` (no freshness badge) rather than a fake number.
   reconcilerLastRunMinutesAgo: number | null;
+}
+
+/** Max of a money field, or null when there is nothing to reduce (honest blank, never 0). */
+function maxBy<T>(rows: T[], pick: (r: T) => MicroUSD): { value: MicroUSD; row: T } | null {
+  if (rows.length === 0) return null;
+  return rows.reduce<{ value: MicroUSD; row: T }>(
+    (best, r) => {
+      const v = pick(r);
+      return v > best.value ? { value: v, row: r } : best;
+    },
+    { value: pick(rows[0]), row: rows[0] },
+  );
 }
 
 export function AgentsLive({
@@ -55,8 +84,53 @@ export function AgentsLive({
   });
   const asOf = asOfLabel(reconciledThrough);
 
+  // Money headlines: each is an aggregate of figures already rendered below, so no new number is
+  // introduced. A null when there is nothing to reduce keeps the honest-blank posture over a fake 0.
+  const totalCostPerDay = agents.reduce((s, a) => s + a.costPerDayMicroUsd, 0);
+  const priciestAgent = maxBy(agents, (a) => a.costPerDayMicroUsd);
+  const sortedRuns = runs.slice().sort((a, b) => b.totalCostMicroUsd - a.totalCostMicroUsd);
+  const topOutlier = maxBy(runs, (r) => r.totalCostMicroUsd);
+  const outlierTotal = runs.reduce((s, r) => s + r.totalCostMicroUsd, 0);
+
+  // The FilterBar's feature filter lists the agents themselves (agents are features in the cost
+  // model): filtering to one narrows the live chart to that agent's spend.
+  const agentOptions = agents.map((a) => ({ value: a.name }));
+
   const body = (
     <div className="space-y-6">
+      <TileGrid>
+        <SummaryTile
+          label="Cost/day · all agents"
+          micro={agents.length > 0 ? totalCostPerDay : null}
+          reason="no agent telemetry for this period"
+          hint={`${agents.length} agent${agents.length === 1 ? "" : "s"}`}
+        />
+        <SummaryTile
+          label="Priciest agent/day"
+          micro={priciestAgent?.value ?? null}
+          reason="no agent telemetry for this period"
+          hint={priciestAgent?.row.name}
+        />
+        <SummaryTile
+          label="Top outlier run"
+          micro={topOutlier?.value ?? null}
+          reason="no outlier runs captured"
+          hint={topOutlier ? `${topOutlier.row.multipleOfMedian}× median` : undefined}
+        />
+        <SummaryTile
+          label="Flagged outlier spend"
+          micro={runs.length > 0 ? outlierTotal : null}
+          reason="no outlier runs captured"
+          hint={`${runs.length} run${runs.length === 1 ? "" : "s"}`}
+        />
+      </TileGrid>
+
+      <ExploreChartCard
+        title="Agent cost over time"
+        groupByChoices={["feature", "model", "provider"]}
+        defaultGroupBy="feature"
+      />
+
       <Card title="Agent cost — distribution is the story">
         <table className="w-full text-sm">
           <thead className="text-xs uppercase text-muted">
@@ -98,24 +172,21 @@ export function AgentsLive({
 
       <Card title="Pathological runs (top cost outliers)">
         <ul className="divide-y divide-edge text-sm">
-          {runs
-            .slice()
-            .sort((a, b) => b.totalCostMicroUsd - a.totalCostMicroUsd)
-            .map((r) => (
-              <li key={r.runId} className="flex items-center justify-between gap-3 py-2">
-                <Link
-                  href={`/agents/runs/${r.runId}`}
-                  className="font-mono text-accent hover:underline"
-                >
-                  {r.runId}
-                </Link>
-                <span className="flex items-center gap-3">
-                  <OutcomeBadge outcome={r.outcome} />
-                  <span className="tabular-nums">{formatUSD(r.totalCostMicroUsd)}</span>
-                  <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
-                </span>
-              </li>
-            ))}
+          {sortedRuns.map((r) => (
+            <li key={r.runId} className="flex items-center justify-between gap-3 py-2">
+              <Link
+                href={`/agents/runs/${r.runId}`}
+                className="font-mono text-accent hover:underline"
+              >
+                {r.runId}
+              </Link>
+              <span className="flex items-center gap-3">
+                <OutcomeBadge outcome={r.outcome} />
+                <span className="tabular-nums">{formatUSD(r.totalCostMicroUsd)}</span>
+                <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+              </span>
+            </li>
+          ))}
         </ul>
       </Card>
     </div>
@@ -123,15 +194,27 @@ export function AgentsLive({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">Agents</h1>
-        <div className="flex items-center gap-2">
-          <LiveIndicator updatedAt={updatedAt} />
-          {state !== "empty" && asOf && (
-            <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
-          )}
-        </div>
-      </div>
+      <PageHeader
+        title="Agents"
+        subtitle="Per-agent cost, distribution, and the runs that blow the budget."
+        actions={
+          <>
+            <LiveIndicator updatedAt={updatedAt} />
+            {state !== "empty" && asOf && (
+              <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
+            )}
+          </>
+        }
+        toolbar={
+          <Suspense fallback={null}>
+            <FilterBar
+              groupByChoices={["feature", "model", "provider"]}
+              defaultGroupBy="feature"
+              options={{ feature: agentOptions }}
+            />
+          </Suspense>
+        }
+      />
 
       {state === "partial" && <PartialDataBanner missing="telemetry for some agents" />}
 

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -1,10 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
+// Cross-provider Compare, rebuilt on the interactive design foundation (CTO-224, on CTO-221 /
+// CTO-220). Design + interactivity only: the candidates table (with its CTO-114/115/123 honest
+// blank cells), the recommendation card and the replay diagnostics are preserved verbatim. Added:
+// the FilterBar (time range + group-by model/provider + model/provider filters), the money
+// headlines as SummaryTiles, and the interactive cost-over-time-by-model chart.
+import { Suspense } from "react";
+
 import { Card } from "@/components/Card";
 import {
   PartialDataBanner,
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
+import { ExploreChartCard } from "@/components/ExploreChartCard";
+import { FilterBar } from "@/components/FilterBar";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import { apiGet } from "@/lib/api";
 import { type Comparison, deltaPct } from "@/lib/compare";
 import { asOfLabel, boundaryFromMinutesAgo, deriveDataState, relativeAge } from "@/lib/dataState";
@@ -34,8 +45,56 @@ export default async function ComparePage({
   });
   const asOf = asOfLabel(reconciledThrough);
 
+  // Money headlines from the payload. Cheapest candidate is a genuine min over real figures; null
+  // when there are no candidates (honest blank rather than a fabricated 0).
+  const cheapest =
+    candidates.length > 0
+      ? candidates.reduce((best, c) =>
+          c.monthlyCostMicroUsd < best.monthlyCostMicroUsd ? c : best,
+        )
+      : null;
+  const savingsPct = Math.round(recommendation.projectedSavingsPct * 100);
+
+  // FilterBar options: the models in play and their distinct providers, so the live chart can be
+  // narrowed to a model or a provider.
+  const modelOptions = [current, ...candidates].map((m) => ({ value: m.model }));
+  const providerOptions = Array.from(new Set([current, ...candidates].map((m) => m.provider))).map(
+    (p) => ({ value: p }),
+  );
+
   const body = (
     <div className="space-y-6">
+      <TileGrid>
+        <SummaryTile
+          label="Current cost/mo"
+          micro={current.monthlyCostMicroUsd}
+          hint={current.model}
+        />
+        <SummaryTile
+          label="Cheapest candidate/mo"
+          micro={cheapest?.monthlyCostMicroUsd ?? null}
+          reason="no candidate cleared replay yet"
+          hint={cheapest?.model}
+        />
+        <SummaryTile
+          label="Projected savings/mo"
+          micro={recommendation.projectedSavingsMicroUsd}
+          higherIsBetter
+          hint={`${savingsPct}% reduction`}
+        />
+        <SummaryTile
+          label="Replay cost"
+          micro={diagnostics.replayCostMicroUsd}
+          hint={`${diagnostics.samplesReplayed.toLocaleString()} traces replayed`}
+        />
+      </TileGrid>
+
+      <ExploreChartCard
+        title="Model cost over time"
+        groupByChoices={["model", "provider"]}
+        defaultGroupBy="model"
+      />
+
       <Card title="Candidates vs. current">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
@@ -89,17 +148,28 @@ export default async function ComparePage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-semibold">Compare</h1>
-          <p className="mt-1 text-sm text-muted">
+      <PageHeader
+        title="Compare"
+        subtitle={
+          <>
             Workload: <span className="font-mono text-gray-300">{workload}</span>
-          </p>
-        </div>
-        {state !== "empty" && asOf && (
-          <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
-        )}
-      </div>
+          </>
+        }
+        actions={
+          state !== "empty" && asOf ? (
+            <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
+          ) : undefined
+        }
+        toolbar={
+          <Suspense fallback={null}>
+            <FilterBar
+              groupByChoices={["model", "provider"]}
+              defaultGroupBy="model"
+              options={{ model: modelOptions, provider: providerOptions }}
+            />
+          </Suspense>
+        }
+      />
 
       {state === "partial" && <PartialDataBanner missing="the replay sampler" />}
 

--- a/web/app/features/page.tsx
+++ b/web/app/features/page.tsx
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
+// Features / business attribution, rebuilt on the interactive design foundation (CTO-224, on
+// CTO-221 / CTO-220). Design + interactivity only: the per-feature unit-economics table (with its
+// honest blank cells and inline value-event config), the finish-setup banner and the attribution
+// diagnostics are preserved verbatim. Added: the FilterBar (time range + group-by feature/model +
+// a feature filter) and the interactive cost-over-time-by-feature chart.
+import { Suspense } from "react";
+
 import { Card } from "@/components/Card";
 import { StaleBadge, SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { ExploreChartCard } from "@/components/ExploreChartCard";
+import { FilterBar } from "@/components/FilterBar";
+import { PageHeader } from "@/components/PageHeader";
 import { apiGet } from "@/lib/api";
 import { deriveDataState, relativeAge, STALE_AFTER_MS } from "@/lib/dataState";
 import {
@@ -34,8 +44,16 @@ export default async function FeaturesPage() {
   // The "Finish setup" onboarding banner and the per-row "configure value event →" CTA live inside
   // FeatureValueEvents (CTO-140) — a client component so both can open the config modal and clear
   // the banner reactively as each feature gets a value event.
+  const featureOptions = features.map((f) => ({ value: f.feature }));
+
   const body = (
     <div className="space-y-6">
+      <ExploreChartCard
+        title="Feature cost over time"
+        groupByChoices={["feature", "model"]}
+        defaultGroupBy="feature"
+      />
+
       <FeatureValueEvents initialFeatures={features} />
 
       <Card title="Attribution diagnostics">
@@ -79,16 +97,28 @@ export default async function FeaturesPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">Features</h1>
-        {state !== "empty" && (
-          <StaleBadge
-            asOf={relativeAge(reconciledThrough)}
-            age={relativeAge(reconciledThrough)}
-            stale={state === "stale"}
-          />
-        )}
-      </div>
+      <PageHeader
+        title="Features"
+        subtitle="What each feature costs per user, the value attributed to it, and the ROI margin."
+        actions={
+          state !== "empty" ? (
+            <StaleBadge
+              asOf={relativeAge(reconciledThrough)}
+              age={relativeAge(reconciledThrough)}
+              stale={state === "stale"}
+            />
+          ) : undefined
+        }
+        toolbar={
+          <Suspense fallback={null}>
+            <FilterBar
+              groupByChoices={["feature", "model"]}
+              defaultGroupBy="feature"
+              options={{ feature: featureOptions }}
+            />
+          </Suspense>
+        }
+      />
 
       {state === "empty" ? (
         <SyntheticPreviewBanner workflow="Features">{body}</SyntheticPreviewBanner>

--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -5,8 +5,14 @@
 // configurable (CTO-126): resolved thresholds come from /api/unit-economics/config and thread into
 // every classify call; a tenant with no override falls back to the hardcoded defaults.
 
+import { Suspense } from "react";
+
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { ExploreChartCard } from "@/components/ExploreChartCard";
+import { FilterBar } from "@/components/FilterBar";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile } from "@/components/SummaryTile";
 import { apiGet } from "@/lib/api";
 import type { CacPayload } from "@/app/api/cac/route";
 import type { ThresholdConfigPayload } from "@/app/api/unit-economics/config/route";
@@ -98,16 +104,34 @@ export default async function UnitEconomicsPage() {
 
   const body = (
     <div className="space-y-6">
+      {/* Money headlines go through SummaryTile / the Money primitive (CTO-224), so a missing input
+          is the honest blank, not a fabricated 0. Payback (months) and LTV:CAC (a ratio) keep the
+          custom Metric because they carry band coloring and non-money units SummaryTile does not. */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
-        <Metric label="Blended CAC" value={fmtMoney(blended)} hint="(paid+sales+content) / new customers" />
-        <Metric label="Paid CAC" value={fmtMoney(paid)} hint="paid spend / new paid customers" />
+        <SummaryTile
+          label="Blended CAC"
+          micro={blended}
+          reason="need paid+sales+content spend and new customers"
+          hint="(paid+sales+content) / new customers"
+        />
+        <SummaryTile
+          label="Paid CAC"
+          micro={paid}
+          reason="need paid spend and new paid customers"
+          hint="paid spend / new paid customers"
+        />
         <Metric
           label="Payback"
           value={fmtMonths(payback)}
           valueClass={bandText(paybackBand(payback, thresholds))}
           hint="fully-loaded CAC / monthly margin"
         />
-        <Metric label="LTV" value={fmtMoney(ltvValue)} hint="margin × expected retention" />
+        <SummaryTile
+          label="LTV"
+          micro={ltvValue}
+          reason="need monthly margin and expected retention"
+          hint="margin × expected retention"
+        />
         <Metric
           label="LTV : CAC"
           value={fmtRatio(ratio)}
@@ -115,6 +139,12 @@ export default async function UnitEconomicsPage() {
           hint="vs. fully-loaded CAC"
         />
       </div>
+
+      <ExploreChartCard
+        title="Feature cost over time"
+        groupByChoices={["feature", "model", "provider"]}
+        defaultGroupBy="feature"
+      />
 
       <ThresholdSettings
         initial={thresholds}
@@ -194,14 +224,15 @@ export default async function UnitEconomicsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-semibold">Unit Economics</h1>
-          <p className="mt-1 text-sm text-muted">
-            CAC by flavor, payback, and LTV — honest under uncertainty. Undefined metrics render {DASH}.
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="Unit Economics"
+        subtitle={`CAC by flavor, payback, and LTV — honest under uncertainty. Undefined metrics render ${DASH}.`}
+        toolbar={
+          <Suspense fallback={null}>
+            <FilterBar groupByChoices={["feature", "model", "provider"]} defaultGroupBy="feature" />
+          </Suspense>
+        }
+      />
 
       {isMock ? (
         <SyntheticPreviewBanner workflow="Unit Economics">{body}</SyntheticPreviewBanner>

--- a/web/components/ExploreChartCard.tsx
+++ b/web/components/ExploreChartCard.tsx
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// The filter-aware interactive cost chart the analysis pages mount (CTO-224, building on the CTO-221
+// / CTO-220 design foundation). One client component, reused by /agents, /compare, /features and
+// /unit-economics, so every page gets the same interactive surface (tooltip, legend toggle,
+// click-to-drill) wired to the SAME URL filters the FilterBar writes.
+//
+// WHY it reads /api/explore and not each page's own endpoint: the reconciled per-page endpoints
+// (/api/agents, /api/compare, ...) return a fixed reconciled slice and do not take the filter query.
+// The explore endpoint is the foundation's filter-aware surface: it parses the exact range / group-by
+// / dimension-filter params the FilterBar owns, so mounting it here is what makes an active filter
+// actually change what the page shows. The page's reconciled tables below stay their own source of
+// truth; this card is the live, sliceable view over the top.
+//
+// Honest-under-uncertainty: /api/explore returns `source: "unavailable"` with a null series when
+// ClickHouse is unreachable (there is deliberately no mock fallback for arbitrary live slices). We
+// render an explained blank in that case, never a fabricated or zero-filled chart.
+
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  InteractiveStackedChart,
+  type StackedChartDay,
+} from "@/components/InteractiveStackedChart";
+import {
+  DIMENSION_LABEL,
+  type Dimension,
+  filtersToQueryString,
+  withGroupBy,
+} from "@/lib/filters";
+import { formatUSD, type MicroUSD } from "@/lib/types";
+import { useFilters } from "@/lib/useFilters";
+
+interface ExploreBreakdownRow {
+  group: string;
+  totalMicroUsd: MicroUSD;
+  spanCount: number;
+}
+
+interface ExploreSeries {
+  groupBy: Dimension;
+  windowStart: string;
+  windowEnd: string;
+  windowDays: number;
+  groups: string[];
+  days: StackedChartDay[];
+  breakdown: ExploreBreakdownRow[];
+  totalMicroUsd: MicroUSD;
+  truncatedGroups: number;
+}
+
+interface ExploreResponse {
+  source: "live" | "unavailable";
+  groupBy: Dimension;
+  series: ExploreSeries | null;
+}
+
+export function ExploreChartCard({
+  title,
+  groupByChoices,
+  defaultGroupBy,
+}: {
+  title: string;
+  /** The group-by dimensions this page offers, mirroring the page's FilterBar. */
+  groupByChoices?: readonly Dimension[];
+  /** The group-by to use when the URL carries none this page offers (mirrors the FilterBar). */
+  defaultGroupBy?: Dimension;
+}) {
+  const { state, toggleFilter } = useFilters();
+  const searchParams = useSearchParams();
+  const [resp, setResp] = useState<ExploreResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  // Resolve the group-by exactly the way the FilterBar does, so the very first fetch already groups
+  // by the page's dimension instead of the global `layer` default the FilterBar is still committing.
+  // The chart and the toolbar therefore never disagree, not even for the first paint.
+  const effectiveGroupBy =
+    defaultGroupBy && groupByChoices && !groupByChoices.includes(state.groupBy)
+      ? defaultGroupBy
+      : state.groupBy;
+  const queryString = useMemo(() => {
+    const base = new URLSearchParams(searchParams?.toString() ?? "");
+    const effectiveState =
+      effectiveGroupBy === state.groupBy ? state : withGroupBy(state, effectiveGroupBy);
+    return filtersToQueryString(effectiveState, base);
+  }, [state, effectiveGroupBy, searchParams]);
+
+  // Refetch whenever the managed query string changes (a range flip, a group-by change, a dimension
+  // filter toggle) so the chart always reflects the URL. AbortController cancels an in-flight request
+  // when the filters change again mid-flight, so a slow response can't clobber a newer one.
+  useEffect(() => {
+    let cancelled = false;
+    const ctrl = new AbortController();
+    setLoading(true);
+    setFailed(false);
+    fetch(`/api/explore?${queryString}`, { signal: ctrl.signal, cache: "no-store" })
+      .then((r) => {
+        if (!r.ok) throw new Error(`explore ${r.status}`);
+        return r.json() as Promise<ExploreResponse>;
+      })
+      .then((j) => {
+        if (cancelled) return;
+        setResp(j);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (e instanceof Error && e.name === "AbortError") return;
+        if (cancelled) return;
+        setFailed(true);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      ctrl.abort();
+    };
+  }, [queryString]);
+
+  const series = resp?.series ?? null;
+  const unavailable = failed || resp?.source === "unavailable" || series === null;
+
+  return (
+    <section className="rounded-xl border border-edge bg-panel p-5">
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-muted">{title}</h2>
+        {series && (
+          <span className="text-xs text-muted">
+            by {DIMENSION_LABEL[series.groupBy].toLowerCase()} ·{" "}
+            <span className="tabular-nums text-gray-200">{formatUSD(series.totalMicroUsd)}</span> ·{" "}
+            <span className="tabular-nums">
+              {series.windowStart} → {series.windowEnd}
+            </span>
+          </span>
+        )}
+      </div>
+
+      {loading && !series ? (
+        <p className="py-10 text-center text-sm text-muted">Loading breakdown…</p>
+      ) : unavailable ? (
+        // Honest blank: no live source for this slice, with the reason on hover. Never a fake chart.
+        <p
+          className="cursor-help py-10 text-center text-sm text-muted underline decoration-dotted decoration-muted/60 underline-offset-4"
+          title="ClickHouse is unreachable, so this live slice has no data. It is left blank rather than fabricated."
+        >
+          Live breakdown unavailable for this slice
+        </p>
+      ) : (
+        <>
+          <InteractiveStackedChart
+            days={series.days}
+            groups={series.groups}
+            ariaLabel={`cost over time by ${DIMENSION_LABEL[series.groupBy].toLowerCase()}`}
+            // Click a bar segment or legend swatch to filter on the grouped dimension. exploreParams
+            // excludes a dimension's own filter while it is the group-by (see explore.ts), so the
+            // drill lands as a URL filter chip; switching Group by then reveals that slice.
+            onDrill={(group) => toggleFilter(effectiveGroupBy, group)}
+          />
+          {series.truncatedGroups > 0 && (
+            <p className="mt-2 text-xs text-muted">
+              {series.truncatedGroups} smaller{" "}
+              {DIMENSION_LABEL[series.groupBy].toLowerCase()}
+              {series.truncatedGroups === 1 ? "" : "s"} folded into “· other”.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/components/FilterBar.tsx
+++ b/web/components/FilterBar.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import {
+  DEFAULT_GROUP_BY,
   DIMENSION_LABEL,
   DIMENSIONS,
   type Dimension,
@@ -36,6 +37,14 @@ export interface FilterBarProps {
   groupByChoices?: readonly Dimension[];
   /** Hide the group-by selector entirely (a page that groups by a fixed dimension). */
   hideGroupBy?: boolean;
+  /**
+   * The group-by a page falls back to when the URL carries none (CTO-224). The global default is
+   * `layer`, which is not in every page's `groupByChoices` (Compare offers only model/provider), so
+   * without this the select value would not match any option. When the active group-by is outside
+   * `groupByChoices`, the bar commits this default to the URL once so the state, the select and the
+   * chart that reads the same group-by all agree.
+   */
+  defaultGroupBy?: Dimension;
 }
 
 const RANGE_PRESETS: { preset: Exclude<TimeRangePreset, "custom">; label: string }[] = [
@@ -44,7 +53,12 @@ const RANGE_PRESETS: { preset: Exclude<TimeRangePreset, "custom">; label: string
   { preset: "90d", label: "90d" },
 ];
 
-export function FilterBar({ options, groupByChoices = DIMENSIONS, hideGroupBy }: FilterBarProps) {
+export function FilterBar({
+  options,
+  groupByChoices = DIMENSIONS,
+  hideGroupBy,
+  defaultGroupBy,
+}: FilterBarProps) {
   const {
     state,
     setRangePreset,
@@ -56,6 +70,20 @@ export function FilterBar({ options, groupByChoices = DIMENSIONS, hideGroupBy }:
   } = useFilters();
 
   const anyActive = DIMENSIONS.some((d) => state.filters[d].length > 0);
+
+  // If the active group-by is not one this page offers, adopt the page default so the select value
+  // is always a real option and the explore chart (which reads the same group-by from the URL) groups
+  // by the page's natural dimension rather than the global `layer` default. One commit, then the
+  // guard is false and it never loops. Only fires when a page both restricts choices and names a
+  // default; a bare FilterBar keeps the foundation's every-dimension behavior untouched.
+  const groupByValid = groupByChoices.includes(state.groupBy);
+  const fallbackGroupBy = defaultGroupBy ?? DEFAULT_GROUP_BY;
+  useEffect(() => {
+    if (!hideGroupBy && !groupByValid && groupByChoices.includes(fallbackGroupBy)) {
+      setGroupBy(fallbackGroupBy);
+    }
+  }, [hideGroupBy, groupByValid, fallbackGroupBy, groupByChoices, setGroupBy]);
+  const selectedGroupBy = groupByValid ? state.groupBy : fallbackGroupBy;
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-xl border border-edge bg-panel px-3 py-2 text-sm">
@@ -86,7 +114,7 @@ export function FilterBar({ options, groupByChoices = DIMENSIONS, hideGroupBy }:
         <label className="flex items-center gap-1.5 text-muted">
           <span className="uppercase text-xs tracking-wide">Group by</span>
           <select
-            value={state.groupBy}
+            value={selectedGroupBy}
             onChange={(e) => setGroupBy(e.target.value as Dimension)}
             className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100 focus:border-accent focus:outline-none"
           >


### PR DESCRIPTION
## What this covers

D4 of the dashboard overhaul (CTO-224): the **Agents, Compare, Features, and Unit Economics** pages, rebuilt on the interactive design foundation from CTO-221 / CTO-220. One PR — it stays reviewable (4 pages + 1 shared component + a small additive FilterBar prop).

This is a **design + interactivity** pass. Every feature, table, column, number, `useLivePoll`, data-state banner, and honest-blank rule is preserved. No existing figure is recomputed.

## Shared additions

- **`components/ExploreChartCard.tsx`** — a filter-aware `InteractiveStackedChart` (hover tooltip, legend toggle, click-to-drill) fed by `/api/explore`, so an active FilterBar slice (time range / group-by / dimension filters) actually changes what the page shows. Honest under uncertainty: it renders an **explained blank**, never a fabricated or zero-filled chart, when ClickHouse is unreachable (the explore endpoint has no mock fallback by design).
- **`components/FilterBar.tsx`** — gains an optional `defaultGroupBy`. A page whose group-by choices exclude the global `layer` default now keeps the select value, the URL, and the chart in agreement; `ExploreChartCard` resolves the same default so the first paint never disagrees with the toolbar. Purely additive — a bare `FilterBar` is unchanged.

## Per page (all via `PageHeader` + `FilterBar`)

- **Agents** — group-by feature/model/provider + a feature filter listing the agents. Money headlines become `SummaryTile`s (all-agent cost/day, priciest agent, top outlier run, flagged-outlier spend), each an aggregate of figures already on the page through the honest `Money` primitive. Adds a cost-over-time-by-agent chart. Reconciled distribution table and pathological-runs list kept verbatim.
- **Compare** — group-by model/provider + model/provider filters. Money headlines as `SummaryTile`s (current cost, cheapest candidate, projected savings, replay cost). Adds a cost-over-time-by-model chart. Candidates table (CTO-114/115/123 honest `—` cells), recommendation card, and replay diagnostics kept verbatim.
- **Features** — group-by feature/model + a feature filter. Adds a cost-over-time-by-feature chart. Per-feature economics table, inline value-event config + finish-setup banner, and attribution diagnostics kept verbatim.
- **Unit Economics** — group-by feature. The money headlines (Blended CAC, Paid CAC, LTV) are converted to `SummaryTile`s through the honest `Money` primitive; **Payback** (months) and **LTV:CAC** (ratio) stay as the band-colored tiles, since `SummaryTile` carries neither those units nor the band coloring. Adds a cost-over-time-by-feature chart. Thresholds panel and monthly-history table (locked rows, band colors, honest blanks) kept verbatim.

## Notes on theme

The app ships **dark-only** by design (`globals.css` sets `color-scheme: dark` and a fixed `bg-ink` body; only the `--chart-*` tokens carry a light variant, per the foundation). All new UI uses the same semantic tokens (`edge`/`panel`/`muted`/`accent`) and `--chart-*` vars as the rest of the app, so it is exactly as theme-correct as the foundation. There is no separate light chrome to screenshot.

## Screenshots (dark, live ClickHouse data)

- **Agents** — FilterBar (Group by Feature + Feature filter), 4 SummaryTiles, "Agent cost over time" grouped by feature, distribution table, pathological runs.
- **Compare** — Group by Model + Model/Provider filters, 4 SummaryTiles, "Model cost over time", candidates table with honest `—` quality cells, recommendation, diagnostics.
- **Features** — Group by Feature, "Feature cost over time", partial-data banner, per-feature table with honest `—` cells and configure-value-event CTAs, attribution diagnostics.
- **Unit Economics** — Group by Feature, money SummaryTiles + band-colored Payback/LTV:CAC, "Feature cost over time", thresholds panel, monthly history with locked rows and honest blanks.

Verified a filter changes the page: clicking **7d** narrows the chart window (e.g. `2026-08-20 → 2026-08-26`) and reflows the bars.

## Verification

From `web/`: `npm run typecheck`, `npm run lint` (no new warnings), `npm run test` (only the two long-standing `app/api/api.test.ts` ClickHouse-running cases fail locally), and `npm run build` (no dev server active) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)