### PR TITLE
feat(web): waste-detection framework and types (CTO-228)

### DIFF
--- a/web/lib/waste.test.ts
+++ b/web/lib/waste.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for the waste-detection roll-up (CTO-228, epic CTO-227). Each case pins one honesty or
+// determinism guarantee that would otherwise regress silently: an unbounded finding must stay OUT of
+// the total and sort LAST, an all-unbounded report must read as a blank (null) not a zero total, and
+// identical findings from independent detectors must collapse to one.
+
+import { describe, expect, it } from "vitest";
+
+import { aggregateWaste, type WasteCategory, type WasteFinding } from "./waste";
+
+const USD = 1_000_000;
+
+/** Build a finding with sensible defaults; override only what a case cares about. */
+function finding(over: Partial<WasteFinding> = {}): WasteFinding {
+  return {
+    category: "paid_for_nothing",
+    scopeKind: "feature",
+    scopeValue: "chatbot",
+    recoverableMicroUsd: 10 * USD,
+    windowSpendMicroUsd: 100 * USD,
+    confidence: "high",
+    title: "Idle spend",
+    reason: "spend with no successful runs",
+    evidence: {},
+    drillHref: null,
+    ...over,
+  };
+}
+
+describe("aggregateWaste", () => {
+  it("rolls up recoverable per category", () => {
+    const report = aggregateWaste(
+      [
+        finding({ category: "paid_for_nothing", scopeValue: "a", recoverableMicroUsd: 10 * USD }),
+        finding({ category: "paid_for_nothing", scopeValue: "b", recoverableMicroUsd: 5 * USD }),
+        finding({ category: "duplicated_work", scopeValue: "c", recoverableMicroUsd: 7 * USD }),
+      ],
+      30,
+    );
+
+    expect(report.byCategory.paid_for_nothing).toBe(15 * USD);
+    expect(report.byCategory.duplicated_work).toBe(7 * USD);
+    expect(report.totalRecoverableMicroUsd).toBe(22 * USD);
+    expect(report.generatedForWindowDays).toBe(30);
+    expect(report.unavailable).toBeNull();
+  });
+
+  it("populates every category key, null for categories with no findings", () => {
+    const report = aggregateWaste(
+      [finding({ category: "paid_for_nothing", recoverableMicroUsd: 3 * USD })],
+      7,
+    );
+    const cats: WasteCategory[] = [
+      "paid_for_nothing",
+      "duplicated_work",
+      "wrong_sized_model",
+      "no_measured_return",
+      "structural_inefficiency",
+    ];
+    for (const c of cats) expect(c in report.byCategory).toBe(true);
+    expect(report.byCategory.paid_for_nothing).toBe(3 * USD);
+    expect(report.byCategory.wrong_sized_model).toBeNull();
+  });
+
+  it("keeps a null recoverable out of the total and sorts it last", () => {
+    const report = aggregateWaste(
+      [
+        finding({ scopeValue: "unbounded", recoverableMicroUsd: null }),
+        finding({ scopeValue: "small", recoverableMicroUsd: 2 * USD }),
+        finding({ scopeValue: "big", recoverableMicroUsd: 9 * USD }),
+      ],
+      30,
+    );
+
+    // Total counts only the two bounded findings.
+    expect(report.totalRecoverableMicroUsd).toBe(11 * USD);
+    // Sorted: big, small, then the unbounded one last.
+    expect(report.findings.map((f) => f.scopeValue)).toEqual(["big", "small", "unbounded"]);
+    expect(report.findings[2].recoverableMicroUsd).toBeNull();
+  });
+
+  it("reports byCategory null when a category has findings but none are bounded", () => {
+    const report = aggregateWaste(
+      [
+        finding({ category: "no_measured_return", scopeValue: "x", recoverableMicroUsd: null }),
+        finding({ category: "no_measured_return", scopeValue: "y", recoverableMicroUsd: null }),
+      ],
+      30,
+    );
+    expect(report.byCategory.no_measured_return).toBeNull();
+    expect(report.totalRecoverableMicroUsd).toBeNull();
+  });
+
+  it("returns null total when every finding is unbounded", () => {
+    const report = aggregateWaste(
+      [
+        finding({ scopeValue: "a", recoverableMicroUsd: null }),
+        finding({ scopeValue: "b", recoverableMicroUsd: null }),
+      ],
+      30,
+    );
+    expect(report.totalRecoverableMicroUsd).toBeNull();
+    expect(report.findings).toHaveLength(2);
+  });
+
+  it("de-dupes findings identical on category+scopeKind+scopeValue+title", () => {
+    const dupe = () =>
+      finding({
+        category: "duplicated_work",
+        scopeKind: "agent",
+        scopeValue: "summarizer",
+        title: "Redundant retries",
+        recoverableMicroUsd: 4 * USD,
+      });
+    const report = aggregateWaste([dupe(), dupe(), dupe()], 30);
+
+    expect(report.findings).toHaveLength(1);
+    expect(report.byCategory.duplicated_work).toBe(4 * USD);
+    expect(report.totalRecoverableMicroUsd).toBe(4 * USD);
+  });
+
+  it("does not treat findings differing only in title as duplicates", () => {
+    const report = aggregateWaste(
+      [
+        finding({ title: "One", recoverableMicroUsd: 1 * USD }),
+        finding({ title: "Two", recoverableMicroUsd: 1 * USD }),
+      ],
+      30,
+    );
+    expect(report.findings).toHaveLength(2);
+    expect(report.totalRecoverableMicroUsd).toBe(2 * USD);
+  });
+
+  it("empty input yields an all-null report", () => {
+    const report = aggregateWaste([], 90);
+    expect(report.findings).toHaveLength(0);
+    expect(report.totalRecoverableMicroUsd).toBeNull();
+    expect(report.byCategory.paid_for_nothing).toBeNull();
+    expect(report.generatedForWindowDays).toBe(90);
+    expect(report.unavailable).toBeNull();
+  });
+});

