### PR TITLE
feat(web): "spend with no measured return" waste detector (CTO-232)

### DIFF
--- a/web/lib/waste/no-measured-return.test.ts
+++ b/web/lib/waste/no-measured-return.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for the pure "spend with no measured return" detector (CTO-232, W5; epic CTO-227). Each case
+// pins the honesty guarantee that makes this the detector least likely to cry wolf: it flags a
+// costly-but-unattributed feature ONLY on a tenant that attributes value somewhere, emits NOTHING
+// when the whole tenant has no revenue wired, caps confidence when the tenant's attribution is
+// sparse, and never flags a feature that has real measured return. The live SQL in
+// `collectNoMeasuredReturn` is exercised against ClickHouse (numbers in the PR body); these cover the
+// judgement that shapes its output.
+
+import { describe, expect, it } from "vitest";
+
+import { detectNoMeasuredReturn, type NoReturnEconRow } from "./no-measured-return";
+
+const USD = 1_000_000;
+
+/** Build an econ row with sensible defaults; override only what a case cares about. */
+function row(over: Partial<NoReturnEconRow> = {}): NoReturnEconRow {
+  return {
+    scopeKind: "feature",
+    scopeValue: "chatbot",
+    windowSpendMicroUsd: 100 * USD,
+    attributionRate: null,
+    ...over,
+  };
+}
+
+describe("detectNoMeasuredReturn", () => {
+  it("flags a costly, unattributed feature on an otherwise-attributed tenant", () => {
+    const findings = detectNoMeasuredReturn(
+      [row({ scopeValue: "summarizer", windowSpendMicroUsd: 250 * USD, attributionRate: null })],
+      // Tenant attributes value elsewhere and does so healthily.
+      0.8,
+    );
+
+    expect(findings).toHaveLength(1);
+    const f = findings[0];
+    expect(f.category).toBe("no_measured_return");
+    expect(f.scopeKind).toBe("feature");
+    expect(f.scopeValue).toBe("summarizer");
+    // Recoverable = the at-risk (windowed) spend, not null and not zero.
+    expect(f.recoverableMicroUsd).toBe(250 * USD);
+    expect(f.windowSpendMicroUsd).toBe(250 * USD);
+    expect(f.drillHref).toBe("/attribution");
+    // The reason MUST name the category phrase and carry the investigate-not-verdict caveat.
+    expect(f.reason.toLowerCase()).toContain("spend with no measured return");
+    expect(f.reason.toLowerCase()).toContain("investigate");
+    expect(f.evidence).toMatchObject({
+      windowSpend: 250 * USD,
+      attributedValue: 0,
+      tenantAttributionRate: 0.8,
+    });
+  });
+
+  it("returns [] when the whole tenant has no revenue wired (rate 0 or null)", () => {
+    const rows = [
+      row({ scopeValue: "a", windowSpendMicroUsd: 500 * USD, attributionRate: null }),
+      row({ scopeValue: "b", windowSpendMicroUsd: 300 * USD, attributionRate: null }),
+    ];
+    // No business events at all -> null: an instrumentation gap, never a wall of false positives.
+    expect(detectNoMeasuredReturn(rows, null)).toEqual([]);
+    // Events exist but none attributed -> 0: same honesty gate.
+    expect(detectNoMeasuredReturn(rows, 0)).toEqual([]);
+  });
+
+  it("caps confidence at low when the tenant's attribution is sparse", () => {
+    const sparse = detectNoMeasuredReturn(
+      [row({ attributionRate: null })],
+      0.1, // some attribution, but thin
+    );
+    expect(sparse[0].confidence).toBe("low");
+
+    const healthy = detectNoMeasuredReturn(
+      [row({ attributionRate: null })],
+      0.7, // otherwise well-attributed tenant
+    );
+    expect(healthy[0].confidence).toBe("medium");
+  });
+
+  it("does not flag a feature with real measured return", () => {
+    const findings = detectNoMeasuredReturn(
+      [
+        row({ scopeValue: "paid-search", windowSpendMicroUsd: 400 * USD, attributionRate: 1 }),
+        row({ scopeValue: "orphan", windowSpendMicroUsd: 120 * USD, attributionRate: null }),
+      ],
+      0.9,
+    );
+    // Only the unattributed one is flagged; the attributed feature is left alone.
+    expect(findings.map((f) => f.scopeValue)).toEqual(["orphan"]);
+  });
+
+  it("does not flag a scope with no spend at risk", () => {
+    const findings = detectNoMeasuredReturn(
+      [row({ scopeValue: "free", windowSpendMicroUsd: 0, attributionRate: null })],
+      0.8,
+    );
+    expect(findings).toEqual([]);
+  });
+});

