### PR TITLE
feat(web): %-of-total, trend, and sparkline columns for the Cost breakdown (CTO-244)

### DIFF
--- a/web/app/api/explore/route.ts
+++ b/web/app/api/explore/route.ts
@@ -11,7 +11,11 @@
 
 import { NextResponse } from "next/server";
 
-import { queryCostExplore, queryCostSliceTotals } from "@/lib/clickhouse";
+import {
+  queryCostBreakdownPrior,
+  queryCostExplore,
+  queryCostSliceTotals,
+} from "@/lib/clickhouse";
 import { exploreParamsFromFilters } from "@/lib/explore";
 import { parseFilters, rangeDays } from "@/lib/filters";
 
@@ -30,14 +34,19 @@ export async function GET(req: Request) {
   // carries every filter), so a feature filter narrows the tiles, the chart and the breakdown alike
   // instead of the chart disagreeing with the tiles. Each is independently honest: either can come
   // back null when ClickHouse is unreachable and the page states so rather than zero-filling.
-  const [series, totals] = await Promise.all([
+  // The prior-window per-group totals (CTO-244) feed the breakdown table's trend column. It is
+  // independently honest: its own null (prior read failed) blanks only the trend cells while the
+  // series, totals and the rest of the table still render, so it never gates the page.
+  const [series, totals, breakdownPrior] = await Promise.all([
     queryCostExplore(params),
     queryCostSliceTotals(rangeDays(state.range), state.filters),
+    queryCostBreakdownPrior(params),
   ]);
   return NextResponse.json({
     source: series === null ? "unavailable" : "live",
     groupBy: params.groupBy,
     series,
     totals,
+    breakdownPrior,
   });
 }

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -35,8 +35,9 @@ import { Card } from "@/components/Card";
 import { FilterBar, type FilterOption } from "@/components/FilterBar";
 import { InteractiveStackedChart, type StackedChartDay } from "@/components/InteractiveStackedChart";
 import { LiveIndicator } from "@/components/LiveIndicator";
-import { Money } from "@/components/HonestValue";
+import { Blank, Money, Pct } from "@/components/HonestValue";
 import { PageHeader } from "@/components/PageHeader";
+import { Sparkline } from "@/components/Sparkline";
 import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import {
   LAYER_COLORS,
@@ -51,8 +52,14 @@ import {
   totalRange,
 } from "@/lib/cost";
 import { asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
-import type { CostSliceTotals, ExploreBreakdownRow, ExploreSeries } from "@/lib/explore";
-import { OTHER_GROUP } from "@/lib/explore";
+import type {
+  CostSliceTotals,
+  ExploreBreakdownPrior,
+  ExploreBreakdownRow,
+  ExploreDayPoint,
+  ExploreSeries,
+} from "@/lib/explore";
+import { costTrend, OTHER_GROUP } from "@/lib/explore";
 import {
   DEFAULT_GROUP_BY,
   DEFAULT_RANGE_PRESET,
@@ -88,6 +95,9 @@ interface ExploreState {
   series: ExploreSeries | null;
   /** Filter-aware headline totals for the tiles. null when unreachable (rendered as honest blank). */
   totals: CostSliceTotals | null;
+  /** Prior-window per-group totals for the breakdown trend column (CTO-244). null blanks the trend
+   *  cells (prior read failed or slice idle) while the rest of the table still renders. */
+  breakdownPrior: ExploreBreakdownPrior | null;
 }
 
 /**
@@ -142,6 +152,7 @@ export function CostLive({
     source: null,
     series: null,
     totals: null,
+    breakdownPrior: null,
   });
 
   useEffect(() => {
@@ -156,15 +167,28 @@ export function CostLive({
           source: "live" | "unavailable";
           series: ExploreSeries | null;
           totals: CostSliceTotals | null;
+          breakdownPrior: ExploreBreakdownPrior | null;
         }) => {
-          setExplore({ loading: false, source: j.source, series: j.series, totals: j.totals ?? null });
+          setExplore({
+            loading: false,
+            source: j.source,
+            series: j.series,
+            totals: j.totals ?? null,
+            breakdownPrior: j.breakdownPrior ?? null,
+          });
         },
       )
       .catch((err: unknown) => {
         // An abort is expected on a fast filter change; keep the last state instead of flashing.
         if (err instanceof Error && err.name === "AbortError") return;
         // Honest-under-uncertainty: a failed fetch is "unavailable", never a zero-filled slice.
-        setExplore({ loading: false, source: "unavailable", series: null, totals: null });
+        setExplore({
+          loading: false,
+          source: "unavailable",
+          series: null,
+          totals: null,
+          breakdownPrior: null,
+        });
       });
     return () => ctrl.abort();
   }, [queryString]);
@@ -312,6 +336,8 @@ export function CostLive({
       <BreakdownTable
         groupBy={breakdownGroupBy}
         rows={breakdownRows}
+        prior={explore.breakdownPrior}
+        days={explore.series?.days ?? null}
         search={search}
         onSearch={setSearch}
         matchesSearch={matchesSearch}
@@ -477,14 +503,24 @@ function CostChart({
 }
 
 /**
- * The general "By {dimension}" breakdown table (CTO-240): one row per group value, a single cost
- * column, sortable by cost, with a footer that re-totals exactly the rows on screen. A client-side
- * search box narrows the rows (and, via the shared predicate, the chart bands above). When there is
- * nothing to show the table states why (loading, unavailable, or no match) rather than an empty grid.
+ * The general "By {dimension}" breakdown table (CTO-240, extended in CTO-244): one row per group
+ * value with its cost, its share of the shown total, its trend vs the prior equal-length window, and
+ * a daily-cost sparkline. Cost and % of total are sortable (they share a denominator, so they order
+ * identically, but each header is its own affordance). A footer re-totals exactly the rows on screen.
+ * A client-side search box narrows the rows (and, via the shared predicate, the chart bands above).
+ * When there is nothing to show the table states why (loading, unavailable, or no match).
+ *
+ * Every added column is honest under uncertainty (CTO-244): share blanks when the shown total is
+ * zero; trend renders a "new" marker for a group with no prior spend and blanks when the prior read
+ * was unavailable or the row is the aggregated "other" tail, never a fabricated percent or a
+ * divide-by-zero; the sparkline is omitted for a group with fewer than two days of spend rather than
+ * drawing a degenerate line.
  */
 function BreakdownTable({
   groupBy,
   rows,
+  prior,
+  days,
   search,
   onSearch,
   matchesSearch,
@@ -492,21 +528,41 @@ function BreakdownTable({
 }: {
   groupBy: Dimension;
   rows: ExploreBreakdownRow[];
+  /** Prior-window per-group totals keyed by raw group value; null blanks every trend cell. */
+  prior: ExploreBreakdownPrior | null;
+  /** The chart's own day×group series, reused for the per-row sparkline; null omits sparklines. */
+  days: readonly ExploreDayPoint[] | null;
   search: string;
   onSearch: (value: string) => void;
   matchesSearch: (value: string) => boolean;
   unavailable: boolean;
 }) {
-  // Default sort is cost desc (the big spenders first, like the shipped by-feature table); the
-  // header toggles it. Search is applied before the sort so the footer totals what is shown.
+  // Default sort is cost desc (the big spenders first, like the shipped by-feature table); either
+  // sortable header toggles direction. % of total shares cost's denominator so it orders the same
+  // way, but it is its own column so a reader can sort from the share header directly. Search is
+  // applied before the sort so the footer totals what is shown.
+  const [sortKey, setSortKey] = useState<"cost" | "share">("cost");
   const [dir, setDir] = useState<"desc" | "asc">("desc");
   const visible = rows
     .filter((r) => matchesSearch(r.group))
     .sort((a, b) =>
       dir === "desc" ? b.totalMicroUsd - a.totalMicroUsd : a.totalMicroUsd - b.totalMicroUsd,
     );
+  // The share denominator is the footer total (the rows on screen, CTO-244), so shares always sum to
+  // 100% of what the footer shows; guarded so a zero total renders an honest blank, not a divide.
   const footerTotal = visible.reduce((s, r) => s + r.totalMicroUsd, 0);
   const dimLabel = DIMENSION_LABEL[groupBy].toLowerCase();
+
+  const toggleSort = (key: "cost" | "share") => {
+    if (key === sortKey) {
+      setDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortKey(key);
+      setDir("desc");
+    }
+  };
+  const sortArrow = (key: "cost" | "share") =>
+    key === sortKey ? (dir === "desc" ? "▼" : "▲") : "";
 
   return (
     <Card title={`By ${dimLabel}`}>
@@ -531,27 +587,40 @@ function BreakdownTable({
       </div>
 
       <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+        <table className="w-full min-w-[36rem] text-sm">
           <thead className="text-xs uppercase text-muted">
             <tr>
               <th className="py-1 text-left font-medium">{DIMENSION_LABEL[groupBy]}</th>
               <th className="py-1 text-right font-medium">
                 <button
                   type="button"
-                  onClick={() => setDir((d) => (d === "desc" ? "asc" : "desc"))}
+                  onClick={() => toggleSort("cost")}
                   className="inline-flex items-center gap-1 uppercase hover:text-fg"
-                  aria-label={`Sort by cost ${dir === "desc" ? "ascending" : "descending"}`}
+                  aria-label={`Sort by cost ${sortKey === "cost" && dir === "desc" ? "ascending" : "descending"}`}
                 >
                   Cost
-                  <span aria-hidden>{dir === "desc" ? "▼" : "▲"}</span>
+                  <span aria-hidden>{sortArrow("cost")}</span>
                 </button>
               </th>
+              <th className="py-1 text-right font-medium">
+                <button
+                  type="button"
+                  onClick={() => toggleSort("share")}
+                  className="inline-flex items-center gap-1 uppercase hover:text-fg"
+                  aria-label={`Sort by share of total ${sortKey === "share" && dir === "desc" ? "ascending" : "descending"}`}
+                >
+                  % of total
+                  <span aria-hidden>{sortArrow("share")}</span>
+                </button>
+              </th>
+              <th className="py-1 text-right font-medium">Trend</th>
+              <th className="py-1 text-right font-medium">30d</th>
             </tr>
           </thead>
           <tbody>
             {visible.length === 0 ? (
               <tr className="border-t border-edge">
-                <td colSpan={2} className="py-6 text-center text-muted">
+                <td colSpan={5} className="py-6 text-center text-muted">
                   {unavailable
                     ? "This slice is served live and the telemetry source could not be reached."
                     : search
@@ -565,6 +634,21 @@ function BreakdownTable({
                   <tr key={r.group} className="border-t border-edge">
                     <td className="py-2 font-medium">{groupLabel(groupBy, r.group)}</td>
                     <td className="py-2 text-right tabular-nums">{formatUSD(r.totalMicroUsd)}</td>
+                    <td className="py-2 text-right tabular-nums">
+                      {footerTotal > 0 ? (
+                        <Pct value={r.totalMicroUsd / footerTotal} />
+                      ) : (
+                        <Blank reason="no spend in this slice, so there is no total to take a share of" />
+                      )}
+                    </td>
+                    <td className="py-2 text-right">
+                      <TrendCell group={r.group} current={r.totalMicroUsd} prior={prior} />
+                    </td>
+                    <td className="py-2">
+                      <div className="flex justify-end">
+                        <RowSparkline group={r.group} days={days} />
+                      </div>
+                    </td>
                   </tr>
                 ))}
                 <tr className="border-t border-edge bg-ink/40 font-medium">
@@ -574,6 +658,15 @@ function BreakdownTable({
                   <td className="py-2 text-right tabular-nums">
                     <Money micro={footerTotal} />
                   </td>
+                  <td className="py-2 text-right tabular-nums">
+                    {footerTotal > 0 ? (
+                      <Pct value={1} />
+                    ) : (
+                      <Blank reason="no spend in this slice" />
+                    )}
+                  </td>
+                  <td className="py-2" />
+                  <td className="py-2" />
                 </tr>
               </>
             )}
@@ -582,4 +675,70 @@ function BreakdownTable({
       </div>
     </Card>
   );
+}
+
+/**
+ * The trend cell for one breakdown row (CTO-244): this window's cost for the group vs the prior
+ * equal-length window, as a ▲/▼ + percent. Cost trend colouring is inverted from a value metric: up
+ * is bad, down is good, flat is muted. Honest under uncertainty on three branches: the aggregated
+ * "other" tail has no single prior group to compare, a null prior map means the prior read was
+ * unavailable, and a group with no prior spend is genuinely "new" rather than an up-infinity percent.
+ */
+function TrendCell({
+  group,
+  current,
+  prior,
+}: {
+  group: string;
+  current: number;
+  prior: ExploreBreakdownPrior | null;
+}) {
+  if (group === OTHER_GROUP) {
+    return <Blank reason="aggregated tail, no single prior group to compare" />;
+  }
+  if (prior === null) {
+    return <Blank reason="prior window unavailable, no comparison" />;
+  }
+  const trend = costTrend(current, prior[group]);
+  if (trend.kind === "new") {
+    // A real marker, not a fabricated percent: this group had no spend in the prior window.
+    return (
+      <span
+        title="new this period, no prior window to compare"
+        className="cursor-help rounded-full bg-accent/10 px-1.5 py-0.5 text-[11px] font-medium uppercase text-accent"
+      >
+        new
+      </span>
+    );
+  }
+  const rising = trend.fraction > 0;
+  const flat = trend.fraction === 0;
+  // Cost: up is bad, down is good, flat is muted.
+  const tone = flat ? "text-muted" : rising ? "text-bad" : "text-good";
+  const arrow = flat ? "→" : rising ? "▲" : "▼";
+  return (
+    <span className={`inline-flex items-center justify-end gap-1 tabular-nums ${tone}`}>
+      <span aria-hidden>{arrow}</span>
+      <Pct value={Math.abs(trend.fraction)} />
+    </span>
+  );
+}
+
+/**
+ * A per-row daily-cost sparkline (CTO-244) off the chart's own day×group series, so it adds no query.
+ * A group with fewer than two days of spend has no meaningful line, so it renders a flat dash rather
+ * than a degenerate or broken SVG.
+ */
+function RowSparkline({
+  group,
+  days,
+}: {
+  group: string;
+  days: readonly ExploreDayPoint[] | null;
+}) {
+  if (!days) return <span className="text-muted">{"—"}</span>;
+  const values = days.map((d) => d.byGroup[group] ?? 0);
+  const daysWithSpend = values.filter((v) => v > 0).length;
+  if (daysWithSpend < 2) return <span className="text-muted">{"—"}</span>;
+  return <Sparkline values={values} width={80} height={20} ariaLabel={`daily cost for ${group}`} />;
 }

--- a/web/components/Sparkline.tsx
+++ b/web/components/Sparkline.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// A tiny inline sparkline (CTO-221 D1, extracted to its own module in CTO-244 so the SummaryTile and
+// the Cost explorer's breakdown table draw the same shape instead of two copies drifting apart).
+//
+// No chart library: a single polyline scaled to its own min/max. Theme-token coloured via
+// `currentColor` so a caller sets the stroke through a text-* class (default frost accent) and it
+// tracks the palette rather than a hard-coded hex.
+
+export interface SparklineProps {
+  /** The series to draw, oldest to newest. */
+  values: readonly number[];
+  width?: number;
+  height?: number;
+  /** Overrides the default text-accent stroke colour; any text-* token class works. */
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function Sparkline({
+  values,
+  width = 72,
+  height = 24,
+  className = "text-accent",
+  ariaLabel = "trend sparkline",
+}: SparklineProps) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+  const points = values
+    .map((v, i) => `${(i * step).toFixed(1)},${(height - ((v - min) / span) * height).toFixed(1)}`)
+    .join(" ");
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      role="img"
+      aria-label={ariaLabel}
+      className={`shrink-0 ${className}`.trim()}
+    >
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  );
+}

--- a/web/components/SummaryTile.tsx
+++ b/web/components/SummaryTile.tsx
@@ -10,6 +10,7 @@
 import type { ReactNode } from "react";
 
 import { Money, Pct } from "@/components/HonestValue";
+import { Sparkline } from "@/components/Sparkline";
 import type { MicroUSD } from "@/lib/types";
 
 export interface SummaryTileProps {
@@ -90,31 +91,6 @@ function DeltaBadge({
       <span aria-hidden>{arrow}</span>
       <Pct value={Math.abs(delta)} />
     </span>
-  );
-}
-
-/** A tiny inline sparkline. No chart library; a single polyline scaled to its own min/max. */
-function Sparkline({ values }: { values: readonly number[] }) {
-  const w = 72;
-  const h = 24;
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const span = max - min || 1;
-  const step = values.length > 1 ? w / (values.length - 1) : w;
-  const points = values
-    .map((v, i) => `${(i * step).toFixed(1)},${(h - ((v - min) / span) * h).toFixed(1)}`)
-    .join(" ");
-  return (
-    <svg
-      viewBox={`0 0 ${w} ${h}`}
-      width={w}
-      height={h}
-      role="img"
-      aria-label="trend sparkline"
-      className="shrink-0"
-    >
-      <polyline points={points} fill="none" stroke="#5e81ac" strokeWidth="1.5" />
-    </svg>
   );
 }
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -25,6 +25,7 @@ import type {
 import type { CostDayPoint, CostSeries, FeatureCostRow, HiddenCostAlert } from "./cost";
 import { LAYERS, type Layer } from "./cost";
 import {
+  type ExploreBreakdownPrior,
   type ExploreCostRow,
   type ExploreDimension,
   type ExploreFilters,
@@ -559,6 +560,82 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
       totalMicroUsd: capped.totalMicroUsd,
       truncatedGroups: capped.truncatedGroups,
     };
+  });
+}
+
+/**
+ * PRIOR-window per-group cost totals for the breakdown table's trend column (CTO-244).
+ *
+ * WHY A COMPANION READ: the trend column compares this window's per-group spend to the equal-length
+ * window immediately before it, but queryCostExplore only scans the current window. Rather than widen
+ * that scan (and pay for double the day×group rows the chart never draws), this does one grouped
+ * SELECT over just the prior window and returns a raw-group→micro map the caller diffs against the
+ * breakdown rows it already has.
+ *
+ * WINDOW (ClickHouse clock only, never the Node clock, per CTO-203): the current window's bounds come
+ * from the same bounds SELECT queryCostExplore uses, then the prior window is the `windowDays` days
+ * ending the day before `windowStart` (`>= toDate(windowStart) - windowDays AND < toDate(windowStart)`).
+ * So if the current slice is `toDate(now()) - INTERVAL (w-1) DAY .. now`, the prior is exactly the w
+ * days before it, on one clock, even across a midnight boundary.
+ *
+ * The group expression, the group-scope predicate (agent's run-shaped exclusions) and the bound
+ * multi-select filter clauses are all identical to queryCostExplore, so a prior total is the same
+ * kind of number as the current one it is compared against. Returns `null` (via tryLive) when
+ * ClickHouse is unreachable; the caller blanks the trend cells and the rest of the table still works.
+ */
+export async function queryCostBreakdownPrior(
+  params: ExploreParams,
+): Promise<ExploreBreakdownPrior | null> {
+  return tryLive(async (db, tenant) => {
+    const groupExpr = EXPLORE_GROUP_EXPR[params.groupBy];
+
+    // Same bounds SELECT as queryCostExplore so the prior window is anchored to the exact current
+    // window, clamped to MAX_WINDOW_DAYS at the SQL boundary.
+    const maxBack = clampWindowDays(Number.MAX_SAFE_INTEGER) - 1; // = MAX_WINDOW_DAYS - 1
+    let boundsRows: { windowStart: string; windowDays: number }[];
+    if (params.window.kind === "range") {
+      boundsRows = await rowsP(
+        db,
+        `WITH toDate({from:String}) AS f0,
+              least(toDate({to:String}), toDate(now())) AS t,
+              greatest(f0, t - {maxBack:UInt32}) AS f
+         SELECT toString(f) AS windowStart,
+                toUInt32(greatest(dateDiff('day', f, t) + 1, 0)) AS windowDays`,
+        { from: params.window.from, to: params.window.to, maxBack },
+      );
+    } else {
+      const back = clampWindowDays(params.window.days) - 1;
+      boundsRows = await rowsP(
+        db,
+        `WITH toDate(now()) AS td
+         SELECT toString(td - {back:UInt32}) AS windowStart,
+                toUInt32({back:UInt32} + 1) AS windowDays`,
+        { back },
+      );
+    }
+    const b = boundsRows[0];
+    const windowDays = b ? Number(b.windowDays) || 0 : 0;
+    if (!b || windowDays <= 0) return null;
+
+    const { clause: filterClause, params: filterParams } = exploreFilterClauses(params.filters);
+    const groupScope = EXPLORE_GROUP_SCOPE[params.groupBy] ?? "";
+    // Prior window: the `windowDays` days ending the day before windowStart. Half-open on the high
+    // end so the boundary day (windowStart itself, the current window's first day) is never counted.
+    const scope = `TenantId = {tenant:String}
+        AND Timestamp >= toDate({windowStart:String}) - {windowDays:UInt32}
+        AND Timestamp < toDate({windowStart:String})
+        ${groupScope}`;
+    const rows = await rowsP<{ grp: string; cost: string }>(
+      db,
+      `SELECT ${groupExpr} AS grp, sum(EstimatedCost) AS cost
+       FROM otel_spans
+       WHERE ${scope} ${filterClause}
+       GROUP BY grp`,
+      { tenant, windowStart: b.windowStart, windowDays, ...filterParams },
+    );
+    const prior: ExploreBreakdownPrior = {};
+    for (const r of rows) prior[r.grp] = micro(r.cost);
+    return prior;
   });
 }
 

--- a/web/lib/explore.test.ts
+++ b/web/lib/explore.test.ts
@@ -12,6 +12,7 @@ import {
   type ExploreGroupTotal,
   capGroups,
   clampWindowDays,
+  costTrend,
   exploreParamsFromFilters,
   pivotExploreDays,
 } from "./explore";
@@ -106,6 +107,21 @@ describe("clampWindowDays", () => {
     expect(clampWindowDays(10_000)).toBe(MAX_WINDOW_DAYS);
     expect(clampWindowDays(Number.NaN)).toBe(1);
     expect(clampWindowDays(30.9)).toBe(30);
+  });
+});
+
+describe("costTrend (CTO-244)", () => {
+  it("returns a signed fraction when there is prior spend to divide by", () => {
+    expect(costTrend(120, 100)).toEqual({ kind: "delta", fraction: 0.2 });
+    expect(costTrend(80, 100)).toEqual({ kind: "delta", fraction: -0.2 });
+    expect(costTrend(100, 100)).toEqual({ kind: "delta", fraction: 0 });
+  });
+
+  it("is 'new' (never a fabricated percent or divide-by-zero) when there is no prior spend", () => {
+    // Group absent from the prior window map.
+    expect(costTrend(100, undefined)).toEqual({ kind: "new" });
+    // Group present in the prior window but with zero spend: still nothing to divide by.
+    expect(costTrend(100, 0)).toEqual({ kind: "new" });
   });
 });
 

--- a/web/lib/explore.ts
+++ b/web/lib/explore.ts
@@ -94,6 +94,28 @@ export interface CostSliceTotals {
   reconciledThrough: string;
 }
 
+/**
+ * Prior-window per-group cost totals for the trend column (CTO-244), keyed by the SAME raw group
+ * value the breakdown rows carry. The prior window is the equal-length window immediately before the
+ * current one; a group present now but absent here (or here with no spend) has no honest percent to
+ * show, so it is left out of the map and rendered as "new" rather than an invented number. A `null`
+ * map (the prior read failed) blanks every trend cell while the rest of the table still renders.
+ */
+export type ExploreBreakdownPrior = Record<string, MicroUSD>;
+
+/**
+ * Period-over-period trend for one group (CTO-244). PURE so the honest branches are unit-testable
+ * without a database. "new" is the honest answer when there is no prior spend to divide by (group
+ * absent from the prior window, or present with zero): never a fabricated percent, never a
+ * divide-by-zero infinity. Otherwise a signed fraction (-0.2 = down 20%) the caller renders as ▲/▼.
+ */
+export type CostTrend = { kind: "new" } | { kind: "delta"; fraction: number };
+
+export function costTrend(currentMicro: MicroUSD, priorMicro: MicroUSD | undefined): CostTrend {
+  if (priorMicro === undefined || priorMicro <= 0) return { kind: "new" };
+  return { kind: "delta", fraction: (currentMicro - priorMicro) / priorMicro };
+}
+
 /** A raw per-group total row as it comes back from ClickHouse before capping. */
 export interface ExploreGroupTotal {
   group: string;


### PR DESCRIPTION
## CTO-244: three columns for the Cost explorer breakdown table

Adds **% of total**, **trend vs prior period**, and a **sparkline** to the `BreakdownTable` in `web/app/cost/Live.tsx`. Additive to the table only; the tiles/chart default-slice parity is untouched. All three columns re-key with the active window / group-by / dimension filters / search, because they read the current breakdown rows and the chart's own series.

### The three columns
- **% of total** — row cost / the shown total (the footer total, reused as the denominator). Rendered `<Pct />`, and a sortable column next to Cost. A zero total renders an honest `<Blank />`, never a divide-by-zero.
- **Trend vs previous period** — this window's per-group cost vs the equal-length window immediately before it, as a ▲/▼ + percent. Cost colouring is inverted from a value metric: up = `text-bad`, down = `text-good`, flat = muted. Honest branches: a group with **no prior spend** shows a small **"new"** marker (title: "new this period, no prior window to compare"); the aggregated `· other` tail and a failed prior read show a `<Blank>` with a reason. Never a fabricated percent or a divide-by-zero.
- **Sparkline** — a small daily-cost line per row from `series.days[].byGroup[group]` (the data the chart already uses, so no new query). Extracted the existing `SummaryTile` sparkline to `web/components/Sparkline.tsx` and reused it from both places (theme-token coloured via `currentColor`). A group with fewer than two days of spend renders a flat dash, not a broken SVG.

### The prior-window query
`queryCostBreakdownPrior(params)` in `web/lib/clickhouse.ts`: one grouped SELECT over the prior window, keyed by raw group value, surfaced from `/api/explore` as `breakdownPrior`. The prior window is the `windowDays` days ending the day before the current `windowStart`, derived from the same ClickHouse bounds SELECT `queryCostExplore` uses (ClickHouse-clock only, per CTO-203), under the identical group expression, group-scope predicate and bound multi-select filter clauses (params bound, never string-concatenated; tenant-scoped). The pure trend math lives in `costTrend()` in `web/lib/explore.ts` with unit tests.

### Honest under uncertainty
The prior read is independently null-safe: if it returns null (ClickHouse unreachable), only the trend cells blank while the series, tile totals and the rest of the table still render. Money stays integer micro-USD throughout; shares and trends are computed from those integers and rendered through `<Pct>`.

### Verification
`npm run typecheck`, `npm run lint` (only the pre-existing `useLivePoll.ts` warning), `npm run test` (only the long-standing `api.test.ts` ClickHouse-running case fails; no new failures) and a clean `npm run build` (`rm -rf .next`, no dev server) all pass. Then ran the worktree dev server against the live stack (tenant `local-dev`) and confirmed on both slices.

Screenshots (dev server, live `local-dev` stack):
- **Default (by layer):** table shows Layer / Cost / % of total / Trend / 30d. LLM $46,882.47 · 52.2% · ▲595.0%; Compute $38,837.83 · 43.3% · ▲611.0%; Vector DB ▲566.6%; Egress ▲366.0%; Tool calls / Embeddings show the **"new"** marker; footer 100.0%.
- **Group-by = feature:** all three columns re-key. research_agent $52,578.16 · 58.6% · ▲597.7%; chatbot ▲731.8%; smart_search ▲699.3%; chatbot.brainstorm **▼59.1%** (a real down-trend, tinted good); wastedemo_flaky / wastedemo_retry / wastedemo_loop show **"new"** (present now, absent from the prior window).

Live trend values proving both windows and the honest "new": `chatbot ▲731.8%` and `chatbot.brainstorm ▼59.1%` both compare against real prior spend; `wastedemo_flaky` renders "new" because it had no spend in the prior window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)