### PR TITLE
feat(web): paid-for-nothing waste detector (CTO-229)

### DIFF
--- a/web/lib/waste/paid-for-nothing.test.ts
+++ b/web/lib/waste/paid-for-nothing.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Unit tests for the pure paid-for-nothing detector (CTO-229, epic CTO-227). We test only the pure
+// `detectPaidForNothing`; the query and `tryLive` wiring in `collectPaidForNothing` are exercised
+// against the live stack (see the PR body), not mocked here.
+
+import { describe, it, expect } from "vitest";
+import {
+  detectPaidForNothing,
+  type PaidForNothingRow,
+} from "./paid-for-nothing";
+
+/** A fully-specified fixture row; individual tests override just the fields they care about. */
+function row(overrides: Partial<PaidForNothingRow>): PaidForNothingRow {
+  return {
+    scopeKind: "feature",
+    scopeValue: "search",
+    wastedCost: "0",
+    scopeCost: "0",
+    failedRuns: "0",
+    abandonedRuns: "0",
+    exampleTrace: "",
+    ...overrides,
+  };
+}
+
+describe("detectPaidForNothing", () => {
+  it("flags a failed billed run with the wasted amount as the recoverable", () => {
+    const findings = detectPaidForNothing([
+      row({
+        scopeKind: "feature",
+        scopeValue: "search",
+        wastedCost: "0.25", // $0.25 wasted
+        scopeCost: "1.00", // $1.00 total on the scope
+        failedRuns: "3",
+        exampleTrace: "abc123",
+      }),
+    ]);
+
+    expect(findings).toHaveLength(1);
+    const f = findings[0];
+    expect(f.category).toBe("paid_for_nothing");
+    expect(f.confidence).toBe("high");
+    expect(f.scopeKind).toBe("feature");
+    expect(f.scopeValue).toBe("search");
+    // Recoverable = wasted spend, integer micro-USD, always bounded (never null).
+    expect(f.recoverableMicroUsd).toBe(250_000);
+    expect(f.windowSpendMicroUsd).toBe(1_000_000);
+    expect(f.drillHref).toBe("/agents");
+    expect(f.evidence.failedRuns).toBe(3);
+    expect(f.evidence.abandonedRuns).toBe(0);
+    expect(f.evidence.exampleTrace).toBe("abc123");
+    // 0.25 / 1.00 = 25%.
+    expect(f.evidence.shareOfScopeSpend).toBe(25);
+  });
+
+  it("does not flag a successful run (no wasted spend)", () => {
+    const findings = detectPaidForNothing([
+      row({ wastedCost: "0", scopeCost: "2.00", failedRuns: "0" }),
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag a failed run that cost nothing (zero billed)", () => {
+    // A run can fail before consuming billable tokens; there is nothing to recover, so no finding.
+    const findings = detectPaidForNothing([
+      row({ wastedCost: "0", scopeCost: "0", failedRuns: "1" }),
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it("groups by feature and by agent independently", () => {
+    const findings = detectPaidForNothing([
+      row({
+        scopeKind: "feature",
+        scopeValue: "search",
+        wastedCost: "0.10",
+        scopeCost: "0.40",
+        failedRuns: "1",
+      }),
+      row({
+        scopeKind: "agent",
+        scopeValue: "aider",
+        wastedCost: "0.30",
+        scopeCost: "0.60",
+        failedRuns: "2",
+      }),
+    ]);
+
+    expect(findings).toHaveLength(2);
+    const byScope = Object.fromEntries(findings.map((f) => [f.scopeKind, f]));
+    expect(byScope.feature.scopeValue).toBe("search");
+    expect(byScope.feature.recoverableMicroUsd).toBe(100_000);
+    expect(byScope.agent.scopeValue).toBe("aider");
+    expect(byScope.agent.recoverableMicroUsd).toBe(300_000);
+    expect(byScope.agent.evidence.shareOfScopeSpend).toBe(50);
+  });
+
+  it("counts abandoned runs into the wasted-run tally when present", () => {
+    const findings = detectPaidForNothing([
+      row({
+        wastedCost: "0.05",
+        scopeCost: "0.05",
+        failedRuns: "1",
+        abandonedRuns: "2",
+      }),
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].evidence.failedRuns).toBe(1);
+    expect(findings[0].evidence.abandonedRuns).toBe(2);
+    // 100% of this scope's spend was wasted.
+    expect(findings[0].evidence.shareOfScopeSpend).toBe(100);
+  });
+});

--- a/web/lib/waste/paid-for-nothing.ts
+++ b/web/lib/waste/paid-for-nothing.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// The "paid-for-nothing" waste detector (CTO-229, W2 of epic CTO-227).
+//
+// This is the most literal form of AI waste: a run that consumed billable tokens and then produced
+// nothing usable -- it ended in a terminal error (failed) or was abandoned. The tenant paid for the
+// tokens; there is no result to show for them. Recovering this spend is the highest-confidence
+// finding the epic emits, because "billed AND no successful outcome" needs no modelling or
+// counterfactual: the dollars were spent, the outcome was empty.
+//
+// The module is deliberately SELF-CONTAINED (CTO-227 boundary): it owns BOTH its ClickHouse query
+// and its pure detector, so it never edits clickhouse.ts, waste.ts, or any shared surface. It reuses
+// the exported helpers (`tryLive`, `rowsP`, `micro`) and, critically, the SAME run-outcome derivation
+// as `queryAgents` -- a run is failed when `max(StatusCode) = 2` (OTel semconv: 2 = Error), success
+// otherwise. We do not invent a second outcome definition.
+//
+// Honesty posture (CLAUDE.md): money is integer micro-USD throughout; a scope with no wasted spend
+// yields no finding (never a fabricated or zero-dollar finding). `recoverableMicroUsd` here is always
+// bounded and non-null because the wasted spend is directly observed, not estimated.
+
+import type { WasteFinding } from "@/lib/waste";
+import type { DimensionFilters } from "@/lib/filters";
+import { tryLive, rowsP, micro } from "@/lib/clickhouse";
+import { clampWindowDays } from "@/lib/explore";
+
+/**
+ * One aggregated "paid-for-nothing" row for a single scope (a feature tag or an agent/service name).
+ * `wastedCost` and `scopeCost` are decimal-USD strings straight from ClickHouse `sum(...)`; the pure
+ * detector converts them to integer micro-USD via {@link micro}. Counts arrive as strings too
+ * (ClickHouse serializes UInt aggregates as strings in JSONEachRow).
+ */
+export interface PaidForNothingRow {
+  scopeKind: "feature" | "agent";
+  scopeValue: string;
+  /** Summed EstimatedCost of the wasted (billed-but-empty) runs in this scope. Decimal-USD string. */
+  wastedCost: string;
+  /** Summed EstimatedCost of ALL runs in this scope over the window. Decimal-USD string. */
+  scopeCost: string;
+  /** Count of wasted runs that ended failed (terminal error StatusCode). */
+  failedRuns: string;
+  /** Count of wasted runs that ended abandoned. Not derivable from OTel StatusCode today, so 0. */
+  abandonedRuns: string;
+  /** One example wasted TraceId, for the drill-down. May be empty. */
+  exampleTrace: string;
+}
+
+/**
+ * Pure detector: turn aggregated per-scope rows into {@link WasteFinding}s. No I/O, no clock, no
+ * randomness -- unit-tested directly on fixtures.
+ *
+ * A row becomes a finding only when it has wasted spend (`wastedCost` > 0 in micro-USD). The
+ * recoverable is exactly that wasted spend (dollars already paid with no result), and it is always
+ * bounded (never null): the money is observed, not modelled. `windowSpendMicroUsd` is the scope's
+ * total spend over the window, so the finding can show wasted spend as a share of the whole.
+ */
+export function detectPaidForNothing(rows: PaidForNothingRow[]): WasteFinding[] {
+  const findings: WasteFinding[] = [];
+  for (const r of rows) {
+    const wasted = micro(r.wastedCost);
+    // No wasted spend -> no finding. Never emit a zero-dollar "waste" (CTO-227 honesty).
+    if (wasted <= 0) continue;
+
+    const scopeSpend = micro(r.scopeCost);
+    const failedRuns = parseInt(r.failedRuns, 10) || 0;
+    const abandonedRuns = parseInt(r.abandonedRuns, 10) || 0;
+    const wastedRuns = failedRuns + abandonedRuns;
+    // Share of the scope's spend that went to nothing. Guard against a zero/again-smaller total
+    // (shouldn't happen: wasted is a subset of scope spend) so the percentage stays sane.
+    const shareOfScopeSpend =
+      scopeSpend > 0 ? Math.round((wasted / scopeSpend) * 100) : 100;
+
+    const scopeLabel = r.scopeKind === "feature" ? "feature" : "agent";
+    findings.push({
+      category: "paid_for_nothing",
+      scopeKind: r.scopeKind,
+      scopeValue: r.scopeValue,
+      // Directly observed wasted spend -> always a bounded recoverable, never null.
+      recoverableMicroUsd: wasted,
+      windowSpendMicroUsd: scopeSpend,
+      confidence: "high",
+      title: `Billed runs that returned nothing on ${scopeLabel} "${r.scopeValue}"`,
+      reason: `${wastedRuns} billed run(s) on this ${scopeLabel} ended failed or abandoned, so ${shareOfScopeSpend}% of its spend bought no result.`,
+      evidence: {
+        failedRuns,
+        abandonedRuns,
+        exampleTrace: r.exampleTrace,
+        shareOfScopeSpend,
+      },
+      // The run view (/agents) is where a user inspects failed/abandoned runs.
+      drillHref: "/agents",
+    });
+  }
+  return findings;
+}
+
+/**
+ * Build the feature / agent multi-select clauses for this detector. `filters.feature` narrows
+ * `FeatureTag`, `filters.agent` narrows `ServiceName`; every other dimension is irrelevant here and
+ * ignored. Values are bound as `Array(String)` params (never interpolated), exactly like the other
+ * ClickHouse reads in this codebase.
+ *
+ * `filters` is typed as {@link DimensionFilters} (feature/model/layer/provider/account). "agent" is
+ * not one of those dimension keys, so we read it defensively off the record -- the aggregation
+ * endpoint (W7) may pass an agent narrowing under that key without it being a formal Dimension.
+ */
+function detectorFilters(filters: DimensionFilters): {
+  clause: string;
+  params: Record<string, string[]>;
+} {
+  const clauses: string[] = [];
+  const params: Record<string, string[]> = {};
+
+  const features = filters.feature ?? [];
+  if (features.length > 0) {
+    clauses.push("AND FeatureTag IN {f_features:Array(String)}");
+    params.f_features = features;
+  }
+  const agents = (filters as Record<string, string[] | undefined>).agent ?? [];
+  if (agents.length > 0) {
+    clauses.push("AND ServiceName IN {f_agents:Array(String)}");
+    params.f_agents = agents;
+  }
+
+  return { clause: clauses.join(" "), params };
+}
+
+/**
+ * Entry point (W7 calls this): run the paid-for-nothing query for the window + filters, map through
+ * the pure detector, and return the findings. Returns `[]` when ClickHouse is unreachable (`tryLive`
+ * returns null) -- no mock/static fallback, so a blank stack is honest rather than fabricated.
+ *
+ * The query works in two stages, both anchored on the ClickHouse clock (`now() - INTERVAL {w} DAY`),
+ * never the Node clock (CTO-203):
+ *   1. Collapse spans into runs (per TraceId): total run cost and whether the run ended in error
+ *      (`max(StatusCode) = 2`), matching `queryAgents` exactly. A run also carries its feature tag
+ *      and its agent (ServiceName). `GenAiOperation NOT IN ('compute','egress')` keeps this to
+ *      run-shaped, billable spend (the synthetic infra rows are not runs).
+ *   2. Roll runs up BY feature and BY agent separately, summing wasted cost (cost of the runs that
+ *      ended failed) and total scope cost, and counting the wasted runs.
+ */
+export async function collectPaidForNothing(
+  windowDays: number,
+  filters: DimensionFilters,
+): Promise<WasteFinding[]> {
+  const found = await tryLive(async (db, tenant) => {
+    const w = clampWindowDays(windowDays);
+    const { clause, params } = detectorFilters(filters);
+
+    // Stage 1 (runs subquery): one row per TraceId with its cost, terminal-error flag, feature and
+    // agent. `isFailed` reuses queryAgents' derivation: max(StatusCode)=2 (OTel Error) => failed.
+    // Stage 2 (outer): two GROUP BYs unioned -- by feature and by agent -- each emitting a scope row
+    // with wasted vs. total spend and the wasted-run counts. `wastedCost`/`failedRuns` gate on the
+    // run being both billed (runCost > 0) AND failed. `abandonedRuns` is 0: abandonment is not
+    // derivable from OTel StatusCode today (see queryAgents), but the column is kept so the shape and
+    // the evidence are stable if a future signal lands.
+    const runsCte = `
+      SELECT
+        TraceId AS runId,
+        any(FeatureTag) AS feature,
+        any(ServiceName) AS agent,
+        sum(EstimatedCost) AS runCost,
+        max(StatusCode) = 2 AS isFailed
+      FROM otel_spans
+      WHERE TenantId = {tenant:String}
+        AND Timestamp >= now() - INTERVAL ${w} DAY
+        AND GenAiOperation NOT IN ('compute', 'egress')
+        ${clause}
+      GROUP BY TraceId`;
+
+    // A wasted run: billed (runCost > 0) and failed. We express the gate once as a reusable flag.
+    const wastedRunExpr = "(runCost > 0 AND isFailed)";
+
+    const sql = `
+      WITH runs AS (${runsCte})
+      SELECT
+        'feature' AS scopeKind,
+        feature AS scopeValue,
+        toString(sumIf(runCost, ${wastedRunExpr})) AS wastedCost,
+        toString(sum(runCost)) AS scopeCost,
+        toString(countIf(${wastedRunExpr})) AS failedRuns,
+        '0' AS abandonedRuns,
+        anyIf(runId, ${wastedRunExpr}) AS exampleTrace
+      FROM runs
+      WHERE feature != ''
+      GROUP BY feature
+      HAVING sumIf(runCost, ${wastedRunExpr}) > 0
+
+      UNION ALL
+
+      SELECT
+        'agent' AS scopeKind,
+        agent AS scopeValue,
+        toString(sumIf(runCost, ${wastedRunExpr})) AS wastedCost,
+        toString(sum(runCost)) AS scopeCost,
+        toString(countIf(${wastedRunExpr})) AS failedRuns,
+        '0' AS abandonedRuns,
+        anyIf(runId, ${wastedRunExpr}) AS exampleTrace
+      FROM runs
+      WHERE agent != '' AND agent != 'unknown'
+      GROUP BY agent
+      HAVING sumIf(runCost, ${wastedRunExpr}) > 0`;
+
+    const raw = await rowsP<PaidForNothingRow>(db, sql, { tenant, ...params });
+    return detectPaidForNothing(raw);
+  });
+
+  // tryLive returns null on unreachable ClickHouse; the contract is [] in that case.
+  return found ?? [];
+}


### PR DESCRIPTION
## What (CTO-229, W2 of epic CTO-227)

The **paid-for-nothing** waste detector: the most literal form of AI waste, a run that consumed billable tokens and then produced nothing usable. The tenant paid for the tokens; there is no result to show for them.

Entirely inside a new self-contained module `web/lib/waste/paid-for-nothing.ts` (+ its test). It owns BOTH its query and its pure detector, so it touches no shared file (`clickhouse.ts`, `waste.ts`, pages all unmodified).

## Detection method

A run is paid-for-nothing when it **consumed billable tokens** (`sum(EstimatedCost) > 0`) but **ended failed or abandoned**. The run-outcome derivation is REUSED from `queryAgents`, not reinvented: a run is failed when `max(StatusCode) = 2` (OTel semconv, 2 = Error). Abandonment is not derivable from OTel `StatusCode` today (same limitation `queryAgents` documents), so `abandonedRuns` is 0 for now but kept in the shape/evidence for when a signal lands.

The query runs in two stages, both ClickHouse-clock anchored (`now() - INTERVAL {w} DAY`, never the Node clock, CTO-203):
1. Collapse spans into runs per `TraceId` (cost, failed-flag, feature, agent); `GenAiOperation NOT IN ('compute','egress')` keeps it to run-shaped billable spend.
2. Roll runs up BY feature and BY agent separately, summing wasted cost (cost of the failed billed runs) and total scope cost.

`recoverableMicroUsd` = the summed wasted `EstimatedCost` (directly observed, so always a bounded non-null recoverable). `windowSpendMicroUsd` = the scope's total spend.

## Export contract

- `detectPaidForNothing(rows): WasteFinding[]` — pure, no I/O/clock/randomness. Emits `category: 'paid_for_nothing'`, `confidence: 'high'`, `scopeKind`/`scopeValue` (feature or agent), `drillHref: '/agents'`, `evidence: { failedRuns, abandonedRuns, exampleTrace, shareOfScopeSpend }`. A row with no wasted spend yields no finding (never a zero-dollar "waste").
- `collectPaidForNothing(windowDays, filters): Promise<WasteFinding[]>` — the W7 entry point. Window is `clampWindowDays`. `filters.feature` narrows `FeatureTag`, `filters.agent` narrows `ServiceName`; both bind as `Array(String)` params (never interpolated). Returns `[]` when ClickHouse is unreachable (`tryLive` null) — no mock/static fallback.

## Live verification

Ran `collectPaidForNothing(30, emptyFilters)` against the live stack (ClickHouse up, tenant `local-dev`). The query reaches ClickHouse (317,750 run-shaped spans in the 30-day window), but the clean demo data has **zero error spans**, hence zero failed-billed runs and **0 findings, $0.000000 wasted**. That is an honest empty result on clean demo data, not a failure: with no failed/abandoned billed runs there is nothing to flag. The detector's grouping/amounts are covered by unit tests on fixtures instead.

## Tests

`web/lib/waste/paid-for-nothing.test.ts` unit-tests the pure detector: a failed billed run flags with the wasted amount; a successful run does not; a failed run with zero cost does not; grouping by feature and by agent works; abandoned counts fold into the wasted-run tally. All pass.

Checks: `npm run typecheck` clean, `npm run lint` clean (only the pre-existing `useLivePoll.ts` warning), `npm run test` 629 passed with only the long-standing `app/api/api.test.ts` ClickHouse-running failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)