### PR TITLE
feat(web): waste aggregation endpoint /api/waste (CTO-234, W7)

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -19,6 +19,7 @@ import {
 import { GET as GuardrailsGET, POST as GuardrailsPOST } from "./guardrails/route";
 import { GET as AttributionGET } from "./attribution/route";
 import { GET as CacGET } from "./cac/route";
+import { GET as WasteGET } from "./waste/route";
 
 async function json<T = unknown>(res: Response): Promise<T> {
   return (await res.json()) as T;
@@ -203,5 +204,18 @@ describe("api routes", () => {
       }),
     );
     expect(bad.status).toBe(422);
+  });
+
+  it("GET /api/waste returns a WasteReport (findings + byCategory), resilient to empty", async () => {
+    // CTO-234: the waste endpoint runs all five detectors and rolls them up with aggregateWaste.
+    // Detectors return [] when their data is unavailable, so the report may be empty; assert only the
+    // stable WasteReport shape, never a specific finding count.
+    const body = await json<{
+      findings: unknown[];
+      byCategory: Record<string, unknown>;
+    }>(await WasteGET(new Request("http://test/api/waste")));
+    expect(Array.isArray(body.findings)).toBe(true);
+    expect(body.byCategory).toBeTypeOf("object");
+    expect(body.byCategory).not.toBeNull();
   });
 });

--- a/web/app/api/waste/route.ts
+++ b/web/app/api/waste/route.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// The waste-detection aggregation endpoint (CTO-234, W7 of epic CTO-227). This is the single surface
+// the waste page reads: it runs every detector over the SAME URL-synced filter state the FilterBar
+// writes (range / from / to / feature / model / provider / layer / account) and rolls the findings
+// up with the pure `aggregateWaste`, so a shared dashboard link and its data request are one string.
+//
+// Why run all five concurrently and tolerate empties (CTO-227 boundary): each detector already
+// tenant-scopes, windows off the ClickHouse clock, and returns `[]` when its data is unavailable, so
+// one dead detector must never blank the whole page. Promise.all fans them out; the flat union feeds
+// the roll-up.
+//
+// Honesty posture (CLAUDE.md, CTO-227): this endpoint never fabricates a finding. The detectors emit
+// nothing on unavailability rather than a guessed figure, and `aggregateWaste` keeps recoverable
+// dollars null (an honest blank) rather than 0 when they cannot be bounded. Only a HARD failure (a
+// thrown error) sets `report.unavailable` to a real reason on an otherwise-empty report shell.
+
+import { NextResponse } from "next/server";
+
+import { collectPaidForNothing } from "@/lib/waste/paid-for-nothing";
+import { collectDuplicatedWork } from "@/lib/waste/duplicated-work";
+import { collectWrongSizedModel } from "@/lib/waste/wrong-sized-model";
+import { collectNoMeasuredReturn } from "@/lib/waste/no-measured-return";
+import { collectStructuralInefficiency } from "@/lib/waste/structural-inefficiency";
+import { aggregateWaste, type WasteReport } from "@/lib/waste";
+import { parseFilters, rangeDays } from "@/lib/filters";
+
+// Read live data per request (never statically cached): the window and dimension filters come off the
+// URL, so the report is dynamic, not static.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  // Plain URL API (not NextRequest.nextUrl) so unit tests can pass a bare Request.
+  const sp = new URL(request.url).searchParams;
+  const state = parseFilters(sp);
+  // Window is the URL time-range resolved to a day count; the detectors clamp it against the
+  // ClickHouse clock. Never hardcoded (CTO-234).
+  const windowDays = rangeDays(state.range);
+
+  try {
+    // Fan every detector out over the same (windowDays, filters). Each returns [] on unavailability,
+    // so a single dead detector never blanks the page (CTO-227).
+    const perDetector = await Promise.all([
+      collectPaidForNothing(windowDays, state.filters),
+      collectDuplicatedWork(windowDays, state.filters),
+      collectWrongSizedModel(windowDays, state.filters),
+      collectNoMeasuredReturn(windowDays, state.filters),
+      collectStructuralInefficiency(windowDays, state.filters),
+    ]);
+    const allFindings = perDetector.flat();
+    return NextResponse.json(aggregateWaste(allFindings, windowDays));
+  } catch (err) {
+    // Hard failure: return an honest unavailable shell (empty findings, null totals) rather than a
+    // fabricated or partial report (CTO-227 honesty). Never invent findings.
+    const reason = err instanceof Error ? err.message : "waste report unavailable";
+    const shell: WasteReport = {
+      findings: [],
+      totalRecoverableMicroUsd: null,
+      byCategory: {
+        paid_for_nothing: null,
+        duplicated_work: null,
+        wrong_sized_model: null,
+        no_measured_return: null,
+        structural_inefficiency: null,
+      },
+      generatedForWindowDays: windowDays,
+      unavailable: reason,
+    };
+    return NextResponse.json(shell);
+  }
+}


