### PR TITLE
feat(gateway): wire replay capture into ingest + realistic mock judge (CTO-237)

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -24,7 +24,8 @@ nuke: ## Stop and wipe all data volumes (DDL re-applies on next up)
 # Canonical ClickHouse DDL, in the same dependency order compose mounts it into initdb.
 CH_DDL := ../db/clickhouse/otel_spans.sql ../db/clickhouse/rollups.sql \
           ../db/clickhouse/account_rollups.sql \
-          ../db/clickhouse/last_touch_index.sql ../db/clickhouse/attribution.sql
+          ../db/clickhouse/last_touch_index.sql ../db/clickhouse/attribution.sql \
+          ../db/clickhouse/replay_samples.sql
 
 ch-migrate: ## Apply db/clickhouse DDL to a RUNNING stack (initdb only fires on a fresh volume)
 	@# The /docker-entrypoint-initdb.d mounts in docker-compose.yml run ONLY on a first boot

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -41,6 +41,10 @@ services:
       - ../db/clickhouse/account_rollups.sql:/docker-entrypoint-initdb.d/03_account_rollups.sql:ro
       - ../db/clickhouse/last_touch_index.sql:/docker-entrypoint-initdb.d/04_last_touch_index.sql:ro
       - ../db/clickhouse/attribution.sql:/docker-entrypoint-initdb.d/05_attribution.sql:ro
+      # CTO-237: the opt-in replay corpus index. The gateway writes sampled index rows here and
+      # re-hydrates its in-memory corpus from this table on boot, so replay-backed Compare/eval
+      # survives a restart. No dependency on the tables above, so any tail number is fine.
+      - ../db/clickhouse/replay_samples.sql:/docker-entrypoint-initdb.d/06_replay_samples.sql:ro
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -169,6 +169,15 @@ from tally.hmac_keys import HmacKeyRegistry
 
 logger = logging.getLogger("tally.gateway")
 
+# CTO-237: bound on the in-memory replay sample index, per tenant, newest-wins. The index is read
+# on the hot /v1/replay + /v1/eval paths and persists for the process lifetime; capping it keeps a
+# high-volume tenant from growing it without limit while leaving a healthy corpus to project from.
+REPLAY_INDEX_PER_TENANT_CAP = 500
+# How many recent replay_samples rows to pull back from ClickHouse on boot to re-hydrate the
+# in-memory index (CTO-237). Bounded so a large corpus does not blow up startup; the per-tenant cap
+# above then trims each tenant's slice to REPLAY_INDEX_PER_TENANT_CAP.
+REPLAY_HYDRATE_LIMIT = 5000
+
 # Guards _configure_logging so a re-created app (e.g. the test suite spinning up many TestClients in
 # one process) attaches the root handler exactly once and never stacks duplicates. See CTO-218.
 _logging_configured = False
@@ -291,6 +300,20 @@ async def lifespan(app: FastAPI):
     app.state.tenant_replay = TenantReplayStore(settings)
     app.state.replay_blob_store = _build_replay_blob_store(settings)
     app.state.replay_sample_index = []  # list[ReplaySampleRow]
+    # Hydrate the in-memory replay index from ClickHouse so /v1/replay + /v1/eval serve a captured
+    # corpus after a restart, not just what this process has ingested since boot (CTO-237). The
+    # index resets to [] every boot, so without this a fresh gateway would show an empty Compare /
+    # eval even though the samples are durably persisted. Fail-soft: a fresh or unreachable
+    # ClickHouse (or a not-yet-migrated replay_samples table) just leaves the index empty and boots.
+    try:
+        hydrated = app.state.store.recent_replay_samples(REPLAY_HYDRATE_LIMIT)
+        # recent_replay_samples returns newest-first; reverse to chronological so the bounded append
+        # keeps the newest per tenant when trimming.
+        _extend_replay_index_bounded(app.state.replay_sample_index, list(reversed(hydrated)))
+        if hydrated:
+            logger.info("replay: hydrated %d sample(s) from ClickHouse", len(hydrated))
+    except Exception as exc:  # noqa: BLE001 - hydrate must never crash boot
+        logger.warning("replay: hydrate skipped (%s)", exc)
     app.state.replay_runs = []  # list[ReplayRunRow]
     # Eval harness (CTO-114): pairwise-LLM-judge over the replay outputs. Opt-in like replay;
     # judge calls accumulate in-memory until the ClickHouse writeback path lands.
