### PR TITLE
Rebuild Cost per customer + Attribution on the design foundation (CTO-223)

### DIFF
--- a/web/app/api/attribution/route.ts
+++ b/web/app/api/attribution/route.ts
@@ -7,6 +7,10 @@ import {
   parseFilters,
 } from "@/lib/attribution";
 import { queryAttribution } from "@/lib/clickhouse";
+// The design-foundation FilterBar (CTO-221) writes range/from/to and a `feature` multi-select into
+// the same query string. Reading it here (CTO-223) lets the time range and feature filter drive the
+// live attribution report, while the attribution-specific tag/provider/outcome params keep working.
+import { parseFilters as parseDashboardFilters, rangeDays } from "@/lib/filters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -14,7 +18,11 @@ export const runtime = "nodejs";
 export async function GET(req: Request): Promise<NextResponse> {
   const url = new URL(req.url);
   const filters = parseFilters(url.searchParams);
-  const live = await queryAttribution(filters);
+  const dashboard = parseDashboardFilters(url.searchParams);
+  const live = await queryAttribution(filters, {
+    windowDays: rangeDays(dashboard.range),
+    features: dashboard.filters.feature,
+  });
   // Fall back to the mock report when the query failed (null) OR when there's
   // no chatbot-demo data yet (live but empty). Mirrors the pattern used by
   // /api/agents and /api/cost — and keeps the demo's attribution view useful

--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -6,16 +6,25 @@
 // blank. Value/user and margin/user are the blanks that matter here. They are empty because no
 // revenue source is wired for the tenant, not because those providers earn nothing, and until now
 // the page rendered a bare glyph that read as a bug.
+//
+// CTO-223 rebuilds the page onto the design foundation: a `PageHeader` + `FilterBar` (time range,
+// provider, feature) drives the window and slice, the four headline metrics are `SummaryTile`s, and
+// the provider breakdown is an `InteractiveStackedChart` of daily LLM cost per provider. None of the
+// numbers, columns, or honest-blank rules change; this is a design + interactivity pass.
 
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useMemo } from "react";
 
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
 import { DataTable, type Column } from "@/components/DataTable";
+import { FilterBar, type FilterOption } from "@/components/FilterBar";
 import { Money, Pct } from "@/components/HonestValue";
+import { InteractiveStackedChart, type StackedChartDay } from "@/components/InteractiveStackedChart";
 import { LiveIndicator } from "@/components/LiveIndicator";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import type { AttributionReport, ProviderAttribution } from "@/lib/attribution";
 import { useLivePoll } from "@/lib/useLivePoll";
 
@@ -32,18 +41,23 @@ const NO_REVENUE_WIRED =
 const NO_REVENUE_FOR_MARGIN =
   "margin needs revenue: no revenue source is wired for this tenant, so only the cost side is known";
 
