### PR TITLE
fix(web): time-range window drives Home/Agents/Cost tiles (CTO-226)

### DIFF
--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -7,12 +7,13 @@
 // changing what they read, the outlier / ROI / per-provider cards are untouched, and the data-state
 // banners, LiveIndicator and StaleBadge all stay exactly where they were.
 //
-// FilterBar sits under the title via PageHeader. Home has no time-parameterised endpoint (its
-// summary is the fixed 30-day roll-up), so the dimension multi-selects filter the rows the page
-// already holds rather than re-querying: selecting a feature narrows the ROI snapshot, selecting a
-// provider narrows the per-provider conversion table. That is an honest hide of rows, never a
-// fabricated slice. Group-by is hidden here because Home has no grouped chart to re-key (see the
-// interactive chart on /cost for the grouped case).
+// FilterBar sits under the title via PageHeader. The time range now re-parameterises the endpoint
+// (CTO-226): the managed query string rides on /api/home, so 7d/30d/90d re-query SPEND, the cost
+// outliers and the ROI snapshot over the chosen window rather than only restyling a fixed roll-up.
+// The dimension multi-selects still filter the rows the page already holds rather than re-querying:
+// selecting a feature narrows the ROI snapshot, selecting a provider narrows the per-provider
+// conversion table. That is an honest hide of rows, never a fabricated slice. Group-by is hidden
+// here because Home has no grouped chart to re-key (see the interactive chart on /cost).
 
 "use client";
 
