### PR TITLE
fix(web): resolve wrong-sized-model incumbent per feature (CTO-238)

### DIFF
--- a/web/lib/waste/wrong-sized-model.collect.test.ts
+++ b/web/lib/waste/wrong-sized-model.collect.test.ts
@@ -1,31 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
-// Collector tests for the wrong-sized-model detector (per-call basis, CTO-236). These lock the LIVE
-// wiring of `collectWrongSizedModel` on the per-call basis that replaced the inert v1 contract.
+// Collector tests for the wrong-sized-model detector (per-call basis CTO-236; per-feature incumbent
+// CTO-238). These lock the LIVE wiring of `collectWrongSizedModel`, which now resolves the incumbent
+// PER FEATURE rather than tenant-wide.
 //
-// The old contract (CTO-227 review pass 2) asserted the collector ALWAYS returned [] because it needed
-// an incumbent row inside `replay.per_candidate` that the gateway never projects. CTO-236 removes that
-// dependency: each candidate's cost per call is `projected_monthly_cost_micro_usd / samples_available`
-// (confirmed against infra/gateway/src/gateway/app.py, which builds the projection as
-// `round(avg_cost_per_call * samples_available)`), and the incumbent's cost per call is measured
-// DIRECTLY from its own real traffic via `queryIncumbentPerCall` (avg EstimatedCost over its chat
-// spans). No incumbent replay row, no cross-id cost join. So on the REAL replay shape (incumbent absent
-// from per_candidate) the collector now FIRES when a candidate is cheaper per call at no quality
-// regression, and still returns [] honestly when any required signal (corpus / eval / incumbent
-// traffic) is missing.
+// The bug CTO-238 fixes: the collector resolved ONE tenant-wide dominant model (queryCurrentModel) and
+// compared every feature's per-feature replay corpus + eval against it, pairing one feature's
+// candidates against a global incumbent. It now reads per (FeatureTag, model) spend + calls in one
+// grouped ClickHouse read, picks each feature's own dominant model as that feature's incumbent, and
+// iterates the top-K features by spend, calling replay/eval per feature and pushing one scope each.
 //