### PR DESCRIPTION
Implements CTO-234 (W7) of the waste-detection epic (CTO-227): the `/api/waste` aggregation endpoint the waste page reads.

## Endpoint contract
`GET /api/waste` (`dynamic = "force-dynamic"`, `runtime = "nodejs"`):
- Parses the URL-synced filter state (`parseFilters`), resolves the window with `rangeDays(state.range)`, and passes `state.filters` (the `DimensionFilters`) to every detector. The window and dimension filters are read off the URL, never hardcoded.
- Runs all five detectors CONCURRENTLY with `Promise.all` over `(windowDays, state.filters)`:
  - `collectPaidForNothing`
  - `collectDuplicatedWork`
  - `collectWrongSizedModel`
  - `collectNoMeasuredReturn`
  - `collectStructuralInefficiency`
- Flattens the findings and returns `aggregateWaste(allFindings, windowDays)` as JSON (a `WasteReport`).
- Honest failure: each detector already tenant-scopes, windows off the ClickHouse clock, and returns `[]` on unavailability, so a single dead detector never blanks the page. Only a HARD thrown failure sets `report.unavailable` to a real reason on an otherwise-empty shell (empty findings, null totals). No findings are ever fabricated.

Detector modules and `lib/waste.ts` were NOT modified; only the route and one smoke test were added.

## Live JSON summary (proves it is dynamic)

Default call `GET /api/waste` (30-day window, no filters):
- findings: **35**
- totalRecoverableMicroUsd: **20775953246** (~$20,776)
- per-category counts: `duplicated_work: 33`, `no_measured_return: 2`
- byCategory: `duplicated_work: 20775872870`, `no_measured_return: 80376`, others `null`
- generatedForWindowDays: 30, unavailable: null

Filtered call `GET /api/waste?range=7d&feature=chatbot`:
- findings: **4**
- totalRecoverableMicroUsd: **448649729** (~$449)
- per-category counts: `duplicated_work: 4`
- byCategory: `duplicated_work: 448649729`, others `null`
- generatedForWindowDays: 7, unavailable: null

The filters change the result: 35 to 4 findings, window 30 to 7 days, and total recoverable drops from ~$20,776 to ~$449. The endpoint is genuinely dynamic and honours both the window and the dimension filters from the URL.

## Verification
From `web/`:
- `npm run typecheck` clean
- `npm run lint` clean (only a pre-existing unrelated warning in `lib/useLivePoll.ts`)
- `npm run test`: the new waste smoke test passes; the only failure is the long-standing `app/api/api.test.ts` ClickHouse-running case ("attribution falls back to mock when ClickHouse is unreachable"), which is expected when a local ClickHouse is up. No new failures introduced.
- `npm run build` (after `rm -rf .next`, no dev server): succeeds; `/api/waste` registers as a dynamic (ƒ) route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)