+/** The providers this workflow knows, for the FilterBar's provider dropdown. */
+const PROVIDER_OPTIONS: FilterOption[] = [
+  { value: "openai", label: "OpenAI" },
+  { value: "anthropic", label: "Anthropic" },
+];
+
 export function AttributionLive({
   endpoint,
   initialData,
   outcome,
-  tag,
-  provider,
+  featureTags,
 }: {
   endpoint: string;
   initialData: AttributionReport;
   outcome: string;
-  tag: string | null;
-  provider: string | null;
+  /** Feature tags in the window, for the FilterBar's feature filter. Empty renders no such control. */
+  featureTags: string[];
 }) {
   const { data: report, updatedAt } = useLivePoll<AttributionReport>(endpoint, initialData);
 
@@ -140,28 +154,38 @@ export function AttributionLive({
     [outcome],
   );
 
+  // The chart's stacking order and legend follow the table order (by sessions), so a reader meets
+  // the same providers in the same order in both places.
+  const chartGroups = useMemo(() => report.perProvider.map((p) => p.provider), [report.perProvider]);
+  const chartDays: StackedChartDay[] = useMemo(
+    () => (report.dailyByProvider ?? []).map((d) => ({ date: d.date, byGroup: d.byProvider })),
+    [report.dailyByProvider],
+  );
+  const hasChart = chartGroups.length > 0 && chartDays.length > 0;
+
   const body = (
     <div className="space-y-6">
-      <Card title="Headline">
-        <dl className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
-          <Headline k="sessions" v={report.totals.sessions.toLocaleString()} />
-          <Headline
-            k={`${outcome} events`}
-            v={report.totals.conversions.toLocaleString()}
+      <TileGrid>
+        <CountTile label="Sessions" value={report.totals.sessions} />
+        <CountTile label={`${outcome} events`} value={report.totals.conversions} />
+        <SummaryTile label="LLM cost" micro={report.totals.costMicroUsd} />
+        <SummaryTile
+          label={`$ / ${outcome}`}
+          micro={report.totals.costPerConversionMicroUsd}
+          reason={`no ${outcome} events in the window, so there is nothing to divide the cost by`}
+        />
+      </TileGrid>
+
+      {hasChart ? (
+        <Card title="LLM cost by provider">
+          <InteractiveStackedChart
+            days={chartDays}
+            groups={chartGroups}
+            ariaLabel="daily LLM cost stacked by provider"
+            emptyLabel="no LLM spend in this window yet"
           />
-          <Headline k="LLM cost" v={<Money micro={report.totals.costMicroUsd} />} />
-          <Headline
-            k={`$ / ${outcome}`}
-            v={
-              <Money
-                micro={report.totals.costPerConversionMicroUsd}
-                reason={`no ${outcome} events in the window, so there is nothing to divide the cost by`}
-              />
-            }
-            highlight
-          />
-        </dl>
-      </Card>
+        </Card>
+      ) : null}
 
       <Card title={`Per-provider · ${outcome}`}>
         {report.perProvider.length === 0 ? (
@@ -193,16 +217,17 @@ export function AttributionLive({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-semibold">Attribution</h1>
-          <p className="mt-1 text-sm text-muted">
+      <PageHeader
+        title="Attribution"
+        subtitle={
+          <>
             $/{outcome} per provider, joined from LLM spans and CDP events on{" "}
             <span className="font-mono">UserIdHash</span>.
-          </p>
-        </div>
-        <LiveIndicator updatedAt={updatedAt} />
-      </div>
+          </>
+        }
+        actions={<LiveIndicator updatedAt={updatedAt} />}
+        toolbar={<FilterBar hideGroupBy options={{ provider: PROVIDER_OPTIONS, feature: featureTags.map((f) => ({ value: f })) }} />}
+      />
       {report.isMock ? (
         <SyntheticPreviewBanner workflow="Attribution">{body}</SyntheticPreviewBanner>
       ) : (
@@ -212,25 +237,12 @@ export function AttributionLive({
   );
 }
 
-function Headline({
-  k,
-  v,
-  highlight,
-}: {
-  k: string;
-  // ReactNode rather than string: the money headlines are <Money> now, so a missing one carries
-  // its own explanation instead of collapsing to a bare glyph on the way in.
-  v: ReactNode;
-  highlight?: boolean;
-}) {
+/** A count headline tile matching {@link SummaryTile}'s shape for the non-money metrics. */
+function CountTile({ label, value }: { label: string; value: number }) {
   return (
-    <div>
-      <dt className="text-xs uppercase text-muted">{k}</dt>
-      <dd
-        className={`mt-0.5 tabular-nums ${highlight ? "text-lg font-semibold text-good" : "text-base"}`}
-      >
-        {v}
-      </dd>
+    <div className="flex flex-col gap-1 rounded-xl border border-edge bg-panel p-4">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted">{label}</span>
+      <span className="text-2xl font-semibold tabular-nums">{value.toLocaleString()}</span>
     </div>
   );
 }

--- a/web/app/attribution/page.tsx
+++ b/web/app/attribution/page.tsx
@@ -4,9 +4,17 @@
 // Reads ?tag=&provider=&outcome= and renders $/conversion per provider with
 // Wilson 95% intervals on conversion rate. The chatbot demo's run.sh deep-links
 // here with ?tag=chatbot-demo&outcome=positive_feedback.
+//
+// CTO-223: the page now also honours the design-foundation FilterBar's query (range/from/to and a
+// `feature` multi-select). Those params ride in the same endpoint string the client polls, so the
+// time range and feature filter drive the live report exactly as tag/provider/outcome always have.
+// The endpoint is built by preserving EVERY incoming param (so `?tag=`/`?scope=` and the FilterBar
+// keys all survive) and only defaulting `outcome`.
 
 import { apiGet } from "@/lib/api";
 import type { AttributionReport } from "@/lib/attribution";
+import { querySpanFeatureTags } from "@/lib/clickhouse";
+import { parseFilters, rangeDays } from "@/lib/filters";
 import { AttributionLive } from "./Live";
 
 interface PageProps {
@@ -24,25 +32,32 @@ function readStr(
 
 export default async function AttributionPage({ searchParams }: PageProps) {
   const params = await searchParams;
-  const tag = readStr(params, "tag");
-  const provider = readStr(params, "provider");
   const outcome = readStr(params, "outcome") ?? "conversion";
 
+  // Preserve every incoming param in the endpoint the client polls, so the FilterBar's window and
+  // feature filter (and tag/scope) all reach /api/attribution unchanged. Only `outcome` is defaulted.
   const qs = new URLSearchParams();
-  if (tag) qs.set("tag", tag);
-  if (provider) qs.set("provider", provider);
+  for (const [k, v] of Object.entries(params)) {
+    if (typeof v === "string") qs.set(k, v);
+    else if (Array.isArray(v) && v[0] !== undefined) qs.set(k, v[0]);
+  }
   qs.set("outcome", outcome);
 
+  const filterState = parseFilters(qs);
+  const windowDays = rangeDays(filterState.range);
+
   const endpoint = `/api/attribution?${qs.toString()}`;
-  const initialData = await apiGet<AttributionReport>(endpoint);
+  const [initialData, featureTags] = await Promise.all([
+    apiGet<AttributionReport>(endpoint),
+    querySpanFeatureTags(windowDays),
+  ]);
 
   return (
     <AttributionLive
       endpoint={endpoint}
       initialData={initialData}
       outcome={outcome}
-      tag={tag}
-      provider={provider}
+      featureTags={featureTags ?? []}
     />
   );
 }

--- a/web/app/cost-per-customer/[account]/page.tsx
+++ b/web/app/cost-per-customer/[account]/page.tsx
@@ -23,6 +23,7 @@ import Link from "next/link";
 
 import { Card } from "@/components/Card";
 import { Blank, Money, Pct } from "@/components/HonestValue";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import {
   DIRECT_LAYERS,
   type AccountDetail,
@@ -120,30 +121,26 @@ function Report({ detail }: { detail: AccountDetail }) {
   const perUser = costPerUser(detail);
   const windowDays = detail.trend.length;
 
+  const windowHint = `last ${windowDays} days`;
+
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-4">
-        <Stat label="Direct cost">
-          <Money micro={detail.directCostMicroUsd} />
-        </Stat>
-        <Stat label="Users">
-          {detail.distinctUsers > 0 ? (
-            detail.distinctUsers.toLocaleString()
-          ) : (
-            <Blank reason="no user id was recorded on this account's spans, so distinct users cannot be counted" />
-          )}
-        </Stat>
-        <Stat label="Spans">
-          <span className="tabular-nums">{detail.spanCount.toLocaleString()}</span>
-        </Stat>
-        <Stat label="Cost per user">
-          {perUser.micro === null ? (
-            <Blank reason={perUser.reason ?? "not enough data to divide cost by users"} />
-          ) : (
-            <Money micro={perUser.micro} />
-          )}
-        </Stat>
-      </div>
+      <TileGrid>
+        <SummaryTile label="Direct cost" micro={detail.directCostMicroUsd} hint={windowHint} />
+        <CountTile
+          label="Users"
+          value={detail.distinctUsers > 0 ? detail.distinctUsers : null}
+          reason="no user id was recorded on this account's spans, so distinct users cannot be counted"
+          hint={windowHint}
+        />
+        <CountTile label="Spans" value={detail.spanCount} hint={windowHint} />
+        <SummaryTile
+          label="Cost per user"
+          micro={perUser.micro}
+          reason={perUser.reason ?? "not enough data to divide cost by users"}
+          hint={windowHint}
+        />
+      </TileGrid>
 
       <p className="max-w-prose text-sm text-muted">
         Directly attributable spend (LLM, tool calls, vector, embeddings) for this account over the
@@ -315,11 +312,33 @@ function Frame({
   );
 }
 
-function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+/**
+ * A count tile matching {@link SummaryTile}'s shape for the non-money headline figures (users,
+ * spans). `value === null` renders the same explained blank the money tiles do, so an uncountable
+ * users figure is a reasoned blank rather than a fabricated zero.
+ */
+function CountTile({
+  label,
+  value,
+  reason,
+  hint,
+}: {
+  label: string;
+  value: number | null;
+  reason?: string;
+  hint?: string;
+}) {
   return (
-    <div className="rounded-xl border border-edge bg-panel p-4">
-      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
-      <div className="mt-1 text-2xl font-semibold tabular-nums">{children}</div>
+    <div className="flex flex-col gap-1 rounded-xl border border-edge bg-panel p-4">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted">{label}</span>
+      <span className="text-2xl font-semibold tabular-nums">
+        {value === null ? (
+          <Blank reason={reason ?? "no value for this figure"} />
+        ) : (
+          value.toLocaleString()
+        )}
+      </span>
+      {hint && <span className="text-xs text-muted">{hint}</span>}
     </div>
   );
 }

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -33,10 +33,14 @@
 // a route handler would only add a hop.
 
 import { Card } from "@/components/Card";
+import { FilterBar, type FilterOption } from "@/components/FilterBar";
 import { Blank, Money } from "@/components/HonestValue";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import {
   ALLOCATION_RULE_DESCRIPTIONS,
   ALLOCATION_RULE_LABELS,
+  accountDisplayName,
   accountsView,
   allocateAccountCosts,
   allocatedRowsTotal,
@@ -52,31 +56,74 @@ import { type AccountRevenueReport } from "@/lib/accountRevenue";
 import { queryAllocationRule, type AllocationRuleSetting } from "@/lib/allocationConfig";
 import {
   queryAccountCosts,
+  queryAccountFeatureTags,
   queryAccountRevenue,
   queryExcludedInfraCost,
 } from "@/lib/clickhouse";
+import { parseFilters, rangeDays } from "@/lib/filters";
 import { AccountTable } from "./AccountTable";
 import { HowToTagDetails, OnboardingEmptyState } from "./Onboarding";
 
 export const dynamic = "force-dynamic";
 
-export default async function CostPerCustomerPage() {
-  const [costs, labels, revenue, excluded, allocationSetting] = await Promise.all([
-    queryAccountCosts(),
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function CostPerCustomerPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  // Read the same URL query the FilterBar writes (CTO-223): the time range drives the window every
+  // read below runs under, and the feature / account multi-selects narrow the slice. `?tag=`/`?scope=`
+  // and any other unrelated param are preserved by the shared filter serialization.
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (typeof v === "string") sp.set(k, v);
+    else if (Array.isArray(v) && v[0] !== undefined) sp.set(k, v[0]);
+  }
+  const filterState = parseFilters(sp);
+  const windowDays = rangeDays(filterState.range);
+  const features = filterState.filters.feature;
+  const accounts = filterState.filters.account;
+  const hasDimFilter = features.length > 0 || accounts.length > 0;
+
+  const [costs, labels, revenue, excluded, allocationSetting, featureTags] = await Promise.all([
+    queryAccountCosts({ windowDays, features, accounts }),
     queryAccountLabels(),
-    queryAccountRevenue(),
-    queryExcludedInfraCost(),
+    queryAccountRevenue(windowDays),
+    queryExcludedInfraCost({ windowDays, features, accounts }),
     queryAllocationRule(),
+    queryAccountFeatureTags(windowDays),
   ]);
+
+  // Filter options for the bar. Features come from the window's directly attributable spend; accounts
+  // are the rows we already have, shown by label where one exists so the dropdown is not a wall of
+  // hashes. A dimension with no options renders no control (see FilterBar), so a fresh tenant with no
+  // features or accounts simply sees the time range.
+  const labelMap = labels ?? new Map<string, string>();
+  const featureOptions: FilterOption[] = (featureTags ?? []).map((f) => ({ value: f }));
+  const accountOptions: FilterOption[] = (costs?.accounts ?? []).map((r) => ({
+    value: r.accountIdHash,
+    label: accountDisplayName(r.accountIdHash, labelMap.get(r.accountIdHash)),
+  }));
+
+  const toolbar = (
+    <FilterBar
+      hideGroupBy
+      options={{ feature: featureOptions, account: accountOptions }}
+    />
+  );
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold">Cost per customer</h1>
-        {costs ? (
-          <span className="text-sm text-muted">Last {costs.windowDays} days</span>
-        ) : null}
-      </div>
+      <PageHeader
+        title="Cost per customer"
+        subtitle={
+          costs
+            ? `Direct spend by account plus each account's allocated share of compute and egress, over the last ${costs.windowDays} days.`
+            : "Direct spend by account plus each account's allocated share of compute and egress."
+        }
+        toolbar={toolbar}
+      />
 
       <p className="max-w-prose text-sm text-muted">
         Directly attributable spend (LLM, tools, vector, embeddings) grouped by the account each span
@@ -94,6 +141,7 @@ export default async function CostPerCustomerPage() {
           revenue={revenue}
           excluded={excluded}
           allocationSetting={allocationSetting}
+          filtered={hasDimFilter}
         />
       )}
     </div>
@@ -106,6 +154,7 @@ function Report({
   revenue,
   excluded,
   allocationSetting,
+  filtered,
 }: {
   costs: AccountCosts;
   labels: Map<string, string> | null;
@@ -113,6 +162,12 @@ function Report({
   revenue: AccountRevenueReport | null;
   excluded: ExcludedInfraCost | null;
   allocationSetting: AllocationRuleSetting;
+  /**
+   * A feature or account filter is narrowing the slice (CTO-223). The whole-tenant reconciliation
+   * line below claims the rows sum to what `/cost` reports for the window, which is only true of the
+   * unfiltered view, so it is suppressed here rather than left to make a false claim about a slice.
+   */
+  filtered: boolean;
 }) {
   const share = unattributedShare(costs);
   const attributed = attributedSpend(costs);
@@ -127,38 +182,45 @@ function Report({
     (revenue?.accounts ?? []).map((a) => [a.accountIdHash, a.revenueMicroUsd]),
   );
 
+  const windowHint = `last ${costs.windowDays} days`;
+
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-4">
-        <Stat label="Direct spend (measured)">
-          <Money micro={costs.totalDirectMicroUsd} />
-        </Stat>
-        <Stat label="Allocated infra (estimated)">
-          {allocated === null ? (
-            <Blank reason="the compute and egress total could not be read, so nothing could be allocated" />
-          ) : (
-            <Money micro={allocated.allocatedTotalMicroUsd} />
-          )}
-        </Stat>
-        <Stat label="Total cost">
-          {allocated === null ? (
-            <Blank reason="total cost needs the compute and egress figure, which could not be read" />
-          ) : (
-            <Money micro={allocated.tenantTotalMicroUsd} />
-          )}
-        </Stat>
-        <Stat label="Direct spend with no account">
-          {/* The valve. `null` only when the tenant recorded no direct spend at all, where "0%
-              unattributed" would claim perfect coverage of nothing. */}
-          {share === null ? (
-            <Blank
-              reason={`no directly attributable spend recorded in the last ${costs.windowDays} days, so there is no share to report`}
-            />
-          ) : (
-            formatShare(share)
-          )}
-        </Stat>
-      </div>
+      <TileGrid>
+        <SummaryTile
+          label="Direct spend (measured)"
+          micro={costs.totalDirectMicroUsd}
+          hint={windowHint}
+        />
+        <SummaryTile
+          label="Allocated infra (estimated)"
+          micro={allocated === null ? null : allocated.allocatedTotalMicroUsd}
+          reason="the compute and egress total could not be read, so nothing could be allocated"
+          hint={windowHint}
+        />
+        <SummaryTile
+          label="Total cost"
+          micro={allocated === null ? null : allocated.tenantTotalMicroUsd}
+          reason="total cost needs the compute and egress figure, which could not be read"
+          hint={windowHint}
+        />
+        {/* The unattributed share is a percentage, not money, so it keeps its own honest-blank tile
+            rather than passing through Money. The valve returns `null` only when the tenant recorded
+            no direct spend at all, where "0% unattributed" would claim perfect coverage of nothing. */}
+        <ShareTile
+          share={share}
+          reason={`no directly attributable spend recorded in the ${windowHint}, so there is no share to report`}
+          hint={windowHint}
+        />
+      </TileGrid>
+
+      {filtered ? (
+        <p className="max-w-prose rounded-lg border border-accent/30 bg-accent/5 px-3 py-2 text-xs text-muted">
+          Filtered view: only the selected features and accounts are counted, so every total here is
+          a slice of the tenant&apos;s spend rather than the whole bill. The whole-tenant
+          reconciliation against the Cost tab is hidden until you clear the filter.
+        </p>
+      ) : null}
 
       <p className="max-w-prose text-xs text-muted">
         Attributed direct spend is <Money micro={attributed} /> of{" "}
@@ -210,8 +272,11 @@ function Report({
       )}
 
       {/* The reconciliation line sums the RENDERED rows, so it only prints where rows were
-          rendered. In the onboarding state there is no table to reconcile. */}
-      {allocated && view !== "onboarding" ? <Reconciliation allocated={allocated} /> : null}
+          rendered. In the onboarding state there is no table to reconcile, and under a dimension
+          filter it would claim a slice equals the whole-tenant bill, so it is suppressed there too. */}
+      {allocated && view !== "onboarding" && !filtered ? (
+        <Reconciliation allocated={allocated} />
+      ) : null}
     </div>
   );
 }
@@ -479,11 +544,29 @@ function Unreachable() {
   );
 }
 
-function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+/**
+ * The unattributed-share tile, matching the SummaryTile shape but rendering a percentage rather than
+ * money. `share === null` is the honesty valve (no direct spend at all), so it renders the same
+ * explained blank the money tiles do rather than a fabricated "0%".
+ */
+function ShareTile({
+  share,
+  reason,
+  hint,
+}: {
+  share: number | null;
+  reason: string;
+  hint: string;
+}) {
   return (
-    <div className="rounded-xl border border-edge bg-panel p-4">
-      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
-      <div className="mt-1 text-2xl font-semibold tabular-nums">{children}</div>
+    <div className="flex flex-col gap-1 rounded-xl border border-edge bg-panel p-4">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted">
+        Direct spend with no account
+      </span>
+      <span className="text-2xl font-semibold tabular-nums">
+        {share === null ? <Blank reason={reason} /> : formatShare(share)}
+      </span>
+      <span className="text-xs text-muted">{hint}</span>
     </div>
   );
 }

--- a/web/lib/accountRevenue.ts
+++ b/web/lib/accountRevenue.ts
@@ -46,6 +46,16 @@ export const REVENUE_WINDOW_SQL = "toDate(now()) - INTERVAL 29 DAY";
 /** Days covered by REVENUE_WINDOW_SQL, for labelling the figure in the UI. */
 export const REVENUE_WINDOW_DAYS = 30;
 
+/**
+ * The window SQL for an arbitrary day count, so the FilterBar's time range can drive revenue over
+ * the same span as cost (CTO-223). `days` is a clamped integer chosen server-side, never user text,
+ * so the interpolation is safe. Defaults to the 30-day constant, which reproduces REVENUE_WINDOW_SQL
+ * byte-for-byte so an unparameterised caller is unchanged.
+ */
+export function revenueWindowSql(days: number = REVENUE_WINDOW_DAYS): string {
+  return `toDate(now()) - INTERVAL ${Math.max(1, Math.trunc(days)) - 1} DAY`;
+}
+
 /** `AccountIdHash` value meaning "no account could be established honestly". */
 export const UNATTRIBUTED_ACCOUNT = "";
 
@@ -114,7 +124,10 @@ function int(v: string | number | null | undefined): number {
  * we have never heard of. Both end up blank in the UI, but only one of them is a connector the
  * tenant can go and configure, so the row is worth returning.
  */
-export function accountRevenueSql(policy: RevenuePolicy): {
+export function accountRevenueSql(
+  policy: RevenuePolicy,
+  windowDays: number = REVENUE_WINDOW_DAYS,
+): {
   sql: string;
   params: Record<string, unknown>;
 } {
@@ -133,7 +146,7 @@ export function accountRevenueSql(policy: RevenuePolicy): {
         uniqExactIf(b.UserIdHash, ${moneyTyped})                                           AS distinct_users
       FROM business_events b
       WHERE b.TenantId = {tenant:String}
-        AND b.OccurredAt >= ${REVENUE_WINDOW_SQL}
+        AND b.OccurredAt >= ${revenueWindowSql(windowDays)}
         ${sourceFilter.sql}
       GROUP BY account_id_hash`,
     params: {
@@ -162,7 +175,10 @@ export function accountRevenueFromRow(row: AccountRevenueSqlRow): AccountRevenue
 }
 
 /** Build the report from raw rows, splitting the unattributed bucket out and ranking the rest. */
-export function accountRevenueReport(rows: AccountRevenueSqlRow[]): AccountRevenueReport {
+export function accountRevenueReport(
+  rows: AccountRevenueSqlRow[],
+  windowDays: number = REVENUE_WINDOW_DAYS,
+): AccountRevenueReport {
   let unattributed: AccountRevenue | null = null;
   const accounts: AccountRevenue[] = [];
 
@@ -187,7 +203,7 @@ export function accountRevenueReport(rows: AccountRevenueSqlRow[]): AccountReven
     }
     return a.accountIdHash.localeCompare(b.accountIdHash);
   });
-  return { accounts, unattributed, windowDays: REVENUE_WINDOW_DAYS };
+  return { accounts, unattributed, windowDays };
 }
 
 /**

--- a/web/lib/attribution.ts
+++ b/web/lib/attribution.ts
@@ -41,6 +41,14 @@ export interface ProviderAttribution {
   marginPct: number | null;
 }
 
+/** One calendar day of LLM cost split by provider, for the provider-breakdown chart (CTO-223). */
+export interface ProviderCostDay {
+  /** ISO yyyy-mm-dd, from ClickHouse's window bounds (never the Node clock, per CTO-203). */
+  date: string;
+  /** Micro-USD per provider for this day. A missing provider is a real zero. */
+  byProvider: Record<string, MicroUSD>;
+}
+
 export interface AttributionReport {
   filters: AttributionFilters;
   perProvider: ProviderAttribution[];
@@ -50,6 +58,12 @@ export interface AttributionReport {
     costMicroUsd: MicroUSD;
     costPerConversionMicroUsd: MicroUSD | null;
   };
+  /**
+   * Daily LLM cost per provider across the window, oldest to newest, for the stacked provider chart.
+   * Optional so the mock/empty reports and any older consumer stay valid; the page renders no chart
+   * when it is absent rather than fabricating a series.
+   */
+  dailyByProvider?: ProviderCostDay[];
   // True when ClickHouse couldn't be reached — the page falls back to mock.
   isMock: boolean;
 }
@@ -160,7 +174,25 @@ export function mockReport(filters: AttributionFilters): AttributionReport {
     costPerConversionMicroUsd:
       conversions > 0 ? Math.round(costMicroUsd / conversions) : null,
   };
-  return { filters, perProvider, totals, isMock: true };
+  // A 30-day synthetic per-provider series so the preview chart renders something shaped like real
+  // traffic. Only ever shown behind the SAMPLE DATA banner (isMock), and a mild deterministic wave
+  // per provider keeps the bars from looking like a flat fabrication.
+  const days = 30;
+  const dailyByProvider: ProviderCostDay[] = [];
+  const anchor = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(anchor);
+    d.setUTCDate(anchor.getUTCDate() - i);
+    const date = d.toISOString().slice(0, 10);
+    const byProvider: Record<string, MicroUSD> = {};
+    for (const p of perProvider) {
+      const base = p.costMicroUsd / days;
+      const wave = 1 + 0.25 * Math.sin((i / days) * Math.PI * 2);
+      byProvider[p.provider] = Math.round(base * wave);
+    }
+    dailyByProvider.push({ date, byProvider });
+  }
+  return { filters, perProvider, totals, dailyByProvider, isMock: true };
 }
 
 /** Parse URL search params into typed filters. */

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -889,6 +889,81 @@ function isoDaysFrom(startIso: string, count: number): string[] {
 }
 
 /**
+ * The window + dimension slice the /cost-per-customer reads run under (CTO-223, D3).
+ *
+ * The page used to be fixed at {@link ACCOUNT_WINDOW_DAYS}; the design foundation's FilterBar now
+ * drives a user-selectable window and optional feature / account filters. Everything is optional so
+ * an unfiltered caller (and the reconciliation-bound default view) behaves exactly as before.
+ */
+export interface AccountCostQuery {
+  /** Calendar days, inclusive of today. Clamped to the shared explore ceiling. Default 30. */
+  windowDays?: number;
+  /** Restrict the direct-cost scan to these feature tags. Empty / absent = every feature. */
+  features?: string[];
+  /** Restrict to these account id hashes. Empty / absent = every account. */
+  accounts?: string[];
+}
+
+/** Clamp a requested account window to a real number of days, defaulting to the 30-day standard. */
+function accountWindowDays(days?: number): number {
+  return clampWindowDays(days ?? ACCOUNT_WINDOW_DAYS);
+}
+
+/** The `daily_account_rollup` day predicate for a window of `days`, calendar-aligned like the fixed
+ *  constant it generalises. `days` is a clamped integer, so the interpolation carries no user text. */
+function accountDayWindow(days: number): string {
+  return `Day >= toDate(now()) - INTERVAL ${days - 1} DAY`;
+}
+
+/**
+ * The feature / account multi-select clauses for the account rollup reads. Each becomes an
+ * `AND <expr> IN {key:Array(String)}` with the values bound as parameters, never interpolated,
+ * exactly like {@link exploreFilterClauses}. Applied identically to the direct and the excluded
+ * reads so a filtered slice stays internally consistent: whatever share of compute and egress the
+ * selected features/accounts carry is narrowed the same way the direct cost is, rather than pairing
+ * a filtered direct total with the tenant's whole infrastructure bill. The page still hides the
+ * whole-tenant reconciliation line under a filter, because a slice is not the tenant total.
+ */
+function accountRollupFilters(query: AccountCostQuery | undefined): {
+  clause: string;
+  params: Record<string, string[]>;
+} {
+  const clauses: string[] = [];
+  const params: Record<string, string[]> = {};
+  if (query?.features && query.features.length > 0) {
+    clauses.push("AND FeatureTag IN {f_features:Array(String)}");
+    params.f_features = query.features;
+  }
+  if (query?.accounts && query.accounts.length > 0) {
+    clauses.push(`AND ${ACCOUNT_ID} IN {f_accounts:Array(String)}`);
+    params.f_accounts = query.accounts;
+  }
+  return { clause: clauses.join(" "), params };
+}
+
+/**
+ * Distinct feature tags seen on directly attributable spend in the window, for the FilterBar's
+ * feature dropdown (CTO-223). Untagged traffic (`FeatureTag = ''`) is not a feature and is left out,
+ * matching how the account-detail top-features list treats it. Returns `null` when unreachable so
+ * the page renders no feature filter rather than a fabricated option list.
+ */
+export async function queryAccountFeatureTags(days?: number): Promise<string[] | null> {
+  return tryLive(async (db, tenant) => {
+    const windowDays = accountWindowDays(days);
+    const out = await rows<{ feature: string }>(
+      db,
+      `SELECT DISTINCT FeatureTag AS feature
+       FROM daily_account_rollup
+       WHERE TenantId = {tenant:String} AND ${accountDayWindow(windowDays)}
+         AND ${DIRECT_ONLY} AND FeatureTag != ''
+       ORDER BY feature`,
+      tenant,
+    );
+    return out.map((r) => r.feature);
+  });
+}
+
+/**
  * Direct cost per account over the window: layer split, distinct users, span count.
  *
  * Real accounts come back ranked by cost; the unattributed bucket is returned separately and is
@@ -896,30 +971,33 @@ function isoDaysFrom(startIso: string, count: number): string[] {
  * no account and it must be statable unconditionally. Returns `null` (via tryLive) when ClickHouse
  * is unreachable so the route can fall back.
  */
-export async function queryAccountCosts(): Promise<AccountCosts | null> {
+export async function queryAccountCosts(query?: AccountCostQuery): Promise<AccountCosts | null> {
   return tryLive(async (db, tenant) => {
+    const windowDays = accountWindowDays(query?.windowDays);
+    const windowClause = accountDayWindow(windowDays);
+    const { clause: filterClause, params: filterParams } = accountRollupFilters(query);
     // Two reads rather than one, and that is forced. Distinct users comes from a `uniq`
     // AggregateFunction state, and merged states cannot be added together: a user who touched both
     // the llm and the tools layer would be counted once per layer if we summed a per-layer
     // uniqMerge. So users and spans are merged at account grain here, and the layer split is a
     // second pass that only ever sums money.
-    const totals = await rows<{ account: string; spans: string; users: string }>(
+    const totals = await rowsP<{ account: string; spans: string; users: string }>(
       db,
       `SELECT ${ACCOUNT_ID} AS account,
               sum(SpanCount) AS spans,
               uniqMerge(UserCountState) AS users
        FROM daily_account_rollup
-       WHERE TenantId = {tenant:String} AND ${ACCOUNT_WINDOW} AND ${DIRECT_ONLY}
+       WHERE TenantId = {tenant:String} AND ${windowClause} AND ${DIRECT_ONLY} ${filterClause}
        GROUP BY account`,
-      tenant,
+      { tenant, ...filterParams },
     );
-    const byLayerRows = await rows<{ account: string; layer: DirectLayer; cost: string }>(
+    const byLayerRows = await rowsP<{ account: string; layer: DirectLayer; cost: string }>(
       db,
       `SELECT ${ACCOUNT_ID} AS account, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM daily_account_rollup
-       WHERE TenantId = {tenant:String} AND ${ACCOUNT_WINDOW} AND ${DIRECT_ONLY}
+       WHERE TenantId = {tenant:String} AND ${windowClause} AND ${DIRECT_ONLY} ${filterClause}
        GROUP BY account, layer`,
-      tenant,
+      { tenant, ...filterParams },
     );
 
     const layers = new Map<string, DirectSpendByLayer>();
@@ -952,7 +1030,7 @@ export async function queryAccountCosts(): Promise<AccountCosts | null> {
     accounts.sort((a, b) => b.directCostMicroUsd - a.directCostMicroUsd);
 
     return {
-      windowDays: ACCOUNT_WINDOW_DAYS,
+      windowDays,
       accounts,
       unattributed,
       // Deliberately the sum of the rows as returned, not a separately rounded tenant-level sum, so
@@ -977,19 +1055,24 @@ export async function queryAccountCosts(): Promise<AccountCosts | null> {
  * Returns `null` (via tryLive) when ClickHouse is unreachable; the caller must not read that as
  * zero excluded cost, which would be the most flattering possible reading of a failed query.
  */
-export async function queryExcludedInfraCost(): Promise<ExcludedInfraCost | null> {
+export async function queryExcludedInfraCost(query?: AccountCostQuery): Promise<ExcludedInfraCost | null> {
   return tryLive(async (db, tenant) => {
+    const windowDays = accountWindowDays(query?.windowDays);
+    // Same feature / account filter as the direct read (accountRollupFilters), so the excluded pot is
+    // narrowed to the same slice: the compute and egress that the selected features/accounts carry,
+    // rather than the tenant's whole infrastructure bill paired with a filtered direct cost.
+    const { clause: filterClause, params: filterParams } = accountRollupFilters(query);
     // Grouped by layer rather than summed flat so the two figures stay separable: compute and
     // egress have very different fixes, and a later drill-down needs them apart. LAYER_CASE is
     // reused rather than reading GenAiOperation directly so the operation-to-layer mapping keeps
     // living in exactly one place.
-    const out = await rows<{ layer: string; cost: string }>(
+    const out = await rowsP<{ layer: string; cost: string }>(
       db,
       `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM daily_account_rollup
-       WHERE TenantId = {tenant:String} AND ${ACCOUNT_WINDOW} AND NOT (${DIRECT_ONLY})
+       WHERE TenantId = {tenant:String} AND ${accountDayWindow(windowDays)} AND NOT (${DIRECT_ONLY}) ${filterClause}
        GROUP BY layer`,
-      tenant,
+      { tenant, ...filterParams },
     );
     let computeMicroUsd = 0;
     let egressMicroUsd = 0;
@@ -998,7 +1081,7 @@ export async function queryExcludedInfraCost(): Promise<ExcludedInfraCost | null
       else if (r.layer === "egress") egressMicroUsd = micro(r.cost);
     }
     return {
-      windowDays: ACCOUNT_WINDOW_DAYS,
+      windowDays,
       computeMicroUsd,
       egressMicroUsd,
       totalMicroUsd: computeMicroUsd + egressMicroUsd,
@@ -2286,8 +2369,46 @@ export async function queryConnectorActivity(): Promise<ConnectorActivity | null
  * Returns null on any ClickHouse error so the API can fall back to the mock
  * report (CI / fresh-clone friendliness).
  */
+/**
+ * The window + feature slice the attribution reads run under (CTO-223, D3).
+ *
+ * The report used to be fixed at a rolling 30-day window with no feature multi-select; the design
+ * foundation's FilterBar now drives both. Both fields are optional so an unparameterised caller
+ * behaves exactly as before. Provider narrowing still comes through {@link AttributionFilters}, whose
+ * single-provider shape the FilterBar honours when exactly one provider is selected.
+ */
+export interface AttributionQuery {
+  /** Rolling days back from now. Clamped to the shared explore ceiling. Default 30. */
+  windowDays?: number;
+  /** Restrict to these feature tags (FilterBar multi-select). Empty / absent = every feature. */
+  features?: string[];
+}
+
+/**
+ * Distinct feature tags seen on spans in the window, for the attribution FilterBar's feature
+ * dropdown (CTO-223). Reads otel_spans (the same table the report joins on) so the options match the
+ * data. Returns `null` when unreachable so the page shows no feature filter rather than a made-up
+ * list. Untagged spans (`FeatureTag = ''`) are not a feature and are excluded.
+ */
+export async function querySpanFeatureTags(days?: number): Promise<string[] | null> {
+  return tryLive(async (db, tenant) => {
+    const windowDays = clampWindowDays(days ?? 30);
+    const out = await rows<{ feature: string }>(
+      db,
+      `SELECT DISTINCT FeatureTag AS feature
+       FROM otel_spans
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${windowDays} DAY
+         AND FeatureTag != ''
+       ORDER BY feature`,
+      tenant,
+    );
+    return out.map((r) => r.feature);
+  });
+}
+
 export async function queryAttribution(
   filters: AttributionFilters,
+  query?: AttributionQuery,
 ): Promise<AttributionReport | null> {
   return tryLive(async (db, tenant) => {
     // CTO-194: which sources/value types count as revenue for this tenant. Resolved from the
@@ -2296,6 +2417,15 @@ export async function queryAttribution(
     // outage degrades to the default policy rather than blanking the whole attribution report.
     const policy = await queryRevenuePolicy();
     const outcomeName = filters.outcome ?? "conversion";
+    // Rolling window, keeping the original semantics (a plain `now() - INTERVAL N DAY`); N is a
+    // clamped integer, never user text, so the interpolation is safe (CTO-223).
+    const windowDays = clampWindowDays(query?.windowDays ?? 30);
+    const windowSql = `now() - INTERVAL ${windowDays} DAY`;
+    // Feature multi-select from the FilterBar, applied on the span side (`s`) the same way the
+    // legacy single `tag` is. Both AND together, which is empty in the normal case where only one is
+    // set; a caller that sets both is deliberately narrowing to their intersection.
+    const featureValues = query?.features ?? [];
+    const featureSql = featureValues.length > 0 ? `AND s.FeatureTag IN {features:Array(String)}` : "";
     const tagSql = filters.tag ? `AND s.FeatureTag = {tag:String}` : "";
     // CTO-106: prefer the typed GenAiSystem column (the real shape post-CTO-106),
     // fall back to the legacy SpanAttributes['chatbot.real_provider'] for
@@ -2317,12 +2447,13 @@ export async function queryAttribution(
          sum(s.EstimatedCost) AS cost
        FROM otel_spans s
        WHERE s.TenantId = {tenant:String}
-         AND s.Timestamp >= now() - INTERVAL 30 DAY
+         AND s.Timestamp >= ${windowSql}
          AND s.GenAiOperation NOT IN ('compute', 'egress')
          ${tagSql}
+         ${featureSql}
          ${providerSql}
        GROUP BY provider`,
-      { tenant, tag: filters.tag ?? "", provider: filters.provider ?? "" },
+      { tenant, tag: filters.tag ?? "", provider: filters.provider ?? "", features: featureValues },
     );
 
     // Conversions per provider: a business_event whose UserIdHash matches a
@@ -2336,9 +2467,10 @@ export async function queryAttribution(
        INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
          AND b.EventName = {outcome:String}
-         AND b.OccurredAt >= now() - INTERVAL 30 DAY
+         AND b.OccurredAt >= ${windowSql}
          AND s.GenAiOperation NOT IN ('compute', 'egress')
          ${tagSql}
+         ${featureSql}
          ${providerSql}
        GROUP BY provider`,
       {
@@ -2346,6 +2478,7 @@ export async function queryAttribution(
         outcome: outcomeName,
         tag: filters.tag ?? "",
         provider: filters.provider ?? "",
+        features: featureValues,
       },
     );
 
@@ -2390,16 +2523,18 @@ export async function queryAttribution(
        FROM business_events b
        INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
-         AND b.OccurredAt >= now() - INTERVAL 30 DAY
+         AND b.OccurredAt >= ${windowSql}
          AND b.UserIdHash != ''
          ${sourceFilter.sql}
          ${tagSql}
+         ${featureSql}
          ${providerSql}
        GROUP BY provider`,
       {
         tenant,
         tag: filters.tag ?? "",
         provider: filters.provider ?? "",
+        features: featureValues,
         positiveTypes,
         refundType: REFUND_VALUE_TYPE,
         ...sourceFilter.params,
@@ -2426,6 +2561,37 @@ export async function queryAttribution(
     });
     perProvider.sort((a, b) => b.sessions - a.sessions);
 
+    // Daily LLM cost per provider for the stacked breakdown chart (CTO-223). The day list is built
+    // from ClickHouse's own clock via a bounds SELECT, never the Node clock, so the axis cannot drift
+    // a day against the SQL window (the CTO-203 seam). Days with no spend are zero-filled so the
+    // chart's window is honest about quiet days rather than collapsing them.
+    const dailyRows = await rowsP<{ day: string; provider: string; cost: string }>(
+      db,
+      `SELECT toString(toDate(s.Timestamp)) AS day, ${providerExpr} AS provider, sum(s.EstimatedCost) AS cost
+       FROM otel_spans s
+       WHERE s.TenantId = {tenant:String}
+         AND s.Timestamp >= ${windowSql}
+         AND s.GenAiOperation NOT IN ('compute', 'egress')
+         ${tagSql}
+         ${featureSql}
+         ${providerSql}
+       GROUP BY day, provider`,
+      { tenant, tag: filters.tag ?? "", provider: filters.provider ?? "", features: featureValues },
+    );
+    const bounds = await rowsP<{ start: string }>(
+      db,
+      `WITH toDate(now()) AS td SELECT toString(td - {back:UInt32}) AS start`,
+      { back: Math.max(0, windowDays - 1) },
+    );
+    const startIso = bounds[0]?.start;
+    const dayList = startIso ? isoDaysFrom(startIso, windowDays) : [];
+    const byDay = new Map<string, Record<string, number>>(dayList.map((d) => [d, {}]));
+    for (const r of dailyRows) {
+      const bucket = byDay.get(r.day);
+      if (bucket) bucket[r.provider] = (bucket[r.provider] ?? 0) + micro(r.cost);
+    }
+    const dailyByProvider = dayList.map((date) => ({ date, byProvider: byDay.get(date)! }));
+
     const totals = {
       sessions: perProvider.reduce((s, p) => s + p.sessions, 0),
       conversions: perProvider.reduce((s, p) => s + p.conversions, 0),
@@ -2436,7 +2602,7 @@ export async function queryAttribution(
       totals.conversions > 0 ? Math.round(totals.costMicroUsd / totals.conversions) : null;
 
     if (perProvider.length === 0) return emptyReport(filters);
-    return { filters, perProvider, totals, isMock: false };
+    return { filters, perProvider, totals, dailyByProvider, isMock: false };
   });
 }
 
@@ -2458,12 +2624,15 @@ export async function queryAttribution(
  *
  * Returns null on any ClickHouse error, so a caller falls back rather than rendering a zero.
  */
-export async function queryAccountRevenue(): Promise<AccountRevenueReport | null> {
+export async function queryAccountRevenue(days?: number): Promise<AccountRevenueReport | null> {
   return tryLive(async (db, tenant) => {
+    const windowDays = accountWindowDays(days);
     const policy = await queryRevenuePolicy();
-    const { sql, params } = accountRevenueSql(policy);
+    // Same window as the cost read, so every margin subtracts two figures measured over the same
+    // days rather than netting 7-day cost against 30-day revenue (CTO-223).
+    const { sql, params } = accountRevenueSql(policy, windowDays);
     const rows = await rowsP<AccountRevenueSqlRow>(db, sql, { tenant, ...params });
-    return accountRevenueReport(rows);
+    return accountRevenueReport(rows, windowDays);
   });
 }
 


### PR DESCRIPTION
## What & why

D3 of the dashboard overhaul (CTO-220): rebuild the **Cost per customer** and **Attribution** pages on the CTO-221 interactive design foundation (`FilterBar`, `PageHeader`, `SummaryTile`, `InteractiveStackedChart`). This is a **design + interactivity pass** — every feature, column, number, and honest-blank rule is preserved, and the default (unfiltered, 30-day) view is unchanged.

## Cost per customer
- **FilterBar mounted via PageHeader.** The time range now drives `windowDays` for `queryAccountCosts` / `queryExcludedInfraCost` / `queryAccountRevenue`, so every "last N days" string reflects the chosen window and the numbers change with it (verified: 30d → 7d halves the totals and re-labels every tile).
- **Feature + account multi-selects** narrow the slice. The same filter is applied to the direct and excluded reads so the slice stays internally consistent; under any dimension filter the whole-tenant reconciliation line is hidden with an honest "this is a slice, not the tenant total" note.
- Headline metrics are `SummaryTile`s; the unattributed-share keeps its own honest-blank tile (it is a percentage, not money).
- **Kept exactly:** the account search box (hash-paste detection + candidate-hash matching + no-spend/failure messages), Direct / Allocated / Total columns with the allocation rule named, the "Direct cost per user" relabel, the gross-margin ranking with unknown-revenue sorting last in both directions, every margin-caveat ▲ mark, the untagged-traffic row, and the reconciliation line. `AccountTable` and its test suite are untouched.
- Account detail view headline metrics moved onto the `SummaryTile` kit.

## Attribution
- **FilterBar mounted via PageHeader** (time range + provider + feature). The range drives a rolling window and the feature multi-select narrows the report. `tag`/`provider`/`outcome` and `?tag=`/`?scope=` still work — the endpoint preserves every incoming param so `useLivePoll` stays in lockstep.
- Headline metrics are `SummaryTile`s; the provider breakdown is now an **`InteractiveStackedChart`** of daily LLM cost per provider (a new optional `dailyByProvider` series, day list derived from ClickHouse's own clock per the CTO-203 seam).

## Notes
- Queries are parameterized with **backward-compatible defaults**, so unfiltered callers and existing tests are unchanged.
- The app ships **dark-only** (`body` is `bg-ink`; only the `--chart-*` chrome tokens carry a light palette). Both pages use the shared token-based kit, so they track a light palette if one is ever applied. Screenshots are the app's live theme.

## Verification
- `npm run typecheck` ✅ · `npm run lint` ✅ (only the pre-existing `useLivePoll.ts` unused-directive warning, untouched file)
- `npm run test` ✅ 616 passed; the only failure is the documented `api.test.ts` "falls back to mock when ClickHouse is unreachable" case, which fails on `main` too whenever a local ClickHouse is running.
- `npm run build` ✅ (clean `.next`)
- `AccountTable.test.tsx` ✅ 16/16.

### Screenshots (captured on the worktree dev server)
- **Cost per customer (30d):** Direct/Allocated/Total tiles, allocation notice, table, reconciliation all intact.
- **Cost per customer (7d):** time range wired — totals and every "last N days" label update.
- **Cost per customer (filtered):** feature filter narrows the slice; reconciliation hidden with an honest note.
- **Attribution:** SummaryTiles + interactive stacked provider-cost chart + per-provider table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
