### PR TITLE
Nav: Cost per Account (tab + title), Conversions moved under it

### DIFF
--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -116,7 +116,7 @@ export default async function CostPerCustomerPage({ searchParams }: PageProps) {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Cost per customer"
+        title="Cost per User"
         subtitle={
           costs
             ? `Direct spend by account plus each account's allocated share of compute and egress, over the last ${costs.windowDays} days.`

--- a/web/app/cost-per-customer/page.tsx
+++ b/web/app/cost-per-customer/page.tsx
@@ -116,7 +116,7 @@ export default async function CostPerCustomerPage({ searchParams }: PageProps) {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Cost per User"
+        title="Cost per Account"
         subtitle={
           costs
             ? `Direct spend by account plus each account's allocated share of compute and egress, over the last ${costs.windowDays} days.`

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -36,9 +36,9 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
     caption: "Analyze",
     items: [
       { label: "Cost Explorer", href: "/cost" },
-      // Cost per User sits directly under the explorer: both answer "where does the spend go", one
-      // by dimension and one by the tenant's own customers.
-      { label: "Cost per User", href: "/cost-per-customer" },
+      // Cost per Account sits directly under the explorer: both answer "where does the spend go",
+      // one by dimension and one by the tenant's own accounts.
+      { label: "Cost per Account", href: "/cost-per-customer" },
       { label: "Conversions", href: "/attribution" },
       // Features folded into the Cost explorer as the `feature` group-by (CTO-242); /features
       // redirects to /cost?groupBy=feature, so the standalone nav item is retired.

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -36,15 +36,15 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
     caption: "Analyze",
     items: [
       { label: "Cost Explorer", href: "/cost" },
-      // Cost per Customer sits directly under the explorer: both answer "where does the spend go",
-      // one by dimension and one by the tenant's own customers.
-      { label: "Cost per Customer", href: "/cost-per-customer" },
+      // Cost per User sits directly under the explorer: both answer "where does the spend go", one
+      // by dimension and one by the tenant's own customers.
+      { label: "Cost per User", href: "/cost-per-customer" },
+      { label: "Conversions", href: "/attribution" },
       // Features folded into the Cost explorer as the `feature` group-by (CTO-242); /features
       // redirects to /cost?groupBy=feature, so the standalone nav item is retired.
       // Agents folded into the Cost explorer as the `agent` group-by (CTO-241); /agents redirects
       // to /cost?groupBy=agent, so the standalone nav item is retired.
       { label: "Model Comparison", href: "/compare" },
-      { label: "Conversions", href: "/attribution" },
       { label: "Unit Economics", href: "/unit-economics" },
       { label: "Recoverable Cost", href: "/waste" },
     ],


### PR DESCRIPTION
- Rename the Cost per Customer tab + page title to **Cost per Account** (route /cost-per-customer unchanged). This matches the page, which allocates cost to the tenant's accounts.
- Move Conversions directly under it in the Analyze section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)