### PR TITLE
Rename Waste tab to Recoverable Cost + copy trims

### DIFF
--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -226,7 +226,7 @@ export default async function UnitEconomicsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Unit Economics"
-        subtitle={`CAC by flavor, payback, and LTV — honest under uncertainty. Undefined metrics render ${DASH}.`}
+        subtitle="CAC by flavor, payback, and LTV"
         toolbar={
           <Suspense fallback={null}>
             <FilterBar groupByChoices={["feature", "model", "provider"]} defaultGroupBy="feature" />

--- a/web/app/waste/Live.tsx
+++ b/web/app/waste/Live.tsx
@@ -163,7 +163,7 @@ export function WasteLive({ initialData }: { initialData: WasteReport }) {
         ))}
       </TileGrid>
 
-      <Card title="Findings — hypotheses with evidence, not verdicts">
+      <Card title="Findings — hypotheses with evidence">
         {report.unavailable ? (
           // Hard failure: the report could not be produced. Render the honest reason, not an empty
           // table that would read as "no waste" (CTO-227).
@@ -192,7 +192,7 @@ export function WasteLive({ initialData }: { initialData: WasteReport }) {
     <div className="space-y-6">
       <PageHeader
         title="Waste"
-        subtitle="Recoverable AI spend: findings are hypotheses with evidence, not verdicts."
+        subtitle="Recoverable AI spend: findings are hypotheses with evidence."
         actions={<LiveIndicator updatedAt={updatedAt} />}
         toolbar={
           <Suspense fallback={null}>

--- a/web/app/waste/Live.tsx
+++ b/web/app/waste/Live.tsx
@@ -191,7 +191,7 @@ export function WasteLive({ initialData }: { initialData: WasteReport }) {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Waste"
+        title="Recoverable Cost"
         subtitle="Recoverable AI spend: findings are hypotheses with evidence."
         actions={<LiveIndicator updatedAt={updatedAt} />}
         toolbar={

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -42,7 +42,7 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
       { label: "Attribution", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },
       { label: "Cost per Customer", href: "/cost-per-customer" },
-      { label: "Waste", href: "/waste" },
+      { label: "Recoverable Cost", href: "/waste" },
     ],
   },
   {


### PR DESCRIPTION
- Rename the nav label and page title `Waste` -> `Recoverable Cost` (route stays `/waste`). The page is about spend you can get back, not blame.
- Drop the `not verdicts` clause from the findings card title and the page subtitle.
- Remove the `honest under uncertainty. Undefined metrics render —` clause from the Unit Economics subtitle.

Verified live: nav label fits, page title/subtitle and findings card updated, Unit Economics subtitle trimmed. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)