### PR TITLE
feat: Initiative 2 SDK one-step connect

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -26,7 +26,7 @@ import tally
 
 tally.init("tally_sk_live_...")   # falls back to TALLY_KEY / TALLY_ENDPOINT env
 
-# From here, unmodified provider calls are metered automatically — no record_* calls:
+# From here, unmodified provider calls are metered automatically - no record_* calls:
 client.chat.completions.create(model="gpt-4o-mini", messages=[...])   # openai
 client.messages.create(model="claude-sonnet-4-5", messages=[...])     # anthropic
 ```
@@ -41,7 +41,7 @@ one-time warning. Sync, async (`AsyncOpenAI` / `AsyncAnthropic`), and streaming 
   wrapper add `include_usage` when the caller did not, so streamed calls price fully.
 - **Accounts.** Set the customer once with `with_account("acct_...")`; every auto-instrumented span
   in the scope carries the HMAC'd account hash, computed in-process under the bootstrapped tenant
-  key. Until the bootstrap completes (or if it fails), accounts land unattributed — never a raw id.
+  key. Until the bootstrap completes (or if it fails), accounts land unattributed - never a raw id.
 - **What is automatic vs. app-side.** The one-liner captures LLM provider calls only. Vector search
   (`tally.record_vector_call`), your own tool calls (`tally.record_tool_call`), and embeddings not
   made through the patched client (`tally.record_embedding_call`) remain explicit one-liners that

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -15,6 +15,57 @@ uv run pytest
 Zero runtime dependencies today (the schema + safety + sampling + guardrail primitives are
 pure-Python). OTel/OpenLLMetry integration lands in later tickets.
 
+## One-line connect (CTO-260)
+
+The fastest path. `tally.init(key)` needs no `tenant_id` (the ingest key is tenant-bound at the
+gateway), auto-instruments the official `openai` and `anthropic` clients, boots the per-tenant
+HMAC key off-thread, and installs a background batching transport to `/v1/batches`.
+
+```python
+import tally
+
+tally.init("tally_sk_live_...")   # falls back to TALLY_KEY / TALLY_ENDPOINT env
+
+# From here, unmodified provider calls are metered automatically — no record_* calls:
+client.chat.completions.create(model="gpt-4o-mini", messages=[...])   # openai
+client.messages.create(model="claude-sonnet-4-5", messages=[...])     # anthropic
+```
+
+`init` is idempotent, never blocks the calling thread, and never raises: a bad key, an unreachable
+gateway, or a missing provider library degrades to unattributed or disabled instrumentation with a
+one-time warning. Sync, async (`AsyncOpenAI` / `AsyncAnthropic`), and streaming are all covered.
+
+- **Streaming tokens.** OpenAI reports usage only when `stream_options={"include_usage": True}` is
+  set. By default a stream without it emits a span with **null** token counts (honest blank, never
+  a fabricated zero). Pass `tally.init(..., instrument_stream_usage=True)` to have the OpenAI
+  wrapper add `include_usage` when the caller did not, so streamed calls price fully.
+- **Accounts.** Set the customer once with `with_account("acct_...")`; every auto-instrumented span
+  in the scope carries the HMAC'd account hash, computed in-process under the bootstrapped tenant
+  key. Until the bootstrap completes (or if it fails), accounts land unattributed — never a raw id.
+- **What is automatic vs. app-side.** The one-liner captures LLM provider calls only. Vector search
+  (`tally.record_vector_call`), your own tool calls (`tally.record_tool_call`), and embeddings not
+  made through the patched client (`tally.record_embedding_call`) remain explicit one-liners that
+  delegate to the process-global client. These are safe no-ops before `init`.
+- **Lifecycle.** `tally.flush()` drains buffered spans (also drained at `atexit`); `tally.uninstrument()`
+  reverses all patches and tears the client down (used by tests).
+
+### Hashing an account for the proxy path
+
+The zero-code proxy holds no HMAC key. To send a pre-hashed `X-Tally-Account-Id-Hash`, compute it
+on your own machine with the same key the SDK uses:
+
+```python
+from tally import hash_account
+h = hash_account("acct_northwind")          # uses the bootstrapped tenant key
+```
+
+```bash
+python -m tally.hash_account acct_northwind  # CLI form, reads TALLY_KEY / TALLY_ENDPOINT
+```
+
+> The gateway endpoint `GET /v1/tenant/hmac-key` that the bootstrap fetches is delivered in a
+> separate PR; the SDK codes against its contract (spec §3.2).
+
 ## Tagging spend with a customer account
 
 An `account_id` says which of *your* customers a call belongs to. It is what turns a cost total

--- a/sdk/python/src/tally/__init__.py
+++ b/sdk/python/src/tally/__init__.py
@@ -2,6 +2,45 @@
 """ai-tally Python SDK.
 
 Cost-and-value observability for AI products. OpenTelemetry ``gen_ai.*`` native.
+
+One-line connect (CTO-260)::
+
+    import tally
+
+    tally.init("tally_sk_live_...")   # reads TALLY_KEY / TALLY_ENDPOINT env if omitted
+    # openai / anthropic calls are now auto-instrumented; nothing else to wire up.
+
+The module-level ``record_*`` helpers, ``flush``, ``hash_account``, and the context primitives
+(``with_account`` / ``start_trace``) are re-exported here so the common paths are true one-liners.
 """
 
 __version__ = "0.0.1"
+
+from tally.context import start_trace, with_account, with_trace_context
+from tally.hash_account import hash_account
+from tally.init import (
+    flush,
+    get_client,
+    init,
+    record_embedding_call,
+    record_llm_call,
+    record_tool_call,
+    record_vector_call,
+    uninstrument,
+)
+
+__all__ = [
+    "__version__",
+    "init",
+    "flush",
+    "uninstrument",
+    "get_client",
+    "hash_account",
+    "record_llm_call",
+    "record_tool_call",
+    "record_vector_call",
+    "record_embedding_call",
+    "with_account",
+    "start_trace",
+    "with_trace_context",
+]

--- a/sdk/python/src/tally/context.py
+++ b/sdk/python/src/tally/context.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Context propagation — trace_id + feature_tag that survive async boundaries.
+"""Context propagation - trace_id + feature_tag that survive async boundaries.
 
 The make-or-break piece (CTO-46): if context is lost across an ``await`` / thread / background
 task, attribution and agent trees break. We use :mod:`contextvars`, which propagate correctly
@@ -7,16 +7,16 @@ across ``asyncio`` tasks (each task copies the current context) and stay isolate
 
 Public surface:
 
-- :func:`start_trace` — begin a new trace context (generates a trace_id).
-- :func:`with_trace_context` — context manager to set/restore explicitly (the escape hatch for
+- :func:`start_trace` - begin a new trace context (generates a trace_id).
+- :func:`with_trace_context` - context manager to set/restore explicitly (the escape hatch for
   places where automatic propagation fails: Celery, Temporal, Lambda cold starts, etc.).
-- :func:`current_context` — read the active context.
+- :func:`current_context` - read the active context.
 - :func:`with_account` sets the tenant's own customer (``account_id``) for a block (CTO-181).
-- :func:`note_context_drop` — two modes (CTO-118):
+- :func:`note_context_drop` - two modes (CTO-118):
     (a) record that an expected trace context was missing (feeds
         ``SelfObservability.context_drop_count``); or
     (b) emit ``gen_ai.context.*`` span attributes describing how many messages /
-        tokens were trimmed to fit the model's context window. Counts only — never
+        tokens were trimmed to fit the model's context window. Counts only - never
         the dropped message text.
 
 The account dimension (CTO-181) rides here rather than on every call site. A web app knows which
@@ -36,9 +36,21 @@ from dataclasses import dataclass
 
 from tally.safety import SelfObservability
 
+#: Sentinel for "the feature-tag contextvar was never set in this context", distinct from an
+#: explicit ``None``. Lets a process default fill in for a thread that never ran ``init`` code while
+#: an explicit ``start_trace(feature_tag=None)`` still reads back as ``None`` (CTO-260 §3).
+_UNSET_FEATURE_TAG = "\x00__tally_unset__"
+
 _trace_id: ContextVar[str | None] = ContextVar("tally_trace_id", default=None)
-_feature_tag: ContextVar[str | None] = ContextVar("tally_feature_tag", default=None)
+_feature_tag: ContextVar[str | None] = ContextVar("tally_feature_tag", default=_UNSET_FEATURE_TAG)
 _session_id: ContextVar[str | None] = ContextVar("tally_session_id", default=None)
+
+# Process-wide default feature tag set by ``tally.init(feature_tag=...)``. A ContextVar set in
+# init's calling thread does not reach a gunicorn/Flask worker thread that started fresh, so the
+# spans it emits carried feature_tag=None despite the docstring (review finding). This module-global
+# is consulted at span build when the contextvar is unset, so the default reaches spans emitted from
+# any thread. The contextvar still wins wherever it is set (explicit trace context overrides).
+_process_default_feature_tag: str | None = None
 # Raw account id + optional label (CTO-181). Never emitted raw; see the module docstring.
 _account_id: ContextVar[str | None] = ContextVar("tally_account_id", default=None)
 _account_label: ContextVar[str | None] = ContextVar("tally_account_label", default=None)
@@ -67,18 +79,30 @@ def set_default_feature_tag(feature_tag: str | None) -> None:
     """Set a process default feature tag for the current context (CTO-260 §3).
 
     ``tally.init(feature_tag=...)`` calls this so auto-instrumented spans carry a default tag when
-    the caller has not opened an explicit :func:`start_trace`. It sets the contextvar in the calling
-    thread's context, which asyncio tasks spawned from it then copy; an explicit ``start_trace`` /
-    ``with_trace_context`` still overrides it for its scope.
+    the caller has not opened an explicit :func:`start_trace`. It records a module-global process
+    default (consulted at span build from any thread, including gunicorn/Flask workers that started
+    after ``init``) and also sets the contextvar in the calling thread so asyncio tasks spawned from
+    it copy it directly. An explicit ``start_trace`` / ``with_trace_context`` still overrides it for
+    its scope.
     """
+    global _process_default_feature_tag
+    _process_default_feature_tag = feature_tag
     _feature_tag.set(feature_tag)
+
+
+def _resolve_feature_tag() -> str | None:
+    """The contextvar when it was set in this context, else the process default (CTO-260 §3)."""
+    tag = _feature_tag.get()
+    if tag is _UNSET_FEATURE_TAG:
+        return _process_default_feature_tag
+    return tag
 
 
 def current_context() -> TraceContext:
     """Snapshot the active context (may be inactive)."""
     return TraceContext(
         _trace_id.get(),
-        _feature_tag.get(),
+        _resolve_feature_tag(),
         _session_id.get(),
         _account_id.get(),
         _account_label.get(),
@@ -98,7 +122,7 @@ def with_trace_context(
     """Set the trace context for the duration of the block, then restore prior values.
 
     This is both the normal entrypoint and the manual escape hatch when automatic propagation
-    can't carry context (e.g. across a process/queue boundary — re-establish it on the far side).
+    can't carry context (e.g. across a process/queue boundary - re-establish it on the far side).
 
     Args:
         trace_id: explicit id; if ``None`` and no active trace, a new one is generated.
@@ -204,20 +228,20 @@ def note_context_drop(
 
     Two related signals share this entrypoint (CTO-118):
 
-    1. **Trace-context drop** — no active ``trace_id`` where one was expected. The existing
+    1. **Trace-context drop** - no active ``trace_id`` where one was expected. The existing
        no-arg call path (``note_context_drop(obs, where="record_llm_call")``) keeps working
        and bumps :attr:`SelfObservability.context_drop_count`.
 
-    2. **Context-window drop** — caller trimmed messages before sending to the model to
+    2. **Context-window drop** - caller trimmed messages before sending to the model to
        fit the context window. Pass ``dropped_messages`` (count), ``dropped_tokens``
-       (total tokens of trimmed content), and ``window_used_pct`` (0..1 — how close the
+       (total tokens of trimmed content), and ``window_used_pct`` (0..1 - how close the
        request got to the window). These are promoted to three span attributes:
 
        - ``gen_ai.context.dropped_messages`` (int)
        - ``gen_ai.context.dropped_tokens`` (int)
        - ``gen_ai.context.window_used_pct`` (float)
 
-       Counts only — never the dropped message text. This is the contract.
+       Counts only - never the dropped message text. This is the contract.
 
     Args:
         obs: self-observability sink for the trace-drop counter.
@@ -233,7 +257,7 @@ def note_context_drop(
     """
     out = attrs if attrs is not None else {}
     if dropped_messages is None and dropped_tokens is None and window_used_pct is None:
-        # Legacy trace-context drop path — unchanged behaviour.
+        # Legacy trace-context drop path - unchanged behaviour.
         obs.context_drop_count += 1
         obs.last_errors.append(f"{where}: context drop (no active trace_id)")
         if len(obs.last_errors) > obs._max_errors:

--- a/sdk/python/src/tally/context.py
+++ b/sdk/python/src/tally/context.py
@@ -63,6 +63,17 @@ def new_trace_id() -> str:
     return uuid.uuid4().hex
 
 
+def set_default_feature_tag(feature_tag: str | None) -> None:
+    """Set a process default feature tag for the current context (CTO-260 §3).
+
+    ``tally.init(feature_tag=...)`` calls this so auto-instrumented spans carry a default tag when
+    the caller has not opened an explicit :func:`start_trace`. It sets the contextvar in the calling
+    thread's context, which asyncio tasks spawned from it then copy; an explicit ``start_trace`` /
+    ``with_trace_context`` still overrides it for its scope.
+    """
+    _feature_tag.set(feature_tag)
+
+
 def current_context() -> TraceContext:
     """Snapshot the active context (may be inactive)."""
     return TraceContext(

--- a/sdk/python/src/tally/hash_account.py
+++ b/sdk/python/src/tally/hash_account.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``hash_account`` helper + ``python -m tally.hash_account`` CLI (CTO-260 §7).
+
+The proxy path holds no HMAC key and will not hash a raw customer id for you (that would route the
+raw id through ai-tally, which is exactly what the hash prevents). This helper computes the account
+hash the same way the SDK does, on the caller's own machine: it uses the tenant HMAC key fetched via
+the bootstrap (CTO-260 §3.2) under the org's ingest key, so a proxy user can send a pre-hashed
+``X-Tally-Account-Id-Hash`` and still get per-customer attribution.
+
+If :func:`tally.init` has already run and bootstrapped, this reuses that in-process key. Otherwise
+it performs a one-off synchronous bootstrap from ``key`` / ``TALLY_KEY`` (this helper is not on the
+customer hot path, so a blocking fetch here is acceptable, unlike ``init``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from tally.hmac_keys import HmacKeyRegistry, RemoteKeyMaterialProvider
+from tally.transport import DEFAULT_ENDPOINT, fetch_hmac_key
+
+
+def hash_account(account_id: str, *, key: str | None = None, endpoint: str | None = None) -> str:
+    """Return the HMAC-SHA256 hex of ``account_id`` under the tenant's active key.
+
+    Reuses the process-global registry from :func:`tally.init` when available; else bootstraps once
+    from ``key`` (or ``TALLY_KEY``) and ``endpoint`` (or ``TALLY_ENDPOINT``). Raises ``ValueError``
+    when no key is available or the id is empty, and propagates a bootstrap/network error to the
+    caller: this helper is a deliberate, explicit call, not the never-raise customer hot path.
+    """
+    if not account_id or not account_id.strip():
+        raise ValueError("account_id must be non-empty")
+
+    registry, tenant_id = _resolve_registry(key, endpoint)
+    return registry.hash_account(tenant_id, account_id.strip()).value
+
+
+def _resolve_registry(
+    key: str | None, endpoint: str | None
+) -> tuple[HmacKeyRegistry, str]:
+    # Prefer an already-bootstrapped in-process registry (no second fetch).
+    from tally import init as _init
+
+    client = _init.get_client()
+    if client is not None and client.hmac_registry is not None and client.tenant_id:
+        return client.hmac_registry, client.tenant_id
+
+    resolved_key = key or os.environ.get("TALLY_KEY")
+    if not resolved_key:
+        raise ValueError("no ingest key: pass key= or set TALLY_KEY")
+    resolved_endpoint = endpoint or os.environ.get("TALLY_ENDPOINT") or DEFAULT_ENDPOINT
+
+    boot = fetch_hmac_key(resolved_endpoint, resolved_key)
+    provider = RemoteKeyMaterialProvider(
+        fetch=lambda: fetch_hmac_key(resolved_endpoint, resolved_key)
+    )
+    provider._cache[boot.key_version] = (provider._clock(), boot.material)
+    registry = HmacKeyRegistry(provider=provider)
+    registry.provision(boot.tenant_id, initial_version=boot.key_version)
+    return registry, boot.tenant_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m tally.hash_account",
+        description="Compute the ai-tally account hash for a raw account id, on your own machine.",
+    )
+    parser.add_argument("account_id", help="raw account id, e.g. acct_northwind")
+    parser.add_argument("--key", default=None, help="ingest key (else TALLY_KEY)")
+    parser.add_argument("--endpoint", default=None, help="ingest base URL (else TALLY_ENDPOINT)")
+    args = parser.parse_args(argv)
+
+    try:
+        print(hash_account(args.account_id, key=args.key, endpoint=args.endpoint))
+    except Exception as exc:  # noqa: BLE001 - CLI surfaces the error plainly and exits non-zero
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/src/tally/hmac_keys.py
+++ b/sdk/python/src/tally/hmac_keys.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Per-tenant HMAC versioned-key scheme — Option B rotation (CTO-74 / spec §14.2, §10).
+"""Per-tenant HMAC versioned-key scheme - Option B rotation (CTO-74 / spec §14.2, §10).
 
-User IDs are never stored raw — they're HMAC-SHA256'd under a **per-tenant** key so a hash can't be
+User IDs are never stored raw - they're HMAC-SHA256'd under a **per-tenant** key so a hash can't be
 correlated across tenants and a leaked digest can't be reversed. Two hard requirements drive this
 module:
 
@@ -15,7 +15,7 @@ module:
    attribution still bridges the boundary. A ~90d active-user re-hash backfill migrates the live
    population forward; cold users age out naturally.
 
-The raw key material lives in cloud KMS/Vault in production — never in Postgres or code. That fetch
+The raw key material lives in cloud KMS/Vault in production - never in Postgres or code. That fetch
 is abstracted behind :class:`KeyMaterialProvider`; :class:`InMemoryKeyMaterialProvider` derives
 deterministic material from a root secret so dev/test needs no KMS. (Encrypted volumes, TLS 1.3, and
 the real KMS wiring are the infra half of CTO-74 and are out of scope for this module.)
@@ -72,7 +72,7 @@ class KeyMaterialProvider(Protocol):
     """Fetches raw HMAC key material for ``(tenant_id, key_version)``.
 
     Backed by KMS/Vault in prod; the returned bytes are used transiently and never persisted by the
-    application (spec §14.2 — no secrets in Postgres or code).
+    application (spec §14.2 - no secrets in Postgres or code).
     """
 
     def material(self, tenant_id: str, key_version: str) -> bytes: ...
@@ -82,7 +82,7 @@ class KeyMaterialProvider(Protocol):
 class InMemoryKeyMaterialProvider:
     """Deterministically derives per-(tenant, version) key material from a root secret.
 
-    Reproducible for tests and dev with no KMS. NOT for production — the root secret would itself
+    Reproducible for tests and dev with no KMS. NOT for production - the root secret would itself
     need to live in KMS.
     """
 
@@ -126,7 +126,7 @@ class RemoteKeyMaterialProvider:
         entry = self._cache.get(key_version)
         if entry is not None and self._fresh(entry):
             return entry[1]
-        # Stale or missing — re-fetch. The response is authoritative for the *active* version.
+        # Stale or missing - re-fetch. The response is authoritative for the *active* version.
         boot = self.fetch()
         self._cache[boot.key_version] = (self._clock(), boot.material)
         if boot.key_version == key_version:
@@ -200,7 +200,7 @@ class HmacKeyRegistry:
         return self.hash_with(tenant_id, user_id, version)
 
     def hash_with(self, tenant_id: str, user_id: str, key_version: str) -> StampedHash:
-        """Hash under a specific version — used for re-hash backfill and historical verification."""
+        """Hash under a specific version - used for re-hash backfill and historical verification."""
         self._require_provisioned(tenant_id)
         if key_version not in self._versions[tenant_id]:
             raise ValueError(f"unknown key_version {key_version!r} for tenant {tenant_id!r}")

--- a/sdk/python/src/tally/hmac_keys.py
+++ b/sdk/python/src/tally/hmac_keys.py
@@ -25,8 +25,9 @@ from __future__ import annotations
 
 import hashlib
 import hmac as _hmac
-from collections.abc import Iterable
-from dataclasses import dataclass
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
@@ -35,6 +36,20 @@ from tally.identity import IdentityGraph, IdentityType
 UTC = timezone.utc
 
 DEFAULT_INITIAL_VERSION = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class HmacKeyBootstrap:
+    """The material a tenant's ``GET /v1/tenant/hmac-key`` response hands back (CTO-260 §3.2).
+
+    ``material`` is the raw HMAC key bytes for the tenant's *active* version only. It is sensitive:
+    held in process memory, never logged, never persisted, never placed on a span or the wire.
+    """
+
+    tenant_id: str
+    key_version: str
+    material: bytes
+    algorithm: str = "HMAC-SHA256"
 
 
 def _hmac_digest(value: str, key: bytes) -> bytes:
@@ -79,6 +94,48 @@ class InMemoryKeyMaterialProvider:
         if not key_version:
             raise ValueError("key_version must be non-empty")
         return _hmac_digest(f"{tenant_id}:{key_version}", self.root_secret)
+
+
+@dataclass(slots=True)
+class RemoteKeyMaterialProvider:
+    """Serves HMAC material from ``GET /v1/tenant/hmac-key``, cached with a TTL (CTO-260 §3.2).
+
+    The SDK does not derive material locally the way :class:`InMemoryKeyMaterialProvider` does; it
+    fetches the tenant's own active key once (authenticated by the ingest key) and caches it in
+    process memory. ``fetch`` is injected so this stays transport-agnostic and testable: it returns
+    an :class:`HmacKeyBootstrap` (or raises). On TTL expiry the next :meth:`material` call
+    re-fetches, which is also how a server-side rotation is picked up (a higher ``key_version``).
+
+    The material is never logged or persisted here; only the raw bytes are held, keyed by version.
+    """
+
+    fetch: Callable[[], HmacKeyBootstrap]
+    ttl_seconds: float = 3600.0
+    _clock: Callable[[], float] = time.monotonic
+    #: version -> (fetched_at_monotonic, material bytes)
+    _cache: dict[str, tuple[float, bytes]] = field(default_factory=dict)
+
+    def _fresh(self, entry: tuple[float, bytes]) -> bool:
+        return (self._clock() - entry[0]) < self.ttl_seconds
+
+    def material(self, tenant_id: str, key_version: str) -> bytes:
+        if not tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if not key_version:
+            raise ValueError("key_version must be non-empty")
+        entry = self._cache.get(key_version)
+        if entry is not None and self._fresh(entry):
+            return entry[1]
+        # Stale or missing — re-fetch. The response is authoritative for the *active* version.
+        boot = self.fetch()
+        self._cache[boot.key_version] = (self._clock(), boot.material)
+        if boot.key_version == key_version:
+            return boot.material
+        # The caller asked for a version the server no longer serves as active. Fall back to a
+        # still-cached (possibly stale) copy so historical hashes verify; else it is unknown.
+        if entry is not None:
+            return entry[1]
+        raise ValueError(f"no material for key_version {key_version!r}")
 
 
 @dataclass(frozen=True, slots=True)

--- a/sdk/python/src/tally/init.py
+++ b/sdk/python/src/tally/init.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``tally.init`` — one-line connect (CTO-260 §3).
+
+``tally.init(key)`` installs one process-global :class:`~tally.client.TallyClient`, wires a
+background batching transport (CTO-260 §5), boots the per-tenant HMAC key off-thread (CTO-260 §3.2),
+and monkeypatches the official ``openai`` / ``anthropic`` clients (CTO-260 §4). It is:
+
+- **Tenant-free.** The ingest key is tenant-bound at the gateway, so no ``tenant_id`` is needed; the
+  tenant UUID comes back once from the bootstrap and is used only as a local hash-registry key,
+  never sent on the wire (CTO-260 §3.1).
+- **Idempotent.** A second call returns the same client and does not double-patch.
+- **Non-blocking.** No network I/O runs on the calling thread; the HMAC bootstrap and transport run
+  off-thread.
+- **Never-raise.** A bad key, an unreachable gateway, or a missing provider library degrades to
+  unattributed or disabled instrumentation with a one-time warning, never an exception into the
+  caller.
+
+Before the bootstrap completes (or if it fails), account ids land in the ``UNATTRIBUTED`` bucket
+rather than raw on the wire (CTO-260 §3.3): LLM cost and model still flow, only the per-customer
+dimension waits for the key.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+from tally import context
+from tally.client import TallyClient
+from tally.hmac_keys import HmacKeyBootstrap, HmacKeyRegistry, RemoteKeyMaterialProvider
+from tally.instrumentation.patch import patch_anthropic, patch_openai, unpatch_all
+from tally.pricing import PriceCatalog, seed_catalog
+from tally.safety import SelfObservability
+from tally.transport import DEFAULT_ENDPOINT, BatchingTransport, fetch_hmac_key
+
+_log = logging.getLogger("tally")
+
+_lock = threading.RLock()
+_client: TallyClient | None = None
+_transport: BatchingTransport | None = None
+_obs: SelfObservability | None = None
+_key: str | None = None
+_endpoint: str | None = None
+_warned_uninit: set[str] = set()
+_warned_bootstrap = False
+
+
+def init(
+    key: str | None = None,
+    *,
+    endpoint: str | None = None,
+    feature_tag: str | None = None,
+    instrument: bool = True,
+    instrument_stream_usage: bool = False,
+    flush_interval_s: float = 1.0,
+    catalog: PriceCatalog | None = None,
+) -> TallyClient:
+    """Connect the process to ai-tally in one line. Idempotent, non-blocking, never raises.
+
+    Args mirror the spec (CTO-260 §3). ``key`` falls back to ``TALLY_KEY``; ``endpoint`` to
+    ``TALLY_ENDPOINT`` then the hosted default. Returns the process-global client (also usable
+    directly, though the module-level ``record_*`` helpers make that unnecessary).
+    """
+    global _client, _transport, _obs, _key, _endpoint
+
+    with _lock:
+        if _client is not None:
+            # Idempotent: a second init does not rebuild the client or double-patch.
+            return _client
+
+        obs = SelfObservability()
+        _obs = obs
+        try:
+            resolved_key = key or os.environ.get("TALLY_KEY")
+            resolved_endpoint = (
+                endpoint or os.environ.get("TALLY_ENDPOINT") or DEFAULT_ENDPOINT
+            )
+            resolved_catalog = catalog or seed_catalog()
+
+            if feature_tag:
+                context.set_default_feature_tag(feature_tag)
+
+            if not resolved_key:
+                # No key: degrade to a disabled client (spans buffer nowhere) with one warning,
+                # rather than raising. Instrumentation is skipped since it could not ship anyway.
+                _log.warning(
+                    "tally.init() called with no key (and no TALLY_KEY); telemetry disabled"
+                )
+                _client = TallyClient(catalog=resolved_catalog, observability=obs)
+                return _client
+
+            from tally import __version__
+
+            transport = BatchingTransport(
+                resolved_endpoint,
+                resolved_key,
+                sdk_version=__version__,
+                observability=obs,
+                flush_interval_s=flush_interval_s,
+            )
+            transport.start()
+
+            client = TallyClient(
+                api_key=resolved_key,
+                endpoint=resolved_endpoint,
+                exporter=transport,
+                catalog=resolved_catalog,
+                observability=obs,
+            )
+
+            _client = client
+            _transport = transport
+            _key = resolved_key
+            _endpoint = resolved_endpoint
+
+            # HMAC bootstrap off-thread: never block init (CTO-260 §3.2).
+            threading.Thread(
+                target=_bootstrap_hmac,
+                args=(client, resolved_endpoint, resolved_key, obs),
+                name="tally-hmac-bootstrap",
+                daemon=True,
+            ).start()
+
+            if instrument:
+                account_resolver = lambda: client._resolve_account(None, None)  # noqa: E731
+                patch_openai(
+                    on_span=client.ingest_span,
+                    obs=obs,
+                    catalog=resolved_catalog,
+                    account_resolver=account_resolver,
+                    instrument_stream_usage=instrument_stream_usage,
+                )
+                patch_anthropic(
+                    on_span=client.ingest_span,
+                    obs=obs,
+                    catalog=resolved_catalog,
+                    account_resolver=account_resolver,
+                )
+
+            return client
+        except BaseException as exc:  # noqa: BLE001 - init must never raise into the caller
+            obs.record_error(exc, "tally.init")
+            if _client is None:
+                _client = TallyClient(observability=obs)
+            return _client
+
+
+def _bootstrap_hmac(
+    client: TallyClient, endpoint: str, key: str, obs: SelfObservability
+) -> None:
+    """Fetch the tenant's active HMAC material once and install a cached registry. Never raises.
+
+    On any failure the account dimension stays unattributed (CTO-260 §3.3) — the raw id is never
+    substituted, cost/model spans keep flowing, and only the per-customer tag waits for the key.
+    """
+    global _warned_bootstrap
+    try:
+        boot = fetch_hmac_key(endpoint, key)
+        registry = _registry_from_bootstrap(boot, endpoint, key)
+        # Mutating these two attributes is the whole handoff: _resolve_account reads them live, so
+        # spans after this point carry the HMAC'd account, and ones before stay honest-blank.
+        client.tenant_id = boot.tenant_id
+        client.hmac_registry = registry
+    except BaseException as exc:  # noqa: BLE001 - bootstrap failure must never crash the SDK
+        obs.record_error(exc, "tally.hmac_bootstrap")
+        if not _warned_bootstrap:
+            _warned_bootstrap = True
+            _log.warning(
+                "tally: HMAC bootstrap failed (%s); accounts emitted unattributed", exc
+            )
+
+
+def _registry_from_bootstrap(
+    boot: HmacKeyBootstrap, endpoint: str, key: str
+) -> HmacKeyRegistry:
+    """Build a registry backed by a TTL-cached remote provider, primed with the first fetch."""
+    provider = RemoteKeyMaterialProvider(fetch=lambda: fetch_hmac_key(endpoint, key))
+    # Prime the cache so hashing does not re-fetch until the TTL lapses.
+    provider._cache[boot.key_version] = (provider._clock(), boot.material)
+    registry = HmacKeyRegistry(provider=provider)
+    registry.provision(boot.tenant_id, initial_version=boot.key_version)
+    return registry
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle
+# --------------------------------------------------------------------------- #
+def flush(timeout: float = 5.0) -> None:
+    """Drain buffered spans to the gateway synchronously (bounded). Safe no-op before init."""
+    transport = _transport
+    if transport is not None:
+        transport.flush(timeout=timeout)
+
+
+def uninstrument() -> None:
+    """Reverse all provider patches and tear down the process-global client (CTO-260 §4.1).
+
+    Tests call this between cases to avoid cross-test leakage; a subsequent :func:`init` starts
+    fresh.
+    """
+    global _client, _transport, _obs, _key, _endpoint
+    with _lock:
+        unpatch_all()
+        if _transport is not None:
+            _transport.stop(timeout=2.0)
+        _client = None
+        _transport = None
+        _obs = None
+        _key = None
+        _endpoint = None
+
+
+def get_client() -> TallyClient | None:
+    """The process-global client, or ``None`` before :func:`init`."""
+    return _client
+
+
+# --------------------------------------------------------------------------- #
+# Module-level convenience: delegate to the process-global client (CTO-260 §3.1)
+# --------------------------------------------------------------------------- #
+def _warn_uninit(name: str) -> None:
+    if name in _warned_uninit:
+        return
+    _warned_uninit.add(name)
+    _log.warning("tally.%s() called before tally.init(); ignored", name)
+
+
+def record_llm_call(**kwargs):
+    """Record an LLM call via the process-global client. Safe no-op before ``init``."""
+    client = _client
+    if client is None:
+        _warn_uninit("record_llm_call")
+        return None
+    return client.record_llm_call(**kwargs)
+
+
+def record_tool_call(**kwargs):
+    """Record a tool call via the process-global client. Safe no-op before ``init``."""
+    client = _client
+    if client is None:
+        _warn_uninit("record_tool_call")
+        return None
+    return client.record_tool_call(**kwargs)
+
+
+def record_vector_call(**kwargs):
+    """Record a vector-DB call via the process-global client. Safe no-op before ``init``."""
+    client = _client
+    if client is None:
+        _warn_uninit("record_vector_call")
+        return None
+    return client.record_vector_call(**kwargs)
+
+
+def record_embedding_call(**kwargs):
+    """Record an embedding call via the process-global client. Safe no-op before ``init``."""
+    client = _client
+    if client is None:
+        _warn_uninit("record_embedding_call")
+        return None
+    return client.record_embedding_call(**kwargs)

--- a/sdk/python/src/tally/init.py
+++ b/sdk/python/src/tally/init.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""``tally.init`` — one-line connect (CTO-260 §3).
+"""``tally.init`` - one-line connect (CTO-260 §3).
 
 ``tally.init(key)`` installs one process-global :class:`~tally.client.TallyClient`, wires a
 background batching transport (CTO-260 §5), boots the per-tenant HMAC key off-thread (CTO-260 §3.2),
@@ -151,7 +151,7 @@ def _bootstrap_hmac(
 ) -> None:
     """Fetch the tenant's active HMAC material once and install a cached registry. Never raises.
 
-    On any failure the account dimension stays unattributed (CTO-260 §3.3) — the raw id is never
+    On any failure the account dimension stays unattributed (CTO-260 §3.3) - the raw id is never
     substituted, cost/model spans keep flowing, and only the per-customer tag waits for the key.
     """
     global _warned_bootstrap

--- a/sdk/python/src/tally/instrumentation/__init__.py
+++ b/sdk/python/src/tally/instrumentation/__init__.py
@@ -1,30 +1,60 @@
 # SPDX-License-Identifier: Apache-2.0
 """Auto-instrumentation — provider call wrappers that emit conformant spans.
 
-Implements CTO-48 (OpenAI first).
+Implements CTO-48 (OpenAI first) and CTO-260 (the one-line ``tally.init`` path: Anthropic, async,
+streaming, and the ``patch_openai`` / ``patch_anthropic`` monkeypatchers).
 
 The design is pluggable: a :class:`ProviderInstrumentor` knows how to (a) extract token usage from a
-provider response and (b) name the model/system. Everything else — building the conformant span via
-:mod:`tally.schema`, pricing via :mod:`tally.pricing`, and the never-crash boundary — is shared, so
-adding a new provider is just another extractor (no core change).
+provider response and (b) name the model/system/operation. Everything else — building the conformant
+span via :mod:`tally.schema`, pricing via :mod:`tally.pricing`, and the never-crash boundary — is
+shared, so adding a new provider is just another extractor (no core change).
 
 Instrumentation must NEVER swallow the provider's own exceptions (the customer needs their real
 API errors). Only *our* span-building runs inside the safety boundary.
 """
 
+from tally.instrumentation.anthropic import (
+    AnthropicInstrumentor,
+    instrument_anthropic_create,
+)
 from tally.instrumentation.base import (
     ProviderInstrumentor,
+    StreamInstrumentor,
     Usage,
     build_span,
     wrap_create,
+    wrap_create_async,
+    wrap_stream,
+    wrap_stream_async,
 )
-from tally.instrumentation.openai import OpenAIInstrumentor, instrument_openai_create
+from tally.instrumentation.openai import (
+    OpenAIEmbeddingsInstrumentor,
+    OpenAIInstrumentor,
+    OpenAIResponsesInstrumentor,
+    instrument_openai_create,
+)
+from tally.instrumentation.patch import (
+    patch_anthropic,
+    patch_openai,
+    unpatch_all,
+)
 
 __all__ = [
     "ProviderInstrumentor",
+    "StreamInstrumentor",
     "Usage",
     "build_span",
     "wrap_create",
+    "wrap_create_async",
+    "wrap_stream",
+    "wrap_stream_async",
     "OpenAIInstrumentor",
+    "OpenAIResponsesInstrumentor",
+    "OpenAIEmbeddingsInstrumentor",
     "instrument_openai_create",
+    "AnthropicInstrumentor",
+    "instrument_anthropic_create",
+    "patch_openai",
+    "patch_anthropic",
+    "unpatch_all",
 ]

--- a/sdk/python/src/tally/instrumentation/__init__.py
+++ b/sdk/python/src/tally/instrumentation/__init__.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Auto-instrumentation — provider call wrappers that emit conformant spans.
+"""Auto-instrumentation - provider call wrappers that emit conformant spans.
 
 Implements CTO-48 (OpenAI first) and CTO-260 (the one-line ``tally.init`` path: Anthropic, async,
 streaming, and the ``patch_openai`` / ``patch_anthropic`` monkeypatchers).
 
 The design is pluggable: a :class:`ProviderInstrumentor` knows how to (a) extract token usage from a
-provider response and (b) name the model/system/operation. Everything else — building the conformant
-span via :mod:`tally.schema`, pricing via :mod:`tally.pricing`, and the never-crash boundary — is
+provider response and (b) name the model/system/operation. Everything else - building the conformant
+span via :mod:`tally.schema`, pricing via :mod:`tally.pricing`, and the never-crash boundary - is
 shared, so adding a new provider is just another extractor (no core change).
 
 Instrumentation must NEVER swallow the provider's own exceptions (the customer needs their real

--- a/sdk/python/src/tally/instrumentation/anthropic.py
+++ b/sdk/python/src/tally/instrumentation/anthropic.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Anthropic instrumentor — Messages API, sync/async/streaming (CTO-260 §4.1/§4.2/§4.3).
+"""Anthropic instrumentor - Messages API, sync/async/streaming (CTO-260 §4.1/§4.2/§4.3).
 
 Mirrors :mod:`tally.instrumentation.openai`. A pure function over a provider response object,
 testable with fakes and no network. Reads only ``usage`` / ``model`` metadata:

--- a/sdk/python/src/tally/instrumentation/anthropic.py
+++ b/sdk/python/src/tally/instrumentation/anthropic.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Anthropic instrumentor — Messages API, sync/async/streaming (CTO-260 §4.1/§4.2/§4.3).
+
+Mirrors :mod:`tally.instrumentation.openai`. A pure function over a provider response object,
+testable with fakes and no network. Reads only ``usage`` / ``model`` metadata:
+
+* ``usage.input_tokens``            -> ``gen_ai.usage.input_tokens``
+* ``usage.output_tokens``           -> ``gen_ai.usage.output_tokens``
+* ``usage.cache_read_input_tokens`` -> ``gen_ai.usage.cached_input_tokens`` (where present)
+
+Streaming: Anthropic reports input tokens on the ``message_start`` event and the running output
+count on ``message_delta`` events, so :meth:`accumulate` folds both and :meth:`finalize` returns
+the terminal totals. A stream that never yields a usage-bearing event finalizes to ``None`` usage
+(honest null tokens, never a fabricated zero).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tally.instrumentation.base import ProviderInstrumentor, wrap_create
+from tally.pricing import PriceCatalog, Usage
+from tally.safety import SelfObservability
+
+
+def _get(obj: object, key: str, default: object = None) -> object:
+    """Attribute-or-key accessor (supports SDK objects and dicts)."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _usage_from(usage: object) -> Usage | None:
+    if usage is None:
+        return None
+    input_tokens = int(_get(usage, "input_tokens", 0) or 0)
+    output_tokens = int(_get(usage, "output_tokens", 0) or 0)
+    cached = int(_get(usage, "cache_read_input_tokens", 0) or 0)
+    return Usage(
+        input_tokens=input_tokens, output_tokens=output_tokens, cached_input_tokens=cached
+    )
+
+
+class AnthropicInstrumentor:
+    """Anthropic Messages API (``client.messages.create`` and ``client.messages.stream``)."""
+
+    system = "anthropic"
+    operation = "chat"
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None:
+        return kwargs.get("model")
+
+    def response_model(self, response: object) -> str | None:
+        model = _get(response, "model")
+        return model if isinstance(model, str) else None
+
+    def extract_usage(self, response: object) -> Usage | None:
+        return _usage_from(_get(response, "usage"))
+
+    # --- streaming (CTO-260 §4.3) ---
+    def accumulate(self, state: dict, chunk: object) -> None:
+        event_type = _get(chunk, "type")
+        # message_start carries the input tokens and the model on a nested message object.
+        message = _get(chunk, "message")
+        if message is not None:
+            model = _get(message, "model")
+            if isinstance(model, str) and model:
+                state["model"] = model
+            start_usage = _get(message, "usage")
+            if start_usage is not None:
+                state["input_tokens"] = int(_get(start_usage, "input_tokens", 0) or 0)
+                cached = _get(start_usage, "cache_read_input_tokens")
+                if cached is not None:
+                    state["cached_input_tokens"] = int(cached or 0)
+                # A final message (used to seed usage when the caller never iterated events)
+                # carries the full output count on the same usage object.
+                message_output = _get(start_usage, "output_tokens")
+                if message_output is not None:
+                    state["output_tokens"] = int(message_output or 0)
+        # message_delta carries the running output token count.
+        delta_usage = _get(chunk, "usage")
+        if delta_usage is not None and event_type != "message_start":
+            output = _get(delta_usage, "output_tokens")
+            if output is not None:
+                state["output_tokens"] = int(output or 0)
+            model = _get(chunk, "model")
+            if isinstance(model, str) and model:
+                state.setdefault("model", model)
+
+    def finalize(self, state: dict) -> tuple[str | None, Usage | None]:
+        if "input_tokens" not in state and "output_tokens" not in state:
+            return state.get("model"), None
+        usage = Usage(
+            input_tokens=int(state.get("input_tokens", 0)),
+            output_tokens=int(state.get("output_tokens", 0)),
+            cached_input_tokens=int(state.get("cached_input_tokens", 0)),
+        )
+        return state.get("model"), usage
+
+
+# satisfy the Protocol at import time (structural; a no-op assertion for readers)
+_INSTRUMENTOR: ProviderInstrumentor = AnthropicInstrumentor()
+
+
+def instrument_anthropic_create(
+    create_fn: Callable[..., object],
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+) -> Callable[..., object]:
+    """Wrap ``client.messages.create`` so each call emits a conformant span (sync)."""
+    return wrap_create(
+        create_fn,
+        AnthropicInstrumentor(),
+        on_span=on_span,
+        obs=obs,
+        catalog=catalog,
+        tenant_id=tenant_id,
+    )

--- a/sdk/python/src/tally/instrumentation/base.py
+++ b/sdk/python/src/tally/instrumentation/base.py
@@ -22,7 +22,8 @@ Two invariants ride through every wrapper here and are not negotiable (CLAUDE.md
 from __future__ import annotations
 
 import functools
-from collections.abc import AsyncIterator, Callable, Iterator
+import inspect
+from collections.abc import Callable
 from datetime import date
 from typing import Protocol
 
@@ -136,7 +137,7 @@ def wrap_create(
 ) -> Callable[..., object]:
     """Wrap a sync provider ``create``-style callable so each successful call emits a span.
 
-    The provider call itself is NOT guarded — its exceptions propagate to the caller unchanged.
+    The provider call itself is NOT guarded - its exceptions propagate to the caller unchanged.
     Only span building + ``on_span`` run inside the safety boundary, so instrumentation can never
     break the customer's call.
     """
@@ -144,7 +145,7 @@ def wrap_create(
 
     @functools.wraps(create_fn)
     def wrapper(*args, **kwargs):
-        response = create_fn(*args, **kwargs)  # provider errors propagate — by design
+        response = create_fn(*args, **kwargs)  # provider errors propagate - by design
         with safe_block(observ, where=f"instrument.{instrumentor.system}"):
             attrs = build_span(
                 instrumentor,
@@ -180,7 +181,7 @@ def wrap_create_async(
 
     @functools.wraps(create_fn)
     async def wrapper(*args, **kwargs):
-        response = await create_fn(*args, **kwargs)  # provider errors propagate — by design
+        response = await create_fn(*args, **kwargs)  # provider errors propagate - by design
         with safe_block(observ, where=f"instrument.{instrumentor.system}"):
             attrs = build_span(
                 instrumentor,
@@ -202,7 +203,7 @@ class StreamInstrumentor(Protocol):
 
     ``accumulate`` folds one chunk/event into an opaque per-stream ``state`` dict (never shared,
     so concurrent streams cannot cross-contaminate). ``finalize`` reads the accumulated state and
-    returns ``(model, usage)`` — ``usage`` is ``None`` when the stream carried no terminal usage
+    returns ``(model, usage)`` - ``usage`` is ``None`` when the stream carried no terminal usage
     event, which yields an honest null-token span rather than a fabricated zero (CTO-260 §4.3).
     """
 
@@ -273,6 +274,120 @@ def _emit_stream_span(
         on_span(build_span_attributes(fields))
 
 
+class _InstrumentedStream:
+    """Pass-through wrapper over a provider sync ``Stream`` object (CTO-260 §4.3, review finding).
+
+    Yields each chunk untouched while folding usage/model, and emits the terminal span exactly once
+    (when iteration is exhausted or the ``with`` block exits, whichever comes first). Crucially it
+    preserves the underlying object: attribute access is delegated (``.response``, ``.close()``) and
+    the context-manager protocol is honored, so ``with client.chat.completions.create(stream=True)
+    as s:`` and ``s.response`` keep working instead of breaking on a bare generator.
+    """
+
+    def __init__(self, raw, instrumentor, emit):
+        object.__setattr__(self, "_raw", raw)
+        object.__setattr__(self, "_instr", instrumentor)
+        object.__setattr__(self, "_emit", emit)
+        object.__setattr__(self, "_state", {})
+        object.__setattr__(self, "_emitted", False)
+
+    def _emit_once(self):
+        if not object.__getattribute__(self, "_emitted"):
+            object.__setattr__(self, "_emitted", True)
+            object.__getattribute__(self, "_emit")(object.__getattribute__(self, "_state"))
+
+    def __iter__(self):
+        instr = object.__getattribute__(self, "_instr")
+        state = object.__getattribute__(self, "_state")
+        try:
+            for chunk in object.__getattribute__(self, "_raw"):
+                _safe_accumulate(instr, state, chunk)
+                yield chunk
+        finally:
+            self._emit_once()
+
+    def __enter__(self):
+        enter = getattr(object.__getattribute__(self, "_raw"), "__enter__", None)
+        if callable(enter):
+            enter()
+        return self
+
+    def __exit__(self, *exc):
+        try:
+            raw = object.__getattribute__(self, "_raw")
+            exit_ = getattr(raw, "__exit__", None)
+            if callable(exit_):
+                return exit_(*exc)
+            close = getattr(raw, "close", None)
+            if callable(close):
+                close()
+            return False
+        finally:
+            self._emit_once()
+
+    def __getattr__(self, name):
+        # Delegate everything else (response, close, ...) to the real Stream object.
+        return getattr(object.__getattribute__(self, "_raw"), name)
+
+
+class _InstrumentedAsyncStream:
+    """Async counterpart of :class:`_InstrumentedStream`, preserving the async ``Stream`` object."""
+
+    def __init__(self, raw, instrumentor, emit):
+        object.__setattr__(self, "_raw", raw)
+        object.__setattr__(self, "_instr", instrumentor)
+        object.__setattr__(self, "_emit", emit)
+        object.__setattr__(self, "_state", {})
+        object.__setattr__(self, "_emitted", False)
+
+    def _emit_once(self):
+        if not object.__getattribute__(self, "_emitted"):
+            object.__setattr__(self, "_emitted", True)
+            object.__getattribute__(self, "_emit")(object.__getattribute__(self, "_state"))
+
+    async def __aiter__(self):
+        instr = object.__getattribute__(self, "_instr")
+        state = object.__getattribute__(self, "_state")
+        try:
+            async for chunk in object.__getattribute__(self, "_raw"):
+                _safe_accumulate(instr, state, chunk)
+                yield chunk
+        finally:
+            self._emit_once()
+
+    async def __aenter__(self):
+        aenter = getattr(object.__getattribute__(self, "_raw"), "__aenter__", None)
+        if callable(aenter):
+            await aenter()
+        return self
+
+    async def __aexit__(self, *exc):
+        try:
+            raw = object.__getattribute__(self, "_raw")
+            aexit = getattr(raw, "__aexit__", None)
+            if callable(aexit):
+                return await aexit(*exc)
+            aclose = getattr(raw, "aclose", None) or getattr(raw, "close", None)
+            if callable(aclose):
+                result = aclose()
+                if inspect.isawaitable(result):
+                    await result
+            return False
+        finally:
+            self._emit_once()
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_raw"), name)
+
+
+def _safe_accumulate(instrumentor: StreamInstrumentor, state: dict, chunk: object) -> None:
+    """Fold one chunk into per-stream state. Must never break the caller's iteration."""
+    try:
+        instrumentor.accumulate(state, chunk)
+    except Exception:  # noqa: BLE001 - a bad chunk must never raise into the customer's loop
+        pass
+
+
 def wrap_stream(
     stream_fn: Callable[..., object],
     instrumentor: StreamInstrumentor,
@@ -285,37 +400,31 @@ def wrap_stream(
 ) -> Callable[..., object]:
     """Wrap a sync streaming ``create(stream=True)`` call (CTO-260 §4.3).
 
-    Returns a thin pass-through iterator that yields each chunk untouched and folds usage/model
-    from the terminal event; the span is emitted once, when the stream is exhausted. The stream is
-    never buffered or altered.
+    Returns a pass-through proxy that yields each chunk untouched and folds usage/model from the
+    terminal event; the span is emitted once, when the stream is exhausted or its ``with`` block
+    exits. The stream is never buffered or altered, and the underlying provider ``Stream`` object's
+    attributes and context-manager protocol are preserved.
     """
     observ = obs or SelfObservability()
 
     @functools.wraps(stream_fn)
     def wrapper(*args, **kwargs):
-        raw = stream_fn(*args, **kwargs)  # provider errors propagate — by design
-        state: dict = {}
+        raw = stream_fn(*args, **kwargs)  # provider errors propagate - by design
 
-        def _gen() -> Iterator[object]:
-            try:
-                for chunk in raw:
-                    with safe_block(observ, where=f"instrument.{instrumentor.system}.chunk"):
-                        instrumentor.accumulate(state, chunk)
-                    yield chunk
-            finally:
-                _emit_stream_span(
-                    instrumentor,
-                    args=args,
-                    kwargs=kwargs,
-                    state=state,
-                    on_span=on_span,
-                    obs=observ,
-                    catalog=catalog,
-                    tenant_id=tenant_id,
-                    account_resolver=account_resolver,
-                )
+        def _emit(state: dict) -> None:
+            _emit_stream_span(
+                instrumentor,
+                args=args,
+                kwargs=kwargs,
+                state=state,
+                on_span=on_span,
+                obs=observ,
+                catalog=catalog,
+                tenant_id=tenant_id,
+                account_resolver=account_resolver,
+            )
 
-        return _gen()
+        return _InstrumentedStream(raw, instrumentor, _emit)
 
     return wrapper
 
@@ -332,35 +441,29 @@ def wrap_stream_async(
 ) -> Callable[..., object]:
     """Async variant of :func:`wrap_stream` for an async streamed ``create(stream=True)``.
 
-    The wrapped coroutine returns an async iterator; each chunk is yielded untouched and the span
-    is emitted once the async stream is exhausted.
+    The wrapped coroutine returns a pass-through proxy that yields each chunk untouched and emits
+    the span once the async stream is exhausted or its ``async with`` block exits, preserving the
+    underlying async ``Stream`` object's attributes and context-manager protocol.
     """
     observ = obs or SelfObservability()
 
     @functools.wraps(stream_fn)
     async def wrapper(*args, **kwargs):
-        raw = await stream_fn(*args, **kwargs)  # provider errors propagate — by design
-        state: dict = {}
+        raw = await stream_fn(*args, **kwargs)  # provider errors propagate - by design
 
-        async def _agen() -> AsyncIterator[object]:
-            try:
-                async for chunk in raw:
-                    with safe_block(observ, where=f"instrument.{instrumentor.system}.chunk"):
-                        instrumentor.accumulate(state, chunk)
-                    yield chunk
-            finally:
-                _emit_stream_span(
-                    instrumentor,
-                    args=args,
-                    kwargs=kwargs,
-                    state=state,
-                    on_span=on_span,
-                    obs=observ,
-                    catalog=catalog,
-                    tenant_id=tenant_id,
-                    account_resolver=account_resolver,
-                )
+        def _emit(state: dict) -> None:
+            _emit_stream_span(
+                instrumentor,
+                args=args,
+                kwargs=kwargs,
+                state=state,
+                on_span=on_span,
+                obs=observ,
+                catalog=catalog,
+                tenant_id=tenant_id,
+                account_resolver=account_resolver,
+            )
 
-        return _agen()
+        return _InstrumentedAsyncStream(raw, instrumentor, _emit)
 
     return wrapper

--- a/sdk/python/src/tally/instrumentation/base.py
+++ b/sdk/python/src/tally/instrumentation/base.py
@@ -1,10 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared instrumentation machinery: provider interface, span builder, call wrapper."""
+"""Shared instrumentation machinery: provider interface, span builder, call wrappers.
+
+The sync :func:`wrap_create` (CTO-48) is unchanged. Initiative 2 (CTO-260) adds the async and
+streaming wrapper variants the one-line ``tally.init`` path needs, plus two optional hooks on the
+:class:`ProviderInstrumentor` protocol:
+
+- ``operation`` names the ``gen_ai.operation.name`` bucket (default ``"chat"``), so the same
+  machinery serves embeddings and the Responses API without a per-op fork.
+- ``compute_cost`` lets a provider price its own operation (embeddings price under
+  ``PriceType.EMBEDDING``, not the chat input/output rates); when absent, the chat pricing path is
+  used.
+
+Two invariants ride through every wrapper here and are not negotiable (CLAUDE.md):
+
+- The provider call runs OUTSIDE the safety boundary, so the customer's real API error propagates
+  unchanged and instrumentation can never swallow it.
+- Only span building + hand-off run inside ``safe_block``, so a bug in extraction, pricing, or the
+  transport can never raise into the caller.
+"""
 
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Iterator
 from datetime import date
 from typing import Protocol
 
@@ -13,15 +31,30 @@ from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
 from tally.safety import SelfObservability, safe_block
 from tally.schema import SpanFields, build_span_attributes
 
+#: Resolves the active account dimension for a span: ``(hash, key_version, label)``. Wired to
+#: ``TallyClient._resolve_account`` by ``tally.init`` so an auto-instrumented span carries the same
+#: HMAC'd account the manual ``record_*`` path would (CTO-260 §4.4). Returns all-``None`` when no
+#: account is in scope or it cannot be hashed (honest unattributed, never a raw id).
+AccountResolver = Callable[[], tuple[str | None, str | None, str | None]]
+
 
 class ProviderInstrumentor(Protocol):
-    """Per-provider knowledge. Pure functions over a provider response object."""
+    """Per-provider knowledge. Pure functions over a provider response object.
+
+    ``extract_usage`` may return ``None`` to signal usage is genuinely unknown (a streamed call
+    that carried no terminal usage event): the span is then emitted with null token counts rather
+    than a fabricated zero, per "honest under uncertainty".
+    """
 
     system: str
 
     def request_model(self, args: tuple, kwargs: dict) -> str | None: ...
     def response_model(self, response: object) -> str | None: ...
-    def extract_usage(self, response: object) -> Usage: ...
+    def extract_usage(self, response: object) -> Usage | None: ...
+
+
+def _instrumentor_operation(instrumentor: ProviderInstrumentor) -> str:
+    return getattr(instrumentor, "operation", "chat")
 
 
 def build_span(
@@ -33,39 +66,62 @@ def build_span(
     catalog: PriceCatalog | None = None,
     tenant_id: str | None = None,
     at: date | None = None,
+    account: tuple[str | None, str | None, str | None] | None = None,
 ) -> dict[str, object]:
     """Build a conformant span attribute dict from a provider response.
 
     Pulls feature_tag/session from the active trace context, computes cost from the catalog (if
-    given), and returns attributes guaranteed to pass ``validate_span_attributes``.
+    given and usage is known), stamps the account dimension (if ``account`` is supplied), and
+    returns attributes guaranteed to pass ``validate_span_attributes``.
+
+    When ``instrumentor.extract_usage`` returns ``None`` the token counts are left null and no cost
+    is computed: an honest blank, never a guessed zero (CTO-260 §4.3).
     """
     usage = instrumentor.extract_usage(response)
     req_model = instrumentor.request_model(args, kwargs)
     resp_model = instrumentor.response_model(response) or req_model
+    operation = _instrumentor_operation(instrumentor)
     ctx = current_context()
 
     cost_micro: int | None = None
     catalog_version: str | None = None
-    if catalog is not None and resp_model:
-        cost_micro, version = compute_cost_micro_usd(
-            catalog, instrumentor.system, resp_model, usage, at=at, tenant_id=tenant_id
-        )
+    if catalog is not None and resp_model and usage is not None:
+        cost_fn = getattr(instrumentor, "compute_cost", None)
+        if cost_fn is not None:
+            cost_micro, version = cost_fn(
+                catalog, resp_model, usage, at=at, tenant_id=tenant_id
+            )
+        else:
+            cost_micro, version = compute_cost_micro_usd(
+                catalog, instrumentor.system, resp_model, usage, at=at, tenant_id=tenant_id
+            )
         catalog_version = version or None
+
+    acct_hash, acct_version, acct_label = account or (None, None, None)
 
     fields = SpanFields(
         system=instrumentor.system,
         request_model=req_model,
         response_model=resp_model,
-        operation="chat",
-        input_tokens=usage.input_tokens,
-        output_tokens=usage.output_tokens,
-        cached_input_tokens=usage.cached_input_tokens or None,
+        operation=operation,
+        input_tokens=None if usage is None else usage.input_tokens,
+        output_tokens=None if usage is None else usage.output_tokens,
+        cached_input_tokens=None if usage is None else (usage.cached_input_tokens or None),
         cost_estimated_micro_usd=cost_micro,
         price_catalog_version=catalog_version,
         feature_tag=ctx.feature_tag,
         session_id=ctx.session_id,
+        account_id_hash=acct_hash,
+        account_id_hash_key_version=acct_version,
+        account_label=acct_label,
     )
     return build_span_attributes(fields)
+
+
+def _resolve_account(account_resolver: AccountResolver | None):
+    if account_resolver is None:
+        return None
+    return account_resolver()
 
 
 def wrap_create(
@@ -76,8 +132,9 @@ def wrap_create(
     obs: SelfObservability | None = None,
     catalog: PriceCatalog | None = None,
     tenant_id: str | None = None,
+    account_resolver: AccountResolver | None = None,
 ) -> Callable[..., object]:
-    """Wrap a provider ``create``-style callable so each successful call emits a span.
+    """Wrap a sync provider ``create``-style callable so each successful call emits a span.
 
     The provider call itself is NOT guarded — its exceptions propagate to the caller unchanged.
     Only span building + ``on_span`` run inside the safety boundary, so instrumentation can never
@@ -96,8 +153,214 @@ def wrap_create(
                 response=response,
                 catalog=catalog,
                 tenant_id=tenant_id,
+                account=_resolve_account(account_resolver),
             )
             on_span(attrs)
         return response
+
+    return wrapper
+
+
+def wrap_create_async(
+    create_fn: Callable[..., object],
+    instrumentor: ProviderInstrumentor,
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    account_resolver: AccountResolver | None = None,
+) -> Callable[..., object]:
+    """Async variant of :func:`wrap_create` for ``AsyncOpenAI`` / ``AsyncAnthropic`` (CTO-260 §4.2).
+
+    Only awaits the customer's coroutine; span building + hand-off never await the transport, which
+    enqueues without blocking (CTO-260 §5).
+    """
+    observ = obs or SelfObservability()
+
+    @functools.wraps(create_fn)
+    async def wrapper(*args, **kwargs):
+        response = await create_fn(*args, **kwargs)  # provider errors propagate — by design
+        with safe_block(observ, where=f"instrument.{instrumentor.system}"):
+            attrs = build_span(
+                instrumentor,
+                args=args,
+                kwargs=kwargs,
+                response=response,
+                catalog=catalog,
+                tenant_id=tenant_id,
+                account=_resolve_account(account_resolver),
+            )
+            on_span(attrs)
+        return response
+
+    return wrapper
+
+
+class StreamInstrumentor(Protocol):
+    """A :class:`ProviderInstrumentor` that also accumulates usage across a streamed response.
+
+    ``accumulate`` folds one chunk/event into an opaque per-stream ``state`` dict (never shared,
+    so concurrent streams cannot cross-contaminate). ``finalize`` reads the accumulated state and
+    returns ``(model, usage)`` — ``usage`` is ``None`` when the stream carried no terminal usage
+    event, which yields an honest null-token span rather than a fabricated zero (CTO-260 §4.3).
+    """
+
+    system: str
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None: ...
+    def accumulate(self, state: dict, chunk: object) -> None: ...
+    def finalize(self, state: dict) -> tuple[str | None, Usage | None]: ...
+
+
+def _emit_stream_span(
+    instrumentor: StreamInstrumentor,
+    *,
+    args: tuple,
+    kwargs: dict,
+    state: dict,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability,
+    catalog: PriceCatalog | None,
+    tenant_id: str | None,
+    account_resolver: AccountResolver | None,
+) -> None:
+    """Build + hand off the terminal span for an exhausted stream. Never raises."""
+    with safe_block(obs, where=f"instrument.{instrumentor.system}.stream"):
+        resp_model, usage = instrumentor.finalize(state)
+        req_model = instrumentor.request_model(args, kwargs)
+        resp_model = resp_model or req_model
+        operation = _instrumentor_operation(instrumentor)
+        ctx = current_context()
+
+        cost_micro: int | None = None
+        catalog_version: str | None = None
+        if catalog is not None and resp_model and usage is not None:
+            cost_micro, version = compute_cost_micro_usd(
+                catalog, instrumentor.system, resp_model, usage, tenant_id=tenant_id
+            )
+            catalog_version = version or None
+
+        acct_hash, acct_version, acct_label = _resolve_account(account_resolver) or (
+            None,
+            None,
+            None,
+        )
+        fields = SpanFields(
+            system=instrumentor.system,
+            request_model=req_model,
+            response_model=resp_model,
+            operation=operation,
+            input_tokens=None if usage is None else usage.input_tokens,
+            output_tokens=None if usage is None else usage.output_tokens,
+            cached_input_tokens=None if usage is None else (usage.cached_input_tokens or None),
+            cost_estimated_micro_usd=cost_micro,
+            price_catalog_version=catalog_version,
+            feature_tag=ctx.feature_tag,
+            session_id=ctx.session_id,
+            account_id_hash=acct_hash,
+            account_id_hash_key_version=acct_version,
+            account_label=acct_label,
+        )
+        if usage is None:
+            # Honest blank, not a silent drop: record why tokens are null so the SDK's
+            # self-observability can surface "streamed without usage" (CTO-260 §4.3).
+            obs.last_errors.append(
+                f"instrument.{instrumentor.system}.stream: no usage on stream (tokens null)"
+            )
+            if len(obs.last_errors) > obs._max_errors:
+                del obs.last_errors[0]
+        on_span(build_span_attributes(fields))
+
+
+def wrap_stream(
+    stream_fn: Callable[..., object],
+    instrumentor: StreamInstrumentor,
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    account_resolver: AccountResolver | None = None,
+) -> Callable[..., object]:
+    """Wrap a sync streaming ``create(stream=True)`` call (CTO-260 §4.3).
+
+    Returns a thin pass-through iterator that yields each chunk untouched and folds usage/model
+    from the terminal event; the span is emitted once, when the stream is exhausted. The stream is
+    never buffered or altered.
+    """
+    observ = obs or SelfObservability()
+
+    @functools.wraps(stream_fn)
+    def wrapper(*args, **kwargs):
+        raw = stream_fn(*args, **kwargs)  # provider errors propagate — by design
+        state: dict = {}
+
+        def _gen() -> Iterator[object]:
+            try:
+                for chunk in raw:
+                    with safe_block(observ, where=f"instrument.{instrumentor.system}.chunk"):
+                        instrumentor.accumulate(state, chunk)
+                    yield chunk
+            finally:
+                _emit_stream_span(
+                    instrumentor,
+                    args=args,
+                    kwargs=kwargs,
+                    state=state,
+                    on_span=on_span,
+                    obs=observ,
+                    catalog=catalog,
+                    tenant_id=tenant_id,
+                    account_resolver=account_resolver,
+                )
+
+        return _gen()
+
+    return wrapper
+
+
+def wrap_stream_async(
+    stream_fn: Callable[..., object],
+    instrumentor: StreamInstrumentor,
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    account_resolver: AccountResolver | None = None,
+) -> Callable[..., object]:
+    """Async variant of :func:`wrap_stream` for an async streamed ``create(stream=True)``.
+
+    The wrapped coroutine returns an async iterator; each chunk is yielded untouched and the span
+    is emitted once the async stream is exhausted.
+    """
+    observ = obs or SelfObservability()
+
+    @functools.wraps(stream_fn)
+    async def wrapper(*args, **kwargs):
+        raw = await stream_fn(*args, **kwargs)  # provider errors propagate — by design
+        state: dict = {}
+
+        async def _agen() -> AsyncIterator[object]:
+            try:
+                async for chunk in raw:
+                    with safe_block(observ, where=f"instrument.{instrumentor.system}.chunk"):
+                        instrumentor.accumulate(state, chunk)
+                    yield chunk
+            finally:
+                _emit_stream_span(
+                    instrumentor,
+                    args=args,
+                    kwargs=kwargs,
+                    state=state,
+                    on_span=on_span,
+                    obs=observ,
+                    catalog=catalog,
+                    tenant_id=tenant_id,
+                    account_resolver=account_resolver,
+                )
+
+        return _agen()
 
     return wrapper

--- a/sdk/python/src/tally/instrumentation/openai.py
+++ b/sdk/python/src/tally/instrumentation/openai.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""OpenAI instrumentors — Chat Completions (CTO-48), Responses, and Embeddings (CTO-260 §4.1/§4.2).
+"""OpenAI instrumentors - Chat Completions (CTO-48), Responses, and Embeddings (CTO-260 §4.1/§4.2).
 
 Every instrumentor is a pure function over a provider response object and works with both the SDK's
 object responses and plain dicts, so it can be tested with a fake client and no network. Nothing
-here reads message content or secrets — only ``usage`` / ``model`` metadata.
+here reads message content or secrets - only ``usage`` / ``model`` metadata.
 """
 
 from __future__ import annotations
@@ -102,6 +102,24 @@ class OpenAIResponsesInstrumentor:
         return Usage(
             input_tokens=input_tokens, output_tokens=output_tokens, cached_input_tokens=cached
         )
+
+    # --- streaming (CTO-260 §4.3) ---
+    def accumulate(self, state: dict, chunk: object) -> None:
+        # The Responses stream carries terminal usage on the completed event's nested ``response``
+        # payload (response.completed); intermediate events may name model/usage directly.
+        response = _get(chunk, "response")
+        source = response if response is not None else chunk
+        model = _get(source, "model")
+        if isinstance(model, str) and model:
+            state["model"] = model
+        usage = _get(source, "usage")
+        if usage is not None:
+            state["usage"] = usage
+
+    def finalize(self, state: dict) -> tuple[str | None, Usage | None]:
+        usage_obj = state.get("usage")
+        usage = self.extract_usage({"usage": usage_obj}) if usage_obj is not None else None
+        return state.get("model"), usage
 
 
 class OpenAIEmbeddingsInstrumentor:

--- a/sdk/python/src/tally/instrumentation/openai.py
+++ b/sdk/python/src/tally/instrumentation/openai.py
@@ -1,17 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
-"""OpenAI instrumentor — extracts usage from a Chat Completions response.
+"""OpenAI instrumentors — Chat Completions (CTO-48), Responses, and Embeddings (CTO-260 §4.1/§4.2).
 
-Works with both the SDK's object responses and plain dicts, so it can be tested with a fake client
-and no network. Reads ``usage.prompt_tokens`` / ``usage.completion_tokens`` and
-``usage.prompt_tokens_details.cached_tokens`` when present.
+Every instrumentor is a pure function over a provider response object and works with both the SDK's
+object responses and plain dicts, so it can be tested with a fake client and no network. Nothing
+here reads message content or secrets — only ``usage`` / ``model`` metadata.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import date
 
 from tally.instrumentation.base import ProviderInstrumentor, wrap_create
-from tally.pricing import PriceCatalog, Usage
+from tally.pricing import (
+    PriceCatalog,
+    Usage,
+    compute_cost_micro_usd,
+    compute_embedding_cost_micro_usd,
+)
 from tally.safety import SelfObservability
 
 
@@ -25,7 +31,16 @@ def _get(obj: object, key: str, default: object = None) -> object:
 
 
 class OpenAIInstrumentor:
+    """Chat Completions. Reads ``usage.prompt_tokens`` / ``usage.completion_tokens`` and
+    ``usage.prompt_tokens_details.cached_tokens`` when present.
+
+    Also serves streamed chat (``stream=True``) via :meth:`accumulate` / :meth:`finalize`:
+    OpenAI reports usage only in the terminal chunk (when ``stream_options.include_usage`` is set),
+    so usage stays ``None`` until that chunk arrives (CTO-260 §4.3).
+    """
+
     system = "openai"
+    operation = "chat"
 
     def request_model(self, args: tuple, kwargs: dict) -> str | None:
         return kwargs.get("model")
@@ -34,8 +49,10 @@ class OpenAIInstrumentor:
         model = _get(response, "model")
         return model if isinstance(model, str) else None
 
-    def extract_usage(self, response: object) -> Usage:
+    def extract_usage(self, response: object) -> Usage | None:
         usage = _get(response, "usage")
+        if usage is None:
+            return None
         prompt = int(_get(usage, "prompt_tokens", 0) or 0)
         completion = int(_get(usage, "completion_tokens", 0) or 0)
         details = _get(usage, "prompt_tokens_details")
@@ -44,9 +61,89 @@ class OpenAIInstrumentor:
             input_tokens=prompt, output_tokens=completion, cached_input_tokens=cached
         )
 
+    # --- streaming (CTO-260 §4.3) ---
+    def accumulate(self, state: dict, chunk: object) -> None:
+        model = _get(chunk, "model")
+        if isinstance(model, str) and model:
+            state["model"] = model
+        usage = _get(chunk, "usage")
+        if usage is not None:
+            state["usage"] = usage
+
+    def finalize(self, state: dict) -> tuple[str | None, Usage | None]:
+        usage_obj = state.get("usage")
+        usage = self.extract_usage({"usage": usage_obj}) if usage_obj is not None else None
+        return state.get("model"), usage
+
+
+class OpenAIResponsesInstrumentor:
+    """OpenAI Responses API (``client.responses.create``). Usage under
+    ``response.usage.input_tokens`` / ``output_tokens`` (CTO-260 §4.2)."""
+
+    system = "openai"
+    operation = "chat"
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None:
+        return kwargs.get("model")
+
+    def response_model(self, response: object) -> str | None:
+        model = _get(response, "model")
+        return model if isinstance(model, str) else None
+
+    def extract_usage(self, response: object) -> Usage | None:
+        usage = _get(response, "usage")
+        if usage is None:
+            return None
+        # The Responses API names these input_tokens / output_tokens (unlike Chat Completions).
+        input_tokens = int(_get(usage, "input_tokens", 0) or 0)
+        output_tokens = int(_get(usage, "output_tokens", 0) or 0)
+        details = _get(usage, "input_tokens_details")
+        cached = int(_get(details, "cached_tokens", 0) or 0)
+        return Usage(
+            input_tokens=input_tokens, output_tokens=output_tokens, cached_input_tokens=cached
+        )
+
+
+class OpenAIEmbeddingsInstrumentor:
+    """OpenAI Embeddings (``client.embeddings.create``). ``usage.prompt_tokens`` is the input;
+    there are no output tokens, and cost prices under ``PriceType.EMBEDDING`` (CTO-260 §4.2)."""
+
+    system = "openai"
+    operation = "embeddings"
+
+    def request_model(self, args: tuple, kwargs: dict) -> str | None:
+        return kwargs.get("model")
+
+    def response_model(self, response: object) -> str | None:
+        model = _get(response, "model")
+        return model if isinstance(model, str) else None
+
+    def extract_usage(self, response: object) -> Usage | None:
+        usage = _get(response, "usage")
+        if usage is None:
+            return None
+        prompt = int(_get(usage, "prompt_tokens", 0) or 0)
+        return Usage(input_tokens=prompt, output_tokens=0)
+
+    def compute_cost(
+        self,
+        catalog: PriceCatalog,
+        model: str,
+        usage: Usage,
+        *,
+        at: date | None = None,
+        tenant_id: str | None = None,
+    ) -> tuple[int, str]:
+        return compute_embedding_cost_micro_usd(
+            catalog, self.system, model, usage.input_tokens, at=at, tenant_id=tenant_id
+        )
+
 
 # satisfy the Protocol at import time (structural; this is a no-op assertion for readers)
 _INSTRUMENTOR: ProviderInstrumentor = OpenAIInstrumentor()
+
+# Compat: some call sites reference the chat cost path directly.
+_ = compute_cost_micro_usd
 
 
 def instrument_openai_create(

--- a/sdk/python/src/tally/instrumentation/patch.py
+++ b/sdk/python/src/tally/instrumentation/patch.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Monkeypatch the official ``openai`` / ``anthropic`` clients in place (CTO-260 §4).
+
+``tally.init(instrument=True)`` calls :func:`patch_openai` / :func:`patch_anthropic`. Each patches
+provider methods at the CLASS / unbound-method level, so every client instance (including ones
+constructed after ``init``) is covered, and stores a handle so :func:`unpatch_all` can reverse it
+(tests use this to avoid cross-test leakage). Patching is:
+
+- **Never a hard dependency.** Nothing here imports ``openai`` / ``anthropic`` unless it is already
+  installed; a missing library is a no-op, not an error (the SDK keeps zero required runtime deps).
+- **Idempotent.** Each wrapper is tagged with a sentinel attribute; a second patch is skipped.
+- **Never-raise.** The provider call runs outside the safety boundary (see
+  :mod:`tally.instrumentation.base`); resolution and patching here are wrapped so a shape change in
+  a future provider release degrades to "not instrumented", never a crash into ``init``.
+
+Tests inject fake provider classes via the ``targets`` argument, so the wrappers can be exercised
+without installing ``openai`` / ``anthropic`` or hitting the network.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from tally.instrumentation.anthropic import AnthropicInstrumentor
+from tally.instrumentation.base import (
+    AccountResolver,
+    wrap_create,
+    wrap_create_async,
+    wrap_stream,
+    wrap_stream_async,
+)
+from tally.instrumentation.openai import (
+    OpenAIEmbeddingsInstrumentor,
+    OpenAIInstrumentor,
+    OpenAIResponsesInstrumentor,
+)
+from tally.pricing import PriceCatalog
+from tally.safety import SelfObservability, safe_block
+
+_log = logging.getLogger("tally")
+
+_SENTINEL = "_tally_wrapped"
+
+# (cls, attr, original) so uninstrument restores the exact prior attribute. Process-global, like
+# the patch itself; ``init`` is single-tenant per process by design (CTO-260 §3).
+_PATCHES: list[tuple[type, str, object]] = []
+
+
+@dataclass(frozen=True, slots=True)
+class _Common:
+    on_span: Callable[[dict[str, object]], None]
+    obs: SelfObservability
+    catalog: PriceCatalog | None
+    tenant_id: str | None
+    account_resolver: AccountResolver | None
+
+    def kw(self) -> dict:
+        return {
+            "on_span": self.on_span,
+            "obs": self.obs,
+            "catalog": self.catalog,
+            "tenant_id": self.tenant_id,
+            "account_resolver": self.account_resolver,
+        }
+
+
+def _resolve(module_path: str, class_name: str) -> type | None:
+    """Import ``module_path`` and return its ``class_name``, or ``None`` if unavailable."""
+    try:
+        module = importlib.import_module(module_path)
+    except Exception:  # noqa: BLE001 - a missing provider lib is a no-op, not an error
+        return None
+    return getattr(module, class_name, None)
+
+
+def _apply(cls: type | None, attr: str, builder: Callable[[object], object]) -> None:
+    """Replace ``cls.attr`` with ``builder(original)``, idempotent and reversible. Never raises."""
+    if cls is None:
+        return
+    original = getattr(cls, attr, None)
+    if original is None:
+        return
+    if getattr(original, _SENTINEL, False):
+        return  # already patched — idempotent
+    wrapped = builder(original)
+    try:
+        setattr(wrapped, _SENTINEL, True)
+        wrapped._tally_original = original
+    except (AttributeError, TypeError):
+        pass
+    setattr(cls, attr, wrapped)
+    _PATCHES.append((cls, attr, original))
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI
+# --------------------------------------------------------------------------- #
+def _openai_chat_builder(common: _Common, *, is_async: bool, stream_usage: bool):
+    instr = OpenAIInstrumentor()
+
+    def builder(original):
+        if is_async:
+            nonstream = wrap_create_async(original, instr, **common.kw())
+            streamed = wrap_stream_async(original, instr, **common.kw())
+
+            @functools.wraps(original)
+            async def wrapper(*args, **kwargs):
+                if kwargs.get("stream"):
+                    if stream_usage and "stream_options" not in kwargs:
+                        kwargs = {**kwargs, "stream_options": {"include_usage": True}}
+                    return await streamed(*args, **kwargs)
+                return await nonstream(*args, **kwargs)
+
+            return wrapper
+
+        nonstream = wrap_create(original, instr, **common.kw())
+        streamed = wrap_stream(original, instr, **common.kw())
+
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            if kwargs.get("stream"):
+                if stream_usage and "stream_options" not in kwargs:
+                    kwargs = {**kwargs, "stream_options": {"include_usage": True}}
+                return streamed(*args, **kwargs)
+            return nonstream(*args, **kwargs)
+
+        return wrapper
+
+    return builder
+
+
+def _plain_builder(common: _Common, instrumentor, *, is_async: bool):
+    def builder(original):
+        if is_async:
+            return wrap_create_async(original, instrumentor, **common.kw())
+        return wrap_create(original, instrumentor, **common.kw())
+
+    return builder
+
+
+def patch_openai(
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    account_resolver: AccountResolver | None = None,
+    instrument_stream_usage: bool = False,
+    targets: dict[str, type] | None = None,
+) -> None:
+    """Patch the installed ``openai`` client (Chat Completions, Responses, Embeddings).
+
+    ``targets`` overrides class resolution for tests: a mapping with any of the roles ``chat``,
+    ``chat_async``, ``responses``, ``responses_async``, ``embeddings``, ``embeddings_async`` to a
+    class whose ``create`` method should be wrapped. When omitted, the real ``openai`` classes are
+    resolved (and silently skipped if the library is not installed).
+    """
+    observ = obs or SelfObservability()
+    common = _Common(on_span, observ, catalog, tenant_id, account_resolver)
+
+    with safe_block(observ, where="patch_openai"):
+        roles = targets or _openai_targets()
+        if not roles:
+            _log.debug("tally: openai not installed; skipping instrumentation")
+            return
+
+        for role, is_async in (("chat", False), ("chat_async", True)):
+            _apply(
+                roles.get(role),
+                "create",
+                _openai_chat_builder(
+                    common, is_async=is_async, stream_usage=instrument_stream_usage
+                ),
+            )
+        for role, is_async in (("responses", False), ("responses_async", True)):
+            _apply(
+                roles.get(role),
+                "create",
+                _plain_builder(common, OpenAIResponsesInstrumentor(), is_async=is_async),
+            )
+        for role, is_async in (("embeddings", False), ("embeddings_async", True)):
+            _apply(
+                roles.get(role),
+                "create",
+                _plain_builder(common, OpenAIEmbeddingsInstrumentor(), is_async=is_async),
+            )
+
+
+def _openai_targets() -> dict[str, type]:
+    roles: dict[str, type] = {}
+    candidates = {
+        "chat": ("openai.resources.chat.completions", "Completions"),
+        "chat_async": ("openai.resources.chat.completions", "AsyncCompletions"),
+        "responses": ("openai.resources.responses", "Responses"),
+        "responses_async": ("openai.resources.responses", "AsyncResponses"),
+        "embeddings": ("openai.resources.embeddings", "Embeddings"),
+        "embeddings_async": ("openai.resources.embeddings", "AsyncEmbeddings"),
+    }
+    for role, (module_path, class_name) in candidates.items():
+        cls = _resolve(module_path, class_name)
+        if cls is not None:
+            roles[role] = cls
+    return roles
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic
+# --------------------------------------------------------------------------- #
+class _StreamProxy:
+    """Wraps the object a stream context manager yields, folding usage as events pass through."""
+
+    def __init__(self, inner: object, instrumentor: AnthropicInstrumentor, state: dict) -> None:
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_instr", instrumentor)
+        object.__setattr__(self, "_state", state)
+
+    def __iter__(self):
+        for event in self._inner:
+            _safe_accumulate(self._instr, self._state, event)
+            yield event
+
+    def __aiter__(self):
+        return self._aiter()
+
+    async def _aiter(self):
+        async for event in self._inner:  # type: ignore[attr-defined]
+            _safe_accumulate(self._instr, self._state, event)
+            yield event
+
+    def __getattr__(self, name: str):
+        # Delegate everything else (text_stream, get_final_message, ...) to the real stream.
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+
+def _safe_accumulate(instr: AnthropicInstrumentor, state: dict, event: object) -> None:
+    try:
+        instr.accumulate(state, event)
+    except Exception:  # noqa: BLE001 - accumulation must never break the customer's iteration
+        pass
+
+
+class _StreamManagerProxy:
+    """Pass-through for ``client.messages.stream(...)``: emits one span when the block exits."""
+
+    def __init__(
+        self,
+        manager: object,
+        instrumentor: AnthropicInstrumentor,
+        args: tuple,
+        kwargs: dict,
+        common: _Common,
+    ) -> None:
+        self._manager = manager
+        self._instr = instrumentor
+        self._args = args
+        self._kwargs = kwargs
+        self._common = common
+        self._state: dict = {}
+
+    def __enter__(self):
+        inner = self._manager.__enter__()
+        return _StreamProxy(inner, self._instr, self._state)
+
+    def __exit__(self, *exc):
+        result = self._manager.__exit__(*exc)
+        self._emit()
+        return result
+
+    async def __aenter__(self):
+        inner = await self._manager.__aenter__()
+        return _StreamProxy(inner, self._instr, self._state)
+
+    async def __aexit__(self, *exc):
+        result = await self._manager.__aexit__(*exc)
+        self._emit()
+        return result
+
+    def __getattr__(self, name: str):
+        return getattr(object.__getattribute__(self, "_manager"), name)
+
+    def _emit(self) -> None:
+        from tally.instrumentation.base import _emit_stream_span
+
+        # If the caller never iterated events, try the authoritative final message for usage.
+        if "input_tokens" not in self._state and "output_tokens" not in self._state:
+            with safe_block(self._common.obs, where="instrument.anthropic.stream.final"):
+                get_final = getattr(self._manager, "get_final_message", None)
+                if callable(get_final):
+                    _safe_accumulate(self._instr, self._state, {"message": get_final()})
+        _emit_stream_span(
+            self._instr,
+            args=self._args,
+            kwargs=self._kwargs,
+            state=self._state,
+            on_span=self._common.on_span,
+            obs=self._common.obs,
+            catalog=self._common.catalog,
+            tenant_id=self._common.tenant_id,
+            account_resolver=self._common.account_resolver,
+        )
+
+
+def _anthropic_stream_builder(common: _Common):
+    instr = AnthropicInstrumentor()
+
+    def builder(original):
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            manager = original(*args, **kwargs)  # provider errors propagate — by design
+            return _StreamManagerProxy(manager, instr, args, kwargs, common)
+
+        return wrapper
+
+    return builder
+
+
+def patch_anthropic(
+    *,
+    on_span: Callable[[dict[str, object]], None],
+    obs: SelfObservability | None = None,
+    catalog: PriceCatalog | None = None,
+    tenant_id: str | None = None,
+    account_resolver: AccountResolver | None = None,
+    targets: dict[str, type] | None = None,
+) -> None:
+    """Patch the installed ``anthropic`` client (Messages create + stream, sync + async).
+
+    ``targets`` overrides class resolution for tests: a mapping with any of the roles ``messages``,
+    ``messages_async`` (whose ``create`` and ``stream`` are wrapped). When omitted, the real
+    ``anthropic`` classes are resolved (and silently skipped if the library is not installed).
+    """
+    observ = obs or SelfObservability()
+    common = _Common(on_span, observ, catalog, tenant_id, account_resolver)
+    instr = AnthropicInstrumentor()
+
+    with safe_block(observ, where="patch_anthropic"):
+        roles = targets or _anthropic_targets()
+        if not roles:
+            _log.debug("tally: anthropic not installed; skipping instrumentation")
+            return
+
+        _apply(roles.get("messages"), "create", _plain_builder(common, instr, is_async=False))
+        _apply(
+            roles.get("messages_async"),
+            "create",
+            _plain_builder(common, instr, is_async=True),
+        )
+        _apply(roles.get("messages"), "stream", _anthropic_stream_builder(common))
+        _apply(roles.get("messages_async"), "stream", _anthropic_stream_builder(common))
+
+
+def _anthropic_targets() -> dict[str, type]:
+    roles: dict[str, type] = {}
+    for role, class_name in (("messages", "Messages"), ("messages_async", "AsyncMessages")):
+        cls = _resolve("anthropic.resources.messages", class_name) or _resolve(
+            "anthropic.resources.messages.messages", class_name
+        )
+        if cls is not None:
+            roles[role] = cls
+    return roles
+
+
+# --------------------------------------------------------------------------- #
+# Reversal
+# --------------------------------------------------------------------------- #
+def unpatch_all() -> None:
+    """Restore every patched method to its original. Idempotent; used by ``tally.uninstrument``."""
+    while _PATCHES:
+        cls, attr, original = _PATCHES.pop()
+        try:
+            setattr(cls, attr, original)
+        except Exception:  # noqa: BLE001 - reversal is best-effort, never raises
+            pass
+
+
+def is_patched() -> bool:
+    return bool(_PATCHES)

--- a/sdk/python/src/tally/instrumentation/patch.py
+++ b/sdk/python/src/tally/instrumentation/patch.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import functools
 import importlib
+import inspect
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -85,7 +86,7 @@ def _apply(cls: type | None, attr: str, builder: Callable[[object], object]) -> 
     if original is None:
         return
     if getattr(original, _SENTINEL, False):
-        return  # already patched — idempotent
+        return  # already patched - idempotent
     wrapped = builder(original)
     try:
         setattr(wrapped, _SENTINEL, True)
@@ -142,6 +143,42 @@ def _plain_builder(common: _Common, instrumentor, *, is_async: bool):
     return builder
 
 
+def _create_stream_builder(common: _Common, instrumentor, *, is_async: bool):
+    """A ``create``-style builder that routes ``stream=True`` to the streaming wrapper.
+
+    The supported streamed form of ``Anthropic.messages.create`` and ``OpenAI.responses.create``
+    passes ``stream=True`` and returns an iterator, so wrapping it with the non-streaming wrapper
+    emitted a null-token, no-cost span (CTO-260 §4.3, review finding). This dispatches to
+    ``wrap_stream`` so usage is accumulated from the stream, without buffering or altering it.
+    """
+
+    def builder(original):
+        if is_async:
+            nonstream = wrap_create_async(original, instrumentor, **common.kw())
+            streamed = wrap_stream_async(original, instrumentor, **common.kw())
+
+            @functools.wraps(original)
+            async def wrapper(*args, **kwargs):
+                if kwargs.get("stream"):
+                    return await streamed(*args, **kwargs)
+                return await nonstream(*args, **kwargs)
+
+            return wrapper
+
+        nonstream = wrap_create(original, instrumentor, **common.kw())
+        streamed = wrap_stream(original, instrumentor, **common.kw())
+
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            if kwargs.get("stream"):
+                return streamed(*args, **kwargs)
+            return nonstream(*args, **kwargs)
+
+        return wrapper
+
+    return builder
+
+
 def patch_openai(
     *,
     on_span: Callable[[dict[str, object]], None],
@@ -180,7 +217,9 @@ def patch_openai(
             _apply(
                 roles.get(role),
                 "create",
-                _plain_builder(common, OpenAIResponsesInstrumentor(), is_async=is_async),
+                _create_stream_builder(
+                    common, OpenAIResponsesInstrumentor(), is_async=is_async
+                ),
             )
         for role, is_async in (("embeddings", False), ("embeddings_async", True)):
             _apply(
@@ -260,37 +299,50 @@ class _StreamManagerProxy:
         self._kwargs = kwargs
         self._common = common
         self._state: dict = {}
+        # The stream object the manager yields on enter. get_final_message lives here, not on the
+        # manager, on the real client (CTO-260 §4.3, review finding).
+        self._entered: object | None = None
 
     def __enter__(self):
         inner = self._manager.__enter__()
+        self._entered = inner
         return _StreamProxy(inner, self._instr, self._state)
 
     def __exit__(self, *exc):
         result = self._manager.__exit__(*exc)
-        self._emit()
+        self._emit_sync()
         return result
 
     async def __aenter__(self):
         inner = await self._manager.__aenter__()
+        self._entered = inner
         return _StreamProxy(inner, self._instr, self._state)
 
     async def __aexit__(self, *exc):
         result = await self._manager.__aexit__(*exc)
-        self._emit()
+        await self._emit_async()
         return result
 
     def __getattr__(self, name: str):
         return getattr(object.__getattribute__(self, "_manager"), name)
 
-    def _emit(self) -> None:
+    def _needs_final(self) -> bool:
+        return "input_tokens" not in self._state and "output_tokens" not in self._state
+
+    def _final_message_getter(self) -> Callable[[], object] | None:
+        # Prefer the entered stream object (where the real client exposes it); fall back to the
+        # manager for shapes that expose it there.
+        for target in (self._entered, self._manager):
+            if target is None:
+                continue
+            getter = getattr(target, "get_final_message", None)
+            if callable(getter):
+                return getter
+        return None
+
+    def _emit_span(self) -> None:
         from tally.instrumentation.base import _emit_stream_span
 
-        # If the caller never iterated events, try the authoritative final message for usage.
-        if "input_tokens" not in self._state and "output_tokens" not in self._state:
-            with safe_block(self._common.obs, where="instrument.anthropic.stream.final"):
-                get_final = getattr(self._manager, "get_final_message", None)
-                if callable(get_final):
-                    _safe_accumulate(self._instr, self._state, {"message": get_final()})
         _emit_stream_span(
             self._instr,
             args=self._args,
@@ -303,6 +355,30 @@ class _StreamManagerProxy:
             account_resolver=self._common.account_resolver,
         )
 
+    def _emit_sync(self) -> None:
+        # If the caller never iterated events, seed usage from the authoritative final message.
+        if self._needs_final():
+            with safe_block(self._common.obs, where="instrument.anthropic.stream.final"):
+                getter = self._final_message_getter()
+                if getter is not None:
+                    msg = getter()
+                    if not inspect.isawaitable(msg):
+                        _safe_accumulate(self._instr, self._state, {"message": msg})
+        self._emit_span()
+
+    async def _emit_async(self) -> None:
+        # On the async client get_final_message is a coroutine; await it rather than stamping the
+        # unawaited coroutine as usage (which yielded null tokens and a "never awaited" warning).
+        if self._needs_final():
+            with safe_block(self._common.obs, where="instrument.anthropic.stream.final"):
+                getter = self._final_message_getter()
+                if getter is not None:
+                    msg = getter()
+                    if inspect.isawaitable(msg):
+                        msg = await msg
+                    _safe_accumulate(self._instr, self._state, {"message": msg})
+        self._emit_span()
+
 
 def _anthropic_stream_builder(common: _Common):
     instr = AnthropicInstrumentor()
@@ -310,7 +386,7 @@ def _anthropic_stream_builder(common: _Common):
     def builder(original):
         @functools.wraps(original)
         def wrapper(*args, **kwargs):
-            manager = original(*args, **kwargs)  # provider errors propagate — by design
+            manager = original(*args, **kwargs)  # provider errors propagate - by design
             return _StreamManagerProxy(manager, instr, args, kwargs, common)
 
         return wrapper
@@ -343,11 +419,15 @@ def patch_anthropic(
             _log.debug("tally: anthropic not installed; skipping instrumentation")
             return
 
-        _apply(roles.get("messages"), "create", _plain_builder(common, instr, is_async=False))
+        _apply(
+            roles.get("messages"),
+            "create",
+            _create_stream_builder(common, instr, is_async=False),
+        )
         _apply(
             roles.get("messages_async"),
             "create",
-            _plain_builder(common, instr, is_async=True),
+            _create_stream_builder(common, instr, is_async=True),
         )
         _apply(roles.get("messages"), "stream", _anthropic_stream_builder(common))
         _apply(roles.get("messages_async"), "stream", _anthropic_stream_builder(common))

--- a/sdk/python/src/tally/transport.py
+++ b/sdk/python/src/tally/transport.py
@@ -124,7 +124,14 @@ class BatchingTransport:
         self.retry_max = retry_max
 
         self._buf: deque[dict[str, object]] = deque()
+        # _lock guards every read and write of _buf, _pending and _consecutive_failures. It is held
+        # only for brief state transitions, never across the network send, so export() on the hot
+        # path is never blocked by an in-flight flush (CTO-260 §5).
         self._lock = threading.Lock()
+        # _flush_lock serializes flush_once so the daemon worker and a concurrent flush() cannot run
+        # two sends at once. Without it they race on _pending and either double-send a batch or drop
+        # an already-dequeued batch's spans (CTO-260 §5, review finding).
+        self._flush_lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._consecutive_failures = 0
@@ -143,66 +150,77 @@ class BatchingTransport:
                 self._buf.append(attributes)
 
     def pending(self) -> int:
+        # Both reads are under the lock, and every write to _pending is too, so the ternary cannot
+        # observe _pending flip to None between the check and the subscript (the TOCTOU that used to
+        # raise TypeError and kill the daemon worker outside safe_block).
         with self._lock:
             extra = 0 if self._pending is None else len(self._pending[0].resource_spans)
             return len(self._buf) + extra
 
     # --- envelope ---
     def _build_batch(self, spans: list[dict[str, object]]) -> BatchRequest:
-        # tenant_id="" — the bearer key decides the tenant at the gateway (CTO-260 §3.1).
+        # tenant_id="" - the bearer key decides the tenant at the gateway (CTO-260 §3.1).
         return BatchRequest(tenant_id="", sdk_version=self._sdk_version, resource_spans=spans)
 
-    def _take_batch(self) -> BatchRequest | None:
-        """Return the in-flight batch if one is pinned, else assemble a fresh one. None if empty."""
-        if self._pending is not None:
-            return self._pending[0]
-        with self._lock:
-            if not self._buf:
-                return None
-            n = min(self.max_batch_size, len(self._buf))
-            spans = [self._buf.popleft() for _ in range(n)]
-        return self._build_batch(spans)
-
     def flush_once(self) -> bool:
-        """Flush a single batch. Returns True on delivery, False on empty/failure. Never raises."""
-        batch = self._take_batch()
-        if batch is None:
+        """Flush a single batch. Returns True on delivery, False on empty/failure. Never raises.
+
+        Serialized by _flush_lock so a concurrent daemon flush and a caller flush() never send two
+        batches at once or race on _pending; the buffer pop and every _pending/_consecutive_failures
+        transition happen under _lock, so no span is lost and no batch is double-sent (CTO-260 §5).
+        """
+        with self._flush_lock:
+            # Assemble or reclaim the in-flight batch, then pin it before the send so a mid-send
+            # failure (even a thread death) can never lose the already-dequeued spans.
+            with self._lock:
+                if self._pending is not None:
+                    batch, attempts = self._pending
+                else:
+                    if not self._buf:
+                        return False
+                    n = min(self.max_batch_size, len(self._buf))
+                    spans = [self._buf.popleft() for _ in range(n)]
+                    batch = self._build_batch(spans)
+                    attempts = 0
+                    self._pending = (batch, attempts)
+
+            headers = {
+                "Authorization": f"Bearer {self._key}",
+                "Content-Type": "application/json",
+            }
+            body = encode_request(batch).encode("utf-8")
+            try:
+                status = self._sender(self._url, headers, body)
+                ok = 200 <= status < 300
+            except Exception as exc:  # noqa: BLE001 - transport errors must never escape
+                self.obs.record_error(exc, "BatchingTransport.flush")
+                ok = False
+
+            with self._lock:
+                if ok:
+                    self._pending = None
+                    self._consecutive_failures = 0
+                    return True
+
+                # Failure: keep the batch pinned for retry, bounded by retry_max (idempotent resend
+                # by batch_id).
+                attempts += 1
+                self._consecutive_failures += 1
+                if attempts >= self.retry_max:
+                    self.obs.dropped_span_count += len(batch.resource_spans)
+                    self.obs.record_error(
+                        RuntimeError(f"batch dropped after {attempts} attempts"),
+                        "BatchingTransport.flush",
+                    )
+                    self._pending = None
+                else:
+                    self._pending = (batch, attempts)
             return False
-        attempts = 0 if self._pending is None else self._pending[1]
-
-        headers = {
-            "Authorization": f"Bearer {self._key}",
-            "Content-Type": "application/json",
-        }
-        body = encode_request(batch).encode("utf-8")
-        try:
-            status = self._sender(self._url, headers, body)
-            ok = 200 <= status < 300
-        except Exception as exc:  # noqa: BLE001 - transport errors must never escape
-            self.obs.record_error(exc, "BatchingTransport.flush")
-            ok = False
-
-        if ok:
-            self._pending = None
-            self._consecutive_failures = 0
-            return True
-
-        # Failure: pin the batch for retry, bounded by retry_max (idempotent resend by batch_id).
-        attempts += 1
-        self._consecutive_failures += 1
-        if attempts >= self.retry_max:
-            self.obs.dropped_span_count += len(batch.resource_spans)
-            self.obs.record_error(
-                RuntimeError(f"batch dropped after {attempts} attempts"),
-                "BatchingTransport.flush",
-            )
-            self._pending = None
-        else:
-            self._pending = (batch, attempts)
-        return False
 
     def current_backoff_ms(self) -> float:
-        return self.backoff.delay_ms(self._consecutive_failures)
+        with self._lock:
+            failures = self._consecutive_failures
+        return self.backoff.delay_ms(failures)
 
     # --- background loop ---
     def start(self) -> None:

--- a/sdk/python/src/tally/transport.py
+++ b/sdk/python/src/tally/transport.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Background batching ingest transport for ``tally.init`` (CTO-260 §5).
+
+``init`` installs a :class:`BatchingTransport` as the client's ``Exporter``. Spans enqueue onto a
+bounded in-memory buffer; a daemon worker thread flushes on ``flush_interval_s`` or when a size
+threshold is reached, POSTing a :class:`~tally.wire.BatchRequest` to ``{endpoint}/v1/batches`` with
+the ingest key as bearer. The design guarantees, all non-negotiable (CLAUDE.md, CTO-260 §5):
+
+- **Never blocks the caller.** ``export`` only appends under a lock; no network I/O on the calling
+  thread. A full buffer drops the oldest span and counts it (backpressure, drop-oldest).
+- **Never raises.** Every path runs inside the safety boundary; a transport error is recorded to
+  self-observability, never propagated.
+- **Buffering + retry.** A failed flush retries the whole batch (idempotent by ``batch_id``) with
+  capped exponential backoff + jitter, bounded by ``retry_max``; an exhausted batch is dropped with
+  a counter, never retried forever.
+- **Drains on shutdown.** :meth:`flush` and an ``atexit`` hook drain with a bounded timeout so a
+  short-lived script still ships its spans.
+
+The tenant is omitted from the envelope: the bearer key is authoritative and the gateway maps it to
+the tenant (CTO-260 §3.1). The batch carries ``tenant_id=""`` so it claims no tenant.
+
+HTTP uses the standard library only (the SDK keeps zero required runtime deps). The ``sender`` is
+injectable so tests exercise batching, retry, and backpressure without a network or a live gateway.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import threading
+import urllib.error
+import urllib.request
+from collections import deque
+from collections.abc import Callable
+
+from tally.egress import BackoffPolicy
+from tally.hmac_keys import HmacKeyBootstrap
+from tally.safety import SelfObservability, safe_block
+from tally.wire import BatchRequest, encode_request
+
+_log = logging.getLogger("tally")
+
+DEFAULT_ENDPOINT = "https://ingest.ai-tally.com"
+
+#: Sends one POST. Returns the HTTP status code; raises on a network-level failure. Injectable.
+Sender = Callable[[str, dict[str, str], bytes], int]
+
+
+def _urllib_sender(url: str, headers: dict[str, str], body: bytes, *, timeout: float = 5.0) -> int:
+    """Default POST sender over ``urllib`` (stdlib). Raises ``urllib.error.URLError`` on failure."""
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed https endpoint
+        return int(resp.status)
+
+
+def fetch_hmac_key(
+    endpoint: str,
+    key: str,
+    *,
+    opener: Callable[[str, dict[str, str], float], dict] | None = None,
+    timeout: float = 5.0,
+) -> HmacKeyBootstrap:
+    """GET ``{endpoint}/v1/tenant/hmac-key`` under the ingest key and parse the bootstrap material.
+
+    ``opener`` is injectable for tests: it takes ``(url, headers, timeout)`` and returns the parsed
+    JSON body. The default reads over ``urllib``. The response body is never logged (CTO-260 §3.2).
+    """
+    url = f"{endpoint.rstrip('/')}/v1/tenant/hmac-key"
+    headers = {"Authorization": f"Bearer {key}", "Accept": "application/json"}
+    if opener is None:
+        opener = _urllib_get_json
+    body = opener(url, headers, timeout)
+    import base64
+
+    return HmacKeyBootstrap(
+        tenant_id=str(body["tenant_id"]),
+        key_version=str(body["key_version"]),
+        material=base64.b64decode(body["key_material_b64"]),
+        algorithm=str(body.get("algorithm", "HMAC-SHA256")),
+    )
+
+
+def _urllib_get_json(url: str, headers: dict[str, str], timeout: float) -> dict:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed https endpoint
+        return json.loads(resp.read().decode("utf-8"))
+
+
+class BatchingTransport:
+    """Bounded buffer + background, retrying, backpressure-aware ingest exporter.
+
+    Implements the ``Exporter`` protocol (``export(attributes)``) so it drops straight into
+    :class:`~tally.client.TallyClient`.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        key: str,
+        *,
+        sdk_version: str,
+        sender: Sender | None = None,
+        observability: SelfObservability | None = None,
+        max_buffer: int = 10_000,
+        max_batch_size: int = 512,
+        flush_interval_s: float = 1.0,
+        backoff: BackoffPolicy | None = None,
+        retry_max: int = 5,
+        timeout_s: float = 5.0,
+    ) -> None:
+        self.obs = observability or SelfObservability()
+        self._endpoint = endpoint.rstrip("/")
+        self._url = f"{self._endpoint}/v1/batches"
+        self._key = key
+        self._sdk_version = sdk_version
+        self._sender: Sender = sender or (
+            lambda u, h, b: _urllib_sender(u, h, b, timeout=timeout_s)
+        )
+        self.max_buffer = max_buffer
+        self.max_batch_size = max_batch_size
+        self.flush_interval_s = flush_interval_s
+        self.backoff = backoff or BackoffPolicy()
+        self.retry_max = retry_max
+
+        self._buf: deque[dict[str, object]] = deque()
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._consecutive_failures = 0
+        # A batch pinned in flight across retries, so its batch_id is stable (idempotent resend).
+        self._pending: tuple[BatchRequest, int] | None = None
+        self._atexit_registered = False
+
+    # --- Exporter protocol (hot path) ---
+    def export(self, attributes: dict[str, object]) -> None:
+        """Enqueue a span. Never blocks, never raises. Drops oldest on overflow (counted)."""
+        with safe_block(self.obs, where="BatchingTransport.export"):
+            with self._lock:
+                if len(self._buf) >= self.max_buffer:
+                    self._buf.popleft()
+                    self.obs.dropped_span_count += 1
+                self._buf.append(attributes)
+
+    def pending(self) -> int:
+        with self._lock:
+            extra = 0 if self._pending is None else len(self._pending[0].resource_spans)
+            return len(self._buf) + extra
+
+    # --- envelope ---
+    def _build_batch(self, spans: list[dict[str, object]]) -> BatchRequest:
+        # tenant_id="" — the bearer key decides the tenant at the gateway (CTO-260 §3.1).
+        return BatchRequest(tenant_id="", sdk_version=self._sdk_version, resource_spans=spans)
+
+    def _take_batch(self) -> BatchRequest | None:
+        """Return the in-flight batch if one is pinned, else assemble a fresh one. None if empty."""
+        if self._pending is not None:
+            return self._pending[0]
+        with self._lock:
+            if not self._buf:
+                return None
+            n = min(self.max_batch_size, len(self._buf))
+            spans = [self._buf.popleft() for _ in range(n)]
+        return self._build_batch(spans)
+
+    def flush_once(self) -> bool:
+        """Flush a single batch. Returns True on delivery, False on empty/failure. Never raises."""
+        batch = self._take_batch()
+        if batch is None:
+            return False
+        attempts = 0 if self._pending is None else self._pending[1]
+
+        headers = {
+            "Authorization": f"Bearer {self._key}",
+            "Content-Type": "application/json",
+        }
+        body = encode_request(batch).encode("utf-8")
+        try:
+            status = self._sender(self._url, headers, body)
+            ok = 200 <= status < 300
+        except Exception as exc:  # noqa: BLE001 - transport errors must never escape
+            self.obs.record_error(exc, "BatchingTransport.flush")
+            ok = False
+
+        if ok:
+            self._pending = None
+            self._consecutive_failures = 0
+            return True
+
+        # Failure: pin the batch for retry, bounded by retry_max (idempotent resend by batch_id).
+        attempts += 1
+        self._consecutive_failures += 1
+        if attempts >= self.retry_max:
+            self.obs.dropped_span_count += len(batch.resource_spans)
+            self.obs.record_error(
+                RuntimeError(f"batch dropped after {attempts} attempts"),
+                "BatchingTransport.flush",
+            )
+            self._pending = None
+        else:
+            self._pending = (batch, attempts)
+        return False
+
+    def current_backoff_ms(self) -> float:
+        return self.backoff.delay_ms(self._consecutive_failures)
+
+    # --- background loop ---
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        if not self._atexit_registered:
+            atexit.register(self._atexit_drain)
+            self._atexit_registered = True
+
+        def _run() -> None:
+            while not self._stop.is_set():
+                delivered = self.flush_once()
+                if delivered:
+                    wait_s = self.flush_interval_s
+                else:
+                    backoff_ms = self.current_backoff_ms()
+                    wait_s = (backoff_ms / 1000.0) if backoff_ms > 0 else self.flush_interval_s
+                self._stop.wait(timeout=max(wait_s, 0.001))
+            # Best-effort drain on stop.
+            while self.pending() and self.flush_once():
+                pass
+
+        self._thread = threading.Thread(target=_run, name="tally-ingest", daemon=True)
+        self._thread.start()
+
+    def flush(self, timeout: float = 5.0) -> None:
+        """Drain the buffer synchronously with a bounded time budget. Never raises."""
+        import time
+
+        deadline = time.monotonic() + timeout
+        with safe_block(self.obs, where="BatchingTransport.flush_drain"):
+            while self.pending() and time.monotonic() < deadline:
+                if not self.flush_once():
+                    # A failing gateway: back off briefly rather than spin the deadline away.
+                    delay = min(self.current_backoff_ms() / 1000.0, 0.1)
+                    if delay > 0:
+                        time.sleep(delay)
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+    def _atexit_drain(self) -> None:
+        with safe_block(self.obs, where="BatchingTransport.atexit"):
+            self.flush(timeout=2.0)
+            self.stop(timeout=2.0)

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -5,10 +5,46 @@ import threading
 from tally.context import (
     current_context,
     note_context_drop,
+    set_default_feature_tag,
     start_trace,
     with_trace_context,
 )
 from tally.safety import SelfObservability
+
+
+def test_process_default_feature_tag_reaches_worker_threads():
+    # set_default_feature_tag sets a contextvar in the calling thread; a gunicorn/Flask worker
+    # thread starts fresh and never copies it, so its spans used to carry feature_tag=None despite
+    # the docstring (CTO-260 §3, finding #4). The module-global default must reach any thread.
+    set_default_feature_tag("research")
+    try:
+        assert current_context().feature_tag == "research"  # calling thread
+        seen: dict[str, str | None] = {}
+
+        def _worker() -> None:
+            seen["tag"] = current_context().feature_tag
+
+        th = threading.Thread(target=_worker)
+        th.start()
+        th.join()
+        assert seen["tag"] == "research"  # a fresh worker thread inherits the process default
+
+        # An explicit trace context still overrides the process default within its scope.
+        with with_trace_context(trace_id="t1", feature_tag="checkout"):
+            assert current_context().feature_tag == "checkout"
+    finally:
+        set_default_feature_tag(None)  # do not leak the default into other tests
+
+
+def test_explicit_none_feature_tag_beats_process_default():
+    # An explicit start_trace with no tag reads back as None, not the process default, because the
+    # contextvar was set (to None) in this context; the default only fills a genuinely-unset slot.
+    set_default_feature_tag("research")
+    try:
+        with start_trace():
+            assert current_context().feature_tag is None
+    finally:
+        set_default_feature_tag(None)
 
 
 def test_inactive_by_default():

--- a/sdk/python/tests/test_hmac_bootstrap.py
+++ b/sdk/python/tests/test_hmac_bootstrap.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-260 §3.2/§3.3 — HMAC bootstrap: fetch/parse, TTL cache, registry hashing, fallback."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from tally.hmac_keys import (
+    HmacKeyBootstrap,
+    HmacKeyRegistry,
+    RemoteKeyMaterialProvider,
+)
+from tally.transport import fetch_hmac_key
+
+_MATERIAL = b"0123456789abcdef0123456789abcdef"  # 32 bytes
+_TENANT = "11111111-2222-3333-4444-555555555555"
+
+
+def _fake_response() -> dict:
+    return {
+        "tenant_id": _TENANT,
+        "key_version": "v3",
+        "key_material_b64": base64.b64encode(_MATERIAL).decode("ascii"),
+        "algorithm": "HMAC-SHA256",
+    }
+
+
+def test_fetch_hmac_key_parses_response():
+    seen = {}
+
+    def opener(url, headers, timeout):
+        seen["url"] = url
+        seen["auth"] = headers["Authorization"]
+        return _fake_response()
+
+    boot = fetch_hmac_key("http://gw.test", "tally_sk_live_x", opener=opener)
+    assert seen["url"] == "http://gw.test/v1/tenant/hmac-key"
+    assert seen["auth"] == "Bearer tally_sk_live_x"
+    assert boot.tenant_id == _TENANT
+    assert boot.key_version == "v3"
+    assert boot.material == _MATERIAL
+
+
+def test_remote_provider_caches_until_ttl():
+    calls = {"n": 0}
+    clock = {"t": 0.0}
+
+    def fetch() -> HmacKeyBootstrap:
+        calls["n"] += 1
+        return HmacKeyBootstrap(_TENANT, "v3", _MATERIAL)
+
+    provider = RemoteKeyMaterialProvider(
+        fetch=fetch, ttl_seconds=100.0, _clock=lambda: clock["t"]
+    )
+    assert provider.material(_TENANT, "v3") == _MATERIAL
+    assert provider.material(_TENANT, "v3") == _MATERIAL
+    assert calls["n"] == 1  # served from cache
+    clock["t"] = 200.0  # advance past TTL
+    assert provider.material(_TENANT, "v3") == _MATERIAL
+    assert calls["n"] == 2  # re-fetched after expiry
+
+
+def test_registry_hashes_under_bootstrapped_key():
+    provider = RemoteKeyMaterialProvider(fetch=lambda: HmacKeyBootstrap(_TENANT, "v3", _MATERIAL))
+    provider._cache["v3"] = (provider._clock(), _MATERIAL)
+    registry = HmacKeyRegistry(provider=provider)
+    registry.provision(_TENANT, initial_version="v3")
+    stamped = registry.hash_account(_TENANT, "acct_northwind")
+    assert stamped.key_version == "v3"
+    assert len(stamped.value) == 64  # sha256 hex
+    # Deterministic under the same key material.
+    assert registry.hash_account(_TENANT, "acct_northwind").value == stamped.value
+
+
+def test_init_bootstrap_sets_registry(monkeypatch):
+    import sys
+    init_mod = sys.modules["tally.init"]
+
+    monkeypatch.setattr(
+        init_mod, "fetch_hmac_key", lambda endpoint, key: HmacKeyBootstrap(_TENANT, "v3", _MATERIAL)
+    )
+    from tally.client import TallyClient
+    from tally.safety import SelfObservability
+
+    client = TallyClient()
+    init_mod._bootstrap_hmac(client, "http://gw.test", "tally_sk_live_x", SelfObservability())
+    assert client.tenant_id == _TENANT
+    assert client.hmac_registry is not None
+    # And it can hash without a second network fetch (primed cache).
+    assert len(client.hmac_registry.hash_account(_TENANT, "acct_x").value) == 64
+
+
+def test_init_bootstrap_failure_leaves_unattributed(monkeypatch):
+    import sys
+    init_mod = sys.modules["tally.init"]
+
+    def boom(endpoint, key):
+        raise ConnectionError("gateway down")
+
+    monkeypatch.setattr(init_mod, "fetch_hmac_key", boom)
+    from tally.client import TallyClient
+    from tally.safety import SelfObservability
+
+    client = TallyClient()
+    obs = SelfObservability()
+    init_mod._bootstrap_hmac(client, "http://gw.test", "tally_sk_live_x", obs)
+    # No raise; account stays unattributed (tenant/ registry never set).
+    assert client.tenant_id is None
+    assert client.hmac_registry is None
+    assert obs.internal_error_count >= 1
+
+
+def test_provider_unknown_version_raises_when_uncached():
+    provider = RemoteKeyMaterialProvider(fetch=lambda: HmacKeyBootstrap(_TENANT, "v3", _MATERIAL))
+    with pytest.raises(ValueError):
+        provider.material(_TENANT, "v9")

--- a/sdk/python/tests/test_hmac_bootstrap.py
+++ b/sdk/python/tests/test_hmac_bootstrap.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CTO-260 §3.2/§3.3 — HMAC bootstrap: fetch/parse, TTL cache, registry hashing, fallback."""
+"""CTO-260 §3.2/§3.3 - HMAC bootstrap: fetch/parse, TTL cache, registry hashing, fallback."""
 
 from __future__ import annotations
 

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CTO-260 §3 — tally.init: idempotent, env fallback, never-raise, module-level delegation."""
+"""CTO-260 §3 - tally.init: idempotent, env fallback, never-raise, module-level delegation."""
 
 from __future__ import annotations
 

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-260 §3 — tally.init: idempotent, env fallback, never-raise, module-level delegation."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import tally
+from tally.context import current_context
+
+# ``tally.init`` the attribute is the init() function (it shadows the submodule), so reach the
+# module object through sys.modules.
+init_mod = sys.modules["tally.init"]
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    # Keep the bootstrap thread off the network: fail fast instead of hitting a real gateway.
+    def _no_net(endpoint, key):
+        raise ConnectionError("no network in tests")
+
+    monkeypatch.setattr(init_mod, "fetch_hmac_key", _no_net)
+    monkeypatch.delenv("TALLY_KEY", raising=False)
+    monkeypatch.delenv("TALLY_ENDPOINT", raising=False)
+    yield
+    tally.uninstrument()
+
+
+def test_returns_client_and_is_idempotent():
+    c1 = tally.init("tally_sk_live_a", instrument=False)
+    c2 = tally.init("tally_sk_live_b", instrument=False)  # ignored: already initialised
+    assert c1 is c2
+    assert c1._api_key == "tally_sk_live_a"
+
+
+def test_reads_env(monkeypatch):
+    monkeypatch.setenv("TALLY_KEY", "tally_sk_live_env")
+    monkeypatch.setenv("TALLY_ENDPOINT", "http://gw.env")
+    c = tally.init(instrument=False)
+    assert c._api_key == "tally_sk_live_env"
+    assert c._endpoint == "http://gw.env"
+
+
+def test_no_key_disables_without_raising():
+    c = tally.init(instrument=False)  # no key, no env
+    assert c is not None
+    # Safe: recording still never raises, it just lands nowhere useful.
+    assert tally.record_tool_call(provider="openai", tool="web_search") is None
+
+
+def test_feature_tag_becomes_process_default():
+    tally.init("tally_sk_live_a", feature_tag="research", instrument=False)
+    assert current_context().feature_tag == "research"
+
+
+def test_module_record_delegates_to_client():
+    tally.init("tally_sk_live_a", instrument=False)
+    tally.record_tool_call(provider="openai", tool="web_search")
+    # The span was enqueued on the background transport (not flushed / no network).
+    assert init_mod._transport is not None
+    assert init_mod._transport.pending() >= 1
+
+
+def test_record_before_init_is_noop():
+    # Be explicit about the uninstrumented state regardless of test ordering.
+    tally.uninstrument()
+    assert tally.record_vector_call(provider="p", index="i", operation="query") is None
+    assert tally.record_llm_call(provider="openai", model="gpt-4o", usage=None) is None
+
+
+def test_init_never_raises_on_internal_failure(monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("transport construction failed")
+
+    monkeypatch.setattr(init_mod, "BatchingTransport", _boom)
+    # Must swallow the internal failure and still hand back a benign client.
+    c = tally.init("tally_sk_live_a", instrument=False)
+    assert c is not None
+    assert init_mod._obs.internal_error_count >= 1
+
+
+def test_flush_is_safe_before_init():
+    tally.uninstrument()
+    tally.flush()  # no client / transport -> no-op, no raise

--- a/sdk/python/tests/test_patch_anthropic.py
+++ b/sdk/python/tests/test_patch_anthropic.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CTO-260 §4 — patch_anthropic over fake Anthropic classes (create + stream, sync/async)."""
+"""CTO-260 §4 - patch_anthropic over fake Anthropic classes (create + stream, sync/async)."""
 
 from __future__ import annotations
 
@@ -66,7 +66,10 @@ class _StreamManager:
 
 
 class FakeMessages:
-    def create(self, *, model, input_tokens=100, output_tokens=50, cached=0):
+    def create(self, *, model, input_tokens=100, output_tokens=50, cached=0, stream=False):
+        if stream:
+            # The supported streamed form of create(): returns an iterator of events.
+            return iter([_start_event(model, input_tokens), _delta_event(output_tokens)])
         return _Resp(model, _U(input_tokens, output_tokens, cached))
 
     def stream(self, *, model, input_tokens=100, output_tokens=50, iterate=True):
@@ -103,13 +106,57 @@ class _AsyncStreamManager:
 
 
 class FakeAsyncMessages:
-    async def create(self, *, model, input_tokens=100, output_tokens=50):
+    async def create(self, *, model, input_tokens=100, output_tokens=50, stream=False):
+        if stream:
+            return _AsyncStream([_start_event(model, input_tokens), _delta_event(output_tokens)])
         return _Resp(model, _U(input_tokens, output_tokens))
 
     def stream(self, *, model, input_tokens=100, output_tokens=50):
         events = [_start_event(model, input_tokens), _delta_event(output_tokens)]
         final = _final_message(model, input_tokens, output_tokens)
         return _AsyncStreamManager(events, final)
+
+
+class _AsyncFinalStream:
+    """Entered async stream whose get_final_message is a coroutine, as the real client's is.
+
+    Crucially the coroutine lives here, on the entered stream, not on the manager (finding #5).
+    """
+
+    def __init__(self, events, final):
+        self._events = events
+        self._final = final
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for e in self._events:
+            yield e
+
+    async def get_final_message(self):
+        return self._final
+
+
+class _AsyncFinalStreamManager:
+    def __init__(self, events, final):
+        self._events = events
+        self._final = final
+
+    async def __aenter__(self):
+        return _AsyncFinalStream(self._events, self._final)
+
+    async def __aexit__(self, *exc):
+        return False
+
+    # Deliberately NO get_final_message here: it belongs on the entered stream object.
+
+
+class FakeAsyncFinalMessages:
+    def stream(self, *, model, input_tokens=100, output_tokens=50):
+        # Empty events so the caller never iterates and the final-message path is exercised.
+        final = _final_message(model, input_tokens, output_tokens)
+        return _AsyncFinalStreamManager([], final)
 
 
 @pytest.fixture(autouse=True)
@@ -168,6 +215,59 @@ def test_stream_without_iteration_uses_final_message():
         pass  # caller never iterates the events
     assert len(spans) == 1
     # Seeded from get_final_message() rather than fabricated.
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 42
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 7
+
+
+def test_create_stream_true_accumulates_usage():
+    # messages.create(stream=True) is a supported streamed form; before the fix it was wrapped
+    # non-streaming and emitted null tokens with no cost (CTO-260 §4.3, finding #2).
+    spans: list[dict] = []
+    _patch(spans)
+    stream = FakeMessages().create(model=_MODEL, stream=True, input_tokens=250, output_tokens=75)
+    collected = list(stream)  # events pass through untouched
+    assert len(collected) == 2
+    assert len(spans) == 1
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 250
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 75
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] > 0
+
+
+def test_async_create_stream_true_accumulates_usage():
+    spans: list[dict] = []
+    _patch(spans)
+
+    async def _run():
+        agen = await FakeAsyncMessages().create(
+            model=_MODEL, stream=True, input_tokens=120, output_tokens=30
+        )
+        return [e async for e in agen]
+
+    collected = asyncio.run(_run())
+    assert len(collected) == 2
+    assert len(spans) == 1
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 120
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 30
+
+
+def test_async_stream_awaits_final_message_coroutine():
+    # On the async client get_final_message is a coroutine on the entered stream. The emit path must
+    # look it up there (not on the manager) and await it, else usage is null (finding #5).
+    spans: list[dict] = []
+    patch_anthropic(
+        on_span=spans.append,
+        catalog=seed_catalog(),
+        targets={"messages_async": FakeAsyncFinalMessages},
+    )
+
+    async def _run():
+        async with FakeAsyncFinalMessages().stream(
+            model=_MODEL, input_tokens=42, output_tokens=7
+        ):
+            pass  # never iterate, forcing the final-message fallback
+
+    asyncio.run(_run())
+    assert len(spans) == 1
     assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 42
     assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 7
 

--- a/sdk/python/tests/test_patch_anthropic.py
+++ b/sdk/python/tests/test_patch_anthropic.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-260 §4 — patch_anthropic over fake Anthropic classes (create + stream, sync/async)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from tally.instrumentation.patch import patch_anthropic, unpatch_all
+from tally.pricing import seed_catalog
+from tally.schema import GenAI, validate_span_attributes
+
+_MODEL = "claude-sonnet-4-5"
+
+
+@dataclass
+class _U:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+@dataclass
+class _Resp:
+    model: str
+    usage: _U
+
+
+def _start_event(model, input_tokens):
+    msg = {"model": model, "usage": {"input_tokens": input_tokens}}
+    return {"type": "message_start", "message": msg}
+
+
+def _delta_event(output_tokens):
+    return {"type": "message_delta", "usage": {"output_tokens": output_tokens}}
+
+
+def _final_message(model, input_tokens, output_tokens):
+    usage = {"input_tokens": input_tokens, "output_tokens": output_tokens}
+    return {"model": model, "usage": usage}
+
+
+class _Stream:
+    def __init__(self, events):
+        self._events = events
+
+    def __iter__(self):
+        return iter(self._events)
+
+
+class _StreamManager:
+    def __init__(self, events, final):
+        self._events = events
+        self._final = final
+
+    def __enter__(self):
+        return _Stream(self._events)
+
+    def __exit__(self, *exc):
+        return False
+
+    def get_final_message(self):
+        return self._final
+
+
+class FakeMessages:
+    def create(self, *, model, input_tokens=100, output_tokens=50, cached=0):
+        return _Resp(model, _U(input_tokens, output_tokens, cached))
+
+    def stream(self, *, model, input_tokens=100, output_tokens=50, iterate=True):
+        events = [_start_event(model, input_tokens), _delta_event(output_tokens)]
+        final = _final_message(model, input_tokens, output_tokens)
+        return _StreamManager(events if iterate else [], final)
+
+
+class _AsyncStream:
+    def __init__(self, events):
+        self._events = events
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for e in self._events:
+            yield e
+
+
+class _AsyncStreamManager:
+    def __init__(self, events, final):
+        self._events = events
+        self._final = final
+
+    async def __aenter__(self):
+        return _AsyncStream(self._events)
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def get_final_message(self):
+        return self._final
+
+
+class FakeAsyncMessages:
+    async def create(self, *, model, input_tokens=100, output_tokens=50):
+        return _Resp(model, _U(input_tokens, output_tokens))
+
+    def stream(self, *, model, input_tokens=100, output_tokens=50):
+        events = [_start_event(model, input_tokens), _delta_event(output_tokens)]
+        final = _final_message(model, input_tokens, output_tokens)
+        return _AsyncStreamManager(events, final)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    unpatch_all()
+
+
+def _patch(spans):
+    patch_anthropic(
+        on_span=spans.append,
+        catalog=seed_catalog(),
+        targets={"messages": FakeMessages, "messages_async": FakeAsyncMessages},
+    )
+
+
+def test_sync_create_emits_span_with_usage():
+    spans: list[dict] = []
+    _patch(spans)
+    resp = FakeMessages().create(
+        model=_MODEL, input_tokens=1_000_000, output_tokens=1_000_000, cached=0
+    )
+    assert isinstance(resp, _Resp)
+    assert validate_span_attributes(spans[0]) == []
+    assert spans[0][GenAI.SYSTEM] == "anthropic"
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 1_000_000
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 1_000_000
+    # 3.00 input + 15.00 output USD per 1M = 18_000_000 micro.
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] == 18_000_000
+
+
+def test_cache_read_maps_to_cached_input():
+    spans: list[dict] = []
+    _patch(spans)
+    FakeMessages().create(model=_MODEL, input_tokens=1000, output_tokens=10, cached=1000)
+    assert spans[0][GenAI.USAGE_CACHED_INPUT_TOKENS] == 1000
+
+
+def test_sync_stream_accumulates_usage():
+    spans: list[dict] = []
+    _patch(spans)
+    collected = []
+    with FakeMessages().stream(model=_MODEL, input_tokens=200, output_tokens=80) as stream:
+        for event in stream:
+            collected.append(event)
+    assert len(collected) == 2  # events passed through untouched
+    assert len(spans) == 1
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 200
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 80
+
+
+def test_stream_without_iteration_uses_final_message():
+    spans: list[dict] = []
+    _patch(spans)
+    with FakeMessages().stream(model=_MODEL, input_tokens=42, output_tokens=7, iterate=False):
+        pass  # caller never iterates the events
+    assert len(spans) == 1
+    # Seeded from get_final_message() rather than fabricated.
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 42
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 7
+
+
+def test_stream_provider_error_propagates():
+    class Boom:
+        def stream(self, *, model):
+            raise RuntimeError("anthropic 529")
+
+    spans: list[dict] = []
+    patch_anthropic(on_span=spans.append, targets={"messages": Boom})
+    with pytest.raises(RuntimeError, match="anthropic 529"):
+        Boom().stream(model=_MODEL)
+
+
+def test_async_create_and_stream():
+    spans: list[dict] = []
+    _patch(spans)
+
+    async def _run():
+        resp = await FakeAsyncMessages().create(model=_MODEL, input_tokens=100, output_tokens=50)
+        assert isinstance(resp, _Resp)
+        collected = []
+        mgr = FakeAsyncMessages().stream(model=_MODEL, input_tokens=300, output_tokens=90)
+        async with mgr as s:
+            async for e in s:
+                collected.append(e)
+        return collected
+
+    collected = asyncio.run(_run())
+    assert len(collected) == 2
+    assert len(spans) == 2
+    stream_span = spans[1]
+    assert stream_span[GenAI.USAGE_INPUT_TOKENS] == 300
+    assert stream_span[GenAI.USAGE_OUTPUT_TOKENS] == 90

--- a/sdk/python/tests/test_patch_openai.py
+++ b/sdk/python/tests/test_patch_openai.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CTO-260 §4 — patch_openai over fake OpenAI classes (sync/async/streaming, no network)."""
+"""CTO-260 §4 - patch_openai over fake OpenAI classes (sync/async/streaming, no network)."""
 
 from __future__ import annotations
 
@@ -88,6 +88,59 @@ class FakeAsyncCompletions:
 class FakeEmbeddings:
     def create(self, *, model, tokens=1000):
         return _EmbResp(model, _EmbUsage(tokens))
+
+
+# --- Responses API fakes (usage named input_tokens / output_tokens; terminal event nests it) ---
+@dataclass
+class _RespUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclass
+class _RespObj:
+    model: str
+    usage: _RespUsage
+
+
+@dataclass
+class _RespEvent:
+    response: _RespObj | None = None
+    model: str | None = None
+
+
+class FakeResponses:
+    def create(self, *, model, stream=False, input_tokens=100, output_tokens=50):
+        if stream:
+            terminal = _RespEvent(response=_RespObj(model, _RespUsage(input_tokens, output_tokens)))
+            return _OpenAIStream([_RespEvent(model=model), terminal])
+        return _RespObj(model, _RespUsage(input_tokens, output_tokens))
+
+
+class _OpenAIStream:
+    """Mimics an ``openai`` ``Stream``: iterable, a context manager, with ``.response``/``.close``.
+
+    This is the object ``create(stream=True)`` returns; the instrumentation must preserve it rather
+    than replace it with a bare generator (CTO-260 §4.3, review finding #6).
+    """
+
+    def __init__(self, chunks, response="HTTP-RESP"):
+        self._chunks = chunks
+        self.response = response
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def close(self):
+        self.closed = True
 
 
 @pytest.fixture(autouse=True)
@@ -217,3 +270,58 @@ def test_async_chat_and_stream():
     assert len(chunks) == 1  # no usage without include_usage
     # Two spans: one from the non-stream call, one from the exhausted stream.
     assert len(spans) == 2
+
+
+def test_responses_nonstream_emits_span():
+    spans: list[dict] = []
+    patch_openai(
+        on_span=spans.append, catalog=seed_catalog(), targets={"responses": FakeResponses}
+    )
+    FakeResponses().create(model="gpt-4o-mini", input_tokens=10, output_tokens=5)
+    assert len(spans) == 1
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 10
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 5
+
+
+def test_responses_stream_accumulates_usage():
+    # Before the fix responses.create(stream=True) was wrapped non-streaming and emitted null
+    # tokens with no cost. It must now accumulate usage from the stream (CTO-260 §4.2, finding #3).
+    spans: list[dict] = []
+    patch_openai(
+        on_span=spans.append, catalog=seed_catalog(), targets={"responses": FakeResponses}
+    )
+    stream = FakeResponses().create(
+        model="gpt-4o-mini", stream=True, input_tokens=1000, output_tokens=500
+    )
+    chunks = list(stream)
+    assert len(chunks) == 2  # events passed through untouched
+    assert len(spans) == 1
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 1000
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 500
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] > 0
+
+
+def test_openai_stream_preserves_context_manager_and_attributes():
+    # The OpenAI streaming wrapper must preserve the provider Stream object: attribute delegation
+    # (.response), close(), and the with-statement protocol (CTO-260 §4.3, finding #6).
+    spans: list[dict] = []
+
+    class FakeStreamChat:
+        def create(self, *, model, stream=False, stream_options=None):
+            chunks = [_Chunk(model=model), _Chunk(model=model, usage=_U(100, 50))]
+            return _OpenAIStream(chunks)
+
+    patch_openai(
+        on_span=spans.append, catalog=seed_catalog(), targets={"chat": FakeStreamChat}
+    )
+    client = FakeStreamChat()
+    collected = []
+    with client.create(model="gpt-4o-mini", stream=True) as s:
+        assert s.response == "HTTP-RESP"  # attribute delegated to the real Stream
+        for chunk in s:
+            collected.append(chunk)
+    assert len(collected) == 2
+    assert s.closed is True  # __exit__ delegated to the real Stream.close()
+    assert len(spans) == 1  # span emitted exactly once
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 100
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 50

--- a/sdk/python/tests/test_patch_openai.py
+++ b/sdk/python/tests/test_patch_openai.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-260 §4 — patch_openai over fake OpenAI classes (sync/async/streaming, no network)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from tally.instrumentation.patch import patch_openai, unpatch_all
+from tally.pricing import seed_catalog
+from tally.schema import GenAI, validate_span_attributes
+
+
+# --- fake OpenAI response + chunk shapes ---
+@dataclass
+class _U:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
+@dataclass
+class _Resp:
+    model: str
+    usage: _U
+
+
+@dataclass
+class _Chunk:
+    model: str
+    usage: _U | None = None
+
+
+@dataclass
+class _EmbUsage:
+    prompt_tokens: int
+
+
+@dataclass
+class _EmbResp:
+    model: str
+    usage: _EmbUsage
+
+
+class FakeCompletions:
+    def __init__(self) -> None:
+        self.received: list = []
+
+    def create(self, *, model, stream=False, stream_options=None, prompt=10, completion=5):
+        self.received.append(stream_options)
+        if stream:
+            chunks = [_Chunk(model=model)]
+            if stream_options and stream_options.get("include_usage"):
+                chunks.append(_Chunk(model=model, usage=_U(prompt, completion)))
+            return iter(chunks)
+        return _Resp(model, _U(prompt, completion))
+
+
+class _AsyncChunks:
+    def __init__(self, model, with_usage, prompt, completion):
+        self._model = model
+        self._with_usage = with_usage
+        self._prompt = prompt
+        self._completion = completion
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        yield _Chunk(model=self._model)
+        if self._with_usage:
+            yield _Chunk(model=self._model, usage=_U(self._prompt, self._completion))
+
+
+class FakeAsyncCompletions:
+    def __init__(self) -> None:
+        self.received: list = []
+
+    async def create(self, *, model, stream=False, stream_options=None, prompt=10, completion=5):
+        self.received.append(stream_options)
+        if stream:
+            with_usage = bool(stream_options and stream_options.get("include_usage"))
+            return _AsyncChunks(model, with_usage, prompt, completion)
+        return _Resp(model, _U(prompt, completion))
+
+
+class FakeEmbeddings:
+    def create(self, *, model, tokens=1000):
+        return _EmbResp(model, _EmbUsage(tokens))
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    unpatch_all()
+
+
+def _patch(spans, **kw):
+    patch_openai(
+        on_span=spans.append,
+        catalog=seed_catalog(),
+        targets={
+            "chat": FakeCompletions,
+            "chat_async": FakeAsyncCompletions,
+            "embeddings": FakeEmbeddings,
+        },
+        **kw,
+    )
+
+
+def test_sync_chat_emits_conformant_span():
+    spans: list[dict] = []
+    _patch(spans)
+    client = FakeCompletions()
+    resp = client.create(model="gpt-4o-mini", prompt=1_000_000, completion=1_000_000)
+    assert isinstance(resp, _Resp)  # original returned unchanged
+    assert len(spans) == 1
+    assert validate_span_attributes(spans[0]) == []
+    assert spans[0][GenAI.SYSTEM] == "openai"
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 1_000_000
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] > 0
+
+
+def test_idempotent_double_patch_emits_once():
+    spans: list[dict] = []
+    _patch(spans)
+    _patch(spans)  # second patch is a no-op
+    FakeCompletions().create(model="gpt-4o-mini")
+    assert len(spans) == 1
+
+
+def test_uninstrument_reverses():
+    spans: list[dict] = []
+    _patch(spans)
+    unpatch_all()
+    FakeCompletions().create(model="gpt-4o-mini")
+    assert spans == []
+
+
+def test_provider_error_propagates():
+    class Boom:
+        def create(self, *, model):
+            raise RuntimeError("openai 500")
+
+    spans: list[dict] = []
+    patch_openai(on_span=spans.append, targets={"chat": Boom})
+    with pytest.raises(RuntimeError, match="openai 500"):
+        Boom().create(model="gpt-4o-mini")
+
+
+def test_faulty_sink_never_breaks_call():
+    def bad_sink(_attrs):
+        raise ValueError("sink boom")
+
+    patch_openai(
+        on_span=bad_sink, catalog=seed_catalog(), targets={"chat": FakeCompletions}
+    )
+    resp = FakeCompletions().create(model="gpt-4o-mini")
+    assert isinstance(resp, _Resp)
+
+
+def test_streaming_without_usage_yields_null_tokens():
+    spans: list[dict] = []
+    _patch(spans)
+    stream = FakeCompletions().create(model="gpt-4o-mini", stream=True)
+    chunks = list(stream)  # caller iterates untouched chunks
+    assert len(chunks) == 1  # no usage chunk since include_usage not set
+    assert len(spans) == 1
+    # Honest blank: tokens null, never a fabricated zero.
+    assert GenAI.USAGE_INPUT_TOKENS not in spans[0]
+    assert GenAI.COST_ESTIMATED_MICRO_USD not in spans[0]
+
+
+def test_stream_usage_optin_injects_include_usage_and_prices():
+    spans: list[dict] = []
+    _patch(spans, instrument_stream_usage=True)
+    client = FakeCompletions()
+    chunks = list(client.create(model="gpt-4o-mini", stream=True, prompt=1000, completion=500))
+    # The wrapper added stream_options when the caller did not set it.
+    assert client.received[-1] == {"include_usage": True}
+    assert len(chunks) == 2  # usage chunk now present
+    assert spans[0][GenAI.USAGE_INPUT_TOKENS] == 1000
+    assert spans[0][GenAI.USAGE_OUTPUT_TOKENS] == 500
+
+
+def test_stream_usage_respects_caller_options():
+    spans: list[dict] = []
+    _patch(spans, instrument_stream_usage=True)
+    client = FakeCompletions()
+    list(client.create(model="gpt-4o-mini", stream=True, stream_options={"include_usage": True}))
+    # Caller already set it; the wrapper must not overwrite.
+    assert client.received[-1] == {"include_usage": True}
+
+
+def test_embeddings_priced_under_embedding_tier():
+    spans: list[dict] = []
+    _patch(spans)
+    FakeEmbeddings().create(model="text-embedding-3-small", tokens=1_000_000)
+    assert len(spans) == 1
+    assert spans[0][GenAI.OPERATION_NAME] == "embeddings"
+    assert spans[0][GenAI.COST_ESTIMATED_MICRO_USD] == 20_000  # 0.02 USD / 1M tokens
+
+
+def test_async_chat_and_stream():
+    spans: list[dict] = []
+    _patch(spans)
+
+    async def _run():
+        resp = await FakeAsyncCompletions().create(model="gpt-4o-mini", prompt=100, completion=50)
+        assert isinstance(resp, _Resp)
+        agen = await FakeAsyncCompletions().create(model="gpt-4o-mini", stream=True)
+        out = [c async for c in agen]
+        return out
+
+    chunks = asyncio.run(_run())
+    assert len(chunks) == 1  # no usage without include_usage
+    # Two spans: one from the non-stream call, one from the exhausted stream.
+    assert len(spans) == 2

--- a/sdk/python/tests/test_transport.py
+++ b/sdk/python/tests/test_transport.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CTO-260 §5 — background batching transport: batching, retry, backpressure, drain, envelope."""
+"""CTO-260 §5 - background batching transport: batching, retry, backpressure, drain, envelope."""
 
 from __future__ import annotations
+
+import threading
 
 from tally.egress import BackoffPolicy
 from tally.transport import BatchingTransport
@@ -54,7 +56,7 @@ def test_envelope_has_bearer_and_empty_tenant():
     assert url == "http://gw.test/v1/batches"
     assert headers["Authorization"] == "Bearer tally_sk_live_x"
     req = decode_request(body.decode("utf-8"))
-    # tenant omitted — the key decides at the gateway (CTO-260 §3.1).
+    # tenant omitted - the key decides at the gateway (CTO-260 §3.1).
     assert req.tenant_id == ""
     assert len(req.resource_spans) == 1
 
@@ -102,6 +104,91 @@ def test_flush_drains_all_batches():
     t.flush(timeout=2.0)
     assert t.pending() == 0
     assert len(sender.calls) == 5
+
+
+class _ConcurrentSender:
+    """Thread-safe sender that fails every Nth call and records the spans each 2xx batch carried.
+
+    Delivered batch ids and their span markers are captured under a lock so the test can assert,
+    across a daemon flush racing a caller flush(), that every span is delivered exactly once.
+    """
+
+    def __init__(self, fail_every: int = 4) -> None:
+        self._lock = threading.Lock()
+        self._n = 0
+        self.fail_every = fail_every
+        self.delivered: list[int] = []
+        self.delivered_batch_ids: list[str] = []
+
+    def __call__(self, url: str, headers: dict, body: bytes) -> int:
+        req = decode_request(body.decode("utf-8"))
+        with self._lock:
+            self._n += 1
+            fail = self._n % self.fail_every == 0
+            if not fail:
+                self.delivered_batch_ids.append(req.batch_id)
+                self.delivered.extend(int(s["i"]) for s in req.resource_spans)
+        if fail:
+            raise ConnectionError("simulated blip")
+        return 200
+
+
+def test_concurrent_flush_and_failures_lose_no_spans():
+    # The daemon worker and a caller flush() run flush_once concurrently while sends intermittently
+    # fail. The guarded flush path must lose no span, double-send none, and never crash the worker.
+    sender = _ConcurrentSender(fail_every=4)
+    t = _transport(
+        sender,
+        max_batch_size=8,
+        retry_max=1000,  # high so no batch is dropped; the point is loss-free delivery
+        flush_interval_s=0.001,
+        backoff=BackoffPolicy(base_ms=0, max_ms=0),
+    )
+    total = 400
+    t.start()
+    try:
+        for i in range(total):
+            t.export({"i": i})
+            if i % 5 == 0:
+                t.flush(timeout=1.0)  # caller flush races the daemon worker
+    finally:
+        t.flush(timeout=5.0)
+        t.stop(timeout=5.0)
+
+    # Every exported span delivered exactly once: no loss, no duplicate.
+    assert sorted(sender.delivered) == list(range(total))
+    # A delivered batch id is never delivered twice (idempotent, pinned batch not double-sent).
+    assert len(sender.delivered_batch_ids) == len(set(sender.delivered_batch_ids))
+    assert t.pending() == 0
+
+
+def test_pending_never_raises_under_concurrent_flush():
+    # pending() reading _pending used to TOCTOU-crash the daemon (it runs outside safe_block).
+    # Hammer it from many threads while flush_once churns _pending; it must never raise.
+    sender = _RecordingSender(fail_times=50)
+    t = _transport(sender, max_batch_size=1, backoff=BackoffPolicy(base_ms=0, max_ms=0))
+    for i in range(50):
+        t.export({"i": i})
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def _poll() -> None:
+        try:
+            while not stop.is_set():
+                t.pending()
+        except BaseException as exc:  # noqa: BLE001 - the whole point is that none escapes
+            errors.append(exc)
+
+    pollers = [threading.Thread(target=_poll) for _ in range(8)]
+    for p in pollers:
+        p.start()
+    for _ in range(200):
+        t.flush_once()
+    stop.set()
+    for p in pollers:
+        p.join(timeout=2.0)
+    assert errors == []
 
 
 def test_sender_error_never_raises():

--- a/sdk/python/tests/test_transport.py
+++ b/sdk/python/tests/test_transport.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-260 §5 — background batching transport: batching, retry, backpressure, drain, envelope."""
+
+from __future__ import annotations
+
+from tally.egress import BackoffPolicy
+from tally.transport import BatchingTransport
+from tally.wire import decode_request
+
+
+class _RecordingSender:
+    """Captures POSTs; ``fail_times`` initial calls raise, then succeeds with 200."""
+
+    def __init__(self, fail_times: int = 0, status: int = 200) -> None:
+        self._fail = fail_times
+        self._status = status
+        self.calls: list[tuple[str, dict, bytes]] = []
+
+    def __call__(self, url: str, headers: dict, body: bytes) -> int:
+        self.calls.append((url, headers, body))
+        if self._fail > 0:
+            self._fail -= 1
+            raise ConnectionError("simulated outage")
+        return self._status
+
+
+def _transport(sender, **kw) -> BatchingTransport:
+    return BatchingTransport(
+        "http://gw.test",
+        "tally_sk_live_x",
+        sdk_version="0.0.1",
+        sender=sender,
+        **kw,
+    )
+
+
+def test_export_never_blocks_and_flush_delivers():
+    sender = _RecordingSender()
+    t = _transport(sender)
+    t.export({"gen_ai.system": "openai"})
+    t.export({"gen_ai.system": "anthropic"})
+    assert t.pending() == 2
+    assert t.flush_once() is True
+    assert t.pending() == 0
+    assert len(sender.calls) == 1  # one batch
+
+
+def test_envelope_has_bearer_and_empty_tenant():
+    sender = _RecordingSender()
+    t = _transport(sender)
+    t.export({"gen_ai.system": "openai"})
+    t.flush_once()
+    url, headers, body = sender.calls[0]
+    assert url == "http://gw.test/v1/batches"
+    assert headers["Authorization"] == "Bearer tally_sk_live_x"
+    req = decode_request(body.decode("utf-8"))
+    # tenant omitted — the key decides at the gateway (CTO-260 §3.1).
+    assert req.tenant_id == ""
+    assert len(req.resource_spans) == 1
+
+
+def test_retry_reuses_batch_id_and_eventually_delivers():
+    sender = _RecordingSender(fail_times=2)
+    t = _transport(sender)
+    t.export({"gen_ai.system": "openai"})
+    assert t.flush_once() is False  # attempt 1 fails
+    assert t.flush_once() is False  # attempt 2 fails
+    assert t.flush_once() is True  # attempt 3 succeeds
+    # Same batch_id across retries (idempotent resend).
+    ids = {decode_request(b.decode()).batch_id for (_, _, b) in sender.calls}
+    assert len(ids) == 1
+
+
+def test_retry_exhaustion_drops_batch_with_counter():
+    sender = _RecordingSender(fail_times=99)
+    t = _transport(sender, retry_max=3)
+    t.export({"gen_ai.system": "openai"})
+    for _ in range(3):
+        t.flush_once()
+    assert t.pending() == 0  # dropped after retry_max
+    assert t.obs.dropped_span_count == 1
+
+
+def test_backpressure_drops_oldest():
+    sender = _RecordingSender()
+    t = _transport(sender, max_buffer=2)
+    t.export({"n": 1})
+    t.export({"n": 2})
+    t.export({"n": 3})  # overflow -> drop oldest ({"n": 1})
+    assert t.pending() == 2
+    assert t.obs.dropped_span_count == 1
+    t.flush_once()
+    delivered = decode_request(sender.calls[0][2].decode()).resource_spans
+    assert {s["n"] for s in delivered} == {2, 3}
+
+
+def test_flush_drains_all_batches():
+    sender = _RecordingSender()
+    t = _transport(sender, max_batch_size=1)
+    for i in range(5):
+        t.export({"n": i})
+    t.flush(timeout=2.0)
+    assert t.pending() == 0
+    assert len(sender.calls) == 5
+
+
+def test_sender_error_never_raises():
+    def boom(url, headers, body):
+        raise RuntimeError("kaboom")
+
+    t = _transport(boom, backoff=BackoffPolicy(base_ms=0, max_ms=0))
+    t.export({"n": 1})
+    # Must not raise; failure recorded to self-observability.
+    assert t.flush_once() is False
+    assert t.obs.internal_error_count >= 1


### PR DESCRIPTION
## Initiative 2: Real one-step connect — SDK portion (CTO-260)

Client side only. Builds spec sections 3, 3.1, 3.2 (client side), 3.3, 4 (4.1–4.6), 5, and 7 (SDK helper side). Scoped to `sdk/python/`; the gateway (`web`/`gateway`) and edge-proxy portions ship in parallel PRs.

### What is built

- **`tally.init(key, *, endpoint, feature_tag, instrument, instrument_stream_usage, flush_interval_s, catalog)`** (`src/tally/init.py`, §3): tenant-free (the key is authoritative), idempotent, never blocks the calling thread, never raises. Reads `TALLY_KEY` / `TALLY_ENDPOINT` env fallbacks. Installs one process-global `TallyClient`, starts the background transport, boots the HMAC key off-thread, and monkeypatches the providers.
- **Module-level convenience** `record_tool_call` / `record_vector_call` / `record_embedding_call` / `record_llm_call` (§3.1) delegating to the process-global client; safe no-ops with a one-time warning before `init`. `__init__.py` exports `init`, `flush`, `uninstrument`, `hash_account`, and these.
- **HMAC bootstrap** (`hmac_keys.RemoteKeyMaterialProvider` + `HmacKeyBootstrap`, `transport.fetch_hmac_key`, §3.2): fetches active key material + version from `GET /v1/tenant/hmac-key` under the ingest key, caches in-process with a TTL, treated as sensitive (never logged/persisted/on the wire). **Unattributed fallback** (§3.3): on failure the SDK emits accounts unattributed (the `UNATTRIBUTED` sentinel via the client's existing `_resolve_account`), never a raw id, and never blocks `init`.
- **Auto-instrumentation** (§4) on the existing `instrumentation/base.py` seam: `patch_openai()` / `patch_anthropic()` (`instrumentation/patch.py`), a new `AnthropicInstrumentor`, async + streaming wrapper variants, OpenAI Responses/Embeddings extraction (§4.2), streaming per §4.3 including the `instrument_stream_usage` opt-in that adds `stream_options={"include_usage": True}` only when the caller did not. Reversible (`tally.uninstrument()`), idempotent (sentinel-tagged), never-raise (the provider call stays outside `safe_block`). Streams without usage emit **null** tokens, never a fabricated zero.
- **Background batching transport** (`transport.BatchingTransport`, §5): batches to `POST /v1/batches` with the key as bearer and no tenant in the envelope, daemon flush, non-blocking enqueue, drop-oldest backpressure with a counter, bounded retry with a stable `batch_id`, `flush()` + `atexit` drain. Stdlib-only HTTP (the SDK keeps zero required runtime deps); the sender is injectable for tests.
- **`hash_account` helper + `python -m tally.hash_account` CLI** (`hash_account.py`, §7): reuses the bootstrapped in-process key, or bootstraps once from `TALLY_KEY`.

### Invariants

Honest under uncertainty (null tokens with a recorded reason, never 0/guessed); money stays integer micro-USD with `Decimal` rate math via the existing pricing path; identifiers hashed in-process, raw ids never on the wire; and the SDK never raises into the customer code path (provider calls run outside `safe_block`; `init` and every wrapper are boundary-guarded).

### Gateway endpoint

The gateway `GET /v1/tenant/hmac-key` endpoint is a **separate PR**. This PR codes against its contract from spec §3.2 and mocks it in tests (injected `opener` / `fetch` callables); no network or provider keys are required to run the suite.

### CI

Run in `sdk/python/`:

- `uv run --extra dev pytest -q` → **1062 passed** (37 new across `test_init.py`, `test_patch_openai.py`, `test_patch_anthropic.py`, `test_transport.py`, `test_hmac_bootstrap.py`, covering streaming, async, and never-raise cases). No pre-existing tests broken.
- `uv run ruff check .` → **All checks passed!**

`openai` / `anthropic` are not installed in the environment; patching resolves the real classes when present and is a no-op otherwise, so tests inject fake provider classes via a `targets` argument.

Draft — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
