### PR TITLE
feat(web): waste dashboard page /waste (CTO-235, W8)

### DIFF
--- a/web/app/waste/Live.tsx
+++ b/web/app/waste/Live.tsx
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Client-side live wrapper for /waste (CTO-235, W8 of epic CTO-227), on the interactive design
+// foundation (CTO-224 primitives: PageHeader + FilterBar + SummaryTile + DataTable + honest values).
+//
+// The server component owns the first paint; here we re-derive the endpoint from useFilters so a
+// window or dimension change re-queries, and useLivePoll refreshes it on an interval (mirrors
+// agents/Live.tsx). Every dollar renders through <Money>: a finding that cannot bound its recoverable
+// spend is a null, shown as an honest <Blank> with a reason, NEVER $0 (CTO-227 honesty posture) --
+// a guessed zero would read as "nothing to save here", the opposite of an un-quantifiable finding.
+
+"use client";
+
+import Link from "next/link";
+import { Suspense, useMemo } from "react";
+
+import { Card } from "@/components/Card";
+import { DataTable, type Column } from "@/components/DataTable";
+import { FilterBar, type FilterOption } from "@/components/FilterBar";
+import { Blank, Money } from "@/components/HonestValue";
+import { LiveIndicator } from "@/components/LiveIndicator";
+import { PageHeader } from "@/components/PageHeader";
+import { SummaryTile, TileGrid } from "@/components/SummaryTile";
+import { useFilters } from "@/lib/useFilters";
+import { useLivePoll } from "@/lib/useLivePoll";
+import {
+  WASTE_CATEGORIES,
+  type WasteCategory,
+  type WasteConfidence,
+  type WasteFinding,
+  type WasteReport,
+} from "@/lib/waste";
+
+// Readable labels for the closed WasteCategory union (CTO-235). Kept local, per the ticket, so the
+// pure lib/waste.ts stays free of presentation. The union is closed, so this Record is exhaustive and
+// a new category would force a compile error here until it is labelled.
+const CATEGORY_LABEL: Record<WasteCategory, string> = {
+  paid_for_nothing: "Paid for nothing",
+  duplicated_work: "Duplicated work",
+  wrong_sized_model: "Wrong-sized model",
+  no_measured_return: "No measured return",
+  structural_inefficiency: "Structural inefficiency",
+};
+
+// Why a per-category tile / the headline can be blank: at least one finding may exist yet none could
+// put a defensible dollar bound on what stopping it recovers. That is a null all the way through the
+// report (CTO-227), rendered as an honest blank rather than $0.
+const NO_BOUNDED_TOTAL = "no finding could be bounded to a dollar amount";
+const NO_BOUNDED_CATEGORY = "no finding in this category could be bounded to a dollar amount";
+
+export function WasteLive({ initialData }: { initialData: WasteReport }) {
+  // The FilterBar writes the window + dimension filters to the URL; useFilters reads them back as a
+  // query string that rides onto /api/waste, so flipping 7d/30d/90d or a feature/model filter
+  // re-parameterises the endpoint and useLivePoll re-fetches the re-windowed report (CTO-235).
+  const { queryString } = useFilters();
+  const endpoint = queryString ? `/api/waste?${queryString}` : "/api/waste";
+  const { data: report, updatedAt } = useLivePoll<WasteReport>(endpoint, initialData);
+
+  const findings = report.findings;
+
+  // Filter options come from the findings themselves (their scopeValues), not a separate fetch: the
+  // report is the only data this page has, and a dimension with no findings simply offers no control.
+  const featureOptions = scopeOptions(findings, "feature");
+  const modelOptions = scopeOptions(findings, "model");
+
+  // Per-category finding counts, for the tile hints. A category with no findings still gets a key.
+  const countByCategory = useMemo(() => {
+    const counts = {} as Record<WasteCategory, number>;
+    for (const c of WASTE_CATEGORIES) counts[c] = 0;
+    for (const f of findings) counts[f.category] += 1;
+    return counts;
+  }, [findings]);
+
+  const columns = useMemo<Column<WasteFinding>[]>(
+    () => [
+      {
+        key: "category",
+        header: "Category",
+        sortValue: (f) => CATEGORY_LABEL[f.category],
+        render: (f) => <span className="font-medium">{CATEGORY_LABEL[f.category]}</span>,
+      },
+      {
+        key: "where",
+        header: "Where",
+        sortValue: (f) => f.scopeValue,
+        render: (f) => (
+          <span className="flex items-center gap-1.5">
+            <span className="rounded bg-ink px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted">
+              {f.scopeKind}
+            </span>
+            {f.drillHref ? (
+              <Link href={f.drillHref} className="font-mono text-accent hover:underline">
+                {f.scopeValue}
+              </Link>
+            ) : (
+              <span className="font-mono">{f.scopeValue}</span>
+            )}
+          </span>
+        ),
+      },
+      {
+        key: "recoverable",
+        header: "Recoverable",
+        align: "right",
+        cellClassName: "font-semibold",
+        // Nulls sort last in DataTable, so the biggest bounded opportunities lead and the
+        // un-quantifiable ones trail -- matching aggregateWaste's own ordering.
+        sortValue: (f) => f.recoverableMicroUsd,
+        render: (f) => (
+          // A null recoverable is an honest blank with a reason, NEVER $0 (CTO-227).
+          <Money
+            micro={f.recoverableMicroUsd}
+            reason="this finding is real but its recoverable spend could not be defensibly bounded"
+          />
+        ),
+      },
+      {
+        key: "windowSpend",
+        header: "Window spend",
+        align: "right",
+        cellClassName: "text-muted",
+        sortValue: (f) => f.windowSpendMicroUsd,
+        // Always known (observed spend on the scope over the window), so no blank branch here.
+        render: (f) => <Money micro={f.windowSpendMicroUsd} />,
+      },
+      {
+        key: "confidence",
+        header: "Confidence",
+        // Sort high -> medium -> low by an explicit rank, not the string, so the order is meaningful.
+        sortValue: (f) => confidenceRank(f.confidence),
+        render: (f) => <ConfidenceBadge confidence={f.confidence} />,
+      },
+      {
+        key: "reason",
+        header: "Reason",
+        headerClassName: "pl-4",
+        cellClassName: "pl-4 text-muted max-w-md",
+        render: (f) => <span>{f.reason}</span>,
+      },
+    ],
+    [],
+  );
+
+  const body = (
+    <div className="space-y-6">
+      <TileGrid>
+        <SummaryTile
+          label="Recoverable"
+          micro={report.totalRecoverableMicroUsd}
+          reason={NO_BOUNDED_TOTAL}
+          // The total is over the SELECTED window, not a month -- label it with the real day count.
+          hint={`last ${report.generatedForWindowDays} days · ${findings.length} finding${
+            findings.length === 1 ? "" : "s"
+          }`}
+        />
+        {WASTE_CATEGORIES.map((c) => (
+          <SummaryTile
+            key={c}
+            label={CATEGORY_LABEL[c]}
+            micro={report.byCategory[c]}
+            reason={NO_BOUNDED_CATEGORY}
+            hint={`${countByCategory[c]} finding${countByCategory[c] === 1 ? "" : "s"}`}
+          />
+        ))}
+      </TileGrid>
+
+      <Card title="Findings — hypotheses with evidence, not verdicts">
+        {report.unavailable ? (
+          // Hard failure: the report could not be produced. Render the honest reason, not an empty
+          // table that would read as "no waste" (CTO-227).
+          <p className="text-sm">
+            <Blank reason={report.unavailable} /> the waste report is unavailable for this window.
+          </p>
+        ) : findings.length === 0 ? (
+          // GOOD news, not a broken page: nothing recoverable was detected in this window.
+          <p className="text-sm text-good">
+            No recoverable waste found in this window. Every detector ran and flagged nothing.
+          </p>
+        ) : (
+          <DataTable
+            columns={columns}
+            rows={findings}
+            rowKey={(f, i) => `${f.category}:${f.scopeKind}:${f.scopeValue}:${f.title}:${i}`}
+            initialSort={{ key: "recoverable", direction: "desc" }}
+            pageSize={25}
+          />
+        )}
+      </Card>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Waste"
+        subtitle="Recoverable AI spend: findings are hypotheses with evidence, not verdicts."
+        actions={<LiveIndicator updatedAt={updatedAt} />}
+        toolbar={
+          <Suspense fallback={null}>
+            <FilterBar
+              hideGroupBy
+              options={{ feature: featureOptions, model: modelOptions }}
+            />
+          </Suspense>
+        }
+      />
+      {body}
+    </div>
+  );
+}
+
+/** Distinct scopeValues for a dimension across the findings, as FilterBar options (dedup, in order). */
+function scopeOptions(findings: WasteFinding[], kind: WasteFinding["scopeKind"]): FilterOption[] {
+  const seen = new Set<string>();
+  const out: FilterOption[] = [];
+  for (const f of findings) {
+    if (f.scopeKind !== kind || seen.has(f.scopeValue)) continue;
+    seen.add(f.scopeValue);
+    out.push({ value: f.scopeValue });
+  }
+  return out;
+}
+
+/** Rank for sorting: a higher number is more confident, so a descending sort leads with high. */
+function confidenceRank(c: WasteConfidence): number {
+  return c === "high" ? 3 : c === "medium" ? 2 : 1;
+}
+
+/**
+ * Confidence badge. Confidence is trust in the FINDING, not a severity score, so none of the tones is
+ * green: a low-confidence finding is a caveat ("we are less sure this is waste"), and must NOT read as
+ * a clean bill of health (CTO-235). High is the strongest signal, low the most tentative.
+ */
+function ConfidenceBadge({ confidence }: { confidence: WasteConfidence }) {
+  const cls =
+    confidence === "high"
+      ? "bg-bad/20 text-bad"
+      : confidence === "medium"
+        ? "bg-warn/20 text-warn"
+        : "border border-dashed border-edge text-muted";
+  return (
+    <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>
+      {confidence}
+    </span>
+  );
+}