@@ -29,6 +30,7 @@ import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import type { ProviderAttribution } from "@/lib/attribution";
 import { LAYERS, type Layer } from "@/lib/cost";
 import { allZero, asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
+import { rangeDays } from "@/lib/filters";
 import type { CostOutlier, FeatureRoi, SpendSummary } from "@/lib/types";
 import { formatUSD } from "@/lib/types";
 import { useFilters } from "@/lib/useFilters";
@@ -42,19 +44,21 @@ export interface HomePayload {
 }
 
 export function HomeLive({
-  endpoint,
   initialData,
   enabledLayers,
 }: {
-  endpoint: string;
   initialData: HomePayload;
   enabledLayers: readonly Layer[];
 }) {
+  // Same URL-synced filter state the FilterBar writes. Home reads it BOTH to narrow the tables it
+  // holds and, since CTO-226, to drive the time-range window: the endpoint carries the managed query
+  // string, so flipping 7d/30d/90d changes the endpoint and useLivePoll re-fetches the new window.
+  const { state: filterState, queryString } = useFilters();
+  const windowDays = rangeDays(filterState.range);
+  const endpoint = queryString ? `/api/home?${queryString}` : "/api/home";
   const { data, updatedAt } = useLivePoll<HomePayload>(endpoint, initialData);
   const { spend: s, outliers, roi, perProviderConversion } = data;
 
-  // Same URL-synced filter state the FilterBar writes. Home reads it to narrow the tables it holds.
-  const { state: filterState } = useFilters();
   const featureFilter = filterState.filters.feature;
   const providerFilter = filterState.filters.provider;
 
@@ -93,7 +97,12 @@ export function HomeLive({
 
   const tiles = (
     <TileGrid>
-      <SummaryTile label="Spend" micro={s.totalMicroUsd} hint="last 30 days" higherIsBetter={false} />
+      <SummaryTile
+        label="Spend"
+        micro={s.totalMicroUsd}
+        hint={`last ${windowDays} days`}
+        higherIsBetter={false}
+      />
       <SummaryTile label="Estimated" micro={s.estimatedMicroUsd} hint="not yet reconciled" />
       <SummaryTile
         label="Reconciled"
@@ -110,7 +119,7 @@ export function HomeLive({
 
   const grid = (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-      <Card title="Top cost outliers (30d)">
+      <Card title={`Top cost outliers (${windowDays}d)`}>
         <ul className="space-y-2 text-sm">
           {outliers.map((o) => (
             <li key={o.runId} className="flex items-center justify-between gap-3">

--- a/web/app/agents/Live.tsx
+++ b/web/app/agents/Live.tsx
@@ -41,6 +41,7 @@ import {
   relativeAge,
 } from "@/lib/dataState";
 import { formatUSD, type MicroUSD } from "@/lib/types";
+import { useFilters } from "@/lib/useFilters";
 import { useLivePoll } from "@/lib/useLivePoll";
 
 export interface AgentsPayload {
@@ -64,12 +65,16 @@ function maxBy<T>(rows: T[], pick: (r: T) => MicroUSD): { value: MicroUSD; row: 
 }
 
 export function AgentsLive({
-  endpoint,
   initialData,
 }: {
-  endpoint: string;
   initialData: AgentsPayload;
 }) {
+  // The time-range selector re-parameterises the endpoint (CTO-226): the managed query string rides
+  // on /api/agents (preserving any ?tag=/?run= deep link), so flipping 7d/30d/90d re-queries the
+  // windowed cost/day average and useLivePoll re-fetches. See queryAgents for why cost/day is a
+  // windowed daily average rather than a trailing-24h Node-clock sum.
+  const { queryString } = useFilters();
+  const endpoint = queryString ? `/api/agents?${queryString}` : "/api/agents";
   const { data, updatedAt } = useLivePoll<AgentsPayload>(endpoint, initialData);
   const { agents, runs, reconcilerLastRunMinutesAgo } = data;
 

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import { apiGet } from "@/lib/api";
+import { filtersToQueryString, parseFilters } from "@/lib/filters";
+import { searchParamsFromRecord } from "@/lib/searchParams";
 import { AgentsLive, type AgentsPayload } from "./Live";
 
 export default async function AgentsPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ tag?: string; run?: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  // Forward ?tag= / ?run= to the API so the table is pre-filtered (CTO-104 deep links).
-  const sp = (await searchParams) ?? {};
-  const qs = new URLSearchParams();
-  if (sp.tag) qs.set("tag", sp.tag);
-  if (sp.run) qs.set("run", sp.run);
-  const query = qs.toString() ? `?${qs.toString()}` : "";
-  const endpoint = `/api/agents${query}`;
+  // Forward ?tag= / ?run= (CTO-104 deep links) AND the URL-synced time range (CTO-226): the managed
+  // filter serializer preserves the unmanaged tag/run keys while adding the range, so SSR's first
+  // paint matches the URL and the client re-derives the same endpoint from useFilters as it changes.
+  const sp = searchParamsFromRecord(await searchParams);
+  const qs = filtersToQueryString(parseFilters(sp), sp);
+  const endpoint = qs ? `/api/agents?${qs}` : "/api/agents";
   const initialData = await apiGet<AgentsPayload>(endpoint);
-  return <AgentsLive endpoint={endpoint} initialData={initialData} />;
+  return <AgentsLive initialData={initialData} />;
 }

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 
 import { agents, runs } from "@/lib/agents";
 import { queryAgents, queryReconcilerLastRun } from "@/lib/clickhouse";
+import { parseFilters, rangeDays } from "@/lib/filters";
 
 // Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
 export const dynamic = "force-dynamic";
@@ -17,11 +18,14 @@ export async function GET(req: Request) {
   const tag = searchParams.get("tag") ?? "";
   const run = searchParams.get("run") ?? "";
   const hasFilter = Boolean(tag || run);
+  // The time-range selector drives the windowed cost/day average (CTO-226): resolve the URL-synced
+  // filter state to a day count the ClickHouse-derived window clamps and interpolates.
+  const windowDays = rangeDays(parseFilters(searchParams).range);
   // Read agents telemetry and the reconciler's real last-run in parallel. The freshness signal is
   // the real reconciliation_runs value (CTO-169) — or null when the reconciler has never run / the
   // gateway is unavailable, which the page renders as `—` rather than a fabricated constant.
   const [live, reconcilerLastRunMinutesAgo] = await Promise.all([
-    queryAgents({ tag, run }),
+    queryAgents({ tag, run }, windowDays),
     queryReconcilerLastRun(),
   ]);
   return NextResponse.json({

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -26,7 +26,11 @@ async function json<T = unknown>(res: Response): Promise<T> {
 
 describe("api routes", () => {
   it("GET /api/home returns the four cards", async () => {
-    const body = await json<{ spend: unknown; outliers: unknown[]; roi: unknown[]; dq: unknown }>(await HomeGET());
+    const body = await json<{ spend: unknown; outliers: unknown[]; roi: unknown[]; dq: unknown }>(
+      // CTO-226: /api/home now reads the time-range window from the request URL; the default (no
+      // range param) preserves the historical 30-day view this smoke test asserts.
+      await HomeGET(new Request("http://test/api/home")),
+    );
     expect(body.spend).toBeDefined();
     expect(Array.isArray(body.outliers)).toBe(true);
     expect(Array.isArray(body.roi)).toBe(true);

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -7,6 +7,7 @@ import {
   queryFeatureCostRows,
   queryHiddenCostAlerts,
 } from "@/lib/clickhouse";
+import { parseFilters, rangeDays } from "@/lib/filters";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -16,11 +17,16 @@ export async function GET(req: Request) {
   // a single feature tag. When the filter is set we never fall back to unfiltered mock — that would
   // misrepresent the filtered view as real data.
   // Use the standard URL API rather than NextRequest.nextUrl so unit tests can pass plain Request.
-  const tag = new URL(req.url).searchParams.get("tag") ?? "";
+  const searchParams = new URL(req.url).searchParams;
+  const tag = searchParams.get("tag") ?? "";
   const hasFilter = Boolean(tag);
+  // The time-range selector reshapes the headline tiles and the By-feature table (CTO-226): resolve
+  // the URL-synced filter state to a day count the ClickHouse-derived window clamps and interpolates.
+  // The interactive chart itself is served by /api/explore, so the chart contract is untouched.
+  const windowDays = rangeDays(parseFilters(searchParams).range);
   const [series, rows, alerts] = await Promise.all([
-    queryCostSeries({ tag }),
-    queryFeatureCostRows({ tag }),
+    queryCostSeries({ tag }, windowDays),
+    queryFeatureCostRows({ tag }, windowDays),
     queryHiddenCostAlerts({ tag }),
   ]);
   return NextResponse.json({

--- a/web/app/api/home/route.ts
+++ b/web/app/api/home/route.ts
@@ -9,21 +9,27 @@ import {
   queryRoi,
   querySpendSummary,
 } from "@/lib/clickhouse";
+import { parseFilters, rangeDays } from "@/lib/filters";
 
 // Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(request: Request) {
+  // The Home time-range selector drives every headline (CTO-226): parse the URL-synced filter state
+  // and resolve it to a day count the ClickHouse-derived window queries clamp and interpolate.
+  const sp = new URL(request.url).searchParams;
+  const state = parseFilters(sp);
+  const windowDays = rangeDays(state.range);
   // Match the Attribution page's default view so the Home compact table reads
   // the same numbers a user would see on /attribution with no filters set.
   const attributionFilters = { tag: null, provider: null, outcome: "conversion" as const };
   const [spend, outliers, roi, dq, attribution] = await Promise.all([
-    querySpendSummary(),
-    queryOutliers(),
-    queryRoi(),
+    querySpendSummary(windowDays),
+    queryOutliers(windowDays),
+    queryRoi(windowDays),
     queryDataQuality(),
-    queryAttribution(attributionFilters),
+    queryAttribution(attributionFilters, { windowDays }),
   ]);
   return NextResponse.json({
     spend: spend ?? mockSpend,

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -58,6 +58,7 @@ import {
   DEFAULT_RANGE_PRESET,
   DIMENSION_LABEL,
   hasActiveFilters,
+  rangeDays,
 } from "@/lib/filters";
 import { formatUSD, type SpendByLayer } from "@/lib/types";
 import { useFilters } from "@/lib/useFilters";
@@ -85,13 +86,11 @@ interface ExploreState {
 }
 
 export function CostLive({
-  endpoint,
   initialData,
   enabledLayers,
   budget,
   tag = null,
 }: {
-  endpoint: string;
   initialData: CostPayload;
   enabledLayers: readonly Layer[];
   // Not part of the polled payload (CTO-209/210): a budget changes about monthly and the settled
@@ -101,10 +100,15 @@ export function CostLive({
   /** The active ?tag= breakdown filter, carried so a scope change does not silently drop it. */
   tag?: string | null;
 }) {
+  const { state: filterState, toggleFilter, queryString } = useFilters();
+  // The time-range selector re-parameterises the headline tiles + By-feature table (CTO-226): the
+  // managed query string (preserving any ?tag=/?scope=) rides on /api/cost, so 7d/30d/90d re-query
+  // the window and useLivePoll re-fetches. The interactive chart is still served by /api/explore.
+  const endpoint = queryString ? `/api/cost?${queryString}` : "/api/cost";
+  const windowDays = rangeDays(filterState.range);
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
   const { series: costSeries, featureRows, alerts: hiddenCostAlerts } = data;
 
-  const { state: filterState, toggleFilter, queryString } = useFilters();
   const featureFilter = filterState.filters.feature;
 
   // The default slice is drawn from the shipped payload; anything else goes through /api/explore.
@@ -179,7 +183,7 @@ export function CostLive({
   const body = (
     <div className="space-y-6">
       <TileGrid>
-        <SummaryTile label="Total" micro={total} hint="last 30 days" />
+        <SummaryTile label="Total" micro={total} hint={`last ${windowDays} days`} />
         <SummaryTile
           label="Reconciled"
           micro={reconciled}

--- a/web/app/cost/page.tsx
+++ b/web/app/cost/page.tsx
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { apiGet } from "@/lib/api";
+import { filtersToQueryString, parseFilters } from "@/lib/filters";
+import { searchParamsFromRecord } from "@/lib/searchParams";
 import { queryEnabledConnectors } from "@/lib/tenant";
 import type { CostBudgetPayload } from "./BurndownCard";
 import { CostLive, type CostPayload } from "./Live";
@@ -7,12 +9,17 @@ import { CostLive, type CostPayload } from "./Live";
 export default async function CostPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ tag?: string; scope?: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  // Forward ?tag= to the API so the breakdown is pre-filtered to one feature (CTO-104).
-  const sp = (await searchParams) ?? {};
-  const query = sp.tag ? `?tag=${encodeURIComponent(sp.tag)}` : "";
-  const endpoint = `/api/cost${query}`;
+  // Forward ?tag= (CTO-104) AND the URL-synced time range (CTO-226) to the API. The managed filter
+  // serializer preserves the unmanaged tag/scope keys while adding the range, so the headline tiles
+  // and the By-feature table honour the window; the interactive chart is served by /api/explore.
+  const spRecord = (await searchParams) ?? {};
+  const sp = searchParamsFromRecord(spRecord);
+  const qs = filtersToQueryString(parseFilters(sp), sp);
+  const endpoint = qs ? `/api/cost?${qs}` : "/api/cost";
+  const tagValue = typeof spRecord.tag === "string" ? spRecord.tag : undefined;
+  const scopeValue = typeof spRecord.scope === "string" ? spRecord.scope : undefined;
   // The budget comparison (CTO-209) and the burn-down forecast (CTO-210/211) are fetched once per
   // render rather than joining the live poll: they change on a human/daily cadence rather than a
   // 5-second one, and a forecast that flickered every 5 seconds would read as far less trustworthy
@@ -22,7 +29,7 @@ export default async function CostPage({
   // deliberately so. ?tag= filters the 30-day breakdown; ?scope= chooses which budget the forecast
   // is measured against, and it can also name a model or a layer. Collapsing them would mean
   // clicking a feature in the breakdown silently swapped which budget the page reports on.
-  const budgetQuery = sp.scope ? `?scope=${encodeURIComponent(sp.scope)}` : "";
+  const budgetQuery = scopeValue ? `?scope=${encodeURIComponent(scopeValue)}` : "";
   const [initialData, enabledLayers, budget] = await Promise.all([
     apiGet<CostPayload>(endpoint),
     queryEnabledConnectors(),
@@ -30,11 +37,10 @@ export default async function CostPage({
   ]);
   return (
     <CostLive
-      endpoint={endpoint}
       initialData={initialData}
       enabledLayers={enabledLayers}
       budget={budget}
-      tag={sp.tag ?? null}
+      tag={tagValue ?? null}
     />
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,15 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 import { apiGet } from "@/lib/api";
+import { filtersToQueryString, parseFilters } from "@/lib/filters";
+import { searchParamsFromRecord } from "@/lib/searchParams";
 import { queryEnabledConnectors } from "@/lib/tenant";
 import { HomeLive, type HomePayload } from "./Live";
 
-export default async function HomePage() {
-  const endpoint = "/api/home";
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  // Forward the URL-synced filter slice (CTO-226) so SSR's first paint matches the range the URL
+  // asks for; the client then re-derives the same endpoint from useFilters as the range changes.
+  const sp = searchParamsFromRecord(await searchParams);
+  const qs = filtersToQueryString(parseFilters(sp), sp);
+  const endpoint = qs ? `/api/home?${qs}` : "/api/home";
   const [initialData, enabledLayers] = await Promise.all([
     apiGet<HomePayload>(endpoint),
     queryEnabledConnectors(),
   ]);
-  return (
-    <HomeLive endpoint={endpoint} initialData={initialData} enabledLayers={enabledLayers} />
-  );
+  return <HomeLive initialData={initialData} enabledLayers={enabledLayers} />;
 }

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -164,8 +164,12 @@ function quantile(xs: number[], q: number): number {
 
 // --- Home / spend -------------------------------------------------------------------------------
 
-export async function querySpendSummary(): Promise<SpendSummary | null> {
+export async function querySpendSummary(windowDays = 30): Promise<SpendSummary | null> {
   return tryLive(async (db, tenant) => {
+    // User-selectable window (CTO-226): `w` calendar days inclusive, anchored on toDate(now()) so the
+    // window stays ClickHouse-clock derived (CTO-203), never the Node clock. `w - 1` keeps the
+    // historical 29-day-for-30 form so the default view is byte-for-byte unchanged.
+    const w = clampWindowDays(windowDays);
     const totals = await rows<{ total: string; estimated: string; reconciled: string; recThrough: string | null }>(
       db,
       `SELECT
@@ -174,14 +178,14 @@ export async function querySpendSummary(): Promise<SpendSummary | null> {
          sumIf(EstimatedCost, CostSource = 'reconciled') AS reconciled,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY`,
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY`,
       tenant,
     );
     const byLayerRows = await rows<{ layer: Layer; cost: string }>(
       db,
       `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY
        GROUP BY layer`,
       tenant,
     );
@@ -201,14 +205,17 @@ export async function querySpendSummary(): Promise<SpendSummary | null> {
   });
 }
 
-export async function queryOutliers(): Promise<CostOutlier[] | null> {
+export async function queryOutliers(windowDays = 30): Promise<CostOutlier[] | null> {
   return tryLive(async (db, tenant) => {
+    // User-selectable window (CTO-226): rolling `now() - INTERVAL w DAY`, w a bound-checked int
+    // (injection-safe), anchored on the ClickHouse clock (CTO-203), never the Node clock.
+    const w = clampWindowDays(windowDays);
     const out = await rows<{ runId: string; agent: string; cost: string; mult: string | null }>(
       db,
       `WITH runs AS (
          SELECT TraceId AS runId, any(ServiceName) AS agent, sum(EstimatedCost) AS cost
          FROM otel_spans
-         WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
+         WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY
            AND ServiceName != '' AND ServiceName != 'unknown'
            AND GenAiOperation NOT IN ('compute', 'egress')
          GROUP BY TraceId
@@ -229,13 +236,14 @@ export async function queryOutliers(): Promise<CostOutlier[] | null> {
   });
 }
 
-export async function queryRoi(): Promise<FeatureRoi[] | null> {
+export async function queryRoi(windowDays = 30): Promise<FeatureRoi[] | null> {
   // The Home ROI snapshot is a strict subset of the /features economics table, so it delegates
   // rather than keeping its own copy. It used to hardcode value/payback/attribution to null with a
   // "not wired yet" note; once the attribution stitcher started populating attribution_records
   // (CTO-200) that note was stale and the snapshot silently disagreed with /features. One source of
   // truth now: whatever /features shows per feature, Home shows the same for value and payback.
-  const econ = await queryFeatureEconomics();
+  // The window flows through so the Home range selector reshapes the snapshot too (CTO-226).
+  const econ = await queryFeatureEconomics(windowDays);
   if (econ === null) return null;
   return econ.map((e) => ({
     feature: e.feature,
@@ -268,20 +276,28 @@ export async function queryDataQuality(): Promise<DataQuality | null> {
 
 // --- Cost workflow ------------------------------------------------------------------------------
 
-// The cost chart spans `toDate(now()) - INTERVAL 29 DAY` through today inclusive, i.e. 30 calendar
-// days. The window boundary stays this calendar-aligned form (not a rolling `now() - INTERVAL 30
-// DAY`) so /cost and Home agree to the penny; see CTO-203.
-const COST_SERIES_WINDOW_DAYS = 30;
+// The cost series spans `toDate(now()) - INTERVAL (w - 1) DAY` through today inclusive, i.e. `w`
+// calendar days (default 30). The window boundary stays this calendar-aligned form (not a rolling
+// `now() - INTERVAL w DAY`) so /cost and Home agree to the penny; see CTO-203. `w` is now
+// user-selectable (CTO-226); see queryCostSeries.
 
-export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSeries | null> {
+export async function queryCostSeries(
+  filter?: { tag?: string },
+  windowDays = 30,
+): Promise<CostSeries | null> {
   return tryLive(async (db, tenant) => {
     const tag = filter?.tag ?? "";
     const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
+    // User-selectable window (CTO-226): `w` calendar days inclusive, `w - 1` back from toDate(now())
+    // so it keeps the calendar-aligned CTO-203 form (never the Node clock). Default 30 leaves the
+    // headline /cost view byte-for-byte unchanged; the day list below reuses `w` so both the SQL
+    // predicate and the pivot buckets stay on the one ClickHouse clock.
+    const w = clampWindowDays(windowDays);
     const out = await rowsP<{ day: string; layer: Layer; cost: string }>(
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY ${tagClause}
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY ${tagClause}
        GROUP BY day, layer
        ORDER BY day`,
       { tenant, tag },
@@ -297,14 +313,14 @@ export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSe
     // no spend in the window still renders 30 zero days).
     const boundary = await rowsP<{ windowStart: string }>(
       db,
-      `SELECT toString(toDate(now()) - INTERVAL 29 DAY) AS windowStart`,
+      `SELECT toString(toDate(now()) - INTERVAL ${w - 1} DAY) AS windowStart`,
       {},
     );
     const windowStart = boundary[0].windowStart;
     // Pivot into one CostDayPoint per calendar day (fill gaps with zero layers). Both ends of the
     // list now come from the same ClickHouse clock as the window predicate above.
     const byDay = new Map<string, CostDayPoint>();
-    for (const iso of isoDaysFrom(windowStart, COST_SERIES_WINDOW_DAYS)) {
+    for (const iso of isoDaysFrom(windowStart, w)) {
       byDay.set(iso, { date: iso, byLayer: zeroLayers() });
     }
     for (const r of out) {
@@ -320,15 +336,21 @@ export async function queryCostSeries(filter?: { tag?: string }): Promise<CostSe
   });
 }
 
-export async function queryFeatureCostRows(filter?: { tag?: string }): Promise<FeatureCostRow[] | null> {
+export async function queryFeatureCostRows(
+  filter?: { tag?: string },
+  windowDays = 30,
+): Promise<FeatureCostRow[] | null> {
   return tryLive(async (db, tenant) => {
     const tag = filter?.tag ?? "";
     const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
+    // Same user-selectable window as queryCostSeries (CTO-226) so the By-feature table matches the
+    // headline tiles at any range. `w - 1` back from toDate(now()) keeps the CTO-203 calendar form.
+    const w = clampWindowDays(windowDays);
     const out = await rowsP<{ feature: string; layer: Layer; cost: string }>(
       db,
       `SELECT FeatureTag AS feature, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL 29 DAY AND FeatureTag != '' ${tagClause}
+       WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY AND FeatureTag != '' ${tagClause}
        GROUP BY feature, layer`,
       { tenant, tag },
     );
@@ -1416,13 +1438,16 @@ const MIN_CONVERSIONS_FOR_ECONOMICS = 5;
 // and add `unmatched` = total-users-with-event minus attributed-users. The four sum to the
 // per-feature user total. Honest-null floor: fewer than MIN_CONVERSIONS_FOR_ECONOMICS attributed
 // conversions ⇒ value/payback/attributionRate are null (rendered `—`), never fabricated.
-export async function queryFeatureEconomics(): Promise<FeatureEconomics[] | null> {
+export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEconomics[] | null> {
   return tryLive(async (db, tenant) => {
+    // User-selectable window (CTO-226): bound-checked int (injection-safe), rolling and anchored on
+    // the ClickHouse clock (CTO-203). Default 30 keeps every existing caller byte-for-byte unchanged.
+    const w = clampWindowDays(windowDays);
     const cost = await rows<{ feature: string; cost: string; users: string }>(
       db,
       `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users
        FROM otel_spans
-       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY AND FeatureTag != ''
+       WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY AND FeatureTag != ''
        GROUP BY FeatureTag
        ORDER BY cost DESC`,
       tenant,
@@ -1455,7 +1480,7 @@ export async function queryFeatureEconomics(): Promise<FeatureEconomics[] | null
          WHERE TenantId = {tenant:String}
        ) AS be
          ON ar.TenantId = be.TenantId AND ar.BusinessEventId = be.BusinessEventId
-       WHERE ar.TenantId = {tenant:String} AND ar.AttributedTraceTs >= now() - INTERVAL 30 DAY
+       WHERE ar.TenantId = {tenant:String} AND ar.AttributedTraceTs >= now() - INTERVAL ${w} DAY
        GROUP BY feature`,
       tenant,
     );
@@ -1970,8 +1995,14 @@ function buildRun(agg: RunAgg, spans: RunSpan[], agentMedian: number): AgentRun 
 }
 
 /** Per-agent summaries + the top expensive runs (with span trees), built from otel_spans. */
-export async function queryAgents(filter?: { tag?: string; run?: string }): Promise<{ agents: AgentSummary[]; runs: AgentRun[] } | null> {
+export async function queryAgents(
+  filter?: { tag?: string; run?: string },
+  windowDays = 30,
+): Promise<{ agents: AgentSummary[]; runs: AgentRun[] } | null> {
   return tryLive(async (db, tenant) => {
+    // User-selectable window (CTO-226): bound-checked int (injection-safe), rolling and anchored on
+    // the ClickHouse clock (CTO-203). Default 30 keeps every existing caller byte-for-byte unchanged.
+    const w = clampWindowDays(windowDays);
     const tag = filter?.tag ?? "";
     const run = filter?.run ?? "";
     const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
@@ -1989,7 +2020,7 @@ export async function queryAgents(filter?: { tag?: string; run?: string }): Prom
               toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
        FROM otel_spans
        WHERE TenantId = {tenant:String}
-         AND Timestamp >= now() - INTERVAL 30 DAY
+         AND Timestamp >= now() - INTERVAL ${w} DAY
          AND ServiceName != ''
          AND ServiceName != 'unknown'
          AND GenAiOperation NOT IN ('compute', 'egress')
@@ -2007,20 +2038,23 @@ export async function queryAgents(filter?: { tag?: string; run?: string }): Prom
       list.push(a);
       byAgent.set(a.agent, list);
     }
-    const nowEpoch = Math.floor(Date.now() / 1000);
-    const dayAgo = nowEpoch - 24 * 3600;
     const agentMedian = new Map<string, number>();
 
     const agents: AgentSummary[] = [...byAgent.entries()].map(([name, list]) => {
       const costs = list.map((r) => micro(r.cost));
       agentMedian.set(name, median(costs));
-      const last24 = list.filter((r) => (parseInt(r.tsEpoch, 10) || 0) >= dayAgo);
       const distribution = new Array(10).fill(0);
       for (const c of costs) distribution[costBucket(c)]++;
+      // Cost/day is a windowed daily average (CTO-226): total spend over the window divided by the
+      // window's day count. The old logic summed only runs in the trailing 24h off the NODE clock
+      // (Date.now()), so it read 0 whenever the freshest span was >24h old (e.g. the demo's newest
+      // agent span is ~77h old) and disagreed with the ClickHouse-derived window everywhere else
+      // (CTO-203). Averaging over the actual window is both honest and clock-consistent.
+      const totalCostOverWindow = costs.reduce((s, c) => s + c, 0);
       return {
         name,
-        runsPerDay: last24.length,
-        costPerDayMicroUsd: last24.reduce((s, r) => s + micro(r.cost), 0),
+        runsPerDay: Math.round(list.length / w),
+        costPerDayMicroUsd: Math.round(totalCostOverWindow / w),
         p50MicroUsd: quantile(costs, 0.5),
         p99MicroUsd: quantile(costs, 0.99),
         distribution,

--- a/web/lib/searchParams.ts
+++ b/web/lib/searchParams.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Bridge Next 15's page `searchParams` record to a URLSearchParams (CTO-226).
+//
+// Server Components receive the query as a `Record<string, string | string[] | undefined>` (a repeated
+// key arrives as an array). The pure filter parser in lib/filters.ts speaks URLSearchParams, so the
+// range-aware pages funnel their awaited `searchParams` through this one converter rather than each
+// re-implementing the array/undefined handling. Kept tiny and dependency-free so it round-trips the
+// same way the client's `new URLSearchParams(searchParams.toString())` does.
+
+export function searchParamsFromRecord(
+  record?: Record<string, string | string[] | undefined>,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (!record) return params;
+  for (const [key, value] of Object.entries(record)) {
+    if (Array.isArray(value)) {
+      for (const v of value) params.append(key, v);
+    } else if (value !== undefined) {
+      params.set(key, value);
+    }
+  }
+  return params;
+}

--- a/web/lib/useLivePoll.ts
+++ b/web/lib/useLivePoll.ts
@@ -62,6 +62,11 @@ export function useLivePoll<T>(
   // Refs keep the polling loop stable across renders without re-subscribing.
   const abortRef = useRef<AbortController | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // First-run flag (CTO-226): SSR provides initialData for the mount endpoint, so the FIRST effect
+  // run must not fetch immediately (that is the deliberate "no double-render storm on mount"). But a
+  // LATER endpoint change (e.g. flipping the Home time range) must repaint at once rather than wait a
+  // whole interval, so any run after the first fetches immediately when the tab is visible.
+  const firstRunRef = useRef(true);
 
   useEffect(() => {
     if (!enabled) return;
@@ -121,8 +126,12 @@ export function useLivePoll<T>(
     if (typeof document !== "undefined" && document.visibilityState === "hidden") {
       // Paused initially; wait for visibilitychange to resume.
     } else {
+      // A post-mount endpoint change fetches immediately so the new slice paints without a full
+      // interval's wait; the very first run stays SSR-only (no immediate fetch).
+      if (!firstRunRef.current) void fetchOnce();
       startInterval();
     }
+    firstRunRef.current = false;
 
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", onVisibilityChange);


### PR DESCRIPTION
Fixes CTO-226: two live bugs in the shipped design overhaul.

## Root causes

**Bug 1 — Home time-range filter was inert.** On `/`, clicking 7d/30d/90d only toggled the active button; SPEND, "Top cost outliers", and the ROI snapshot never moved. `web/app/Live.tsx` never read `filterState.range`, the endpoint was a fixed `/api/home`, and the underlying queries hardcoded the window.

**Bug 2 — Agents cost/day tiles read $0.00.** On `/agents`, "Cost/day · all agents" and "Priciest agent/day" showed $0.00 despite 2 agents with 30 days of spend. In `queryAgents`, `costPerDayMicroUsd`/`runsPerDay` were computed from `last24` = runs within the trailing 24h of the **Node** clock (`Date.now()`/`dayAgo`). The demo's freshest agent span is ~77h old (vercel-chatbot's last span is 2026-08-23), so `last24` was empty and cost/day rounded to 0. This was also a CTO-203-class Node-clock window that should be ClickHouse-derived.

## What changed

- **Parameterized the shared queries with a ClickHouse-clock-derived window**, reusing the existing bound-checked `clampWindowDays` (a clamped integer literal, so the `INTERVAL` interpolation is injection-safe) anchored on `toDate(now())`/`now()`: `querySpendSummary`, `queryOutliers`, `queryRoi`, `queryFeatureEconomics`, `queryAgents`, `queryCostSeries`, `queryFeatureCostRows`, and `queryAttribution` (via `{ windowDays }`). Every window param defaults to `30`, so callers that do not pass a window are byte-for-byte unchanged (the `api.test.ts` baseline does not move).
- **queryAgents cost/day is now a true windowed daily average** (Bug 2 fix): `costPerDayMicroUsd = round(totalCostOverWindow / w)` and `runsPerDay = round(list.length / w)`. Deleted the `nowEpoch`/`dayAgo`/`last24` Node-clock logic (the CTO-203-class removal). p50/p99, `distribution`, medians, and the top-runs list are untouched. A genuinely all-zero period still yields `$0.00`, honestly.
- **Routes read the URL-synced filter state and pass `windowDays`**: `/api/home` (GET now takes a `Request`), `/api/agents`, `/api/cost`. For `/cost` the interactive chart still responds via `/api/explore`; here the headline tiles + By-feature table honour the window.
- **SSR + client wiring**: `page.tsx` (home/agents/cost) `await` `searchParams` and forward the managed query string so first paint matches the URL; `Live.tsx` (home/agents/cost) derive the endpoint from `useFilters()` so a range change swaps the endpoint and `useLivePoll` re-fetches. Visible labels now reflect the window ("last N days", "Top cost outliers (Nd)").
- **useLivePoll**: a post-mount endpoint change triggers an immediate fetch instead of waiting a full interval (a `useRef` first-run flag keeps the mount SSR-only; the visibility-pause logic is unchanged).
- **New `web/lib/searchParams.ts`** bridges Next 15's page `searchParams` record to a `URLSearchParams` for the pure filter parser.

## Before / after (tenant `local-dev`)

| | Before | After |
|---|---|---|
| Home SPEND, 30d | $92,472.81 | $92,472.81 (unchanged) |
| Home SPEND, 7d | $92,472.81 (inert) | **$14,708.35** |
| Home SPEND, 90d | $92,472.81 (inert) | $102,487.14 |
| Agents cost/day · all agents (30d) | **$0.00** | **$1,756** |
| Agents priciest agent/day (30d) | **$0.00** | **$1,756** (vercel-chatbot) |

Verified in the browser against the live stack: clicking 7d on Home (no reload) dropped SPEND to $14,708.35 and flipped the "last 30 days" / "(30D)" labels to 7-day; the Agents tiles render non-zero windowed daily averages.

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` (only the long-standing `app/api/api.test.ts` "falls back to mock when ClickHouse is unreachable" case fails, and only because a local ClickHouse is up — no new failures), and `npm run build` (clean, `rm -rf .next` first, no dev server) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
