### PR TITLE
Nav: clearer labels (Cost Explorer / Model Comparison / Value) + separated sections

### DIFF
--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -218,7 +218,7 @@ export function AttributionLive({
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Attribution"
+        title="Value"
         subtitle={
           <>
             $/{outcome} per provider, joined from LLM spans and CDP events on{" "}

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -150,7 +150,7 @@ export default async function ComparePage({
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Compare"
+        title="Model Comparison"
         subtitle={
           <>
             Workload: <span className="font-mono text-muted">{workload}</span>

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -362,7 +362,7 @@ export function CostLive({
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Cost"
+        title="Cost Explorer"
         subtitle="Where the spend goes, by layer and by feature"
         actions={
           <>

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -35,13 +35,13 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
   {
     caption: "Analyze",
     items: [
-      { label: "Cost", href: "/cost" },
+      { label: "Cost Explorer", href: "/cost" },
       // Features folded into the Cost explorer as the `feature` group-by (CTO-242); /features
       // redirects to /cost?groupBy=feature, so the standalone nav item is retired.
       // Agents folded into the Cost explorer as the `agent` group-by (CTO-241); /agents redirects
       // to /cost?groupBy=agent, so the standalone nav item is retired.
-      { label: "Compare", href: "/compare" },
-      { label: "Attribution", href: "/attribution" },
+      { label: "Model Comparison", href: "/compare" },
+      { label: "Value", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },
       { label: "Cost per Customer", href: "/cost-per-customer" },
       { label: "Recoverable Cost", href: "/waste" },
@@ -83,10 +83,15 @@ export function Shell({ children }: { children: ReactNode }) {
           </span>
         </div>
 
-        <nav className="app-scroll flex-1 space-y-6 overflow-y-auto px-3 pb-6" aria-label="Primary">
+        <nav className="app-scroll flex-1 space-y-4 overflow-y-auto px-3 pb-6" aria-label="Primary">
           {NAV_GROUPS.map((group) => (
-            <div key={group.caption} className="space-y-1">
-              <div className="px-3 text-[11px] font-medium uppercase tracking-wider text-muted">
+            // A hairline + top padding sets each section apart so the captions do not read as merged
+            // into one flat list. The first group needs neither (it sits right under the wordmark).
+            <div
+              key={group.caption}
+              className="space-y-1 border-t border-edge pt-4 first:border-t-0 first:pt-0"
+            >
+              <div className="px-3 text-[11px] font-semibold uppercase tracking-wider text-fg/70">
                 {group.caption}
               </div>
               <div className="space-y-0.5">


### PR DESCRIPTION
Two things:
- **Clearer labels**: Cost -> Cost Explorer, Compare -> Model Comparison, Attribution -> Value (nav labels + page titles; routes unchanged). Cost Explorer was confirmed; Model Comparison / Value are my picks for the ambiguous ones, easy to change.
- **Separated sections**: the Overview / Analyze / Configure group captions blended into the sidebar. Added a hairline divider between groups and a stronger caption color so each section reads as its own block, rather than per-group background colors (which read busy in a nav).

Verified live. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)