### PR TITLE
Cost per Customer: simpler copy

### DIFF
--- a/web/app/cost-per-customer/AccountTable.tsx
+++ b/web/app/cost-per-customer/AccountTable.tsx
@@ -331,9 +331,8 @@ export function AccountTable({
       </form>
 
       <p className="max-w-prose text-xs text-muted">
-        Enter a plaintext account id or paste an account hash from the table. A plaintext id is
-        hashed with this tenant&apos;s own key to find its row, and is never stored, logged, or shown
-        back to you, which is also why there is no way to search the other direction.
+        Enter an account id or paste a hash from the table. An id is hashed with your tenant&apos;s
+        key to find its row, and is never stored, logged, or shown back.
       </p>
 
       {search ? (

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -126,10 +126,9 @@ export default async function CostPerCustomerPage({ searchParams }: PageProps) {
       />
 
       <p className="max-w-prose text-sm text-muted">
-        Directly attributable spend (LLM, tools, vector, embeddings) grouped by the account each span
-        was tagged with, plus each account&apos;s allocated share of compute and egress, which carry
-        no account of their own. Direct cost is measured. Allocated cost is an estimate, and the two
-        are never added into a single number without saying so.
+        Cost per account: measured direct spend (LLM, tools, vector, embeddings), plus each
+        account&apos;s estimated share of shared compute and egress. Direct is measured, allocated is
+        an estimate, and the two are shown separately.
       </p>
 
       {costs === null ? (
@@ -394,21 +393,17 @@ function AllocationNotice({
             place they open a sentence, so the first letter is raised here rather than duplicating
             the text in two cases. */}
         {ALLOCATION_RULE_DESCRIPTIONS[rule].charAt(0).toUpperCase()}
-        {ALLOCATION_RULE_DESCRIPTIONS[rule].slice(1)}. Those spans arrive from the cloud billing
-        connectors as
-        tenant-level daily totals with no account on them, so an allocated figure is an estimate and
-        is shown in its own column rather than folded into direct cost.
+        {ALLOCATION_RULE_DESCRIPTIONS[rule].slice(1)}. Compute and egress arrive as tenant-level
+        totals with no account attached, so this is an estimate, shown in its own column.
       </p>
       <p className="mt-2 max-w-prose text-sm text-muted">
         {/* The unattributed-bucket decision, stated where the reader meets its consequences. On a
             tenant that has barely instrumented account_id, this paragraph is the difference between
             a page that reads as broken and one that reads as true. */}
-        Untagged traffic takes part in the split as one participant, so it carries{" "}
+        Untagged traffic joins the split as one participant, carrying{" "}
         <Money micro={unattributedAllocated} />
-        {bucketShare === null ? "" : ` (${formatShare(bucketShare)})`} of the infrastructure it
-        caused. Excluding it would divide the whole infrastructure bill
-        across only the accounts that happen to be tagged today, which would overstate every one of
-        them and make each newly tagged account look like it cut the others&apos; costs.
+        {bucketShare === null ? "" : ` (${formatShare(bucketShare)})`} of the shared infrastructure
+        it caused. Leaving it out would overstate every tagged account.
       </p>
     </div>
   );

--- a/web/lib/accounts.ts
+++ b/web/lib/accounts.ts
@@ -581,9 +581,8 @@ export const ALLOCATION_RULE_LABELS: Record<AllocationRule, string> = {
 /** One sentence saying what the rule did, for the reader who wants to check the arithmetic. */
 export const ALLOCATION_RULE_DESCRIPTIONS: Record<AllocationRule, string> = {
   pro_rata_direct:
-    "each account carries a share of compute and egress in proportion to its own direct spend, so an account with twice the model bill carries twice the infrastructure",
-  even_split:
-    "compute and egress are divided equally across every account and the untagged bucket, regardless of how much each one used",
+    "each account's share of compute and egress is proportional to its own direct spend",
+  even_split: "compute and egress are split equally across every account and the untagged bucket",
 };
 
 // --- Which of the tab's states to render (CTO-191, plan D5) --------------------------------------


### PR DESCRIPTION
Per request, the Cost per Customer page had a lot of long explanatory text. Tightened four spots to the essential honest meaning:
- intro (direct measured, allocated estimate, shown separately),
- the allocation-rule descriptions,
- the allocation explainer + untagged-bucket note,
- the account-search help (ids hashed with the tenant key, never stored).

No numbers or behavior change. typecheck clean; accounts + AccountTable tests (68) pass; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)