### PR TITLE
Fix sidebar logo: keep ai-tally wordmark together

### DIFF
--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -72,7 +72,12 @@ export function Shell({ children }: { children: ReactNode }) {
             aria-hidden
             className="inline-block h-2.5 w-2.5 rounded-sm bg-accent"
           />
-          ai-<span className="text-accent">tally</span>
+          {/* The wordmark is one flex child so the row `gap-2` only separates it from the mark, not
+              the two halves of "ai-tally"; without this wrapper the gap split it into "ai- tally"
+              with a dangling hyphen (CTO-227). */}
+          <span>
+            ai-<span className="text-accent">tally</span>
+          </span>
         </div>
 
         <nav className="app-scroll flex-1 space-y-6 overflow-y-auto px-3 pb-6" aria-label="Primary">


### PR DESCRIPTION
## Problem
The sidebar logo rendered as "ai- tally" with a gap and a dangling hyphen.

## Cause
The brand row is `flex ... gap-2`. The mark, the `ai-` text node, and the accented `tally` span were three separate flex children, so the row gap fell between `ai-` and `tally` too.

## Fix
Wrap the wordmark in a single `<span>` so `gap-2` only separates it from the square mark. One-line markup change, no style tokens touched. Verified in the browser: reads "ai-tally" as one wordmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)