@@ -666,6 +689,11 @@ async def _run_pipeline(batch: BatchRequest, authorization: str | None) -> JSONR
     validator: SpanValidator = app.state.validator
     metering: UsageRollup = app.state.metering
     rows: list[tuple[object, ...]] = []
+    # CTO-237: candidates for the opt-in replay corpus, collected in lockstep with the written
+    # rows. Building these is cheap and body-free (token counts + resolved-context metadata only);
+    # the tenant's replay config gates whether any are actually sampled/persisted, in
+    # capture_replay_samples_for_batch below.
+    replay_candidates: list[SampleCandidate] = []
     drift_count = 0
     for index, span in enumerate(batch.resource_spans):
         item_id = span_item_id(span, index) if isinstance(span, dict) else f"#{index}"
@@ -700,6 +728,37 @@ async def _run_pipeline(batch: BatchRequest, authorization: str | None) -> JSONR
                 tenant_id=batch.tenant_id,
                 effective_ts_ns=skew.effective_ts_ns,
                 sample_rate=batch.sampling.head_sample_rate,
+            )
+        )
+        # CTO-237: mirror this accepted span into a replay SampleCandidate. The envelope carries
+        # ONLY token counts + resolved-context metadata, never a prompt/completion body (the SDK
+        # never sends one and the validator rejects bodies), so the no-bodies-in-telemetry posture
+        # is preserved; build_payloads still PII-scrubs the envelope before it reaches object
+        # storage. The mock candidate client replays purely off these token counts.
+        span_id = span.get("SpanId") or span.get("span_id")
+        input_tokens = _as_int(result.attributes.get(GenAI.USAGE_INPUT_TOKENS))
+        output_tokens = _as_int(result.attributes.get(GenAI.USAGE_OUTPUT_TOKENS))
+        provider = result.attributes.get(GenAI.SYSTEM)
+        model = result.attributes.get(GenAI.RESPONSE_MODEL) or result.attributes.get(
+            GenAI.REQUEST_MODEL
+        )
+        replay_candidates.append(
+            SampleCandidate(
+                trace_id=trace_id if isinstance(trace_id, str) else "",
+                span_id=span_id if isinstance(span_id, str) else "",
+                feature_tag=feature_tag if isinstance(feature_tag, str) else "untagged",
+                real_provider=str(provider) if provider else "",
+                real_model=str(model) if model else "",
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                envelope={
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "real_provider": str(provider) if provider else "",
+                    "real_model": str(model) if model else "",
+                    "feature_tag": feature_tag if isinstance(feature_tag, str) else "untagged",
+                    "context_fidelity": "resolved-context",
+                },
             )
         )
 
@@ -751,6 +810,22 @@ async def _run_pipeline(batch: BatchRequest, authorization: str | None) -> JSONR
             resp = BatchResponse(batch_id=batch.batch_id, status=Status.RETRY, server_hints=hints)
             idempotency.record(batch, resp)
             return JSONResponse(_response_dict(resp), status_code=503)
+
+    # --- replay capture (CTO-237): populate the opt-in replay corpus from this batch ---
+    # Runs AFTER the ClickHouse write and AFTER per-item validation (the no-bodies/PII guard), so a
+    # sample is only ever captured for a span that was accepted and scrubbed. Gated inside
+    # capture_replay_samples_for_batch on the tenant's replay config (default OFF): a non-opted-in
+    # tenant captures nothing. Best-effort: a capture or Postgres-config hiccup must never fail an
+    # already-accepted ingest, so it is wrapped and swallowed with a logged exception.
+    if replay_candidates:
+        try:
+            capture_replay_samples_for_batch(
+                batch.tenant_id,
+                replay_candidates,
+                store=store,
+            )
+        except Exception:  # noqa: BLE001 - capture is best-effort; never fail accepted ingest
+            logger.exception("replay capture failed for batch %s", batch.batch_id)
 
     if drift_count:
         logger.info("catalog drift on %d/%d spans (batch %s)", drift_count, len(rows), batch.batch_id)
