### PR TITLE
fix(web): correct four waste-detection dollar bugs (CTO-227 review)

### DIFF
--- a/web/app/features/FeatureValueEvents.test.tsx
+++ b/web/app/features/FeatureValueEvents.test.tsx
@@ -24,6 +24,7 @@ function feature(overrides: Partial<FeatureEconomics>): FeatureEconomics {
     valuePerUserMicroUsd: null,
     paybackDays: null,
     attributionRate: null,
+    conversions: 0,
     attributionBreakdown: { direct: 0, sessionStitched: 0, identityGraphStitched: 0, unmatched: 0 },
     ...overrides,
   };

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -1540,6 +1540,10 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
           valuePerUserMicroUsd: null,
           paybackDays: null,
           attributionRate: null,
+          // CTO-227 review finding (Bug 3): carry the RAW conversion count even when the rate is
+          // nulled for trust. A sparse-but-converting feature has conversions > 0 here, which lets
+          // the no-measured-return detector tell it apart from a genuinely-unattributed one (0).
+          conversions,
           attributionBreakdown,
         };
       }
@@ -1557,6 +1561,7 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
         valuePerUserMicroUsd,
         paybackDays,
         attributionRate,
+        conversions,
         attributionBreakdown,
       };
     });
@@ -2713,12 +2718,15 @@ export async function queryCurrentModel(): Promise<{
       // uses `=== 2` for OTel error semantics, e.g. agents.ts toRunSpan().)
       // DurationNs is wrapped in `if(... > 0, ..., NULL)` because some insertion paths land
       // 0-ns durations (mid-stream / early-fail) which would otherwise drag the p95 down.
+      // CTO-227 review finding (Bug 4): the incumbent id this returns is joined by string equality
+      // against queryCostExplore's per-model breakdown, which keys models by EXPLORE_GROUP_EXPR.model
+      // (response model first, request model otherwise). Resolving the model any other way (e.g. the
+      // old SpanAttributes['chatbot.real_model'] coalesce, whose historical-fallback rows have long
+      // rolled out of the 30-day window per CTO-106) produced an id that never matched a breakdown row
+      // on the chatbot demo, so the wrong-sized-model detector always returned []. Resolve — and GROUP
+      // BY — on the SAME expression the cost breakdown uses so the join key matches by construction.
       `SELECT
-         coalesce(
-           nullIf(any(SpanAttributes['chatbot.real_model']), ''),
-           any(GenAiResponseModel),
-           any(GenAiRequestModel)
-         ) AS model,
+         ${EXPLORE_GROUP_EXPR.model} AS model,
          coalesce(
            nullIf(any(SpanAttributes['chatbot.real_provider']), ''),
            any(GenAiSystem)
@@ -2730,8 +2738,8 @@ export async function queryCurrentModel(): Promise<{
        FROM otel_spans
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 7 DAY
-         AND coalesce(GenAiResponseModel, GenAiRequestModel) != ''
-       GROUP BY coalesce(GenAiResponseModel, GenAiRequestModel)
+         AND (GenAiResponseModel != '' OR GenAiRequestModel != '')
+       GROUP BY ${EXPLORE_GROUP_EXPR.model}
        ORDER BY count() DESC
        LIMIT 1`,
       tenant,

--- a/web/lib/features.ts
+++ b/web/lib/features.ts
@@ -11,6 +11,14 @@ export interface FeatureEconomics {
   valuePerUserMicroUsd: MicroUSD | null;
   paybackDays: number | null;
   attributionRate: number | null; // 0..1
+  /**
+   * Raw count of attributed conversions for this feature over the window. Unlike `attributionRate`
+   * (which `queryFeatureEconomics` nulls out below the MIN_CONVERSIONS_FOR_ECONOMICS trust floor),
+   * this is the honest observed count and is `0` only when the feature genuinely attributes nothing.
+   * CTO-227 review finding: the no-measured-return detector needs a true zero, not a null-because-
+   * untrusted rate, to avoid false-flagging a sparse-but-converting feature.
+   */
+  conversions: number;
   /** events attributed by stitching source */
   attributionBreakdown: {
     direct: number;
@@ -40,6 +48,7 @@ export const features: FeatureEconomics[] = [
     valuePerUserMicroUsd: 1_400_000,
     paybackDays: 13,
     attributionRate: 0.91,
+    conversions: 1658,
     attributionBreakdown: { direct: 1313, sessionStitched: 255, identityGraphStitched: 90, unmatched: 162 },
   },
   {
@@ -49,6 +58,7 @@ export const features: FeatureEconomics[] = [
     valuePerUserMicroUsd: 210_000,
     paybackDays: 7,
     attributionRate: 0.88,
+    conversions: 1035,
     attributionBreakdown: { direct: 880, sessionStitched: 120, identityGraphStitched: 35, unmatched: 145 },
   },
   {
@@ -58,6 +68,7 @@ export const features: FeatureEconomics[] = [
     valuePerUserMicroUsd: null,
     paybackDays: null,
     attributionRate: null,
+    conversions: 0,
     attributionBreakdown: { direct: 0, sessionStitched: 0, identityGraphStitched: 0, unmatched: 0 },
   },
 ];

--- a/web/lib/waste/no-measured-return.test.ts
+++ b/web/lib/waste/no-measured-return.test.ts
@@ -20,6 +20,9 @@ function row(over: Partial<NoReturnEconRow> = {}): NoReturnEconRow {
     scopeValue: "chatbot",
     windowSpendMicroUsd: 100 * USD,
     attributionRate: null,
+    // Default is genuinely-zero attribution (flaggable). Cases that model a converting feature set
+    // conversions > 0 explicitly.
+    conversions: 0,
     ...over,
   };
 }
@@ -86,6 +89,32 @@ describe("detectNoMeasuredReturn", () => {
     );
     // Only the unattributed one is flagged; the attributed feature is left alone.
     expect(findings.map((f) => f.scopeValue)).toEqual(["orphan"]);
+  });
+
+  // CTO-227 review finding (Bug 3): a sparse-but-converting feature has conversions > 0 while its
+  // attributionRate is null (below the MIN_CONVERSIONS_FOR_ECONOMICS trust floor). It must NOT be
+  // flagged: it DID convert, just sparsely. Only a genuinely-zero-conversion feature is waste.
+  it("does not flag a sparse-but-converting feature (conversions > 0, rate null)", () => {
+    const findings = detectNoMeasuredReturn(
+      [
+        // Genuinely unattributed: zero conversions -> flagged.
+        row({ scopeValue: "orphan", windowSpendMicroUsd: 300 * USD, attributionRate: null, conversions: 0 }),
+        // Converted, but too few to trust the rate (null). Real return -> NOT flagged.
+        row({ scopeValue: "sparse", windowSpendMicroUsd: 400 * USD, attributionRate: null, conversions: 3 }),
+      ],
+      0.8,
+    );
+    expect(findings.map((f) => f.scopeValue)).toEqual(["orphan"]);
+  });
+
+  it("flags a genuinely-zero-conversion feature even when its rate is null", () => {
+    const findings = detectNoMeasuredReturn(
+      [row({ scopeValue: "dead-weight", windowSpendMicroUsd: 500 * USD, attributionRate: null, conversions: 0 })],
+      0.6,
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].scopeValue).toBe("dead-weight");
+    expect(findings[0].recoverableMicroUsd).toBe(500 * USD);
   });
 
   it("does not flag a scope with no spend at risk", () => {

--- a/web/lib/waste/no-measured-return.ts
+++ b/web/lib/waste/no-measured-return.ts
@@ -49,6 +49,14 @@ export interface NoReturnEconRow {
   windowSpendMicroUsd: MicroUSD;
   /** 0..1, or `null` for "no measured attribution". From `queryFeatureEconomics`, never re-derived. */
   attributionRate: number | null;
+  /**
+   * Raw attributed-conversion count for the scope over the window, from `queryFeatureEconomics`.
+   * CTO-227 review finding (Bug 3): `attributionRate` is `null` in TWO different states — a feature
+   * with genuinely zero attribution AND a feature with some conversions but below the trust floor
+   * (MIN_CONVERSIONS_FOR_ECONOMICS). Only the count tells them apart, so the detector gates on this,
+   * not on the null rate, to avoid false-flagging a sparse-but-converting feature as pure waste.
+   */
+  conversions: number;
 }
 
 /**
@@ -79,6 +87,14 @@ export function detectNoMeasuredReturn(
   const findings: WasteFinding[] = [];
   for (const row of econRows) {
     if (row.windowSpendMicroUsd <= 0) continue; // no spend at risk, nothing to flag
+    // CTO-227 review finding (Bug 3): flag ONLY when attribution is genuinely zero. A feature with
+    // any attributed conversions (conversions > 0) has measured return, even when its `attributionRate`
+    // is null because it sits below the MIN_CONVERSIONS_FOR_ECONOMICS trust floor. Reading that
+    // null-because-untrusted rate as "zero attribution" false-flagged sparse-but-converting features
+    // for their full spend. Treat conversions > 0 as "unknown / real return", never waste.
+    if (row.conversions > 0) continue;
+    // Defensive: a positive rate should never coincide with zero conversions, but if it does, honor
+    // the measured return rather than flag.
     const hasReturn =
       row.attributionRate !== null && row.attributionRate > NEAR_ZERO_ATTRIBUTION;
     if (hasReturn) continue; // real measured return -> not waste
@@ -140,6 +156,9 @@ export async function collectNoMeasuredReturn(
   const econ = await queryFeatureEconomics(w);
   if (econ === null) return [];
   const attrRateByFeature = new Map(econ.map((e) => [e.feature, e.attributionRate]));
+  // CTO-227 review finding (Bug 3): carry the RAW conversion count too, so the detector can tell a
+  // genuinely-unattributed feature (0) from a sparse-but-converting one (rate null, conversions > 0).
+  const conversionsByFeature = new Map(econ.map((e) => [e.feature, e.conversions]));
 
   const featureFilter = filters.feature ?? [];
   const hasFeatureFilter = featureFilter.length > 0;
@@ -190,6 +209,8 @@ export async function collectNoMeasuredReturn(
     scopeValue: r.feature,
     windowSpendMicroUsd: micro(r.cost),
     attributionRate: attrRateByFeature.get(r.feature) ?? null,
+    // A feature with spend but no economics row attributes nothing -> 0 (genuinely zero, flaggable).
+    conversions: conversionsByFeature.get(r.feature) ?? 0,
   }));
 
   return detectNoMeasuredReturn(econRows, live.tenantAttributionRate);

--- a/web/lib/waste/paid-for-nothing.test.ts
+++ b/web/lib/waste/paid-for-nothing.test.ts
@@ -8,6 +8,7 @@ import {
   detectPaidForNothing,
   type PaidForNothingRow,
 } from "./paid-for-nothing";
+import { aggregateWaste } from "@/lib/waste";
 
 /** A fully-specified fixture row; individual tests override just the fields they care about. */
 function row(overrides: Partial<PaidForNothingRow>): PaidForNothingRow {
@@ -93,6 +94,32 @@ describe("detectPaidForNothing", () => {
     expect(byScope.agent.scopeValue).toBe("aider");
     expect(byScope.agent.recoverableMicroUsd).toBe(300_000);
     expect(byScope.agent.evidence.shareOfScopeSpend).toBe(50);
+  });
+
+  // CTO-227 review finding (Bug 2): a single failed feature-tagged run must produce exactly ONE
+  // finding and be counted ONCE in the roll-up total. The old SQL rolled the same runs up BY feature
+  // AND BY agent, so the run surfaced as two findings and its recoverable was summed twice, overstating
+  // "Recoverable" up to 2x. The query now assigns each run to one scope; this locks the single-count
+  // guarantee at the row -> detector -> aggregate boundary the endpoint actually uses.
+  it("counts a single feature-tagged wasted run once in the aggregate total", () => {
+    // The single-scope query yields ONE row for a feature-tagged run (no overlapping agent row).
+    const rows: PaidForNothingRow[] = [
+      row({
+        scopeKind: "feature",
+        scopeValue: "search",
+        wastedCost: "0.25",
+        scopeCost: "1.00",
+        failedRuns: "1",
+        exampleTrace: "trace-1",
+      }),
+    ];
+    const findings = detectPaidForNothing(rows);
+    expect(findings).toHaveLength(1);
+
+    const report = aggregateWaste(findings, 30);
+    // Counted exactly once: total equals the single wasted amount, not double it.
+    expect(report.totalRecoverableMicroUsd).toBe(250_000);
+    expect(report.byCategory.paid_for_nothing).toBe(250_000);
   });
 
   it("counts abandoned runs into the wasted-run tally when present", () => {

--- a/web/lib/waste/paid-for-nothing.ts
+++ b/web/lib/waste/paid-for-nothing.ts
@@ -134,8 +134,10 @@ function detectorFilters(filters: DimensionFilters): {
  *      (`max(StatusCode) = 2`), matching `queryAgents` exactly. A run also carries its feature tag
  *      and its agent (ServiceName). `GenAiOperation NOT IN ('compute','egress')` keeps this to
  *      run-shaped, billable spend (the synthetic infra rows are not runs).
- *   2. Roll runs up BY feature and BY agent separately, summing wasted cost (cost of the runs that
- *      ended failed) and total scope cost, and counting the wasted runs.
+ *   2. Assign each run to EXACTLY ONE scope (its feature when tagged, else its agent) and roll those
+ *      single-scope groups up, summing wasted cost (cost of the runs that ended failed) and total
+ *      scope cost, and counting the wasted runs. One run's dollars land in one scope, never two
+ *      (CTO-227 review finding, Bug 2: the previous by-feature-AND-by-agent union double-counted).
  */
 export async function collectPaidForNothing(
   windowDays: number,
@@ -147,8 +149,9 @@ export async function collectPaidForNothing(
 
     // Stage 1 (runs subquery): one row per TraceId with its cost, terminal-error flag, feature and
     // agent. `isFailed` reuses queryAgents' derivation: max(StatusCode)=2 (OTel Error) => failed.
-    // Stage 2 (outer): two GROUP BYs unioned -- by feature and by agent -- each emitting a scope row
-    // with wasted vs. total spend and the wasted-run counts. `wastedCost`/`failedRuns` gate on the
+    // Stage 2 (outer): attribute each run to ONE scope (feature when tagged, else agent), then GROUP
+    // BY that scope, each group emitting a row with wasted vs. total spend and the wasted-run counts.
+    // One run's dollars count once (CTO-227 Bug 2). `wastedCost`/`failedRuns` gate on the
     // run being both billed (runCost > 0) AND failed. `abandonedRuns` is 0: abandonment is not
     // derivable from OTel StatusCode today (see queryAgents), but the column is kept so the shape and
     // the evidence are stable if a future signal lands.
@@ -169,34 +172,38 @@ export async function collectPaidForNothing(
     // A wasted run: billed (runCost > 0) and failed. We express the gate once as a reusable flag.
     const wastedRunExpr = "(runCost > 0 AND isFailed)";
 
+    // CTO-227 review finding (Bug 2): assign each run to EXACTLY ONE scope before rolling up, so its
+    // dollars are counted once. The old query rolled the same runs up BY feature AND BY agent in a
+    // UNION ALL, so a failed feature-tagged run on a named agent surfaced as TWO findings whose
+    // recoverables BOTH fed `aggregateWaste`'s total — overstating "Recoverable" up to 2x. Here a run
+    // with a FeatureTag is attributed to its feature; an untagged run falls back to its agent. Runs
+    // that are neither tagged nor on a usable agent cannot be attributed to any scope, so they are
+    // dropped rather than double-counted or mis-assigned.
+    const scopeKindExpr = "if(feature != '', 'feature', 'agent')";
+    const scopeValueExpr = "if(feature != '', feature, agent)";
+
     const sql = `
-      WITH runs AS (${runsCte})
+      WITH runs AS (${runsCte}),
+      scoped AS (
+        SELECT
+          ${scopeKindExpr} AS scopeKind,
+          ${scopeValueExpr} AS scopeValue,
+          runCost,
+          isFailed,
+          runId
+        FROM runs
+        WHERE NOT (feature = '' AND (agent = '' OR agent = 'unknown'))
+      )
       SELECT
-        'feature' AS scopeKind,
-        feature AS scopeValue,
+        scopeKind,
+        scopeValue,
         toString(sumIf(runCost, ${wastedRunExpr})) AS wastedCost,
         toString(sum(runCost)) AS scopeCost,
         toString(countIf(${wastedRunExpr})) AS failedRuns,
         '0' AS abandonedRuns,
         anyIf(runId, ${wastedRunExpr}) AS exampleTrace
-      FROM runs
-      WHERE feature != ''
-      GROUP BY feature
-      HAVING sumIf(runCost, ${wastedRunExpr}) > 0
-
-      UNION ALL
-
-      SELECT
-        'agent' AS scopeKind,
-        agent AS scopeValue,
-        toString(sumIf(runCost, ${wastedRunExpr})) AS wastedCost,
-        toString(sum(runCost)) AS scopeCost,
-        toString(countIf(${wastedRunExpr})) AS failedRuns,
-        '0' AS abandonedRuns,
-        anyIf(runId, ${wastedRunExpr}) AS exampleTrace
-      FROM runs
-      WHERE agent != '' AND agent != 'unknown'
-      GROUP BY agent
+      FROM scoped
+      GROUP BY scopeKind, scopeValue
       HAVING sumIf(runCost, ${wastedRunExpr}) > 0`;
 
     const raw = await rowsP<PaidForNothingRow>(db, sql, { tenant, ...params });

--- a/web/lib/waste/wrong-sized-model.collect.test.ts
+++ b/web/lib/waste/wrong-sized-model.collect.test.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Collector tests for the wrong-sized-model detector (CTO-227 review findings, Bugs 1 & 4). Unlike
+// the pure-detector suite, these mock the Compare-path ClickHouse reads to lock the WIRING the two
+// bugs live in:
+//   * Bug 1: the rescale denominator is the incumbent's REPLAY-corpus projection, the same basis the
+//     candidates use — never the 7-day-traffic projection. A candidate cheaper only because of the
+//     old basis mismatch does NOT flag; and when the incumbent has no replay entry (so the sides
+//     cannot be compared apples-to-apples) the collector returns NOTHING, honestly.
+//   * Bug 4: the incumbent id joins a cost-breakdown row (both resolved response-model-first), so the
+//     detector actually fires instead of silently returning [] on a key mismatch.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/clickhouse", () => ({
+  queryCurrentModel: vi.fn(),
+  queryReplayCandidates: vi.fn(),
+  queryEvalCandidates: vi.fn(),
+  queryCostExplore: vi.fn(),
+}));
+
+import { collectWrongSizedModel } from "./wrong-sized-model";
+import * as ch from "@/lib/clickhouse";
+import type { DimensionFilters } from "@/lib/filters";
+
+const queryCurrentModel = ch.queryCurrentModel as unknown as ReturnType<typeof vi.fn>;
+const queryReplayCandidates = ch.queryReplayCandidates as unknown as ReturnType<typeof vi.fn>;
+const queryEvalCandidates = ch.queryEvalCandidates as unknown as ReturnType<typeof vi.fn>;
+const queryCostExplore = ch.queryCostExplore as unknown as ReturnType<typeof vi.fn>;
+
+const NO_FILTERS: DimensionFilters = {
+  feature: [],
+  model: [],
+  layer: [],
+  provider: [],
+  account: [],
+};
+
+// Incumbent = gpt-4o. Its replay projection is 8B micro-USD/mo; the candidate haiku replays at 2B on
+// the SAME corpus, so it is genuinely half-of-a-quarter cheaper and qualifies. Window spend is 20B.
+function currentModel(over: Record<string, unknown> = {}) {
+  return {
+    model: "gpt-4o",
+    provider: "openai",
+    // Deliberately DIFFERENT basis/scale from the replay projection: this is the 7-day-traffic figure
+    // Bug 1 must NOT use as the denominator. If it leaked back in, the recoverable math would break.
+    monthlyCostMicroUsd: 40_000_000_000,
+    latencyP95Ms: 2400,
+    errorRate: 0.01,
+    sampleCount: 500,
+    ...over,
+  };
+}
+
+function replay(perCandidate: Array<Record<string, unknown>>) {
+  return {
+    samples_available: 200,
+    per_candidate: perCandidate,
+    diagnostics: { context_fidelity: "resolved-context", replay_cost_micro_usd: 1000 },
+  };
+}
+
+function replayRow(over: Record<string, unknown> = {}) {
+  return {
+    provider: "openai",
+    model: "gpt-4o",
+    projected_monthly_cost_micro_usd: 8_000_000_000,
+    p50_latency_ms: 900,
+    p95_latency_ms: 1800,
+    error_rate: 0.01,
+    samples_replayed: 120,
+    excluded_budget_count: 0,
+    ...over,
+  };
+}
+
+function evalRow(over: Record<string, unknown> = {}) {
+  return {
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    samples_judged: 40,
+    current_wins: 18,
+    candidate_wins: 20,
+    ties: 2,
+    errors: 0,
+    win_rate: 0.5,
+    win_rate_ci_lo: 0.44,
+    win_rate_ci_hi: 0.56,
+    judge_cost_micro_usd: 100,
+    ...over,
+  };
+}
+
+function costExplore(breakdown: Array<{ group: string; totalMicroUsd: number }>) {
+  return {
+    groupBy: "model" as const,
+    windowStart: "2026-08-01",
+    windowEnd: "2026-08-26",
+    windowDays: 30,
+    groups: breakdown.map((b) => b.group),
+    days: [],
+    breakdown: breakdown.map((b) => ({ ...b, spanCount: 100 })),
+    totalMicroUsd: breakdown.reduce((s, b) => s + b.totalMicroUsd, 0),
+    truncatedGroups: 0,
+  };
+}
+
+beforeEach(() => {
+  queryEvalCandidates.mockReset();
+  queryReplayCandidates.mockReset();
+  queryCurrentModel.mockReset();
+  queryCostExplore.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("collectWrongSizedModel — replay-basis rescale (CTO-227 Bug 1) + id join (Bug 4)", () => {
+  it("flags a candidate cheaper on the shared replay basis with the correct recoverable", async () => {
+    queryCurrentModel.mockResolvedValue(currentModel());
+    // Replay set includes the incumbent (gpt-4o @ 8B) AND a cheaper candidate (haiku @ 2B), same basis.
+    queryReplayCandidates.mockResolvedValue(
+      replay([
+        replayRow({ provider: "openai", model: "gpt-4o", projected_monthly_cost_micro_usd: 8_000_000_000 }),
+        replayRow({
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 2_000_000_000,
+        }),
+      ]),
+    );
+    queryEvalCandidates.mockResolvedValue({
+      samples_available: 200,
+      per_candidate: [evalRow()],
+      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
+    });
+    // Cost breakdown keyed by the SAME response-model-first id the incumbent resolves to.
+    queryCostExplore.mockResolvedValue(costExplore([{ group: "gpt-4o", totalMicroUsd: 20_000_000_000 }]));
+
+    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    expect(findings).toHaveLength(1);
+    const f = findings[0];
+    expect(f.category).toBe("wrong_sized_model");
+    expect(f.scopeValue).toBe("gpt-4o");
+    expect(f.evidence.candidateModel).toBe("claude-haiku-4-5");
+    // ratio = 2B/8B = 0.25 of the 20B window spend rescales to 5B, recoverable = 15B. NOT computed
+    // off the 40B traffic projection (which would have made the ratio 0.05 and the recoverable absurd).
+    expect(f.recoverableMicroUsd).toBe(15_000_000_000);
+    expect(f.windowSpendMicroUsd).toBe(20_000_000_000);
+  });
+
+  it("does NOT flag a candidate that is cheaper only against the traffic projection (basis mismatch)", async () => {
+    queryCurrentModel.mockResolvedValue(currentModel());
+    // On the replay basis the candidate (10B) is MORE expensive than the incumbent (8B). It would only
+    // look "cheaper" if compared against the incumbent's 40B traffic projection — the exact Bug 1 trap.
+    queryReplayCandidates.mockResolvedValue(
+      replay([
+        replayRow({ provider: "openai", model: "gpt-4o", projected_monthly_cost_micro_usd: 8_000_000_000 }),
+        replayRow({
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 10_000_000_000,
+        }),
+      ]),
+    );
+    queryEvalCandidates.mockResolvedValue({
+      samples_available: 200,
+      per_candidate: [evalRow()],
+      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
+    });
+    queryCostExplore.mockResolvedValue(costExplore([{ group: "gpt-4o", totalMicroUsd: 20_000_000_000 }]));
+
+    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    expect(findings).toEqual([]);
+  });
+
+  it("returns NOTHING when the incumbent has no replay entry (cannot compare apples-to-apples)", async () => {
+    queryCurrentModel.mockResolvedValue(currentModel());
+    // Replay set does NOT include the incumbent gpt-4o, only a candidate. No shared basis -> honest [].
+    queryReplayCandidates.mockResolvedValue(
+      replay([
+        replayRow({
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 2_000_000_000,
+        }),
+      ]),
+    );
+    queryEvalCandidates.mockResolvedValue({
+      samples_available: 200,
+      per_candidate: [evalRow()],
+      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
+    });
+    queryCostExplore.mockResolvedValue(costExplore([{ group: "gpt-4o", totalMicroUsd: 20_000_000_000 }]));
+
+    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    expect(findings).toEqual([]);
+  });
+
+  it("returns [] when the incumbent id matches no cost-breakdown row", async () => {
+    queryCurrentModel.mockResolvedValue(currentModel({ model: "gpt-4o" }));
+    queryReplayCandidates.mockResolvedValue(
+      replay([
+        replayRow({ provider: "openai", model: "gpt-4o", projected_monthly_cost_micro_usd: 8_000_000_000 }),
+        replayRow({
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 2_000_000_000,
+        }),
+      ]),
+    );
+    queryEvalCandidates.mockResolvedValue({
+      samples_available: 200,
+      per_candidate: [evalRow()],
+      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
+    });
+    // Breakdown keyed by a DIFFERENT id than the incumbent resolves to -> no join, no finding.
+    queryCostExplore.mockResolvedValue(costExplore([{ group: "some-other-model", totalMicroUsd: 20_000_000_000 }]));
+
+    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    expect(findings).toEqual([]);
+  });
+});

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -194,7 +194,10 @@ export function detectWrongSizedModel(input: WrongSizedModelInput): WasteFinding
 /**
  * The model id ClickHouse attributes spend to, matching the resolution `queryCostExplore`'s `model`
  * dimension and `queryCurrentModel` both use (response model when present, request model otherwise).
- * The incumbent from `queryCurrentModel` already resolves this way, so we compare against it directly.
+ * CTO-227 review finding (Bug 4): `queryCurrentModel` now resolves the incumbent on that SAME
+ * response-model-first expression (previously it preferred `SpanAttributes['chatbot.real_model']`,
+ * which never matched a cost-breakdown group on the chatbot demo, so this detector always returned []).
+ * With both sides aligned, we compare the id directly.
  */
 function resolveIncumbentModel(model: string): string {
   return model;
@@ -256,6 +259,19 @@ export async function collectWrongSizedModel(
   // No observed spend on the incumbent in this window → nothing to recover, so nothing to report.
   if (!incumbentRow || incumbentRow.totalMicroUsd <= 0) return [];
 
+  // CTO-227 review finding (Bug 1): the rescale denominator MUST be the incumbent's REPLAY-corpus
+  // projection, the SAME basis every candidate's `projected_monthly_cost_micro_usd` is measured on.
+  // The old denominator was `live.monthlyCostMicroUsd`, a 7-day-traffic figure linearly projected to
+  // 30d — an incompatible basis. Dividing a replay-corpus candidate cost by a traffic projection made
+  // the "cheaper" gate and the recoverable ratio meaningless (a candidate could pass while being more
+  // expensive per call, yielding absurd recoverables). The replay projection includes the incumbent
+  // model (the gateway projects it alongside the candidates); if it does NOT — so the two sides cannot
+  // be compared apples-to-apples — we return NOTHING for this scope (honest), never fall back to the
+  // traffic projection.
+  const incumbentReplay = replay.per_candidate.find((r) => r.model === incumbentModel);
+  if (!incumbentReplay || incumbentReplay.projected_monthly_cost_micro_usd <= 0) return [];
+  const incumbentProjectedMonthlyMicroUsd = incumbentReplay.projected_monthly_cost_micro_usd;
+
   // Join replay (cost) and eval (quality) by provider+model, excluding the incumbent itself.
   const candidates: WrongSizedModelCandidate[] = [];
   for (const r of replay.per_candidate) {
@@ -284,7 +300,8 @@ export async function collectWrongSizedModel(
         feature: featureTag,
         incumbentModel,
         windowSpendMicroUsd: incumbentRow.totalMicroUsd,
-        incumbentProjectedMonthlyMicroUsd: live.monthlyCostMicroUsd,
+        // Replay-corpus projection for the incumbent — shares the candidates' basis (see above).
+        incumbentProjectedMonthlyMicroUsd,
         candidates,
       },
     ],


### PR DESCRIPTION
Code review of the shipped waste-detection epic (CTO-227) found four bugs that produce **wrong or overstated recoverable dollars**, violating the honest-under-uncertainty invariant. Each fix preserves the honesty posture: when the correct number cannot be computed, the detector emits nothing (a blank / no finding), never a fabricated or inflated figure.

## Bug 1 (worst) — wrong-sized-model cost-basis mismatch
`collectWrongSizedModel` used the incumbent's **traffic-based** monthly projection (`queryCurrentModel().monthlyCostMicroUsd`, a 7-day-live figure linearly projected to 30d) as the rescale denominator, while each candidate carries a **replay-corpus** projection. Incompatible bases meant the "cheaper" gate passed candidates that were actually more expensive per call, and the ratio produced absurd recoverables.

**Fix:** rescale both sides on the shared replay basis. The denominator is now the incumbent's own replay projection (`replay.per_candidate` entry for the incumbent model). If the incumbent has no replay entry (the two cannot be compared apples-to-apples), the detector returns nothing rather than falling back to the traffic projection.

## Bug 2 — paid-for-nothing double-counts the total
The query rolled wasted spend up BY feature **and** BY agent in a `UNION ALL`, so a failed run tagged `FeatureTag='x'` on `ServiceName='svc'` became two findings whose recoverables both fed `aggregateWaste`'s total, overstating "Recoverable" up to 2x.

**Fix:** each run is assigned to exactly one scope (its feature when tagged, else its agent) before roll-up, so its dollars count once. Runs that are neither tagged nor on a usable agent are dropped rather than mis-assigned.

## Bug 3 — no-measured-return false-flags sparse-but-real features
`queryFeatureEconomics` returns `attributionRate: null` both when a feature has **no** attribution and when it has some conversions but below the `MIN_CONVERSIONS_FOR_ECONOMICS` trust floor. The detector read `null` as zero attribution and flagged the feature's full spend, so a feature that did convert (just sparsely) became a false "no measured return".

**Fix:** `queryFeatureEconomics` now carries the raw conversion count (additive field, no existing behaviour changed); the detector flags only when conversions are exactly `0`. A feature with conversions > 0 and a null-because-untrusted rate is treated as unknown / real return and is not flagged.

## Bug 4 — wrong-sized-model incumbent id never matches the cost breakdown
`queryCurrentModel` resolved the incumbent id via `coalesce(chatbot.real_model, GenAiResponseModel, GenAiRequestModel)`, but it is joined against `queryCostExplore` groups keyed response-model-first. On the chatbot demo these differ, so the incumbent never matched a breakdown row and the detector returned `[]`.

**Fix:** `queryCurrentModel` now resolves and `GROUP BY`s on the **same** response-model-first expression the cost breakdown uses (`EXPLORE_GROUP_EXPR.model`), so the join key matches by construction. The historical `chatbot.real_model` fallback has long rolled out of the 30-day window (CTO-106).

## Tests
- `wrong-sized-model.collect.test.ts` (new): candidate cheaper on the shared replay basis flags with the correct recoverable; a candidate cheaper only against the traffic projection does **not**; incumbent absent from replay → nothing; incumbent id not in the cost breakdown → `[]`.
- `paid-for-nothing.test.ts`: a single feature-tagged wasted run yields one finding and is counted once in the `aggregateWaste` total.
- `no-measured-return.test.ts`: a sparse-but-converting feature (conversions > 0, rate null) is not flagged; a genuinely-zero feature still flags.
- All pre-existing waste unit tests still pass. `typecheck`, `lint`, `test` (only the long-standing `app/api/api.test.ts` ClickHouse-running case fails), and a clean `build` are green.

## Live verification (local-dev, running stack)
`/api/waste` totals:

| range | total recoverable (micro-USD) | paid_for_nothing | no_measured_return | wrong_sized_model |
|---|---|---|---|---|
| default (30d) | 21,737,679,907 | `null` (`[]`) | 80,376 | `null` (`[]`) |
| 7d | 5,679,162,437 | `null` (`[]`) | 80,376 | `null` (`[]`) |

- **paid-for-nothing no longer double-counts.** The demo tenant has zero failed billed runs, so the detector is honestly `[]` on both ranges. To prove the structural fix on real data, running the old UNION vs the new single-scope roll-up over all billed runs (as a proxy gate) gives **$105,021.59 (old, double-counted) vs $52,510.79 (new, exactly half)** — the union counted every feature-tagged run again under its agent; the fix removes the ~2x overstatement.
- **wrong-sized-model honestly returns `[]`** on this tenant: the gateway `/v1/replay` reports `samples_available: 0` (no captured replay corpus), so there is no basis to compare against. The incumbent (`gpt-4o`, top model by 7d traffic) now correctly resolves to a matching cost-breakdown row (Bug 4), so if a replay corpus existed the detector would run on the correct shared basis (Bug 1); with no corpus, `[]` is the honest answer.
- **no-measured-return still flags only the genuinely-unattributed features** (`chatbot-demo`, `cto182-e2e`, both with 0 conversions). Every other spending feature has conversions > 0 and is left alone. The false-positive class (a 1–4-conversion feature with spend) does not exist in current demo data but is now closed and covered by the new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)