--- a/web/lib/waste.ts
+++ b/web/lib/waste.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Waste-detection framework and types (CTO-228, epic CTO-227). This is the FOUNDATION that every
+// detector builds on; it lands before any detector so their shapes and the roll-up are fixed once.
+//
+// The whole feature answers "where is this tenant paying for AI that returns nothing" -- money spent
+// with no measured value, duplicated work, an over-sized model, and so on. A detector inspects one
+// slice of telemetry and emits zero or more findings; this module only defines what a finding IS and
+// how a set of findings rolls up into a report. It is deliberately PURE: no queries, no React, no
+// ClickHouse, no clock, no randomness, so the roll-up is trivially testable and deterministic.
+//
+// The honesty posture (see CLAUDE.md and components/HonestValue.tsx) is load-bearing here: a finding
+// can be real and still be unable to bound the dollars it would recover. That case is `null`, never
+// `0`, all the way through the report, so downstream renders a blank with a reason rather than a
+// fabricated recoverable of zero.
+
+import type { MicroUSD } from "@/lib/types";
+
+/**
+ * The kinds of waste the epic detects. One string per detector family; the union is closed so a new
+ * category is a deliberate, reviewed addition (it forces every exhaustive switch and the `byCategory`
+ * map to account for it).
+ */
+export type WasteCategory =
+  | "paid_for_nothing"
+  | "duplicated_work"
+  | "wrong_sized_model"
+  | "no_measured_return"
+  | "structural_inefficiency";
+
+/** Every category, in a stable order, so `byCategory` and any category iteration are deterministic. */
+export const WASTE_CATEGORIES: readonly WasteCategory[] = [
+  "paid_for_nothing",
+  "duplicated_work",
+  "wrong_sized_model",
+  "no_measured_return",
+  "structural_inefficiency",
+];
+
+/** How much we trust a finding. Drives sort/emphasis downstream, not the dollar math. */
+export type WasteConfidence = "high" | "medium" | "low";
+
+/** What a finding is scoped to: the dimension whose value (`scopeValue`) the waste is attributed to. */
+export type WasteScopeKind = "feature" | "agent" | "model" | "layer" | "account";
+
+/**
+ * One unit of detected waste.
+ *
+ * `recoverableMicroUsd` is nullable ON PURPOSE (CTO-227 honesty): a finding can be real and still be
+ * unable to put a defensible dollar bound on what stopping the waste would recover. That is `null`,
+ * which renders a blank downstream, NOT `0` -- a guessed zero would understate recoverable spend and
+ * read as "nothing to save here", the opposite of the truth. `windowSpendMicroUsd` is always known
+ * (it is the observed spend on the scope over the window), so it is not nullable.
+ */
+export interface WasteFinding {
+  category: WasteCategory;
+  scopeKind: WasteScopeKind;
+  scopeValue: string;
+  /** Bounded recoverable spend, or `null` when the finding cannot defensibly bound the dollars. */
+  recoverableMicroUsd: MicroUSD | null;
+  /** Observed spend on the scope over the window. Always known. Integer micro-USD. */
+  windowSpendMicroUsd: MicroUSD;
+  confidence: WasteConfidence;
+  title: string;
+  reason: string;
+  /** Free-form supporting counts/labels for the detail view. Values are display-ready strings/numbers. */
+  evidence: Record<string, string | number>;
+  /** Deep link into the drill-down for this finding, or `null` when there is no meaningful target. */
+  drillHref: string | null;
+}
+
+/**
+ * The rolled-up view a report surface consumes.
+ *
+ * `totalRecoverableMicroUsd` sums ONLY the findings that could bound their dollars, and is `null`
+ * when NOT ONE finding could (an honest blank, never `0`). `byCategory` follows the same rule
+ * per category: see {@link aggregateWaste} for the exact convention, documented there and enforced
+ * by the tests. `unavailable` is a reason string carried by the endpoint when the report could not
+ * be produced at all (e.g. the underlying query failed); the pure aggregation always sets it `null`.
+ */
+export interface WasteReport {
+  findings: WasteFinding[];
+  totalRecoverableMicroUsd: MicroUSD | null;
+  byCategory: Record<WasteCategory, MicroUSD | null>;
+  generatedForWindowDays: number;
+  unavailable: string | null;
+}
+
+/**
+ * A detector: given its own input, yields zero or more findings. Each detector defines its concrete
+ * input in a LATER ticket, so the alias is intentionally permissive (a generic defaulting to
+ * `unknown`) rather than a committed signature -- it documents the shape without constraining it.
+ */
+export type Detector<TInput = unknown> = (input: TInput) => WasteFinding[];
+
+/** Identity of a finding for de-duplication: same category + scope + title is the same finding. */
+function findingKey(f: WasteFinding): string {
+  // JSON.stringify of a fixed-order tuple gives an unambiguous key even when a value contains the
+  // separator we would otherwise join on. Order matters and is fixed here.
+  return JSON.stringify([f.category, f.scopeKind, f.scopeValue, f.title]);
+}
+
+/**
+ * Roll a flat list of findings into a {@link WasteReport}. PURE and deterministic.
+ *
+ * Steps:
+ *   1. De-duplicate: findings identical on (category, scopeKind, scopeValue, title) collapse to the
+ *      first occurrence. Detectors run independently and can legitimately surface the same waste.
+ *   2. Sort by `recoverableMicroUsd` DESCENDING, with `null` (unbounded) findings sorted LAST, so the
+ *      biggest bounded opportunities lead and the un-quantifiable ones trail. Ties preserve input
+ *      order (stable), keeping the output deterministic.
+ *   3. `totalRecoverableMicroUsd` = sum of the non-null recoverables, or `null` when there are zero
+ *      non-null recoverables (an honest blank, never `0`).
+ *   4. `byCategory[c]` = sum of the non-null recoverables of category `c`'s findings; `null` if `c`
+ *      had findings but none were bounded; and ALSO `null` if `c` had no findings at all. We always
+ *      populate every category key (never absent) and use `null` for "no bounded dollars to show",
+ *      whether that is because the category was empty or because none of its findings were bounded.
+ *      A blank is honest for both, and a total-less-than-sum-of-parts never appears.
+ *   5. `unavailable` is always `null` here; only the endpoint sets it, on a failure to produce.
+ */
+export function aggregateWaste(findings: WasteFinding[], windowDays: number): WasteReport {
+  // 1. De-dupe, keeping first occurrence and input order.
+  const seen = new Set<string>();
+  const deduped: WasteFinding[] = [];
+  for (const f of findings) {
+    const key = findingKey(f);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(f);
+  }
+
+  // 2. Stable sort: bounded findings by recoverable descending, then all unbounded (null) findings.
+  // Array.prototype.sort is stable in modern JS, so equal keys keep their de-duped input order.
+  const sorted = deduped.slice().sort((a, b) => {
+    const an = a.recoverableMicroUsd;
+    const bn = b.recoverableMicroUsd;
+    if (an === null && bn === null) return 0;
+    if (an === null) return 1; // a (null) sorts after b
+    if (bn === null) return -1; // b (null) sorts after a
+    return bn - an; // both bounded: larger recoverable first
+  });
+
+  // 3 & 4. Totals. Track whether any bounded finding existed, so "no bounded dollars" is null not 0.
+  const byCategory = {} as Record<WasteCategory, MicroUSD | null>;
+  for (const c of WASTE_CATEGORIES) byCategory[c] = null;
+
+  let total = 0;
+  let anyBounded = false;
+  for (const f of sorted) {
+    if (f.recoverableMicroUsd === null) continue;
+    anyBounded = true;
+    total += f.recoverableMicroUsd;
+    const prev = byCategory[f.category];
+    byCategory[f.category] = (prev ?? 0) + f.recoverableMicroUsd;
+  }
+
+  return {
+    findings: sorted,
+    totalRecoverableMicroUsd: anyBounded ? total : null,
+    byCategory,
+    generatedForWindowDays: windowDays,
+    unavailable: null,
+  };
+}