--- a/web/app/waste/page.tsx
+++ b/web/app/waste/page.tsx
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// The /waste dashboard page (CTO-235, W8 of epic CTO-227). Server component: it forwards the same
+// URL-synced filter state the FilterBar writes (range / from / to / feature / model / provider /
+// layer / account) to /api/waste, so SSR's first paint and the client's re-query read the one string.
+// The endpoint runs every detector and rolls the findings up; this page only renders the report.
+
+import { apiGet } from "@/lib/api";
+import { filtersToQueryString, parseFilters } from "@/lib/filters";
+import { searchParamsFromRecord } from "@/lib/searchParams";
+import type { WasteReport } from "@/lib/waste";
+import { WasteLive } from "./Live";
+
+export default async function WastePage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  // Mirror agents/page.tsx: the managed serializer rebuilds the query from the incoming params, so any
+  // deep-link key is preserved while the window + dimension filters ride onto /api/waste. The client
+  // re-derives the same endpoint from useFilters as the filters change, keeping SSR and CSR in step.
+  const sp = searchParamsFromRecord(await searchParams);
+  const qs = filtersToQueryString(parseFilters(sp), sp);
+  const endpoint = qs ? `/api/waste?${qs}` : "/api/waste";
+  const initialData = await apiGet<WasteReport>(endpoint);
+  return <WasteLive initialData={initialData} />;
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -42,6 +42,7 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
       { label: "Attribution", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },
       { label: "Cost per Customer", href: "/cost-per-customer" },
