### PR TITLE
feat: Initiative 2 edge proxy multi-provider routing

### DIFF
--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -56,8 +56,66 @@ These are enforced by tests, not just documented:
 | `EDGE_PROXY_BROKER_TTL` | `5m` | how long a minted credential is reused before re-minting |
 | `EDGE_PROXY_SELF_HOSTED` | `false` | label emitted telemetry as `self-host` vs `cloud` |
 | `EDGE_PROXY_TELEMETRY_URL` | — | collector endpoint for metadata-only `TraceRecord`s; empty disables shipping |
+| `EDGE_PROXY_ROUTES` | — | hosted multi-provider route table (see below); empty keeps single-origin `EDGE_PROXY_UPSTREAM` |
+| `EDGE_PROXY_ROUTE_MODE` | `host` | `host` (match on hostname, hosted default) or `path` (match+strip a leading prefix) |
+| `EDGE_PROXY_KEYS_URL` | — | gateway delta feed `GET /v1/edge/keys?since={cursor}` for key-to-tenant resolution; empty disables it |
+| `EDGE_PROXY_SERVICE_TOKEN` | — | server-only bearer token the proxy sends to `EDGE_PROXY_KEYS_URL` (required when it is set) |
+| `EDGE_PROXY_KEYS_REFRESH_INTERVAL` | `45s` | how often the key cache polls the feed; also the proxy-path revocation SLA |
 
 `/healthz` is the one path the proxy owns (liveness); everything else is forwarded.
+
+## Hosted multi-provider routing (Initiative 2)
+
+One hosted deployment can serve several providers behind distinct hostnames (or path
+prefixes), resolve the real `X-Tenant-Key` to a tenant UUID with no per-request gateway call,
+and tag telemetry with that canonical UUID. This is layered on top of the CTO-39 core: when
+`EDGE_PROXY_ROUTES` and `EDGE_PROXY_KEYS_URL` are unset the proxy behaves exactly as before
+(single origin, no resolution), so self-host and the existing tests are unaffected.
+
+### Per-request routing (sec 6.1 / 6.4)
+
+`EDGE_PROXY_ROUTES` maps a match key to `{upstream, provider}`. Two wire forms:
+
+```bash
+# comma list: match=upstream[:provider]
+EDGE_PROXY_ROUTES="openai.proxy.ai-tally.com=https://api.openai.com:openai,\
+anthropic.proxy.ai-tally.com=https://api.anthropic.com:anthropic"
+
+# or JSON
+EDGE_PROXY_ROUTES='{"anthropic.proxy.ai-tally.com":{"upstream":"https://api.anthropic.com","provider":"anthropic"}}'
+```
+
+In the comma form the trailing token after the last colon is the provider only when it names a
+known one (`openai` / `anthropic` / `gemini`); otherwise the whole value is the upstream, so an
+origin with a port (`https://host:8443`) is not misread. `host` mode matches on the request
+hostname; `path` mode matches a leading prefix (`/openai/...`) and strips it before forwarding.
+Routing is a pre-forward origin selection only: bodies, headers, and the provider credential
+pass through byte-for-byte, `FlushInterval = -1` streaming is unchanged, and the route's
+`provider` picks the existing `extractMeta` branch, so there is no new parser. A configured
+route table that matches nothing returns `404` rather than forwarding to a wrong origin.
+
+**Per-provider credential (sec 6.4).** Each provider expects a different credential header, and
+the proxy forwards whatever the client sent untouched, stripping only `X-Tenant-Key` and the
+Tally control headers. The Anthropic route therefore forwards `x-api-key` and `anthropic-version`
+(not `Authorization`); the OpenAI/Gemini-OpenAI routes forward `Authorization: Bearer ...`.
+
+### Fast key-to-tenant resolution (sec 6.2 / 6.3)
+
+With `EDGE_PROXY_KEYS_URL` set, the proxy keeps an in-memory map of `sha256(key) ->
+{tenant_uuid, scope}`, built from the gateway's read-only delta feed
+`GET /v1/edge/keys?since={cursor}` (authenticated with `EDGE_PROXY_SERVICE_TOKEN`) and refreshed
+every `EDGE_PROXY_KEYS_REFRESH_INTERVAL`. It computes the same SHA-256 transform the gateway uses
+(`gateway/auth.py hash_key`) on the presented `X-Tenant-Key` and looks the tenant up locally, so
+no Postgres or gateway call sits in the request path. The feed ships only creations and
+revocations since the persisted cursor; a revoked key arrives with `revoked_at` set and is
+dropped, so revocation propagates within one refresh interval (the documented proxy-path
+revocation SLA). The resolved UUID is stamped on `TraceRecord.TenantId` (a UUID is metadata, not
+content), so proxy and SDK traffic for one org share a single `TenantId` and one Cost Explorer
+view. An unknown or revoked key is rejected with `403` when `EDGE_PROXY_REQUIRE_TENANT=true`,
+never forwarded unauthenticated; a brand-new key can miss the cache until the next refresh, which
+is honest and bounded, not a fabricated success. A transient feed error keeps the last good map:
+resolution never fails open. `GET /v1/edge/keys` is delivered by a separate gateway PR; only the
+SHA-256 hash is ever sent over it, never a raw or reversible token.
 
 ## Account attribution (CTO-182)
 

--- a/infra/edge-proxy/cmd/edge-proxy/main.go
+++ b/infra/edge-proxy/cmd/edge-proxy/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/edgekeys"
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/keybroker"
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/proxy"
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/telemetry"
@@ -57,6 +58,31 @@ func main() {
 	// Empty is pure pass-through (CTO-39), the byte-identical default.
 	if cfg.Provider != "" {
 		log.Printf("edge-proxy: provider protocol = %s (response metadata extraction on)", cfg.Provider)
+	}
+
+	// Root context for background workers (the edge-key refresher); cancelled on shutdown.
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	// Multi-provider routing (Initiative 2 sec 6.1): log the route table when configured.
+	if len(cfg.Routes) > 0 {
+		log.Printf("edge-proxy: multi-provider routing (mode=%s, %d routes)", cfg.RouteMode, len(cfg.Routes))
+		for _, rt := range cfg.Routes {
+			log.Printf("edge-proxy:   route %s -> %s (provider=%q)", rt.Match, rt.Upstream, rt.Provider)
+		}
+	}
+
+	// Fast key-to-tenant resolution (Initiative 2 sec 6.2): build the in-memory key cache and start
+	// its delta-sync refresher. Empty KeysURL keeps the CTO-39 core (no resolution, no 403).
+	if cfg.KeysURL != "" {
+		cache := edgekeys.New(edgekeys.Options{
+			URL:          cfg.KeysURL,
+			ServiceToken: cfg.ServiceToken,
+			Interval:     cfg.KeysRefreshInterval,
+		})
+		go cache.Run(rootCtx)
+		opts = append(opts, proxy.WithKeyResolver(cache))
+		log.Printf("edge-proxy: edge key cache <- %s (refresh=%s)", cfg.KeysURL, cfg.KeysRefreshInterval)
 	}
 
 	p := proxy.New(cfg, opts...)

--- a/infra/edge-proxy/cmd/edge-proxy/main.go
+++ b/infra/edge-proxy/cmd/edge-proxy/main.go
@@ -80,6 +80,17 @@ func main() {
 			ServiceToken: cfg.ServiceToken,
 			Interval:     cfg.KeysRefreshInterval,
 		})
+		// Block on the first sync (bounded retry) before serving so a transient boot-time feed error
+		// does not leave the cache empty and reject all traffic. With RequireTenant set an empty cache
+		// fails every request closed, so a persistent failure is fatal rather than silently 403-ing
+		// everything; in open mode we log and proceed (Run keeps retrying), since an empty cache there
+		// only means requests carry no TenantId.
+		if err := cache.InitialSync(rootCtx, 5, 2*time.Second); err != nil {
+			if cfg.RequireTenant {
+				log.Fatalf("edge-proxy: edge key cache initial sync failed with RequireTenant set: %v", err)
+			}
+			log.Printf("edge-proxy: edge key cache initial sync failed, continuing in open mode: %v", err)
+		}
 		go cache.Run(rootCtx)
 		opts = append(opts, proxy.WithKeyResolver(cache))
 		log.Printf("edge-proxy: edge key cache <- %s (refresh=%s)", cfg.KeysURL, cfg.KeysRefreshInterval)

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -8,12 +8,41 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// RouteMode selects how EDGE_PROXY_ROUTES entries are matched against an inbound request when the
+// hosted multi-provider deployment serves several providers behind one binary (Initiative 2 sec 6.1).
+type RouteMode string
+
+const (
+	// RouteModeHost matches on the request's hostname (the hosted default). Distinct hostnames map
+	// to providers, e.g. openai.proxy.ai-tally.com -> https://api.openai.com. Routing is a
+	// hostname-to-origin lookup with no body inspection, so the hot path stays byte-identical.
+	RouteModeHost RouteMode = "host"
+	// RouteModePath matches on a leading path prefix (fallback for customers who cannot set distinct
+	// hostnames), e.g. /openai/... . The matched prefix is stripped before forwarding.
+	RouteModePath RouteMode = "path"
+)
+
+// Route pins one match key (a hostname in host mode, or a leading path segment in path mode) to an
+// upstream origin and the provider protocol used to read response metadata for that origin. It is a
+// pre-forward origin selection only: bodies, headers, and credentials are still forwarded
+// byte-for-byte (Initiative 2 sec 6.1 / 6.4).
+type Route struct {
+	// Match is the hostname (host mode) or leading path prefix (path mode) this route serves.
+	Match string
+	// Upstream is the provider origin requests on this route are forwarded to.
+	Upstream *url.URL
+	// Provider selects the extractMeta branch for this route's responses (may be empty for pure
+	// pass-through with no metadata extraction).
+	Provider Provider
+}
 
 // Mode selects how the customer's provider key reaches the upstream.
 type Mode string
@@ -103,6 +132,27 @@ type Config struct {
 	// TelemetryURL, if set, is the collector endpoint the proxy POSTs metadata-only TraceRecords
 	// to. Empty disables telemetry shipping (NopSink), as in the CTO-39 core.
 	TelemetryURL string
+
+	// --- Hosted multi-provider routing (Initiative 2 sec 6.1) ---
+
+	// Routes is the per-request route table for the hosted deployment. Empty means single-origin
+	// mode: forward everything to Upstream with Provider, preserving self-host and CTO-39 behavior.
+	Routes []Route
+	// RouteMode selects host- or path-based matching for Routes. Defaults to host.
+	RouteMode RouteMode
+
+	// --- Fast key-to-tenant resolution (Initiative 2 sec 6.2) ---
+
+	// KeysURL is the gateway's read-only edge-keys delta endpoint (GET /v1/edge/keys?since=cursor)
+	// the proxy polls to build its in-memory sha256(key)->tenant-UUID map. Empty disables edge key
+	// resolution, so self-host and the CTO-39 core are unaffected.
+	KeysURL string
+	// ServiceToken authenticates the proxy to KeysURL (server-only bearer token, never a human
+	// session). Sent as Authorization: Bearer <token>.
+	ServiceToken string
+	// KeysRefreshInterval bounds how often the proxy polls KeysURL for changes; it is also the
+	// revocation-propagation SLA on the proxy path.
+	KeysRefreshInterval time.Duration
 }
 
 // Defaults applied when the corresponding env var is unset.
