### PR TITLE
feat(web): wrong-sized-model waste detector (CTO-231, W4)

### DIFF
--- a/web/lib/waste/wrong-sized-model.test.ts
+++ b/web/lib/waste/wrong-sized-model.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for the pure wrong-sized-model detector (CTO-231, W4). These cover the detection LOGIC:
+// it flags a cheaper candidate whose quality CI overlaps the incumbent (no significant regression),
+// it does NOT flag a candidate the judge finds significantly worse, and it emits nothing (never a
+// zero-dollar finding) when the eval is below the judged floor or the input is empty. The live
+// collectWrongSizedModel wiring is exercised against the stack (numbers in the PR body).
+
+import { describe, expect, it } from "vitest";
+
+import {
+  detectWrongSizedModel,
+  type WrongSizedModelCandidate,
+  type WrongSizedModelInput,
+  type WrongSizedModelScope,
+} from "./wrong-sized-model";
+
+function candidate(over: Partial<WrongSizedModelCandidate> = {}): WrongSizedModelCandidate {
+  return {
+    candidateModel: "claude-haiku-4-5",
+    provider: "anthropic",
+    projectedMonthlyMicroUsd: 5_000_000_000, // cheaper than the 10B incumbent below
+    winRate: 0.49, // just below even, but CI overlaps 0.5 → no significant regression
+    ciLow: 0.44,
+    ciHigh: 0.54,
+    samplesJudged: 40,
+    samplesReplayed: 120,
+    ...over,
+  };
+}
+
+function scope(over: Partial<WrongSizedModelScope> = {}): WrongSizedModelScope {
+  return {
+    scopeKind: "model",
+    scopeValue: "claude-sonnet-4-5",
+    incumbentModel: "claude-sonnet-4-5",
+    windowSpendMicroUsd: 20_000_000_000, // $20,000 observed over the window
+    incumbentProjectedMonthlyMicroUsd: 10_000_000_000,
+    candidates: [candidate()],
+    ...over,
+  };
+}
+
+function input(scopes: WrongSizedModelScope[]): WrongSizedModelInput {
+  return { windowDays: 30, scopes };
+}
+
+describe("detectWrongSizedModel", () => {
+  it("flags a cheaper candidate whose quality CI overlaps the incumbent", () => {
+    const findings = detectWrongSizedModel(input([scope()]));
+    expect(findings).toHaveLength(1);
+    const f = findings[0];
+    expect(f.category).toBe("wrong_sized_model");
+    expect(f.scopeKind).toBe("model");
+    expect(f.scopeValue).toBe("claude-sonnet-4-5");
+    expect(f.drillHref).toBe("/compare");
+    // Candidate is half the incumbent's projected cost, so the window spend rescales to half and the
+    // recoverable is the other half: $20,000 → $10,000 recoverable.
+    expect(f.recoverableMicroUsd).toBe(10_000_000_000);
+    expect(f.windowSpendMicroUsd).toBe(20_000_000_000);
+    expect(f.evidence.incumbentModel).toBe("claude-sonnet-4-5");
+    expect(f.evidence.candidateModel).toBe("claude-haiku-4-5");
+    expect(f.evidence.projectedMonthlySavings).toBe(5_000_000_000);
+    expect(f.evidence.qualityCiLow).toBe(0.44);
+    expect(f.evidence.qualityCiHigh).toBe(0.54);
+    // Fidelity caveat is carried on the reason, matching the Compare diagnostics.
+    expect(f.reason).toContain("resolved-context replay, no live retrieval");
+  });
+
+  it("reports high confidence on a tight CI and medium on a wide one", () => {
+    const tight = detectWrongSizedModel(input([scope()]));
+    expect(tight[0].confidence).toBe("high"); // width 0.10
+
+    const wide = detectWrongSizedModel(
+      input([scope({ candidates: [candidate({ ciLow: 0.35, ciHigh: 0.6 })] })]),
+    );
+    expect(wide[0].confidence).toBe("medium"); // width 0.25
+  });
+
+  it("does NOT flag when the candidate quality significantly regresses (CI below the even line)", () => {
+    const regressed = candidate({ winRate: 0.3, ciLow: 0.2, ciHigh: 0.42 }); // ciHigh < 0.5
+    const findings = detectWrongSizedModel(input([scope({ candidates: [regressed] })]));
+    expect(findings).toEqual([]);
+  });
+
+  it("does NOT flag when the candidate is not cheaper", () => {
+    const pricey = candidate({ projectedMonthlyMicroUsd: 10_000_000_000 }); // equal to incumbent
+    const findings = detectWrongSizedModel(input([scope({ candidates: [pricey] })]));
+    expect(findings).toEqual([]);
+  });
+
+  it("returns nothing (never a zero-dollar finding) when eval is below the judged floor", () => {
+    const belowFloor = candidate({ samplesJudged: 4 }); // < MIN_JUDGED_SAMPLES
+    const findings = detectWrongSizedModel(input([scope({ candidates: [belowFloor] })]));
+    expect(findings).toEqual([]);
+  });
+
+  it("returns nothing when replay is below the replayed floor", () => {
+    const thinReplay = candidate({ samplesReplayed: 10 }); // < MIN_REPLAYED_SAMPLES
+    const findings = detectWrongSizedModel(input([scope({ candidates: [thinReplay] })]));
+    expect(findings).toEqual([]);
+  });
+
+  it("returns [] for empty input, not a fabricated finding", () => {
+    expect(detectWrongSizedModel(input([]))).toEqual([]);
+    expect(detectWrongSizedModel(input([scope({ candidates: [] })]))).toEqual([]);
+  });
+
+  it("surfaces the cheapest qualifying candidate (largest recoverable)", () => {
+    const cheaper = candidate({
+      candidateModel: "gemini-3-flash",
+      provider: "google",
+      projectedMonthlyMicroUsd: 2_500_000_000, // cheaper than the 5B haiku candidate
+    });
+    const findings = detectWrongSizedModel(input([scope({ candidates: [candidate(), cheaper] })]));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].evidence.candidateModel).toBe("gemini-3-flash");
+    // $20,000 rescaled to a quarter (2.5B/10B) = $5,000, recoverable $15,000.
+    expect(findings[0].recoverableMicroUsd).toBe(15_000_000_000);
+  });
+
+  it("ignores a regressing candidate but still flags a qualifying cheaper one in the same scope", () => {
+    const regressed = candidate({
+      candidateModel: "gpt-5-mini",
+      provider: "openai",
+      projectedMonthlyMicroUsd: 1_000_000_000,
+      winRate: 0.25,
+      ciLow: 0.15,
+      ciHigh: 0.35, // significantly worse — disqualified despite being cheapest
+    });
+    const findings = detectWrongSizedModel(input([scope({ candidates: [regressed, candidate()] })]));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].evidence.candidateModel).toBe("claude-haiku-4-5");
+  });
+
+  it("does not flag when the incumbent has no positive projection to rescale against", () => {
+    const findings = detectWrongSizedModel(
+      input([scope({ incumbentProjectedMonthlyMicroUsd: 0 })]),
+    );
+    expect(findings).toEqual([]);
+  });
+});

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Wrong-sized-model waste detector (CTO-231, W4; epic CTO-227).
+//
+// WHY: the epic answers "where is this tenant paying for AI that returns nothing". One shape of that
+// waste is running an expensive model on work a cheaper one handles at statistically indistinguishable
+// quality. The Compare workflow (CTO-113 replay + CTO-114 pairwise-judge eval) already measures both
+// halves of that claim honestly: a cheaper candidate's replay-projected cost AND its pairwise win-rate
+// vs the incumbent with a Wilson 95% CI. This detector does not re-measure anything; it reads those
+// existing results and, ONLY when they clear the same judged/replayed floors the /compare route uses,
+// turns a clear cost win at no significant quality regression into a WasteFinding.
+//
+// The honesty posture (CLAUDE.md, and the "no fake quality number" rule the /compare page already
+// enforces) is load-bearing: if there is no eval pass (below the judged floor) or no replay for the
+// tenant, this detector emits NOTHING for that scope. There is deliberately NO mock path. A quality
+// regression whose CI sits below the pairwise even line disqualifies the candidate; we never present a
+// guessed saving over a candidate we cannot show is at least as good.
+//
+// The pure detector (detectWrongSizedModel) is I/O-free and deterministic so it is trivially testable;
+// collectWrongSizedModel does the ClickHouse + Compare-path reads and maps them through it.
+
+import type { MicroUSD } from "@/lib/types";
+import type { WasteConfidence, WasteFinding, WasteScopeKind } from "@/lib/waste";
+import { clampWindowDays } from "@/lib/explore";
+import type { DimensionFilters } from "@/lib/filters";
+import {
+  queryCostExplore,
+  queryCurrentModel,
+  queryEvalCandidates,
+  queryReplayCandidates,
+} from "@/lib/clickhouse";
+
+// The pairwise-LLM-judge win-rate is candidate-vs-incumbent, so the incumbent's own quality is the
+// 0.5 "even" line by construction: a candidate that wins half the judged pairs is a statistical tie
+// with the incumbent. "No significant regression" is therefore "the candidate's win-rate CI still
+// reaches the even line", i.e. its upper bound is at least 0.5. A CI sitting entirely below 0.5 is a
+// candidate the judge finds significantly WORSE, and it is disqualified.
+const PAIRWISE_EVEN = 0.5;
+
+// Match the /compare route's floors exactly (CTO-114 MIN_JUDGED_SAMPLES, CTO-123 MIN_REPLAYED_SAMPLES):
+// below these a candidate's quality / cost projection is too thin to act on, so it contributes no
+// finding. Keeping the same constants means this detector and /compare agree on when a candidate
+// "counts", rather than inventing a second, looser bar.
+const MIN_JUDGED_SAMPLES = 10;
+const MIN_REPLAYED_SAMPLES = 50;
+
+// A Wilson 95% CI narrower than this is "tight" — a clear, well-bounded overlap with the even line,
+// which we report at high confidence. A wider (but still non-regressing) CI is real signal but a
+// looser one, so it lands at medium. This gates ONLY confidence, never the dollar math.
+const TIGHT_CI_WIDTH = 0.1;
+
+// The fidelity caveat every Compare projection carries (CTO diagnostics / the /compare page): the
+// replay resolves captured context rather than re-running live retrieval, so a finding built on it
+// must say so rather than imply a live A/B. Kept verbatim so the wording matches the page.
+const REPLAY_FIDELITY_CAVEAT = "resolved-context replay, no live retrieval";
+
+/**
+ * One cheaper candidate for a scope, as measured by the Compare workflow. `projectedMonthlyMicroUsd`
+ * is the candidate's replay-projected monthly cost over the SAME corpus the incumbent projection uses,
+ * so its ratio to the incumbent's projection is the per-call cost ratio we rescale current spend by.
+ * `winRate` / `ciLow` / `ciHigh` are the pairwise-judge win-rate (0..1) vs the incumbent and its
+ * Wilson 95% CI. Sample counts are the judged / replayed floors gate.
+ */
+export interface WrongSizedModelCandidate {
+  candidateModel: string;
+  provider: string;
+  projectedMonthlyMicroUsd: MicroUSD;
+  winRate: number;
+  ciLow: number;
+  ciHigh: number;
+  samplesJudged: number;
+  samplesReplayed: number;
+}
+
+/**
+ * One scope (an incumbent model, optionally within a feature) with its current windowed spend, the
+ * incumbent's own replay-projected monthly cost (the rescale denominator), and the cheaper candidates
+ * the Compare workflow measured against it.
+ */
+export interface WrongSizedModelScope {
+  scopeKind: WasteScopeKind;
+  scopeValue: string;
+  /** Feature label for the detail view, when the scope is narrowed to one feature. */
+  feature?: string;
+  incumbentModel: string;
+  /** Observed spend on this scope over the window. Always known. Integer micro-USD. */
+  windowSpendMicroUsd: MicroUSD;
+  /** Incumbent's replay-projected monthly cost over the same corpus as the candidates. */
+  incumbentProjectedMonthlyMicroUsd: MicroUSD;
+  candidates: WrongSizedModelCandidate[];
+}
+
+export interface WrongSizedModelInput {
+  windowDays: number;
+  scopes: WrongSizedModelScope[];
+}
+
+/** Round to integer micro-USD. Money is never a float across the boundary. */
+function microRound(n: number): number {
+  return Math.round(n);
+}
+
+/**
+ * Does this candidate qualify? It must be measured over both floors, be cheaper than the incumbent on
+ * the replay projection, AND show no significant quality regression (its win-rate CI upper bound still
+ * reaches the pairwise even line). A candidate the judge finds significantly worse (ciHigh < 0.5) is
+ * rejected even when it is cheaper — that is the whole "no fake saving over a worse model" rule.
+ */
+function qualifies(c: WrongSizedModelCandidate, incumbentProjectedMonthlyMicroUsd: MicroUSD): boolean {
+  if (c.samplesJudged < MIN_JUDGED_SAMPLES) return false;
+  if (c.samplesReplayed < MIN_REPLAYED_SAMPLES) return false;
+  // A ratio is only defensible when the incumbent has a positive projection to rescale against.
+  if (incumbentProjectedMonthlyMicroUsd <= 0) return false;
+  if (c.projectedMonthlyMicroUsd >= incumbentProjectedMonthlyMicroUsd) return false;
+  // No significant regression: the CI still overlaps (or sits above) the even line.
+  return c.ciHigh >= PAIRWISE_EVEN;
+}
+
+/**
+ * Detect wrong-sized-model waste. PURE and deterministic.
+ *
+ * For each scope, consider only candidates that clear both sample floors, are cheaper on the replay
+ * projection, and show no significant quality regression (see {@link qualifies}). Among those, the one
+ * with the lowest projected cost recovers the most, so it is the one we surface — one finding per
+ * scope. Recoverable is the current windowed spend minus that spend rescaled to the candidate's
+ * per-call replay cost:
+ *
+ *     recoverable = windowSpend - round(windowSpend × candidateProjected / incumbentProjected)
+ *
+ * which is always positive here (the candidate is strictly cheaper). Confidence is `high` when the
+ * winning candidate's CI is tight, `medium` otherwise. A scope with no qualifying candidate yields
+ * NOTHING — never a zero-dollar finding.
+ */
+export function detectWrongSizedModel(input: WrongSizedModelInput): WasteFinding[] {
+  const findings: WasteFinding[] = [];
+
+  for (const scope of input.scopes) {
+    const eligible = scope.candidates.filter((c) =>
+      qualifies(c, scope.incumbentProjectedMonthlyMicroUsd),
+    );
+    if (eligible.length === 0) continue;
+
+    // Cheapest qualifying candidate = largest recoverable. Ties break on the higher win-rate, then on
+    // the model id, so the choice is deterministic regardless of input order.
+    const best = eligible.reduce((a, b) => {
+      if (b.projectedMonthlyMicroUsd !== a.projectedMonthlyMicroUsd) {
+        return b.projectedMonthlyMicroUsd < a.projectedMonthlyMicroUsd ? b : a;
+      }
+      if (b.winRate !== a.winRate) return b.winRate > a.winRate ? b : a;
+      return b.candidateModel < a.candidateModel ? b : a;
+    });
+
+    const ratio = best.projectedMonthlyMicroUsd / scope.incumbentProjectedMonthlyMicroUsd;
+    const rescaled = microRound(scope.windowSpendMicroUsd * ratio);
+    const recoverableMicroUsd = Math.max(0, scope.windowSpendMicroUsd - rescaled);
+    const projectedMonthlySavings = Math.max(
+      0,
+      scope.incumbentProjectedMonthlyMicroUsd - best.projectedMonthlyMicroUsd,
+    );
+    const qualityDelta = best.winRate - PAIRWISE_EVEN;
+    // Round the width before the threshold test so float noise (0.54 - 0.44 = 0.1000…03) does not
+    // tip a genuinely tight CI over the boundary.
+    const ciWidth = Math.round((best.ciHigh - best.ciLow) * 1000) / 1000;
+    const confidence: WasteConfidence = ciWidth <= TIGHT_CI_WIDTH ? "high" : "medium";
+
+    const featureClause = scope.feature ? ` on ${scope.feature}` : "";
+    findings.push({
+      category: "wrong_sized_model",
+      scopeKind: scope.scopeKind,
+      scopeValue: scope.scopeValue,
+      recoverableMicroUsd,
+      windowSpendMicroUsd: scope.windowSpendMicroUsd,
+      confidence,
+      title: `${scope.incumbentModel} is over-sized for this workload`,
+      reason:
+        `${best.candidateModel} replayed cheaper than ${scope.incumbentModel}${featureClause} at no ` +
+        `significant quality regression (pairwise win-rate ${best.winRate.toFixed(2)}, 95% CI ` +
+        `${best.ciLow.toFixed(2)}-${best.ciHigh.toFixed(2)} overlaps the even line). Figures are from ` +
+        `${REPLAY_FIDELITY_CAVEAT}.`,
+      evidence: {
+        incumbentModel: scope.incumbentModel,
+        candidateModel: best.candidateModel,
+        qualityDelta: Math.round(qualityDelta * 1000) / 1000,
+        qualityCiLow: Math.round(best.ciLow * 1000) / 1000,
+        qualityCiHigh: Math.round(best.ciHigh * 1000) / 1000,
+        projectedMonthlySavings,
+      },
+      drillHref: "/compare",
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * The model id ClickHouse attributes spend to, matching the resolution `queryCostExplore`'s `model`
+ * dimension and `queryCurrentModel` both use (response model when present, request model otherwise).
+ * The incumbent from `queryCurrentModel` already resolves this way, so we compare against it directly.
+ */
+function resolveIncumbentModel(model: string): string {
+  return model;
+}
+
+/**
+ * Collect wrong-sized-model findings from the LIVE stack (CTO-231).
+ *
+ * This reuses the EXISTING Compare workflow reads — the cached `/v1/replay` (CTO-113) and `/v1/eval`
+ * (CTO-114) projections behind the /compare page, plus the live current model — rather than re-running
+ * replay or eval. It joins them to the windowed cost-by-model read (`queryCostExplore` grouped by
+ * model) so the incumbent's window spend, the rescale denominator, and the candidates all describe the
+ * same tenant slice, then maps through {@link detectWrongSizedModel}.
+ *
+ * Filter-driven: the window is clamped ClickHouse-clock days, `filters.feature` narrows the Compare
+ * projection (a single selected feature becomes the compare tag) and the cost read, and `filters.model`
+ * restricts which incumbent model we will flag. There is NO static fallback: if replay, eval, the
+ * current model, or the cost read is unavailable — as on a demo tenant with no eval pass — this returns
+ * `[]`, which is the honest answer, not a failure.
+ */
+export async function collectWrongSizedModel(
+  windowDays: number,
+  filters: DimensionFilters,
+): Promise<WasteFinding[]> {
+  const window = clampWindowDays(windowDays);
+
+  // The Compare projection is per-feature-tag. Only a single selected feature maps cleanly onto one
+  // tag; zero or several features means "all traffic" (undefined tag), matching how /compare scopes.
+  const featureTag = filters.feature.length === 1 ? filters.feature[0] : undefined;
+
+  // Reuse the cached Compare-path reads. Any null means the signal we require is unavailable; there is
+  // no mock path, so we return [] rather than guess.
+  const [replay, evalProj, live] = await Promise.all([
+    queryReplayCandidates(featureTag),
+    queryEvalCandidates(featureTag),
+    queryCurrentModel(),
+  ]);
+  if (!replay || !evalProj || !live) return [];
+
+  const incumbentModel = resolveIncumbentModel(live.model);
+
+  // If the caller filtered to specific models and the incumbent is not among them, there is nothing to
+  // flag for this slice.
+  if (filters.model.length > 0 && !filters.model.includes(incumbentModel)) return [];
+
+  // Windowed cost-by-model over the same slice, so the incumbent's window spend comes from real
+  // telemetry rather than the 7-day→30-day projection the Compare current-cost uses.
+  const costByModel = await queryCostExplore({
+    window: { kind: "preset", days: window },
+    groupBy: "model",
+    filters: {
+      ...(filters.feature.length > 0 ? { feature: filters.feature } : {}),
+      ...(filters.model.length > 0 ? { model: filters.model } : {}),
+    },
+  });
+  if (!costByModel) return [];
+
+  const incumbentRow = costByModel.breakdown.find((r) => r.group === incumbentModel);
+  // No observed spend on the incumbent in this window → nothing to recover, so nothing to report.
+  if (!incumbentRow || incumbentRow.totalMicroUsd <= 0) return [];
+
+  // Join replay (cost) and eval (quality) by provider+model, excluding the incumbent itself.
+  const candidates: WrongSizedModelCandidate[] = [];
+  for (const r of replay.per_candidate) {
+    if (r.model === incumbentModel) continue;
+    const e = evalProj.per_candidate.find((x) => x.provider === r.provider && x.model === r.model);
+    if (!e) continue;
+    candidates.push({
+      candidateModel: r.model,
+      provider: r.provider,
+      projectedMonthlyMicroUsd: r.projected_monthly_cost_micro_usd,
+      winRate: e.win_rate,
+      ciLow: e.win_rate_ci_lo,
+      ciHigh: e.win_rate_ci_hi,
+      samplesJudged: e.samples_judged,
+      samplesReplayed: r.samples_replayed,
+    });
+  }
+  if (candidates.length === 0) return [];
+
+  return detectWrongSizedModel({
+    windowDays: window,
+    scopes: [
+      {
+        scopeKind: "model",
+        scopeValue: incumbentModel,
+        feature: featureTag,
+        incumbentModel,
+        windowSpendMicroUsd: incumbentRow.totalMicroUsd,
+        incumbentProjectedMonthlyMicroUsd: live.monthlyCostMicroUsd,
+        candidates,
+      },
+    ],
+  });
+}


### PR DESCRIPTION
## What

W4 of the waste-detection epic (CTO-227): the **wrong-sized-model** detector. It flags an expensive model doing work a cheaper one handles at statistically indistinguishable quality. One self-contained module, `web/lib/waste/wrong-sized-model.ts` (+ test). No shared files touched.

## How it stays grounded (never guessed)

It does **not** re-run replay or eval. It reuses the existing Compare workflow reads (CTO-113 `/v1/replay` cost projection, CTO-114 `/v1/eval` pairwise-judge win-rate + Wilson 95% CI) and joins them to the windowed cost-by-model read (`queryCostExplore` grouped by model).

A cheaper candidate qualifies **only** when:
- it clears the same judged (>= 10) and replayed (>= 50) floors the `/compare` route uses, AND
- its replay-projected cost is lower than the incumbent's, AND
- its win-rate CI shows **no significant regression** — the pairwise judge measures candidate-vs-incumbent, so the incumbent's own quality is the 0.5 even line; the candidate's CI must still reach it (`ciHigh >= 0.5`). A CI sitting entirely below 0.5 (significantly worse) is disqualified even when cheaper.

`recoverable = windowSpend - round(windowSpend x candidateProjected / incumbentProjected)` — current spend minus that spend rescaled to the candidate's per-call replay cost. Confidence is `high` on a tight CI, else `medium`. Evidence carries `{ incumbentModel, candidateModel, qualityDelta, qualityCiLow, qualityCiHigh, projectedMonthlySavings }`; `drillHref` is `/compare`; the `reason` carries the Compare fidelity caveat ("resolved-context replay, no live retrieval").

**There is no mock path by design** (matches the "no fake quality number" rule on `/compare`): if there is no eval pass or no replay for the tenant, the detector emits nothing for that scope — never a zero-dollar finding.

## Dynamic + filter-driven

`collectWrongSizedModel(windowDays, filters)` clamps the window (ClickHouse-clock derived via `clampWindowDays`), applies `filters.feature` (a single selected feature becomes the compare tag) and `filters.model` (restricts the incumbent), binds filter values as params, and returns `[]` when any required signal is unavailable.

## Live verification

`collectWrongSizedModel(30, emptyFilters)` against the live stack returns `[]`. The demo tenant has **no eval pass**, so the honest answer is an empty finding set — this is correct behaviour, not a failure.

## Tests

Pure detector: flags a cheaper candidate whose CI overlaps the incumbent (recoverable = the rescaled delta); does NOT flag on a quality regression or when the candidate is not cheaper; returns `[]` when eval/replay is below the floor or the input is empty (never a zero-dollar finding); picks the cheapest qualifying candidate; high/medium confidence on tight/wide CI.

## Checks

- `npm run typecheck` clean
- `npm run lint` clean (only the pre-existing `useLivePoll.ts` warning)
- `npm run test`: 634 passed; the sole failure is the long-standing `api.test.ts` "falls back to mock when ClickHouse is unreachable" case, which fails whenever a local ClickHouse IS running (documented in CLAUDE.md; passes in CI). No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)