@@ -2446,6 +2521,49 @@ async def set_tenant_replay_config(
     return JSONResponse({"tenant_id": tenant_id, "config": cfg.as_dict()})
 
 
+def _as_int(value: object) -> int:
+    """Coerce a span-attribute value to int, defaulting to 0. Token counts arrive as ints, but a
+    malformed/absent value must never crash replay capture (CTO-237)."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extend_replay_index_bounded(
+    sample_index: list,
+    rows: list,
+    *,
+    per_tenant_cap: int | None = None,
+) -> None:
+    """Append ``rows`` to the in-memory index, then trim to the newest ``per_tenant_cap`` per tenant.
+
+    CTO-237: the index is read on the hot ``/v1/replay`` + ``/v1/eval`` paths and lives for the
+    life of the process, so it must not grow without bound. The list is append-ordered (oldest
+    first), so newest-wins trimming keeps the tail. Kept tenant-scoped so a noisy tenant cannot
+    evict another tenant's corpus. Mutates ``sample_index`` in place so app.state and every handler
+    holding the same list object see the trim. ``per_tenant_cap`` defaults to the module constant,
+    read at call time so it can be tuned/patched.
+    """
+    cap = per_tenant_cap if per_tenant_cap is not None else REPLAY_INDEX_PER_TENANT_CAP
+    sample_index.extend(rows)
+    counts: dict[str, int] = {}
+    for r in sample_index:
+        counts[r.tenant_id] = counts.get(r.tenant_id, 0) + 1
+    over = {t for t, c in counts.items() if c > cap}
+    if not over:
+        return
+    kept_reversed: list = []
+    seen: dict[str, int] = {}
+    for r in reversed(sample_index):
+        if r.tenant_id in over:
+            if seen.get(r.tenant_id, 0) >= cap:
+                continue
+            seen[r.tenant_id] = seen.get(r.tenant_id, 0) + 1
+        kept_reversed.append(r)
+    sample_index[:] = list(reversed(kept_reversed))
+
+
 def capture_replay_samples_for_batch(
     tenant_id: str,
     candidates: list[SampleCandidate],
@@ -2453,12 +2571,20 @@ def capture_replay_samples_for_batch(
     config_store: TenantReplayStore | None = None,
     blob_store=None,
     sample_index: list | None = None,
+    store: ClickHouseStore | None = None,
     captured_at=None,
 ) -> int:
     """Hook the gateway calls per accepted batch. Returns the number of samples persisted.
 
     Pulled out as a free function so tests can drive it without standing up a FastAPI app. The
     real ``POST /v1/batches`` path wires this in after the ingest pipeline writes to ClickHouse.
+
+    Persistence (CTO-237): each sampled envelope is written to object storage (``persist_sample``)
+    and its index row is (a) appended to the bounded in-memory ``sample_index`` that ``/v1/replay``
+    and ``/v1/eval`` read, and (b) inserted into the ``replay_samples`` ClickHouse table when a
+    ``store`` is provided, so the corpus survives a gateway restart and can be re-hydrated on boot.
+    The ClickHouse write is best-effort: a failure there is logged but never loses the in-memory
+    capture nor fails ingest.
 
     No-op (returns 0) when the tenant has not opted in.
     """
@@ -2474,15 +2600,24 @@ def capture_replay_samples_for_batch(
 
     sampled = stratified_sample(candidates, sample_rate=cfg.sample_rate)
     payloads = build_payloads(sampled, scrub=True)
-    for p in payloads:
-        row = persist_sample(
+    rows = [
+        persist_sample(
             blob_store=blob_store,
             tenant_id=tenant_id,
             payload=p,
             captured_at=captured_at,
         )
-        sample_index.append(row)
-    return len(payloads)
+        for p in payloads
+    ]
+    # Durable index (CTO-237): mirror the rows into ClickHouse so a restart can re-hydrate them.
+    # Best-effort: the in-memory corpus is authoritative for this process either way.
+    if rows and store is not None:
+        try:
+            store.insert_replay_samples(rows)
+        except Exception:  # noqa: BLE001 - durable writeback is best-effort; keep the in-memory row
+            logger.exception("replay: ClickHouse writeback failed for %d sample(s)", len(rows))
+    _extend_replay_index_bounded(sample_index, rows)
+    return len(rows)
 
 
 @app.post("/v1/replay")
@@ -3156,13 +3291,37 @@ def _todays_eval_spend(rows: list, tenant_id: str) -> int:
 
 
 async def _mock_judge_client(call: JudgeCall) -> JudgeResponse:
-    """Deterministic mock judge for tests / dev. Always emits "TIE" with token counts
-    derived from the prompt length. Production deployments wire a real Anthropic client via
-    ``app.state.eval_judge_client``.
+    """Deterministic MOCK judge for local dev + tests (CTO-237). NOT a real judge: production
+    wires a real Anthropic client via ``app.state.eval_judge_client``.
+
+    The previous mock always emitted "TIE", which made every candidate's win-rate 0.0 and left the
+    replay-backed Compare/eval and the wrong-sized-model waste detector unable to produce the one
+    signal they exist for: "this cheaper model is statistically indistinguishable in quality".
+
+    This mock instead derives a verdict letter deterministically from the rubric prompt (same
+    prompt -> same letter, so tests stay stable) with a balanced split: ~47.5% A, ~47.5% B, ~5%
+    TIE. The executor already randomizes A/B placement per sample (position-bias mitigation), so a
+    balanced A/B letter maps to a candidate win-rate of ~(1 - tie_fraction)/2 ≈ 0.475 whose Wilson
+    CI overlaps 0.5 at the sample sizes real Compare/eval passes use. That "statistically
+    indistinguishable" outcome is exactly the honest right-sizing signal the wrong-sized-model
+    waste detector keys on; the mock deliberately does NOT favor the candidate. The small tie
+    fraction keeps win-rate near 0.5 (ties count in the win-rate denominator, so a large tie share
+    would drag it down and let a fair candidate look worse than it is).
     """
+    # blake2b over the full prompt (instruction + both responses) -> a stable, uniform bucket.
+    import hashlib
+    bucket = int.from_bytes(
+        hashlib.blake2b(call.prompt.encode("utf-8"), digest_size=8).digest(), "big"
+    ) % 40
+    if bucket < 19:
+        text = "A"
+    elif bucket < 38:
+        text = "B"
+    else:
+        text = "TIE"
     input_tokens = max(10, len(call.prompt) // 4)
     return JudgeResponse(
-        text="TIE",
+        text=text,
         input_tokens=input_tokens,
         output_tokens=2,
         status_code=200,

--- a/infra/gateway/src/gateway/store.py
+++ b/infra/gateway/src/gateway/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from uuid import UUID
 
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
@@ -11,6 +12,7 @@ from tally.wire import BusinessEvent, IdentityLink
 
 from gateway.config import Settings
 from gateway.mapping import COLUMNS
+from gateway.replay_store import REPLAY_SAMPLE_COLS, ReplaySampleRow
 
 _BUSINESS_EVENT_COLS = (
     "TenantId", "BusinessEventId", "EventName", "UserIdHash", "AccountIdHash", "OccurredAt",
@@ -157,6 +159,57 @@ class ClickHouseStore:
         ]
         self.client.insert("identity_graph", rows, column_names=list(_IDENTITY_COLS))
         return len(rows)
+
+    def insert_replay_samples(self, rows: list[ReplaySampleRow]) -> int:
+        """Insert opt-in replay sample index rows into ``replay_samples`` (CTO-237).
+
+        The scrubbed envelope body itself lives in object storage (MinIO/S3/GCS); this table is the
+        durable index the gateway re-hydrates its in-memory corpus from on boot, so replay-backed
+        Compare/eval survives a restart. Only counts + the object key are stored here, never a body
+        (the body carve-out is object storage, gated by the tenant's opt-in retention TTL).
+        """
+        if not rows:
+            return 0
+        self.client.insert(
+            "replay_samples",
+            [r.as_clickhouse_row() for r in rows],
+            column_names=list(REPLAY_SAMPLE_COLS),
+        )
+        return len(rows)
+
+    def recent_replay_samples(self, limit: int) -> list[ReplaySampleRow]:
+        """Return the most recent ``limit`` replay sample index rows, newest first (CTO-237).
+
+        Used once on boot to re-hydrate the in-memory ``replay_sample_index`` so a fresh gateway
+        process serves the durably captured corpus rather than an empty one. Bounded by ``limit``.
+        """
+        if limit <= 0:
+            return []
+        result = self.client.query(
+            "SELECT TenantId, SampleId, TraceId, FeatureTag, RealProvider, RealModel, "
+            "InputTokens, OutputTokens, CapturedAt, S3ObjectKey, PIIScrubbed, ContextFidelity "
+            "FROM replay_samples ORDER BY CapturedAt DESC LIMIT %(n)s",
+            parameters={"n": int(limit)},
+        )
+        out: list[ReplaySampleRow] = []
+        for r in result.result_rows:
+            out.append(
+                ReplaySampleRow(
+                    tenant_id=str(r[0]),
+                    sample_id=r[1] if isinstance(r[1], UUID) else UUID(str(r[1])),
+                    trace_id=str(r[2]),
+                    feature_tag=str(r[3]),
+                    real_provider=str(r[4]),
+                    real_model=str(r[5]),
+                    input_tokens=int(r[6]),
+                    output_tokens=int(r[7]),
+                    captured_at=r[8],
+                    s3_object_key=str(r[9]),
+                    pii_scrubbed=bool(r[10]),
+                    context_fidelity=str(r[11]),
+                )
+            )
+        return out
 
     def close(self) -> None:
         if self._client is not None:

--- a/infra/gateway/tests/test_app_mock_judge.py
+++ b/infra/gateway/tests/test_app_mock_judge.py
@@ -1,0 +1,71 @@
+"""The local MOCK judge distribution (CTO-237).
+
+The dev/test judge used to always emit "TIE", which pinned every candidate win-rate to 0.0 and made
+the replay-backed Compare/eval and the wrong-sized-model waste detector produce no usable signal.
+It now derives a deterministic-but-balanced verdict from the prompt, so a candidate's pairwise
+win-rate lands near 0.5 with a Wilson CI that overlaps 0.5 ("statistically indistinguishable").
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from gateway.app import _mock_judge_client, _wilson_interval
+from gateway.eval_executor import JudgeCall
+
+
+def _judge(prompt: str) -> str:
+    resp = asyncio.run(_mock_judge_client(JudgeCall(provider="anthropic", model="m", prompt=prompt)))
+    return resp.text
+
+
+def test_mock_judge_is_deterministic() -> None:
+    prompt = "INSTRUCTION: sum\nRESPONSE A: 4\nRESPONSE B: four"
+    assert _judge(prompt) == _judge(prompt)
+
+
+def test_mock_judge_distribution_is_non_degenerate() -> None:
+    verdicts = [_judge(f"instruction {i}\nA: alpha {i}\nB: beta {i}") for i in range(400)]
+    counts = {v: verdicts.count(v) for v in ("A", "B", "TIE")}
+    # Not all-TIE, and every bucket is actually populated.
+    assert counts["A"] > 0
+    assert counts["B"] > 0
+    assert counts["TIE"] > 0
+    assert counts["TIE"] < len(verdicts)
+    # Roughly balanced A vs B (target ~47.5/47.5/5). Wide band keeps the test stable.
+    assert 0.40 < counts["A"] / len(verdicts) < 0.55
+    assert 0.40 < counts["B"] / len(verdicts) < 0.55
+    assert counts["TIE"] / len(verdicts) < 0.15
+
+
+def test_mock_judge_yields_winrate_indistinguishable_from_half() -> None:
+    """The aggregate candidate win-rate is fair: candidate wins ~= current wins, CI overlaps 0.5.
+
+    The executor randomizes A/B placement per sample (position-bias mitigation); here we model that
+    deterministically by alternating which side carries the candidate, so the test has no RNG
+    dependence. With a balanced A/B letter from the mock, candidate wins land level with current
+    wins and the candidate win-rate's Wilson CI straddles 0.5 - exactly the "statistically
+    indistinguishable quality" verdict the wrong-sized-model waste detector keys on. It must NOT
+    be biased toward the candidate.
+    """
+    candidate_wins = current_wins = ties = 0
+    for i in range(200):
+        a_is_candidate = (i % 2 == 0)  # deterministic 50/50 position split
+        cand, cur = f"cand-{i}", f"cur-{i}"
+        resp_a = cand if a_is_candidate else cur
+        resp_b = cur if a_is_candidate else cand
+        letter = _judge(f"INSTRUCTION: q{i}\nRESPONSE A: {resp_a}\nRESPONSE B: {resp_b}")
+        if letter == "TIE":
+            ties += 1
+        elif (letter == "A") == a_is_candidate:  # mirrors eval_executor.parse_verdict
+            candidate_wins += 1
+        else:
+            current_wins += 1
+    non_error = candidate_wins + current_wins + ties  # ties count in the denominator
+    win_rate = candidate_wins / non_error
+    lo, hi = _wilson_interval(candidate_wins, non_error)
+    # Fair: neither side dominates, and win-rate sits near 0.5.
+    assert abs(candidate_wins - current_wins) < 0.25 * non_error
+    assert 0.40 < win_rate < 0.60
+    # The whole point: quality is indistinguishable, so the CI must straddle 0.5.
+    assert lo <= 0.5 <= hi

--- a/infra/gateway/tests/test_app_replay_capture.py
+++ b/infra/gateway/tests/test_app_replay_capture.py
@@ -1,0 +1,192 @@
+"""Ingest-path replay capture wiring (CTO-237).
+
+Proves that /v1/batches now populates the opt-in replay corpus when (and only when) the tenant has
+replay enabled, and that the captured samples are what /v1/replay projects from. Auth is disabled
+and the ClickHouse store is an in-memory fake, so the ingest write path runs without any infra.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from tally.schema import GenAI
+
+from gateway.app import app
+from gateway.replay_store import InMemoryReplayBlobStore
+from gateway.tenant_replay import ReplayConfig
+
+T = "t-local"
+
+
+class FakeStore:
+    """In-memory ClickHouse stand-in that also records replay-sample writeback."""
+
+    def __init__(self) -> None:
+        self.spans: list[tuple] = []
+        self.replay_samples: list = []
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        self.spans.extend(rows)
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def insert_replay_samples(self, rows: list) -> int:
+        self.replay_samples.extend(rows)
+        return len(rows)
+
+    def recent_replay_samples(self, limit: int) -> list:
+        return []
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+class FakeReplayStore:
+    """In-memory TenantReplayStore stand-in, no Postgres."""
+
+    def __init__(self, cfg: ReplayConfig) -> None:
+        self._cfg = cfg
+
+    def get(self, tenant_id: str) -> ReplayConfig:
+        return self._cfg
+
+
+@contextmanager
+def _client(cfg: ReplayConfig) -> Iterator[tuple[TestClient, FakeStore]]:
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = False
+        store = FakeStore()
+        app.state.store = store
+        app.state.tenant_replay = FakeReplayStore(cfg)
+        app.state.replay_blob_store = InMemoryReplayBlobStore()
+        app.state.replay_sample_index = []
+        app.state.replay_runs = []
+        if hasattr(app.state, "replay_candidate_client"):
+            delattr(app.state, "replay_candidate_client")
+        yield client, store
+
+
+def _span(i: int) -> dict:
+    return {
+        "trace_id": f"t{i}",
+        "span_id": f"s{i}",
+        GenAI.SYSTEM: "openai",
+        GenAI.OPERATION_NAME: "chat",
+        GenAI.FEATURE_TAG: "research",
+        GenAI.REQUEST_MODEL: "gpt-4o",
+        GenAI.RESPONSE_MODEL: "gpt-4o",
+        GenAI.USAGE_INPUT_TOKENS: 100 + i,
+        GenAI.USAGE_OUTPUT_TOKENS: 40 + i,
+    }
+
+
+def _post(c: TestClient, spans: list[dict]) -> dict:
+    body = {"tenant_id": T, "sdk_version": "test", "resource_spans": spans}
+    r = c.post("/v1/batches", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+_ENABLED = ReplayConfig(
+    enabled=True, sample_rate=1.0, retention_days=30, daily_budget_usd=Decimal("5.00")
+)
+_DISABLED = ReplayConfig(
+    enabled=False, sample_rate=0.05, retention_days=30, daily_budget_usd=Decimal("5.00")
+)
+
+
+def test_enabled_tenant_captures_into_index_and_clickhouse() -> None:
+    with _client(_ENABLED) as (c, store):
+        body = _post(c, [_span(i) for i in range(8)])
+        assert body["status"] == "accepted"
+        # sample_rate=1.0 => every accepted span is captured.
+        index = app.state.replay_sample_index
+        assert len(index) == 8
+        assert {r.tenant_id for r in index} == {T}
+        assert {r.feature_tag for r in index} == {"research"}
+        # Token counts survive onto the index row (the mock candidate client replays off them).
+        assert all(r.input_tokens > 0 and r.output_tokens > 0 for r in index)
+        assert all(r.pii_scrubbed for r in index)
+        # Durably mirrored into ClickHouse for restart re-hydration.
+        assert len(store.replay_samples) == 8
+
+
+def test_enabled_tenant_replay_projection_sees_the_corpus() -> None:
+    with _client(_ENABLED) as (c, _store):
+        _post(c, [_span(i) for i in range(6)])
+        r = c.post(
+            "/v1/replay",
+            headers={"X-Tenant-Id": T},
+            json={
+                "tenant_id": T,
+                "feature_tag": "research",
+                "candidate_models": [{"provider": "anthropic", "model": "claude-haiku-4-5"}],
+                "sample_size": 50,
+            },
+        )
+        assert r.status_code == 200, r.text
+        payload = r.json()
+        assert payload["samples_available"] == 6
+        assert len(payload["per_candidate"]) == 1
+        assert payload["per_candidate"][0]["samples_replayed"] > 0
+
+
+def test_disabled_tenant_captures_nothing() -> None:
+    with _client(_DISABLED) as (c, store):
+        body = _post(c, [_span(i) for i in range(8)])
+        assert body["status"] == "accepted"
+        assert len(store.spans) == 8  # ingest still writes spans
+        # ...but nothing is captured for a tenant that has not opted in.
+        assert app.state.replay_sample_index == []
+        assert store.replay_samples == []
+
+
+def test_capture_never_breaks_ingest_when_writeback_raises() -> None:
+    """A ClickHouse replay-sample writeback failure must not fail the accepted ingest (CTO-237)."""
+    class BoomStore(FakeStore):
+        def insert_replay_samples(self, rows: list) -> int:
+            raise RuntimeError("clickhouse down")
+
+    with TestClient(app) as c:
+        app.state.settings.require_api_key = False
+        store = BoomStore()
+        app.state.store = store
+        app.state.tenant_replay = FakeReplayStore(_ENABLED)
+        app.state.replay_blob_store = InMemoryReplayBlobStore()
+        app.state.replay_sample_index = []
+        app.state.replay_runs = []
+        body = _post(c, [_span(1), _span(2)])
+        assert body["status"] == "accepted"
+        assert body["accepted_spans"] == 2
+        # In-memory capture still succeeded even though the durable writeback raised.
+        assert len(app.state.replay_sample_index) == 2
+
+
+@pytest.mark.parametrize("cap", [3])
+def test_in_memory_index_is_bounded_newest_wins(cap: int) -> None:
+    from gateway import app as app_module
+
+    with _client(_ENABLED) as (c, _store):
+        original = app_module.REPLAY_INDEX_PER_TENANT_CAP
+        app_module.REPLAY_INDEX_PER_TENANT_CAP = cap
+        try:
+            _post(c, [_span(i) for i in range(2)])
+            _post(c, [_span(i) for i in range(2, 7)])  # 7 captured total, cap is 3
+        finally:
+            app_module.REPLAY_INDEX_PER_TENANT_CAP = original
+        index = app.state.replay_sample_index
+        assert len(index) == cap
+        # Newest-wins: the last three trace ids captured are retained.
+        assert [r.trace_id for r in index] == ["t4", "t5", "t6"]


### PR DESCRIPTION
## What this wires

Replay-backed Compare/eval and the wrong-sized-model waste detector were dead code on the running gateway: `capture_replay_samples_for_batch` was **never called**, so the replay corpus stayed empty, and `_mock_judge_client` **always returned "TIE"**, pinning every candidate win-rate to 0.0. CTO-237 makes both actually work.

### Part A - capture wired into ingest
- `/v1/batches` `_run_pipeline` now mirrors each **accepted** span into a replay `SampleCandidate` and calls `capture_replay_samples_for_batch` **after the ClickHouse write and after per-item validation** (the no-bodies/PII guard). Gated on the tenant's `tenant_replay` config (`enabled` + `sample_rate`), default OFF, so a non-opted-in tenant captures nothing.
- **PII posture preserved:** the captured envelope carries token counts + resolved-context metadata only, never a prompt/completion body (the SDK never sends one and the validator rejects bodies), and `build_payloads` still PII-scrubs before object storage. The mock candidate client replays purely off the token counts.
- **Best-effort:** capture is wrapped so a capture/Postgres-config/ClickHouse hiccup can never fail an already-accepted ingest. The replay daily-budget guard (in the executor) is untouched.

### Persistence approach (hydrate-on-boot INCLUDED)
- Sampled index rows are inserted into the `replay_samples` ClickHouse table (`ClickHouseStore.insert_replay_samples`), and the in-memory `replay_sample_index` is **hydrated on boot** from a bounded recent slice (`recent_replay_samples`, `REPLAY_HYDRATE_LIMIT=5000`). So `/v1/replay` + `/v1/eval` serve a captured corpus after a restart, not just what the process ingested since boot. Both the writeback and the hydrate are fail-soft (a fresh/unreachable/not-yet-migrated ClickHouse just boots with an empty index).
- The in-memory index is **bounded per tenant, newest-wins** (`REPLAY_INDEX_PER_TENANT_CAP=500`) so a high-volume tenant can't grow it without limit on the hot read path, and can't evict another tenant's slice.
- **DDL wiring:** `replay_samples.sql` is now mounted in `docker-compose.yml` initdb (`06_replay_samples.sql`) and added to the Makefile `ch-migrate` DDL set. The table was never created before this. SDK/web/edge builds are untouched.

### Part B - realistic, fair mock judge
`_mock_judge_client` now derives a deterministic verdict from a blake2b hash of the rubric prompt with a balanced **~47.5% A / ~47.5% B / ~5% TIE** split (was a hardcoded "TIE"). It is:
- **Deterministic** (same prompt -> same verdict) so tests stay stable.
- **Fair, not candidate-biased:** combined with the executor's existing per-sample A/B randomization, a candidate's pairwise win-rate lands near 0.5 with a Wilson CI that overlaps 0.5 - the honest "statistically indistinguishable quality" right-sizing signal. The small tie fraction keeps win-rate near 0.5 (ties count in the win-rate denominator, so a large tie share would drag a fair candidate below 0.5).
- **Still clearly a MOCK** (docstring says so); production wires a real judge via `app.state.eval_judge_client`. Existing eval tests inject their own judges, so none asserted the old all-TIE default.

## Tests
- `test_app_replay_capture.py`: replay ENABLED makes the index non-empty and `/v1/replay` `samples_available > 0` and mirrors to ClickHouse; DISABLED captures nothing (spans still written); a writeback failure never breaks ingest; the in-memory index is bounded newest-wins.
- `test_app_mock_judge.py`: the mock judge is deterministic, yields a non-degenerate (not all-TIE) roughly-balanced distribution, and produces a fair candidate win-rate whose Wilson CI overlaps 0.5.

Gateway: `uv run --extra dev pytest -q` -> **833 passed**; `uv run ruff check .` -> clean.

## Operator note
A gateway container **rebuild/restart is required** to load this change (and `make ch-migrate` / a fresh volume to create the `replay_samples` table on an already-running stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)