@@ -122,6 +172,9 @@ const (
 	DefaultUpstreamTimeout = 10 * time.Minute
 	// DefaultBrokerTTL bounds minted-token reuse in broker mode.
 	DefaultBrokerTTL = 5 * time.Minute
+	// DefaultKeysRefreshInterval is how often the proxy polls the edge-keys delta feed. The spec
+	// suggests 30 to 60s; 45s keeps the revocation window bounded without hammering the gateway.
+	DefaultKeysRefreshInterval = 45 * time.Second
 )
 
 // Env is a minimal indirection over os.Getenv so tests can supply a fixed environment.
@@ -223,7 +276,151 @@ func FromEnv(lookup Env) (Config, error) {
 		return Config{}, fmt.Errorf("EDGE_PROXY_MODE=broker requires EDGE_PROXY_BROKER_FILE")
 	}
 
+	// Hosted multi-provider routing (sec 6.1). RouteMode is parsed regardless so an operator can set
+	// it explicitly; it only takes effect once EDGE_PROXY_ROUTES is non-empty.
+	cfg.RouteMode = RouteModeHost
+	if v := lookup("EDGE_PROXY_ROUTE_MODE"); v != "" {
+		switch RouteMode(v) {
+		case RouteModeHost, RouteModePath:
+			cfg.RouteMode = RouteMode(v)
+		default:
+			return Config{}, fmt.Errorf("invalid EDGE_PROXY_ROUTE_MODE %q (want host|path)", v)
+		}
+	}
+	if v := lookup("EDGE_PROXY_ROUTES"); strings.TrimSpace(v) != "" {
+		routes, err := parseRoutes(v, cfg.RouteMode)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Routes = routes
+	}
+
+	// Fast key-to-tenant resolution (sec 6.2). Empty KeysURL keeps the CTO-39 core: no edge key
+	// cache, no per-request resolution.
+	cfg.KeysURL = lookup("EDGE_PROXY_KEYS_URL")
+	cfg.ServiceToken = lookup("EDGE_PROXY_SERVICE_TOKEN")
+	cfg.KeysRefreshInterval = DefaultKeysRefreshInterval
+	if v := lookup("EDGE_PROXY_KEYS_REFRESH_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid EDGE_PROXY_KEYS_REFRESH_INTERVAL %q: %w", v, err)
+		}
+		if d <= 0 {
+			return Config{}, fmt.Errorf("EDGE_PROXY_KEYS_REFRESH_INTERVAL must be > 0, got %s", d)
+		}
+		cfg.KeysRefreshInterval = d
+	}
+	if cfg.KeysURL != "" && cfg.ServiceToken == "" {
+		return Config{}, fmt.Errorf("EDGE_PROXY_KEYS_URL requires EDGE_PROXY_SERVICE_TOKEN")
+	}
+
 	return cfg, nil
+}
+
+// parseRoutes builds the route table from EDGE_PROXY_ROUTES. Two wire forms are accepted:
+//
+//   - JSON object: {"openai.proxy.ai-tally.com": {"upstream": "https://api.openai.com",
+//     "provider": "openai"}}
+//   - comma list:  openai.proxy.ai-tally.com=https://api.openai.com:openai,anthropic...=...:anthropic
+//
+// In the comma form the provider is the token after the LAST colon when it names a known provider;
+// otherwise the whole value is treated as the upstream with an empty (pure pass-through) provider,
+// so an origin carrying a port (https://host:8443) is not misread as a provider.
+func parseRoutes(raw string, mode RouteMode) ([]Route, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "{") {
+		return parseRoutesJSON(raw, mode)
+	}
+	var routes []Route
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		eq := strings.IndexByte(entry, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("invalid EDGE_PROXY_ROUTES entry %q (want match=upstream[:provider])", entry)
+		}
+		match := strings.TrimSpace(entry[:eq])
+		value := strings.TrimSpace(entry[eq+1:])
+		rawUpstream, prov := value, Provider("")
+		if colon := strings.LastIndexByte(value, ':'); colon >= 0 {
+			if p, ok := parseProvider(value[colon+1:]); ok {
+				rawUpstream, prov = value[:colon], p
+			}
+		}
+		route, err := buildRoute(match, rawUpstream, prov, mode)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, route)
+	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("EDGE_PROXY_ROUTES is set but parsed to no routes")
+	}
+	return routes, nil
+}
+
+func parseRoutesJSON(raw string, mode RouteMode) ([]Route, error) {
+	var m map[string]struct {
+		Upstream string `json:"upstream"`
+		Provider string `json:"provider"`
+	}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("invalid EDGE_PROXY_ROUTES JSON: %w", err)
+	}
+	var routes []Route
+	for match, spec := range m {
+		prov := Provider("")
+		if spec.Provider != "" {
+			p, ok := parseProvider(spec.Provider)
+			if !ok {
+				return nil, fmt.Errorf("invalid provider %q for route %q", spec.Provider, match)
+			}
+			prov = p
+		}
+		route, err := buildRoute(match, spec.Upstream, prov, mode)
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, route)
+	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("EDGE_PROXY_ROUTES is set but parsed to no routes")
+	}
+	return routes, nil
+}
+
+func parseProvider(s string) (Provider, bool) {
+	switch Provider(s) {
+	case ProviderOpenAI, ProviderAnthropic, ProviderGemini:
+		return Provider(s), true
+	default:
+		return "", false
+	}
+}
+
+func buildRoute(match, rawUpstream string, prov Provider, mode RouteMode) (Route, error) {
+	if match == "" {
+		return Route{}, fmt.Errorf("EDGE_PROXY_ROUTES entry has an empty match key")
+	}
+	// In path mode the match is a leading path prefix; normalize to a single leading slash and no
+	// trailing slash so prefix stripping is unambiguous.
+	if mode == RouteModePath {
+		match = "/" + strings.Trim(match, "/")
+	}
+	u, err := url.Parse(strings.TrimSpace(rawUpstream))
+	if err != nil {
+		return Route{}, fmt.Errorf("invalid upstream %q for route %q: %w", rawUpstream, match, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return Route{}, fmt.Errorf("upstream for route %q must be http(s), got %q", match, rawUpstream)
+	}
+	if u.Host == "" {
+		return Route{}, fmt.Errorf("upstream %q for route %q has no host", rawUpstream, match)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return Route{Match: match, Upstream: u, Provider: prov}, nil
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/infra/edge-proxy/internal/config/routes_test.go
+++ b/infra/edge-proxy/internal/config/routes_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+package config
+
+import "testing"
+
+func TestRoutesUnsetKeepsSingleOrigin(t *testing.T) {
+	cfg, err := FromEnv(envMap(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Routes) != 0 {
+		t.Errorf("Routes should be empty by default, got %d", len(cfg.Routes))
+	}
+	if cfg.RouteMode != RouteModeHost {
+		t.Errorf("RouteMode default = %q, want host", cfg.RouteMode)
+	}
+}
+
+func TestRoutesCommaListHostMode(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_ROUTES": "openai.proxy.ai-tally.com=https://api.openai.com:openai," +
+			"anthropic.proxy.ai-tally.com=https://api.anthropic.com:anthropic",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Routes) != 2 {
+		t.Fatalf("want 2 routes, got %d", len(cfg.Routes))
+	}
+	byMatch := map[string]Route{}
+	for _, r := range cfg.Routes {
+		byMatch[r.Match] = r
+	}
+	oa := byMatch["openai.proxy.ai-tally.com"]
+	if oa.Upstream == nil || oa.Upstream.String() != "https://api.openai.com" {
+		t.Errorf("openai upstream = %v, want https://api.openai.com", oa.Upstream)
+	}
+	if oa.Provider != ProviderOpenAI {
+		t.Errorf("openai provider = %q, want openai", oa.Provider)
+	}
+	an := byMatch["anthropic.proxy.ai-tally.com"]
+	if an.Provider != ProviderAnthropic {
+		t.Errorf("anthropic provider = %q, want anthropic", an.Provider)
+	}
+}
+
+// A port in the upstream must not be mistaken for a provider name (last-colon parsing).
+func TestRoutesUpstreamWithPortNotMisreadAsProvider(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_ROUTES": "self.internal=https://api.internal:8443",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Routes) != 1 {
+		t.Fatalf("want 1 route, got %d", len(cfg.Routes))
+	}
+	r := cfg.Routes[0]
+	if r.Upstream.String() != "https://api.internal:8443" {
+		t.Errorf("upstream = %q, want https://api.internal:8443", r.Upstream)
+	}
+	if r.Provider != "" {
+		t.Errorf("provider = %q, want empty (pass-through)", r.Provider)
+	}
+}
+
+func TestRoutesPathModeNormalizesPrefix(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_ROUTE_MODE": "path",
+		"EDGE_PROXY_ROUTES":     "openai=https://api.openai.com:openai",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RouteMode != RouteModePath {
+		t.Fatalf("RouteMode = %q, want path", cfg.RouteMode)
+	}
+	if cfg.Routes[0].Match != "/openai" {
+		t.Errorf("path match = %q, want /openai (leading slash, no trailing)", cfg.Routes[0].Match)
+	}
+}
+
+func TestRoutesJSONForm(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_ROUTES": `{"anthropic.proxy.ai-tally.com":{"upstream":"https://api.anthropic.com","provider":"anthropic"}}`,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Routes) != 1 || cfg.Routes[0].Provider != ProviderAnthropic {
+		t.Fatalf("want 1 anthropic route, got %+v", cfg.Routes)
+	}
+}
+
+func TestRoutesInvalid(t *testing.T) {
+	cases := map[string]map[string]string{
+		"no equals":         {"EDGE_PROXY_ROUTES": "openai.proxy.ai-tally.com"},
+		"bad scheme":        {"EDGE_PROXY_ROUTES": "h=ftp://api.openai.com:openai"},
+		"empty match":       {"EDGE_PROXY_ROUTES": "=https://api.openai.com:openai"},
+		"bad route mode":    {"EDGE_PROXY_ROUTE_MODE": "sideways", "EDGE_PROXY_ROUTES": "a=https://x.com"},
+		"bad json provider": {"EDGE_PROXY_ROUTES": `{"h":{"upstream":"https://x.com","provider":"bogus"}}`},
+	}
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := FromEnv(envMap(env)); err == nil {
+				t.Errorf("expected error for %s", name)
+			}
+		})
+	}
+}
+
+func TestKeysURLRequiresServiceToken(t *testing.T) {
+	if _, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_KEYS_URL": "https://gateway/v1/edge/keys",
+	})); err == nil {
+		t.Error("EDGE_PROXY_KEYS_URL without a service token should error")
+	}
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_KEYS_URL":              "https://gateway/v1/edge/keys",
+		"EDGE_PROXY_SERVICE_TOKEN":         "svc-token",
+		"EDGE_PROXY_KEYS_REFRESH_INTERVAL": "30s",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.KeysRefreshInterval != 30_000_000_000 {
+		t.Errorf("refresh interval = %s, want 30s", cfg.KeysRefreshInterval)
+	}
+}

