### PR TITLE
Explorer coherence: chart honors the group-by dimension filter

### DIFF
--- a/web/app/api/explore/route.ts
+++ b/web/app/api/explore/route.ts
@@ -25,11 +25,11 @@ export async function GET(req: Request) {
   const params = exploreParamsFromFilters(state);
 
   // One filter-aware fetch feeds all three /cost surfaces (CTO-240): the grouped time series and its
-  // breakdown table (queryCostExplore), and the headline tile totals (queryCostSliceTotals). The tile
-  // totals honor the FULL filter set including the group-by dimension (state.filters), while the
-  // series deliberately drops the group-by's own filter (exploreParamsFromFilters) so grouping by a
-  // dimension does not collapse the chart to a single band. Each is independently honest: either can
-  // come back null when ClickHouse is unreachable and the page states so rather than zero-filling.
+  // breakdown table (queryCostExplore), and the headline tile totals (queryCostSliceTotals). Both
+  // honor the FULL filter set including the group-by dimension (CTO-239: exploreParamsFromFilters now
+  // carries every filter), so a feature filter narrows the tiles, the chart and the breakdown alike
+  // instead of the chart disagreeing with the tiles. Each is independently honest: either can come
+  // back null when ClickHouse is unreachable and the page states so rather than zero-filling.
   const [series, totals] = await Promise.all([
     queryCostExplore(params),
     queryCostSliceTotals(rangeDays(state.range), state.filters),

--- a/web/components/ExploreChartCard.tsx
+++ b/web/components/ExploreChartCard.tsx
@@ -152,9 +152,9 @@ export function ExploreChartCard({
             days={series.days}
             groups={series.groups}
             ariaLabel={`cost over time by ${DIMENSION_LABEL[series.groupBy].toLowerCase()}`}
-            // Click a bar segment or legend swatch to filter on the grouped dimension. exploreParams
-            // excludes a dimension's own filter while it is the group-by (see explore.ts), so the
-            // drill lands as a URL filter chip; switching Group by then reveals that slice.
+            // Click a bar segment or legend swatch to filter on the grouped dimension. Filters now
+            // apply to the chart too (CTO-239), so this drills in: the URL filter chip appears and
+            // the chart narrows to that group. Clear the chip (or the search) to widen back out.
             onDrill={(group) => toggleFilter(effectiveGroupBy, group)}
           />
           {series.truncatedGroups > 0 && (

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -407,9 +407,9 @@ const EXPLORE_GROUP_EXPR: Record<ExploreDimension, string> = {
 
 /**
  * Build the multi-select filter clauses. Each active dimension becomes `AND <expr> IN {key:Array}`
- * with the values bound as an Array(String) parameter (never interpolated). The group-by dimension
- * is expected to be excluded upstream (see exploreParamsFromFilters); if it is not, filtering on the
- * grouped dimension is still a valid, if narrow, query.
+ * with the values bound as an Array(String) parameter (never interpolated). Every active dimension
+ * is applied, the group-by dimension included (CTO-239): filtering on the grouped dimension is a
+ * valid, if narrow, query and keeps the chart consistent with the filter-aware tiles.
  */
 function exploreFilterClauses(filters: ExploreFilters | undefined): {
   clause: string;

--- a/web/lib/explore.test.ts
+++ b/web/lib/explore.test.ts
@@ -110,14 +110,14 @@ describe("clampWindowDays", () => {
 });
 
 describe("exploreParamsFromFilters", () => {
-  it("maps a preset range and excludes the group-by dimension from its own filter", () => {
+  it("maps a preset range and carries every dimension filter, including the group-by's own (CTO-239)", () => {
     let s = withGroupBy(defaultFilterState(), "provider");
-    s = toggleDimensionValue(s, "provider", "openai"); // filter on the grouped dim -> dropped
+    s = toggleDimensionValue(s, "provider", "openai"); // filter on the grouped dim -> now kept
     s = toggleDimensionValue(s, "model", "gpt-4o"); // filter on another dim -> kept
     const p = exploreParamsFromFilters(s);
     expect(p.groupBy).toBe("provider");
     expect(p.window).toEqual({ kind: "preset", days: 30 });
-    expect(p.filters?.provider).toBeUndefined();
+    expect(p.filters?.provider).toEqual(["openai"]);
     expect(p.filters?.model).toEqual(["gpt-4o"]);
   });
 

--- a/web/lib/explore.ts
+++ b/web/lib/explore.ts
@@ -190,15 +190,17 @@ export function clampWindowDays(days: number): number {
 }
 
 /**
- * Translate the URL-driven {@link FilterState} into {@link ExploreParams}. The group-by dimension is
- * excluded from its own dimension filter: grouping by provider AND filtering to one provider would
- * collapse the chart to a single band, which is never what a group-by intends. Every other
- * dimension's filter is carried through.
+ * Translate the URL-driven {@link FilterState} into {@link ExploreParams}. EVERY active dimension
+ * filter is carried through, including the group-by dimension's own filter (CTO-239): a filter
+ * narrows everything on the page consistently, so grouping by feature AND filtering to one feature
+ * shows that feature's own series, matching the filter-aware tiles and breakdown. (It used to drop
+ * the group-by dimension's filter for a highlight-one-among-many effect, but that left the chart
+ * disagreeing with the tiles once those became filter-aware; to compare all groups, group by the
+ * dimension with no filter, or use the legend to hide series.)
  */
 export function exploreParamsFromFilters(state: FilterState): ExploreParams {
   const filters: ExploreFilters = {};
   for (const dim of DIMENSIONS) {
-    if (dim === state.groupBy) continue;
     if (state.filters[dim].length > 0) filters[dim] = state.filters[dim];
   }
 


### PR DESCRIPTION
Follow-on to M1 (CTO-239). M1 made the Cost tiles filter-aware, but `exploreParamsFromFilters` still dropped the group-by dimension's own filter — so grouping by feature and filtering to one feature showed the tiles at that feature's spend while the chart still drew every feature. The two disagreed.

Fix: carry every active dimension filter through, the group-by included. A filter now narrows the tiles, the chart, and the breakdown together. To compare all groups, group by the dimension with no filter (or hide series via the legend). Verified live: `groupBy=feature&feature=research_agent` shows TOTAL $54,184 and a chart with only the research_agent series.

Test + comments updated. typecheck/lint/build clean; only the long-standing api.test.ts ClickHouse-running case fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)