### PR TITLE
fix(deploy): demo deploy-kit review fixes + hoist shared Diag (CTO-243)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Root build-context ignore (CTO-243).
+#
+# Both root-context image builds honor this file:
+#   - deploy/demo/web.Dockerfile   (docker build -f deploy/demo/web.Dockerfile .)   -> COPY web/ .
+#   - infra/gateway/Dockerfile     (compose `context: ..`)                           -> COPY sdk/ + infra/gateway/
+#
+# web/.dockerignore only applies when the context is web/, so a root-context build ignored it and
+# dragged web/node_modules (wrong-arch native binaries that break the build) and web/.env* (secret
+# leak) into the image. This file restores those exclusions at the context root. Everything here is
+# either reinstalled from a lockfile inside the image (node_modules), rebuilt (.next), or never
+# needed at build time (.env, .git), so excluding it is safe for BOTH builds. Do NOT add source
+# dirs (sdk, infra, web app source, db) - the gateway build copies sdk/ and infra/gateway/ and the
+# web build copies the web app source.
+
+# Dependencies and build output - reinstalled/rebuilt inside the image.
+**/node_modules
+**/.next
+**/tsconfig.tsbuildinfo
+
+# Local env files must never ship into an image (secret leak). Keep the example, which is safe.
+**/.env
+**/.env.*
+!**/.env.example
+
+# VCS, editor, CI, and agent working trees - not needed by any build.
+.git
+.gitignore
+.github
+.claude
+
+# Logs and OS cruft.
+**/npm-debug.log*
+**/*.log
+.DS_Store

--- a/deploy/demo/.env.example
+++ b/deploy/demo/.env.example
@@ -26,5 +26,9 @@ MINIO_ROOT_USER=tally
 MINIO_ROOT_PASSWORD=tally-minio
 
 # --- Tenant the dashboard renders --------------------------------------------------------------
-# The dashboard passes the tenant NAME. `make seed` creates `local-dev`; keep this in sync.
+# PINNED, not a free knob. The demo data is seeded under `local-dev`: `gateway.seed` (make seed)
+# creates the `local-dev` tenant and deploy.sh/reseed.sh backfill under it. The dashboard queries
+# whatever tenant NAME is set here, so it MUST stay `local-dev` to match the seeded data. Changing
+# it points the dashboard at a tenant that has no demo data and renders an empty dashboard with no
+# error. Leave as-is.
 TALLY_TENANT_ID=local-dev

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -79,13 +79,17 @@ echo "==> Backfilling 30 days of SYNTHETIC demo spans"
 # internally as http://gateway:8080/v1/batches. Same generator, same $0 synthetic output.
 # COMPOSE_NETWORK is `<project>_default`; the project name is `ai-tally` (infra/docker-compose.yml
 # `name:`). Override COMPOSE_NETWORK in the environment if you renamed the project.
+#
+# Backfill under the SAME tenant the dashboard renders (TALLY_TENANT_ID). `gateway.seed` creates the
+# demo tenant as `local-dev`, so this is pinned to local-dev in .env.example; passing it here keeps
+# the seeded data and the dashboard's tenant from drifting into an empty dashboard (CTO-243).
 COMPOSE_NETWORK="${COMPOSE_NETWORK:-ai-tally_default}"
 docker run --rm \
   --network "${COMPOSE_NETWORK}" \
   -v "${REPO_ROOT}/examples/vercel-chatbot/scripts:/scripts:ro" \
   -e TALLY_GATEWAY_URL="http://gateway:8080/v1/batches" \
   node:22-bookworm-slim \
-  npx --yes tsx /scripts/backfill-spans.ts
+  npx --yes tsx /scripts/backfill-spans.ts --tenant "${TALLY_TENANT_ID:-local-dev}"
 
 # --- Done ---------------------------------------------------------------------------------------
 cat <<EOF

--- a/deploy/demo/reseed.sh
+++ b/deploy/demo/reseed.sh
@@ -14,6 +14,13 @@
 # WHY truncate first: the backfill dedups by a deterministic batch_id with a 24h TTL. After 24h the
 # dedup cache has expired, so a second run would double-count unless the prior rows are cleared.
 #
+# WHY a fresh --seed on every reseed: the backfill derives its batch_ids deterministically from
+# --seed, so a reseed run within 24h of a prior backfill (deploy or a same-day reseed) would post
+# the SAME batch_ids, the gateway would dedup them, and TRUNCATE-then-repost would leave the
+# dashboard blank. Seeding with a per-run nonce (the wall-clock epoch below) gives fresh batch_ids
+# so the reposted rows always land. The dataset stays the same synthetic ~$52,400/mo story; only
+# the RNG draws (and thus the batch_ids) differ (CTO-243).
+#
 # Cron example (nightly at 03:15, logging to a file) - `crontab -e` on the VM:
 #
 #   15 3 * * * /opt/ai-tally/deploy/demo/reseed.sh >> /var/log/ai-tally-reseed.log 2>&1
@@ -74,12 +81,16 @@ make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${R
 
 echo "==> Re-backfilling 30 days of SYNTHETIC demo spans"
 # Same throwaway-container approach as deploy.sh: no host Node, reaches the gateway internally.
+# --seed: a per-run nonce so batch_ids are fresh and the gateway's 24h dedup never drops a reseed
+#         (see the WHY block above). Override with BACKFILL_SEED if you need a reproducible run.
+# --tenant: pin to the dashboard's tenant so seed data and the rendered tenant cannot drift.
 COMPOSE_NETWORK="${COMPOSE_NETWORK:-ai-tally_default}"
+BACKFILL_SEED="${BACKFILL_SEED:-$(date +%s)}"
 docker run --rm \
   --network "${COMPOSE_NETWORK}" \
   -v "${REPO_ROOT}/examples/vercel-chatbot/scripts:/scripts:ro" \
   -e TALLY_GATEWAY_URL="http://gateway:8080/v1/batches" \
   node:22-bookworm-slim \
-  npx --yes tsx /scripts/backfill-spans.ts
+  npx --yes tsx /scripts/backfill-spans.ts --seed "${BACKFILL_SEED}" --tenant "${TALLY_TENANT_ID:-local-dev}"
 
 echo "==> Demo data reset. The dashboard now shows a fresh synthetic 30-day window."

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -12,6 +12,7 @@ import {
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
+import { Diag } from "@/components/Diag";
 import { ExploreChartCard } from "@/components/ExploreChartCard";
 import { FilterBar } from "@/components/FilterBar";
 import { PageHeader } from "@/components/PageHeader";
@@ -293,14 +294,5 @@ function DeltaPp({ v, betterWhenPositive }: { v: number; betterWhenPositive: boo
       {sign}
       {v.toFixed(1)}pp
     </span>
-  );
-}
-
-function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
-  return (
-    <>
-      <dt className="text-muted">{k}</dt>
-      <dd className={good ? "text-good" : ""}>{v}</dd>
-    </>
   );
 }

--- a/web/app/cost/FeatureDetail.tsx
+++ b/web/app/cost/FeatureDetail.tsx
@@ -22,6 +22,7 @@ import { useEffect, useState } from "react";
 
 import { Card } from "@/components/Card";
 import { StaleBadge } from "@/components/DataStateBanner";
+import { Diag } from "@/components/Diag";
 import {
   type AttributionDiagnostics,
   type FeatureEconomics,
@@ -156,12 +157,18 @@ export function FeatureDetail({ feature }: { feature: string }) {
               <Diag
                 k="late-arriving events (7d)"
                 v={data.diagnostics.lateArrivalEvents7d.toLocaleString()}
+                row
               />
-              <Diag k="median lag" v={`${data.diagnostics.lateArrivalMedianHours.toFixed(1)}h`} />
+              <Diag
+                k="median lag"
+                v={`${data.diagnostics.lateArrivalMedianHours.toFixed(1)}h`}
+                row
+              />
               <Diag
                 k="reconciler last ran"
                 v={`${data.diagnostics.reconcilerLastRunMinutesAgo} min ago`}
                 good={!reconcilerStale}
+                row
               />
             </dl>
           </div>
@@ -214,14 +221,5 @@ function Legend() {
       <li className="flex items-center gap-1.5">{dot("bg-warn")} identity graph</li>
       <li className="flex items-center gap-1.5">{dot("bg-bad/70")} unmatched</li>
     </ul>
-  );
-}
-
-function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
-  return (
-    <div className="flex items-baseline justify-between">
-      <dt className="text-muted">{k}</dt>
-      <dd className={good ? "text-good" : ""}>{v}</dd>
-    </div>
   );
 }

--- a/web/app/estimate/EstimateWhatIf.tsx
+++ b/web/app/estimate/EstimateWhatIf.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react";
 import { Card } from "@/components/Card";
+import { Diag } from "@/components/Diag";
 import { pctDelta, type Projection, type WhatIfProjection } from "@/lib/estimate";
 import { formatUSD } from "@/lib/types";
 
@@ -235,14 +236,5 @@ function Kpi({
       )}
       {hint && <div className="mt-2 text-xs text-muted">{hint}</div>}
     </div>
-  );
-}
-
-function Diag({ k, v, good }: { k: string; v: string; good?: boolean }) {
-  return (
-    <>
-      <dt className="text-muted">{k}</dt>
-      <dd className={good ? "text-good" : ""}>{v}</dd>
-    </>
   );
 }

--- a/web/components/Diag.tsx
+++ b/web/components/Diag.tsx
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Shared diagnostics-row helper, hoisted from three verbatim-ish copies in /cost, /compare and
+// /estimate (CTO-243). Renders a labelled key/value pair for the small "diagnostics" dl blocks.
+//
+// Two call shapes exist and both must stay pixel-identical:
+//   - default: emits a bare <dt>/<dd> fragment, for a two-column grid <dl> (compare, estimate) where
+//     dt and dd are direct grid children.
+//   - row: wraps the pair in a flex row, for a `space-y` <dl> (cost/FeatureDetail) where each entry
+//     is one spaced-out line.
+
+export function Diag({
+  k,
+  v,
+  good,
+  row,
+}: {
+  k: string;
+  v: string;
+  good?: boolean;
+  row?: boolean;
+}) {
+  const inner = (
+    <>
+      <dt className="text-muted">{k}</dt>
+      <dd className={good ? "text-good" : ""}>{v}</dd>
+    </>
+  );
+  return row ? <div className="flex items-baseline justify-between">{inner}</div> : inner;
+}


### PR DESCRIPTION
Fixes four code-review findings on the demo deploy kit (CTO-243): three real bugs plus one duplication cleanup.

## Bug 1 (security + broken build): root-context build ignored web/.dockerignore
The kit builds the web image from the repo root (`docker build -f deploy/demo/web.Dockerfile .`), and `web/.dockerignore` only applies when the context is `web/`. With no root `.dockerignore`, `COPY web/ .` dragged host `web/node_modules` (wrong-arch native binaries that overwrite the linux deps and break `next build`) and `web/.env*` (secret leak) into the image.

Fix: add a root `.dockerignore` excluding `**/node_modules`, `**/.env`, `**/.env.*` (keeping `!**/.env.example`), `**/.next`, `.git`, `.claude`, and build cruft. Verified safe for the gateway image, which also builds from the root context (`context: ..`) but copies only `sdk/` + `infra/gateway/`.

## Bug 2: reseed within the 24h dedup window repopulated nothing
The backfill derives `batch_id`s deterministically from `--seed`, so a reseed within 24h of a prior backfill posted the same batch_ids, the gateway deduped them, and TRUNCATE-then-repost left the dashboard blank.

Fix: `reseed.sh` now passes a per-run nonce `--seed` (wall-clock epoch, overridable via `BACKFILL_SEED`) so batch_ids are always fresh. Same synthetic ~\$52,400/mo story; only the RNG draws differ. `deploy.sh` keeps the deterministic seed (no truncate there, so dedup on a repeat run is correct). Documented in the reseed WHY block.

## Bug 3: TALLY_TENANT_ID drift left an empty dashboard
`.env.example` presented `TALLY_TENANT_ID` as a free knob, but `gateway.seed` + the backfill only populate `local-dev`, so any other value rendered an empty dashboard with no error.

Fix: pin `TALLY_TENANT_ID=local-dev` in `.env.example` with a clear comment that it must match the seeded data, and pass `--tenant "${TALLY_TENANT_ID:-local-dev}"` from both `deploy.sh` and `reseed.sh` so seeded data and the rendered tenant cannot drift.

## Cleanup 4: hoist the duplicated Diag helper
`Diag({ k, v, good })` was copied across `/cost`, `/compare`, and `/estimate`. Hoisted to `web/components/Diag.tsx`. The copies were not byte-identical (`FeatureDetail` wraps the pair in a flex row for its `space-y` dl; the other two emit a bare fragment for a grid dl), so the shared component takes an optional `row` prop and output stays pixel-identical at every call site.

## Verified
- `docker build -f deploy/demo/web.Dockerfile -t ai-tally-web-demo .` succeeds; builder stage confirmed clean (a marker `web/.env` and host `web/node_modules` are NOT copied into the image, and `next build` runs against the linux deps).
- `docker build -f infra/gateway/Dockerfile -t ai-tally-gateway-check .` succeeds (gateway root context unaffected).
- `docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml config` validates.
- `bash -n deploy/demo/deploy.sh deploy/demo/reseed.sh` clean.
- web CI green: `npm run typecheck`, `npm run lint` (only a pre-existing unrelated warning), `npm run build` pass; `npm run test` shows only the long-standing api.test.ts ClickHouse-reachable case, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)