### PR DESCRIPTION
## What

W1 of the waste-detection epic (CTO-227): the pure framework and types that every detector builds on. It merges before any detector so their shapes and the roll-up are fixed once.

Adds `web/lib/waste.ts`:

- **Types**: `WasteCategory` (`paid_for_nothing | duplicated_work | wrong_sized_model | no_measured_return | structural_inefficiency`), `WasteConfidence`, `WasteScopeKind`, plus the `WasteFinding` and `WasteReport` interfaces.
- **`Detector<TInput = unknown>`**: a permissive type alias documenting the detector shape; each detector defines its own concrete input in a later ticket.
- **`aggregateWaste(findings, windowDays)`**: pure and deterministic. De-dupes identical findings (category + scopeKind + scopeValue + title), sorts by recoverable descending with unbounded (`null`) findings last, sums only bounded recoverables into `totalRecoverableMicroUsd`, and rolls up `byCategory` under the same rule. `unavailable` is always `null` here; the endpoint sets it on failure.

### Honesty contract
`recoverableMicroUsd` is nullable on purpose. A real finding that cannot bound its dollars stays `null` (an honest blank downstream), stays out of every total, and is never a fabricated `0`. `totalRecoverableMicroUsd` and each `byCategory` entry are `null` when no bounded finding exists (empty category or all-unbounded category alike); every category key is always present.

No detector, no query, no React, no ClickHouse, no clock/randomness. Money is integer micro-USD.

## Tests
`web/lib/waste.test.ts` (8 cases): per-category roll-up, every category key populated (`null` when empty), a `null` recoverable kept out of the total and sorted last, `byCategory` `null` when a category has only unbounded findings, `null` total when every finding is unbounded, de-dupe of identical findings, non-dupe when only the title differs, and an all-`null` empty report.

## Verify
- `npm run typecheck`: clean.
- `npm run lint`: clean (one pre-existing warning in `useLivePoll.ts`, unrelated).
- `npm run test`: 8 new tests pass; only the long-standing `app/api/api.test.ts` "falls back to mock when ClickHouse is unreachable" failure remains (local ClickHouse is up), no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)