### PR TITLE
Switch dashboard to a Nord light theme

### DIFF
--- a/web/app/agents/runs/[runId]/page.tsx
+++ b/web/app/agents/runs/[runId]/page.tsx
@@ -41,7 +41,7 @@ export default async function RunPage({ params }: { params: Promise<{ runId: str
       </div>
 
       <Card title="Why expensive">
-        <p className="text-sm leading-relaxed text-gray-200">{run.whyExpensive}</p>
+        <p className="text-sm leading-relaxed text-fg">{run.whyExpensive}</p>
       </Card>
 
       <Card title="Run waterfall">

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -118,7 +118,7 @@ export default async function ComparePage({
       </Card>
 
       <Card title={`Recommendation — ${recommendation.verdict}`}>
-        <p className="text-sm text-gray-200">{recommendation.summary}</p>
+        <p className="text-sm text-fg">{recommendation.summary}</p>
         <div className="mt-3 flex items-baseline gap-2 text-sm">
           <span className="text-good text-lg font-semibold">
             saves {formatUSD(recommendation.projectedSavingsMicroUsd)}/mo
@@ -129,7 +129,7 @@ export default async function ComparePage({
         </div>
         <button
           type="button"
-          className="mt-3 rounded-md border border-edge bg-ink px-3 py-1.5 text-sm text-gray-200 hover:bg-edge"
+          className="mt-3 rounded-md border border-edge bg-ink px-3 py-1.5 text-sm text-fg hover:bg-edge"
         >
           Export routing rule
         </button>
@@ -152,7 +152,7 @@ export default async function ComparePage({
         title="Compare"
         subtitle={
           <>
-            Workload: <span className="font-mono text-gray-300">{workload}</span>
+            Workload: <span className="font-mono text-muted">{workload}</span>
           </>
         }
         actions={

--- a/web/app/cost-per-customer/AccountIdentity.tsx
+++ b/web/app/cost-per-customer/AccountIdentity.tsx
@@ -56,7 +56,7 @@ export function CopyHashButton({
       type="button"
       onClick={copy}
       title={`Copy the full account hash: ${accountIdHash}`}
-      className={`rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-white ${className}`.trim()}
+      className={`rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-fg ${className}`.trim()}
     >
       {copied ? "Copied" : "Copy hash"}
     </button>

--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -323,7 +323,7 @@ export function AccountTable({
               setQuery("");
               setSearch(null);
             }}
-            className="rounded-md border border-edge px-3 py-1.5 text-sm text-muted hover:text-white"
+            className="rounded-md border border-edge px-3 py-1.5 text-sm text-muted hover:text-fg"
           >
             Clear
           </button>

--- a/web/app/cost-per-customer/Onboarding.tsx
+++ b/web/app/cost-per-customer/Onboarding.tsx
@@ -73,7 +73,7 @@ export function OnboardingEmptyState({ windowDays }: { windowDays: number }) {
       <div className="mt-4 space-y-3">
         <h3 className="text-base font-semibold">What this page is for</h3>
         <p className="max-w-prose text-sm text-muted">
-          It breaks your AI spend down by <span className="text-white">your own customers</span>, so
+          It breaks your AI spend down by <span className="text-fg">your own customers</span>, so
           you can see which accounts are expensive to serve and which ones are worth what they pay.
           Everywhere else in this dashboard groups spend by model, feature or provider. This is the
           only tab that groups it by who you are serving.
@@ -115,18 +115,18 @@ export function OnboardingEmptyState({ windowDays }: { windowDays: number }) {
 
         <ul className="max-w-prose list-disc space-y-1.5 pl-5 text-sm text-muted">
           <li>
-            <span className="text-white">The label is optional.</span> Leave it out and the account
+            <span className="text-fg">The label is optional.</span> Leave it out and the account
             shows as a shortened hash, which is a supported way to run. The label is wire-only: it
             is stored against the hash and never written to the telemetry store, so no customer name
             lands in your span data.
           </li>
           <li>
-            <span className="text-white">The raw account id never leaves your process.</span> It is
+            <span className="text-fg">The raw account id never leaves your process.</span> It is
             HMAC-SHA256&apos;d under your per-tenant key at emit time, exactly like a user id, which
             is also why the table can only show you a hash you already know.
           </li>
           <li>
-            <span className="text-white">
+            <span className="text-fg">
               Rows appear as soon as the next tagged spans land.
             </span>{" "}
             The hash is written at emit time, so spans already recorded stay unattributed. The
@@ -192,7 +192,7 @@ function Snippet({ code }: { code: string }) {
       <button
         type="button"
         onClick={copy}
-        className="absolute right-2 top-2 rounded border border-edge bg-panel px-2 py-1 text-[11px] text-muted hover:text-white"
+        className="absolute right-2 top-2 rounded border border-edge bg-panel px-2 py-1 text-[11px] text-muted hover:text-fg"
       >
         {copied ? "Copied" : "Copy"}
       </button>

--- a/web/app/cost-per-customer/[account]/TrendChart.tsx
+++ b/web/app/cost-per-customer/[account]/TrendChart.tsx
@@ -26,7 +26,7 @@ export function TrendChart({ trend }: { trend: readonly AccountTrendPoint[] }) {
   if (n === 0) {
     return (
       <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="no trend data" className="w-full">
-        <text x={W / 2} y={H / 2} fontSize="12" fill="#8a93a6" textAnchor="middle">
+        <text x={W / 2} y={H / 2} fontSize="12" fill="var(--chart-muted)" textAnchor="middle">
           no daily cost recorded for this account
         </text>
       </svg>
@@ -66,7 +66,7 @@ export function TrendChart({ trend }: { trend: readonly AccountTrendPoint[] }) {
               <title>{`${p.date} · ${formatUSD(p.directCostMicroUsd)}`}</title>
             </rect>
             {i % 5 === 0 ? (
-              <text x={cx} y={H - 8} fontSize="9" fill="#8a93a6" textAnchor="middle">
+              <text x={cx} y={H - 8} fontSize="9" fill="var(--chart-muted)" textAnchor="middle">
                 {p.date.slice(5)}
               </text>
             ) : null}

--- a/web/app/cost/BudgetVsActualCard.tsx
+++ b/web/app/cost/BudgetVsActualCard.tsx
@@ -73,7 +73,7 @@ export function BudgetVsActualCard({ payload }: { payload: BudgetPayload }) {
           {budget === null ? (
             <p className="mt-2 text-sm text-muted">
               Month to date is {" "}
-              <span className="font-medium text-white">
+              <span className="font-medium text-fg">
                 <Money micro={c.actualMicroUsd} />
               </span>
               .{" "}

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -345,7 +345,7 @@ function CostChart({
       <InteractiveStackedChart
         days={days}
         groups={LAYERS}
-        color={(g) => LAYER_COLORS[g as Layer] ?? "#8a93a6"}
+        color={(g) => LAYER_COLORS[g as Layer] ?? "#4c566a"}
         label={(g) => LAYER_LABEL[g as Layer] ?? g}
         onDrill={onDrillLayer}
         ariaLabel="stacked cost by layer over time"

--- a/web/app/data-quality/page.tsx
+++ b/web/app/data-quality/page.tsx
@@ -110,7 +110,7 @@ export default async function DataQualityPage() {
               return (
                 <tr key={`${d.service}-${d.sdkVersion}`} className="border-t border-edge">
                   <td className="py-2">{d.service}</td>
-                  <td className="py-2 font-mono text-xs text-gray-300">{d.sdkVersion}</td>
+                  <td className="py-2 font-mono text-xs text-muted">{d.sdkVersion}</td>
                   <td className="py-2 text-right tabular-nums">
                     {inactive ? (
                       <span className="text-muted" title="no spans in the last 24h">—</span>
@@ -146,7 +146,7 @@ export default async function DataQualityPage() {
               const h = classify("calibration", Math.abs(pct));
               return (
                 <tr key={c.date} className="border-t border-edge">
-                  <td className="py-2 font-mono text-xs text-gray-300">{c.date}</td>
+                  <td className="py-2 font-mono text-xs text-muted">{c.date}</td>
                   <td className="py-2 text-right tabular-nums">{formatUSD(c.estimatedMicroUsd)}</td>
                   <td className="py-2 text-right tabular-nums">{formatUSD(c.reconciledMicroUsd)}</td>
                   <td className="py-2 text-right tabular-nums">
@@ -339,10 +339,10 @@ function AccountStitchingCard({ stitching }: { stitching?: AccountStitching }) {
             <tbody>
               {conflicts.map((c) => (
                 <tr key={c.userIdHash} className="border-t border-edge">
-                  <td className="py-2 font-mono text-xs text-gray-300" title={c.userIdHash}>
+                  <td className="py-2 font-mono text-xs text-muted" title={c.userIdHash}>
                     {c.userIdHash.slice(0, 12)}…
                   </td>
-                  <td className="py-2 font-mono text-xs text-gray-300" title={c.accounts.join(", ")}>
+                  <td className="py-2 font-mono text-xs text-muted" title={c.accounts.join(", ")}>
                     {c.accounts.map((a) => a.slice(0, 8)).join(" · ")}
                   </td>
                   <td className="py-2 text-right tabular-nums">

--- a/web/app/estimate/EstimateWhatIf.tsx
+++ b/web/app/estimate/EstimateWhatIf.tsx
@@ -157,7 +157,7 @@ export function EstimateWhatIf({ initial }: { initial: Projection }) {
         <ul className="space-y-2 text-sm">
           {initial.drivers.map((d) => (
             <li key={d.reason} className="flex items-baseline justify-between gap-3">
-              <span className="text-gray-300">{d.reason}</span>
+              <span className="text-muted">{d.reason}</span>
               <span
                 className={`tabular-nums font-medium ${d.delta > 0 ? "text-bad" : "text-good"}`}
               >

--- a/web/app/estimate/page.tsx
+++ b/web/app/estimate/page.tsx
@@ -48,7 +48,7 @@ export default async function EstimatePage() {
         <div>
           <h1 className="text-xl font-semibold">Estimate</h1>
           <p className="mt-1 text-sm text-muted">
-            Workload: <span className="font-mono text-gray-300">{workload}</span>
+            Workload: <span className="font-mono text-muted">{workload}</span>
           </p>
         </div>
         {state !== "empty" && asOf && (

--- a/web/app/features/FeatureValueEvents.tsx
+++ b/web/app/features/FeatureValueEvents.tsx
@@ -145,7 +145,7 @@ export function FeatureValueEvents({ initialFeatures }: { initialFeatures: Featu
                           configure value event →
                         </button>
                       ) : (
-                        <span className="font-mono text-xs text-gray-300">{f.valueEvent}</span>
+                        <span className="font-mono text-xs text-muted">{f.valueEvent}</span>
                       )}
                     </td>
                   </tr>
@@ -346,7 +346,7 @@ function ConfigureModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-edge px-3 py-1.5 text-sm text-muted hover:text-gray-200"
+            className="rounded-md border border-edge px-3 py-1.5 text-sm text-muted hover:text-fg"
           >
             Cancel
           </button>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3,47 +3,22 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 
   /* Chart chrome tokens (CTO-221). SVG fill/stroke cannot read Tailwind classes, so the inline-SVG
-     charts reference these variables instead of hardcoding hex. The dark values are byte-identical
-     to the palette the existing charts already inline (edge #252b37, muted #8a93a6, panel #161a22),
-     so dark mode is unchanged; the light block below lets the same charts track a light palette if
-     one is ever applied. Series/data colors (LAYER_COLORS) are intentionally NOT here: those encode
-     data identity and read in both themes. */
-  --chart-axis: #252b37;
-  --chart-muted: #8a93a6;
-  --chart-surface: #161a22;
-  --chart-surface-border: #252b37;
-  --chart-est-band: #252b37;
-  --chart-crosshair: #8a93a6;
-}
-
-/* A light palette for the same tokens. Guarded so an explicit dark choice still wins, matching the
-   theme-aware pattern; the app ships dark today, so this only engages under a light preference or an
-   explicit [data-theme="light"]. */
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) {
-    --chart-axis: #dfe3ea;
-    --chart-muted: #5b6470;
-    --chart-surface: #ffffff;
-    --chart-surface-border: #dfe3ea;
-    --chart-est-band: #eef1f6;
-    --chart-crosshair: #5b6470;
-  }
-}
-
-:root[data-theme="light"] {
-  --chart-axis: #dfe3ea;
-  --chart-muted: #5b6470;
+     charts reference these variables instead of hardcoding hex. These are the Nord-light values that
+     track the palette the app now ships: a white plotting surface with nord4 axes and nord3 muted
+     text. Series/data colors (LAYER_COLORS) are intentionally NOT here: those encode data identity. */
+  --chart-axis: #d8dee9;
+  --chart-muted: #4c566a;
   --chart-surface: #ffffff;
-  --chart-surface-border: #dfe3ea;
-  --chart-est-band: #eef1f6;
-  --chart-crosshair: #5b6470;
+  --chart-surface-border: #d8dee9;
+  --chart-est-band: #e5e9f0;
+  --chart-crosshair: #4c566a;
 }
 
 body {
-  @apply bg-ink text-gray-100;
+  @apply bg-ink text-fg;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/web/app/guardrails/GuardrailRow.tsx
+++ b/web/app/guardrails/GuardrailRow.tsx
@@ -149,7 +149,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
               type="button"
               onClick={openEdit}
               disabled={pending}
-              className="rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:bg-edge hover:text-white"
+              className="rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:bg-edge hover:text-fg"
             >
               Edit
             </button>
@@ -183,7 +183,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
             disabled={pending}
             onChange={(e) => onModeChange(e.target.value as GuardrailMode)}
             aria-label={`Mode for ${rule.scope}`}
-            className="rounded border border-edge bg-ink/40 px-2 py-1 text-xs text-white disabled:opacity-50"
+            className="rounded border border-edge bg-ink/40 px-2 py-1 text-xs text-fg disabled:opacity-50"
           >
             {GUARDRAIL_MODES.map((m) => (
               <option key={m.mode} value={m.mode}>
@@ -202,7 +202,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
             type="button"
             onClick={toggleAudit}
             aria-expanded={auditOpen}
-            className="rounded border border-edge px-2 py-1 text-xs text-muted hover:bg-edge hover:text-white"
+            className="rounded border border-edge px-2 py-1 text-xs text-muted hover:bg-edge hover:text-fg"
           >
             {auditOpen ? "Hide" : "Audit"}
           </button>
@@ -222,7 +222,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
                   value={costInput}
                   onChange={(e) => setCostInput(e.target.value)}
                   placeholder="none"
-                  className="mt-1 w-32 rounded border border-edge bg-ink/40 px-2 py-1 text-sm text-white"
+                  className="mt-1 w-32 rounded border border-edge bg-ink/40 px-2 py-1 text-sm text-fg"
                 />
               </label>
               <label className="flex flex-col text-xs text-muted">
@@ -234,7 +234,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
                   value={stepsInput}
                   onChange={(e) => setStepsInput(e.target.value)}
                   placeholder="none"
-                  className="mt-1 w-32 rounded border border-edge bg-ink/40 px-2 py-1 text-sm text-white"
+                  className="mt-1 w-32 rounded border border-edge bg-ink/40 px-2 py-1 text-sm text-fg"
                 />
               </label>
               <div className="ml-auto flex items-center gap-2">
@@ -244,7 +244,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
                 <button
                   type="button"
                   onClick={() => setEditing(false)}
-                  className="rounded border border-edge px-2.5 py-1 text-xs text-muted hover:bg-edge hover:text-white"
+                  className="rounded border border-edge px-2.5 py-1 text-xs text-muted hover:bg-edge hover:text-fg"
                 >
                   Cancel
                 </button>
@@ -270,7 +270,7 @@ export function GuardrailRow({ initialRule }: { initialRule: GuardrailRule }) {
               <ul className="space-y-1 text-xs">
                 {auditRows.map((c) => (
                   <li key={c.change_id} className="flex flex-wrap gap-2 text-muted">
-                    <span className="text-white">{c.changed_at || "—"}</span>
+                    <span className="text-fg">{c.changed_at || "—"}</span>
                     <span>
                       {(c.before?.state ?? "∅")} → {(c.after?.state ?? "∅")}
                     </span>

--- a/web/app/onboarding/Onboarding.tsx
+++ b/web/app/onboarding/Onboarding.tsx
@@ -99,7 +99,7 @@ export function Onboarding({
             1 · Point your app at the proxy
           </h2>
           <p className="mb-3 text-sm text-muted">
-            Set two environment variables. Your <code className="text-gray-300">OPENAI_API_KEY</code>{" "}
+            Set two environment variables. Your <code className="text-muted">OPENAI_API_KEY</code>{" "}
             stays in your environment — we never see it.
           </p>
 
@@ -113,13 +113,13 @@ export function Onboarding({
           </div>
 
           <div className="relative">
-            <pre className="overflow-x-auto rounded-lg border border-edge bg-ink p-3 font-mono text-xs leading-relaxed text-gray-200">
+            <pre className="overflow-x-auto rounded-lg border border-edge bg-ink p-3 font-mono text-xs leading-relaxed text-fg">
               {snippet}
             </pre>
             <button
               type="button"
               onClick={onCopy}
-              className="absolute right-2 top-2 rounded-md border border-edge bg-panel px-2 py-1 text-xs text-gray-300 hover:text-accent"
+              className="absolute right-2 top-2 rounded-md border border-edge bg-panel px-2 py-1 text-xs text-muted hover:text-accent"
             >
               {copied ? "Copied ✓" : "Copy"}
             </button>
@@ -137,7 +137,7 @@ export function Onboarding({
 
           {progress.firstTraceAt === null ? (
             <div className="flex items-center justify-between gap-4 rounded-lg border border-edge bg-ink p-4">
-              <span className="flex items-center gap-2 text-sm text-gray-200">
+              <span className="flex items-center gap-2 text-sm text-fg">
                 <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" />
                 Waiting for your first trace…
               </span>
@@ -183,7 +183,7 @@ export function Onboarding({
                   {s.done ? "✓" : ""}
                 </span>
                 <div>
-                  <div className={`text-sm ${s.done ? "text-gray-200" : "text-gray-300"}`}>
+                  <div className={`text-sm ${s.done ? "text-fg" : "text-muted"}`}>
                     {s.title}
                   </div>
                   <div className="text-xs text-muted">{s.hint}</div>
@@ -214,7 +214,7 @@ function TabButton({
       type="button"
       onClick={onClick}
       className={`rounded-md px-2 py-1 ${
-        active ? "bg-edge text-white" : "text-muted hover:text-gray-200"
+        active ? "bg-edge text-fg" : "text-muted hover:text-fg"
       }`}
     >
       {children}

--- a/web/app/settings/GuardrailConfig.tsx
+++ b/web/app/settings/GuardrailConfig.tsx
@@ -270,7 +270,7 @@ function ObserveStats({
         : "bg-edge text-muted";
   return (
     <>
-      <span className="rounded bg-edge px-1.5 py-0.5 tabular-nums text-gray-200">
+      <span className="rounded bg-edge px-1.5 py-0.5 tabular-nums text-fg">
         would have fired{" "}
         <strong>{rule.wouldHaveFiredThisWeek.toLocaleString()}</strong> ×/wk
         {rule.runsThisWeek > 0 && <> ({(rate * 100).toFixed(1)}% of runs)</>}

--- a/web/app/settings/budgets/BudgetManager.tsx
+++ b/web/app/settings/budgets/BudgetManager.tsx
@@ -267,7 +267,7 @@ export function BudgetManager({ initialBudgets, periods, scopeKinds, reachable }
               <button
                 type="button"
                 onClick={() => openConflicting(status.conflictingBudgetId as string)}
-                className="ml-2 rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-white"
+                className="ml-2 rounded border border-edge px-1.5 py-0.5 text-[11px] text-muted hover:text-fg"
               >
                 Edit {status.conflictingBudgetId}
               </button>

--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -184,7 +184,7 @@ export default async function UnitEconomicsPage() {
                     className={`border-t border-edge ${p.locked ? "text-muted" : ""}`}
                   >
                     <td className="py-2 font-medium">
-                      <span className={p.locked ? "" : "text-white"}>{fmtMonthLabel(p.periodStart)}</span>
+                      <span className={p.locked ? "" : "text-fg"}>{fmtMonthLabel(p.periodStart)}</span>
                       {p.locked && (
                         <span
                           className="ml-2 rounded bg-edge px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted"

--- a/web/components/BurndownChart.tsx
+++ b/web/components/BurndownChart.tsx
@@ -42,14 +42,14 @@ const PLOT_H = H - PAD_T - PAD_B;
 
 /** Theme tokens, inlined because SVG `fill`/`stroke` cannot read Tailwind classes. */
 const COLOR = {
-  actual: "#5e6ad2", // accent
+  actual: "#5e81ac", // accent
   projection: "#26b5ce",
   cone: "#26b5ce",
-  budget: "#f2c94c", // warn
-  breach: "#eb5757", // bad
-  naive: "#8a93a6", // muted
-  axis: "#252b37", // edge
-  text: "#8a93a6",
+  budget: "#cc9a1f", // warn
+  breach: "#bf616a", // bad
+  naive: "#4c566a", // muted
+  axis: "#d8dee9", // edge
+  text: "#4c566a",
 };
 
 export interface BurndownChartProps {

--- a/web/components/DataTable.tsx
+++ b/web/components/DataTable.tsx
@@ -195,7 +195,7 @@ export function DataTable<Row>({
                         setSort((current) => nextSort(c, current));
                         setPage(0);
                       }}
-                      className={`inline-flex items-center gap-1 uppercase hover:text-white ${
+                      className={`inline-flex items-center gap-1 uppercase hover:text-fg ${
                         c.align === "right" ? "flex-row-reverse" : ""
                       }`}
                     >
@@ -276,7 +276,7 @@ function PagerButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="rounded-md border border-edge px-2 py-1 hover:text-white disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-muted"
+      className="rounded-md border border-edge px-2 py-1 hover:text-fg disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-muted"
     >
       {children}
     </button>

--- a/web/components/ExploreChartCard.tsx
+++ b/web/components/ExploreChartCard.tsx
@@ -128,7 +128,7 @@ export function ExploreChartCard({
         {series && (
           <span className="text-xs text-muted">
             by {DIMENSION_LABEL[series.groupBy].toLowerCase()} ·{" "}
-            <span className="tabular-nums text-gray-200">{formatUSD(series.totalMicroUsd)}</span> ·{" "}
+            <span className="tabular-nums text-fg">{formatUSD(series.totalMicroUsd)}</span> ·{" "}
             <span className="tabular-nums">
               {series.windowStart} → {series.windowEnd}
             </span>

--- a/web/components/FilterBar.tsx
+++ b/web/components/FilterBar.tsx
@@ -116,7 +116,7 @@ export function FilterBar({
           <select
             value={selectedGroupBy}
             onChange={(e) => setGroupBy(e.target.value as Dimension)}
-            className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100 focus:border-accent focus:outline-none"
+            className="rounded-md border border-edge bg-ink px-2 py-1 text-fg focus:border-accent focus:outline-none"
           >
             {groupByChoices.map((dim) => (
               <option key={dim} value={dim}>
@@ -143,7 +143,7 @@ export function FilterBar({
         <button
           type="button"
           onClick={clearAll}
-          className="ml-auto rounded-md px-2 py-1 text-xs text-muted hover:text-white"
+          className="ml-auto rounded-md px-2 py-1 text-xs text-muted hover:text-fg"
         >
           Clear filters
         </button>
@@ -155,7 +155,7 @@ export function FilterBar({
 function segmentClass(active: boolean): string {
   return [
     "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-    active ? "bg-accent text-white" : "text-muted hover:text-white",
+    active ? "bg-accent text-white" : "text-muted hover:text-fg",
   ].join(" ");
 }
 
@@ -199,7 +199,7 @@ function CustomRangeControl({
               value={draftFrom}
               max={draftTo}
               onChange={(e) => setDraftFrom(e.target.value)}
-              className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100"
+              className="rounded-md border border-edge bg-ink px-2 py-1 text-fg"
             />
           </label>
           <label className="flex items-center justify-between gap-2 text-xs text-muted">
@@ -209,7 +209,7 @@ function CustomRangeControl({
               value={draftTo}
               min={draftFrom}
               onChange={(e) => setDraftTo(e.target.value)}
-              className="rounded-md border border-edge bg-ink px-2 py-1 text-gray-100"
+              className="rounded-md border border-edge bg-ink px-2 py-1 text-fg"
             />
           </label>
           <button
@@ -264,8 +264,8 @@ function FilterDropdown({
         className={[
           "flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium",
           count > 0
-            ? "border-accent/60 bg-accent/10 text-white"
-            : "border-edge text-muted hover:text-white",
+            ? "border-accent/60 bg-accent/10 text-fg"
+            : "border-edge text-muted hover:text-fg",
         ].join(" ")}
       >
         {DIMENSION_LABEL[dim]}
@@ -285,7 +285,7 @@ function FilterDropdown({
             return (
               <label
                 key={opt.value}
-                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs text-gray-200 hover:bg-edge"
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-xs text-fg hover:bg-edge"
               >
                 <input
                   type="checkbox"
@@ -301,7 +301,7 @@ function FilterDropdown({
             <button
               type="button"
               onClick={onClear}
-              className="mt-1 w-full rounded-md px-2 py-1 text-left text-xs text-muted hover:text-white"
+              className="mt-1 w-full rounded-md px-2 py-1 text-left text-xs text-muted hover:text-fg"
             >
               Clear {DIMENSION_LABEL[dim].toLowerCase()}
             </button>

--- a/web/components/InteractiveStackedChart.tsx
+++ b/web/components/InteractiveStackedChart.tsx
@@ -57,12 +57,12 @@ export interface InteractiveStackedChartProps {
 // spenders) are the most distinct; it repeats past its length, which the group cap (MAX_EXPLORE_
 // GROUPS) keeps us well short of in practice.
 const PALETTE = [
-  "#5e6ad2", // accent
+  "#5e81ac", // accent
   "#26b5ce",
-  "#4cb782", // good
-  "#f2c94c", // warn
+  "#4c9f70", // good
+  "#cc9a1f", // warn
   "#bb87fc",
-  "#eb5757", // bad
+  "#bf616a", // bad
   "#5cc8ff",
   "#f2994a",
   "#7ed3b2",
@@ -105,7 +105,7 @@ export function InteractiveStackedChart({
   const colorOf = useMemo(() => {
     const m = new Map<string, string>();
     groups.forEach((g, i) => m.set(g, color(g, i)));
-    return (g: string) => m.get(g) ?? "#8a93a6";
+    return (g: string) => m.get(g) ?? "#4c566a";
   }, [groups, color]);
 
   const visibleGroups = groups.filter((g) => !hidden.has(g));
@@ -221,7 +221,7 @@ export function InteractiveStackedChart({
                     })
                   }
                   aria-pressed={!off}
-                  className={`flex items-center gap-1.5 hover:text-white ${off ? "opacity-40" : ""}`}
+                  className={`flex items-center gap-1.5 hover:text-fg ${off ? "opacity-40" : ""}`}
                   title={off ? `Show ${label(g)}` : `Hide ${label(g)}`}
                 >
                   <span
@@ -283,10 +283,10 @@ function Tooltip({
           className="inline-block h-2 w-2 rounded-sm"
           style={{ background: swatch }}
         />
-        <span className="font-medium text-gray-100">{group}</span>
+        <span className="font-medium text-fg">{group}</span>
       </div>
       <div className="mt-0.5 tabular-nums">
-        {date} · <span className="text-gray-100">{value}</span>
+        {date} · <span className="text-fg">{value}</span>
       </div>
     </div>
   );

--- a/web/components/Placeholder.tsx
+++ b/web/components/Placeholder.tsx
@@ -5,7 +5,7 @@ export function Placeholder({ title, ticket }: { title: string; ticket: string }
       <h1 className="text-xl font-semibold">{title}</h1>
       <p className="max-w-prose text-sm text-muted">
         This workflow is scaffolded but not yet built. Tracked as{" "}
-        <span className="font-mono text-gray-300">{ticket}</span>. The app shell, routing, mock-data
+        <span className="font-mono text-muted">{ticket}</span>. The app shell, routing, mock-data
         layer, and design tokens are in place — screens land in follow-up PRs.
       </p>
     </div>

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -99,8 +99,8 @@ export function Shell({ children }: { children: ReactNode }) {
                         "relative block rounded-md px-3 py-2 text-sm transition-colors",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                         active
-                          ? "bg-edge font-medium text-white"
-                          : "text-gray-300 hover:bg-edge/60 hover:text-white",
+                          ? "bg-edge font-medium text-fg"
+                          : "text-muted hover:bg-edge/60 hover:text-fg",
                       ].join(" ")}
                     >
                       {active && (

--- a/web/components/StackedBarChart.tsx
+++ b/web/components/StackedBarChart.tsx
@@ -17,7 +17,7 @@ export function StackedBarChart({ series }: { series: CostSeries }) {
   if (n === 0) {
     return (
       <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="no data" className="w-full">
-        <text x={W / 2} y={H / 2} fontSize="12" fill="#8a93a6" textAnchor="middle">
+        <text x={W / 2} y={H / 2} fontSize="12" fill="var(--chart-muted)" textAnchor="middle">
           no data for this filter yet
         </text>
       </svg>
@@ -42,11 +42,11 @@ export function StackedBarChart({ series }: { series: CostSeries }) {
         y={PAD_T}
         width={W - PAD_R - boundaryX}
         height={plotH}
-        fill="#252b37"
+        fill="var(--chart-est-band)"
         opacity="0.35"
       />
-      <line x1={boundaryX} x2={boundaryX} y1={PAD_T} y2={H - PAD_B} stroke="#8a93a6" strokeDasharray="4 3" />
-      <text x={boundaryX + 4} y={PAD_T + 12} fontSize="10" fill="#8a93a6">
+      <line x1={boundaryX} x2={boundaryX} y1={PAD_T} y2={H - PAD_B} stroke="var(--chart-muted)" strokeDasharray="4 3" />
+      <text x={boundaryX + 4} y={PAD_T + 12} fontSize="10" fill="var(--chart-muted)">
         ← reconciled · estimated →
       </text>
 
@@ -73,7 +73,7 @@ export function StackedBarChart({ series }: { series: CostSeries }) {
               );
             })}
             {i % 3 === 0 && (
-              <text x={cx} y={H - 10} fontSize="9" fill="#8a93a6" textAnchor="middle">
+              <text x={cx} y={H - 10} fontSize="9" fill="var(--chart-muted)" textAnchor="middle">
                 {d.date.slice(5)}
               </text>
             )}

--- a/web/components/SummaryTile.tsx
+++ b/web/components/SummaryTile.tsx
@@ -113,7 +113,7 @@ function Sparkline({ values }: { values: readonly number[] }) {
       aria-label="trend sparkline"
       className="shrink-0"
     >
-      <polyline points={points} fill="none" stroke="#5e6ad2" strokeWidth="1.5" />
+      <polyline points={points} fill="none" stroke="#5e81ac" strokeWidth="1.5" />
     </svg>
   );
 }

--- a/web/lib/cost.ts
+++ b/web/lib/cost.ts
@@ -29,12 +29,12 @@ export const LAYERS = ["llm", "vector", "tools", "compute", "embeddings", "egres
 export type Layer = (typeof LAYERS)[number];
 
 export const LAYER_COLORS: Record<Layer, string> = {
-  llm: "#5e6ad2",      // accent
+  llm: "#5e81ac",      // accent
   vector: "#26b5ce",
-  tools: "#4cb782",    // good
-  compute: "#f2c94c",  // warn
+  tools: "#4c9f70",    // good
+  compute: "#cc9a1f",  // warn
   embeddings: "#bb87fc",
-  egress: "#8a93a6",   // muted
+  egress: "#4c566a",   // muted
 };
 
 export const LAYER_LABEL: Record<Layer, string> = {

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -6,14 +6,19 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        ink: "#0f1115",
-        panel: "#161a22",
-        edge: "#252b37",
-        muted: "#8a93a6",
-        accent: "#5e6ad2",
-        good: "#4cb782",
-        warn: "#f2c94c",
-        bad: "#eb5757",
+        // Nord light palette (chosen over the original dark theme): a calm, low-glare snow-storm
+        // background with a frost-blue accent and aurora status colors, all kept dark enough to
+        // read as text on the light surface. `fg` is the primary text token that replaced the
+        // former white/light-gray text the dark theme relied on.
+        ink: "#eceff4", // page background (nord6)
+        panel: "#ffffff", // cards / raised surfaces
+        edge: "#d8dee9", // hairline borders (nord4)
+        muted: "#4c566a", // secondary text (nord3), readable on light
+        fg: "#2e3440", // primary text (nord0)
+        accent: "#5e81ac", // frost blue (nord10)
+        good: "#4c9f70", // success, darkened from nord14 so it reads as text
+        warn: "#b7791f", // warning, darkened from nord13 so it reads as text
+        bad: "#bf616a", // danger (nord11)
       },
     },
   },


### PR DESCRIPTION
Replaces the fixed dark palette with **Nord light** (picked from a set of palette options): a calm off-white background (#eceff4), white cards, muted nord3 text, a frost-blue accent (#5e81ac), and aurora status colors darkened enough to read on a light surface. Single fixed theme, as requested.

## What changed
- `tailwind.config.ts`: remap `ink/panel/edge/muted/accent/good/warn/bad` to Nord light; add an `fg` primary-text token.
- `globals.css`: `color-scheme: light`, body text → `fg`, chart chrome vars → light values.
- Components: remap dark-assuming classes — `text-gray-100/200/300` → `fg`/`muted`, `text-white` → `fg` (kept only on solid `bg-accent` buttons), `hover:text-white` → `hover:text-fg`.
- Charts: remap series + chrome hexes for white surfaces. The yellow compute/budget series was near-invisible on white, so it's darkened to a readable gold; older inline-SVG charts now read the `--chart-*` vars.

## Verified
Live across Home, Cost, Waste, Guardrails: readable text, visible accent, legible charts, honest `—` blanks intact. typecheck + lint clean; build clean; tests pass except the one long-standing `api.test.ts` ClickHouse-running case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)