--- a/web/lib/waste/no-measured-return.ts
+++ b/web/lib/waste/no-measured-return.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// "Spend with no measured return" waste detector (CTO-232, W5; epic CTO-227).
+//
+// This is the detector most likely to cry wolf, so its honesty posture is load-bearing. It flags a
+// feature that burned real spend over the window yet has NO measured value tracing back to it -- but
+// only when the tenant HAS attribution wired somewhere else. The distinction is the whole point:
+//
+//   * "this whole tenant has no revenue source wired" (no business_events, or none attributed) is an
+//     instrumentation gap, not waste. Flagging every costly feature in that state would be a wall of
+//     false positives. So when the tenant-wide attribution rate is 0 / null, we emit NOTHING.
+//   * "this tenant attributes value elsewhere, but this one costly feature attributes none" is the
+//     real signal. Only THEN do we flag the feature, and even then as a flag to INVESTIGATE, never a
+//     verdict of pure waste: top-of-funnel work and revenue that is simply not yet wired to the
+//     feature look identical to genuine waste from telemetry alone. The reason carries that caveat.
+//
+// Attribution is NOT re-derived here (CTO-124 owns it): `collectNoMeasuredReturn` reuses
+// `queryFeatureEconomics` for the per-feature attribution rate and only queries the windowed spend
+// and the tenant-wide attribution rate it needs on top. The pure `detectNoMeasuredReturn` does the
+// judgement so it is deterministic and testable without a database.
+
+import type { MicroUSD } from "@/lib/types";
+import type { WasteConfidence, WasteFinding, WasteScopeKind } from "@/lib/waste";
+import { clampWindowDays } from "@/lib/explore";
+import type { DimensionFilters } from "@/lib/filters";
+import { micro, queryFeatureEconomics, rowsP, tryLive } from "@/lib/clickhouse";
+
+// At or below this attribution rate a scope has, for our purposes, NO measured return: in practice
+// `queryFeatureEconomics` returns either ~1.0 (conversions attributed) or null (none), but a small
+// epsilon keeps "near zero" from hinging on an exact float.
+const NEAR_ZERO_ATTRIBUTION = 0.02;
+
+// Above this tenant-wide attribution rate we treat the tenant's attribution as "otherwise healthy",
+// so a feature with none stands out and earns `medium` confidence. Below it (but still > 0) the
+// tenant has only sparse attribution wired, so the same feature is a weaker signal -- capped at
+// `low`. This is a confidence knob only; it never changes the dollar math.
+const TENANT_HEALTHY_ATTRIBUTION = 0.5;
+
+/**
+ * One scope's economics as this detector needs them. Intentionally NOT `FeatureEconomics`: that type
+ * exposes cost PER USER, and this detector reasons about the scope's whole windowed spend (the
+ * at-risk dollars). `attributionRate` is carried straight from `queryFeatureEconomics` so attribution
+ * is reused, not recomputed; `null` there means "no measured attribution for this scope".
+ */
+export interface NoReturnEconRow {
+  /** Almost always `feature`; the shape allows `agent` so an agent-scoped caller can reuse it. */
+  scopeKind: WasteScopeKind;
+  scopeValue: string;
+  /** The scope's total spend over the window. Integer micro-USD. Always known. */
+  windowSpendMicroUsd: MicroUSD;
+  /** 0..1, or `null` for "no measured attribution". From `queryFeatureEconomics`, never re-derived. */
+  attributionRate: number | null;
+}
+
+/**
+ * PURE detector. Flags each scope that spent real money over the window with no measured return,
+ * subject to the honesty gate below. Deterministic: no queries, no clock, no randomness.
+ *
+ * Honesty gate (CTO-232): if the tenant has NO attribution wired at all (`tenantAttributionRate` is
+ * `null` or <= 0), return `[]`. A tenant with no revenue source connected cannot have "unreturned"
+ * spend distinguished from "un-instrumented" spend, so flagging anything would be a false positive.
+ *
+ * When the gate passes, a scope is flagged iff it has `windowSpendMicroUsd > 0` AND an attribution
+ * rate at or near zero (or `null`). `recoverableMicroUsd` is the at-risk spend (the windowed cost)
+ * because that is the exact figure an investigation would be trying to justify -- but the reason is
+ * explicit that this is a flag to investigate, not proven waste. Confidence is capped at `low` when
+ * the tenant's own attribution is sparse and is `medium` (never `high`, this detector cannot be sure)
+ * when the tenant is otherwise well-attributed.
+ */
+export function detectNoMeasuredReturn(
+  econRows: NoReturnEconRow[],
+  tenantAttributionRate: number | null,
+): WasteFinding[] {
+  // Gate: whole-tenant no-attribution state emits nothing, never a wall of false positives.
+  if (tenantAttributionRate === null || tenantAttributionRate <= 0) return [];
+
+  const confidence: WasteConfidence =
+    tenantAttributionRate >= TENANT_HEALTHY_ATTRIBUTION ? "medium" : "low";
+
+  const findings: WasteFinding[] = [];
+  for (const row of econRows) {
+    if (row.windowSpendMicroUsd <= 0) continue; // no spend at risk, nothing to flag
+    const hasReturn =
+      row.attributionRate !== null && row.attributionRate > NEAR_ZERO_ATTRIBUTION;
+    if (hasReturn) continue; // real measured return -> not waste
+
+    findings.push({
+      category: "no_measured_return",
+      scopeKind: row.scopeKind,
+      scopeValue: row.scopeValue,
+      // The at-risk spend IS the windowed cost: what an investigation would be sizing.
+      recoverableMicroUsd: row.windowSpendMicroUsd,
+      windowSpendMicroUsd: row.windowSpendMicroUsd,
+      confidence,
+      title: `${row.scopeValue}: spend with no measured return`,
+      reason:
+        "Spend with no measured return: this scope cost real money over the window, yet no " +
+        "converting business event traces back to it, while the tenant attributes value " +
+        "elsewhere. Caveat: top-of-funnel work, or revenue that is simply not yet wired to this " +
+        "scope, looks identical from telemetry alone, so treat this as a flag to investigate, not " +
+        "a verdict of pure waste.",
+      evidence: {
+        windowSpend: row.windowSpendMicroUsd,
+        attributedValue: 0,
+        tenantAttributionRate,
+      },
+      drillHref: "/attribution",
+    });
+  }
+
+  return findings;
+}
+
+/** Per-feature windowed spend row as it comes back from ClickHouse. */
+interface FeatureSpendRow {
+  feature: string;
+  cost: string;
+}
+
+/** The two scalars of the tenant-wide attribution query. */
+interface TenantAttributionRow {
+  total_events: string;
+  attributed_events: string;
+}
+
+/**
+ * Live collector. Runs the windowed feature economics (reused for attribution) and the tenant-wide
+ * attribution rate against ClickHouse, maps them through the pure detector, and returns `[]` when the
+ * data is unavailable (ClickHouse unreachable or economics could not be produced) so a down backend
+ * never fabricates findings. `filters.feature`, when set, narrows the scan to those features.
+ */
+export async function collectNoMeasuredReturn(
+  windowDays: number,
+  filters: DimensionFilters,
+): Promise<WasteFinding[]> {
+  // Window is ClickHouse-clock derived (CTO-203) and bound-checked (injection-safe int), matching the
+  // form `queryFeatureEconomics` uses so the spend and attribution windows line up.
+  const w = clampWindowDays(windowDays);
+
+  // Reuse the per-feature attribution rate; do NOT re-derive it (CTO-124 owns that math).
+  const econ = await queryFeatureEconomics(w);
+  if (econ === null) return [];
+  const attrRateByFeature = new Map(econ.map((e) => [e.feature, e.attributionRate]));
+
+  const featureFilter = filters.feature ?? [];
+  const hasFeatureFilter = featureFilter.length > 0;
+
+  const live = await tryLive(async (db, tenant) => {
+    // Per-feature windowed spend. `w` is a clamped int, so interpolating it is injection-safe (same
+    // pattern as the sibling queries in lib/clickhouse.ts). `filters.feature` binds as an array param.
+    const spendRows = await rowsP<FeatureSpendRow>(
+      db,
+      `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost
+       FROM otel_spans
+       WHERE TenantId = {tenant:String}
+         AND Timestamp >= now() - INTERVAL ${w} DAY
+         AND FeatureTag != ''
+         ${hasFeatureFilter ? "AND FeatureTag IN {features:Array(String)}" : ""}
+       GROUP BY FeatureTag`,
+      { tenant, features: featureFilter },
+    );
+
+    // Tenant-wide attribution rate: distinct business events that got an attribution record over the
+    // window / all business events over the window. This is the honesty discriminator -- 0 (or no
+    // events at all) means the tenant has no revenue source wired, and the detector then emits [].
+    const [attrRow] = await rowsP<TenantAttributionRow>(
+      db,
+      `SELECT
+         uniqExact(BusinessEventId) AS total_events,
+         uniqExactIf(BusinessEventId, BusinessEventId IN (
+           SELECT BusinessEventId FROM attribution_records FINAL
+           WHERE TenantId = {tenant:String} AND AttributedTraceTs >= now() - INTERVAL ${w} DAY
+         )) AS attributed_events
+       FROM business_events FINAL
+       WHERE TenantId = {tenant:String} AND OccurredAt >= now() - INTERVAL ${w} DAY`,
+      { tenant },
+    );
+
+    const totalEvents = attrRow ? parseInt(attrRow.total_events, 10) || 0 : 0;
+    const attributedEvents = attrRow ? parseInt(attrRow.attributed_events, 10) || 0 : 0;
+    // No business events at all -> null (honest blank), NOT 0: distinct from "events, none attributed"
+    // for a reader, though both hit the same [] gate in the pure detector.
+    const tenantAttributionRate = totalEvents > 0 ? attributedEvents / totalEvents : null;
+
+    return { spendRows, tenantAttributionRate };
+  });
+  if (live === null) return [];
+
+  const econRows: NoReturnEconRow[] = live.spendRows.map((r) => ({
+    scopeKind: "feature" as const,
+    scopeValue: r.feature,
+    windowSpendMicroUsd: micro(r.cost),
+    attributionRate: attrRateByFeature.get(r.feature) ?? null,
+  }));
+
+  return detectNoMeasuredReturn(econRows, live.tenantAttributionRate);
+}