--- a/infra/edge-proxy/internal/edgekeys/edgekeys.go
+++ b/infra/edge-proxy/internal/edgekeys/edgekeys.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Package edgekeys is the proxy's in-memory, delta-synced view of the control plane's api_keys
+// (Initiative 2 sec 6.2).
+//
+// To hold p99 < 3ms the proxy must map the real X-Tenant-Key (tally_sk_live_...) to a tenant UUID
+// with no per-request gateway round-trip. It keeps a map of sha256(key) -> {tenant_uuid, scope}
+// and computes the same sha256 transform the gateway uses (gateway/auth.py hash_key: SHA-256 hex of
+// the UTF-8 token) to look the presented key up locally.
+//
+// The map is built from the gateway's read-only delta feed GET /v1/edge/keys?since={cursor}: each
+// tick ships only creations and revocations since the last cursor, so steady state is cheap and a
+// cold start (empty cursor) pages the full active set once. Revoked keys arrive with revoked_at set
+// and are dropped, so revocation propagates within one refresh interval (the proxy-path revocation
+// SLA).
+//
+// The hash map is sensitive: the hashes are not reversible, but a compromised proxy could use them
+// for offline guess-validation, so it is held in memory only and never logged.
+package edgekeys
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// HashKey computes the same key hash the gateway stores in api_keys.key_hash: the SHA-256 hex of
+// the UTF-8 token (gateway/auth.py hash_key). Keeping this identical is what lets the proxy resolve
+// a presented X-Tenant-Key against the control plane's stored hashes without ever seeing raw keys.
+func HashKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// entry is the resolved identity for one key hash.
+type entry struct {
+	tenantID string
+	scope    string
+}
+
+// change is one row of the delta feed. Only the SHA-256 hash is ever sent, never a raw key.
+type change struct {
+	KeyHash   string `json:"key_hash"`
+	TenantID  string `json:"tenant_id"`
+	Scope     string `json:"scope"`
+	RevokedAt string `json:"revoked_at"`
+}
+
+// feedResponse is the /v1/edge/keys payload: the changes since the requested cursor plus the new
+// watermark to poll from next.
+type feedResponse struct {
+	Changes []change `json:"changes"`
+	Cursor  string   `json:"cursor"`
+}
+
+// Cache is the proxy's live key->tenant view. It is safe for concurrent use: Resolve runs on the
+// request hot path from many goroutines while Refresh applies deltas.
+type Cache struct {
+	url      string
+	token    string
+	interval time.Duration
+	client   *http.Client
+
+	mu     sync.RWMutex
+	m      map[string]entry
+	cursor string
+}
+
+// Options configures a Cache.
+type Options struct {
+	// URL is the gateway edge-keys endpoint, e.g. https://gateway/v1/edge/keys.
+	URL string
+	// ServiceToken is the server-only bearer token sent as Authorization to the feed.
+	ServiceToken string
+	// Interval bounds how often Run polls the feed.
+	Interval time.Duration
+	// Client overrides the HTTP client (tests). Defaults to a short-timeout client.
+	Client *http.Client
+}
+
+// New builds an empty Cache. Call Refresh (or Run) to populate it from the feed.
+func New(opts Options) *Cache {
+	client := opts.Client
+	if client == nil {
+		// The feed is off the request hot path, but a hung poll must not stall refresh forever.
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Cache{
+		url:      opts.URL,
+		token:    opts.ServiceToken,
+		interval: opts.Interval,
+		client:   client,
+		m:        make(map[string]entry),
+	}
+}
+
+// Resolve returns the tenant UUID for a key hash and whether it is present (and not revoked). A
+// revoked key is absent, so Resolve returns ("", false) and the proxy fails closed. This is the
+// only method on the request hot path; it takes a read lock and does an O(1) map lookup.
+func (c *Cache) Resolve(keyHash string) (string, bool) {
+	c.mu.RLock()
+	e, ok := c.m[keyHash]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	return e.tenantID, true
+}
+
+// Run polls the feed every interval until ctx is cancelled. It refreshes once immediately so the
+// cache is warm as soon as it starts. A failed poll is left to the next tick: the last good map is
+// kept, so a transient gateway blip never empties the cache and never fails open.
+func (c *Cache) Run(ctx context.Context) {
+	// Warm start; a cold-start error is non-fatal (retried on the tick) so the proxy still boots.
+	_ = c.Refresh(ctx)
+	t := time.NewTicker(c.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			_ = c.Refresh(ctx)
+		}
+	}
+}
+
+// Refresh polls the feed once from the persisted cursor and applies the returned delta. Creations
+// (and scope changes) upsert; revocations delete. The cursor is advanced only on success.
+func (c *Cache) Refresh(ctx context.Context) error {
+	c.mu.RLock()
+	since := c.cursor
+	c.mu.RUnlock()
+
+	u, err := url.Parse(c.url)
+	if err != nil {
+		return fmt.Errorf("edgekeys: bad url %q: %w", c.url, err)
+	}
+	q := u.Query()
+	q.Set("since", since)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("edgekeys: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("edgekeys: poll: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("edgekeys: feed returned %d", resp.StatusCode)
+	}
+	var fr feedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		return fmt.Errorf("edgekeys: decode feed: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, ch := range fr.Changes {
+		if ch.KeyHash == "" {
+			continue
+		}
+		if ch.RevokedAt != "" {
+			delete(c.m, ch.KeyHash)
+			continue
+		}
+		c.m[ch.KeyHash] = entry{tenantID: ch.TenantID, scope: ch.Scope}
+	}
+	if fr.Cursor != "" {
+		c.cursor = fr.Cursor
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+// Len reports the number of live keys in the cache (tests / diagnostics only).
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.m)
+}

--- a/infra/edge-proxy/internal/edgekeys/edgekeys.go
+++ b/infra/edge-proxy/internal/edgekeys/edgekeys.go
@@ -100,17 +100,53 @@ func New(opts Options) *Cache {
 	}
 }
 
