### PR TITLE
Fix burn-down chart: day-29 and day-31 axis labels overlapping

### DIFF
--- a/web/components/BurndownChart.tsx
+++ b/web/components/BurndownChart.tsx
@@ -281,9 +281,11 @@ export function BurndownChart({
       )}
 
       {points.map((p, i) =>
-        // The last day always gets a label (it is the period end); the tick before it is dropped
-        // when it would collide, which on a 31-day month it otherwise does.
-        (i % labelEvery === 0 && i < n - 2) || i === n - 1 ? (
+        // The last day always gets a label (it is the period end); any regular tick within one
+        // label-interval of it is dropped so the two do not overprint. On a 31-day month with
+        // labelEvery=4 the regular tick at day 29 (i=28) otherwise collides with the day-31 label at
+        // the right edge; requiring a full interval of clearance (i <= n-1-labelEvery) fixes it.
+        (i % labelEvery === 0 && i <= n - 1 - labelEvery) || i === n - 1 ? (
           <text
             key={p.date}
             x={x(i)}


### PR DESCRIPTION
On a 31-day month the burn-down (forecast) chart drew a regular x-axis tick at day 29 and always drew the period-end label at day 31. About 40px apart, their 9px text overprinted at the right edge, so "08-29" and "08-31" collided ("not rendered right").

The code comment claimed the colliding tick was dropped, but the guard (`i < n - 2`) only dropped day 30, not day 29. Fix: require a full label-interval of clearance for regular ticks (`i <= n - 1 - labelEvery`), so the last regular tick (08-25) and the period end (08-31) sit cleanly apart. Verified live: the axis now reads 08-01, 08-05, … 08-25, 08-31 with no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)