-// The pure detector (`detectWrongSizedModel`) is unit-tested separately in wrong-sized-model.test.ts;
-// this file pins the collector's reads and the read ORDER (replay first, then eval, then incumbent).
+// Each candidate's cost per call is `projected_monthly_cost_micro_usd / samples_available`, and the
+// incumbent's cost per call is measured from that feature's own dominant-model traffic (spend / calls
+// from the grouped read). The pure detector (`detectWrongSizedModel`) is unit-tested separately in
+// wrong-sized-model.test.ts; this file pins the collector's reads, the per-feature scoping, and the
+// filter narrowing.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Partial mock: keep the real `micro` and `clampWindowDays`-adjacent helpers, stub only the reads.
-// `tryLive` is stubbed to run its callback (so `queryIncumbentPerCall`'s body executes against a
-// stubbed `rowsP`), and `rowsP` returns the incumbent's spend/call row.
+// Partial mock: keep the real `micro` at the money boundary, stub only the reads. `tryLive` runs its
+// callback (so `queryFeatureIncumbents`'s body executes against the stubbed `rowsP`), `rowsP` returns
+// the grouped (feature, model) spend/call rows, and replay/eval are stubbed per feature.
 vi.mock("@/lib/clickhouse", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/clickhouse")>();
   return {
     ...actual,
-    queryCurrentModel: vi.fn(),
     queryReplayCandidates: vi.fn(),
     queryEvalCandidates: vi.fn(),
     tryLive: vi.fn(),
@@ -37,91 +35,102 @@ import { collectWrongSizedModel } from "./wrong-sized-model";
 import * as ch from "@/lib/clickhouse";
 import type { DimensionFilters } from "@/lib/filters";
 
-const queryCurrentModel = ch.queryCurrentModel as unknown as ReturnType<typeof vi.fn>;
 const queryReplayCandidates = ch.queryReplayCandidates as unknown as ReturnType<typeof vi.fn>;
 const queryEvalCandidates = ch.queryEvalCandidates as unknown as ReturnType<typeof vi.fn>;
 const tryLive = ch.tryLive as unknown as ReturnType<typeof vi.fn>;
 const rowsP = ch.rowsP as unknown as ReturnType<typeof vi.fn>;
 
-const NO_FILTERS: DimensionFilters = {
-  feature: [],
-  model: [],
-  layer: [],
-  provider: [],
-  account: [],
-};
-
-// Incumbent = gpt-4o (the current model).
-function currentModel(over: Record<string, unknown> = {}) {
-  return {
-    model: "gpt-4o",
-    provider: "openai",
-    monthlyCostMicroUsd: 40_000_000_000,
-    latencyP95Ms: 2400,
-    errorRate: 0.01,
-    sampleCount: 500,
-    ...over,
-  };
+function filters(over: Partial<DimensionFilters> = {}): DimensionFilters {
+  return { feature: [], model: [], layer: [], provider: [], account: [], ...over };
 }
 
-// The REAL replay shape: per_candidate carries ONLY the requested candidate models, never the
-// incumbent. haiku is present; gpt-4o (the incumbent) is deliberately ABSENT, exactly as the gateway
-// returns it. samples_available = 200, haiku projected 2B -> per-call 10,000,000 micro-USD.
-function replayCandidatesOnly() {
-  return {
-    samples_available: 200,
-    per_candidate: [
-      {
-        provider: "anthropic",
-        model: "claude-haiku-4-5",
-        projected_monthly_cost_micro_usd: 2_000_000_000,
-        p50_latency_ms: 900,
-        p95_latency_ms: 1800,
-        error_rate: 0.01,
-        samples_replayed: 120,
-        excluded_budget_count: 0,
-      },
-    ],
-    diagnostics: { context_fidelity: "resolved-context", replay_cost_micro_usd: 1000 },
-  };
+// The grouped (FeatureTag, model) read the collector runs. research_agent's dominant model is
+// claude-sonnet-4-5 (max spend); chatbot's is gpt-4o. Each dominant model: spend "20000"/"10000",
+// 1000 calls -> per-call 20,000,000 / 10,000,000 micro-USD. A cheap secondary model row on
+// research_agent exercises dominance (it must NOT win) and the feature-total ranking key.
+function groupedRows() {
+  return [
+    { feature: "research_agent", model: "claude-sonnet-4-5", spend: "20000", calls: 1000 },
+    { feature: "research_agent", model: "gpt-4o-mini", spend: "50", calls: 200 },
+    { feature: "chatbot", model: "gpt-4o", spend: "10000", calls: 1000 },
+  ];
 }
 
-function evalCandidatesOnly() {
-  return {
-    samples_available: 200,
-    per_candidate: [
-      {
-        provider: "anthropic",
-        model: "claude-haiku-4-5",
-        samples_judged: 40,
-        current_wins: 18,
-        candidate_wins: 20,
-        ties: 2,
-        errors: 0,
-        win_rate: 0.5,
-        win_rate_ci_lo: 0.44,
-        win_rate_ci_hi: 0.56,
-        judge_cost_micro_usd: 100,
-      },
-    ],
-    diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
-  };
-}
-
-// Stub the incumbent per-call read: `queryIncumbentPerCall` runs inside `tryLive`, whose body calls
-// `rowsP` -> [{ spend, calls }]. Real `micro` converts "20000" -> 20,000,000,000 micro-USD; 1000 calls
-// -> per-call 20,000,000 micro-USD (twice the haiku candidate's 10,000,000, so haiku qualifies).
-function incumbentTraffic(spend = "20000", calls = 1000) {
+// tryLive runs the callback; rowsP returns the grouped rows. `micro` converts "20000" ->
+// 20,000,000,000 micro-USD (window spend), /1000 -> 20,000,000 per call.
+function incumbents(rows: unknown[] = groupedRows()) {
   tryLive.mockImplementation(async (fn: (db: unknown, tenant: string) => Promise<unknown>) =>
     fn({}, "local-dev"),
   );
-  rowsP.mockResolvedValue([{ spend, calls }]);
+  rowsP.mockResolvedValue(rows);
+}
+
+// Per-feature replay: haiku is the cheaper candidate for research_agent (projected 2B / 200 ->
+// per-call 10,000,000, half the sonnet incumbent); gpt-5-mini for chatbot (projected 1B / 200 ->
+// 5,000,000, half the gpt-4o incumbent). Any other feature has no corpus (null).
+function replayFor(feature?: string) {
+  const cand = (provider: string, model: string, projected: number) => ({
+    provider,
+    model,
+    projected_monthly_cost_micro_usd: projected,
+    p50_latency_ms: 900,
+    p95_latency_ms: 1800,
+    error_rate: 0.01,
+    samples_replayed: 120,
+    excluded_budget_count: 0,
+  });
+  const map: Record<string, unknown> = {
+    research_agent: {
+      samples_available: 200,
+      per_candidate: [cand("anthropic", "claude-haiku-4-5", 2_000_000_000)],
+      diagnostics: { context_fidelity: "resolved-context", replay_cost_micro_usd: 1000 },
+    },
+    chatbot: {
+      samples_available: 200,
+      per_candidate: [cand("openai", "gpt-5-mini", 1_000_000_000)],
+      diagnostics: { context_fidelity: "resolved-context", replay_cost_micro_usd: 1000 },
+    },
+  };
+  return map[feature ?? ""] ?? null;
+}
+
+function evalFor(feature?: string) {
+  const cand = (provider: string, model: string) => ({
+    provider,
+    model,
+    samples_judged: 40,
+    current_wins: 18,
+    candidate_wins: 20,
+    ties: 2,
+    errors: 0,
+    win_rate: 0.5,
+    win_rate_ci_lo: 0.44,
+    win_rate_ci_hi: 0.56,
+    judge_cost_micro_usd: 100,
+  });
+  const map: Record<string, unknown> = {
+    research_agent: {
+      samples_available: 200,
+      per_candidate: [cand("anthropic", "claude-haiku-4-5")],
+      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
+    },
+    chatbot: {
+      samples_available: 200,
+      per_candidate: [cand("openai", "gpt-5-mini")],
+      diagnostics: { judge_model: "j", rubric_version: "1", judge_cost_micro_usd: 1 },
+    },
+  };
+  return map[feature ?? ""] ?? null;
+}
+
+function wireCorpora() {
+  queryReplayCandidates.mockImplementation(async (feature?: string) => replayFor(feature));
+  queryEvalCandidates.mockImplementation(async (feature?: string) => evalFor(feature));
 }
 
 beforeEach(() => {
   queryEvalCandidates.mockReset();
   queryReplayCandidates.mockReset();
-  queryCurrentModel.mockReset();
   tryLive.mockReset();
   rowsP.mockReset();
 });
@@ -130,73 +139,114 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("collectWrongSizedModel per-call basis (CTO-236)", () => {
-  it("FIRES on the real replay shape (incumbent absent from per_candidate) for a cheaper, quality-passing candidate", async () => {
-    queryReplayCandidates.mockResolvedValue(replayCandidatesOnly());
-    queryEvalCandidates.mockResolvedValue(evalCandidatesOnly());
-    queryCurrentModel.mockResolvedValue(currentModel());
-    incumbentTraffic();
+describe("collectWrongSizedModel per-feature incumbent (CTO-238)", () => {
+  it("emits one finding per feature, each scoped to its OWN incumbent (dominant model)", async () => {
+    incumbents();
+    wireCorpora();
 
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    const findings = await collectWrongSizedModel(30, filters());
+    expect(findings).toHaveLength(2);
+
+    const byFeature = new Map(findings.map((f) => [f.scopeValue, f]));
+
+    const research = byFeature.get("research_agent")!;
+    expect(research.scopeKind).toBe("feature");
+    expect(research.evidence.incumbentModel).toBe("claude-sonnet-4-5"); // NOT the cheap gpt-4o-mini row
+    expect(research.evidence.candidateModel).toBe("claude-haiku-4-5");
+    expect(research.evidence.incumbentPerCall).toBe(20_000_000);
+    expect(research.evidence.candidatePerCall).toBe(10_000_000);
+    // window 20B rescaled by 10M/20M -> 10B, recoverable 10B.
+    expect(research.recoverableMicroUsd).toBe(10_000_000_000);
+    expect(research.windowSpendMicroUsd).toBe(20_000_000_000);
+    expect(research.reason).toContain("on research_agent");
+
+    const chatbot = byFeature.get("chatbot")!;
+    expect(chatbot.scopeKind).toBe("feature");
+    expect(chatbot.evidence.incumbentModel).toBe("gpt-4o");
+    expect(chatbot.evidence.candidateModel).toBe("gpt-5-mini");
+    expect(chatbot.evidence.incumbentPerCall).toBe(10_000_000);
+    expect(chatbot.evidence.candidatePerCall).toBe(5_000_000);
+    // window 10B rescaled by 5M/10M -> 5B, recoverable 5B.
+    expect(chatbot.recoverableMicroUsd).toBe(5_000_000_000);
+    expect(chatbot.reason).toContain("on chatbot");
+  });
+
+  it("skips a feature with no corpus/eval, still flags the ones that have both", async () => {
+    incumbents();
+    // research_agent has a corpus + eval; chatbot's replay comes back null (no captured corpus).
+    queryReplayCandidates.mockImplementation(async (feature?: string) =>
+      feature === "chatbot" ? null : replayFor(feature),
+    );
+    queryEvalCandidates.mockImplementation(async (feature?: string) => evalFor(feature));
+
+    const findings = await collectWrongSizedModel(30, filters());
     expect(findings).toHaveLength(1);
-    const f = findings[0];
-    expect(f.category).toBe("wrong_sized_model");
-    expect(f.evidence.incumbentModel).toBe("gpt-4o");
-    expect(f.evidence.candidateModel).toBe("claude-haiku-4-5");
-    expect(f.evidence.incumbentPerCall).toBe(20_000_000);
-    expect(f.evidence.candidatePerCall).toBe(10_000_000);
-    // windowSpend 20B rescaled by 10M/20M -> 10B, recoverable 10B.
-    expect(f.recoverableMicroUsd).toBe(10_000_000_000);
-    expect(f.windowSpendMicroUsd).toBe(20_000_000_000);
-    // Per-call, resolved-context caveat carried on the reason.
-    expect(f.reason).toContain("per call");
-    expect(f.reason).toContain("resolved-context replay, no live retrieval");
+    expect(findings[0].scopeValue).toBe("research_agent");
   });
 
-  it("returns [] and does NO further read when there is no captured corpus (samples_available <= 0)", async () => {
-    // Replay first: null corpus short-circuits before eval / current-model / incumbent reads run.
-    queryReplayCandidates.mockResolvedValue(null);
-    queryEvalCandidates.mockResolvedValue(evalCandidatesOnly());
-    queryCurrentModel.mockResolvedValue(currentModel());
-    incumbentTraffic();
+  it("skips a feature whose eval has no judged candidate over the floor", async () => {
+    incumbents();
+    queryReplayCandidates.mockImplementation(async (feature?: string) => replayFor(feature));
+    // chatbot's eval returns null (opted out / no judge pass); research_agent still fires.
+    queryEvalCandidates.mockImplementation(async (feature?: string) =>
+      feature === "chatbot" ? null : evalFor(feature),
+    );
 
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    const findings = await collectWrongSizedModel(30, filters());
+    expect(findings).toHaveLength(1);
+    expect(findings[0].scopeValue).toBe("research_agent");
+  });
+
+  it("narrows to a single selected feature (filters.feature)", async () => {
+    incumbents();
+    wireCorpora();
+
+    const findings = await collectWrongSizedModel(30, filters({ feature: ["chatbot"] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].scopeValue).toBe("chatbot");
+    // Only the selected feature's corpus is read; research_agent is never replayed.
+    const replayed = queryReplayCandidates.mock.calls.map((c) => c[0]);
+    expect(replayed).toEqual(["chatbot"]);
+  });
+
+  it("keeps only features whose incumbent is in filters.model", async () => {
+    incumbents();
+    wireCorpora();
+
+    // gpt-4o is chatbot's incumbent; research_agent's incumbent (claude-sonnet-4-5) is filtered out.
+    const findings = await collectWrongSizedModel(30, filters({ model: ["gpt-4o"] }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].scopeValue).toBe("chatbot");
+    expect(findings[0].evidence.incumbentModel).toBe("gpt-4o");
+  });
+
+  it("returns [] when there is no tagged chat traffic in the window", async () => {
+    incumbents([]);
+    wireCorpora();
+
+    const findings = await collectWrongSizedModel(30, filters());
     expect(findings).toEqual([]);
-    // Honest, and cheap: no corpus means we never touched eval, current-model, or the incumbent read.
+    // No incumbents -> no replay/eval reads at all.
+    expect(queryReplayCandidates).not.toHaveBeenCalled();
     expect(queryEvalCandidates).not.toHaveBeenCalled();
-    expect(queryCurrentModel).not.toHaveBeenCalled();
-    expect(rowsP).not.toHaveBeenCalled();
   });
 
-  it("returns [] when there is no eval quality signal (below the judged floor / null)", async () => {
-    // The demo-tenant path: replay corpus exists but no eval projection -> honest [].
-    queryReplayCandidates.mockResolvedValue(replayCandidatesOnly());
-    queryEvalCandidates.mockResolvedValue(null);
-    queryCurrentModel.mockResolvedValue(currentModel());
-    incumbentTraffic();
+  it("returns [] when ClickHouse is unreachable (grouped incumbent read null)", async () => {
+    // tryLive returns null (query threw) -> queryFeatureIncumbents null -> honest [].
+    tryLive.mockResolvedValue(null);
+    wireCorpora();
 
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    const findings = await collectWrongSizedModel(30, filters());
     expect(findings).toEqual([]);
+    expect(queryReplayCandidates).not.toHaveBeenCalled();
   });
 
-  it("returns [] when the candidate is not cheaper per call than the incumbent", async () => {
-    queryReplayCandidates.mockResolvedValue(replayCandidatesOnly());
-    queryEvalCandidates.mockResolvedValue(evalCandidatesOnly());
-    queryCurrentModel.mockResolvedValue(currentModel());
-    // Incumbent per-call 5,000,000 < candidate 10,000,000 -> candidate is pricier, no finding.
-    incumbentTraffic("5000", 1000);
+  it("returns [] when a feature's candidate is not cheaper per call than its incumbent", async () => {
+    // research_agent incumbent per-call 5,000,000 (spend "5000"/1000) < haiku candidate 10,000,000.
+    incumbents([{ feature: "research_agent", model: "claude-sonnet-4-5", spend: "5000", calls: 1000 }]);
+    wireCorpora();
 
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
-    expect(findings).toEqual([]);
-  });
-
-  it("returns [] when the incumbent has no traffic in the window (no per-call basis)", async () => {
-    queryReplayCandidates.mockResolvedValue(replayCandidatesOnly());
-    queryEvalCandidates.mockResolvedValue(evalCandidatesOnly());
-    queryCurrentModel.mockResolvedValue(currentModel());
-    incumbentTraffic("0", 0);
-
-    const findings = await collectWrongSizedModel(30, NO_FILTERS);
+    const findings = await collectWrongSizedModel(30, filters());
     expect(findings).toEqual([]);
   });
 });

--- a/web/lib/waste/wrong-sized-model.test.ts
+++ b/web/lib/waste/wrong-sized-model.test.ts
@@ -171,4 +171,42 @@ describe("detectWrongSizedModel", () => {
     expect(findings[0].scopeKind).toBe("feature");
     expect(findings[0].reason).toContain("on chatbot");
   });
+
+  it("emits one finding per feature scope, each with its OWN feature + incumbent (CTO-238)", () => {
+    // Two features, each with a different incumbent and a different cheaper candidate. The detector
+    // must not collapse them: one finding per scope, scoped to that feature's own incumbent.
+    const research = scope({
+      scopeKind: "feature",
+      scopeValue: "research_agent",
+      feature: "research_agent",
+      incumbentModel: "claude-sonnet-4-5",
+      incumbentPerCallMicroUsd: 10_000,
+      candidates: [candidate({ candidateModel: "claude-haiku-4-5", perCallMicroUsd: 5_000 })],
+    });
+    const chatbot = scope({
+      scopeKind: "feature",
+      scopeValue: "chatbot",
+      feature: "chatbot",
+      incumbentModel: "gpt-4o",
+      incumbentPerCallMicroUsd: 8_000,
+      candidates: [
+        candidate({ candidateModel: "gpt-5-mini", provider: "openai", perCallMicroUsd: 2_000 }),
+      ],
+    });
+    const findings = detectWrongSizedModel(input([research, chatbot]));
+    expect(findings).toHaveLength(2);
+
+    const byFeature = new Map(findings.map((f) => [f.scopeValue, f]));
+    const r = byFeature.get("research_agent")!;
+    expect(r.scopeKind).toBe("feature");
+    expect(r.evidence.incumbentModel).toBe("claude-sonnet-4-5");
+    expect(r.evidence.candidateModel).toBe("claude-haiku-4-5");
+    expect(r.reason).toContain("on research_agent");
+
+    const c = byFeature.get("chatbot")!;
+    expect(c.scopeKind).toBe("feature");
+    expect(c.evidence.incumbentModel).toBe("gpt-4o");
+    expect(c.evidence.candidateModel).toBe("gpt-5-mini");
+    expect(c.reason).toContain("on chatbot");
+  });
 });

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Wrong-sized-model waste detector (CTO-231, W4; epic CTO-227; per-call basis CTO-236).
+// Wrong-sized-model waste detector (CTO-231, W4; epic CTO-227; per-call basis CTO-236; per-feature
+// incumbent CTO-238).
 //
 // WHY: the epic answers "where is this tenant paying for AI that returns nothing". One shape of that
 // waste is running an expensive model on work a cheaper one handles at statistically indistinguishable
@@ -29,6 +30,17 @@
 // least as good. Candidate cost is from resolved-context replay (no live retrieval); the incumbent
 // cost is measured on real traffic; the two are compared per call and the reason says exactly that.
 //
+// CTO-238 (the per-feature incumbent): the collector used to resolve ONE tenant-wide dominant model
+// (queryCurrentModel, e.g. gpt-4o) and compare every feature's replay candidates against it. But the
+// replay corpus and the eval are captured PER FEATURE TAG, so this paired one feature's candidates
+// against a global incumbent that may not even be the model that feature runs. The incumbent is a
+// property of the feature, not the tenant: each feature's own dominant model (max spend) is the thing
+// a cheaper candidate must beat. So the collector now resolves the incumbent per feature from a single
+// grouped (FeatureTag, model) read, iterates the top-K features by spend, and emits one scope per
+// feature with THAT feature's incumbent + window spend + measured per-call cost. queryCurrentModel is
+// no longer the incumbent source here. The pure detector already supported multiple per-feature scopes,
+// so only the collector changes.
+//
 // The pure detector (detectWrongSizedModel) is I/O-free and deterministic so it is trivially testable;
 // collectWrongSizedModel does the ClickHouse + Compare-path reads and maps them through it.
 
@@ -38,7 +50,6 @@ import { clampWindowDays } from "@/lib/explore";
 import type { DimensionFilters } from "@/lib/filters";
 import {
   micro,
-  queryCurrentModel,
   queryEvalCandidates,
   queryReplayCandidates,
   rowsP,
@@ -227,66 +238,126 @@ export function detectWrongSizedModel(input: WrongSizedModelInput): WasteFinding
   return findings;
 }
 
+// The replay corpus + eval are captured per FeatureTag, so an incumbent resolved tenant-wide would be
+// compared against a different feature's traffic (CTO-238). Cap the per-feature replay/eval fan-out at
+// the top-K features by spend: replay/eval each burn real provider/judge spend, and the tail of tiny
+// features is not where the tenant's money is. K is a named const so the bound is visible.
+const MAX_FEATURES = 12;
+
+/** One feature's incumbent: its dominant model (max spend) and that model's window spend + per-call
+ *  cost, plus the feature's total spend across all models (the top-K ranking key). Integer micro-USD. */
+interface FeatureIncumbent {
+  feature: string;
+  incumbentModel: string;
+  /** The dominant model's observed spend over the window. Always known. */
+  windowSpendMicroUsd: number;
+  /** The dominant model's measured average cost per call over the window (real traffic). */
+  incumbentPerCallMicroUsd: number;
+  /** The feature's spend across ALL its models, used only to rank features for the top-K cap. */
+  totalSpendMicroUsd: number;
+}
+
 /**
- * The incumbent's measured average cost PER CALL and its windowed total spend, read directly from the
- * incumbent's own chat traffic (CTO-236). This is the per-call basis the candidate replay projections
- * are compared against: `avg(EstimatedCost)` over the incumbent model's chat spans (LLM-family only,
- * excluding the synthetic compute/egress rows), tenant-scoped, over the clamped ClickHouse-clock
- * window. It never touches a candidate id or a replay row, so neither prior bug (incumbent-not-in-replay
- * or dated-vs-base id mis-keying) can occur.
+ * Resolve each feature's incumbent in ONE grouped ClickHouse read (CTO-238).
  *
- * The model id is resolved on the SAME response-model-first expression `queryCurrentModel` /
- * `queryCostExplore` use, so `incumbentModel` here is the id the caller already holds. Returns null on
- * any ClickHouse error (honest fall-through); a zero-count/zero-cost slice yields callCount 0, which
- * the caller treats as "no incumbent traffic to rescale" -> no finding.
+ * The incumbent is a property of the FEATURE, not the tenant: the replay corpus and eval this detector
+ * compares against are captured per feature tag, so the model a cheaper candidate must beat is the one
+ * THAT feature actually runs, not the tenant's globally dominant model. We read per (FeatureTag, model)
+ * `sum(EstimatedCost)` and `count()` over the same LLM-family, chat-only, clamped-window slice the rest
+ * of the code uses (response-model-first id, matching EXPLORE_GROUP_EXPR.model), and for each feature
+ * pick its dominant model (max spend; tie-break higher call count, then higher id, so it is
+ * deterministic regardless of row order). The dominant model's spend / calls give the per-feature
+ * incumbent window spend and its measured per-call cost, and the feature's total spend across models is
+ * the top-K ranking key. Features with an empty FeatureTag are skipped (untagged traffic is not a
+ * feature). Returns null on any ClickHouse error (honest fall-through), or [] when there is no tagged
+ * chat traffic in the window.
  */
-async function queryIncumbentPerCall(
-  incumbentModel: string,
-  windowDays: number,
-  featureTag: string | undefined,
-): Promise<{ perCallMicroUsd: number; windowSpendMicroUsd: number; callCount: number } | null> {
+async function queryFeatureIncumbents(windowDays: number): Promise<FeatureIncumbent[] | null> {
   const w = clampWindowDays(windowDays);
   return tryLive(async (db, tenant) => {
-    const tagClause = featureTag ? "AND FeatureTag = {feature:String}" : "";
-    // Resolve the incumbent on the response-model-first expression (matches EXPLORE_GROUP_EXPR.model),
-    // filter to that model's chat spans over the window, and read total spend + call count so the
-    // per-call average and the window spend come from ONE tenant-scoped read of the same slice.
-    const out = await rowsP<{ spend: string; calls: string | number }>(
+    const out = await rowsP<{ feature: string; model: string; spend: string; calls: string | number }>(
       db,
-      `SELECT sum(EstimatedCost) AS spend, count() AS calls
+      `SELECT FeatureTag AS feature,
+              if(GenAiResponseModel != '', GenAiResponseModel,
+                 if(GenAiRequestModel != '', GenAiRequestModel, 'unknown')) AS model,
+              sum(EstimatedCost) AS spend,
+              count() AS calls
        FROM otel_spans
        WHERE TenantId = {tenant:String}
          AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY
          AND GenAiOperation NOT IN ('compute', 'egress')
-         AND if(GenAiResponseModel != '', GenAiResponseModel,
-                if(GenAiRequestModel != '', GenAiRequestModel, 'unknown')) = {model:String}
-         ${tagClause}`,
-      { tenant, model: incumbentModel, ...(featureTag ? { feature: featureTag } : {}) },
+         AND FeatureTag != ''
+       GROUP BY feature, model`,
+      { tenant },
     );
-    const row = out[0];
-    const calls =
-      row == null ? 0 : typeof row.calls === "number" ? row.calls : parseInt(row.calls, 10) || 0;
-    const windowSpendMicroUsd = row == null ? 0 : micro(row.spend);
-    // Money stays integer micro-USD; the per-call average is rounded at this boundary.
-    const perCallMicroUsd = calls > 0 ? Math.round(windowSpendMicroUsd / calls) : 0;
-    return { perCallMicroUsd, windowSpendMicroUsd, callCount: calls };
+
+    // Fold (feature, model) rows into one incumbent per feature. The dominant model is the running
+    // max on (spend, calls, id); the feature total sums every model's spend for the top-K ranking.
+    interface Agg {
+      incumbentModel: string;
+      windowSpendMicroUsd: number;
+      incumbentCalls: number;
+      totalSpendMicroUsd: number;
+    }
+    const byFeature = new Map<string, Agg>();
+    for (const r of out) {
+      if (!r.feature) continue; // defensive: the SQL already excludes '' FeatureTag
+      const spend = micro(r.spend);
+      const calls =
+        typeof r.calls === "number" ? r.calls : parseInt(r.calls, 10) || 0;
+      let a = byFeature.get(r.feature);
+      if (!a) {
+        a = { incumbentModel: r.model, windowSpendMicroUsd: spend, incumbentCalls: calls, totalSpendMicroUsd: 0 };
+        byFeature.set(r.feature, a);
+      }
+      a.totalSpendMicroUsd += spend;
+      // Dominant = max spend; tie-break on higher call count, then higher id, for a deterministic pick.
+      const better =
+        spend > a.windowSpendMicroUsd ||
+        (spend === a.windowSpendMicroUsd &&
+          (calls > a.incumbentCalls ||
+            (calls === a.incumbentCalls && r.model > a.incumbentModel)));
+      if (better) {
+        a.incumbentModel = r.model;
+        a.windowSpendMicroUsd = spend;
+        a.incumbentCalls = calls;
+      }
+    }
+
+    const features: FeatureIncumbent[] = [];
+    for (const [feature, a] of byFeature) {
+      features.push({
+        feature,
+        incumbentModel: a.incumbentModel,
+        windowSpendMicroUsd: a.windowSpendMicroUsd,
+        // Money stays integer micro-USD; the per-call average is rounded at this boundary.
+        incumbentPerCallMicroUsd:
+          a.incumbentCalls > 0 ? Math.round(a.windowSpendMicroUsd / a.incumbentCalls) : 0,
+        totalSpendMicroUsd: a.totalSpendMicroUsd,
+      });
+    }
+    return features;
   });
 }
 
 /**
- * Collect wrong-sized-model findings from the LIVE stack (CTO-231; per-call basis CTO-236).
+ * Collect wrong-sized-model findings from the LIVE stack, PER FEATURE (CTO-231; per-call basis CTO-236;
+ * per-feature incumbent CTO-238).
  *
- * Order matters for honesty and for not doing pointless reads:
- *   1. Replay projection first. No captured corpus (`samples_available <= 0`) -> [] before any other
- *      read. No corpus means no candidate cost, so there is nothing to compute and nothing to fabricate.
- *   2. Eval projection. If no candidate has a judged win-rate (all below the floor / null) there is no
- *      quality signal, and the "/compare no fake quality number" rule says we emit nothing.
- *   3. Incumbent identity + its MEASURED per-call cost from real traffic, plus its window spend.
- *   4. Map to the pure detector on the per-call basis.
+ * The incumbent is resolved per feature (a single grouped read), never tenant-wide. For each in-scope
+ * feature, honesty and read-frugality drive the order:
+ *   1. Feature incumbent from real traffic (dominant model, its window spend, its measured per-call
+ *      cost). No positive per-call cost / no traffic -> skip before any replay/eval read.
+ *   2. Replay projection for THAT feature. No captured corpus (`samples_available <= 0`) -> skip.
+ *   3. Eval projection for THAT feature. No candidate over the judged floor (or eval null) -> skip.
+ *   4. Build the feature's per-call candidates (join replay cost + eval quality by provider+model).
+ *   5. Push one scope per qualifying feature; call the pure detector ONCE over all scopes.
  *
- * Filter-driven: the window is clamped ClickHouse-clock days, a single selected `filters.feature`
- * becomes the compare tag and scopes the incumbent read, and `filters.model` restricts which incumbent
- * model we will flag. There is NO static fallback: any missing signal returns [], the honest answer.
+ * Filter-driven: the window is clamped ClickHouse-clock days; a single selected `filters.feature`
+ * restricts to that one feature; a non-empty `filters.model` keeps only features whose incumbent
+ * (dominant) model is in the set. The fan-out is bounded to the top-{@link MAX_FEATURES} features by
+ * spend. There is NO static fallback: any missing signal yields no finding for that feature, and an
+ * empty result overall is the honest answer.
  */
 export async function collectWrongSizedModel(
   windowDays: number,
@@ -294,69 +365,88 @@ export async function collectWrongSizedModel(
 ): Promise<WasteFinding[]> {
   const window = clampWindowDays(windowDays);
 
-  // The Compare projection is per-feature-tag. Only a single selected feature maps cleanly onto one
-  // tag; zero or several features means "all traffic" (undefined tag), matching how /compare scopes.
-  const featureTag = filters.feature.length === 1 ? filters.feature[0] : undefined;
+  // Per-feature incumbents in one grouped read. Null (ClickHouse down) or [] (no tagged traffic) both
+  // mean nothing to flag.
+  const features = await queryFeatureIncumbents(window);
+  if (!features || features.length === 0) return [];
 
-  // (1) Replay FIRST. No corpus -> [] before we issue any other read (CTO-236: honest, no fabrication,
-  // and no wasted reads when there is nothing to compare against).
-  const replay = await queryReplayCandidates(featureTag);
-  if (!replay || replay.samples_available <= 0) return [];
-  const samplesAvailable = replay.samples_available;
+  // Respect the FilterBar: a single selected feature narrows to that feature; a model filter keeps only
+  // features whose incumbent is one of the selected models (the model we would actually flag).
+  let inScope = features;
+  if (filters.feature.length === 1) {
+    const only = filters.feature[0];
+    inScope = inScope.filter((f) => f.feature === only);
+  }
+  if (filters.model.length > 0) {
+    const models = new Set(filters.model);
+    inScope = inScope.filter((f) => models.has(f.incumbentModel));
+  }
+  if (inScope.length === 0) return [];
 
-  // (2) Eval quality signal. If NO candidate cleared the judged floor (or eval is null), there is no
-  // honest quality number, so we flag nothing - the same rule /compare enforces.
-  const evalProj = await queryEvalCandidates(featureTag);
-  if (!evalProj) return [];
-  const hasJudged = evalProj.per_candidate.some((e) => e.samples_judged >= MIN_JUDGED_SAMPLES);
-  if (!hasJudged) return [];
+  // Bound the replay/eval fan-out to the top-K features by spend (deterministic: spend desc, then
+  // feature id asc) so per-feature Compare-path reads stay bounded.
+  const ranked = [...inScope]
+    .sort((a, b) =>
+      b.totalSpendMicroUsd !== a.totalSpendMicroUsd
+        ? b.totalSpendMicroUsd - a.totalSpendMicroUsd
+        : a.feature < b.feature
+          ? -1
+          : 1,
+    )
+    .slice(0, MAX_FEATURES);
 
-  // (3) Incumbent identity from real traffic (response-model-first, matching the cost breakdown).
-  const live = await queryCurrentModel();
-  if (!live) return [];
-  const incumbentModel = live.model;
+  const scopes: WrongSizedModelScope[] = [];
+  for (const f of ranked) {
+    // (1) No incumbent traffic to rescale against -> no finding for this feature (skip before the
+    // replay/eval reads, which each burn real provider/judge spend).
+    if (f.incumbentPerCallMicroUsd <= 0 || f.windowSpendMicroUsd <= 0) continue;
 
-  // If the caller filtered to specific models and the incumbent is not among them, nothing to flag.
-  if (filters.model.length > 0 && !filters.model.includes(incumbentModel)) return [];
+    // (2) Replay corpus for THIS feature. No corpus -> skip.
+    const replay = await queryReplayCandidates(f.feature);
+    if (!replay || replay.samples_available <= 0) continue;
+    const samplesAvailable = replay.samples_available;
 
-  // The incumbent's MEASURED per-call cost and window spend over the same slice. This is the per-call
-  // rescale basis - no incumbent replay row and no cross-id cost join (CTO-227 review's two bugs).
-  const incumbent = await queryIncumbentPerCall(incumbentModel, window, featureTag);
-  if (!incumbent || incumbent.callCount <= 0 || incumbent.perCallMicroUsd <= 0) return [];
-  if (incumbent.windowSpendMicroUsd <= 0) return [];
+    // (3) Eval quality signal for THIS feature. No candidate cleared the judged floor (or eval null) ->
+    // no honest quality number, skip (the same rule /compare enforces).
+    const evalProj = await queryEvalCandidates(f.feature);
+    if (!evalProj) continue;
+    const hasJudged = evalProj.per_candidate.some((e) => e.samples_judged >= MIN_JUDGED_SAMPLES);
+    if (!hasJudged) continue;
 
-  // (4) Build per-call candidates: join replay (cost) and eval (quality) by provider+model. Each
-  // candidate's per-call cost is `projected_monthly_cost_micro_usd / samples_available` (the gateway
-  // built the projection as `round(avg_per_call * samples_available)`, so this recovers avg per call).
-  const candidates: WrongSizedModelCandidate[] = [];
-  for (const r of replay.per_candidate) {
-    const e = evalProj.per_candidate.find((x) => x.provider === r.provider && x.model === r.model);
-    if (!e) continue;
-    candidates.push({
-      candidateModel: r.model,
-      provider: r.provider,
-      perCallMicroUsd: Math.round(r.projected_monthly_cost_micro_usd / samplesAvailable),
-      winRate: e.win_rate,
-      ciLow: e.win_rate_ci_lo,
-      ciHigh: e.win_rate_ci_hi,
-      samplesJudged: e.samples_judged,
-      samplesReplayed: r.samples_replayed,
+    // (4) Build per-call candidates: join replay (cost) and eval (quality) by provider+model. Each
+    // candidate's per-call cost is `projected_monthly_cost_micro_usd / samples_available` (the gateway
+    // built the projection as `round(avg_per_call * samples_available)`, so this recovers avg per call).
+    const candidates: WrongSizedModelCandidate[] = [];
+    for (const r of replay.per_candidate) {
+      const e = evalProj.per_candidate.find((x) => x.provider === r.provider && x.model === r.model);
+      if (!e) continue;
+      candidates.push({
+        candidateModel: r.model,
+        provider: r.provider,
+        perCallMicroUsd: Math.round(r.projected_monthly_cost_micro_usd / samplesAvailable),
+        winRate: e.win_rate,
+        ciLow: e.win_rate_ci_lo,
+        ciHigh: e.win_rate_ci_hi,
+        samplesJudged: e.samples_judged,
+        samplesReplayed: r.samples_replayed,
+      });
+    }
+    if (candidates.length === 0) continue;
+
+    // (5) One scope per qualifying feature, carrying THAT feature's incumbent + spend + per-call basis.
+    scopes.push({
+      scopeKind: "feature",
+      scopeValue: f.feature,
+      feature: f.feature,
+      incumbentModel: f.incumbentModel,
+      windowSpendMicroUsd: f.windowSpendMicroUsd,
+      incumbentPerCallMicroUsd: f.incumbentPerCallMicroUsd,
+      candidates,
     });
   }
-  if (candidates.length === 0) return [];
+  if (scopes.length === 0) return [];
 
-  return detectWrongSizedModel({
-    windowDays: window,
-    scopes: [
-      {
-        scopeKind: featureTag ? "feature" : "model",
-        scopeValue: featureTag ?? incumbentModel,
-        feature: featureTag,
-        incumbentModel,
-        windowSpendMicroUsd: incumbent.windowSpendMicroUsd,
-        incumbentPerCallMicroUsd: incumbent.perCallMicroUsd,
-        candidates,
-      },
-    ],
-  });
+  // One call, all per-feature scopes: the pure detector already emits one finding per scope with the
+  // right per-feature incumbent in its reason.
+  return detectWrongSizedModel({ windowDays: window, scopes });
 }


### PR DESCRIPTION
## The bug: coarse, tenant-wide incumbent

`collectWrongSizedModel` resolved a single **tenant-wide** dominant model via `queryCurrentModel()` (e.g. `gpt-4o`) and compared *every* feature's candidates against it. But the replay corpus (CTO-113) and the pairwise-judge eval (CTO-114) it reads are captured **per feature tag**. So it paired one feature's candidates against a global incumbent that feature may not even run, and rescaled the *tenant's* per-call basis instead of the feature's own. One feature's cheaper-candidate claim was being measured against the wrong baseline.

## The fix: resolve the incumbent per feature

The incumbent is a property of the **feature**, not the tenant. `collectWrongSizedModel` now:

- reads per `(FeatureTag, model)` `sum(EstimatedCost)` + `count()` in **one** grouped, tenant-scoped, chat-only (`GenAiOperation NOT IN ('compute','egress')`), clamped-window ClickHouse read, on the same response-model-first model expression the rest of the code uses;
- picks each feature's **own** dominant model (max spend, tie-break higher call count then id) as that feature's incumbent, with its feature-scoped window spend and measured per-call cost;
- bounds the replay/eval fan-out to the **top-12 features by spend** (`MAX_FEATURES`), and respects filters (a single `filters.feature` narrows to it; a non-empty `filters.model` keeps only features whose incumbent is in the set);
- pushes **one scope per qualifying feature** and calls the pure `detectWrongSizedModel` once.

`queryCurrentModel` / `queryIncumbentPerCall` are no longer the incumbent source here. The **pure detector's contract is unchanged** (it already supported multiple per-feature scopes). Every honesty rule is preserved: no corpus / no judged eval / no incumbent traffic yields **no finding** for that feature, never a zero-dollar or fabricated one. No static fallback.

## Before / after (live, `local-dev`, `research_agent` has the captured corpus)

| | scopeKind | scopeValue | window spend | incumbent per-call | recoverable |
|---|---|---|---|---|---|
| **before** | `model` | `gpt-4o` (tenant-wide) | $23,777.52 | 214,653 | 18,105,442,138 |
| **after** | `feature` | `research_agent` | $12,984.70 | 309,440 | 10,836,041,335 |

The finding now scopes to the **feature** and rescales that feature's own spend on its own per-call basis, rather than the tenant global. The incumbent stays `gpt-4o` because on the current seed `gpt-4o` genuinely dominates `research_agent` (spend $12,984 / 41,962 calls vs `claude-sonnet-4-5` $11,795 / 28,534 calls) - it leads by both spend and calls, so the max-spend rule correctly picks it. Candidate `gpt-5-mini` clears the floors at no significant quality regression (win-rate 0.49, 95% CI 0.42-0.56).

## Tests

- Pure detector: added a case asserting two feature scopes yield two findings, each scoped to its own feature + incumbent (multi-scope was already supported).
- Collector: rewired mocks for the grouped per-feature read + per-feature replay/eval; covers the multi-feature path (two features -> two findings, each with its own incumbent), a feature with no corpus / no judged eval (-> no finding), and the `filters.feature` / `filters.model` narrowing.

## Verification (from `web/`)

- `npm run typecheck` clean
- `npm run lint` clean (only the pre-existing `useLivePoll.ts` warning)
- `npm run test`: 674 passed, 1 failed - the long-standing `api.test.ts` "falls back to mock when ClickHouse is unreachable" case that fails only when a local ClickHouse is running; passes in CI
- `npm run build` succeeds
- live `curl /api/waste` confirms the per-feature scoping above

🤖 Generated with [Claude Code](https://claude.com/claude-code)