+      { label: "Waste", href: "/waste" },
     ],
   },
   {


### PR DESCRIPTION
## What this adds (CTO-235, W8 of epic CTO-227)

The `/waste` dashboard page: the reader-facing surface for the waste-detection feature. It renders the `WasteReport` from the `/api/waste` endpoint (W7) on the interactive design foundation, matching `agents/page.tsx` exactly.

- **`web/app/waste/page.tsx`** (server): forwards the URL-synced filter query string to `/api/waste` (`searchParamsFromRecord` -> `filtersToQueryString(parseFilters(sp), sp)`), `apiGet<WasteReport>`, renders `<WasteLive>`.
- **`web/app/waste/Live.tsx`** (`"use client"`): re-derives the endpoint from `useFilters().queryString` and polls with `useLivePoll<WasteReport>`, so the time range and feature/model filters re-query. `PageHeader` + `LiveIndicator` + `FilterBar` (feature/model dimension filters, group-by hidden). A `SummaryTile` row (Recoverable headline + a tile per `byCategory` entry). A sortable `DataTable` of findings (Category human label, Where with `drillHref` link + scope-kind chip, Recoverable, Window spend, Confidence badge, Reason), sorted by recoverable desc.
- **`web/components/Shell.tsx`**: adds `{ label: "Waste", href: "/waste" }` to the Analyze group, after Cost per Customer.

## Honesty posture (CTO-227)

Every dollar renders through `<Money>`. A finding that cannot bound its recoverable spend is an honest `<Blank>` with a reason, never `$0`. The Recoverable tile is labelled with the actual selected window ("last N days", not "per month" — the total is over the window). The confidence badge uses no green: `high` is the strongest signal, `low` is a dashed muted caveat that never reads as a clean bill of health. Empty findings render a good-news state; a hard `unavailable` renders its reason via `<Blank>`.

## Live finding summary (demo data)

At 30d the report yields ~35 findings dominated by `duplicated_work` (33 findings) and `no_measured_return` (2), totalling roughly $20.5k recoverable. Filtering to 7d re-queries to ~31 findings / ~$6.1k, confirming the window drives the query end-to-end.

## Screenshots

- **With findings**: 35 findings at 30d, Recoverable headline plus per-category tiles (Duplicated work dominant, others honest-blank), the findings table with scope chips, linked scope values, medium confidence badges, and one-line reasons.
- **7d re-query**: navigating to `?range=7d` re-fetches server-side — 31 findings, a different total (~$6.15k), and the Recoverable hint correctly reads "last 7 days".
- **Empty / honest state**: filtering to a feature that matches nothing renders the good-news message "No recoverable waste found in this window. Every detector ran and flagged nothing." in green, with every tile an honest blank and a Clear-filters affordance — not a broken page.

## Verification

From `web/`: `npm run typecheck`, `npm run lint` (only the pre-existing `useLivePoll.ts` unused-disable warning), `npm run test` (only the long-standing `app/api/api.test.ts` ClickHouse-running failure; the new `/api/waste` test passes), and `npm run build` (with no dev server active) all green. `/waste` is present in the build output.

Note: live click-to-re-query relies on `useLivePoll`, which pauses when the tab reports `visibilityState: hidden` (by design, shared by every dashboard page). The automated browser always reports hidden, so the 7d re-query was verified via a fresh server navigation, which exercises the same filter -> query path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)