### PR TITLE
feat(deploy): demo deploy kit for single-VM hosting behind Caddy (CTO-243)

### DIFF
--- a/deploy/demo/.env.example
+++ b/deploy/demo/.env.example
@@ -1,0 +1,30 @@
+# ai-tally demo-deploy-kit - per-host config (CTO-243). Copy to `.env` and fill in, then ./deploy.sh
+#
+#   cp deploy/demo/.env.example deploy/demo/.env
+#
+# .env is host-specific and must NOT be committed (it holds the basic-auth hash).
+
+# --- Public site -------------------------------------------------------------------------------
+# The domain you pointed at this VM's public IP (DNS A record). Caddy gets a TLS cert for it.
+DOMAIN=demo.example.com
+
+# --- Basic auth (the single shared login you share privately with testers) ---------------------
+BASIC_AUTH_USER=tester
+# bcrypt hash of the password. Generate it (do NOT store the plaintext here):
+#   docker run --rm caddy:2 caddy hash-password --plaintext 'yourpassword'
+# Paste the $2a$... output below. Wrap it in single quotes so the shell keeps the $ literals.
+BASIC_AUTH_HASH=
+
+# --- Backing stack credentials (defaults match infra/docker-compose.yml) -----------------------
+# Override on a real host. The web service reads CLICKHOUSE_USER/PASSWORD via the compose overlay.
+CLICKHOUSE_USER=tally
+CLICKHOUSE_PASSWORD=tally
+POSTGRES_DB=tally
+POSTGRES_USER=tally
+POSTGRES_PASSWORD=tally
+MINIO_ROOT_USER=tally
+MINIO_ROOT_PASSWORD=tally-minio
+
+# --- Tenant the dashboard renders --------------------------------------------------------------
+# The dashboard passes the tenant NAME. `make seed` creates `local-dev`; keep this in sync.
+TALLY_TENANT_ID=local-dev

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -1,0 +1,43 @@
+# ai-tally demo-deploy-kit - Caddy site config (CTO-243).
+#
+# Caddy is the only public surface. It gets a real Let's Encrypt certificate for ${DOMAIN}
+# automatically (ACME HTTP-01 over port 80), terminates TLS, challenges every request with HTTP
+# basic-auth, and reverse-proxies the dashboard. The DBs and the gateway are never exposed.
+#
+# Env used (set by docker-compose.prod.yml from .env):
+#   ${DOMAIN}           e.g. demo.example.com
+#   ${BASIC_AUTH_USER}  e.g. tester
+#   ${BASIC_AUTH_HASH}  bcrypt hash from: docker run --rm caddy:2 caddy hash-password --plaintext '...'
+
+{$DOMAIN} {
+	# One shared login for all testers. The hash is a bcrypt string, never the plaintext.
+	basic_auth {
+		{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+	}
+
+	# The browser only ever talks to the dashboard; the web server reads ClickHouse and calls the
+	# gateway internally over the compose network.
+	reverse_proxy web:3000
+
+	# ---- OPTIONAL: let testers send their OWN telemetry to the gateway ingest ------------------
+	# Uncomment to expose ONLY the ingest endpoint (still behind the same basic-auth). Everything
+	# else on the gateway (control plane, health) stays internal. See README "Exposing the gateway".
+	#
+	# handle /v1/batches* {
+	# 	reverse_proxy gateway:8080
+	# }
+}
+
+# ---- LOCAL SMOKE TEST (no TLS) ------------------------------------------------------------------
+# For a laptop smoke test with no domain and no certificates, run a Caddy container with a config
+# like the block below (http on a spare port, 8088) instead of the site above:
+#
+#   :8088 {
+#   	basic_auth {
+#   		{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+#   	}
+#   	reverse_proxy web:3000
+#   }
+#
+# Then: curl -i localhost:8088                     -> 401 (auth required)
+#       curl -i -u tester:secret localhost:8088    -> 200 (reaches the dashboard)

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -1,0 +1,162 @@
+# ai-tally demo-deploy-kit
+
+Drop-in kit to host the **whole ai-tally stack on one cloud VM**, behind Caddy (automatic HTTPS +
+HTTP basic-auth), so testers get a single private link to the seeded demo. (CTO-243)
+
+Everything runs from `docker compose`, layered on top of the existing local stack:
+
+```
+docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml up -d --build
+```
+
+The overlay adds a `web` (Next.js dashboard) and a `caddy` service, and makes **Caddy the only
+service that publishes host ports** (80/443). ClickHouse, Postgres, Redpanda, MinIO and the gateway
+keep talking to each other over the compose network but are not reachable from the internet.
+
+> The demo dataset is **synthetic** - seeded and backfilled by this kit (no real users, no real LLM
+> calls, no API keys). See `deploy.sh` / `reseed.sh`.
+
+## What's in here
+
+| File | Purpose |
+|------|---------|
+| `web.Dockerfile` | Multi-stage build of the Next.js dashboard (standalone, `node:22`), root build context. |
+| `docker-compose.prod.yml` | Overlay: adds `web` + `caddy`, strips host ports off the base services. |
+| `Caddyfile` | `${DOMAIN}` site: automatic TLS, basic-auth, `reverse_proxy web:3000`. Commented gateway-ingest and local-HTTP variants. |
+| `.env.example` | Per-host config: domain, basic-auth user + bcrypt hash, stack creds, tenant. |
+| `deploy.sh` | Bring the stack up, wait for health, apply DDL, seed + backfill, print the link. |
+| `reseed.sh` | Reset + re-seed the synthetic data (run nightly via cron). |
+
+## Operator runbook
+
+### 1. Provision a VM
+
+Any Docker-capable Linux VM works (DigitalOcean, Hetzner, GCP, Fly, AWS EC2, ...). ClickHouse likes
+RAM, so size for it:
+
+- **4 vCPU / 8-16 GB RAM**, ~40 GB disk.
+- Open inbound TCP **80** and **443** only. Nothing else needs a public port.
+
+Install Docker Engine + the Compose plugin (Docker's official convenience script is fine):
+
+```
+curl -fsSL https://get.docker.com | sh
+```
+
+Then clone this repo onto the VM (e.g. into `/opt/ai-tally`).
+
+### 2. Point DNS at the VM
+
+Create a DNS **A record** for your `${DOMAIN}` (e.g. `demo.example.com`) pointing at the VM's public
+IP. Caddy needs this resolvable to obtain a Let's Encrypt certificate over the port-80 ACME
+challenge. Wait for it to propagate before the first deploy.
+
+### 3. Configure `.env`
+
+```
+cp deploy/demo/.env.example deploy/demo/.env
+```
+
+Edit `deploy/demo/.env`:
+
+- Set `DOMAIN` to your record.
+- Set `BASIC_AUTH_USER` (e.g. `tester`).
+- Generate the bcrypt hash for the shared password and paste it into `BASIC_AUTH_HASH`:
+
+  ```
+  docker run --rm caddy:2 caddy hash-password --plaintext 'yourpassword'
+  ```
+
+  Store only the `$2a$...` hash in `.env`; keep the plaintext to share with testers. `.env` is
+  host-specific and is git-ignored - do not commit it.
+
+### 4. Deploy
+
+```
+./deploy/demo/deploy.sh
+```
+
+This builds the images, starts the stack, waits for the gateway to be healthy, applies the
+ClickHouse DDL (including `replay_samples`), seeds the tenant, and backfills 30 days of synthetic
+spans. When it finishes it prints:
+
+```
+URL:   https://demo.example.com
+Login: tester  (password: the plaintext you hashed)
+```
+
+### 5. Share privately
+
+Send the link and the shared password to testers **privately** (DM / password manager share). This
+beta is **private, not open** - the single basic-auth login is the only gate, so treat it like a
+password.
+
+## Security posture
+
+- **Only Caddy is public.** It publishes 80/443; every other service has its host ports removed by
+  the overlay and is reachable only over the internal compose network.
+- **The gateway stays internal behind auth.** It carries write endpoints (`/v1/batches` ingest,
+  control-plane `/v1/tenant/*`), so it must not be exposed directly. The dashboard reaches it as
+  `http://gateway:8080` server-side; the browser only ever talks to the dashboard.
+- **Basic-auth on everything.** Caddy challenges every request, so the dashboard is never anonymous.
+- Use a strong shared password and rotate it (re-hash, update `.env`, `docker compose ... up -d
+  caddy`) if it leaks.
+
+## Exposing the gateway ingest (optional)
+
+If testers should send **their own** telemetry, expose only the ingest endpoint (still behind the
+same basic-auth) by uncommenting the `handle /v1/batches*` block in the `Caddyfile`, then:
+
+```
+docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml up -d caddy
+```
+
+Point their SDK / edge-proxy at `https://${DOMAIN}/v1/batches` with the basic-auth credentials. Do
+**not** publish a host port for the gateway; keep it behind Caddy.
+
+## Resetting the data
+
+The demo data is synthetic and backdated relative to "now", so re-running keeps the window current.
+
+- **On demand:** `./deploy/demo/reseed.sh` truncates the telemetry tables and re-seeds + re-backfills.
+- **Nightly:** add a cron entry (see the comment block in `reseed.sh`):
+
+  ```
+  15 3 * * * /opt/ai-tally/deploy/demo/reseed.sh >> /var/log/ai-tally-reseed.log 2>&1
+  ```
+
+## Local smoke test (no VM, no TLS)
+
+You can validate the pieces on a laptop without binding 80/443 or owning a domain:
+
+```
+# Config resolves:
+docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml config
+
+# The dashboard image builds:
+docker build -f deploy/demo/web.Dockerfile -t ai-tally-web-demo .
+
+# Caddy config is valid:
+docker run --rm -v "$PWD/deploy/demo/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  -e DOMAIN=:8088 -e BASIC_AUTH_USER=tester -e BASIC_AUTH_HASH='<hash>' \
+  caddy:2 caddy validate --config /etc/caddy/Caddyfile
+```
+
+For an end-to-end auth check, run Caddy with the commented `:8088` HTTP block from the `Caddyfile`
+proxying to a `web` container on a spare port and `curl` it: no creds -> `401`, correct creds ->
+`200`.
+
+## Feedback
+
+Share a lightweight feedback link alongside the demo (a Google Form, Canny board, or a Linear
+intake link) so testers can report what they see. Keep it in the same private message as the
+credentials.
+
+## Notes
+
+- Runs on any Docker-capable VM; per-host specifics (domain, password, creds) live in `.env`.
+- This kit does not modify `infra/docker-compose.yml` or the app; it is additive under
+  `deploy/demo/`.
+- The `chatbot-demo-backfill` make target runs on the host and hits `localhost:8080`; on a
+  locked-down VM (no host Node, gateway not published) `deploy.sh`/`reseed.sh` instead run the same
+  backfill script inside a throwaway `node:22` container attached to the compose network.

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# ai-tally demo-deploy-kit - one-shot deploy for a single VM behind Caddy (CTO-243).
+#
+# Brings up the whole stack (ClickHouse, Postgres, Redpanda, MinIO, gateway, web, Caddy), applies
+# the ClickHouse DDL, and loads the SYNTHETIC demo dataset. Re-running is safe: compose reconciles
+# to the desired state, the DDL is idempotent (CREATE ... IF NOT EXISTS), and seed/backfill are the
+# same generators the local `make` targets use.
+#
+# Prereqs: Docker + Docker Compose v2, a filled-in deploy/demo/.env, and DNS for $DOMAIN pointed at
+# this host (needed for Caddy to obtain a TLS cert, not for the containers to start).
+#
+# Usage:  ./deploy/demo/deploy.sh        (run from the repo root or anywhere; it finds the root)
+
+set -euo pipefail
+
+# --- Locate the repo root so this script works from any CWD -------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+ENV_FILE="deploy/demo/.env"
+BASE_COMPOSE="infra/docker-compose.yml"
+PROD_COMPOSE="deploy/demo/docker-compose.prod.yml"
+
+# --- Load .env ----------------------------------------------------------------------------------
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "ERROR: ${ENV_FILE} not found. Copy deploy/demo/.env.example to ${ENV_FILE} and fill it in." >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+: "${DOMAIN:?DOMAIN must be set in ${ENV_FILE}}"
+: "${BASIC_AUTH_USER:?BASIC_AUTH_USER must be set in ${ENV_FILE}}"
+: "${BASIC_AUTH_HASH:?BASIC_AUTH_HASH must be set in ${ENV_FILE} (see .env.example for the generator)}"
+
+# Compose reads the same .env for base-stack defaults; pass it explicitly so both files see it.
+COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
+
+echo "==> Building images and starting the stack"
+"${COMPOSE[@]}" up -d --build
+
+# --- Wait for the gateway to be healthy before seeding ------------------------------------------
+echo "==> Waiting for the gateway to become healthy"
+for i in $(seq 1 60); do
+  if "${COMPOSE[@]}" exec -T gateway \
+      python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/healthz').status==200 else 1)" \
+      >/dev/null 2>&1; then
+    echo "    gateway healthy"
+    break
+  fi
+  if [[ "${i}" -eq 60 ]]; then
+    echo "ERROR: gateway did not become healthy in time. Check: ${COMPOSE[*]} logs gateway" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+# --- Apply ClickHouse DDL (incl. replay_samples) to the running stack ---------------------------
+# initdb mounts only fire on a first boot against an empty volume, so replay the idempotent DDL.
+echo "==> Applying ClickHouse DDL (make ch-migrate)"
+make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" ch-migrate
+
+# --- Load the SYNTHETIC demo dataset ------------------------------------------------------------
+# seed: creates the local-dev tenant + API key + price catalog.
+# chatbot-demo-backfill: POSTs 30 days of backdated synthetic spans ($0, no LLM calls, no API keys).
+echo "==> Seeding the demo tenant (make seed)"
+make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" seed
+
+echo "==> Backfilling 30 days of SYNTHETIC demo spans"
+# The `make chatbot-demo-backfill` target runs on the HOST and POSTs to localhost:8080 - neither
+# works on a locked-down single VM (no host Node, and the gateway publishes no host port in prod).
+# The backfill script (examples/vercel-chatbot/scripts/backfill-spans.ts) imports only node:crypto,
+# so we run it in a throwaway node container attached to the compose network, reaching the gateway
+# internally as http://gateway:8080/v1/batches. Same generator, same $0 synthetic output.
+# COMPOSE_NETWORK is `<project>_default`; the project name is `ai-tally` (infra/docker-compose.yml
+# `name:`). Override COMPOSE_NETWORK in the environment if you renamed the project.
+COMPOSE_NETWORK="${COMPOSE_NETWORK:-ai-tally_default}"
+docker run --rm \
+  --network "${COMPOSE_NETWORK}" \
+  -v "${REPO_ROOT}/examples/vercel-chatbot/scripts:/scripts:ro" \
+  -e TALLY_GATEWAY_URL="http://gateway:8080/v1/batches" \
+  node:22-bookworm-slim \
+  npx --yes tsx /scripts/backfill-spans.ts
+
+# --- Done ---------------------------------------------------------------------------------------
+cat <<EOF
+
+==================================================================
+  ai-tally demo is up.
+
+  URL:   https://${DOMAIN}
+  Login: ${BASIC_AUTH_USER}  (password: the plaintext you hashed into BASIC_AUTH_HASH)
+
+  The dataset is SYNTHETIC (seeded + backfilled), safe to share with testers.
+  Share the link and password privately. Reset the data with deploy/demo/reseed.sh.
+==================================================================
+EOF

--- a/deploy/demo/docker-compose.prod.yml
+++ b/deploy/demo/docker-compose.prod.yml
@@ -1,0 +1,85 @@
+# ai-tally demo-deploy-kit - single-VM production overlay (CTO-243).
+#
+# Layered ON TOP of the base stack, never instead of it:
+#
+#   docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml up -d --build
+#
+# What this overlay does:
+#   - Adds a `web` service (the Next.js dashboard) built from deploy/demo/web.Dockerfile.
+#   - Adds a `caddy` service that terminates TLS and enforces HTTP basic-auth. Caddy is the ONLY
+#     service that publishes host ports (80/443).
+#   - Removes the host port publishing from clickhouse / postgres / redpanda / minio / gateway so
+#     that on a public VM nothing is reachable except through Caddy. They keep talking to each other
+#     over the compose network by service name, exactly as before.
+#
+# `ports: !reset []` uses Compose's override reset so the base file's port list is dropped rather
+# than merged (a plain `ports: []` is ignored by the merge). Requires Docker Compose v2.24.4+; if
+# your Compose is older, replace `!reset []` with `expose:`-only by hand.
+#
+# The demo data this stack serves is SYNTHETIC (see deploy.sh / reseed.sh). No real tenant traffic.
+
+services:
+  # --- Base services: keep them internal-only (no host ports on a public VM) -------------------
+  clickhouse:
+    ports: !reset []
+  postgres:
+    ports: !reset []
+  redpanda:
+    ports: !reset []
+  minio:
+    ports: !reset []
+  gateway:
+    # The gateway carries WRITE endpoints (/v1/batches ingest, control-plane /v1/tenant/*). It must
+    # stay behind Caddy/basic-auth on a public VM; the web service reaches it as http://gateway:8080
+    # over the internal network. To let testers push their OWN telemetry, expose /v1/batches via the
+    # commented block in the Caddyfile instead of publishing a host port here.
+    ports: !reset []
+
+  # --- Dashboard (server-side reads ClickHouse, calls the gateway) -----------------------------
+  web:
+    build:
+      # Relative paths in a compose overlay resolve against the FIRST -f file's directory (infra/),
+      # not this file's location. So `..` is the repo root and the Dockerfile path is repo-relative.
+      # Always invoke as: docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml
+      context: ..
+      dockerfile: deploy/demo/web.Dockerfile
+    container_name: ai-tally-web
+    environment:
+      # EXACT env var names the web reads (web/lib/clickhouse.ts, web/lib/tenant.ts, etc.).
+      TALLY_CLICKHOUSE_URL: http://clickhouse:8123
+      TALLY_CLICKHOUSE_USER: ${CLICKHOUSE_USER:-tally}
+      TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
+      TALLY_CLICKHOUSE_DB: default
+      TALLY_GATEWAY_URL: http://gateway:8080
+      TALLY_TENANT_ID: ${TALLY_TENANT_ID:-local-dev}
+    # No host port: the browser reaches the dashboard only through Caddy (caddy -> web:3000).
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      gateway:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # --- Reverse proxy: automatic TLS + HTTP basic-auth, the only public surface -----------------
+  caddy:
+    image: caddy:2
+    container_name: ai-tally-caddy
+    depends_on:
+      - web
+    ports:
+      - "80:80"    # ACME HTTP-01 challenge + redirect to HTTPS
+      - "443:443"  # the private demo link
+    environment:
+      DOMAIN: ${DOMAIN:?set DOMAIN in .env}
+      BASIC_AUTH_USER: ${BASIC_AUTH_USER:?set BASIC_AUTH_USER in .env}
+      # bcrypt hash, generated with: docker run --rm caddy:2 caddy hash-password --plaintext '...'
+      BASIC_AUTH_HASH: ${BASIC_AUTH_HASH:?set BASIC_AUTH_HASH in .env}
+    volumes:
+      - ../deploy/demo/Caddyfile:/etc/caddy/Caddyfile:ro   # path is relative to infra/ (first -f file)
+      - caddy_data:/data    # ACME account + issued certs; persist so restarts do not re-issue
+      - caddy_config:/config
+    restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/deploy/demo/reseed.sh
+++ b/deploy/demo/reseed.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# ai-tally demo-deploy-kit - reset + re-seed the SYNTHETIC demo data (CTO-243).
+#
+# Run nightly so the demo always shows a fresh, backdated "last 30 days". It:
+#   1. TRUNCATEs the ClickHouse telemetry tables (spans, events, rollups, replay corpus).
+#   2. Re-runs `make seed` (idempotent: tenant + API key + price catalog).
+#   3. Re-POSTs 30 days of backdated synthetic spans via the backfill script.
+#
+# The stack keeps running throughout (no container restart); only the data is reset. The Postgres
+# control plane (tenant row, API key, connector config) is left intact.
+#
+# WHY truncate first: the backfill dedups by a deterministic batch_id with a 24h TTL. After 24h the
+# dedup cache has expired, so a second run would double-count unless the prior rows are cleared.
+#
+# Cron example (nightly at 03:15, logging to a file) - `crontab -e` on the VM:
+#
+#   15 3 * * * /opt/ai-tally/deploy/demo/reseed.sh >> /var/log/ai-tally-reseed.log 2>&1
+#
+# (Point the path at wherever you checked the repo out on the VM.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+ENV_FILE="deploy/demo/.env"
+BASE_COMPOSE="infra/docker-compose.yml"
+PROD_COMPOSE="deploy/demo/docker-compose.prod.yml"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "ERROR: ${ENV_FILE} not found. Copy deploy/demo/.env.example to ${ENV_FILE} first." >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
+
+CH_USER="${CLICKHOUSE_USER:-tally}"
+CH_PASSWORD="${CLICKHOUSE_PASSWORD:-tally}"
+
+# Data-bearing telemetry tables (the _mv views are triggers with no storage of their own, so
+# clearing their target tables is enough).
+TABLES=(
+  otel_spans
+  business_events
+  attribution_records
+  unattributed_events
+  last_touch_index
+  identity_graph
+  daily_account_rollup
+  daily_feature_rollup
+  hourly_feature_rollup
+  eval_runs
+  replay_runs
+  replay_samples
+)
+
+echo "==> Truncating ClickHouse telemetry tables"
+for t in "${TABLES[@]}"; do
+  echo "    TRUNCATE ${t}"
+  "${COMPOSE[@]}" exec -T clickhouse \
+    clickhouse-client -u "${CH_USER}" --password "${CH_PASSWORD}" -d default \
+    --query "TRUNCATE TABLE IF EXISTS ${t}"
+done
+
+echo "==> Re-seeding the demo tenant (make seed)"
+make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" seed
+
+echo "==> Re-backfilling 30 days of SYNTHETIC demo spans"
+# Same throwaway-container approach as deploy.sh: no host Node, reaches the gateway internally.
+COMPOSE_NETWORK="${COMPOSE_NETWORK:-ai-tally_default}"
+docker run --rm \
+  --network "${COMPOSE_NETWORK}" \
+  -v "${REPO_ROOT}/examples/vercel-chatbot/scripts:/scripts:ro" \
+  -e TALLY_GATEWAY_URL="http://gateway:8080/v1/batches" \
+  node:22-bookworm-slim \
+  npx --yes tsx /scripts/backfill-spans.ts
+
+echo "==> Demo data reset. The dashboard now shows a fresh synthetic 30-day window."

--- a/deploy/demo/web.Dockerfile
+++ b/deploy/demo/web.Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+# ai-tally dashboard (Next.js 15 / React 19) - demo-deploy-kit production image (CTO-243).
+#
+# Unlike web/Dockerfile (whose build context is web/), this image builds from the REPO ROOT so the
+# whole kit can be built with one command from the checkout:
+#
+#   docker build -f deploy/demo/web.Dockerfile -t ai-tally-web-demo .
+#
+# It is functionally the same standalone build as web/Dockerfile, just re-pathed for a root context.
+#
+# Multi-stage:
+#   deps    - install node_modules from the lockfile (cache-friendly layer).
+#   builder - `next build` in standalone mode, emitting a self-contained server.
+#   runner  - a slim runtime carrying only the standalone server + static assets.
+#
+# Standalone output: web/next.config.mjs is intentionally NOT modified by this ticket (additive
+# only), so rather than setting `output: "standalone"` in the config we force it at build time with
+# NEXT_PRIVATE_STANDALONE=true. Next.js reads that env and emits `.next/standalone` exactly as the
+# config flag would.
+
+# ---- deps ---------------------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS deps
+WORKDIR /app
+# Only the manifests, so this layer is reused whenever source (but not deps) changes.
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+# ---- builder ------------------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PRIVATE_STANDALONE=true
+COPY --from=deps /app/node_modules ./node_modules
+COPY web/ .
+RUN npm run build
+
+# ---- runner -------------------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    # Next's standalone server honours PORT/HOSTNAME. 0.0.0.0 so the container is reachable from the
+    # other compose services (Caddy proxies to web:3000).
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Run as an unprivileged, numeric non-root user.
+RUN groupadd --system --gid 1001 nodejs \
+ && useradd  --system --uid 1001 --gid nodejs nextjs
+
+# The standalone build bundles a minimal node_modules and a server.js. Static assets are served
+# from .next/static and must be copied alongside it (standalone does not inline them).
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+CMD ["node", "server.js"]


### PR DESCRIPTION
## What this adds

A drop-in **demo deploy kit** under `deploy/demo/` that hosts the whole ai-tally stack on **one cloud VM** behind Caddy (automatic TLS + HTTP basic-auth), so testers get a single private link to the seeded, synthetic demo.

Everything runs by layering one compose overlay on the existing local stack:

```
docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml up -d --build
```

The overlay adds a `web` (Next.js dashboard) and a `caddy` service, and makes **Caddy the only service publishing host ports** (80/443). ClickHouse, Postgres, Redpanda, MinIO and the gateway keep talking over the compose network but are not reachable from the internet. The gateway has write endpoints, so it deliberately stays internal behind auth.

### Files
| File | Purpose |
|------|---------|
| `web.Dockerfile` | Multi-stage Next.js standalone build (`node:22`), root build context. |
| `docker-compose.prod.yml` | Overlay: adds `web` + `caddy`, strips host ports off the base services via `ports: !reset []`. Web env uses the exact vars the app reads (`TALLY_CLICKHOUSE_URL`, `TALLY_GATEWAY_URL`, `TALLY_TENANT_ID`, ...). |
| `Caddyfile` | `${DOMAIN}` site: automatic TLS, `basic_auth`, `reverse_proxy web:3000`. Commented gateway-ingest and local `:8088` no-TLS variants. |
| `.env.example` | Domain, basic-auth user + bcrypt hash generator one-liner, stack creds, tenant. |
| `deploy.sh` | Up the stack, wait for gateway health, `ch-migrate`, `seed`, backfill synthetic spans, print the link. |
| `reseed.sh` | Reset + re-seed the synthetic data, with a nightly cron example. |
| `README.md` | Full operator runbook + security posture + data-reset notes. |

## Operator steps
1. **Provision a VM** (4 vCPU / 8-16 GB, ClickHouse likes RAM); open inbound 80 + 443 only; install Docker; clone the repo.
2. **DNS**: point an A record for `${DOMAIN}` at the VM's public IP.
3. **`.env`**: `cp deploy/demo/.env.example deploy/demo/.env`, set `DOMAIN` / `BASIC_AUTH_USER`, and paste a bcrypt hash from `docker run --rm caddy:2 caddy hash-password --plaintext 'yourpassword'` into `BASIC_AUTH_HASH`.
4. **Deploy**: `./deploy/demo/deploy.sh`, which prints `https://${DOMAIN}` and the login.
5. **Share** the link + password privately (the beta is private, not open).

Reset data on demand with `reseed.sh`, or nightly via cron.

## Verified locally (no VM, no 80/443 binding)
- `docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml config` validates; only `caddy` publishes ports (80/443); all base services have their host ports removed; web env points at `clickhouse:8123` / `gateway:8080`.
- `docker build -f deploy/demo/web.Dockerfile -t ai-tally-web-demo .` builds successfully (standalone output).
- `caddy validate` passes with no warnings.
- End-to-end auth smoke on spare port 8088 (Caddy -> web container): no creds and wrong creds return **401**; correct creds reach the dashboard (`X-Powered-By: Next.js`; it returns 500 only because no ClickHouse/gateway backend was attached in the isolated smoke).
- `bash -n` clean on both scripts.

## Scope
Additive only under `deploy/demo/`. Does **not** modify `infra/docker-compose.yml` or the app. The four CI jobs (web/gateway/sdk/edge-proxy) are unaffected since the kit lives outside those source dirs.

## Notes
The `chatbot-demo-backfill` make target runs on the host and hits `localhost:8080`, which does not work on a locked-down VM (no host Node, gateway not published). `deploy.sh` / `reseed.sh` instead run the same backfill script (it imports only `node:crypto`) inside a throwaway `node:22` container attached to the compose network, reaching the gateway internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)