### PR TITLE
fix(web): correct paid-for-nothing share denominator; make wrong-sized-model honest on v1

### DIFF
--- a/web/lib/waste/paid-for-nothing.test.ts
+++ b/web/lib/waste/paid-for-nothing.test.ts
@@ -122,6 +122,37 @@ describe("detectPaidForNothing", () => {
     expect(report.byCategory.paid_for_nothing).toBe(250_000);
   });
 
+  // CTO-227 review pass 2 (Fix A): the per-scope DENOMINATOR is the scope's TRUE total spend, not the
+  // single-scoped subtotal. For an agent, that total includes the feature-tagged runs on it that the
+  // wasted-cost roll-up attributed to a feature scope. The query now supplies that true total as
+  // `scopeCost`; here we lock the detector's contract on it: an agent whose $0.20 wasted spend is 20%
+  // of its real $1.00 total must report windowSpend = full $1.00 and share = 20%, NOT windowSpend =
+  // $0.20 and share = 100% (the pre-fix behaviour when scopeCost excluded feature-tagged runs).
+  it("uses the agent's true total spend as the share denominator (not the single-scoped subtotal)", () => {
+    const findings = detectPaidForNothing([
+      row({
+        scopeKind: "agent",
+        scopeValue: "aider",
+        wastedCost: "0.20", // $0.20 wasted (single-scoped, counted once)
+        // True agent total over the window: includes this agent's feature-tagged runs too.
+        scopeCost: "1.00", // $1.00 real total on the agent
+        failedRuns: "2",
+        exampleTrace: "trace-agent",
+      }),
+    ]);
+
+    expect(findings).toHaveLength(1);
+    const f = findings[0];
+    expect(f.scopeKind).toBe("agent");
+    expect(f.scopeValue).toBe("aider");
+    expect(f.recoverableMicroUsd).toBe(200_000);
+    // Full agent spend, not the $0.20 single-scoped subtotal.
+    expect(f.windowSpendMicroUsd).toBe(1_000_000);
+    // 0.20 / 1.00 = 20%, not the 100% the pre-fix (subtotal) denominator produced.
+    expect(f.evidence.shareOfScopeSpend).toBe(20);
+    expect(f.reason).toContain("20%");
+  });
+
   it("counts abandoned runs into the wasted-run tally when present", () => {
     const findings = detectPaidForNothing([
       row({

--- a/web/lib/waste/paid-for-nothing.ts
+++ b/web/lib/waste/paid-for-nothing.ts
@@ -33,7 +33,12 @@ export interface PaidForNothingRow {
   scopeValue: string;
   /** Summed EstimatedCost of the wasted (billed-but-empty) runs in this scope. Decimal-USD string. */
   wastedCost: string;
-  /** Summed EstimatedCost of ALL runs in this scope over the window. Decimal-USD string. */
+  /**
+   * The scope's TRUE total EstimatedCost over the window: the denominator for `shareOfScopeSpend`.
+   * For a feature scope this is every run carrying that FeatureTag; for an agent scope it is every run
+   * on that ServiceName, INCLUDING the runs that were attributed to a feature for the wasted-cost
+   * roll-up (CTO-227 review pass 2). It is NOT the sum of the single-scoped runs. Decimal-USD string.
+   */
   scopeCost: string;
   /** Count of wasted runs that ended failed (terminal error StatusCode). */
   failedRuns: string;
@@ -50,7 +55,9 @@ export interface PaidForNothingRow {
  * A row becomes a finding only when it has wasted spend (`wastedCost` > 0 in micro-USD). The
  * recoverable is exactly that wasted spend (dollars already paid with no result), and it is always
  * bounded (never null): the money is observed, not modelled. `windowSpendMicroUsd` is the scope's
- * total spend over the window, so the finding can show wasted spend as a share of the whole.
+ * TRUE total spend over the window (see {@link PaidForNothingRow.scopeCost}), so `shareOfScopeSpend`
+ * is wasted-over-true-total and neither it nor the reason text overstates the scope (CTO-227 review
+ * pass 2): an agent whose wasted spend is 20% of its real total reports 20%, not 100%.
  */
 export function detectPaidForNothing(rows: PaidForNothingRow[]): WasteFinding[] {
   const findings: WasteFinding[] = [];
@@ -135,9 +142,15 @@ function detectorFilters(filters: DimensionFilters): {
  *      and its agent (ServiceName). `GenAiOperation NOT IN ('compute','egress')` keeps this to
  *      run-shaped, billable spend (the synthetic infra rows are not runs).
  *   2. Assign each run to EXACTLY ONE scope (its feature when tagged, else its agent) and roll those
- *      single-scope groups up, summing wasted cost (cost of the runs that ended failed) and total
- *      scope cost, and counting the wasted runs. One run's dollars land in one scope, never two
- *      (CTO-227 review finding, Bug 2: the previous by-feature-AND-by-agent union double-counted).
+ *      single-scope groups up, summing wasted cost (cost of the runs that ended failed) and counting
+ *      the wasted runs. One run's dollars land in one scope, never two (CTO-227 review finding, Bug 2:
+ *      the previous by-feature-AND-by-agent union double-counted the recoverable total).
+ *   3. Separately, compute each scope's TRUE total spend (all runs of that FeatureTag; all runs of
+ *      that ServiceName, feature-tagged ones included) and join it in as the share DENOMINATOR
+ *      (CTO-227 review pass 2). The wasted attribution stays single-scoped so the recoverable total
+ *      still counts each dollar once, but the denominator is no longer the single-scoped subtotal;
+ *      that subtotal made an agent's `shareOfScopeSpend` read 100% when its feature-tagged spend was
+ *      excluded.
  */
 export async function collectPaidForNothing(
   windowDays: number,
@@ -149,12 +162,16 @@ export async function collectPaidForNothing(
 
     // Stage 1 (runs subquery): one row per TraceId with its cost, terminal-error flag, feature and
     // agent. `isFailed` reuses queryAgents' derivation: max(StatusCode)=2 (OTel Error) => failed.
-    // Stage 2 (outer): attribute each run to ONE scope (feature when tagged, else agent), then GROUP
-    // BY that scope, each group emitting a row with wasted vs. total spend and the wasted-run counts.
-    // One run's dollars count once (CTO-227 Bug 2). `wastedCost`/`failedRuns` gate on the
-    // run being both billed (runCost > 0) AND failed. `abandonedRuns` is 0: abandonment is not
-    // derivable from OTel StatusCode today (see queryAgents), but the column is kept so the shape and
-    // the evidence are stable if a future signal lands.
+    // Stage 2 (scoped/wasted): attribute each run to ONE scope (feature when tagged, else agent), then
+    // GROUP BY that scope for the wasted spend and the wasted-run counts. One run's dollars count once
+    // (CTO-227 Bug 2). `wastedCost`/`failedRuns` gate on the run being both billed (runCost > 0) AND
+    // failed. `abandonedRuns` is 0: abandonment is not derivable from OTel StatusCode today (see
+    // queryAgents), but the column is kept so the shape and the evidence are stable if a future signal
+    // lands.
+    // Stage 3 (scope_totals): the TRUE per-scope total spend, computed independently of the
+    // single-scope assignment: every FeatureTag run for a feature scope, every ServiceName run
+    // (feature-tagged included) for an agent scope. Joined in as `scopeCost` so `shareOfScopeSpend`
+    // divides by the real total, not the single-scoped subtotal (CTO-227 review pass 2).
     const runsCte = `
       SELECT
         TraceId AS runId,
@@ -182,6 +199,20 @@ export async function collectPaidForNothing(
     const scopeKindExpr = "if(feature != '', 'feature', 'agent')";
     const scopeValueExpr = "if(feature != '', feature, agent)";
 
+    // TRUE per-scope totals (the share denominator). Kept apart from the single-scope assignment so an
+    // agent's total includes its feature-tagged runs. Empty/`unknown` scope keys are dropped to match
+    // the `scoped` filter, so every wasted scope has exactly one totals row to join.
+    const scopeTotalsCte = `
+      SELECT 'feature' AS scopeKind, feature AS scopeValue, sum(runCost) AS totalCost
+      FROM runs
+      WHERE feature != ''
+      GROUP BY feature
+      UNION ALL
+      SELECT 'agent' AS scopeKind, agent AS scopeValue, sum(runCost) AS totalCost
+      FROM runs
+      WHERE agent != '' AND agent != 'unknown'
+      GROUP BY agent`;
+
     const sql = `
       WITH runs AS (${runsCte}),
       scoped AS (
@@ -193,18 +224,30 @@ export async function collectPaidForNothing(
           runId
         FROM runs
         WHERE NOT (feature = '' AND (agent = '' OR agent = 'unknown'))
-      )
+      ),
+      wasted AS (
+        SELECT
+          scopeKind,
+          scopeValue,
+          sumIf(runCost, ${wastedRunExpr}) AS wastedCostNum,
+          countIf(${wastedRunExpr}) AS failedRunsNum,
+          anyIf(runId, ${wastedRunExpr}) AS exampleTraceVal
+        FROM scoped
+        GROUP BY scopeKind, scopeValue
+        HAVING sumIf(runCost, ${wastedRunExpr}) > 0
+      ),
+      scope_totals AS (${scopeTotalsCte})
       SELECT
-        scopeKind,
-        scopeValue,
-        toString(sumIf(runCost, ${wastedRunExpr})) AS wastedCost,
-        toString(sum(runCost)) AS scopeCost,
-        toString(countIf(${wastedRunExpr})) AS failedRuns,
+        w.scopeKind AS scopeKind,
+        w.scopeValue AS scopeValue,
+        toString(w.wastedCostNum) AS wastedCost,
+        toString(t.totalCost) AS scopeCost,
+        toString(w.failedRunsNum) AS failedRuns,
         '0' AS abandonedRuns,
-        anyIf(runId, ${wastedRunExpr}) AS exampleTrace
-      FROM scoped
-      GROUP BY scopeKind, scopeValue
-      HAVING sumIf(runCost, ${wastedRunExpr}) > 0`;
+        w.exampleTraceVal AS exampleTrace
+      FROM wasted AS w
+      LEFT JOIN scope_totals AS t
+        ON w.scopeKind = t.scopeKind AND w.scopeValue = t.scopeValue`;
 
     const raw = await rowsP<PaidForNothingRow>(db, sql, { tenant, ...params });
     return detectPaidForNothing(raw);

--- a/web/lib/waste/wrong-sized-model.collect.test.ts
+++ b/web/lib/waste/wrong-sized-model.collect.test.ts
@@ -1,13 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
-// Collector tests for the wrong-sized-model detector (CTO-227 review findings, Bugs 1 & 4). Unlike
-// the pure-detector suite, these mock the Compare-path ClickHouse reads to lock the WIRING the two
-// bugs live in:
-//   * Bug 1: the rescale denominator is the incumbent's REPLAY-corpus projection, the same basis the
-//     candidates use — never the 7-day-traffic projection. A candidate cheaper only because of the
-//     old basis mismatch does NOT flag; and when the incumbent has no replay entry (so the sides
-//     cannot be compared apples-to-apples) the collector returns NOTHING, honestly.
-//   * Bug 4: the incumbent id joins a cost-breakdown row (both resolved response-model-first), so the
-//     detector actually fires instead of silently returning [] on a key mismatch.
+// Collector tests for the wrong-sized-model detector (CTO-227 review pass 2). These lock the HONEST
+// v1 contract of `collectWrongSizedModel`, replacing an earlier suite that asserted the detector
+// FIRING via an incumbent row mocked into `replay.per_candidate`, a shape the real gateway NEVER
+// returns.
+//
+// CONFIRMED against gateway source (infra/gateway/src/gateway/app.py, the /v1/replay per-candidate
+// loop) and `queryReplayCandidates` (web/lib/clickhouse.ts): v1 `/v1/replay` builds `per_candidate`
+// ONLY from the requested `candidate_models`, and `queryReplayCandidates` sends just DEFAULT_CANDIDATES
+// (claude-haiku-4-5, gpt-5-mini, gemini-3-flash). The incumbent is never projected. So the collector's
+// denominator lookup `replay.per_candidate.find(r => r.model === incumbentModel)` is ALWAYS undefined
+// for a real incumbent, and the collector returns [] every time in production. That is deliberate
+// honesty until the per-call-cost rescale lands in CTO-236, not a masked bug. These tests therefore
+// assert [] on the REAL replay shape (incumbent absent from per_candidate); a test that encoded firing
+// off a mocked incumbent row would encode a contract the gateway does not honor.
+//
+// The pure detector (`detectWrongSizedModel`) remains legitimately unit-tested in
+// wrong-sized-model.test.ts: it is correct GIVEN a valid input. This file only pins the collector's
+// wiring, where no such input can be produced on v1.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,14 +44,11 @@ const NO_FILTERS: DimensionFilters = {
   account: [],
 };
 
-// Incumbent = gpt-4o. Its replay projection is 8B micro-USD/mo; the candidate haiku replays at 2B on
-// the SAME corpus, so it is genuinely half-of-a-quarter cheaper and qualifies. Window spend is 20B.
+// Incumbent = gpt-4o (the current model). Its window spend is 20B micro-USD.
 function currentModel(over: Record<string, unknown> = {}) {
   return {
     model: "gpt-4o",
     provider: "openai",
-    // Deliberately DIFFERENT basis/scale from the replay projection: this is the 7-day-traffic figure
-    // Bug 1 must NOT use as the denominator. If it leaked back in, the recoverable math would break.
     monthlyCostMicroUsd: 40_000_000_000,
     latencyP95Ms: 2400,
     errorRate: 0.01,
@@ -51,42 +57,47 @@ function currentModel(over: Record<string, unknown> = {}) {
   };
 }
 
-function replay(perCandidate: Array<Record<string, unknown>>) {
+// The REAL replay shape: per_candidate carries ONLY the requested candidate models, never the
+// incumbent. Here the cheaper, quality-passing candidate haiku is present; gpt-4o (the incumbent) is
+// deliberately ABSENT, exactly as the gateway returns it.
+function replayCandidatesOnly() {
   return {
     samples_available: 200,
-    per_candidate: perCandidate,
+    per_candidate: [
+      {
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+        projected_monthly_cost_micro_usd: 2_000_000_000,
+        p50_latency_ms: 900,
+        p95_latency_ms: 1800,
+        error_rate: 0.01,
+        samples_replayed: 120,
+        excluded_budget_count: 0,
+      },
+    ],
     diagnostics: { context_fidelity: "resolved-context", replay_cost_micro_usd: 1000 },
   };
 }
 
-function replayRow(over: Record<string, unknown> = {}) {
+function evalCandidatesOnly() {
   return {
-    provider: "openai",
-    model: "gpt-4o",
-    projected_monthly_cost_micro_usd: 8_000_000_000,
-    p50_latency_ms: 900,
-    p95_latency_ms: 1800,
-    error_rate: 0.01,
-    samples_replayed: 120,
-    excluded_budget_count: 0,
-    ...over,
-  };
-}
-
-function evalRow(over: Record<string, unknown> = {}) {
-  return {
-    provider: "anthropic",
-    model: "claude-haiku-4-5",
-    samples_judged: 40,
-    current_wins: 18,
-    candidate_wins: 20,
-    ties: 2,
-    errors: 0,
-    win_rate: 0.5,
-    win_rate_ci_lo: 0.44,
-    win_rate_ci_hi: 0.56,
-    judge_cost_micro_usd: 100,
-    ...over,
+    samples_available: 200,
+    per_candidate: [
+      {
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+        samples_judged: 40,
+        current_wins: 18,
+        candidate_wins: 20,
+        ties: 2,
+        errors: 0,
+        win_rate: 0.5,
+        win_rate_ci_lo: 0.44,
+        win_rate_ci_hi: 0.56,
+        judge_cost_micro_usd: 100,
+      },
+    ],
+    diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
   };
 }
 
@@ -115,107 +126,27 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("collectWrongSizedModel — replay-basis rescale (CTO-227 Bug 1) + id join (Bug 4)", () => {
-  it("flags a candidate cheaper on the shared replay basis with the correct recoverable", async () => {
+describe("collectWrongSizedModel honest v1 contract (CTO-227 review pass 2; real impl CTO-236)", () => {
+  it("returns [] on the real replay shape (incumbent absent from per_candidate), even with a cheaper, quality-passing candidate", async () => {
+    // Every read is present and healthy, and haiku is genuinely cheaper on the replay corpus and passes
+    // the quality floor. It STILL yields nothing, because v1 /v1/replay never projects the incumbent,
+    // so the rescale denominator cannot be formed. This is the production reality until CTO-236.
     queryCurrentModel.mockResolvedValue(currentModel());
-    // Replay set includes the incumbent (gpt-4o @ 8B) AND a cheaper candidate (haiku @ 2B), same basis.
-    queryReplayCandidates.mockResolvedValue(
-      replay([
-        replayRow({ provider: "openai", model: "gpt-4o", projected_monthly_cost_micro_usd: 8_000_000_000 }),
-        replayRow({
-          provider: "anthropic",
-          model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 2_000_000_000,
-        }),
-      ]),
-    );
-    queryEvalCandidates.mockResolvedValue({
-      samples_available: 200,
-      per_candidate: [evalRow()],
-      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
-    });
-    // Cost breakdown keyed by the SAME response-model-first id the incumbent resolves to.
+    queryReplayCandidates.mockResolvedValue(replayCandidatesOnly());
+    queryEvalCandidates.mockResolvedValue(evalCandidatesOnly());
     queryCostExplore.mockResolvedValue(costExplore([{ group: "gpt-4o", totalMicroUsd: 20_000_000_000 }]));
 
     const findings = await collectWrongSizedModel(30, NO_FILTERS);
-    expect(findings).toHaveLength(1);
-    const f = findings[0];
-    expect(f.category).toBe("wrong_sized_model");
-    expect(f.scopeValue).toBe("gpt-4o");
-    expect(f.evidence.candidateModel).toBe("claude-haiku-4-5");
-    // ratio = 2B/8B = 0.25 of the 20B window spend rescales to 5B, recoverable = 15B. NOT computed
-    // off the 40B traffic projection (which would have made the ratio 0.05 and the recoverable absurd).
-    expect(f.recoverableMicroUsd).toBe(15_000_000_000);
-    expect(f.windowSpendMicroUsd).toBe(20_000_000_000);
-  });
-
-  it("does NOT flag a candidate that is cheaper only against the traffic projection (basis mismatch)", async () => {
-    queryCurrentModel.mockResolvedValue(currentModel());
-    // On the replay basis the candidate (10B) is MORE expensive than the incumbent (8B). It would only
-    // look "cheaper" if compared against the incumbent's 40B traffic projection — the exact Bug 1 trap.
-    queryReplayCandidates.mockResolvedValue(
-      replay([
-        replayRow({ provider: "openai", model: "gpt-4o", projected_monthly_cost_micro_usd: 8_000_000_000 }),
-        replayRow({
-          provider: "anthropic",
-          model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 10_000_000_000,
-        }),
-      ]),
-    );
-    queryEvalCandidates.mockResolvedValue({
-      samples_available: 200,
-      per_candidate: [evalRow()],
-      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
-    });
-    queryCostExplore.mockResolvedValue(costExplore([{ group: "gpt-4o", totalMicroUsd: 20_000_000_000 }]));
-
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    // Honest []: NOT a firing finding produced by a mocked incumbent row the gateway never returns.
     expect(findings).toEqual([]);
   });
 
-  it("returns NOTHING when the incumbent has no replay entry (cannot compare apples-to-apples)", async () => {
+  it("returns [] when a required read is unavailable (no eval pass)", async () => {
+    // The demo-tenant path: no eval projection -> nothing to compare on quality -> honest [].
     queryCurrentModel.mockResolvedValue(currentModel());
-    // Replay set does NOT include the incumbent gpt-4o, only a candidate. No shared basis -> honest [].
-    queryReplayCandidates.mockResolvedValue(
-      replay([
-        replayRow({
-          provider: "anthropic",
-          model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 2_000_000_000,
-        }),
-      ]),
-    );
-    queryEvalCandidates.mockResolvedValue({
-      samples_available: 200,
-      per_candidate: [evalRow()],
-      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
-    });
+    queryReplayCandidates.mockResolvedValue(replayCandidatesOnly());
+    queryEvalCandidates.mockResolvedValue(null);
     queryCostExplore.mockResolvedValue(costExplore([{ group: "gpt-4o", totalMicroUsd: 20_000_000_000 }]));
-
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
-    expect(findings).toEqual([]);
-  });
-
-  it("returns [] when the incumbent id matches no cost-breakdown row", async () => {
-    queryCurrentModel.mockResolvedValue(currentModel({ model: "gpt-4o" }));
-    queryReplayCandidates.mockResolvedValue(
-      replay([
-        replayRow({ provider: "openai", model: "gpt-4o", projected_monthly_cost_micro_usd: 8_000_000_000 }),
-        replayRow({
-          provider: "anthropic",
-          model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 2_000_000_000,
-        }),
-      ]),
-    );
-    queryEvalCandidates.mockResolvedValue({
-      samples_available: 200,
-      per_candidate: [evalRow()],
-      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
-    });
-    // Breakdown keyed by a DIFFERENT id than the incumbent resolves to -> no join, no finding.
-    queryCostExplore.mockResolvedValue(costExplore([{ group: "some-other-model", totalMicroUsd: 20_000_000_000 }]));
 
     const findings = await collectWrongSizedModel(30, NO_FILTERS);
     expect(findings).toEqual([]);

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -217,6 +217,12 @@ function resolveIncumbentModel(model: string): string {
  * restricts which incumbent model we will flag. There is NO static fallback: if replay, eval, the
  * current model, or the cost read is unavailable — as on a demo tenant with no eval pass — this returns
  * `[]`, which is the honest answer, not a failure.
+ *
+ * CTO-227 review pass 2, inert on v1: even with every read present, this returns `[]` in production
+ * today. v1 `/v1/replay` projects only the requested candidate models, never the incumbent, so the
+ * rescale denominator (the incumbent's replay-corpus projection) cannot be formed and the per-call
+ * rescale is not computable. The honest per-call-cost approach is CTO-236; see the denominator lookup
+ * below for the full explanation. This is documented, intended behaviour, not a masked dead path.
  */
 export async function collectWrongSizedModel(
   windowDays: number,
@@ -259,15 +265,21 @@ export async function collectWrongSizedModel(
   // No observed spend on the incumbent in this window → nothing to recover, so nothing to report.
   if (!incumbentRow || incumbentRow.totalMicroUsd <= 0) return [];
 
-  // CTO-227 review finding (Bug 1): the rescale denominator MUST be the incumbent's REPLAY-corpus
-  // projection, the SAME basis every candidate's `projected_monthly_cost_micro_usd` is measured on.
-  // The old denominator was `live.monthlyCostMicroUsd`, a 7-day-traffic figure linearly projected to
-  // 30d — an incompatible basis. Dividing a replay-corpus candidate cost by a traffic projection made
-  // the "cheaper" gate and the recoverable ratio meaningless (a candidate could pass while being more
-  // expensive per call, yielding absurd recoverables). The replay projection includes the incumbent
-  // model (the gateway projects it alongside the candidates); if it does NOT — so the two sides cannot
-  // be compared apples-to-apples — we return NOTHING for this scope (honest), never fall back to the
-  // traffic projection.
+  // The rescale denominator has to be the incumbent's projection on the SAME replay corpus every
+  // candidate's `projected_monthly_cost_micro_usd` is measured on (CTO-227 review Bug 1: the old
+  // `live.monthlyCostMicroUsd` denominator was a 7-day-traffic figure, an incompatible basis that made
+  // the "cheaper" gate and the recoverable ratio meaningless).
+  //
+  // CTO-227 review pass 2 (HONEST-STATE NOTE): v1 `/v1/replay` does NOT project the incumbent. The
+  // gateway builds `per_candidate` ONLY from the requested `candidate_models` (see app.py: the
+  // per-candidate loop iterates `candidates`), and `queryReplayCandidates` sends just DEFAULT_CANDIDATES
+  // (claude-haiku-4-5, gpt-5-mini, gemini-3-flash), never the incumbent. So for a real incumbent this
+  // `find` is ALWAYS undefined and the collector returns [] here EVERY time in production: an
+  // apples-to-apples per-call rescale is simply not computable on v1. This is deliberate honesty, not a
+  // latent bug; we never fabricate a denominator from an incompatible basis. The real implementation
+  // (an incumbent replay projection, or a per-call-cost rescale that needs no incumbent replay row)
+  // lands in CTO-236; until then this detector is inert by design. The pure `detectWrongSizedModel`
+  // above stays correct FOR A VALID INPUT, but no such input can be produced on v1.
   const incumbentReplay = replay.per_candidate.find((r) => r.model === incumbentModel);
   if (!incumbentReplay || incumbentReplay.projected_monthly_cost_micro_usd <= 0) return [];
   const incumbentProjectedMonthlyMicroUsd = incumbentReplay.projected_monthly_cost_micro_usd;


### PR DESCRIPTION
Second code-review pass on the waste-detection feature (epic CTO-227). Two findings, one live wrong number and one honesty issue.

## Fix A - paid-for-nothing per-agent share denominator (live wrong number)
`web/lib/waste/paid-for-nothing.ts`

The first fix made each run count under exactly one scope (feature when tagged, else agent) so the recoverable TOTAL is not double-counted. That is correct and stays. But it also made the per-scope DENOMINATOR wrong for agents: `scopeCost` (and therefore `windowSpendMicroUsd` and `shareOfScopeSpend`) excluded all feature-tagged runs on that agent. An agent whose real waste is 20% of its spend could report `windowSpend` = only its untagged spend and `shareOfScopeSpend` = 100%, misrepresenting both the evidence and the reason text.

**Fix:** keep the wasted-cost attribution single-scoped (recoverable total still counts each dollar once), but compute each scope's denominator from that scope's TRUE total spend over the window:
- a feature finding's denominator = total spend of that FeatureTag (all its runs)
- an agent finding's denominator = total spend of that ServiceName (ALL its runs, feature-tagged included)

The query now derives a separate `scope_totals` aggregate (feature totals UNION agent totals over the `runs` CTE) and LEFT JOINs it in as `scopeCost`, so `shareOfScopeSpend` = wasted (single-scoped) / true-scope-total.

**Verified:** since the demo has no failed billed runs (paid-for-nothing is `[]` live), the denominator fix is proven with a unit test on fixture rows, not live data: an agent with $0.20 wasted of a real $1.00 total now reports `windowSpend` = full $1.00 and share = 20%, not $0.20 / 100%. The new SQL was also run directly against the local ClickHouse to confirm it is syntactically valid.

## Fix B - wrong-sized-model is inert on v1 replay; stop pretending otherwise (honesty)
`web/lib/waste/wrong-sized-model.ts`

Confirmed against gateway source: `/v1/replay` builds `per_candidate` ONLY from the requested `candidate_models` (DEFAULT_CANDIDATES: claude-haiku-4-5, gpt-5-mini, gemini-3-flash) and never projects the incumbent; `queryReplayCandidates` never sends the incumbent. So `replay.per_candidate.find(r => r.model === incumbentModel)` is always undefined for a real incumbent and the detector returns `[]` every time in production. The old comment claimed "the gateway projects it alongside the candidates" (false), and the collector test masked the dead path by mocking an incumbent row into `per_candidate` that the real gateway never returns.

**Fix (interim honesty only; real implementation is CTO-236):**
- Replaced the false comment with an accurate one: v1 `/v1/replay` does not project the incumbent, so an apples-to-apples per-call rescale is not computable today and the detector returns `[]` until CTO-236 lands.
- Documented the collector as inert-by-design on v1 (docstring + denominator-lookup note).
- Kept the pure `detectWrongSizedModel` unchanged (correct given a valid input; no such input can be produced on v1).
- Rewrote the collector test to assert the HONEST contract: with the real replay shape (incumbent absent from `per_candidate`), `collectWrongSizedModel` returns `[]`, even with a cheaper, quality-passing candidate present. No test encodes a contract the gateway does not honor.

**Verified:** `collectWrongSizedModel(30, emptyFilters)` confirmed to return `[]` live against the running stack, and this is now the documented, intended behaviour rather than a masked bug.

## Verification
From `web/`: `npm run typecheck`, `npm run lint` (only the pre-existing unrelated `useLivePoll.ts` warning), `npm run test` (all 45 waste tests pass; only the long-standing `api.test.ts` "falls back to mock when ClickHouse is unreachable" failure that occurs when a local ClickHouse is running, which passes in CI), and `npm run build` on a clean `.next` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)