### PR TITLE
feat(web): fold Agents into the Cost explorer as an `agent` group-by (CTO-241)

### DIFF
--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -1,20 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-import { apiGet } from "@/lib/api";
-import { filtersToQueryString, parseFilters } from "@/lib/filters";
-import { searchParamsFromRecord } from "@/lib/searchParams";
-import { AgentsLive, type AgentsPayload } from "./Live";
+// The standalone Agents workflow was folded into the unified Cost explorer as the `agent` group-by
+// dimension (CTO-241, M2 of CTO-239). This route now redirects to /cost?groupBy=agent so old links,
+// bookmarks, and the retired nav item all land on the explorer's cost-by-agent view. The run
+// drill-down (/agents/runs/[runId]) and its API are deliberately kept and untouched.
 
-export default async function AgentsPage({
-  searchParams,
-}: {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-}) {
-  // Forward ?tag= / ?run= (CTO-104 deep links) AND the URL-synced time range (CTO-226): the managed
-  // filter serializer preserves the unmanaged tag/run keys while adding the range, so SSR's first
-  // paint matches the URL and the client re-derives the same endpoint from useFilters as it changes.
-  const sp = searchParamsFromRecord(await searchParams);
-  const qs = filtersToQueryString(parseFilters(sp), sp);
-  const endpoint = qs ? `/api/agents?${qs}` : "/api/agents";
-  const initialData = await apiGet<AgentsPayload>(endpoint);
-  return <AgentsLive initialData={initialData} />;
+import { redirect } from "next/navigation";
+
+export default function AgentsPage() {
+  redirect("/cost?groupBy=agent");
 }

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -17,7 +17,11 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const tag = searchParams.get("tag") ?? "";
   const run = searchParams.get("run") ?? "";
-  const hasFilter = Boolean(tag || run);
+  // ?agent=<ServiceName> (CTO-241): the unified Cost explorer requests one agent's detail when
+  // group-by=agent is narrowed to a single agent. Like ?tag=/?run=, a set filter with no live data
+  // returns empty rather than the unfiltered mock, so the inline detail never fabricates numbers.
+  const agent = searchParams.get("agent") ?? "";
+  const hasFilter = Boolean(tag || run || agent);
   // The time-range selector drives the windowed cost/day average (CTO-226): resolve the URL-synced
   // filter state to a day count the ClickHouse-derived window clamps and interpolates.
   const windowDays = rangeDays(parseFilters(searchParams).range);
@@ -25,7 +29,7 @@ export async function GET(req: Request) {
   // the real reconciliation_runs value (CTO-169) — or null when the reconciler has never run / the
   // gateway is unavailable, which the page renders as `—` rather than a fabricated constant.
   const [live, reconcilerLastRunMinutesAgo] = await Promise.all([
-    queryAgents({ tag, run }, windowDays),
+    queryAgents({ tag, run, agent }, windowDays),
     queryReconcilerLastRun(),
   ]);
   return NextResponse.json({

--- a/web/app/cost/AgentDetail.tsx
+++ b/web/app/cost/AgentDetail.tsx
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// The single-agent detail block inside the unified Cost explorer (CTO-241, M2 of CTO-239).
+//
+// When /cost groups by `agent` AND is filtered to exactly one agent, this renders that agent's run
+// distribution below the breakdown table, preserving everything the retired /agents view showed for
+// one agent: the log-scale distribution histogram, p50 / p99 / p99÷p50 ratio, the pathological-runs
+// list linking to the run drill-down, and the reconciler-freshness badge.
+//
+// It reuses the SAME source and shapes as /agents rather than reimplementing: a tenant-scoped fetch
+// of /api/agents?agent=<ServiceName> (queryAgents, filtered to that agent by ServiceName), the
+// AgentSummary / AgentRun types and p99Ratio from lib/agents, the Histogram component, and the
+// dataState / StaleBadge freshness primitives. Honest-under-uncertainty throughout: a source we
+// cannot reach and an agent with no runs each state why, never a fabricated or zero figure.
+
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { Card } from "@/components/Card";
+import { StaleBadge } from "@/components/DataStateBanner";
+import { Histogram } from "@/components/Histogram";
+import { type AgentRun, type AgentSummary, p99Ratio } from "@/lib/agents";
+import {
+  asOfLabel,
+  boundaryFromMinutesAgo,
+  deriveDataState,
+  relativeAge,
+} from "@/lib/dataState";
+import { formatUSD } from "@/lib/types";
+
+interface AgentsDetailPayload {
+  agents: AgentSummary[];
+  runs: AgentRun[];
+  reconcilerLastRunMinutesAgo: number | null;
+}
+
+type FetchStatus = "loading" | "ready" | "unavailable";
+
+/**
+ * @param agent   the selected agent's ServiceName (filters.agent[0]).
+ * @param queryString the managed filter query string, which already carries `agent=<name>` and the
+ *   window, so /api/agents resolves both the ServiceName filter and the same window the tiles use.
+ */
+export function AgentDetail({ agent, queryString }: { agent: string; queryString: string }) {
+  const endpoint = queryString ? `/api/agents?${queryString}` : "/api/agents";
+  const [data, setData] = useState<AgentsDetailPayload | null>(null);
+  const [status, setStatus] = useState<FetchStatus>("loading");
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setStatus("loading");
+    fetch(endpoint, { signal: ctrl.signal, cache: "no-store" })
+      .then((r) => r.json())
+      .then((j: AgentsDetailPayload) => {
+        setData(j);
+        setStatus("ready");
+      })
+      .catch((err: unknown) => {
+        // A fast filter change aborts in-flight; keep the last state rather than flashing a message.
+        if (err instanceof Error && err.name === "AbortError") return;
+        // Honest-under-uncertainty: a failed fetch is "unavailable", never a zero-filled detail.
+        setData(null);
+        setStatus("unavailable");
+      });
+    return () => ctrl.abort();
+  }, [endpoint]);
+
+  const title = `Run distribution — ${agent}`;
+
+  if (status === "loading" && data === null) {
+    return (
+      <Card title={title}>
+        <p className="py-6 text-center text-sm text-muted">Loading this agent’s runs…</p>
+      </Card>
+    );
+  }
+
+  if (status === "unavailable" || data === null) {
+    return (
+      <Card title={title}>
+        <p className="py-6 text-center text-sm text-muted">
+          This detail is served live and the telemetry source could not be reached, so no
+          distribution is drawn.
+        </p>
+      </Card>
+    );
+  }
+
+  const summary = data.agents.find((a) => a.name === agent) ?? null;
+  const agentRuns = data.runs
+    .filter((r) => r.agent === agent)
+    .sort((a, b) => b.totalCostMicroUsd - a.totalCostMicroUsd);
+
+  // No summary for the selected agent means it had no runs in this window. State it; never fabricate.
+  if (summary === null) {
+    return (
+      <Card title={title}>
+        <p className="py-6 text-center text-sm text-muted">
+          No runs for <span className="font-mono">{agent}</span> in this window.
+        </p>
+      </Card>
+    );
+  }
+
+  const ratio = p99Ratio(summary);
+  const hot = ratio > 20;
+
+  // Reconciler freshness, read exactly as the /agents view did (CTO-169): the real last-run boundary,
+  // rendered as `—` (no badge) when the reconciler has never run or its source is unavailable.
+  const reconciledThrough = boundaryFromMinutesAgo(data.reconcilerLastRunMinutesAgo);
+  const asOf = asOfLabel(reconciledThrough);
+  const dataState = deriveDataState({ isEmpty: false, isPartial: false, reconciledThrough });
+
+  return (
+    <Card title={title}>
+      <div className="space-y-5">
+        {asOf && (
+          <div className="flex justify-end">
+            <StaleBadge
+              asOf={asOf}
+              age={relativeAge(reconciledThrough)}
+              stale={dataState === "stale"}
+            />
+          </div>
+        )}
+        <div className="flex flex-wrap items-end gap-x-8 gap-y-3">
+          <Stat label="Runs/day" value={summary.runsPerDay.toLocaleString()} />
+          <Stat label="Cost/day" value={formatUSD(summary.costPerDayMicroUsd)} />
+          <Stat label="p50" value={formatUSD(summary.p50MicroUsd)} />
+          <Stat label="p99" value={formatUSD(summary.p99MicroUsd)} />
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted">p99/p50</div>
+            <div className="mt-0.5 tabular-nums">
+              <span className={hot ? "rounded bg-bad/20 px-1.5 py-0.5 text-bad" : ""}>
+                {ratio.toFixed(0)}×{hot ? " ⚠" : ""}
+              </span>
+            </div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted">Distribution</div>
+            <div className="mt-1">
+              <Histogram buckets={summary.distribution} />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="mb-2 text-xs uppercase tracking-wide text-muted">
+            Pathological runs (top cost outliers)
+          </div>
+          {agentRuns.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted">
+              No outlier runs captured for this agent in this window.
+            </p>
+          ) : (
+            <ul className="divide-y divide-edge text-sm">
+              {agentRuns.map((r) => (
+                <li key={r.runId} className="flex items-center justify-between gap-3 py-2">
+                  <Link
+                    href={`/agents/runs/${r.runId}`}
+                    className="font-mono text-accent hover:underline"
+                  >
+                    {r.runId}
+                  </Link>
+                  <span className="flex items-center gap-3">
+                    <OutcomeBadge outcome={r.outcome} />
+                    <span className="tabular-nums">{formatUSD(r.totalCostMicroUsd)}</span>
+                    <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <div className="mt-0.5 tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome: "success" | "failed" | "abandoned" }) {
+  const cls =
+    outcome === "success"
+      ? "bg-good/20 text-good"
+      : outcome === "failed"
+        ? "bg-bad/20 text-bad"
+        : "bg-edge text-muted";
+  return <span className={`rounded px-1.5 py-0.5 text-xs ${cls}`}>{outcome}</span>;
+}

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -65,6 +65,7 @@ import { formatUSD } from "@/lib/types";
 import { useFilters } from "@/lib/useFilters";
 import { useLivePoll } from "@/lib/useLivePoll";
 
+import { AgentDetail } from "./AgentDetail";
 import { BudgetVsActualCard } from "./BudgetVsActualCard";
 import { BurndownCard, type CostBudgetPayload } from "./BurndownCard";
 
@@ -212,6 +213,24 @@ export function CostLive({
   // The breakdown group-by: whatever /api/explore grouped by, or the URL's group-by while it loads.
   const breakdownGroupBy: Dimension = explore.series?.groupBy ?? filterState.groupBy;
 
+  // Agent filter options (CTO-241): /api/cost doesn't enumerate agents, but the explore breakdown
+  // does once grouped by agent, so the FilterBar offers an Agent dropdown listing the agents in the
+  // slice. The synthetic "other" fold is not a real agent, so it is never a filterable option.
+  const agentOptions: FilterOption[] =
+    breakdownGroupBy === "agent" && explore.series
+      ? explore.series.breakdown
+          .filter((r) => r.group !== OTHER_GROUP)
+          .map((r) => ({ value: r.group }))
+      : [];
+
+  // The single-agent detail is shown only when the explorer groups by agent AND is narrowed to
+  // exactly one agent (CTO-241): that is the slice for which one agent's run distribution and
+  // pathological runs are meaningful. It reuses the /agents data + components (see AgentDetail).
+  const singleAgent =
+    filterState.groupBy === "agent" && filterState.filters.agent.length === 1
+      ? filterState.filters.agent[0]
+      : null;
+
   // Breakdown rows: from /api/explore when present; else, on the default slice, a per-layer fallback
   // off the /api/cost layer totals so the offline / synthetic-preview view keeps a table.
   const breakdownRows: ExploreBreakdownRow[] = useMemo(() => {
@@ -314,6 +333,10 @@ export function CostLive({
         matchesSearch={matchesSearch}
         unavailable={sliceUnavailable}
       />
+
+      {/* The retired /agents view, preserved for one agent (CTO-241): when grouping by agent and
+          narrowed to a single agent, its run distribution + pathological runs render here. */}
+      {singleAgent && <AgentDetail agent={singleAgent} queryString={queryString} />}
     </div>
   );
 
@@ -334,7 +357,11 @@ export function CostLive({
             )}
           </>
         }
-        toolbar={<FilterBar options={{ feature: featureOptions, layer: layerOptions }} />}
+        toolbar={
+          <FilterBar
+            options={{ feature: featureOptions, layer: layerOptions, agent: agentOptions }}
+          />
+        }
       />
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -37,7 +37,8 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
     items: [
       { label: "Cost", href: "/cost" },
       { label: "Features", href: "/features" },
-      { label: "Agents", href: "/agents" },
+      // Agents folded into the Cost explorer as the `agent` group-by (CTO-241); /agents redirects
+      // to /cost?groupBy=agent, so the standalone nav item is retired.
       { label: "Compare", href: "/compare" },
       { label: "Attribution", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -403,6 +403,20 @@ const EXPLORE_GROUP_EXPR: Record<ExploreDimension, string> = {
   provider:
     "coalesce(nullIf(SpanAttributes['chatbot.real_provider'], ''), nullIf(GenAiSystem, ''), 'unknown')",
   account: "if(empty(AccountIdHash), 'unattributed', toString(AccountIdHash))",
+  // Agent identity is ServiceName, exactly as queryAgents reads it (CTO-241). The synthetic
+  // ''/'unknown' services and the compute/egress rows are excluded via EXPLORE_GROUP_SCOPE below,
+  // not here, so the raw expression stays a plain column reference the filter clause can reuse.
+  agent: "ServiceName",
+};
+
+// Extra WHERE predicate applied ONLY when the explorer groups by this dimension (CTO-241). Agent
+// cost is run-shaped: it drops the ''/'unknown' ServiceName rows and the synthetic compute/egress
+// rows that queryAgents also excludes, so group-by=agent lists exactly the agents the retired
+// /agents view listed and each agent's cost matches. Other group-bys are unaffected, and the agent
+// multi-select filter (ServiceName IN ...) is deliberately just the membership test, applied on any
+// group-by, so filtering to an agent narrows every dimension consistently.
+const EXPLORE_GROUP_SCOPE: Partial<Record<ExploreDimension, string>> = {
+  agent: "AND ServiceName NOT IN ('', 'unknown') AND GenAiOperation NOT IN ('compute', 'egress')",
 };
 
 /**
@@ -472,9 +486,13 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
 
     const { clause: filterClause, params: filterParams } = exploreFilterClauses(params.filters);
     // Half-open on the high end so the whole of windowEnd's calendar day is included exactly once.
+    // The group-scope predicate (agent's run-shaped exclusions, CTO-241) rides on every read below
+    // so the totals, the breakdown, and the day×group series all sit on the same excluded slice.
+    const groupScope = EXPLORE_GROUP_SCOPE[params.groupBy] ?? "";
     const scope = `TenantId = {tenant:String}
         AND Timestamp >= toDate({windowStart:String})
-        AND Timestamp < toDate({windowEnd:String}) + 1`;
+        AND Timestamp < toDate({windowEnd:String}) + 1
+        ${groupScope}`;
     const common = { tenant, windowStart: b.windowStart, windowEnd: b.windowEnd, ...filterParams };
 
     // Per-group totals over the whole window. Group cardinality is inherently small (one row per
@@ -2056,7 +2074,7 @@ function buildRun(agg: RunAgg, spans: RunSpan[], agentMedian: number): AgentRun 
 
 /** Per-agent summaries + the top expensive runs (with span trees), built from otel_spans. */
 export async function queryAgents(
-  filter?: { tag?: string; run?: string },
+  filter?: { tag?: string; run?: string; agent?: string },
   windowDays = 30,
 ): Promise<{ agents: AgentSummary[]; runs: AgentRun[] } | null> {
   return tryLive(async (db, tenant) => {
@@ -2065,8 +2083,13 @@ export async function queryAgents(
     const w = clampWindowDays(windowDays);
     const tag = filter?.tag ?? "";
     const run = filter?.run ?? "";
+    // Narrow to a single agent by ServiceName (CTO-241): the unified Cost explorer fetches this when
+    // group-by=agent is filtered to exactly one agent, to render that agent's run distribution and
+    // pathological runs inline. Bound as a param, never interpolated.
+    const agent = filter?.agent ?? "";
     const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
     const runClause = run ? "AND TraceId = {run:String}" : "";
+    const agentClause = agent ? "AND ServiceName = {agent:String}" : "";
     // Agent identity comes from ServiceName (e.g. "aider", "vercel-chatbot-demo"),
     // not FeatureTag (which is the workflow-3 dimension — that's the /features view).
     // ?tag= still narrows agents to runs that produced a given feature.
@@ -2086,8 +2109,9 @@ export async function queryAgents(
          AND GenAiOperation NOT IN ('compute', 'egress')
          ${tagClause}
          ${runClause}
+         ${agentClause}
        GROUP BY TraceId`,
-      { tenant, tag, run },
+      { tenant, tag, run, agent },
     );
     if (aggs.length === 0) return { agents: [], runs: [] };
 

--- a/web/lib/filters.test.ts
+++ b/web/lib/filters.test.ts
@@ -37,6 +37,7 @@ describe("parseFilters", () => {
       layer: [],
       provider: [],
       account: [],
+      agent: [],
     });
   });
 

--- a/web/lib/filters.ts
+++ b/web/lib/filters.ts
@@ -38,7 +38,10 @@ export const PRESET_DAYS: Record<Exclude<TimeRangePreset, "custom">, number> = {
  * The dimensions a page can group by or filter on. These are also the multi-select filter keys, so
  * the list drives both the group-by selector and the set of dimension-filter URL params.
  */
-export const DIMENSIONS = ["feature", "model", "layer", "provider", "account"] as const;
+// `agent` (= ServiceName) folds the retired /agents view into the explorer as one more group-by
+// dimension (CTO-241, M2 of the unified Cost explorer CTO-239). It is a first-class dimension so it
+// flows through group-by, the multi-select filter, and the shareable URL exactly like the others.
+export const DIMENSIONS = ["feature", "model", "layer", "provider", "account", "agent"] as const;
 export type Dimension = (typeof DIMENSIONS)[number];
 
 export const DIMENSION_LABEL: Record<Dimension, string> = {
@@ -47,6 +50,7 @@ export const DIMENSION_LABEL: Record<Dimension, string> = {
   layer: "Layer",
   provider: "Provider",
   account: "Account",
+  agent: "Agent",
 };
 
 export interface TimeRange {
@@ -72,7 +76,7 @@ export const DEFAULT_GROUP_BY: Dimension = "layer";
 export const MANAGED_KEYS: readonly string[] = ["range", "from", "to", "groupBy", ...DIMENSIONS];
 
 function emptyFilters(): DimensionFilters {
-  return { feature: [], model: [], layer: [], provider: [], account: [] };
+  return { feature: [], model: [], layer: [], provider: [], account: [], agent: [] };
 }
 
 export function defaultFilterState(): FilterState {

--- a/web/lib/waste/wrong-sized-model.collect.test.ts
+++ b/web/lib/waste/wrong-sized-model.collect.test.ts
@@ -41,7 +41,7 @@ const tryLive = ch.tryLive as unknown as ReturnType<typeof vi.fn>;
 const rowsP = ch.rowsP as unknown as ReturnType<typeof vi.fn>;
 
 function filters(over: Partial<DimensionFilters> = {}): DimensionFilters {
-  return { feature: [], model: [], layer: [], provider: [], account: [], ...over };
+  return { feature: [], model: [], layer: [], provider: [], account: [], agent: [], ...over };
 }
 
 // The grouped (FeatureTag, model) read the collector runs. research_agent's dominant model is


### PR DESCRIPTION
## What changed

M2 of the unified Cost explorer (CTO-239). Folds the standalone **Agents** page into the Cost explorer as a new `agent` group-by dimension, retiring the separate page while losing no functionality.

- **`lib/filters.ts`** — `agent` (= `ServiceName`) becomes a first-class dimension: added to `DIMENSIONS`, `DIMENSION_LABEL` ("Agent"), and `emptyFilters`. It flows through group-by, the multi-select filter, and the shareable URL exactly like the other dimensions (`MANAGED_KEYS` derives from `DIMENSIONS`, so it round-trips).
- **`lib/clickhouse.ts`** —
  - `EXPLORE_GROUP_EXPR.agent = "ServiceName"`, the same identity `queryAgents` reads.
  - New `EXPLORE_GROUP_SCOPE` predicate applied **only** when grouping by agent: excludes `ServiceName IN ('', 'unknown')` and `GenAiOperation IN ('compute','egress')`, so group-by=agent lists exactly the agents the retired view listed and each agent's cost matches (agent cost is run-shaped).
  - `queryCostSliceTotals` + `exploreFilterClauses` honor `filters.agent` as `ServiceName IN {f_agent:Array(String)}` (bound param, never interpolated) — automatic once `agent` is in `EXPLORE_GROUP_EXPR`.
  - `queryAgents` gains an optional `agent` (ServiceName) filter for the single-agent detail fetch.
- **`app/cost/Live.tsx`** — the FilterBar now offers **Agent** as a group-by choice (default choices already include every dimension) and an **Agent** dimension filter (options sourced from the explore breakdown when grouped by agent). The tiles, chart, breakdown table, and search all flow through M1 for `agent` unchanged.
- **`app/cost/AgentDetail.tsx`** (new) — the preserved agent detail, shown when `groupBy === 'agent'` **and** exactly one agent is selected. Reuses `/api/agents` data, `lib/agents` types + `p99Ratio`, the `Histogram` component, and the `dataState` / `StaleBadge` freshness primitives: run-distribution histogram, p50 / p99 / p99÷p50 ratio, the pathological-runs list linking to `/agents/runs/[runId]`, and the reconciler-freshness badge. Honest empty ("No runs for this agent in this window") and unavailable states, never fabricated or zero numbers.
- **`components/Shell.tsx`** — the "Agents" nav item is retired.
- **`app/agents/page.tsx`** — now a server `redirect("/cost?groupBy=agent")`. The run drill-down `/agents/runs/[runId]` and its API are kept untouched; `/api/agents` stays (it feeds the detail).
- Tests updated for the new dimension key (`filters.test.ts`, `wrong-sized-model.collect.test.ts`).

## How the agent detail is preserved (loses nothing)

Distribution, outliers, p50/p99, p99/p50 ratio, reconciler freshness, and the run drill-down all stay reachable: the drill-down page/API are unchanged, and the single-agent detail re-renders the distribution + pathological runs inline in the explorer by reusing the same `queryAgents` source and the same components, filtered to the selected agent by `ServiceName`.

## Verification (tenant `local-dev`, live stack)

`npm run typecheck`, `npm run lint` (only the pre-existing `useLivePoll` warning), `npm run test` (only the long-standing ClickHouse-running "falls back to mock when ClickHouse is unreachable" case fails; the `/api/agents` smoke test stays green), and a clean `npm run build` (`rm -rf .next`) all pass. Against the live stack:

- **`/cost?groupBy=agent`** lists agents by cost (`vercel-chatbot`, `wastedemo_agent`, `research_agent`, …), tiles and chart are agent-filter-aware, search works.
- **Narrowing to `vercel-chatbot`** shows real numbers — runs/day 7,460, cost/day $1,429.70, p50 $0.178, p99 $0.570, p99/p50 3× — the distribution histogram, and pathological runs with real run IDs linking to `/agents/runs/<id>`.
- **`/agents`** 307-redirects to `/cost?groupBy=agent`; **`/agents/runs/<real-runId>`** still renders.

Screenshots taken of cost-by-agent, the single-agent tiles+chart, and the single-agent RUN DISTRIBUTION detail block (distribution, stats, pathological runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)