-// Resolve returns the tenant UUID for a key hash and whether it is present (and not revoked). A
-// revoked key is absent, so Resolve returns ("", false) and the proxy fails closed. This is the
-// only method on the request hot path; it takes a read lock and does an O(1) map lookup.
-func (c *Cache) Resolve(keyHash string) (string, bool) {
+// Resolve returns the tenant UUID and scope for a key hash and whether it is present (and not
+// revoked). A revoked key is absent, so Resolve returns ("", "", false) and the proxy fails closed.
+// The scope lets the caller apply the gateway's ingest scope gate (CTO-33). This is the only method
+// on the request hot path; it takes a read lock and does an O(1) map lookup.
+func (c *Cache) Resolve(keyHash string) (tenantID string, scope string, ok bool) {
 	c.mu.RLock()
-	e, ok := c.m[keyHash]
+	e, found := c.m[keyHash]
 	c.mu.RUnlock()
-	if !ok {
-		return "", false
+	if !found {
+		return "", "", false
 	}
-	return e.tenantID, true
+	return e.tenantID, e.scope, true
+}
+
+// writeScopes mirrors the gateway's WRITE_SCOPES (gateway/auth.py): the scopes permitted to write
+// ingest data. Kept identical so the proxy and gateway agree on who may write (CTO-33).
+var writeScopes = map[string]bool{"write": true, "admin": true}
+
+// CanWrite reports whether a key scope may write ingest data. Metering a call through the proxy is
+// ingest, so a read-only key authenticates but is not sufficient to be attributed.
+func CanWrite(scope string) bool { return writeScopes[scope] }
+
+// InitialSync performs the first feed sync before the proxy starts serving, retrying a bounded
+// number of times on a transient error. Without a warm cache a boot-time feed blip would leave the
+// map empty and, with RequireTenant set, the proxy fails closed on every request (403) for up to a
+// full refresh interval, and the "keep the last good map" guarantee cannot help because there is no
+// last-good map yet. attempts is clamped to at least 1; between tries it waits backoff (or returns
+// early if ctx is cancelled). Returns nil on the first success, else the last error.
+func (c *Cache) InitialSync(ctx context.Context, attempts int, backoff time.Duration) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = c.Refresh(ctx); err == nil {
+			return nil
+		}
+		if i == attempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return err
 }
 
 // Run polls the feed every interval until ctx is cancelled. It refreshes once immediately so the

--- a/infra/edge-proxy/internal/edgekeys/edgekeys_test.go
+++ b/infra/edge-proxy/internal/edgekeys/edgekeys_test.go
@@ -65,10 +65,10 @@ func TestRefreshColdStartHitAndMiss(t *testing.T) {
 		t.Fatalf("refresh: %v", err)
 	}
 
-	if id, ok := c.Resolve(acme); !ok || id != "uuid-acme" {
+	if id, _, ok := c.Resolve(acme); !ok || id != "uuid-acme" {
 		t.Errorf("hit: got (%q,%v), want (uuid-acme,true)", id, ok)
 	}
-	if _, ok := c.Resolve(hashOf("tally_sk_live_unknown")); ok {
+	if _, _, ok := c.Resolve(hashOf("tally_sk_live_unknown")); ok {
 		t.Error("miss: unknown key should not resolve")
 	}
 	if feed.lastAuth != "Bearer svc-tok" {
@@ -100,7 +100,7 @@ func TestRefreshAppliesDeltaAndRevocation(t *testing.T) {
 	if err := c.Refresh(context.Background()); err != nil {
 		t.Fatalf("first refresh: %v", err)
 	}
-	if _, ok := c.Resolve(acme); !ok {
+	if _, _, ok := c.Resolve(acme); !ok {
 		t.Fatal("acme should resolve after first refresh")
 	}
 
@@ -108,10 +108,10 @@ func TestRefreshAppliesDeltaAndRevocation(t *testing.T) {
 	if err := c.Refresh(context.Background()); err != nil {
 		t.Fatalf("second refresh: %v", err)
 	}
-	if _, ok := c.Resolve(acme); ok {
+	if _, _, ok := c.Resolve(acme); ok {
 		t.Error("revoked key acme should be dropped from the cache")
 	}
-	if id, ok := c.Resolve(globex); !ok || id != "uuid-globex" {
+	if id, _, ok := c.Resolve(globex); !ok || id != "uuid-globex" {
 		t.Errorf("globex: got (%q,%v), want (uuid-globex,true)", id, ok)
 	}
 	if c.Len() != 1 {
@@ -149,8 +149,85 @@ func TestRefreshErrorKeepsLastGoodMap(t *testing.T) {
 	if err := c.Refresh(context.Background()); err == nil {
 		t.Error("expected error on failing feed")
 	}
-	if _, ok := c.Resolve(acme); !ok {
+	if _, _, ok := c.Resolve(acme); !ok {
 		t.Error("cache must keep the last good map after a failed refresh")
+	}
+}
+
+// TestResolveReturnsScope confirms Resolve surfaces the key scope so the proxy can apply the ingest
+// scope gate, and CanWrite matches the gateway's write/admin set.
+func TestResolveReturnsScope(t *testing.T) {
+	writeKey := hashOf("tally_sk_live_write")
+	readKey := hashOf("tally_sk_live_read")
+	feed := &fakeFeed{responses: map[string]feedResponse{
+		"": {
+			Changes: []change{
+				{KeyHash: writeKey, TenantID: "uuid-w", Scope: "write"},
+				{KeyHash: readKey, TenantID: "uuid-r", Scope: "read"},
+			},
+			Cursor: "c1",
+		},
+	}}
+	srv := httptest.NewServer(feed)
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "t", Interval: time.Minute})
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if _, scope, ok := c.Resolve(writeKey); !ok || scope != "write" || !CanWrite(scope) {
+		t.Errorf("write key: got scope=%q ok=%v canWrite=%v, want write/true/true", scope, ok, CanWrite(scope))
+	}
+	if _, scope, ok := c.Resolve(readKey); !ok || scope != "read" || CanWrite(scope) {
+		t.Errorf("read key: got scope=%q ok=%v canWrite=%v, want read/true/false", scope, ok, CanWrite(scope))
+	}
+	if CanWrite("read") || !CanWrite("write") || !CanWrite("admin") || CanWrite("") {
+		t.Error("CanWrite must permit only write/admin, matching gateway WRITE_SCOPES")
+	}
+}
+
+// TestInitialSyncRetriesThenSucceeds confirms a transient boot-time feed error is retried within the
+// bounded initial sync, so the cache is warm before serving and does not reject all traffic.
+func TestInitialSyncRetriesThenSucceeds(t *testing.T) {
+	acme := hashOf("tally_sk_live_acme")
+	var mu sync.Mutex
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n < 3 {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(feedResponse{
+			Changes: []change{{KeyHash: acme, TenantID: "uuid-acme", Scope: "write"}},
+			Cursor:  "c1",
+		})
+	}))
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "t", Interval: time.Minute})
+	if err := c.InitialSync(context.Background(), 5, time.Millisecond); err != nil {
+		t.Fatalf("InitialSync should have succeeded after transient failures: %v", err)
+	}
+	if _, _, ok := c.Resolve(acme); !ok {
+		t.Error("cache must be warm after InitialSync")
+	}
+}
+
+// TestInitialSyncReturnsErrorAfterExhaustion confirms InitialSync gives up (returning the error) when
+// every bounded attempt fails, so the caller can decide whether to fail closed.
+func TestInitialSyncReturnsErrorAfterExhaustion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "t", Interval: time.Minute})
+	if err := c.InitialSync(context.Background(), 3, time.Millisecond); err == nil {
+		t.Error("InitialSync should return an error when all attempts fail")
 	}
 }
 
@@ -169,12 +246,12 @@ func TestRunRefreshesUntilContextCancelled(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if _, ok := c.Resolve(acme); ok {
+		if _, _, ok := c.Resolve(acme); ok {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
-	if _, ok := c.Resolve(acme); !ok {
+	if _, _, ok := c.Resolve(acme); !ok {
 		t.Fatal("Run should have warmed the cache")
 	}
 	cancel()

--- a/infra/edge-proxy/internal/edgekeys/edgekeys_test.go
+++ b/infra/edge-proxy/internal/edgekeys/edgekeys_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+package edgekeys
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// HashKey must match gateway/auth.py hash_key exactly (SHA-256 hex of the UTF-8 token), or the
+// proxy resolves nothing. Pin it against an independent computation.
+func TestHashKeyMatchesGatewayTransform(t *testing.T) {
+	sum := sha256.Sum256([]byte("tally_sk_live_abc"))
+	want := hex.EncodeToString(sum[:])
+	if got := HashKey("tally_sk_live_abc"); got != want {
+		t.Fatalf("HashKey = %q, want %q", got, want)
+	}
+}
+
+// fakeFeed is a stand-in for the gateway GET /v1/edge/keys delta endpoint. It serves a scripted
+// sequence of responses keyed by the incoming `since` cursor and records auth headers seen.
+type fakeFeed struct {
+	mu        sync.Mutex
+	responses map[string]feedResponse // since-cursor -> response
+	lastAuth  string
+	calls     int
+}
+
+func (f *fakeFeed) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	f.lastAuth = r.Header.Get("Authorization")
+	f.calls++
+	since := r.URL.Query().Get("since")
+	resp, ok := f.responses[since]
+	f.mu.Unlock()
+	if !ok {
+		// Unknown cursor: no changes, echo cursor back.
+		resp = feedResponse{Cursor: since}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func hashOf(tok string) string { return HashKey(tok) }
+
+func TestRefreshColdStartHitAndMiss(t *testing.T) {
+	acme := hashOf("tally_sk_live_acme")
+	feed := &fakeFeed{responses: map[string]feedResponse{
+		"": {
+			Changes: []change{{KeyHash: acme, TenantID: "uuid-acme", Scope: "write"}},
+			Cursor:  "c1",
+		},
+	}}
+	srv := httptest.NewServer(feed)
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "svc-tok", Interval: time.Minute})
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	if id, ok := c.Resolve(acme); !ok || id != "uuid-acme" {
+		t.Errorf("hit: got (%q,%v), want (uuid-acme,true)", id, ok)
+	}
+	if _, ok := c.Resolve(hashOf("tally_sk_live_unknown")); ok {
+		t.Error("miss: unknown key should not resolve")
+	}
+	if feed.lastAuth != "Bearer svc-tok" {
+		t.Errorf("service token not sent: got %q", feed.lastAuth)
+	}
+}
+
+func TestRefreshAppliesDeltaAndRevocation(t *testing.T) {
+	acme := hashOf("tally_sk_live_acme")
+	globex := hashOf("tally_sk_live_globex")
+	feed := &fakeFeed{responses: map[string]feedResponse{
+		"": {
+			Changes: []change{{KeyHash: acme, TenantID: "uuid-acme", Scope: "write"}},
+			Cursor:  "c1",
+		},
+		"c1": {
+			// Delta since c1: a new key created, and acme revoked.
+			Changes: []change{
+				{KeyHash: globex, TenantID: "uuid-globex", Scope: "read"},
+				{KeyHash: acme, TenantID: "uuid-acme", RevokedAt: "2026-09-01T00:00:00Z"},
+			},
+			Cursor: "c2",
+		},
+	}}
+	srv := httptest.NewServer(feed)
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "svc-tok", Interval: time.Minute})
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	if _, ok := c.Resolve(acme); !ok {
+		t.Fatal("acme should resolve after first refresh")
+	}
+
+	// Second refresh polls from the persisted cursor c1 and applies the delta incrementally.
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+	if _, ok := c.Resolve(acme); ok {
+		t.Error("revoked key acme should be dropped from the cache")
+	}
+	if id, ok := c.Resolve(globex); !ok || id != "uuid-globex" {
+		t.Errorf("globex: got (%q,%v), want (uuid-globex,true)", id, ok)
+	}
+	if c.Len() != 1 {
+		t.Errorf("cache len = %d, want 1 (acme dropped, globex kept)", c.Len())
+	}
+}
+
+// A transient feed error must not empty the cache or fail open: the last good map survives.
+func TestRefreshErrorKeepsLastGoodMap(t *testing.T) {
+	acme := hashOf("tally_sk_live_acme")
+	var fail bool
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		f := fail
+		mu.Unlock()
+		if f {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(feedResponse{
+			Changes: []change{{KeyHash: acme, TenantID: "uuid-acme", Scope: "write"}},
+			Cursor:  "c1",
+		})
+	}))
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "t", Interval: time.Minute})
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	mu.Lock()
+	fail = true
+	mu.Unlock()
+	if err := c.Refresh(context.Background()); err == nil {
+		t.Error("expected error on failing feed")
+	}
+	if _, ok := c.Resolve(acme); !ok {
+		t.Error("cache must keep the last good map after a failed refresh")
+	}
+}
+
+func TestRunRefreshesUntilContextCancelled(t *testing.T) {
+	acme := hashOf("tally_sk_live_acme")
+	feed := &fakeFeed{responses: map[string]feedResponse{
+		"": {Changes: []change{{KeyHash: acme, TenantID: "uuid-acme", Scope: "write"}}, Cursor: "c1"},
+	}}
+	srv := httptest.NewServer(feed)
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "t", Interval: 5 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := c.Resolve(acme); ok {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, ok := c.Resolve(acme); !ok {
+		t.Fatal("Run should have warmed the cache")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -24,19 +24,31 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/edgekeys"
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/keybroker"
 )
 
+// TenantResolver maps the sha256 hash of a presented X-Tenant-Key to the canonical tenant UUID
+// (Initiative 2 sec 6.2). It is consulted once per request off a local in-memory map, never with a
+// gateway round-trip. ok is false for an unknown or revoked key, which the proxy fails closed on
+// when RequireTenant is set. *edgekeys.Cache satisfies this.
+type TenantResolver interface {
+	Resolve(keyHash string) (tenantID string, ok bool)
+}
+
 // Proxy is an http.Handler that forwards to a configured upstream and emits telemetry copies.
 type Proxy struct {
-	cfg    config.Config
-	rp     *httputil.ReverseProxy
-	sink   Sink
-	broker keybroker.Broker
-	now    func() time.Time
+	cfg      config.Config
+	rp       *httputil.ReverseProxy
+	sink     Sink
+	broker   keybroker.Broker
+	router   *router
+	resolver TenantResolver
+	now      func() time.Time
 }
 
 // Option customizes a Proxy at construction.
@@ -73,6 +85,18 @@ func WithBroker(b keybroker.Broker) Option {
 	}
 }
 
+// WithKeyResolver enables fast key-to-tenant resolution (Initiative 2 sec 6.2). With a resolver set
+// the proxy hashes the presented X-Tenant-Key, looks up the tenant UUID locally, stamps it on the
+// TraceRecord (sec 6.3), and (when RequireTenant is set) fails closed with 403 on an unknown or
+// revoked key. Without a resolver the proxy behaves as the CTO-39 core: no resolution, no 403.
+func WithKeyResolver(r TenantResolver) Option {
+	return func(p *Proxy) {
+		if r != nil {
+			p.resolver = r
+		}
+	}
+}
+
 // withClock overrides the time source (tests only).
 func withClock(now func() time.Time) Option {
 	return func(p *Proxy) {
@@ -85,18 +109,30 @@ func withClock(now func() time.Time) Option {
 // New builds a Proxy for the given config.
 func New(cfg config.Config, opts ...Option) *Proxy {
 	p := &Proxy{
-		cfg:  cfg,
-		sink: NopSink{},
-		now:  time.Now,
+		cfg:    cfg,
+		sink:   NopSink{},
+		router: newRouter(cfg),
+		now:    time.Now,
 	}
 
 	p.rp = &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
-			// SetURL joins the inbound path/query onto the upstream origin, leaving the rest of
-			// the request (method, headers, body) untouched.
-			pr.SetURL(cfg.Upstream)
+			// The per-request route was resolved in ServeHTTP and stashed on the context. In
+			// single-origin mode it is simply cfg.Upstream. Routing is a pre-forward origin swap;
+			// the rest of the request (method, headers, body, credential) is untouched.
+			rt := routeFromContext(pr.In.Context())
+			// Path mode strips the provider prefix (e.g. /openai) before forwarding so the upstream
+			// sees its own path (/v1/chat/completions), not the routing prefix.
+			if rt.stripPrefix != "" {
+				pr.In.URL.Path = strings.TrimPrefix(pr.In.URL.Path, rt.stripPrefix)
+				if !strings.HasPrefix(pr.In.URL.Path, "/") {
+					pr.In.URL.Path = "/" + pr.In.URL.Path
+				}
+			}
+			// SetURL joins the (possibly prefix-stripped) inbound path/query onto the origin.
+			pr.SetURL(rt.upstream)
 			// Send the upstream's own Host so TLS SNI and provider routing are correct.
-			pr.Out.Host = cfg.Upstream.Host
+			pr.Out.Host = rt.upstream.Host
 		},
 		// Stream every write straight to the client — critical for SSE completions.
 		FlushInterval: -1,
@@ -104,17 +140,26 @@ func New(cfg config.Config, opts ...Option) *Proxy {
 		ErrorHandler:  errorHandler,
 	}
 
-	// CTO-167: when a provider protocol is configured, tee each response through a bounded scanner
-	// that extracts scalar model/usage metadata. Left nil in pure pass-through mode so the hot path
-	// never inspects a response body.
-	if cfg.Provider != "" {
-		p.rp.ModifyResponse = p.captureMeta
-	}
+	// CTO-167 / sec 6.1: tee each response through a bounded scanner that extracts scalar
+	// model/usage metadata, using the per-route provider. captureMeta no-ops when the resolved
+	// route has no provider, so pure pass-through routes never inspect a response body.
+	p.rp.ModifyResponse = p.captureMeta
 
 	for _, opt := range opts {
 		opt(p)
 	}
 	return p
+}
+
+// routeCtxKey is the request-context key under which ServeHTTP stashes the resolved route so the
+// ReverseProxy's Rewrite and captureMeta can read it.
+type routeCtxKey struct{}
+
+func routeFromContext(ctx context.Context) resolvedRoute {
+	if rt, ok := ctx.Value(routeCtxKey{}).(resolvedRoute); ok {
+		return rt
+	}
+	return resolvedRoute{}
 }
 
 // metaKey is the request-context key under which ServeHTTP stashes the responseMeta holder that
@@ -128,13 +173,18 @@ func (p *Proxy) captureMeta(resp *http.Response) error {
 	if resp.Body == nil || resp.Request == nil {
 		return nil
 	}
+	rt := routeFromContext(resp.Request.Context())
+	// Pure pass-through route: no provider protocol, so never inspect the response body.
+	if rt.provider == "" {
+		return nil
+	}
 	holder, _ := resp.Request.Context().Value(metaKey{}).(*responseMeta)
 	if holder == nil {
 		return nil
 	}
 	resp.Body = &metaCapture{
 		inner:    resp.Body,
-		provider: p.cfg.Provider,
+		provider: rt.provider,
 		path:     resp.Request.URL.Path,
 		out:      holder,
 	}
@@ -143,10 +193,34 @@ func (p *Proxy) captureMeta(resp *http.Response) error {
 
 // ServeHTTP forwards the request and records a telemetry copy.
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Select the forwarding origin before anything else. A configured route table that matches
+	// nothing is a 404 rather than a forward to a wrong (or fallback) origin.
+	route, ok := p.router.resolve(r)
+	if !ok {
+		http.Error(w, `{"error":"no route for host"}`+"\n", http.StatusNotFound)
+		return
+	}
+
 	tenant := r.Header.Get(p.cfg.TenantHeader)
 	if p.cfg.RequireTenant && tenant == "" {
 		http.Error(w, `{"error":"missing tenant key"}`+"\n", http.StatusBadRequest)
 		return
+	}
+
+	// Fast key-to-tenant resolution (sec 6.2): hash the presented key and look it up in the local
+	// cache. The resolved UUID becomes the canonical TenantId tag (sec 6.3). Fail closed on an
+	// unknown or revoked key when RequireTenant is set, never forwarding an unauthenticated call.
+	var tenantID string
+	if p.resolver != nil && tenant != "" {
+		id, found := p.resolver.Resolve(edgekeys.HashKey(tenant))
+		if !found {
+			if p.cfg.RequireTenant {
+				http.Error(w, `{"error":"unknown tenant key"}`+"\n", http.StatusForbidden)
+				return
+			}
+		} else {
+			tenantID = id
+		}
 	}
 	// Feature tag is optional: capture if present, never reject when absent.
 	var featureTag string
@@ -201,15 +275,19 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Mark whether the upstream was reachable so the telemetry copy can distinguish a real 502
 	// from us synthesizing one.
 	ctx := context.WithValue(r.Context(), failedKey{}, &rec.failed)
-	// In provider-protocol mode, hand captureMeta a holder to fill as the response streams (CTO-167).
+	// Hand the resolved route to the ReverseProxy's Rewrite (origin/path) and captureMeta (provider).
+	ctx = context.WithValue(ctx, routeCtxKey{}, route)
+	// When this route has a provider protocol, hand captureMeta a holder to fill as the response
+	// streams (CTO-167).
 	var meta responseMeta
-	if p.cfg.Provider != "" {
+	if route.provider != "" {
 		ctx = context.WithValue(ctx, metaKey{}, &meta)
 	}
 	p.rp.ServeHTTP(rec, r.WithContext(ctx))
 
 	p.sink.Record(TraceRecord{
 		TenantKey:        tenant,
+		TenantId:         tenantID,
 		FeatureTag:       featureTag,
 		AccountIdHash:    accountIdHash,
 		Method:           r.Method,

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -35,9 +35,11 @@ import (
 // TenantResolver maps the sha256 hash of a presented X-Tenant-Key to the canonical tenant UUID
 // (Initiative 2 sec 6.2). It is consulted once per request off a local in-memory map, never with a
 // gateway round-trip. ok is false for an unknown or revoked key, which the proxy fails closed on
-// when RequireTenant is set. *edgekeys.Cache satisfies this.
+// when RequireTenant is set. It also returns the key's scope (read/write/admin) so the proxy can
+// apply the same ingest scope gate the gateway does (gateway/auth.py, CTO-33): metering a call is a
+// write, so a read-only key must not be attributed. *edgekeys.Cache satisfies this.
 type TenantResolver interface {
-	Resolve(keyHash string) (tenantID string, ok bool)
+	Resolve(keyHash string) (tenantID string, scope string, ok bool)
 }
 
 // Proxy is an http.Handler that forwards to a configured upstream and emits telemetry copies.
@@ -125,13 +127,15 @@ func New(cfg config.Config, opts ...Option) *Proxy {
 			// sees its own path (/v1/chat/completions), not the routing prefix. SetURL joins onto
 			// pr.Out, so strip pr.Out's path (a clone of the inbound path) before the join.
 			if rt.stripPrefix != "" {
-				stripped := strings.TrimPrefix(pr.Out.URL.Path, rt.stripPrefix)
-				if !strings.HasPrefix(stripped, "/") {
-					stripped = "/" + stripped
+				pr.Out.URL.Path = ensureLeadingSlash(strings.TrimPrefix(pr.Out.URL.Path, rt.stripPrefix))
+				// Trim the prefix from the escaped form too, and keep it, so a percent-encoded segment
+				// (e.g. /openai/v1/foo%2Fbar) forwards byte-for-byte instead of being re-encoded from the
+				// decoded Path. RawPath is only set by net/url when it differs from the default encoding
+				// of Path; when it is empty the plain Path has no escaped segments and SetURL's recompute
+				// is already byte-identical, so leave it empty. This matches host mode and single-origin.
+				if pr.Out.URL.RawPath != "" {
+					pr.Out.URL.RawPath = ensureLeadingSlash(strings.TrimPrefix(pr.Out.URL.RawPath, rt.stripPrefix))
 				}
-				pr.Out.URL.Path = stripped
-				// Drop the escaped form so SetURL recomputes it from the stripped Path.
-				pr.Out.URL.RawPath = ""
 			}
 			// SetURL joins the (possibly prefix-stripped) path/query onto the origin.
 			pr.SetURL(rt.upstream)
@@ -201,7 +205,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// nothing is a 404 rather than a forward to a wrong (or fallback) origin.
 	route, ok := p.router.resolve(r)
 	if !ok {
-		http.Error(w, `{"error":"no route for host"}`+"\n", http.StatusNotFound)
+		http.Error(w, p.router.noRouteMessage(), http.StatusNotFound)
 		return
 	}
 
@@ -216,13 +220,23 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// unknown or revoked key when RequireTenant is set, never forwarding an unauthenticated call.
 	var tenantID string
 	if p.resolver != nil && tenant != "" {
-		id, found := p.resolver.Resolve(edgekeys.HashKey(tenant))
-		if !found {
+		id, scope, found := p.resolver.Resolve(edgekeys.HashKey(tenant))
+		switch {
+		case !found:
 			if p.cfg.RequireTenant {
 				http.Error(w, `{"error":"unknown tenant key"}`+"\n", http.StatusForbidden)
 				return
 			}
-		} else {
+		case !edgekeys.CanWrite(scope):
+			// Known key, but its scope may not write ingest data. Metering a call through the proxy is
+			// a write, so a read-only key is rejected the same way the gateway rejects it (CTO-33). Fail
+			// closed only when RequireTenant is set; in open mode the call still forwards but carries no
+			// TenantId (an honest blank, never a fabricated tag for a key that may not be attributed).
+			if p.cfg.RequireTenant {
+				http.Error(w, `{"error":"tenant key lacks write scope"}`+"\n", http.StatusForbidden)
+				return
+			}
+		default:
 			tenantID = id
 		}
 	}

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -122,14 +122,18 @@ func New(cfg config.Config, opts ...Option) *Proxy {
 			// the rest of the request (method, headers, body, credential) is untouched.
 			rt := routeFromContext(pr.In.Context())
 			// Path mode strips the provider prefix (e.g. /openai) before forwarding so the upstream
-			// sees its own path (/v1/chat/completions), not the routing prefix.
+			// sees its own path (/v1/chat/completions), not the routing prefix. SetURL joins onto
+			// pr.Out, so strip pr.Out's path (a clone of the inbound path) before the join.
 			if rt.stripPrefix != "" {
-				pr.In.URL.Path = strings.TrimPrefix(pr.In.URL.Path, rt.stripPrefix)
-				if !strings.HasPrefix(pr.In.URL.Path, "/") {
-					pr.In.URL.Path = "/" + pr.In.URL.Path
+				stripped := strings.TrimPrefix(pr.Out.URL.Path, rt.stripPrefix)
+				if !strings.HasPrefix(stripped, "/") {
+					stripped = "/" + stripped
 				}
+				pr.Out.URL.Path = stripped
+				// Drop the escaped form so SetURL recomputes it from the stripped Path.
+				pr.Out.URL.RawPath = ""
 			}
-			// SetURL joins the (possibly prefix-stripped) inbound path/query onto the origin.
+			// SetURL joins the (possibly prefix-stripped) path/query onto the origin.
 			pr.SetURL(rt.upstream)
 			// Send the upstream's own Host so TLS SNI and provider routing are correct.
 			pr.Out.Host = rt.upstream.Host

--- a/infra/edge-proxy/internal/proxy/routing.go
+++ b/infra/edge-proxy/internal/proxy/routing.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// Initiative 2 sec 6.1: per-request routing.
+//
+// A single hosted deployment forwards to the right provider origin per request. Routing is a
+// pre-forward origin selection: it picks {upstream, provider} from the request's host (host mode)
+// or leading path prefix (path mode), and nothing else. Bodies, headers, and credentials are still
+// forwarded byte-for-byte, so the p99 budget and every CTO-39 invariant hold. When no routes are
+// configured the router falls back to the single-origin cfg.Upstream/cfg.Provider, keeping
+// self-host and the existing tests byte-identical.
+
+// resolvedRoute is the concrete forwarding target chosen for one request.
+type resolvedRoute struct {
+	upstream *url.URL
+	provider config.Provider
+	// stripPrefix, in path mode, is the leading path segment to remove before forwarding (e.g.
+	// "/openai"). Empty in host mode and single-origin mode: the path is forwarded unchanged.
+	stripPrefix string
+}
+
+// router selects a resolvedRoute per request.
+type router struct {
+	mode     config.RouteMode
+	routes   []config.Route
+	fallback resolvedRoute // single-origin target when routes is empty
+}
+
+// newRouter compiles the config route table. When cfg.Routes is empty the router serves only the
+// single-origin fallback, matching every request.
+func newRouter(cfg config.Config) *router {
+	r := &router{
+		mode:   cfg.RouteMode,
+		routes: cfg.Routes,
+		fallback: resolvedRoute{
+			upstream: cfg.Upstream,
+			provider: cfg.Provider,
+		},
+	}
+	// Path mode matches by longest prefix, so order routes longest-match-first once at startup and
+	// keep the hot path a simple linear scan with no per-request sorting.
+	if r.mode == config.RouteModePath {
+		sorted := make([]config.Route, len(r.routes))
+		copy(sorted, r.routes)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return len(sorted[i].Match) > len(sorted[j].Match)
+		})
+		r.routes = sorted
+	}
+	return r
+}
+
+// resolve picks the forwarding target for r. ok is false only when routes are configured but none
+// matches, which the caller turns into a clean error rather than forwarding to a wrong origin.
+func (rt *router) resolve(r *http.Request) (resolvedRoute, bool) {
+	if len(rt.routes) == 0 {
+		return rt.fallback, true
+	}
+	switch rt.mode {
+	case config.RouteModePath:
+		path := r.URL.Path
+		for _, route := range rt.routes {
+			if path == route.Match || strings.HasPrefix(path, route.Match+"/") {
+				return resolvedRoute{
+					upstream:    route.Upstream,
+					provider:    route.Provider,
+					stripPrefix: route.Match,
+				}, true
+			}
+		}
+	default: // host mode
+		host := hostname(r.Host)
+		for _, route := range rt.routes {
+			if strings.EqualFold(host, hostname(route.Match)) {
+				return resolvedRoute{upstream: route.Upstream, provider: route.Provider}, true
+			}
+		}
+	}
+	return resolvedRoute{}, false
+}
+
+// hostname strips an optional :port from a Host header value so host-mode matching compares only
+// the hostname.
+func hostname(h string) string {
+	if i := strings.LastIndexByte(h, ':'); i >= 0 {
+		// Guard against an IPv6 literal without a port ("[::1]"): only treat the tail as a port when
+		// there is no closing bracket after the colon.
+		if !strings.Contains(h[i:], "]") {
+			return h[:i]
+		}
+	}
+	return h
+}

--- a/infra/edge-proxy/internal/proxy/routing.go
+++ b/infra/edge-proxy/internal/proxy/routing.go
@@ -28,19 +28,36 @@ type resolvedRoute struct {
 	stripPrefix string
 }
 
+// compiledRoute is a config.Route with per-route matching data computed once at construction so the
+// hot path stays cheap. In host mode host is the normalized (port-stripped) hostname to compare
+// against; recomputing it per candidate on every request would burn cycles in the p99 budget.
+type compiledRoute struct {
+	config.Route
+	host string
+}
+
 // router selects a resolvedRoute per request.
 type router struct {
 	mode     config.RouteMode
-	routes   []config.Route
+	routes   []compiledRoute
 	fallback resolvedRoute // single-origin target when routes is empty
 }
 
 // newRouter compiles the config route table. When cfg.Routes is empty the router serves only the
 // single-origin fallback, matching every request.
 func newRouter(cfg config.Config) *router {
+	compiled := make([]compiledRoute, len(cfg.Routes))
+	for i, rt := range cfg.Routes {
+		compiled[i] = compiledRoute{Route: rt}
+		// Precompute the normalized host once so resolve does not call hostname() per candidate route
+		// per request on the hot path.
+		if cfg.RouteMode == config.RouteModeHost {
+			compiled[i].host = hostname(rt.Match)
+		}
+	}
 	r := &router{
 		mode:   cfg.RouteMode,
-		routes: cfg.Routes,
+		routes: compiled,
 		fallback: resolvedRoute{
 			upstream: cfg.Upstream,
 			provider: cfg.Provider,
@@ -49,12 +66,9 @@ func newRouter(cfg config.Config) *router {
 	// Path mode matches by longest prefix, so order routes longest-match-first once at startup and
 	// keep the hot path a simple linear scan with no per-request sorting.
 	if r.mode == config.RouteModePath {
-		sorted := make([]config.Route, len(r.routes))
-		copy(sorted, r.routes)
-		sort.SliceStable(sorted, func(i, j int) bool {
-			return len(sorted[i].Match) > len(sorted[j].Match)
+		sort.SliceStable(r.routes, func(i, j int) bool {
+			return len(r.routes[i].Match) > len(r.routes[j].Match)
 		})
-		r.routes = sorted
 	}
 	return r
 }
@@ -80,12 +94,31 @@ func (rt *router) resolve(r *http.Request) (resolvedRoute, bool) {
 	default: // host mode
 		host := hostname(r.Host)
 		for _, route := range rt.routes {
-			if strings.EqualFold(host, hostname(route.Match)) {
+			if strings.EqualFold(host, route.host) {
 				return resolvedRoute{upstream: route.Upstream, provider: route.Provider}, true
 			}
 		}
 	}
 	return resolvedRoute{}, false
+}
+
+// noRouteMessage is the 404 body for a request that matched no configured route. It names what the
+// router matched on (host vs path prefix) so the error is not misleading in path mode.
+func (rt *router) noRouteMessage() string {
+	if rt.mode == config.RouteModePath {
+		return `{"error":"no route for path"}` + "\n"
+	}
+	return `{"error":"no route for host"}` + "\n"
+}
+
+// ensureLeadingSlash guarantees a path (or escaped path) begins with a single slash after the
+// routing prefix is stripped, so the join onto the upstream origin cannot produce a scheme-relative
+// or bare path.
+func ensureLeadingSlash(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
 }
 
 // hostname strips an optional :port from a Host header value so host-mode matching compares only

--- a/infra/edge-proxy/internal/proxy/routing_test.go
+++ b/infra/edge-proxy/internal/proxy/routing_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
@@ -22,25 +23,43 @@ func mustURL(t *testing.T, raw string) *url.URL {
 	return u
 }
 
-// staticResolver is a fixed key-hash -> tenant map for proxy tests.
+// staticResolver is a fixed key-hash -> tenant map for proxy tests. Present keys resolve with a
+// write scope so they pass the proxy's ingest scope gate; scope-specific behavior is exercised by
+// scopeResolver.
 type staticResolver map[string]string
 
-func (s staticResolver) Resolve(keyHash string) (string, bool) {
+func (s staticResolver) Resolve(keyHash string) (string, string, bool) {
 	id, ok := s[keyHash]
-	return id, ok
+	return id, "write", ok
+}
+
+// scopeResolver resolves a single key hash to a fixed tenant and scope, for exercising the proxy's
+// read/write/admin ingest scope gate.
+type scopeResolver struct {
+	keyHash string
+	tenant  string
+	scope   string
+}
+
+func (s scopeResolver) Resolve(keyHash string) (string, string, bool) {
+	if keyHash == s.keyHash {
+		return s.tenant, s.scope, true
+	}
+	return "", "", false
 }
 
 // TestHostRoutingSelectsOrigin verifies host-based routing forwards each hostname to its own
 // upstream, byte-for-byte, and tags the trace with that route's provider metadata.
 func TestHostRoutingSelectsOrigin(t *testing.T) {
-	var openaiHit, anthropicHit bool
+	// atomic: written in the upstream handler goroutines, read in the test goroutine (go test -race).
+	var openaiHit, anthropicHit atomic.Bool
 	openai := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		openaiHit = true
+		openaiHit.Store(true)
 		_, _ = io.WriteString(w, `{"model":"gpt-5","usage":{"prompt_tokens":11,"completion_tokens":7}}`)
 	}))
 	defer openai.Close()
 	anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		anthropicHit = true
+		anthropicHit.Store(true)
 		_, _ = io.WriteString(w, `{"model":"claude","usage":{"input_tokens":3,"output_tokens":9}}`)
 	}))
 	defer anthropic.Close()
@@ -65,8 +84,8 @@ func TestHostRoutingSelectsOrigin(t *testing.T) {
 		t.Fatalf("openai request: %v", err)
 	}
 	_ = resp.Body.Close()
-	if !openaiHit || anthropicHit {
-		t.Fatalf("host routing wrong: openaiHit=%v anthropicHit=%v", openaiHit, anthropicHit)
+	if !openaiHit.Load() || anthropicHit.Load() {
+		t.Fatalf("host routing wrong: openaiHit=%v anthropicHit=%v", openaiHit.Load(), anthropicHit.Load())
 	}
 	sink.waitFor(t, 1)
 	if got := sink.last(); got.Model != "gpt-5" || got.PromptTokens != 11 || got.CompletionTokens != 7 {
@@ -74,7 +93,8 @@ func TestHostRoutingSelectsOrigin(t *testing.T) {
 	}
 
 	// Route to Anthropic by Host header; provider metadata comes from the Anthropic extractor.
-	openaiHit, anthropicHit = false, false
+	openaiHit.Store(false)
+	anthropicHit.Store(false)
 	req2, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages", strings.NewReader(`{}`))
 	req2.Host = "anthropic.proxy.test"
 	resp2, err := http.DefaultClient.Do(req2)
@@ -82,8 +102,8 @@ func TestHostRoutingSelectsOrigin(t *testing.T) {
 		t.Fatalf("anthropic request: %v", err)
 	}
 	_ = resp2.Body.Close()
-	if openaiHit || !anthropicHit {
-		t.Fatalf("host routing wrong on 2nd: openaiHit=%v anthropicHit=%v", openaiHit, anthropicHit)
+	if openaiHit.Load() || !anthropicHit.Load() {
+		t.Fatalf("host routing wrong on 2nd: openaiHit=%v anthropicHit=%v", openaiHit.Load(), anthropicHit.Load())
 	}
 	sink.waitFor(t, 2)
 	if got := sink.last(); got.Model != "claude" || got.PromptTokens != 3 || got.CompletionTokens != 9 {
@@ -144,6 +164,76 @@ func TestPathRoutingStripsPrefix(t *testing.T) {
 	_ = resp.Body.Close()
 	if gotPath != "/v1/chat/completions" {
 		t.Errorf("upstream path = %q, want /v1/chat/completions (prefix stripped)", gotPath)
+	}
+}
+
+// TestPathRoutingPreservesEncodedSegment verifies that stripping the routing prefix keeps a
+// percent-encoded path segment escaped byte-for-byte, so the upstream receives /v1/foo%2Fbar (not
+// the re-encoded /v1/foo/bar). This is the byte-for-byte forwarding invariant on the path-mode hot
+// path, matching host mode and single-origin.
+func TestPathRoutingPreservesEncodedSegment(t *testing.T) {
+	var gotEscaped, gotDecoded string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		gotDecoded = r.URL.Path
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{
+		TenantHeader: "X-Tenant-Key",
+		RouteMode:    config.RouteModePath,
+		Routes:       []config.Route{{Match: "/openai", Upstream: mustURL(t, upstream.URL), Provider: config.ProviderOpenAI}},
+	}
+	front := httptest.NewServer(New(cfg))
+	defer front.Close()
+
+	// Build the request URL with the encoded segment preserved (http.NewRequest would otherwise not
+	// re-encode, but set both Path and RawPath explicitly to be certain the escaped form travels).
+	u := mustURL(t, front.URL)
+	u.Path = "/openai/v1/foo/bar"
+	u.RawPath = "/openai/v1/foo%2Fbar"
+	resp, err := http.Post(u.String(), "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if gotEscaped != "/v1/foo%2Fbar" {
+		t.Errorf("upstream escaped path = %q, want /v1/foo%%2Fbar (encoded segment preserved)", gotEscaped)
+	}
+	if gotDecoded != "/v1/foo/bar" {
+		t.Errorf("upstream decoded path = %q, want /v1/foo/bar", gotDecoded)
+	}
+}
+
+// TestPathRoutingNoMatchReturns404WithPathMessage confirms the 404 body names the path-prefix match
+// mode rather than always claiming "no route for host".
+func TestPathRoutingNoMatchReturns404WithPathMessage(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be reached for an unmatched path")
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{
+		TenantHeader: "X-Tenant-Key",
+		RouteMode:    config.RouteModePath,
+		Routes:       []config.Route{{Match: "/openai", Upstream: mustURL(t, upstream.URL), Provider: config.ProviderOpenAI}},
+	}
+	front := httptest.NewServer(New(cfg))
+	defer front.Close()
+
+	resp, err := http.Get(front.URL + "/unknown/v1/models")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "no route for path") {
+		t.Errorf("404 body = %q, want it to mention \"no route for path\"", string(body))
 	}
 }
 

--- a/infra/edge-proxy/internal/proxy/routing_test.go
+++ b/infra/edge-proxy/internal/proxy/routing_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// mustURL parses a URL or fails the test.
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+// staticResolver is a fixed key-hash -> tenant map for proxy tests.
+type staticResolver map[string]string
+
+func (s staticResolver) Resolve(keyHash string) (string, bool) {
+	id, ok := s[keyHash]
+	return id, ok
+}
+
+// TestHostRoutingSelectsOrigin verifies host-based routing forwards each hostname to its own
+// upstream, byte-for-byte, and tags the trace with that route's provider metadata.
+func TestHostRoutingSelectsOrigin(t *testing.T) {
+	var openaiHit, anthropicHit bool
+	openai := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		openaiHit = true
+		_, _ = io.WriteString(w, `{"model":"gpt-5","usage":{"prompt_tokens":11,"completion_tokens":7}}`)
+	}))
+	defer openai.Close()
+	anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		anthropicHit = true
+		_, _ = io.WriteString(w, `{"model":"claude","usage":{"input_tokens":3,"output_tokens":9}}`)
+	}))
+	defer anthropic.Close()
+
+	cfg := config.Config{
+		TenantHeader: "X-Tenant-Key",
+		RouteMode:    config.RouteModeHost,
+		Routes: []config.Route{
+			{Match: "openai.proxy.test", Upstream: mustURL(t, openai.URL), Provider: config.ProviderOpenAI},
+			{Match: "anthropic.proxy.test", Upstream: mustURL(t, anthropic.URL), Provider: config.ProviderAnthropic},
+		},
+	}
+	sink := &recordingSink{}
+	front := httptest.NewServer(New(cfg, WithSink(sink)))
+	defer front.Close()
+
+	// Route to OpenAI by Host header.
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", strings.NewReader(`{}`))
+	req.Host = "openai.proxy.test"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("openai request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if !openaiHit || anthropicHit {
+		t.Fatalf("host routing wrong: openaiHit=%v anthropicHit=%v", openaiHit, anthropicHit)
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last(); got.Model != "gpt-5" || got.PromptTokens != 11 || got.CompletionTokens != 7 {
+		t.Errorf("openai route trace = %+v, want gpt-5 11/7", got)
+	}
+
+	// Route to Anthropic by Host header; provider metadata comes from the Anthropic extractor.
+	openaiHit, anthropicHit = false, false
+	req2, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages", strings.NewReader(`{}`))
+	req2.Host = "anthropic.proxy.test"
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("anthropic request: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if openaiHit || !anthropicHit {
+		t.Fatalf("host routing wrong on 2nd: openaiHit=%v anthropicHit=%v", openaiHit, anthropicHit)
+	}
+	sink.waitFor(t, 2)
+	if got := sink.last(); got.Model != "claude" || got.PromptTokens != 3 || got.CompletionTokens != 9 {
+		t.Errorf("anthropic route trace = %+v, want claude 3/9", got)
+	}
+}
+
+// TestHostRoutingNoMatchReturns404 confirms a configured route table that matches nothing fails
+// rather than forwarding to a wrong origin.
+func TestHostRoutingNoMatchReturns404(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be reached for an unmatched host")
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{
+		TenantHeader: "X-Tenant-Key",
+		RouteMode:    config.RouteModeHost,
+		Routes:       []config.Route{{Match: "openai.proxy.test", Upstream: mustURL(t, upstream.URL), Provider: config.ProviderOpenAI}},
+	}
+	front := httptest.NewServer(New(cfg))
+	defer front.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, front.URL+"/v1/models", nil)
+	req.Host = "unknown.proxy.test"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestPathRoutingStripsPrefix verifies path-based routing selects the origin by leading prefix and
+// strips that prefix before forwarding, so the upstream sees its own API path.
+func TestPathRoutingStripsPrefix(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = io.WriteString(w, `{"model":"gpt-5","usage":{"prompt_tokens":1,"completion_tokens":2}}`)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{
+		TenantHeader: "X-Tenant-Key",
+		RouteMode:    config.RouteModePath,
+		Routes:       []config.Route{{Match: "/openai", Upstream: mustURL(t, upstream.URL), Provider: config.ProviderOpenAI}},
+	}
+	front := httptest.NewServer(New(cfg))
+	defer front.Close()
+
+	resp, err := http.Post(front.URL+"/openai/v1/chat/completions", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("upstream path = %q, want /v1/chat/completions (prefix stripped)", gotPath)
+	}
+}
+
+// TestAnthropicCredentialPassthrough is the concrete sec 6.4 requirement: the Anthropic route
+// forwards x-api-key and anthropic-version untouched (NOT Authorization), while X-Tenant-Key and
+// the Tally control headers are stripped.
+func TestAnthropicCredentialPassthrough(t *testing.T) {
+	var gotAPIKey, gotVersion, gotAuth string
+	var sawTenant, sawFeature bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		gotAuth = r.Header.Get("Authorization")
+		_, sawTenant = r.Header["X-Tenant-Key"]
+		_, sawFeature = r.Header["X-Tally-Feature-Tag"]
+		_, _ = io.WriteString(w, `{"model":"claude","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{
+		TenantHeader:     "X-Tenant-Key",
+		FeatureTagHeader: "X-Tally-Feature-Tag",
+		RouteMode:        config.RouteModeHost,
+		Routes:           []config.Route{{Match: "anthropic.proxy.test", Upstream: mustURL(t, upstream.URL), Provider: config.ProviderAnthropic}},
+	}
+	front := httptest.NewServer(New(cfg))
+	defer front.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages", strings.NewReader(`{}`))
+	req.Host = "anthropic.proxy.test"
+	req.Header.Set("x-api-key", "sk-ant-realkey")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_acme")
+	req.Header.Set("X-Tally-Feature-Tag", "chat")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if gotAPIKey != "sk-ant-realkey" {
+		t.Errorf("x-api-key = %q, want sk-ant-realkey (forwarded untouched)", gotAPIKey)
+	}
+	if gotVersion != "2023-06-01" {
+		t.Errorf("anthropic-version = %q, want 2023-06-01 (forwarded untouched)", gotVersion)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty (Anthropic uses x-api-key, not Authorization)", gotAuth)
+	}
+	if sawTenant {
+		t.Error("X-Tenant-Key must be stripped before upstream")
+	}
+	if sawFeature {
+		t.Error("X-Tally-Feature-Tag must be stripped before upstream")
+	}
+}

--- a/infra/edge-proxy/internal/proxy/tenant_resolve_test.go
+++ b/infra/edge-proxy/internal/proxy/tenant_resolve_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/edgekeys"
+)
+
+// resolverProxy builds a proxy with a key resolver in front of a recording upstream.
+func resolverProxy(t *testing.T, requireTenant bool, resolver TenantResolver, upstream http.Handler) (*httptest.Server, *recordingSink) {
+	t.Helper()
+	origin := httptest.NewServer(upstream)
+	t.Cleanup(origin.Close)
+	cfg := config.Config{
+		TenantHeader:  "X-Tenant-Key",
+		RequireTenant: requireTenant,
+		Upstream:      mustURL(t, origin.URL),
+	}
+	sink := &recordingSink{}
+	front := httptest.NewServer(New(cfg, WithSink(sink), WithKeyResolver(resolver)))
+	t.Cleanup(front.Close)
+	return front, sink
+}
+
+// echoUpstream returns 200 with a fixed body and records nothing.
+func echoUpstream() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+}
+
+// TestKeyResolveHitStampsTenantId: a known key resolves to its tenant UUID, which lands on the
+// TraceRecord as the canonical tag (sec 6.3), never the raw key string.
+func TestKeyResolveHitStampsTenantId(t *testing.T) {
+	resolver := staticResolver{edgekeys.HashKey("tally_sk_live_acme"): "uuid-acme"}
+	front, sink := resolverProxy(t, true, resolver, echoUpstream())
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_acme")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	sink.waitFor(t, 1)
+	got := sink.last()
+	if got.TenantId != "uuid-acme" {
+		t.Errorf("TenantId = %q, want uuid-acme", got.TenantId)
+	}
+	if got.TenantKey != "tally_sk_live_acme" {
+		t.Errorf("TenantKey = %q, want the presented key", got.TenantKey)
+	}
+}
+
+// TestKeyResolveMissFailsClosed: a key absent from the cache (unknown OR revoked, which the cache
+// represents identically by dropping it) is rejected with 403 when RequireTenant is set, never
+// forwarded unauthenticated.
+func TestKeyResolveMissFailsClosed(t *testing.T) {
+	var forwarded bool
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+	// Cache holds only acme; the revoked/unknown key is simply not present.
+	resolver := staticResolver{edgekeys.HashKey("tally_sk_live_acme"): "uuid-acme"}
+	front, _ := resolverProxy(t, true, resolver, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_revoked")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for unknown/revoked key", resp.StatusCode)
+	}
+	if forwarded {
+		t.Error("unknown key must not be forwarded upstream (fail closed)")
+	}
+}
+
+// TestKeyResolveMissOpenWhenNotRequired: with RequireTenant false, an unresolved key is not
+// rejected; it forwards and simply carries no TenantId (honest blank, not a fabricated tag).
+func TestKeyResolveMissOpenWhenNotRequired(t *testing.T) {
+	resolver := staticResolver{}
+	front, sink := resolverProxy(t, false, resolver, echoUpstream())
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_unknown")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (open when tenant not required)", resp.StatusCode)
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last(); got.TenantId != "" {
+		t.Errorf("TenantId = %q, want empty for an unresolved key", got.TenantId)
+	}
+}
+
+// TestByteForByteUnderRouting: routing and key resolution never touch the body. A 1 MiB payload is
+// echoed back exactly, proving the streaming/no-mutation invariants hold on the routed path.
+func TestByteForByteUnderRouting(t *testing.T) {
+	payload := bytes.Repeat([]byte("A"), 1<<20)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if !bytes.Equal(b, payload) {
+			t.Errorf("upstream received %d bytes, want %d exact", len(b), len(payload))
+		}
+		_, _ = w.Write(b)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{
+		TenantHeader: "X-Tenant-Key",
+		RouteMode:    config.RouteModeHost,
+		Routes:       []config.Route{{Match: "openai.proxy.test", Upstream: mustURL(t, upstream.URL), Provider: config.ProviderOpenAI}},
+	}
+	resolver := staticResolver{edgekeys.HashKey("tally_sk_live_acme"): "uuid-acme"}
+	front := httptest.NewServer(New(cfg, WithKeyResolver(resolver)))
+	defer front.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", bytes.NewReader(payload))
+	req.Host = "openai.proxy.test"
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_acme")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	echoed, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(echoed, payload) {
+		t.Errorf("echoed %d bytes, want %d exact byte-for-byte", len(echoed), len(payload))
+	}
+}

--- a/infra/edge-proxy/internal/proxy/tenant_resolve_test.go
+++ b/infra/edge-proxy/internal/proxy/tenant_resolve_test.go
@@ -111,6 +111,56 @@ func TestKeyResolveMissOpenWhenNotRequired(t *testing.T) {
 	}
 }
 
+// TestKeyResolveReadScopeFailsClosed: a known key whose scope cannot write ingest data (read) is
+// rejected with 403 when RequireTenant is set and never forwarded, matching the gateway's ingest
+// scope gate (CTO-33).
+func TestKeyResolveReadScopeFailsClosed(t *testing.T) {
+	var forwarded bool
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+	resolver := scopeResolver{keyHash: edgekeys.HashKey("tally_sk_live_readonly"), tenant: "uuid-acme", scope: "read"}
+	front, _ := resolverProxy(t, true, resolver, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_readonly")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a read-only key", resp.StatusCode)
+	}
+	if forwarded {
+		t.Error("a read-only key must not be forwarded upstream (fail closed on scope)")
+	}
+}
+
+// TestKeyResolveReadScopeOpenCarriesNoTenantId: with RequireTenant false, a read-only key still
+// forwards but is not attributed (no TenantId), an honest blank rather than a tag for a key that may
+// not write.
+func TestKeyResolveReadScopeOpenCarriesNoTenantId(t *testing.T) {
+	resolver := scopeResolver{keyHash: edgekeys.HashKey("tally_sk_live_readonly"), tenant: "uuid-acme", scope: "read"}
+	front, sink := resolverProxy(t, false, resolver, echoUpstream())
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_readonly")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (open when tenant not required)", resp.StatusCode)
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last(); got.TenantId != "" {
+		t.Errorf("TenantId = %q, want empty for a read-only key", got.TenantId)
+	}
+}
+
 // TestByteForByteUnderRouting: routing and key resolution never touch the body. A 1 MiB payload is
 // echoed back exactly, proving the streaming/no-mutation invariants hold on the routed path.
 func TestByteForByteUnderRouting(t *testing.T) {

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -14,6 +14,14 @@ import (
 type TraceRecord struct {
 	// TenantKey is the ai-tally tenant identifier from the control header (X-Tenant-Key).
 	TenantKey string
+	// TenantId is the canonical tenant UUID the edge key cache resolved from the presented
+	// X-Tenant-Key (Initiative 2 sec 6.3). It is the join key that makes proxy traffic and SDK
+	// traffic for the same org share one TenantId and one Cost Explorer view: when telemetry ships
+	// to EDGE_PROXY_TELEMETRY_URL this UUID lands in otel_spans.TenantId. Empty when no key
+	// resolver is configured (self-host / pass-through) or the key did not resolve. A UUID is not
+	// customer content, so this preserves the metadata-only guarantee; the raw key string is never
+	// emitted as the canonical tag.
+	TenantId string
 	// FeatureTag is the per-request feature/agent identifier from the control header
 	// (X-Tally-Feature-Tag). Optional and informational only — empty when the caller didn't tag
 	// the request. Downstream telemetry uses this to segment cost and traces by feature (CTO-104).


### PR DESCRIPTION
## Initiative 2: Real one-step connect (edge-proxy portion)

Builds sections 6, 6.1, 6.2, 6.3, 6.4 of the Initiative 2 spec. Scope is limited to `infra/edge-proxy/`; web+gateway and sdk/python land in parallel PRs.

### What is built

- **Multi-provider routing (6.1).** New `EDGE_PROXY_ROUTES` (host or path prefix to `{upstream, provider}`, comma-list or JSON) and `EDGE_PROXY_ROUTE_MODE` (`host` default, or `path`). The single-origin `EDGE_PROXY_UPSTREAM` + `EDGE_PROXY_PROVIDER` remains the fallback when no routes are set, so self-host and every existing test are byte-for-byte unaffected. Routing is a pre-forward origin selection only: bodies stay byte-for-byte, `FlushInterval = -1` streaming is unchanged, and the route's `provider` picks the existing `extractMeta` branch (no new parser). Path mode strips the matched prefix before forwarding; a configured table that matches nothing returns `404` rather than forwarding to a wrong origin.
- **Per-provider credential passthrough (6.4).** Each provider's real credential is forwarded untouched while `X-Tenant-Key` and the Tally control headers are stripped. The Anthropic route forwards `x-api-key` and `anthropic-version` (not `Authorization`), asserted by a dedicated test.
- **Fast key-to-tenant resolution (6.2).** New `internal/edgekeys` package: an in-memory `sha256(key) -> {tenant_uuid, scope}` map built from the gateway delta feed `GET /v1/edge/keys?since={cursor}`, refreshed on an interval and applied incrementally with a persisted cursor. `HashKey` matches `gateway/auth.py hash_key` (SHA-256 hex), so the presented `X-Tenant-Key` is resolved locally with no per-request gateway call. Fail-closed `403` on an unknown or revoked key when `EDGE_PROXY_REQUIRE_TENANT=true`; a transient feed error keeps the last good map (never fails open). Authenticated with a server-only `EDGE_PROXY_SERVICE_TOKEN`.
- **Canonical tenant tag (6.3).** Added `TenantId` to `internal/proxy/trace.go`; the proxy stamps the resolved tenant UUID (not the key string or any name) so proxy and SDK traffic share one `TenantId`.

### `/v1/edge/keys` is a separate PR

The gateway endpoint is built by another PR. This PR codes against its contract from spec 6.2 and tests the key cache against a fake HTTP `/v1/edge/keys` server (`internal/edgekeys/edgekeys_test.go`).

### CI commands run and results

From `infra/edge-proxy/`:

- `go build ./...` passes.
- `go test ./...` passes (config, edgekeys, keybroker, proxy, telemetry).
- `go test -race ./...` passes.
- `gofmt -l .` lists nothing.

New tests cover host and path routing (and 404 on no match), path-prefix stripping, the Anthropic `x-api-key` + `anthropic-version` passthrough (Authorization not sent, control headers stripped), edge key cache hit/miss/revoked with delta+cursor sync, `HashKey` parity with the gateway, fail-closed `403` on unknown/revoked keys, `TenantId` stamping, and byte-for-byte 1 MiB forwarding on the routed path. The `TestOverheadBudget` p99 < 3ms test still runs on every `go test` and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
