### PR TITLE
Cost: put the breakdown values table right under the chart

### DIFF
--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -305,6 +305,19 @@ export function CostLive({
         />
       </Card>
 
+      {/* The values behind the chart, directly under it: one row per group with its cost and share,
+          plus the search box that narrows both the rows and the chart bands above. Sits here rather
+          than at the foot of the page so a reader can read the number for any bar without scrolling
+          past the budget and forecast cards. */}
+      <BreakdownTable
+        groupBy={breakdownGroupBy}
+        rows={breakdownRows}
+        search={search}
+        onSearch={setSearch}
+        matchesSearch={matchesSearch}
+        unavailable={sliceUnavailable}
+      />
+
       {/* Directly under the 30-day headline on purpose (CTO-209): this card's figure is smaller
           than that total, and the two only reconcile once you have read the coverage line saying
           which days it counted. Putting them far apart is how the page starts looking broken. */}
@@ -334,15 +347,6 @@ export function CostLive({
           {a.message}
         </div>
       ))}
-
-      <BreakdownTable
-        groupBy={breakdownGroupBy}
-        rows={breakdownRows}
-        search={search}
-        onSearch={setSearch}
-        matchesSearch={matchesSearch}
-        unavailable={sliceUnavailable}
-      />
 
       {/* The retired /agents view, preserved for one agent (CTO-241): when grouping by agent and
           narrowed to a single agent, its run distribution + pathological runs render here. */}


### PR DESCRIPTION
Per request, show the chart's values in a table directly under the graph. The 'By {dimension}' breakdown table (group + cost + share, sortable, with the search box) used to render at the bottom of the page after the budget and burn-down cards; moved it to immediately under the chart. No data or behavior change, just placement.

Verified live: the By layer table (LLM $46,882.47, Compute $38,837.83, ...) now sits between the chart and the budget card. typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)