### PR DESCRIPTION
## What

W5 of the waste-detection epic (CTO-227): the "spend with no measured return" detector, in one self-contained module `web/lib/waste/no-measured-return.ts` (+ test). No shared files touched.

- **Pure `detectNoMeasuredReturn(econRows, tenantAttributionRate)`** flags a feature with `cost > 0` over the window and an attribution rate at/near zero (or null). Emits `category: 'no_measured_return'`, `scopeKind: 'feature'`, `recoverableMicroUsd` = the at-risk windowed spend, `drillHref: '/attribution'`, evidence `{ windowSpend, attributedValue: 0, tenantAttributionRate }`. Confidence is `low` when the tenant's attribution is sparse and `medium` (never `high`) when the tenant is otherwise well-attributed.
- **`collectNoMeasuredReturn(windowDays, filters)`** reuses `queryFeatureEconomics` for the per-feature attribution rate (attribution is not re-derived; CTO-124 owns it) and, inside one `tryLive`, queries the windowed per-feature spend and the tenant-wide attribution rate. Returns `[]` when the backend is unavailable.

## The honesty rule (this is the detector most likely to cry wolf)

The tenant-wide attribution rate is the discriminator. If the tenant has **no** revenue wired at all (rate `0` / no `business_events`), the detector emits **nothing** rather than flagging every costly feature. Only when the tenant attributes value *somewhere* but a specific costly feature attributes *none* is that feature flagged, and the `reason` is explicit that top-of-funnel work or unwired revenue looks identical, so it is a flag to investigate, not a verdict of pure waste.

## Dynamic + filter-driven

Window is `clampWindowDays`, ClickHouse-clock derived (`now() - INTERVAL w DAY`), never the Node clock, threaded into `queryFeatureEconomics` and both live queries. `filters.feature` binds as an `Array(String)` param. No static fallback.

## Verification

- `npm run typecheck`, `npm run lint` clean; `npm run test` green except the long-standing `api.test.ts` "falls back to mock when ClickHouse is unreachable" case that fails only when a local ClickHouse is running (passes in CI).
- Live against ClickHouse (tenant `local-dev`, partial attribution): tenant-wide attribution rate ~0.993, and the detector flags **only** the 2 genuinely unattributed features (`chatbot-demo`, `cto182-e2e`), not a wall of every feature. Confirms it does not false-positive the whole tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)