### PR TITLE
Rename Value to Conversions + reorder Cost per Customer under Cost Explorer

### DIFF
--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -218,7 +218,7 @@ export function AttributionLive({
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Value"
+        title="Conversions"
         subtitle={
           <>
             $/{outcome} per provider, joined from LLM spans and CDP events on{" "}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -41,7 +41,7 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
       // Agents folded into the Cost explorer as the `agent` group-by (CTO-241); /agents redirects
       // to /cost?groupBy=agent, so the standalone nav item is retired.
       { label: "Model Comparison", href: "/compare" },
-      { label: "Value", href: "/attribution" },
+      { label: "Conversions", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },
       { label: "Cost per Customer", href: "/cost-per-customer" },
       { label: "Recoverable Cost", href: "/waste" },

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -36,6 +36,9 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
     caption: "Analyze",
     items: [
       { label: "Cost Explorer", href: "/cost" },
+      // Cost per Customer sits directly under the explorer: both answer "where does the spend go",
+      // one by dimension and one by the tenant's own customers.
+      { label: "Cost per Customer", href: "/cost-per-customer" },
       // Features folded into the Cost explorer as the `feature` group-by (CTO-242); /features
       // redirects to /cost?groupBy=feature, so the standalone nav item is retired.
       // Agents folded into the Cost explorer as the `agent` group-by (CTO-241); /agents redirects
@@ -43,7 +46,6 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
       { label: "Model Comparison", href: "/compare" },
       { label: "Conversions", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },
-      { label: "Cost per Customer", href: "/cost-per-customer" },
       { label: "Recoverable Cost", href: "/waste" },
     ],
   },


### PR DESCRIPTION
'Value' was unclear. The page shows conversions, conversion rate, and $/conversion per provider, so Conversions names what it actually shows. Nav label + page title; route unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)