### PR TITLE
feat: Initiative 1 organizations, users & access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,10 @@ jobs:
       - name: Test
         run: npm run test
       - name: Build
+        # Build via the dev escape hatch (Initiative 1, §10), the same keyless mode `make up` and the
+        # vitest suite run in: with TALLY_DEV_TENANT set the app mounts no ClerkProvider and needs no
+        # Clerk publishableKey, so the static prerender does not require a Clerk account. CI holds no
+        # Clerk keys by design (CTO-259).
         run: npm run build
+        env:
+          TALLY_DEV_TENANT: local-dev

--- a/db/postgres/0029_orgs_and_access.sql
+++ b/db/postgres/0029_orgs_and_access.sql
@@ -1,0 +1,32 @@
+-- 0029_orgs_and_access.sql
+-- Organizations, users & access (Initiative 1). Ticket: TODO (umbrella).
+--
+-- Clerk is the system of record for identity (users, orgs, memberships, roles,
+-- invitations). ai-tally stores only the org-to-tenant mapping plus display-only
+-- metadata on the ingest keys it already owns. No users/memberships tables here:
+-- those live in Clerk by design.
+--
+-- All columns are ADDED nullable so the pre-existing `local-dev` tenant and its
+-- keys survive unchanged. clerk_org_id is nullable for the same reason: the demo
+-- tenant has no Clerk org, and a real org fills it in on provision.
+
+-- Map a Clerk organization to an ai-tally tenant. Nullable: the local-dev demo
+-- tenant has none. Partial UNIQUE index so at most one tenant maps to a given
+-- Clerk org, while any number of tenants may have NULL (only local-dev should).
+ALTER TABLE tenants
+    ADD COLUMN IF NOT EXISTS clerk_org_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenants_clerk_org_id
+    ON tenants (clerk_org_id)
+    WHERE clerk_org_id IS NOT NULL;
+
+-- Display-only metadata on ingest keys. The secret is STILL only ever stored as
+-- key_hash (SHA-256). token_prefix is a non-secret leading slice for the UI so a
+-- human can tell two keys apart in a list; it is not sufficient to authenticate.
+-- created_by is the Clerk user id that minted the key (audit only). last_used_at
+-- is a best-effort UI convenience, updated off the hot path (see §5).
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS name         TEXT,
+    ADD COLUMN IF NOT EXISTS token_prefix TEXT,
+    ADD COLUMN IF NOT EXISTS created_by   TEXT,          -- Clerk user id (user_...)
+    ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ;

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -28,3 +28,9 @@ GATEWAY_PORT=8080
 # When true the gateway requires a Bearer API key whose SHA-256 is registered in Postgres api_keys.
 # Left false for frictionless local dev; `make seed` prints a key you can use when you flip this on.
 TALLY_REQUIRE_API_KEY=false
+
+# --- Organizations, users & access (Initiative 1) ---
+# Control-plane service token (§6). The web server sends this as a bearer token on every
+# control-plane call; the gateway enforces it only when TALLY_REQUIRE_API_KEY is true AND this is
+# set, so local dev with auth off is unaffected. Set a long random value in any real deployment.
+# TALLY_GATEWAY_SERVICE_TOKEN=change-me-in-real-deployments

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -6,6 +6,12 @@ GATEWAY := ai-tally-gateway
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
+# Canonical TenantId is the tenant UUID (Initiative 1, §8). Resolve the seeded local-dev tenant's
+# UUID from Postgres so the demo backfill tags spans with the UUID the dashboard reads, not the
+# name `local-dev`. Lazily expanded (`=`, not `:=`) so it runs when a target uses it, after the
+# stack is up and `make seed` has created the row; empty before then.
+TENANT_UUID = $(shell $(COMPOSE) exec -T postgres psql -U tally -d tally -tAc "SELECT id FROM tenants WHERE name='local-dev' LIMIT 1" 2>/dev/null | tr -d '[:space:]')
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
 
@@ -50,6 +56,10 @@ ps: ## Show stack status
 
 seed: ## Create a local tenant + API key + feature tags in Postgres
 	$(COMPOSE) exec gateway python -m gateway.seed
+	@echo ""
+	@echo "Canonical TenantId is the tenant UUID (Initiative 1, §8). To run the dashboard against"
+	@echo "this tenant with NO Clerk account, set the dev escape hatch (§10):"
+	@echo "  export TALLY_DEV_TENANT=$(TENANT_UUID)"
 
 demo: ## Send a sample batch through the gateway into ClickHouse
 	$(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py
@@ -83,7 +93,7 @@ chatbot-demo-backfill: ## $0 backfill — POST 30 days of backdated synthetic sp
 	  { [ -d node_modules ] || pnpm install --silent --prefer-offline || \
 	    npm install --silent --no-audit --no-fund; } && \
 	  TALLY_GATEWAY_URL="$${TALLY_GATEWAY_URL:-http://localhost:8080/v1/batches}" \
-	  pnpm --silent exec tsx ../scripts/backfill-spans.ts $(BACKFILL_ARGS)
+	  pnpm --silent exec tsx ../scripts/backfill-spans.ts $(if $(strip $(TENANT_UUID)),--tenant $(TENANT_UUID),) $(BACKFILL_ARGS)
 
 chatbot-demo-stop: ## Stop the background chatbot dev server started by chatbot-demo
 	@if [ -f $(CHATBOT_PID) ]; then \

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       # Incremental ingest cursors (CTO-219). Without these every Segment / HubSpot / Pendo cycle
       # re-pulls the provider's whole window, 96 times a day per tenant per connector.
       - ../db/postgres/0028_tenant_ingest_cursors.sql:/docker-entrypoint-initdb.d/0028_tenant_ingest_cursors.sql:ro
+      - ../db/postgres/0029_orgs_and_access.sql:/docker-entrypoint-initdb.d/0029_orgs_and_access.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -11,6 +11,7 @@ pure logic — this module is just the HTTP + storage shell.
 from __future__ import annotations
 
 import logging
+import secrets
 import time
 from contextlib import asynccontextmanager
 from typing import Any
@@ -128,7 +129,14 @@ from gateway.tenant_budgets import (
     TenantNotFound as BudgetTenantNotFound,
     normalize_budget_id,
 )
+from gateway.tenant_api_keys import (
+    ApiKeyError,
+    ApiKeyNotFoundError,
+    TenantApiKeyStore,
+    TenantNotFound as ApiKeyTenantNotFound,
+)
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
+from gateway.tenant_provisioning import ProvisionError, TenantProvisioner
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
 from gateway.tenant_identity import TenantIdentityResolver
@@ -338,6 +346,11 @@ async def lifespan(app: FastAPI):
     # customer's intent rather than our own metering, and every "versus budget" number in the
     # forecasting epic reads from it. No row is the normal state and means "no budget set".
     app.state.tenant_budgets = TenantBudgetStore(settings)
+    # Organizations, users & access (Initiative 1). Provisioning turns a Clerk org into a tenant with
+    # its own per-org HMAC key reference; the keys store is self-serve ingest-key management. Both go
+    # through the service-token-authed control plane; the web server is their only caller.
+    app.state.tenant_provisioner = TenantProvisioner(settings)
+    app.state.tenant_api_keys = TenantApiKeyStore(settings)
     # In-process dedup set for Stripe webhook redeliveries. ClickHouse's ReplacingMergeTree
     # will collapse late duplicates at merge time, but this short-circuits the second insert
     # so the 200 stays well under Stripe's 30s timeout window.
@@ -895,6 +908,42 @@ def _resolve_tenant_for_control_plane(
         return tenant_id
     if not x_tenant_id:
         raise HTTPException(status_code=422, detail="X-Tenant-Id required when auth is disabled")
+    return x_tenant_id
+
+
+def _require_service_token(authorization: str | None) -> None:
+    """Gate a control-plane endpoint on the ``GATEWAY_SERVICE_TOKEN`` (Initiative 1, §6).
+
+    The web server is the only legitimate caller of the control plane; it authenticates with a
+    server-only shared secret and passes the resolved tenant in ``x-tenant-id``. This gate verifies
+    the bearer token equals that secret and rejects with 401 otherwise.
+
+    Gated on the dev escape hatch (§10): the check is ACTIVE only when ``require_api_key`` is on AND a
+    token is configured. With auth off (the ``make up`` / CI default) it is a no-op, so local dev is
+    unaffected. A production deployment sets both, and unauthenticated control-plane calls are
+    rejected.
+    """
+    settings = app.state.settings
+    token = settings.gateway_service_token
+    if not settings.require_api_key or not token:
+        return
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="missing control-plane service token")
+    presented = authorization.split(" ", 1)[1].strip()
+    # Constant-time compare so a wrong token cannot be discovered a byte at a time by timing.
+    if not secrets.compare_digest(presented, token):
+        raise HTTPException(status_code=401, detail="invalid control-plane service token")
+
+
+def _service_token_tenant(x_tenant_id: str | None) -> str:
+    """Tenant identifier for a service-token-authed endpoint.
+
+    The service token authenticates the WEB SERVER, not the tenant, so the tenant always comes from
+    ``x-tenant-id`` (the UUID the web server resolved from the Clerk org). Refuses an absent header
+    rather than guessing a tenant.
+    """
+    if not x_tenant_id:
+        raise HTTPException(status_code=422, detail="X-Tenant-Id required")
     return x_tenant_id
 
 
@@ -1793,6 +1842,165 @@ async def delete_tenant_budget(
         {"tenant_id": tenant_id, "budget_id": target, "removed": removed},
         status_code=200,
     )
+
+
+# --- Organizations, users & access (Initiative 1) ------------------------------------------------
+#
+# All endpoints below are service-token authed (§6): the web server is their only caller. The svix
+# signature on the Clerk webhook is verified once, at the public web route, before it forwards the
+# verified event here.
+
+
+@app.post("/v1/tenant/provision")
+async def provision_tenant(
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    """Provision a tenant from a verified ``organization.created`` event (Initiative 1, §4).
+
+    Called by the web ``/api/webhooks/clerk`` route after it verifies the svix signature. The body
+    carries the Clerk org id and name. Idempotent and race-safe: a redelivery returns the existing
+    tenant and mints no new key material; two concurrent first-deliveries settle on one tenant.
+    """
+    _require_service_token(authorization)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001 - a non-JSON body is a client error, not a 500
+        raise HTTPException(status_code=422, detail="request body must be JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    # Accept either the flattened fields or a raw Clerk event ({"data": {"id", "name"}}), so the web
+    # route can forward the verified event without reshaping it.
+    data = body.get("data") if isinstance(body.get("data"), dict) else body
+    clerk_org_id = body.get("clerk_org_id") or data.get("id")
+    name = body.get("name") or data.get("name")
+
+    provisioner: TenantProvisioner = app.state.tenant_provisioner
+    try:
+        result = provisioner.provision(clerk_org_id=clerk_org_id, name=name)
+    except ProvisionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(result.as_dict(), status_code=200)
+
+
+@app.get("/v1/tenant/by-clerk-org/{org_id}")
+def tenant_by_clerk_org(
+    org_id: str,
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    """Resolve a Clerk org id to ``{tenant_id, plan}`` (Initiative 1, §5).
+
+    The web app calls this once per session to map the active org to its tenant UUID (``getTenant``,
+    cached per-org). Read-only. A 404 when the org has no tenant, never a silent fallback.
+    """
+    _require_service_token(authorization)
+    provisioner: TenantProvisioner = app.state.tenant_provisioner
+    try:
+        result = provisioner.tenant_for_clerk_org(org_id)
+    except ProvisionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"no tenant for clerk org '{org_id}'")
+    return JSONResponse({"tenant_id": result.tenant_id, "plan": result.plan}, status_code=200)
+
+
+@app.get("/v1/tenant/keys")
+def list_tenant_keys(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """List ingest-key metadata for the tenant (Initiative 1, §5). Never returns a secret."""
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    store: TenantApiKeyStore = app.state.tenant_api_keys
+    try:
+        keys = store.list(tenant_id)
+    except ApiKeyTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return JSONResponse(
+        {"tenant_id": tenant_id, "keys": [k.as_dict() for k in keys]}, status_code=200
+    )
+
+
+@app.post("/v1/tenant/keys")
+async def create_tenant_key(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+    x_clerk_user_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Mint a new ingest key (Initiative 1, §5). Returns the raw token EXACTLY ONCE.
+
+    The web server has already checked the caller is an org admin (§9) before reaching here; the
+    gateway sees only the service token and the resolved tenant. ``created_by`` (the Clerk user id)
+    is passed for audit in ``x-clerk-user-id`` or the body.
+    """
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001 - an empty body is fine; name/scope are optional
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    store: TenantApiKeyStore = app.state.tenant_api_keys
+    try:
+        minted = store.create(
+            tenant_id,
+            name=body.get("name"),
+            scope=body.get("scope", "write"),
+            created_by=x_clerk_user_id or body.get("created_by"),
+        )
+    except ApiKeyTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiKeyError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(minted.as_dict(), status_code=201)
+
+
+@app.post("/v1/tenant/keys/{key_id}/rotate")
+async def rotate_tenant_key(
+    key_id: str,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+    x_clerk_user_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Rotate a key: mint a replacement and revoke the old row in one transaction (§5).
+
+    Returns the new raw token once. The old token stops authenticating immediately.
+    """
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    store: TenantApiKeyStore = app.state.tenant_api_keys
+    try:
+        minted = store.rotate(tenant_id, key_id, created_by=x_clerk_user_id)
+    except ApiKeyTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiKeyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApiKeyError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse(minted.as_dict(), status_code=201)
+
+
+@app.delete("/v1/tenant/keys/{key_id}")
+def revoke_tenant_key(
+    key_id: str,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> Response:
+    """Revoke a key (``revoked_at = now()``), returning 204 (Initiative 1, §5).
+
+    A real revoke, not a delete, so the audit trail survives. Double-revoke is not an error.
+    """
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    store: TenantApiKeyStore = app.state.tenant_api_keys
+    try:
+        store.revoke(tenant_id, key_id)
+    except ApiKeyTenantNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return Response(status_code=204)
 
 
 @app.post("/v1/stripe/webhook")

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -261,6 +261,14 @@ async def lifespan(app: FastAPI):
     # Configure logging first so the startup INFO line below (and every other gateway logger.info)
     # is captured rather than dropped by uvicorn's WARNING-only root (CTO-218).
     _configure_logging(settings.log_level)
+    # Fail CLOSED at boot (Initiative 1 §6): if auth is required but no control-plane service token is
+    # configured, the /v1/tenant/* gate would have nothing to check and every control-plane endpoint
+    # would be unauthenticated. Refuse to start rather than come up wide open.
+    if settings.require_api_key and not settings.gateway_service_token:
+        raise RuntimeError(
+            "TALLY_REQUIRE_API_KEY is on but TALLY_GATEWAY_SERVICE_TOKEN is empty: "
+            "the control-plane service-token gate cannot be enforced. Refusing to start."
+        )
     app.state.settings = settings
     app.state.store = ClickHouseStore(settings)
     app.state.auth = ApiKeyAuth(settings)
@@ -918,15 +926,23 @@ def _require_service_token(authorization: str | None) -> None:
     server-only shared secret and passes the resolved tenant in ``x-tenant-id``. This gate verifies
     the bearer token equals that secret and rejects with 401 otherwise.
 
-    Gated on the dev escape hatch (§10): the check is ACTIVE only when ``require_api_key`` is on AND a
-    token is configured. With auth off (the ``make up`` / CI default) it is a no-op, so local dev is
-    unaffected. A production deployment sets both, and unauthenticated control-plane calls are
-    rejected.
+    Gated on the dev escape hatch (§10): with auth off (the ``make up`` / CI default) the gate is a
+    no-op, so local dev is unaffected. When auth is ON the gate is ALWAYS enforced: if no service
+    token is configured the request is REFUSED (fail closed), never allowed through unauthenticated.
+    Boot also refuses to start in that misconfiguration (see ``lifespan``), so this request-time
+    branch is a defence in depth. A production deployment sets both, and unauthenticated
+    control-plane calls are rejected.
     """
     settings = app.state.settings
     token = settings.gateway_service_token
-    if not settings.require_api_key or not token:
+    if not settings.require_api_key:
         return
+    if not token:
+        # Fail CLOSED: auth is required but no service token is configured, so we cannot authenticate
+        # the web server. Refuse rather than leave every /v1/tenant/* endpoint open (Initiative 1 §6).
+        raise HTTPException(
+            status_code=503, detail="control-plane service token not configured"
+        )
     if not authorization or not authorization.lower().startswith("bearer "):
         raise HTTPException(status_code=401, detail="missing control-plane service token")
     presented = authorization.split(" ", 1)[1].strip()

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -31,6 +31,14 @@ class Settings(BaseSettings):
     # must carry `Authorization: Bearer <key>` whose SHA-256 is registered in api_keys.
     require_api_key: bool = False
 
+    # Control-plane service token (Initiative 1, §6). The web server is the ONLY legitimate caller of
+    # the control-plane endpoints (`/v1/tenant/*`); it authenticates with this server-only shared
+    # secret as `Authorization: Bearer <token>` and passes the resolved tenant UUID in `x-tenant-id`.
+    # The token authenticates the WEB SERVER, not the tenant, and never rides in a client bundle. The
+    # gate is active only when auth is on (``require_api_key``) AND a token is configured, so local
+    # dev with auth off is unaffected. Empty means "no service-token gate" (the dev default).
+    gateway_service_token: str = ""
+
     # Idempotency window (seconds) for (tenant_id, batch_id) dedup.
     idempotency_ttl_s: int = 24 * 3600
 

--- a/infra/gateway/src/gateway/seed.py
+++ b/infra/gateway/src/gateway/seed.py
@@ -88,7 +88,10 @@ def seed() -> None:
     print("Seeded local tenant.")
     print(f"  tenant_id : {tenant_id}")
     print(f"  api_key   : {token}")
-    print("  (only its SHA-256 is stored; copy this key now — it is not recoverable.)")
+    print("  (only its SHA-256 is stored; copy this key now, it is not recoverable.)")
+    # Canonical TenantId is the tenant UUID (Initiative 1, §8). The dashboard reads spans by UUID,
+    # so point the dev escape hatch (§10) at this tenant to run the web app with no Clerk account.
+    print(f"  dashboard : export TALLY_DEV_TENANT={tenant_id}")
 
 
 if __name__ == "__main__":

--- a/infra/gateway/src/gateway/tenant_api_keys.py
+++ b/infra/gateway/src/gateway/tenant_api_keys.py
@@ -237,12 +237,12 @@ class TenantApiKeyStore:
         whatever the old key was for. The old token stops authenticating immediately (ingest filters
         ``revoked_at IS NULL``).
         """
-        created_by = normalize_created_by(created_by)
+        supplied_created_by = normalize_created_by(created_by)
         token, token_prefix, key_hash = _mint_token()
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
             resolved = resolve_tenant_uuid(cur, tenant_id)
             cur.execute(
-                "SELECT name, scope FROM api_keys "
+                "SELECT name, scope, created_by FROM api_keys "
                 "WHERE id = %s AND tenant_id = %s AND revoked_at IS NULL",
                 (key_id, resolved),
             )
@@ -251,9 +251,10 @@ class TenantApiKeyStore:
                 # Either the key is not this tenant's, does not exist, or is already revoked. A
                 # revoked key has nothing to rotate.
                 raise ApiKeyNotFoundError(f"no live key '{key_id}' for this tenant")
-            old_name, old_scope = old[0], str(old[1])
-            # Carry the minter forward when the caller does not supply one, so created_by is never
-            # silently blanked on rotate.
+            old_name, old_scope, old_created_by = old[0], str(old[1]), old[2]
+            # Carry the ORIGINAL minter forward when the caller does not supply one, so created_by is
+            # never silently blanked on rotate. The SELECT must fetch created_by for this to work.
+            created_by = supplied_created_by if supplied_created_by is not None else old_created_by
             cur.execute(
                 """
                 INSERT INTO api_keys (tenant_id, key_hash, scope, name, token_prefix, created_by)

--- a/infra/gateway/src/gateway/tenant_api_keys.py
+++ b/infra/gateway/src/gateway/tenant_api_keys.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-org ingest API keys: mint, list (metadata only), rotate, revoke (Initiative 1, §5).
+
+WHY this exists. Ingest keys already authenticated the ``/v1/batches`` hot path and the edge proxy
+(``gateway.auth``), but there was no way for an org to mint or manage its own keys: the seed script
+made the one ``local-dev`` key and that was it. Initiative 1 gives every org self-serve key
+management from the dashboard, still entirely inside ai-tally's control plane (Clerk never sees a
+key, Decision 2).
+
+THE RULE OF THIS MODULE: the raw token is shown EXACTLY ONCE, at mint or rotate, and never stored.
+Only its SHA-256 (``key_hash``) is persisted, hashed with the SAME ``auth.py::hash_key`` ingest uses
+so a minted key authenticates byte-for-byte. ``token_prefix`` is a non-secret leading slice kept so a
+human can tell two keys apart in a list; it cannot authenticate. :meth:`TenantApiKeyStore.list` never
+returns ``key_hash`` or any raw token, only metadata.
+
+Revoke is a real revoke (``revoked_at = now()``), not a DELETE, so the audit trail and any
+``ON DELETE CASCADE`` history survive and a double-revoke is not an error. Rotation is one
+transaction: mint the replacement and revoke the old row together, so there is never a window with
+zero valid keys or two independently-committed halves.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg
+
+from gateway.auth import hash_key
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
+
+#: Re-exported so a caller catching a keys-store failure catches one name (matches tenant_budgets).
+TenantNotFound = TenantNotFoundError
+
+#: Live ingest-token prefix. The scope of a key is stored separately; this prefix only marks the
+#: token as an ai-tally live ingest secret so a leaked string is recognizable in a scanner.
+TOKEN_PREFIX = "tally_sk_live_"
+
+#: Characters of the random suffix surfaced in the non-secret ``token_prefix`` display slice. Six is
+#: enough to disambiguate keys in a list and far too few to brute-force the rest of the token.
+_DISPLAY_SUFFIX_CHARS = 6
+
+#: Scopes a minted key may carry, matching the CHECK on ``api_keys.scope``.
+KEY_SCOPES: tuple[str, ...] = ("read", "write", "admin")
+
+#: A key name is a short human label shown in the UI, not a description.
+MAX_KEY_NAME_CHARS = 120
+
+#: A Clerk user id (``user_...``) recorded for audit. Bounded so a bad caller cannot store a blob.
+MAX_CREATED_BY_CHARS = 255
+
+
+class ApiKeyError(ValueError):
+    """Caller-facing validation error. Surfaces as HTTP 422."""
+
+
+class ApiKeyNotFoundError(ValueError):
+    """The named key does not belong to this tenant (or does not exist). Surfaces as HTTP 404."""
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyMeta:
+    """Display metadata for one key. Deliberately carries no secret material."""
+
+    id: str
+    name: str | None
+    token_prefix: str | None
+    scope: str
+    created_by: str | None
+    created_at: datetime | None
+    last_used_at: datetime | None
+    revoked_at: datetime | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            # null means the key predates named keys (the seeded local-dev key), not "no name".
+            "name": self.name,
+            "token_prefix": self.token_prefix,
+            "scope": self.scope,
+            "created_by": self.created_by,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            # null until a best-effort off-hot-path job stamps it. Honest under uncertainty: never a
+            # fabricated timestamp, never a zero. See §5.
+            "last_used_at": self.last_used_at.isoformat() if self.last_used_at else None,
+            # null means live; a timestamp means revoked. A real statement, not missing data.
+            "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MintedKey:
+    """A freshly minted key: the metadata plus the raw token, returned exactly once."""
+
+    meta: ApiKeyMeta
+    token: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "id": self.meta.id,
+            # The raw token. Never persisted, never returned again after this response.
+            "token": self.token,
+            "token_prefix": self.meta.token_prefix,
+            "name": self.meta.name,
+            "scope": self.meta.scope,
+        }
+
+
+def normalize_name(value: object) -> str | None:
+    """Validate an optional key name. ``None``/empty is allowed: a key need not be named."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ApiKeyError("name must be a string")
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    if len(trimmed) > MAX_KEY_NAME_CHARS:
+        raise ApiKeyError(f"name must be at most {MAX_KEY_NAME_CHARS} characters")
+    return trimmed
+
+
+def normalize_scope(value: object) -> str:
+    """Validate a scope against :data:`KEY_SCOPES`, defaulting to ``write`` when absent."""
+    if value is None:
+        return "write"
+    if not isinstance(value, str):
+        raise ApiKeyError("scope must be a string")
+    trimmed = value.strip().lower()
+    if not trimmed:
+        return "write"
+    if trimmed not in KEY_SCOPES:
+        raise ApiKeyError("scope must be one of: " + ", ".join(KEY_SCOPES))
+    return trimmed
+
+
+def normalize_created_by(value: object) -> str | None:
+    """Validate the optional Clerk user id recorded for audit."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ApiKeyError("created_by must be a string")
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    if len(trimmed) > MAX_CREATED_BY_CHARS:
+        raise ApiKeyError(f"created_by must be at most {MAX_CREATED_BY_CHARS} characters")
+    return trimmed
+
+
+def _mint_token() -> tuple[str, str, str]:
+    """Return ``(token, token_prefix, key_hash)`` for a fresh live ingest key.
+
+    The token is ``tally_sk_live_`` plus a high-entropy CSPRNG suffix. ``token_prefix`` is the live
+    prefix plus the first few suffix characters, a non-secret display slice. Only ``key_hash`` is
+    ever stored.
+    """
+    suffix = secrets.token_urlsafe(32)
+    token = f"{TOKEN_PREFIX}{suffix}"
+    token_prefix = f"{TOKEN_PREFIX}{suffix[:_DISPLAY_SUFFIX_CHARS]}"
+    return token, token_prefix, hash_key(token)
+
+
+_META_COLUMNS = (
+    "id, name, token_prefix, scope, created_by, created_at, last_used_at, revoked_at"
+)
+
+
+def _row_to_meta(row: tuple) -> ApiKeyMeta:
+    return ApiKeyMeta(
+        id=str(row[0]),
+        name=row[1],
+        token_prefix=row[2],
+        scope=str(row[3]),
+        created_by=row[4],
+        created_at=row[5],
+        last_used_at=row[6],
+        revoked_at=row[7],
+    )
+
+
+class TenantApiKeyStore:
+    """Postgres-backed key management over ``api_keys``.
+
+    Every method resolves the caller's tenant onto ``tenants.id`` before touching a row, so the SQL
+    never crosses tenants and a key id from one tenant cannot address another's key.
+    """
+
+    def __init__(self, settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def list(self, tenant_id: str) -> list[ApiKeyMeta]:
+        """Every key this tenant holds, metadata only. Never returns a secret."""
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                f"SELECT {_META_COLUMNS} FROM api_keys WHERE tenant_id = %s "
+                "ORDER BY created_at DESC, id",
+                (resolved,),
+            )
+            return [_row_to_meta(row) for row in cur.fetchall()]
+
+    def create(
+        self,
+        tenant_id: str,
+        *,
+        name: object = None,
+        scope: object = "write",
+        created_by: object = None,
+    ) -> MintedKey:
+        """Mint a new key. Returns the raw token exactly once; only its hash is stored."""
+        name = normalize_name(name)
+        scope = normalize_scope(scope)
+        created_by = normalize_created_by(created_by)
+        token, token_prefix, key_hash = _mint_token()
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                """
+                INSERT INTO api_keys (tenant_id, key_hash, scope, name, token_prefix, created_by)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                RETURNING id, name, token_prefix, scope, created_by, created_at,
+                          last_used_at, revoked_at
+                """,
+                (resolved, key_hash, scope, name, token_prefix, created_by),
+            )
+            row = cur.fetchone()
+            conn.commit()
+            assert row is not None  # RETURNING on an INSERT that cannot no-op
+            return MintedKey(meta=_row_to_meta(row), token=token)
+
+    def rotate(self, tenant_id: str, key_id: str, *, created_by: object = None) -> MintedKey:
+        """Mint a replacement and revoke the old row in ONE transaction. Returns the new token once.
+
+        The replacement inherits the old key's name and scope so a rotation is transparent to
+        whatever the old key was for. The old token stops authenticating immediately (ingest filters
+        ``revoked_at IS NULL``).
+        """
+        created_by = normalize_created_by(created_by)
+        token, token_prefix, key_hash = _mint_token()
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                "SELECT name, scope FROM api_keys "
+                "WHERE id = %s AND tenant_id = %s AND revoked_at IS NULL",
+                (key_id, resolved),
+            )
+            old = cur.fetchone()
+            if old is None:
+                # Either the key is not this tenant's, does not exist, or is already revoked. A
+                # revoked key has nothing to rotate.
+                raise ApiKeyNotFoundError(f"no live key '{key_id}' for this tenant")
+            old_name, old_scope = old[0], str(old[1])
+            # Carry the minter forward when the caller does not supply one, so created_by is never
+            # silently blanked on rotate.
+            cur.execute(
+                """
+                INSERT INTO api_keys (tenant_id, key_hash, scope, name, token_prefix, created_by)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                RETURNING id, name, token_prefix, scope, created_by, created_at,
+                          last_used_at, revoked_at
+                """,
+                (resolved, key_hash, old_scope, old_name, token_prefix, created_by),
+            )
+            new_row = cur.fetchone()
+            cur.execute(
+                "UPDATE api_keys SET revoked_at = now() "
+                "WHERE id = %s AND tenant_id = %s AND revoked_at IS NULL",
+                (key_id, resolved),
+            )
+            conn.commit()
+            assert new_row is not None
+            return MintedKey(meta=_row_to_meta(new_row), token=token)
+
+    def revoke(self, tenant_id: str, key_id: str) -> bool:
+        """Revoke a key (``revoked_at = now()``). Returns True if this call revoked a live key.
+
+        A real revoke, not a delete. Double-revoke is not an error: revoking an already-revoked or
+        absent key returns False rather than 404, so a double-click cannot fail.
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                "UPDATE api_keys SET revoked_at = now() "
+                "WHERE id = %s AND tenant_id = %s AND revoked_at IS NULL",
+                (key_id, resolved),
+            )
+            revoked = cur.rowcount > 0
+            conn.commit()
+            return revoked

--- a/infra/gateway/src/gateway/tenant_lookup.py
+++ b/infra/gateway/src/gateway/tenant_lookup.py
@@ -27,18 +27,26 @@ def resolve_tenant_uuid(cur: Any, tenant_id: str) -> str:
     A caller may address a tenant three ways: the ``tenants.id`` UUID (the canonical form), the
     tenant NAME (``local-dev``, the dev/dashboard spelling), or the Clerk organization id
     (``org_...``, Initiative 1). The UUID fast-path parses first so the common case never touches
-    Postgres to parse. The single lookup matches either ``name`` or ``clerk_org_id`` so a Clerk org
-    id resolves to the tenant provisioned for it. Raises :class:`TenantNotFoundError` when nothing
-    matches.
+    Postgres to parse.
+
+    The name and clerk_org_id lookups are DELIBERATELY separate and ordered, not a single
+    ``WHERE name = %s OR clerk_org_id = %s`` (Initiative 1 review). A combined OR can match two
+    different rows at once, so a tenant whose NAME happens to look like another tenant's Clerk org id
+    (``org_xxxx``) could resolve to the wrong tenant nondeterministically. Clerk org ids are the
+    machine identifier and are checked first; the human-facing name is the fallback. Raises
+    :class:`TenantNotFoundError` when nothing matches.
     """
     try:
         return str(uuid.UUID(tenant_id))
     except (ValueError, AttributeError, TypeError):
         pass
-    cur.execute(
-        "SELECT id FROM tenants WHERE name = %s OR clerk_org_id = %s",
-        (tenant_id, tenant_id),
-    )
+    # Exact Clerk org-id match first (the machine identifier), then the human name. Two ordered
+    # single-column lookups can never straddle two rows the way a combined OR can.
+    cur.execute("SELECT id FROM tenants WHERE clerk_org_id = %s", (tenant_id,))
+    row = cur.fetchone()
+    if row is not None:
+        return str(row[0])
+    cur.execute("SELECT id FROM tenants WHERE name = %s", (tenant_id,))
     row = cur.fetchone()
     if row is None:
         raise TenantNotFoundError(f"no tenant named '{tenant_id}'")

--- a/infra/gateway/src/gateway/tenant_lookup.py
+++ b/infra/gateway/src/gateway/tenant_lookup.py
@@ -22,12 +22,23 @@ class TenantNotFoundError(ValueError):
 
 
 def resolve_tenant_uuid(cur: Any, tenant_id: str) -> str:
-    """Pass a UUID through untouched; look a name up. Raises :class:`TenantNotFoundError`."""
+    """Pass a UUID through untouched; look a name or Clerk org id up.
+
+    A caller may address a tenant three ways: the ``tenants.id`` UUID (the canonical form), the
+    tenant NAME (``local-dev``, the dev/dashboard spelling), or the Clerk organization id
+    (``org_...``, Initiative 1). The UUID fast-path parses first so the common case never touches
+    Postgres to parse. The single lookup matches either ``name`` or ``clerk_org_id`` so a Clerk org
+    id resolves to the tenant provisioned for it. Raises :class:`TenantNotFoundError` when nothing
+    matches.
+    """
     try:
         return str(uuid.UUID(tenant_id))
     except (ValueError, AttributeError, TypeError):
         pass
-    cur.execute("SELECT id FROM tenants WHERE name = %s", (tenant_id,))
+    cur.execute(
+        "SELECT id FROM tenants WHERE name = %s OR clerk_org_id = %s",
+        (tenant_id, tenant_id),
+    )
     row = cur.fetchone()
     if row is None:
         raise TenantNotFoundError(f"no tenant named '{tenant_id}'")

--- a/infra/gateway/src/gateway/tenant_provisioning.py
+++ b/infra/gateway/src/gateway/tenant_provisioning.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Provision an ai-tally tenant from a verified Clerk ``organization.created`` event (Initiative 1).
+
+WHY this exists. Until now ai-tally was single-tenant: the one ``local-dev`` row was created by the
+seed script. Initiative 1 makes Clerk the system of record for identity, and every new Clerk
+organization must become a tenant with its OWN per-org HMAC key set so user and account hashes
+cannot be joined across tenants. This module is the gateway half of that: the web ``/api/webhooks/
+clerk`` route verifies the svix signature (the gateway is private and never sees Clerk directly),
+then forwards the verified event to ``POST /v1/tenant/provision``, which lands here.
+
+THE TWO INVARIANTS THIS MODULE HOLDS.
+
+* **Idempotent and race-safe.** Clerk retries webhooks, and two deliveries can race. Provision is
+  safe to call any number of times for one org: a redelivery returns the existing tenant and mints
+  no new key material, and two concurrent first-deliveries settle on one tenant via
+  ``INSERT ... ON CONFLICT (clerk_org_id) WHERE clerk_org_id IS NOT NULL DO NOTHING RETURNING`` (the
+  arbiter repeats the partial-index predicate so Postgres infers ``uq_tenants_clerk_org_id``).
+
+* **No raw secret, no orphaned key.** The per-org HMAC key set is stored ONLY as a reference in
+  ``tenants.hash_salt_kek_ref``, honoring its ``no_raw_secret`` CHECK (not ``sk-%``, length < 512).
+  A tenant is never created without a usable reference (a mint failure fails the provision), and the
+  loser of a race deletes the key set it minted so no orphaned material is left behind.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+import psycopg
+
+from gateway.config import Settings
+
+#: Data-residency region stamped on a provisioned tenant. Initiative 1 does no residency routing on
+#: ``region`` (§1 non-goals); the column stays and defaults here, matching how the seed defaults it.
+DEFAULT_REGION = "auto"
+
+#: Scheme for the local-dev HMAC key reference. It must satisfy the ``no_raw_secret`` CHECK on
+#: ``tenants.hash_salt_kek_ref`` (not ``sk-%``, length < 512). The trailing ``/v1`` leaves room for a
+#: version selector so a future rotation does not orphan historical hashes (§4.1, "Versioning").
+_LOCAL_KEK_SCHEME = "local"
+
+
+class ProvisionError(ValueError):
+    """Caller-facing validation error on the provision request. Surfaces as HTTP 422."""
+
+
+@runtime_checkable
+class KeyMaterialProvider(Protocol):
+    """Mints and deletes a per-org HMAC key set, returning only an opaque reference.
+
+    Production backs this with Secret Manager / KMS and returns its resource reference; local dev
+    uses :class:`LocalDevKeyProvider`. The application never persists raw key material to Postgres:
+    only the reference is stored, in ``tenants.hash_salt_kek_ref``.
+    """
+
+    def mint(self) -> str: ...
+
+    def delete(self, ref: str) -> None: ...
+
+
+@dataclass
+class LocalDevKeyProvider:
+    """Local-dev HMAC key provider: no cloud KMS, no cloud dependency for ``make up``.
+
+    Generates a 256-bit random key set from a CSPRNG, holds the material in-process keyed by its
+    reference, and returns a reference string that satisfies the ``no_raw_secret`` CHECK. ``delete``
+    removes the material so a lost provision race cleans up its orphaned key set. This is the local
+    analog of Secret Manager / KMS; the raw bytes never touch Postgres or a log.
+    """
+
+    _material: dict[str, bytes] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def mint(self) -> str:
+        material = secrets.token_bytes(32)  # 256-bit key set from a CSPRNG (§4.1)
+        ref = f"{_LOCAL_KEK_SCHEME}://hmac/{uuid.uuid4()}/v1"
+        with self._lock:
+            self._material[ref] = material
+        return ref
+
+    def delete(self, ref: str) -> None:
+        with self._lock:
+            self._material.pop(ref, None)
+
+    def has(self, ref: str) -> bool:
+        """Whether a reference still resolves to material. For orphan-cleanup tests."""
+        with self._lock:
+            return ref in self._material
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionResult:
+    """The outcome of a provision call."""
+
+    tenant_id: str
+    plan: str
+    #: True when this call inserted the tenant; False on a redelivery or a lost race (idempotent).
+    created: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {"tenant_id": self.tenant_id, "plan": self.plan, "created": self.created}
+
+
+def _clean(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ProvisionError(f"{field_name} must be a string")
+    trimmed = value.strip()
+    if not trimmed:
+        raise ProvisionError(f"{field_name} must be non-empty")
+    return trimmed
+
+
+class TenantProvisioner:
+    """Turns a Clerk org into a tenant, idempotently, with its own HMAC key reference.
+
+    See the module docstring for the two invariants. The store owns the DSN and the key provider so
+    a test can inject a fake provider and assert orphan cleanup without a real Secret Manager.
+    """
+
+    def __init__(
+        self, settings: Settings, key_provider: KeyMaterialProvider | None = None
+    ) -> None:
+        self._dsn = settings.postgres_dsn
+        self._keys: KeyMaterialProvider = key_provider or LocalDevKeyProvider()
+
+    def provision(
+        self, *, clerk_org_id: object, name: object, region: str = DEFAULT_REGION
+    ) -> ProvisionResult:
+        clerk_org_id = _clean(clerk_org_id, field_name="clerk_org_id")
+        name = _clean(name, field_name="name")
+
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            # Fast path: an existing mapping means a redelivery. Return it and mint NOTHING, so a
+            # retried webhook never rolls the tenant's HMAC key set.
+            cur.execute(
+                "SELECT id, plan FROM tenants WHERE clerk_org_id = %s", (clerk_org_id,)
+            )
+            row = cur.fetchone()
+            if row is not None:
+                return ProvisionResult(str(row[0]), str(row[1]), created=False)
+
+            # Miss: mint the per-org HMAC key set BEFORE inserting. A mint failure raises and no
+            # tenant row is written, so a tenant that cannot hash is never created (§4.1).
+            kek_ref = self._keys.mint()
+            try:
+                # Ensure the free plan tier exists before usage_limits references it. The seed also
+                # inserts it, but provision can run first on a fresh volume.
+                cur.execute(
+                    """
+                    INSERT INTO plan_tiers (name, max_traces_per_month, max_features, price_micro_usd)
+                    VALUES ('free', 1000000, 10, 0)
+                    ON CONFLICT (name) DO NOTHING
+                    """
+                )
+                # Race-safe insert: two concurrent first-deliveries both miss the SELECT above, and
+                # the partial-unique arbiter lets exactly one win. The predicate is repeated so
+                # Postgres infers uq_tenants_clerk_org_id.
+                cur.execute(
+                    """
+                    INSERT INTO tenants (name, region, plan, hash_salt_kek_ref, clerk_org_id)
+                    VALUES (%s, %s, 'free', %s, %s)
+                    ON CONFLICT (clerk_org_id) WHERE clerk_org_id IS NOT NULL
+                    DO NOTHING
+                    RETURNING id
+                    """,
+                    (name, region, kek_ref, clerk_org_id),
+                )
+                inserted = cur.fetchone()
+                if inserted is not None:
+                    tenant_id = str(inserted[0])
+                    cur.execute(
+                        """
+                        INSERT INTO usage_limits (tenant_id, plan) VALUES (%s, 'free')
+                        ON CONFLICT (tenant_id) DO NOTHING
+                        """,
+                        (tenant_id,),
+                    )
+                    conn.commit()
+                    return ProvisionResult(tenant_id, "free", created=True)
+
+                # Lost the race: a concurrent delivery won. Adopt its tenant and delete the key set
+                # we just minted, so no orphaned material survives.
+                conn.rollback()
+                cur.execute(
+                    "SELECT id, plan FROM tenants WHERE clerk_org_id = %s", (clerk_org_id,)
+                )
+                winner = cur.fetchone()
+                self._keys.delete(kek_ref)
+                if winner is None:
+                    # Extremely unlikely: the conflicting row vanished between the failed insert and
+                    # this read. Surface it rather than fabricate a tenant id.
+                    raise ProvisionError(
+                        "provision lost a race but the winning tenant could not be read"
+                    )
+                return ProvisionResult(str(winner[0]), str(winner[1]), created=False)
+            except Exception:
+                # Any failure after minting must not leak the key set.
+                conn.rollback()
+                self._keys.delete(kek_ref)
+                raise
+
+    def tenant_for_clerk_org(self, clerk_org_id: object) -> ProvisionResult | None:
+        """Resolve a Clerk org id to ``{tenant_id, plan}`` without provisioning. ``None`` if absent."""
+        clerk_org_id = _clean(clerk_org_id, field_name="org_id")
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, plan FROM tenants WHERE clerk_org_id = %s", (clerk_org_id,)
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return ProvisionResult(str(row[0]), str(row[1]), created=False)

--- a/infra/gateway/tests/conftest.py
+++ b/infra/gateway/tests/conftest.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared pytest fixtures for the gateway test suite.
+
+Many test files flip ``require_api_key`` (and, for Initiative 1, ``gateway_service_token``) on the
+process-wide settings singleton AFTER ``TestClient(app)`` has already run the lifespan, so the
+mutation outlives the test and leaks into the next file's startup. That was harmless until the
+control-plane fail-closed boot guard landed (Initiative 1 §6): a leftover ``require_api_key=True``
+with an empty service token now makes the NEXT ``TestClient`` refuse to start, exactly as a real
+misconfigured deployment would. This autouse fixture resets those auth knobs to their safe defaults
+before every test so each file boots from a clean, valid config; a test that wants auth on still
+sets it for itself after startup.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_settings() -> None:
+    settings = get_settings()
+    settings.require_api_key = False
+    settings.gateway_service_token = ""

--- a/infra/gateway/tests/test_app_orgs_access.py
+++ b/infra/gateway/tests/test_app_orgs_access.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Initiative 1 control-plane endpoints: provision, by-clerk-org, keys CRUD, service-token gate.
+
+These use ``TestClient`` with in-memory fakes injected into ``app.state`` so no Postgres is needed,
+matching the pattern in ``test_app_tenant_budgets.py``. They assert the four contracts the task calls
+out: provision idempotency, keys CRUD (with a raw token returned exactly once and never in a list),
+the resolver-backed by-clerk-org lookup, and the ``GATEWAY_SERVICE_TOKEN`` gate.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.tenant_api_keys import ApiKeyMeta, MintedKey
+from gateway.tenant_provisioning import ProvisionResult
+
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+SERVICE_TOKEN = "svc-secret-token"
+
+
+class FakeProvisioner:
+    def __init__(self) -> None:
+        self.mapping: dict[str, tuple[str, str]] = {}
+        self.calls: list[tuple[object, object]] = []
+
+    def provision(self, *, clerk_org_id, name, region="auto") -> ProvisionResult:
+        self.calls.append((clerk_org_id, name))
+        if clerk_org_id in self.mapping:
+            tid, plan = self.mapping[clerk_org_id]
+            return ProvisionResult(tid, plan, created=False)
+        tid = str(uuid.uuid4())
+        self.mapping[clerk_org_id] = (tid, "free")
+        return ProvisionResult(tid, "free", created=True)
+
+    def tenant_for_clerk_org(self, clerk_org_id) -> ProvisionResult | None:
+        if clerk_org_id in self.mapping:
+            tid, plan = self.mapping[clerk_org_id]
+            return ProvisionResult(tid, plan, created=False)
+        return None
+
+
+class FakeKeyStore:
+    def __init__(self) -> None:
+        self._rows: dict[str, ApiKeyMeta] = {}
+
+    def list(self, tenant_id: str) -> list[ApiKeyMeta]:
+        return list(self._rows.values())
+
+    def create(self, tenant_id, *, name=None, scope="write", created_by=None) -> MintedKey:
+        kid = str(uuid.uuid4())
+        meta = ApiKeyMeta(
+            id=kid,
+            name=name,
+            token_prefix="tally_sk_live_abc123",
+            scope=scope,
+            created_by=created_by,
+            created_at=None,
+            last_used_at=None,
+            revoked_at=None,
+        )
+        self._rows[kid] = meta
+        return MintedKey(meta=meta, token="tally_sk_live_abc123SECRETSUFFIX")
+
+    def rotate(self, tenant_id, key_id, *, created_by=None) -> MintedKey:
+        from gateway.tenant_api_keys import ApiKeyNotFoundError
+
+        if key_id not in self._rows:
+            raise ApiKeyNotFoundError("no live key")
+        return self.create(tenant_id, name="rotated", created_by=created_by)
+
+    def revoke(self, tenant_id, key_id) -> bool:
+        return self._rows.pop(key_id, None) is not None
+
+
+@contextmanager
+def _client(*, auth_on: bool, token: str = SERVICE_TOKEN) -> Iterator[TestClient]:
+    with TestClient(app) as client:
+        app.state.settings.require_api_key = auth_on
+        app.state.settings.gateway_service_token = token if auth_on else ""
+        app.state.tenant_provisioner = FakeProvisioner()
+        app.state.tenant_api_keys = FakeKeyStore()
+        yield client
+
+
+def _svc_headers(extra: dict | None = None) -> dict:
+    h = {"Authorization": f"Bearer {SERVICE_TOKEN}"}
+    if extra:
+        h.update(extra)
+    return h
+
+
+# --- service-token gate ---------------------------------------------------------------------------
+
+
+def test_gate_rejects_missing_token_when_auth_on() -> None:
+    with _client(auth_on=True) as c:
+        r = c.get("/v1/tenant/keys", headers={"X-Tenant-Id": TENANT_UUID})
+        assert r.status_code == 401
+
+
+def test_gate_rejects_wrong_token_when_auth_on() -> None:
+    with _client(auth_on=True) as c:
+        r = c.get(
+            "/v1/tenant/keys",
+            headers={"Authorization": "Bearer nope", "X-Tenant-Id": TENANT_UUID},
+        )
+        assert r.status_code == 401
+
+
+def test_gate_is_noop_when_auth_off() -> None:
+    # Dev escape hatch: with auth off the control plane needs no service token (matches today).
+    with _client(auth_on=False) as c:
+        r = c.get("/v1/tenant/keys", headers={"X-Tenant-Id": TENANT_UUID})
+        assert r.status_code == 200
+
+
+def test_keys_require_tenant_header() -> None:
+    with _client(auth_on=True) as c:
+        r = c.get("/v1/tenant/keys", headers=_svc_headers())
+        assert r.status_code == 422
+
+
+# --- provision ------------------------------------------------------------------------------------
+
+
+def test_provision_is_idempotent() -> None:
+    with _client(auth_on=True) as c:
+        body = {"data": {"id": "org_abc", "name": "Acme"}}
+        r1 = c.post("/v1/tenant/provision", json=body, headers=_svc_headers())
+        assert r1.status_code == 200, r1.text
+        first = r1.json()
+        assert first["created"] is True
+        assert first["plan"] == "free"
+
+        r2 = c.post("/v1/tenant/provision", json=body, headers=_svc_headers())
+        assert r2.status_code == 200
+        second = r2.json()
+        assert second["created"] is False
+        assert second["tenant_id"] == first["tenant_id"]
+
+
+def test_provision_rejects_without_service_token() -> None:
+    with _client(auth_on=True) as c:
+        r = c.post("/v1/tenant/provision", json={"data": {"id": "org_x", "name": "X"}})
+        assert r.status_code == 401
+
+
+# --- by-clerk-org ---------------------------------------------------------------------------------
+
+
+def test_by_clerk_org_404_when_unmapped() -> None:
+    with _client(auth_on=True) as c:
+        r = c.get("/v1/tenant/by-clerk-org/org_missing", headers=_svc_headers())
+        assert r.status_code == 404
+
+
+def test_by_clerk_org_returns_tenant_after_provision() -> None:
+    with _client(auth_on=True) as c:
+        c.post(
+            "/v1/tenant/provision",
+            json={"data": {"id": "org_live", "name": "Live"}},
+            headers=_svc_headers(),
+        )
+        r = c.get("/v1/tenant/by-clerk-org/org_live", headers=_svc_headers())
+        assert r.status_code == 200
+        body = r.json()
+        assert body["plan"] == "free"
+        assert uuid.UUID(body["tenant_id"])  # a real UUID, not a name
+
+
+# --- keys CRUD ------------------------------------------------------------------------------------
+
+
+def test_create_key_returns_token_once_and_list_hides_it() -> None:
+    with _client(auth_on=True) as c:
+        r = c.post(
+            "/v1/tenant/keys",
+            json={"name": "prod ingest", "scope": "write"},
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID, "X-Clerk-User-Id": "user_1"}),
+        )
+        assert r.status_code == 201, r.text
+        created = r.json()
+        assert created["token"].startswith("tally_sk_live_")
+        assert created["token_prefix"].startswith("tally_sk_live_")
+
+        r2 = c.get("/v1/tenant/keys", headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}))
+        assert r2.status_code == 200
+        listed = r2.json()["keys"]
+        assert len(listed) == 1
+        # The list must never carry a secret.
+        assert "token" not in listed[0]
+        assert "key_hash" not in listed[0]
+        assert listed[0]["token_prefix"].startswith("tally_sk_live_")
+
+
+def test_rotate_key_returns_new_token() -> None:
+    with _client(auth_on=True) as c:
+        created = c.post(
+            "/v1/tenant/keys",
+            json={"name": "k"},
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
+        ).json()
+        r = c.post(
+            f"/v1/tenant/keys/{created['id']}/rotate",
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
+        )
+        assert r.status_code == 201
+        assert r.json()["token"].startswith("tally_sk_live_")
+
+
+def test_rotate_unknown_key_is_404() -> None:
+    with _client(auth_on=True) as c:
+        r = c.post(
+            f"/v1/tenant/keys/{uuid.uuid4()}/rotate",
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
+        )
+        assert r.status_code == 404
+
+
+def test_revoke_key_returns_204() -> None:
+    with _client(auth_on=True) as c:
+        created = c.post(
+            "/v1/tenant/keys",
+            json={"name": "k"},
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
+        ).json()
+        r = c.delete(
+            f"/v1/tenant/keys/{created['id']}",
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
+        )
+        assert r.status_code == 204

--- a/infra/gateway/tests/test_app_orgs_access.py
+++ b/infra/gateway/tests/test_app_orgs_access.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from fastapi.testclient import TestClient
 
 from gateway.app import app
+from gateway.config import get_settings
 from gateway.tenant_api_keys import ApiKeyMeta, MintedKey
 from gateway.tenant_provisioning import ProvisionResult
 
@@ -79,6 +80,13 @@ class FakeKeyStore:
 
 @contextmanager
 def _client(*, auth_on: bool, token: str = SERVICE_TOKEN) -> Iterator[TestClient]:
+    # Boot with a VALID config (auth off) so the fail-closed boot guard (require_api_key on + no
+    # service token) never trips on leftover singleton state from a prior test. The per-test auth
+    # state is applied AFTER startup below, which is what the request-time gate reads. get_settings()
+    # returns the same object the lifespan assigns to app.state.settings.
+    boot = get_settings()
+    boot.require_api_key = False
+    boot.gateway_service_token = ""
     with TestClient(app) as client:
         app.state.settings.require_api_key = auth_on
         app.state.settings.gateway_service_token = token if auth_on else ""
@@ -117,6 +125,20 @@ def test_gate_is_noop_when_auth_off() -> None:
     with _client(auth_on=False) as c:
         r = c.get("/v1/tenant/keys", headers={"X-Tenant-Id": TENANT_UUID})
         assert r.status_code == 200
+
+
+def test_gate_fails_closed_when_auth_on_but_token_unset() -> None:
+    # Initiative 1 §6 regression: auth is required but NO service token is configured. The gate must
+    # reject (fail CLOSED), never return early and leave every /v1/tenant/* endpoint unauthenticated.
+    with _client(auth_on=True, token="") as c:
+        r = c.get(
+            "/v1/tenant/keys",
+            headers={"Authorization": "Bearer anything", "X-Tenant-Id": TENANT_UUID},
+        )
+        assert r.status_code == 503
+        # And an unauthenticated caller is likewise refused, never served.
+        r2 = c.get("/v1/tenant/keys", headers={"X-Tenant-Id": TENANT_UUID})
+        assert r2.status_code == 503
 
 
 def test_keys_require_tenant_header() -> None:

--- a/infra/gateway/tests/test_tenant_api_keys.py
+++ b/infra/gateway/tests/test_tenant_api_keys.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for :class:`gateway.tenant_api_keys.TenantApiKeyStore.rotate` (Initiative 1 review).
+
+Rotation mints a replacement key and revokes the old one in one transaction. The replacement must
+inherit the ORIGINAL minter (``created_by``) when the caller does not supply one, so a rotation
+never silently blanks the audit trail. These tests drive the store against a fake psycopg
+connection so the exact SQL and the INSERT parameters are asserted without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+from gateway import tenant_api_keys
+from gateway.tenant_api_keys import ApiKeyNotFoundError, TenantApiKeyStore
+
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+KEY_ID = "11111111-1111-4111-8111-111111111111"
+ORIGINAL_MINTER = "user_original_minter"
+
+
+class FakeCursor:
+    """Answers the resolver + rotate SQL from canned rows, recording every INSERT's parameters."""
+
+    def __init__(self, *, old_row: tuple | None) -> None:
+        self._old_row = old_row
+        self._result: tuple | None = None
+        self.insert_params: tuple | None = None
+        self.rowcount = 0
+
+    def execute(self, sql: str, params: tuple) -> None:
+        s = " ".join(sql.split())
+        if s.startswith("SELECT name, scope, created_by FROM api_keys"):
+            self._result = self._old_row
+        elif s.startswith("INSERT INTO api_keys"):
+            self.insert_params = params
+            # Echo an inserted row shaped like the RETURNING clause. created_by is params[5].
+            self._result = (
+                "22222222-2222-4222-8222-222222222222",
+                params[3],  # name
+                params[4],  # token_prefix
+                params[2],  # scope
+                params[5],  # created_by
+                dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+                None,
+                None,
+            )
+        else:  # UPDATE ... revoked_at, and anything else
+            self._result = None
+            self.rowcount = 1
+
+    def fetchone(self) -> tuple | None:
+        return self._result
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConn:
+    def __init__(self, cur: FakeCursor) -> None:
+        self._cur = cur
+        self.committed = False
+
+    def cursor(self) -> FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def __enter__(self) -> "FakeConn":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def _store_with(monkeypatch: pytest.MonkeyPatch, cur: FakeCursor) -> TenantApiKeyStore:
+    monkeypatch.setattr(tenant_api_keys.psycopg, "connect", lambda _dsn: FakeConn(cur))
+    return TenantApiKeyStore(SimpleNamespace(postgres_dsn="postgresql://ignored"))
+
+
+def test_rotate_carries_original_created_by_forward(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Old key was minted by ORIGINAL_MINTER; the rotate call supplies no created_by.
+    cur = FakeCursor(old_row=("prod key", "write", ORIGINAL_MINTER))
+    store = _store_with(monkeypatch, cur)
+
+    minted = store.rotate(TENANT_UUID, KEY_ID)
+
+    # The INSERT must carry the original minter, not NULL.
+    assert cur.insert_params is not None
+    assert cur.insert_params[5] == ORIGINAL_MINTER
+    assert minted.meta.created_by == ORIGINAL_MINTER
+
+
+def test_rotate_prefers_explicit_created_by(monkeypatch: pytest.MonkeyPatch) -> None:
+    cur = FakeCursor(old_row=("prod key", "write", ORIGINAL_MINTER))
+    store = _store_with(monkeypatch, cur)
+
+    minted = store.rotate(TENANT_UUID, KEY_ID, created_by="user_rotator")
+
+    # A supplied minter wins over the inherited one.
+    assert cur.insert_params is not None
+    assert cur.insert_params[5] == "user_rotator"
+    assert minted.meta.created_by == "user_rotator"
+
+
+def test_rotate_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    cur = FakeCursor(old_row=None)
+    store = _store_with(monkeypatch, cur)
+    with pytest.raises(ApiKeyNotFoundError):
+        store.rotate(TENANT_UUID, KEY_ID)

--- a/infra/gateway/tests/test_tenant_lookup.py
+++ b/infra/gateway/tests/test_tenant_lookup.py
@@ -2,9 +2,11 @@
 """Unit tests for the shared tenant-identifier resolver (CTO-201).
 
 Every control-plane store folds a caller's tenant identifier onto ``tenants.id`` through
-:func:`gateway.tenant_lookup.resolve_tenant_uuid`. This pins the three cases the stores rely on: a
-UUID passes through untouched, a NAME is looked up in ``tenants.name``, and an unknown identifier
-raises :class:`TenantNotFoundError` rather than reaching a UUID column and tripping the driver.
+:func:`gateway.tenant_lookup.resolve_tenant_uuid`. This pins the cases the stores rely on: a UUID
+passes through untouched, a Clerk org id and a NAME each resolve to their own tenant, and an unknown
+identifier raises :class:`TenantNotFoundError` rather than reaching a UUID column and tripping the
+driver. The Clerk-org and name lookups are separate ordered single-column selects (Initiative 1
+review), never a combined ``name = %s OR clerk_org_id = %s`` that could straddle two rows.
 """
 
 from __future__ import annotations
@@ -18,36 +20,68 @@ TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
 
 
 class FakeCursor:
-    """Stands in for a psycopg cursor, answering the resolver's single name lookup from a dict."""
+    """Stands in for a psycopg cursor, answering each single-column lookup from its own dict.
 
-    def __init__(self, names_to_ids: dict[str, str]) -> None:
-        self._names = names_to_ids
-        self._last_param: str | None = None
+    Unlike a param-only fake, this reads WHICH column the resolver queried (``clerk_org_id`` vs
+    ``name``) so the ordered, deterministic lookups are exercised faithfully: a value that is one
+    tenant's name and another's Clerk org id resolves to the Clerk-org tenant, never ambiguously.
+    """
+
+    def __init__(
+        self,
+        *,
+        by_clerk_org: dict[str, str] | None = None,
+        by_name: dict[str, str] | None = None,
+    ) -> None:
+        self._by_clerk_org = by_clerk_org or {}
+        self._by_name = by_name or {}
+        self._last: str | None = None
         self.executed: list[str] = []
 
     def execute(self, sql: str, params: tuple) -> None:
         self.executed.append(sql)
-        self._last_param = params[0]
+        if "clerk_org_id" in sql:
+            self._last = self._by_clerk_org.get(params[0])
+        elif "name" in sql:
+            self._last = self._by_name.get(params[0])
+        else:  # pragma: no cover - the resolver only issues the two lookups above
+            self._last = None
 
     def fetchone(self) -> tuple | None:
-        value = self._names.get(self._last_param)
-        return (value,) if value is not None else None
+        return (self._last,) if self._last is not None else None
 
 
 def test_uuid_passes_through_without_a_lookup() -> None:
-    cur = FakeCursor({})
+    cur = FakeCursor()
     assert resolve_tenant_uuid(cur, TENANT_UUID) == TENANT_UUID
     # A UUID caller must not cost a round trip to tenants.
     assert cur.executed == []
 
 
 def test_name_is_resolved_to_its_uuid() -> None:
-    cur = FakeCursor({TENANT_NAME: TENANT_UUID})
+    cur = FakeCursor(by_name={TENANT_NAME: TENANT_UUID})
     assert resolve_tenant_uuid(cur, TENANT_NAME) == TENANT_UUID
     assert cur.executed, "a name must trigger the tenants lookup"
 
 
+def test_clerk_org_id_is_resolved_to_its_uuid() -> None:
+    cur = FakeCursor(by_clerk_org={"org_abc123": TENANT_UUID})
+    assert resolve_tenant_uuid(cur, "org_abc123") == TENANT_UUID
+
+
+def test_clerk_org_id_match_wins_over_a_colliding_name() -> None:
+    # The dangerous case the combined OR allowed: an identifier that is tenant A's Clerk org id AND
+    # tenant B's NAME. The deterministic resolver checks clerk_org_id first, so it can only ever
+    # resolve to tenant A, never nondeterministically to B.
+    tenant_a = "11111111-1111-4111-8111-111111111111"
+    tenant_b = "22222222-2222-4222-8222-222222222222"
+    cur = FakeCursor(by_clerk_org={"org_shared": tenant_a}, by_name={"org_shared": tenant_b})
+    assert resolve_tenant_uuid(cur, "org_shared") == tenant_a
+    # The name lookup must never run once the Clerk-org match is found (short-circuit).
+    assert all("clerk_org_id" in sql for sql in cur.executed)
+
+
 def test_unknown_name_raises_rather_than_reaching_a_uuid_column() -> None:
-    cur = FakeCursor({})
+    cur = FakeCursor()
     with pytest.raises(TenantNotFoundError):
         resolve_tenant_uuid(cur, "no-such-tenant")

--- a/infra/gateway/tests/test_tenant_provisioning.py
+++ b/infra/gateway/tests/test_tenant_provisioning.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tenant provisioning + resolver extension (Initiative 1, §4/§5).
+
+These exercise the store logic without Postgres by monkeypatching ``psycopg.connect`` with a small
+in-memory fake that understands the handful of statements the provisioner runs. The three cases that
+carry the acceptance criteria:
+
+* :func:`test_provision_is_idempotent_on_redelivery`: a Clerk webhook redelivery returns the existing
+  tenant and mints NO new key material (the riskiest failure would be rolling an org's HMAC key set
+  on every retry).
+* :func:`test_provision_fresh_org_mints_and_creates`: a brand-new org gets a tenant and a minted HMAC
+  reference that is NOT deleted.
+* :func:`test_provision_lost_race_cleans_up_orphaned_key`: the loser of a concurrent race adopts the
+  winner's tenant and deletes the key set it minted, so no orphaned material is left behind.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from gateway import tenant_provisioning
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
+from gateway.tenant_provisioning import (
+    LocalDevKeyProvider,
+    ProvisionError,
+    TenantProvisioner,
+)
+
+
+class SpyKeyProvider:
+    """Records mint/delete so a test can assert orphan cleanup exactly."""
+
+    def __init__(self) -> None:
+        self.minted: list[str] = []
+        self.deleted: list[str] = []
+
+    def mint(self) -> str:
+        ref = f"local://hmac/{len(self.minted)}/v1"
+        self.minted.append(ref)
+        return ref
+
+    def delete(self, ref: str) -> None:
+        self.deleted.append(ref)
+
+
+class _FakeCursor:
+    def __init__(self, conn: "_FakeConn") -> None:
+        self._conn = conn
+        self._result = None
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *_a: object) -> bool:
+        return False
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        s = " ".join(sql.split())
+        if s.startswith("SELECT id, plan FROM tenants WHERE clerk_org_id"):
+            org = params[0]
+            if self._conn.race and not self._conn._race_consumed:
+                # Simulate a concurrent writer inserting after our fast-path read: the first
+                # SELECT misses even though the row exists for the INSERT conflict below.
+                self._conn._race_consumed = True
+                self._result = None
+            else:
+                self._result = self._conn.tenants.get(org)
+        elif s.startswith("INSERT INTO plan_tiers"):
+            self._result = None
+        elif s.startswith("INSERT INTO tenants"):
+            org = params[3]
+            if org in self._conn.tenants:
+                self._result = None  # ON CONFLICT DO NOTHING
+            else:
+                tid = str(uuid.uuid4())
+                self._conn.tenants[org] = (tid, "free")
+                self._result = (tid,)
+        elif s.startswith("INSERT INTO usage_limits"):
+            self._result = None
+        else:
+            self._result = None
+
+    def fetchone(self):
+        return self._result
+
+
+class _FakeConn:
+    def __init__(self, tenants: dict, race: bool) -> None:
+        self.tenants = tenants
+        self.race = race
+        self._race_consumed = False
+
+    def __enter__(self) -> "_FakeConn":
+        return self
+
+    def __exit__(self, *_a: object) -> bool:
+        return False
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        pass
+
+    def rollback(self) -> None:
+        pass
+
+
+def _patch_connect(monkeypatch, tenants: dict, *, race: bool = False) -> None:
+    monkeypatch.setattr(
+        tenant_provisioning.psycopg, "connect", lambda *_a, **_k: _FakeConn(tenants, race)
+    )
+
+
+class _Settings:
+    postgres_dsn = "postgresql://ignored"
+
+
+def test_provision_is_idempotent_on_redelivery(monkeypatch) -> None:
+    existing = str(uuid.uuid4())
+    tenants = {"org_abc": (existing, "free")}
+    _patch_connect(monkeypatch, tenants)
+    spy = SpyKeyProvider()
+    prov = TenantProvisioner(_Settings(), key_provider=spy)
+
+    result = prov.provision(clerk_org_id="org_abc", name="Acme")
+
+    assert result.tenant_id == existing
+    assert result.created is False
+    # A redelivery must never mint new key material.
+    assert spy.minted == []
+
+
+def test_provision_fresh_org_mints_and_creates(monkeypatch) -> None:
+    tenants: dict = {}
+    _patch_connect(monkeypatch, tenants)
+    spy = SpyKeyProvider()
+    prov = TenantProvisioner(_Settings(), key_provider=spy)
+
+    result = prov.provision(clerk_org_id="org_new", name="New Co")
+
+    assert result.created is True
+    assert result.plan == "free"
+    assert "org_new" in tenants
+    # One key set minted, and it survives (it is the tenant's live HMAC reference).
+    assert len(spy.minted) == 1
+    assert spy.deleted == []
+
+
+def test_provision_lost_race_cleans_up_orphaned_key(monkeypatch) -> None:
+    winner = str(uuid.uuid4())
+    # The row already exists (the race winner) but the fast-path SELECT is forced to miss once.
+    tenants = {"org_race": (winner, "free")}
+    _patch_connect(monkeypatch, tenants, race=True)
+    spy = SpyKeyProvider()
+    prov = TenantProvisioner(_Settings(), key_provider=spy)
+
+    result = prov.provision(clerk_org_id="org_race", name="Racer")
+
+    assert result.tenant_id == winner
+    assert result.created is False
+    # Exactly one key set minted, and it was deleted because we lost the race (no orphan).
+    assert len(spy.minted) == 1
+    assert spy.minted == spy.deleted
+
+
+def test_provision_rejects_blank_fields(monkeypatch) -> None:
+    _patch_connect(monkeypatch, {})
+    prov = TenantProvisioner(_Settings(), key_provider=SpyKeyProvider())
+    with pytest.raises(ProvisionError):
+        prov.provision(clerk_org_id="", name="Acme")
+    with pytest.raises(ProvisionError):
+        prov.provision(clerk_org_id="org_x", name="   ")
+
+
+def test_tenant_for_clerk_org_missing_is_none(monkeypatch) -> None:
+    _patch_connect(monkeypatch, {})
+    prov = TenantProvisioner(_Settings(), key_provider=SpyKeyProvider())
+    assert prov.tenant_for_clerk_org("org_absent") is None
+
+
+def test_local_dev_provider_mint_is_unique_and_check_safe() -> None:
+    provider = LocalDevKeyProvider()
+    ref_a = provider.mint()
+    ref_b = provider.mint()
+    assert ref_a != ref_b
+    # Must satisfy the no_raw_secret CHECK on tenants.hash_salt_kek_ref.
+    for ref in (ref_a, ref_b):
+        assert not ref.startswith("sk-")
+        assert len(ref) < 512
+        assert provider.has(ref)
+    provider.delete(ref_a)
+    assert not provider.has(ref_a)
+    assert provider.has(ref_b)
+
+
+# --- resolver extension ---------------------------------------------------------------------------
+
+
+class _ResolverCursor:
+    def __init__(self, by_name_or_org: dict) -> None:
+        self._map = by_name_or_org
+        self._row = None
+
+    def execute(self, sql: str, params: tuple) -> None:
+        # Both bind params are the same identifier (name OR clerk_org_id).
+        self._row = self._map.get(params[0])
+
+    def fetchone(self):
+        return self._row
+
+
+def test_resolver_matches_clerk_org_id() -> None:
+    tid = str(uuid.uuid4())
+    cur = _ResolverCursor({"org_123": (tid,)})
+    assert resolve_tenant_uuid(cur, "org_123") == tid
+
+
+def test_resolver_passes_uuid_through_without_query() -> None:
+    tid = str(uuid.uuid4())
+    # A cursor that would raise if queried, proving the UUID fast-path never hits Postgres.
+    class _Boom:
+        def execute(self, *_a: object) -> None:
+            raise AssertionError("UUID fast-path must not query")
+
+        def fetchone(self):
+            raise AssertionError("UUID fast-path must not query")
+
+    assert resolve_tenant_uuid(_Boom(), tid) == tid
+
+
+def test_resolver_unknown_identifier_raises() -> None:
+    cur = _ResolverCursor({})
+    with pytest.raises(TenantNotFoundError):
+        resolve_tenant_uuid(cur, "org_missing")

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,23 @@
+# Copy to web/.env.local and adjust. Local-only defaults; nothing here is a real secret.
+# Organizations, users & access (Initiative 1).
+
+# --- Dev escape hatch (§10) ---
+# Set this to a tenant UUID (or the name `local-dev`) to run the dashboard with NO Clerk account:
+# getTenant() short-circuits, Clerk middleware is a no-op, and no login is required. `make seed`
+# prints the UUID to use. Leave UNSET on the product path; with it unset and no active Clerk org the
+# app refuses to serve tenant data rather than falling back to local-dev.
+# TALLY_DEV_TENANT=local-dev
+
+# --- Gateway ---
+# Where the control-plane gateway lives (server-side only).
+TALLY_GATEWAY_URL=http://localhost:8080
+# Control-plane service token (§6). Must match the gateway's TALLY_GATEWAY_SERVICE_TOKEN. Sent as a
+# bearer token on every control-plane call; server-side only, never in a client bundle. Optional in
+# local dev with gateway auth off.
+# GATEWAY_SERVICE_TOKEN=change-me-in-real-deployments
+
+# --- Clerk (product path only; not needed when TALLY_DEV_TENANT is set) ---
+# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+# CLERK_SECRET_KEY=sk_test_...
+# Svix signing secret for the /api/webhooks/clerk provisioning webhook (§4).
+# CLERK_WEBHOOK_SIGNING_SECRET=whsec_...

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,11 +2,16 @@
 # Organizations, users & access (Initiative 1).
 
 # --- Dev escape hatch (§10) ---
-# Set this to a tenant UUID (or the name `local-dev`) to run the dashboard with NO Clerk account:
-# getTenant() short-circuits, Clerk middleware is a no-op, and no login is required. `make seed`
-# prints the UUID to use. Leave UNSET on the product path; with it unset and no active Clerk org the
-# app refuses to serve tenant data rather than falling back to local-dev.
-# TALLY_DEV_TENANT=local-dev
+# Set this to run the dashboard with NO Clerk account: getTenant() short-circuits, Clerk middleware
+# is a no-op, and no login is required. Leave UNSET on the product path; with it unset and no active
+# Clerk org the app refuses to serve tenant data rather than falling back to local-dev.
+#
+# Use the tenant UUID, NOT the name `local-dev`. The dashboard binds this value straight into the
+# ClickHouse read filter (TenantId = ...), and the demo backfill tags spans with the tenant UUID
+# (see infra/Makefile), so a bare name matches no rows and renders an empty dashboard. `make seed`
+# prints the exact line to copy (`export TALLY_DEV_TENANT=<uuid>`). The value is a UUID like the one
+# below; get yours from `make seed`.
+# TALLY_DEV_TENANT=00000000-0000-0000-0000-000000000000
 
 # --- Gateway ---
 # Where the control-plane gateway lives (server-side only).

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,5 @@
+# @clerk/nextjs (Initiative 1) pins its React peer to ~19.0.3+, while this app pins react to the
+# exact 19.0.0 the rest of the stack was built against. The two are compatible at runtime; only
+# npm's strict peer resolver objects. legacy-peer-deps lets install proceed without downgrading the
+# whole app's React, and keeps `npm ci` reproducible in CI.
+legacy-peer-deps=true

--- a/web/app/api/features/value-events/route.ts
+++ b/web/app/api/features/value-events/route.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "@/lib/getTenant";
 import { NextResponse } from "next/server";
 
 import { queryDistinctBusinessEventNames, queryFeatureValueEvents } from "@/lib/clickhouse";
@@ -10,7 +11,6 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 // GET /api/features/value-events — the modal's data source: distinct business events observed over
 // the last 30 days (for the picker) + the tenant's already-configured feature -> event mappings.
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/feature-value-events`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify(payload),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
@@ -94,7 +94,7 @@ export async function DELETE(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/feature-value-events`, {
       method: "DELETE",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify({ feature_tag: feature, change_id: changeId }),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/app/api/guardrails/route.ts
+++ b/web/app/api/guardrails/route.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "@/lib/getTenant";
 import { NextResponse } from "next/server";
 
 import {
@@ -16,7 +17,6 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 // Map the web mode back onto the control-plane state for the upsert. Only `enabled` actually alters
 // the agent; observe maps to `shadow` (recording-only). The precise mode is preserved in params.mode
@@ -42,7 +42,7 @@ export async function GET(req: Request) {
     try {
       const qs = ruleId ? `?rule_id=${encodeURIComponent(ruleId)}` : "";
       const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails/audit${qs}`, {
-        headers: { "x-tenant-id": TENANT },
+        headers: { "x-tenant-id": await resolveTenantId() },
         cache: "no-store",
         signal: AbortSignal.timeout(2000),
       });
@@ -102,7 +102,7 @@ export async function POST(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify(payload),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/app/api/keys/[id]/rotate/route.ts
+++ b/web/app/api/keys/[id]/rotate/route.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Rotate one ingest key (Initiative 1, §5). Admin-only. The gateway mints a replacement and revokes
+// the old row in one transaction and returns the new raw token ONCE, which we pass straight back.
+import { NextResponse } from "next/server";
+
+import { canManage, controlPlaneHeaders, currentUserId, getTenant } from "@/lib/getTenant";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const tenant = await getTenant();
+  if (!canManage(tenant)) {
+    return NextResponse.json({ error: "admin role required to rotate keys" }, { status: 403 });
+  }
+  const userId = await currentUserId();
+  const res = await fetch(`${GATEWAY_URL}/v1/tenant/keys/${encodeURIComponent(id)}/rotate`, {
+    method: "POST",
+    headers: controlPlaneHeaders(
+      tenant.tenantId,
+      userId ? { "x-clerk-user-id": userId } : {},
+    ),
+  });
+  const body = await res.json().catch(() => ({}));
+  return NextResponse.json(body, { status: res.status });
+}

--- a/web/app/api/keys/[id]/route.ts
+++ b/web/app/api/keys/[id]/route.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Revoke one ingest key (Initiative 1, §5). Admin-only. Forwards DELETE to the gateway, which sets
+// revoked_at = now() (a real revoke, not a delete). Returns the gateway's 204.
+import { NextResponse } from "next/server";
+
+import { canManage, controlPlaneHeaders, getTenant } from "@/lib/getTenant";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const tenant = await getTenant();
+  if (!canManage(tenant)) {
+    return NextResponse.json({ error: "admin role required to revoke keys" }, { status: 403 });
+  }
+  const res = await fetch(`${GATEWAY_URL}/v1/tenant/keys/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: controlPlaneHeaders(tenant.tenantId),
+  });
+  return new NextResponse(null, { status: res.status });
+}

--- a/web/app/api/keys/route.ts
+++ b/web/app/api/keys/route.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Ingest-key management proxy (Initiative 1, §5/§7). The browser must never hold the gateway service
+// token, so these server-side handlers are the seam: they resolve the active tenant from Clerk,
+// enforce the admin role for writes (§9), and forward to the gateway's service-token-authed keys
+// endpoints. The raw token the gateway returns on create is passed straight back to the caller ONCE
+// and never stored here.
+import { NextResponse } from "next/server";
+
+import { canManage, controlPlaneHeaders, currentUserId, getTenant } from "@/lib/getTenant";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+export async function GET(): Promise<NextResponse> {
+  const tenant = await getTenant();
+  const res = await fetch(`${GATEWAY_URL}/v1/tenant/keys`, {
+    headers: controlPlaneHeaders(tenant.tenantId),
+    cache: "no-store",
+  });
+  const body = await res.json().catch(() => ({}));
+  return NextResponse.json(body, { status: res.status });
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const tenant = await getTenant();
+  if (!canManage(tenant)) {
+    return NextResponse.json({ error: "admin role required to mint keys" }, { status: 403 });
+  }
+  const input = await req.json().catch(() => ({}));
+  const userId = await currentUserId();
+  const res = await fetch(`${GATEWAY_URL}/v1/tenant/keys`, {
+    method: "POST",
+    headers: controlPlaneHeaders(tenant.tenantId, {
+      "content-type": "application/json",
+      ...(userId ? { "x-clerk-user-id": userId } : {}),
+    }),
+    body: JSON.stringify({ name: input?.name, scope: input?.scope }),
+  });
+  const body = await res.json().catch(() => ({}));
+  return NextResponse.json(body, { status: res.status });
+}

--- a/web/app/api/revenue-uploads/template/route.ts
+++ b/web/app/api/revenue-uploads/template/route.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "@/lib/getTenant";
 // Serves the revenue-upload CSV template (CTO-198).
 //
 // A thin proxy rather than a copy of the header string: the gateway owns what the columns are, and
@@ -9,13 +10,12 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 export async function GET() {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-uploads/template`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/app/api/unit-economics/config/route.ts
+++ b/web/app/api/unit-economics/config/route.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "@/lib/getTenant";
 import { NextResponse } from "next/server";
 
 import {
@@ -15,7 +16,6 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 export interface ThresholdConfigPayload {
   /** The tenant's resolved thresholds (overrides layered on defaults, or defaults when no row). */
@@ -87,7 +87,7 @@ export async function POST(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/unit-economics/config`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify(payload),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/app/api/webhooks/clerk/route.test.ts
+++ b/web/app/api/webhooks/clerk/route.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Clerk provisioning webhook (Initiative 1, §4). svix is mocked so no real signing secret is needed;
+// the tests assert the route rejects a bad signature, forwards a verified organization.created to
+// the gateway's provision endpoint, and acks other event types without forwarding.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const verify = vi.fn();
+vi.mock("svix", () => ({
+  Webhook: class {
+    verify(...args: unknown[]) {
+      return verify(...args);
+    }
+  },
+}));
+
+import { POST } from "./route";
+
+function req(body: unknown, withHeaders = true): Request {
+  const headers: Record<string, string> = withHeaders
+    ? { "svix-id": "id", "svix-timestamp": "ts", "svix-signature": "sig" }
+    : {};
+  return new Request("http://localhost/api/webhooks/clerk", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/webhooks/clerk", () => {
+  beforeEach(() => {
+    process.env.CLERK_WEBHOOK_SIGNING_SECRET = "whsec_test";
+    verify.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects an invalid svix signature with 401 and never forwards", async () => {
+    verify.mockImplementation(() => {
+      throw new Error("bad signature");
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await POST(req({ type: "organization.created", data: { id: "org_1" } }));
+    expect(res.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards a verified organization.created to the gateway provision endpoint", async () => {
+    verify.mockReturnValue({ type: "organization.created", data: { id: "org_1", name: "Acme" } });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ tenant_id: "t", created: true }), { status: 200 }));
+    const res = await POST(req({}));
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain("/v1/tenant/provision");
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      clerk_org_id: "org_1",
+      name: "Acme",
+    });
+  });
+
+  it("acks a non-org-created event without forwarding", async () => {
+    verify.mockReturnValue({ type: "user.created", data: { id: "user_1" } });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await POST(req({}));
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 5xx when the gateway provision fails so Clerk retries", async () => {
+    verify.mockReturnValue({ type: "organization.created", data: { id: "org_1", name: "Acme" } });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
+    const res = await POST(req({}));
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/web/app/api/webhooks/clerk/route.ts
+++ b/web/app/api/webhooks/clerk/route.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Clerk provisioning webhook (Initiative 1, §4). Clerk emits `organization.created` here, svix-
+// signed. The gateway is private in the hosted topology (only web is public), so Clerk cannot reach
+// it directly: this thin public route verifies the svix signature, then forwards the VERIFIED event
+// to the gateway's service-token-authed POST /v1/tenant/provision.
+//
+// Never trust the body before the signature verifies. This route carries no Clerk session (it is
+// listed public in middleware) and is authenticated solely by its svix signature.
+
+import { Webhook } from "svix";
+
+import { serviceTokenHeader } from "@/lib/getTenant";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+interface ClerkOrgEvent {
+  type: string;
+  data: { id?: string; name?: string };
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const secret = process.env.CLERK_WEBHOOK_SIGNING_SECRET;
+  if (!secret) {
+    // Misconfiguration, not a client error. A 500 makes Clerk retry once the secret is set.
+    return new Response("webhook signing secret not configured", { status: 500 });
+  }
+
+  const svixId = req.headers.get("svix-id");
+  const svixTimestamp = req.headers.get("svix-timestamp");
+  const svixSignature = req.headers.get("svix-signature");
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return new Response("missing svix headers", { status: 400 });
+  }
+
+  const payload = await req.text();
+  let event: ClerkOrgEvent;
+  try {
+    event = new Webhook(secret).verify(payload, {
+      "svix-id": svixId,
+      "svix-timestamp": svixTimestamp,
+      "svix-signature": svixSignature,
+    }) as ClerkOrgEvent;
+  } catch {
+    // Signature did not verify. Reject; do not touch the body.
+    return new Response("invalid signature", { status: 401 });
+  }
+
+  // Only provision on org creation. Ack every other event so Clerk does not redeliver it.
+  if (event.type !== "organization.created") {
+    return new Response(null, { status: 200 });
+  }
+
+  const org = event.data;
+  if (!org?.id) {
+    return new Response("event missing organization id", { status: 400 });
+  }
+
+  const res = await fetch(`${GATEWAY_URL}/v1/tenant/provision`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...serviceTokenHeader() },
+    body: JSON.stringify({ clerk_org_id: org.id, name: org.name ?? org.id }),
+  });
+
+  if (!res.ok) {
+    // Return a 5xx so Clerk's own retry/backoff applies (the provision is idempotent, so a retry is
+    // safe). Never fabricate a success.
+    return new Response("provision failed", { status: 502 });
+  }
+  return new Response(null, { status: 200 });
+}

--- a/web/app/connectors/ConnectorTable.tsx
+++ b/web/app/connectors/ConnectorTable.tsx
@@ -16,7 +16,7 @@ import { DataTable, type Column } from "@/components/DataTable";
 import { Blank } from "@/components/HonestValue";
 import type { ConnectorStatus } from "@/lib/connectors";
 import { relativeAge } from "@/lib/dataState";
-import { type CostConnectorConfig, isConfigurable } from "@/lib/costConnectors";
+import { type CostConnectorConfig, isConfigurable } from "@/lib/costConnectorsShared";
 import { ConnectForm } from "./ConnectForm";
 import { ConnectorToggle } from "./ConnectorToggle";
 

--- a/web/app/connectors/RevenueUpload.tsx
+++ b/web/app/connectors/RevenueUpload.tsx
@@ -20,7 +20,7 @@ import {
   type UploadRowError,
   deriveUploadFreshness,
   formatSnapshotAmount,
-} from "@/lib/revenueUpload";
+} from "@/lib/revenueUploadShared";
 import { deleteRevenueUploadAction, uploadRevenueCsvAction } from "./revenueUploadActions";
 
 interface Props {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ClerkProvider } from "@clerk/nextjs";
 import { Shell } from "@/components/Shell";
+import { devTenant } from "@/lib/getTenant";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,12 +11,23 @@ export const metadata: Metadata = {
   description: "Cost-and-value observability for AI products",
 };
 
+// Dev escape hatch (Initiative 1, §10): with TALLY_DEV_TENANT set the app renders with NO Clerk keys
+// and no login, so `make up` and CI work with no Clerk account. In that mode we skip ClerkProvider
+// entirely (mounting it with no keys would throw) and hide the org controls in the shell. On the
+// product path ClerkProvider wraps the tree and the shell shows the org switcher.
 export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
+  const dev = devTenant() !== null;
+
+  const body = (
     <html lang="en">
       <body>
-        <Shell>{children}</Shell>
+        <Shell showOrgControls={!dev}>{children}</Shell>
       </body>
     </html>
   );
+
+  if (dev) {
+    return body;
+  }
+  return <ClerkProvider>{body}</ClerkProvider>;
 }

--- a/web/app/select-org/page.tsx
+++ b/web/app/select-org/page.tsx
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Select-or-create-organization screen (Initiative 1, §7). A signed-in user with no active org is
+// redirected here by the middleware. Creating an org fires `organization.created`, which provisions
+// the tenant behind the scenes (§4); picking an existing org sets it active. The product has no
+// personal workspace, so both paths lead into the dashboard scoped to the chosen org.
+import { OrganizationList } from "@clerk/nextjs";
+
+export default function SelectOrgPage() {
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center gap-6">
+      <div className="text-center">
+        <h1 className="text-lg font-semibold">Choose an organization</h1>
+        <p className="text-sm text-muted">
+          Create one to get started, or pick an organization you already belong to.
+        </p>
+      </div>
+      <OrganizationList
+        hidePersonal
+        afterSelectOrganizationUrl="/"
+        afterCreateOrganizationUrl="/"
+      />
+    </div>
+  );
+}

--- a/web/app/select-org/page.tsx
+++ b/web/app/select-org/page.tsx
@@ -5,6 +5,11 @@
 // personal workspace, so both paths lead into the dashboard scoped to the chosen org.
 import { OrganizationList } from "@clerk/nextjs";
 
+// Clerk's OrganizationList needs a ClerkProvider and a publishableKey. Rendering per request keeps
+// this off the keyless build prerender (dev escape hatch / CI have no Clerk keys) and resolves Clerk
+// at request time on the product path (CTO-259). The dev middleware never routes here.
+export const dynamic = "force-dynamic";
+
 export default function SelectOrgPage() {
   return (
     <div className="flex min-h-[70vh] flex-col items-center justify-center gap-6">

--- a/web/app/settings/budgets/BudgetManager.tsx
+++ b/web/app/settings/budgets/BudgetManager.tsx
@@ -24,7 +24,7 @@ import { useState, useTransition } from "react";
 
 import { DataTable, type Column } from "@/components/DataTable";
 import { Money } from "@/components/HonestValue";
-import { type Budget, microToDollarInput, scopeLabel } from "@/lib/budgets";
+import { type Budget, microToDollarInput, scopeLabel } from "@/lib/budgetsShared";
 
 import { type BudgetFormValues, deleteBudgetAction, saveBudgetAction } from "./actions";
 

--- a/web/app/settings/keys/KeyManager.tsx
+++ b/web/app/settings/keys/KeyManager.tsx
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// Client-side ingest-key manager (Initiative 1, §7). Lists key METADATA (never a secret), and, for
+// admins, mints a key showing its raw token exactly once, rotates a key, and revokes one. Every
+// write goes to the server-side /api/keys proxy, which holds the gateway service token and re-checks
+// the admin role; this component never sees the service token.
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface KeyMeta {
+  id: string;
+  name: string | null;
+  token_prefix: string | null;
+  scope: string;
+  created_by: string | null;
+  created_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+interface MintedKey {
+  id: string;
+  token: string;
+  token_prefix: string | null;
+  name: string | null;
+  scope: string;
+}
+
+/** A value we do not know is a blank, never a fabricated one (honest under uncertainty). */
+function orDash(v: string | null): string {
+  return v && v.trim() ? v : "—";
+}
+
+export function KeyManager({ canManage }: { canManage: boolean }) {
+  const [keys, setKeys] = useState<KeyMeta[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState("write");
+  const [minted, setMinted] = useState<MintedKey | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/keys", { cache: "no-store" });
+      if (!res.ok) {
+        setError(`Could not load keys (HTTP ${res.status}).`);
+        return;
+      }
+      const body = (await res.json()) as { keys?: KeyMeta[] };
+      setKeys(body.keys ?? []);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function createKey() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/keys", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: name.trim() || undefined, scope }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.error ?? `Mint failed (HTTP ${res.status}).`);
+        return;
+      }
+      setMinted(body as MintedKey);
+      setName("");
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function rotateKey(id: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/keys/${id}/rotate`, { method: "POST" });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.error ?? `Rotate failed (HTTP ${res.status}).`);
+        return;
+      }
+      setMinted(body as MintedKey);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revokeKey(id: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/keys/${id}`, { method: "DELETE" });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error ?? `Revoke failed (HTTP ${res.status}).`);
+        return;
+      }
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      {error && (
+        <div className="rounded-md border border-edge bg-panel px-3 py-2 text-sm text-fg">
+          {error}
+        </div>
+      )}
+
+      {canManage && (
+        <div className="flex flex-wrap items-end gap-3 rounded-md border border-edge bg-panel p-4">
+          <label className="flex flex-col gap-1 text-xs text-muted">
+            Name
+            <input
+              className="w-56 rounded border border-edge bg-transparent px-2 py-1 text-sm text-fg"
+              placeholder="prod ingest"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted">
+            Scope
+            <select
+              className="rounded border border-edge bg-transparent px-2 py-1 text-sm text-fg"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+            >
+              <option value="write">write</option>
+              <option value="read">read</option>
+              <option value="admin">admin</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void createKey()}
+            className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+          >
+            Create key
+          </button>
+        </div>
+      )}
+
+      {minted && (
+        <div className="space-y-2 rounded-md border border-accent bg-panel p-4">
+          <div className="text-sm font-semibold text-fg">
+            Copy this key now. You will not see it again.
+          </div>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 break-all rounded border border-edge bg-transparent px-2 py-1 text-xs text-fg">
+              {minted.token}
+            </code>
+            <button
+              type="button"
+              onClick={() => void navigator.clipboard?.writeText(minted.token)}
+              className="rounded border border-edge px-2 py-1 text-xs text-fg"
+            >
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={() => setMinted(null)}
+              className="rounded border border-edge px-2 py-1 text-xs text-muted"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-md border border-edge">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-panel text-xs uppercase tracking-wider text-muted">
+            <tr>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2">Prefix</th>
+              <th className="px-3 py-2">Scope</th>
+              <th className="px-3 py-2">Created</th>
+              <th className="px-3 py-2">Last used</th>
+              <th className="px-3 py-2">Status</th>
+              {canManage && <th className="px-3 py-2 text-right">Actions</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {keys === null && (
+              <tr>
+                <td className="px-3 py-3 text-muted" colSpan={canManage ? 7 : 6}>
+                  Loading…
+                </td>
+              </tr>
+            )}
+            {keys?.length === 0 && (
+              <tr>
+                <td className="px-3 py-3 text-muted" colSpan={canManage ? 7 : 6}>
+                  No keys yet.
+                </td>
+              </tr>
+            )}
+            {keys?.map((k) => (
+              <tr key={k.id} className="border-t border-edge">
+                <td className="px-3 py-2 text-fg">{orDash(k.name)}</td>
+                <td className="px-3 py-2 font-mono text-xs text-muted">{orDash(k.token_prefix)}</td>
+                <td className="px-3 py-2 text-fg">{k.scope}</td>
+                <td className="px-3 py-2 text-muted">{orDash(k.created_at)}</td>
+                <td className="px-3 py-2 text-muted">{orDash(k.last_used_at)}</td>
+                <td className="px-3 py-2">
+                  {k.revoked_at ? (
+                    <span className="text-muted">revoked</span>
+                  ) : (
+                    <span className="text-fg">active</span>
+                  )}
+                </td>
+                {canManage && (
+                  <td className="px-3 py-2 text-right">
+                    {!k.revoked_at && (
+                      <span className="inline-flex gap-2">
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void rotateKey(k.id)}
+                          className="rounded border border-edge px-2 py-1 text-xs text-fg disabled:opacity-50"
+                        >
+                          Rotate
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => void revokeKey(k.id)}
+                          className="rounded border border-edge px-2 py-1 text-xs text-muted disabled:opacity-50"
+                        >
+                          Revoke
+                        </button>
+                      </span>
+                    )}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {!canManage && (
+        <p className="text-xs text-muted">
+          You have read-only access. Ask an organization admin to mint or rotate keys.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/app/settings/keys/page.tsx
+++ b/web/app/settings/keys/page.tsx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Ingest API keys settings page (Initiative 1, §7). Server component: it resolves the active tenant
+// and the caller's role, then hands the client manager whether this user may mint/rotate/revoke.
+// Members see the list read-only; admins get the write controls (§9).
+import { canManage, getTenant } from "@/lib/getTenant";
+import { KeyManager } from "./KeyManager";
+
+export default async function KeysPage() {
+  const tenant = await getTenant();
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-lg font-semibold">API Keys</h1>
+        <p className="text-sm text-muted">
+          Per-organization ingest keys for the SDK and the edge proxy. A key&apos;s secret is shown
+          once at creation and never again.
+        </p>
+      </div>
+      <KeyManager canManage={canManage(tenant)} />
+    </div>
+  );
+}

--- a/web/app/settings/members/page.tsx
+++ b/web/app/settings/members/page.tsx
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Member management (Initiative 1, §7/§9). ai-tally does not build its own membership UI: Clerk's
+// OrganizationProfile owns invites, role changes, and removals. Clerk itself gates the write actions
+// to admins, matching the role model in §9.
+import { OrganizationProfile } from "@clerk/nextjs";
+
+export default function MembersPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-semibold">Members</h1>
+      <OrganizationProfile routing="hash" />
+    </div>
+  );
+}

--- a/web/app/settings/members/page.tsx
+++ b/web/app/settings/members/page.tsx
@@ -4,7 +4,28 @@
 // to admins, matching the role model in §9.
 import { OrganizationProfile } from "@clerk/nextjs";
 
+import { devTenant } from "@/lib/getTenant";
+
+// Clerk's OrganizationProfile is a client component that requires a ClerkProvider (and a
+// publishableKey). On the dev escape hatch (TALLY_DEV_TENANT set) the layout mounts no ClerkProvider,
+// exactly as the shell omits the org switcher, so rendering it there would throw. Gate the same way
+// the shell does and show why instead. `force-dynamic` keeps the product path off the keyless build
+// prerender, so the page resolves Clerk at request time rather than at build (CTO-259).
+export const dynamic = "force-dynamic";
+
 export default function MembersPage() {
+  if (devTenant() !== null) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-lg font-semibold">Members</h1>
+        <p className="text-sm text-muted">
+          Member management runs through Clerk, which is disabled in the dev escape hatch
+          (TALLY_DEV_TENANT is set). Run with Clerk configured to invite members and manage roles.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
       <h1 className="text-lg font-semibold">Members</h1>

--- a/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -3,6 +3,10 @@
 // in an organization.
 import { SignIn } from "@clerk/nextjs";
 
+// Rendered per request, not at build: the keyless build (dev escape hatch / CI) has no Clerk
+// publishableKey, so this Clerk component must resolve at request time on the product path (CTO-259).
+export const dynamic = "force-dynamic";
+
 export default function SignInPage() {
   return (
     <div className="flex min-h-[70vh] items-center justify-center">

--- a/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Clerk-hosted sign-in (Initiative 1, §7). Public route; no ai-tally tenant exists until the user is
+// in an organization.
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center">
+      <SignIn />
+    </div>
+  );
+}

--- a/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -2,6 +2,10 @@
 // Clerk-hosted sign-up (Initiative 1, §7). Public route.
 import { SignUp } from "@clerk/nextjs";
 
+// Rendered per request, not at build: the keyless build (dev escape hatch / CI) has no Clerk
+// publishableKey, so this Clerk component must resolve at request time on the product path (CTO-259).
+export const dynamic = "force-dynamic";
+
 export default function SignUpPage() {
   return (
     <div className="flex min-h-[70vh] items-center justify-center">

--- a/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Clerk-hosted sign-up (Initiative 1, §7). Public route.
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center">
+      <SignUp />
+    </div>
+  );
+}

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -13,6 +13,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
+import { OrganizationSwitcher, UserButton } from "@clerk/nextjs";
 
 interface NavItem {
   label: string;
@@ -57,6 +58,15 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
       { label: "Budgets", href: "/settings/budgets" },
     ],
   },
+  {
+    caption: "Organization",
+    items: [
+      // Per-org ingest keys and member management (Initiative 1, §7). Both are org-scoped and, for
+      // writes, admin-only; the pages enforce the role.
+      { label: "API Keys", href: "/settings/keys" },
+      { label: "Members", href: "/settings/members" },
+    ],
+  },
 ];
 
 // Active when the path is the link or nested under it. "/" matches only itself so it does not light
@@ -66,7 +76,16 @@ function isActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-export function Shell({ children }: { children: ReactNode }) {
+export function Shell({
+  children,
+  // Clerk org controls (switcher + user button) render only on the product path. In the dev escape
+  // hatch (TALLY_DEV_TENANT set) there is no ClerkProvider, so mounting them would throw; the layout
+  // passes false and the chrome simply omits them.
+  showOrgControls = false,
+}: {
+  children: ReactNode;
+  showOrgControls?: boolean;
+}) {
   const pathname = usePathname() ?? "/";
 
   return (
@@ -127,6 +146,16 @@ export function Shell({ children }: { children: ReactNode }) {
           ))}
         </nav>
 
+        {showOrgControls && (
+          <div className="flex items-center justify-between gap-2 border-t border-edge px-4 py-3">
+            <OrganizationSwitcher
+              hidePersonal
+              afterSelectOrganizationUrl="/"
+              afterCreateOrganizationUrl="/"
+            />
+            <UserButton />
+          </div>
+        )}
         <div className="border-t border-edge px-5 py-3 text-[11px] text-muted">
           Cost-and-value observability
         </div>

--- a/web/lib/accountLabels.ts
+++ b/web/lib/accountLabels.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Dashboard client for the account control plane (CTO-188, plan D2).
 //
 // Two gateway endpoints, one module, because they answer the two halves of the same question "which
@@ -17,7 +18,6 @@
 // dropped. It is never cached, never returned in an error message, and never logged. Every warning
 // below reports the transport failure only.
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 /** A slow gateway must not hold a page render open. Same budget lib/tenant.ts uses. */
@@ -52,7 +52,7 @@ interface AccountLookupResponse {
 export async function queryAccountLabels(): Promise<Map<string, string> | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/account-labels`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });
@@ -101,7 +101,7 @@ export async function lookupAccountHashes(accountId: string): Promise<AccountLoo
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/account-lookup`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify({ account_id: trimmed }),
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),

--- a/web/lib/allocationConfig.ts
+++ b/web/lib/allocationConfig.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Per-tenant shared-cost allocation rule, read via the gateway (CTO-193, plan C2).
 //
 // The rule decides how compute and egress are split across accounts on /cost-per-customer, which on
@@ -18,7 +19,6 @@
 import { DEFAULT_ALLOCATION_RULE, type AllocationRule, ALLOCATION_RULES } from "./allocation";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 /** A slow gateway must not hold a page render open. Same budget lib/accountLabels.ts uses. */
 const TIMEOUT_MS = 2000;
@@ -91,7 +91,7 @@ export function settingFromApi(body: AllocationConfigApi | null): AllocationRule
 export async function queryAllocationRule(): Promise<AllocationRuleSetting> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/allocation-config`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });

--- a/web/lib/budgets.ts
+++ b/web/lib/budgets.ts
@@ -19,158 +19,26 @@ import { resolveTenantId } from "./getTenant";
 //    with, and that name is the whole value of the error: "that overlaps with research-agent-q1"
 //    tells the user which row to edit, "something went wrong" sends them hunting. The
 //    `conflictingBudgetId` is carried out separately as well so the UI can offer to open that row.
+//
+// Client-safe constants, types and the pure money helpers live in budgetsShared.ts (CTO-259) so the
+// client `BudgetManager` can import them without reaching this server-only module. They are
+// re-exported below so existing server call sites keep importing from "@/lib/budgets".
 
-import type { MicroUSD } from "./types";
+import {
+  BUDGET_PERIODS,
+  BUDGET_SCOPE_KINDS,
+  type BudgetInput,
+  type BudgetList,
+  type BudgetWire,
+  budgetFromWire,
+  type DeleteResult,
+  type GatewayFailure,
+  type SaveResult,
+} from "./budgetsShared";
+
+export * from "./budgetsShared";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-
-/** Mirrors gateway.tenant_budgets.BUDGET_PERIODS. The gateway echoes its own list; this is the
- *  fallback used when it is unreachable, so the form still renders something truthful. */
-export const BUDGET_PERIODS = ["month", "quarter"] as const;
-export type BudgetPeriod = (typeof BUDGET_PERIODS)[number];
-
-/** Mirrors gateway.tenant_budgets.BUDGET_SCOPE_KINDS. */
-export const BUDGET_SCOPE_KINDS = ["tenant", "feature", "model", "layer"] as const;
-export type BudgetScopeKind = (typeof BUDGET_SCOPE_KINDS)[number];
-
-/** The scope kind that covers the whole bill and therefore names nothing. */
-export const TENANT_SCOPE_KIND: BudgetScopeKind = "tenant";
-
-export interface Budget {
-  budgetId: string;
-  period: string;
-  amountMicro: MicroUSD;
-  scopeKind: string;
-  /** Always a string, '' for a tenant-wide budget. Never null: see the gateway's as_dict(). */
-  scopeValue: string;
-  /** ISO YYYY-MM-DD. */
-  startsOn: string;
-  /** null means open-ended ("until further notice"), not unknown and not a sentinel date. */
-  endsOn: string | null;
-  createdAt: string | null;
-  updatedAt: string | null;
-}
-
-interface BudgetWire {
-  budget_id: string;
-  period: string;
-  amount_micro: number;
-  scope_kind: string;
-  scope_value: string;
-  starts_on: string;
-  ends_on: string | null;
-  created_at: string | null;
-  updated_at: string | null;
-}
-
-export interface BudgetList {
-  budgets: Budget[];
-  /** false when the tenant has set no budget at all. A normal state, not an error. */
-  configured: boolean;
-  /** What this deployment can store, echoed by the gateway so the form cannot drift from the
-   *  CHECK constraints. Falls back to the constants above when the gateway is unreachable. */
-  periods: string[];
-  scopeKinds: string[];
-  /** false when we could not reach the gateway. Deliberately distinct from `configured`: a page
-   *  must not tell a user "no budget set" when the truth is "we could not ask". */
-  reachable: boolean;
-  /** Verbatim failure text when `reachable` is false. */
-  error: string | null;
-}
-
-export function budgetFromWire(w: BudgetWire): Budget {
-  return {
-    budgetId: w.budget_id,
-    period: w.period,
-    amountMicro: w.amount_micro,
-    scopeKind: w.scope_kind,
-    scopeValue: w.scope_value ?? "",
-    startsOn: w.starts_on,
-    endsOn: w.ends_on,
-    createdAt: w.created_at,
-    updatedAt: w.updated_at,
-  };
-}
-
-/** How a budget reads in a table cell: "Whole tenant", or "feature: research-agent". */
-export function scopeLabel(budget: Pick<Budget, "scopeKind" | "scopeValue">): string {
-  if (budget.scopeKind === TENANT_SCOPE_KIND) return "Whole tenant";
-  return `${budget.scopeKind}: ${budget.scopeValue}`;
-}
-
-// ---------------------------------------------------------------------------------------------
-// Money. Dollars in the form, integer micro-USD on the wire, and no float in between.
-// ---------------------------------------------------------------------------------------------
-
-/** Micro-USD per dollar. The gateway rejects a float amount outright, so the conversion has to be
- *  exact, not merely close. */
-const MICRO_PER_USD = 1_000_000;
-
-export type DollarParse = { ok: true; micro: MicroUSD } | { ok: false; error: string };
-
-/**
- * Parse a dollars-and-cents string into integer micro-USD, by STRING SURGERY rather than
- * arithmetic on a float.
- *
- * `Math.round(Number("30000.07") * 1e6)` looks fine and is fine for most inputs, which is exactly
- * why it is dangerous: it fails on a small, unpredictable subset (0.1 + 0.2 territory) and a budget
- * that is one micro-dollar off is a variance figure that never quite reconciles. Splitting on the
- * decimal point and padding the fraction to six digits is exact for every input the form accepts.
- *
- * Zero is accepted. A budget of zero is a real claim ("this scope may spend nothing"), and it is
- * the ABSENCE of a budget, not a zero, that means "no budget set".
- */
-export function dollarsToMicro(input: string): DollarParse {
-  // Commas and a leading $ are what people paste out of a spreadsheet. Accepting them is not
-  // guessing at intent, it is reading the same number.
-  const cleaned = input.trim().replace(/^\$/, "").replace(/,/g, "");
-  if (!cleaned) return { ok: false, error: "amount is required, in dollars (for example 30000)" };
-  if (!/^\d+(\.\d{1,6})?$/.test(cleaned)) {
-    return {
-      ok: false,
-      error:
-        "amount must be a positive dollar figure with at most 6 decimal places " +
-        "(for example 30000 or 1250.50)",
-    };
-  }
-  const [whole, fraction = ""] = cleaned.split(".");
-  const micro = Number(whole) * MICRO_PER_USD + Number(fraction.padEnd(6, "0"));
-  if (!Number.isSafeInteger(micro)) {
-    return { ok: false, error: "amount is too large to record" };
-  }
-  return { ok: true, micro };
-}
-
-/**
- * Micro-USD back to the exact dollar string the edit form should start from.
- *
- * Not `formatUSD`: that one is for display and rounds to a readable number of decimals, so feeding
- * it back into an input would let an edit-and-save silently change an amount it never showed the
- * user. This is the round-trip inverse of `dollarsToMicro` and nothing else.
- */
-export function microToDollarInput(micro: MicroUSD): string {
-  const negative = micro < 0;
-  const abs = Math.abs(Math.trunc(micro));
-  const whole = Math.floor(abs / MICRO_PER_USD);
-  const fraction = String(abs % MICRO_PER_USD).padStart(6, "0").replace(/0+$/, "");
-  const body = fraction ? `${whole}.${fraction}` : String(whole);
-  return negative ? `-${body}` : body;
-}
-
-// ---------------------------------------------------------------------------------------------
-// Transport
-// ---------------------------------------------------------------------------------------------
-
-export interface GatewayFailure {
-  ok: false;
-  /** The gateway's own words wherever it gave us any. Never reduced to a status code. */
-  error: string;
-  /** Set on a 409, naming the budget the write collided with, so the UI can offer to edit it. */
-  conflictingBudgetId: string | null;
-}
-
-export type SaveResult = { ok: true; budget: Budget } | GatewayFailure;
-export type DeleteResult = { ok: true; removed: boolean } | GatewayFailure;
 
 /**
  * Pull the caller-facing message out of a failed response.
@@ -237,16 +105,6 @@ export async function queryBudgets(): Promise<BudgetList> {
   } catch (err) {
     return { ...fallback, reachable: false, error: (err as Error).message };
   }
-}
-
-export interface BudgetInput {
-  budgetId: string;
-  period: string;
-  amountMicro: MicroUSD;
-  scopeKind: string;
-  scopeValue: string;
-  startsOn: string;
-  endsOn: string | null;
 }
 
 /**

--- a/web/lib/budgets.ts
+++ b/web/lib/budgets.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Typed client for the tenant budget control plane (CTO-208, F4).
 //
 // CTO-205 built the storage and the rules (`db/postgres/0026_tenant_budgets.sql`,
@@ -21,7 +22,6 @@
 
 import type { MicroUSD } from "./types";
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 /** Mirrors gateway.tenant_budgets.BUDGET_PERIODS. The gateway echoes its own list; this is the
@@ -210,7 +210,7 @@ export async function queryBudgets(): Promise<BudgetList> {
   };
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(4000),
     });
@@ -258,7 +258,7 @@ export async function saveBudget(input: BudgetInput): Promise<SaveResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify({
         budget_id: input.budgetId,
         period: input.period,
@@ -289,7 +289,7 @@ export async function deleteBudget(budgetId: string): Promise<DeleteResult> {
       `${GATEWAY_URL}/v1/tenant/budgets?budget_id=${encodeURIComponent(budgetId)}`,
       {
         method: "DELETE",
-        headers: { "x-tenant-id": TENANT },
+        headers: { "x-tenant-id": await resolveTenantId() },
         cache: "no-store",
         signal: AbortSignal.timeout(5000),
       },

--- a/web/lib/budgetsShared.ts
+++ b/web/lib/budgetsShared.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Client-safe budget shapes and money helpers (CTO-208, F4; boundary split CTO-259).
+//
+// The transport half (`budgets.ts`) resolves the tenant via the server-only `getTenant`, so a Client
+// Component cannot import from it without dragging the server graph in. Everything here is pure (no
+// gateway fetch, no Clerk), so `BudgetManager` imports what it needs from this module while
+// `budgets.ts` re-exports it for server callers.
+
+import type { MicroUSD } from "./types";
+
+/** Mirrors gateway.tenant_budgets.BUDGET_PERIODS. The gateway echoes its own list; this is the
+ *  fallback used when it is unreachable, so the form still renders something truthful. */
+export const BUDGET_PERIODS = ["month", "quarter"] as const;
+export type BudgetPeriod = (typeof BUDGET_PERIODS)[number];
+
+/** Mirrors gateway.tenant_budgets.BUDGET_SCOPE_KINDS. */
+export const BUDGET_SCOPE_KINDS = ["tenant", "feature", "model", "layer"] as const;
+export type BudgetScopeKind = (typeof BUDGET_SCOPE_KINDS)[number];
+
+/** The scope kind that covers the whole bill and therefore names nothing. */
+export const TENANT_SCOPE_KIND: BudgetScopeKind = "tenant";
+
+export interface Budget {
+  budgetId: string;
+  period: string;
+  amountMicro: MicroUSD;
+  scopeKind: string;
+  /** Always a string, '' for a tenant-wide budget. Never null: see the gateway's as_dict(). */
+  scopeValue: string;
+  /** ISO YYYY-MM-DD. */
+  startsOn: string;
+  /** null means open-ended ("until further notice"), not unknown and not a sentinel date. */
+  endsOn: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface BudgetWire {
+  budget_id: string;
+  period: string;
+  amount_micro: number;
+  scope_kind: string;
+  scope_value: string;
+  starts_on: string;
+  ends_on: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface BudgetList {
+  budgets: Budget[];
+  /** false when the tenant has set no budget at all. A normal state, not an error. */
+  configured: boolean;
+  /** What this deployment can store, echoed by the gateway so the form cannot drift from the
+   *  CHECK constraints. Falls back to the constants above when the gateway is unreachable. */
+  periods: string[];
+  scopeKinds: string[];
+  /** false when we could not reach the gateway. Deliberately distinct from `configured`: a page
+   *  must not tell a user "no budget set" when the truth is "we could not ask". */
+  reachable: boolean;
+  /** Verbatim failure text when `reachable` is false. */
+  error: string | null;
+}
+
+export function budgetFromWire(w: BudgetWire): Budget {
+  return {
+    budgetId: w.budget_id,
+    period: w.period,
+    amountMicro: w.amount_micro,
+    scopeKind: w.scope_kind,
+    scopeValue: w.scope_value ?? "",
+    startsOn: w.starts_on,
+    endsOn: w.ends_on,
+    createdAt: w.created_at,
+    updatedAt: w.updated_at,
+  };
+}
+
+/** How a budget reads in a table cell: "Whole tenant", or "feature: research-agent". */
+export function scopeLabel(budget: Pick<Budget, "scopeKind" | "scopeValue">): string {
+  if (budget.scopeKind === TENANT_SCOPE_KIND) return "Whole tenant";
+  return `${budget.scopeKind}: ${budget.scopeValue}`;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Money. Dollars in the form, integer micro-USD on the wire, and no float in between.
+// ---------------------------------------------------------------------------------------------
+
+/** Micro-USD per dollar. The gateway rejects a float amount outright, so the conversion has to be
+ *  exact, not merely close. */
+const MICRO_PER_USD = 1_000_000;
+
+export type DollarParse = { ok: true; micro: MicroUSD } | { ok: false; error: string };
+
+/**
+ * Parse a dollars-and-cents string into integer micro-USD, by STRING SURGERY rather than
+ * arithmetic on a float.
+ *
+ * `Math.round(Number("30000.07") * 1e6)` looks fine and is fine for most inputs, which is exactly
+ * why it is dangerous: it fails on a small, unpredictable subset (0.1 + 0.2 territory) and a budget
+ * that is one micro-dollar off is a variance figure that never quite reconciles. Splitting on the
+ * decimal point and padding the fraction to six digits is exact for every input the form accepts.
+ *
+ * Zero is accepted. A budget of zero is a real claim ("this scope may spend nothing"), and it is
+ * the ABSENCE of a budget, not a zero, that means "no budget set".
+ */
+export function dollarsToMicro(input: string): DollarParse {
+  // Commas and a leading $ are what people paste out of a spreadsheet. Accepting them is not
+  // guessing at intent, it is reading the same number.
+  const cleaned = input.trim().replace(/^\$/, "").replace(/,/g, "");
+  if (!cleaned) return { ok: false, error: "amount is required, in dollars (for example 30000)" };
+  if (!/^\d+(\.\d{1,6})?$/.test(cleaned)) {
+    return {
+      ok: false,
+      error:
+        "amount must be a positive dollar figure with at most 6 decimal places " +
+        "(for example 30000 or 1250.50)",
+    };
+  }
+  const [whole, fraction = ""] = cleaned.split(".");
+  const micro = Number(whole) * MICRO_PER_USD + Number(fraction.padEnd(6, "0"));
+  if (!Number.isSafeInteger(micro)) {
+    return { ok: false, error: "amount is too large to record" };
+  }
+  return { ok: true, micro };
+}
+
+/**
+ * Micro-USD back to the exact dollar string the edit form should start from.
+ *
+ * Not `formatUSD`: that one is for display and rounds to a readable number of decimals, so feeding
+ * it back into an input would let an edit-and-save silently change an amount it never showed the
+ * user. This is the round-trip inverse of `dollarsToMicro` and nothing else.
+ */
+export function microToDollarInput(micro: MicroUSD): string {
+  const negative = micro < 0;
+  const abs = Math.abs(Math.trunc(micro));
+  const whole = Math.floor(abs / MICRO_PER_USD);
+  const fraction = String(abs % MICRO_PER_USD).padStart(6, "0").replace(/0+$/, "");
+  const body = fraction ? `${whole}.${fraction}` : String(whole);
+  return negative ? `-${body}` : body;
+}
+
+export interface GatewayFailure {
+  ok: false;
+  /** The gateway's own words wherever it gave us any. Never reduced to a status code. */
+  error: string;
+  /** Set on a 409, naming the budget the write collided with, so the UI can offer to edit it. */
+  conflictingBudgetId: string | null;
+}
+
+export type SaveResult = { ok: true; budget: Budget } | GatewayFailure;
+export type DeleteResult = { ok: true; removed: boolean } | GatewayFailure;
+
+export interface BudgetInput {
+  budgetId: string;
+  period: string;
+  amountMicro: MicroUSD;
+  scopeKind: string;
+  scopeValue: string;
+  startsOn: string;
+  endsOn: string | null;
+}

--- a/web/lib/cac.ts
+++ b/web/lib/cac.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // CAC period type + gateway-backed fetch (CTO-111).
 //
 // Shapes match the gateway's /v1/tenant/cac response. Money is micro-USD on the wire (matching
 // business_events). The TS types use ``MicroUsd = number`` for clarity at call sites.
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 export interface CacPeriod {
   /** ISO date — first day of the month, e.g. "2026-01-01". */
@@ -73,7 +73,7 @@ export interface CacQueryResult {
 export async function queryCacPeriods(): Promise<CacQueryResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cac`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -108,10 +108,19 @@ function client(): ClickHouseClient {
   return _client;
 }
 
-/** Run `fn` against ClickHouse; return null on any failure so callers can fall back to mock. */
+/**
+ * Run `fn` against ClickHouse; return null on a ClickHouse failure so callers can fall back to mock.
+ *
+ * Tenant resolution runs OUTSIDE the mock-fallback try (Initiative 1 review). A NoActiveOrgError or
+ * a gateway 404/outage is a failure to identify WHO is asking, NOT "ClickHouse is unreachable", and
+ * must never be swallowed into mock demo data: doing so would render one party's demo numbers for a
+ * real, unresolved tenant. So a resolution error propagates to the route (an honest error state),
+ * and only a query error against a known tenant falls back to mock.
+ */
 export async function tryLive<T>(fn: (db: ClickHouseClient, tenant: string) => Promise<T>): Promise<T | null> {
+  const tenant = await resolveTenantId();
   try {
-    return await fn(client(), await resolveTenantId());
+    return await fn(client(), tenant);
   } catch (err) {
     console.warn("[clickhouse] live query failed, falling back to mock:", (err as Error).message);
     return null;

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -88,7 +88,10 @@ import {
   type AccountRevenueSqlRow,
 } from "./accountRevenue";
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
+// The active tenant is resolved per call from the Clerk org (or the dev escape hatch), not a
+// module-level `local-dev` constant (Initiative 1, §7/§8). The ClickHouse read filter binds this
+// UUID, so a UUID-scoped read matches UUID-tagged ingest.
+import { resolveTenantId } from "./getTenant";
 
 let _client: ClickHouseClient | null = null;
 
@@ -108,7 +111,7 @@ function client(): ClickHouseClient {
 /** Run `fn` against ClickHouse; return null on any failure so callers can fall back to mock. */
 export async function tryLive<T>(fn: (db: ClickHouseClient, tenant: string) => Promise<T>): Promise<T | null> {
   try {
-    return await fn(client(), TENANT);
+    return await fn(client(), await resolveTenantId());
   } catch (err) {
     console.warn("[clickhouse] live query failed, falling back to mock:", (err as Error).message);
     return null;
@@ -1763,7 +1766,7 @@ interface ReconciliationRun {
 async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/reconciliation/status`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -2288,7 +2291,7 @@ export interface IntegrationStatusRow {
 export async function queryIntegrationStatus(): Promise<IntegrationStatusRow[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/integrations/status`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -2415,7 +2418,7 @@ export async function queryGuardrailActivity(): Promise<Map<string, GuardrailAct
 export async function queryGuardrailRules(): Promise<GuardrailRule[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -2460,7 +2463,7 @@ export interface FeatureValueEventConfig {
 export async function queryFeatureValueEvents(): Promise<FeatureValueEventConfig[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/feature-value-events`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -3003,7 +3006,7 @@ export async function queryReplayCandidates(
   featureTag?: string,
   candidates: Array<{ provider: string; model: string }> = DEFAULT_CANDIDATES,
 ): Promise<ReplayProjection | null> {
-  const tenant = TENANT;
+  const tenant = await resolveTenantId();
   const cacheKey = `${tenant}:${featureTag ?? ""}`;
   const cached = _replayCache.get(cacheKey);
   if (cached && Date.now() - cached.at < REPLAY_CACHE_TTL_MS) {
@@ -3062,7 +3065,7 @@ export interface ReplayEstimateRequest {
 export async function queryReplayEstimate(
   req: ReplayEstimateRequest,
 ): Promise<ReplayProjection | null> {
-  const tenant = TENANT;
+  const tenant = await resolveTenantId();
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/replay/estimate`, {
       method: "POST",
@@ -3134,7 +3137,7 @@ export async function queryEvalCandidates(
   featureTag?: string,
   candidates: Array<{ provider: string; model: string }> = DEFAULT_CANDIDATES,
 ): Promise<EvalProjection | null> {
-  const tenant = TENANT;
+  const tenant = await resolveTenantId();
   const cacheKey = `${tenant}:${featureTag ?? ""}`;
   const cached = _evalCache.get(cacheKey);
   if (cached && Date.now() - cached.at < EVAL_CACHE_TTL_MS) {

--- a/web/lib/costConnectors.ts
+++ b/web/lib/costConnectors.ts
@@ -8,32 +8,16 @@ import { resolveTenantId } from "./getTenant";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
-/** Connector ids the config endpoints understand. Matches config_admin.ALL_CONNECTORS. */
-export const CONFIGURABLE = [
-  "aws_cost_explorer",
-  "gcp_billing",
-  "vercel",
-  "cloudflare",
-  "aws_egress",
-  "vercel_egress",
-] as const;
-export type ConfigurableConnector = (typeof CONFIGURABLE)[number];
-
-export function isConfigurable(id: string): id is ConfigurableConnector {
-  return (CONFIGURABLE as readonly string[]).includes(id);
-}
-
-export interface CostConnectorConfig {
-  connector: string;
-  configured: boolean;
-  credentialsRef: string | null;
-  /** Whether the stored ref matches a known secret-manager shape. Advisory, drives a hint only. */
-  isReference: boolean;
-  details: Record<string, unknown>;
-  lastRunAt: string | null;
-  lastStatus: string | null;
-  connectedAt: string | null;
-}
+// Client-safe constants, types and pure helpers moved to costConnectorsShared.ts (CTO-259) so the
+// client table can import them without reaching this server-only module. Re-exported so existing
+// server call sites keep importing from "@/lib/costConnectors".
+export {
+  CONFIGURABLE,
+  type ConfigurableConnector,
+  isConfigurable,
+  type CostConnectorConfig,
+} from "./costConnectorsShared";
+import type { ConfigurableConnector, CostConnectorConfig } from "./costConnectorsShared";
 
 interface ConfigWire {
   connector: string;

--- a/web/lib/costConnectors.ts
+++ b/web/lib/costConnectors.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Cloud cost-connector configuration (CTO-176).
 //
 // Mirrors lib/stripeConnector.ts: the dashboard never talks to Postgres directly, it goes through
 // the gateway's /v1/tenant/cost-connectors endpoints. Every credential field here is a secret
 // manager REFERENCE, never a raw key, which is all the underlying columns are allowed to hold.
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 /** Connector ids the config endpoints understand. Matches config_admin.ALL_CONNECTORS. */
@@ -50,7 +50,7 @@ interface ConfigWire {
 export async function queryCostConnectorConfigs(): Promise<CostConnectorConfig[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -83,7 +83,7 @@ export async function connectCostConnector(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify({ connector, ...fields }),
       cache: "no-store",
       signal: AbortSignal.timeout(4000),
@@ -111,7 +111,7 @@ export async function disconnectCostConnector(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors/${connector}`, {
       method: "DELETE",
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(4000),
     });

--- a/web/lib/costConnectorsShared.ts
+++ b/web/lib/costConnectorsShared.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Client-safe cost-connector shapes (CTO-176; boundary split CTO-259).
+//
+// The transport half (`costConnectors.ts`) resolves the tenant via the server-only `getTenant`, so a
+// Client Component cannot import from it without dragging the server graph in. These constants,
+// types and pure helpers carry no such dependency, so the client table imports them from here while
+// `costConnectors.ts` re-exports them for server callers.
+
+/** Connector ids the config endpoints understand. Matches config_admin.ALL_CONNECTORS. */
+export const CONFIGURABLE = [
+  "aws_cost_explorer",
+  "gcp_billing",
+  "vercel",
+  "cloudflare",
+  "aws_egress",
+  "vercel_egress",
+] as const;
+export type ConfigurableConnector = (typeof CONFIGURABLE)[number];
+
+export function isConfigurable(id: string): id is ConfigurableConnector {
+  return (CONFIGURABLE as readonly string[]).includes(id);
+}
+
+export interface CostConnectorConfig {
+  connector: string;
+  configured: boolean;
+  credentialsRef: string | null;
+  /** Whether the stored ref matches a known secret-manager shape. Advisory, drives a hint only. */
+  isReference: boolean;
+  details: Record<string, unknown>;
+  lastRunAt: string | null;
+  lastStatus: string | null;
+  connectedAt: string | null;
+}

--- a/web/lib/getTenant.test.ts
+++ b/web/lib/getTenant.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// getTenant dev escape hatch + header helpers (Initiative 1, §7/§10). The vitest env sets
+// TALLY_DEV_TENANT (see vitest.config.ts), so these exercise the short-circuit that lets the app run
+// with no Clerk account: getTenant never imports Clerk and resolves to the pinned tenant.
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  canManage,
+  controlPlaneHeaders,
+  devTenant,
+  getTenant,
+  resolveTenantId,
+  serviceTokenHeader,
+} from "./getTenant";
+
+describe("getTenant dev escape hatch", () => {
+  it("short-circuits to the pinned dev tenant without consulting Clerk", async () => {
+    expect(devTenant()).toBe("local-dev");
+    const t = await getTenant();
+    expect(t).toEqual({ tenantId: "local-dev", orgId: null, orgRole: null });
+    expect(await resolveTenantId()).toBe("local-dev");
+  });
+
+  it("treats dev as admin so local key management works", async () => {
+    expect(canManage(await getTenant())).toBe(true);
+  });
+});
+
+describe("control-plane headers", () => {
+  const original = process.env.GATEWAY_SERVICE_TOKEN;
+  afterEach(() => {
+    if (original === undefined) delete process.env.GATEWAY_SERVICE_TOKEN;
+    else process.env.GATEWAY_SERVICE_TOKEN = original;
+  });
+
+  it("carries the tenant and, when set, the service token", () => {
+    process.env.GATEWAY_SERVICE_TOKEN = "svc-123";
+    expect(serviceTokenHeader()).toEqual({ authorization: "Bearer svc-123" });
+    expect(controlPlaneHeaders("t-uuid", { "content-type": "application/json" })).toEqual({
+      "x-tenant-id": "t-uuid",
+      authorization: "Bearer svc-123",
+      "content-type": "application/json",
+    });
+  });
+
+  it("omits the token header when no service token is configured", () => {
+    delete process.env.GATEWAY_SERVICE_TOKEN;
+    expect(serviceTokenHeader()).toEqual({});
+    expect(controlPlaneHeaders("t-uuid")).toEqual({ "x-tenant-id": "t-uuid" });
+  });
+});

--- a/web/lib/getTenant.ts
+++ b/web/lib/getTenant.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Resolve the active Clerk organization to its ai-tally tenant UUID (Initiative 1, §7/§10).
+//
+// This is the single seam between Clerk identity and ai-tally's tenant scoping. Every server read
+// and every control-plane write asks it "which tenant am I acting for" instead of reading a
+// module-level `TALLY_TENANT_ID ?? "local-dev"` constant, so `local-dev` no longer lives on the
+// product path.
+//
+// TWO MODES.
+//
+//  * Product path. Read `{ orgId, orgRole }` from Clerk `auth()`, resolve the org to a tenant UUID
+//    via the gateway's service-token-authed `GET /v1/tenant/by-clerk-org/{orgId}` (cached per org
+//    with a short TTL so it is not a per-request round-trip), and return the UUID. When there is no
+//    active org we THROW rather than fall back: the product has no personal workspace, and a silent
+//    `local-dev` would leak one tenant's data onto another's screen.
+//
+//  * Dev escape hatch (§10). When `TALLY_DEV_TENANT` is set, `getTenant()` short-circuits and Clerk
+//    is never consulted, so `make up` and CI run with no Clerk account and no Clerk keys. This is
+//    the ONLY place a pinned tenant (including the name `local-dev`) survives, and it is opt-in.
+//
+// Server-only. Imported by Route Handlers and server components; Clerk is loaded lazily so this
+// module (and the dev path) never pulls Clerk into a context that has no keys, including the vitest
+// suite, which sets `TALLY_DEV_TENANT` so the short-circuit is taken.
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+/** Short TTL so switching orgs re-scopes within a minute without a per-request gateway round-trip. */
+const CACHE_TTL_MS = 60_000;
+
+export interface ResolvedTenant {
+  /** The canonical `tenants.id` UUID that scopes every read and write. */
+  tenantId: string;
+  /** The active Clerk org id, or null on the dev escape hatch. */
+  orgId: string | null;
+  /** The caller's Clerk role in the active org (`org:admin` / `org:member`), or null in dev. */
+  orgRole: string | null;
+}
+
+/** No active organization on the Clerk session. Callers redirect to select-or-create-org (§7). */
+export class NoActiveOrgError extends Error {
+  constructor() {
+    super("no active organization");
+    this.name = "NoActiveOrgError";
+  }
+}
+
+/**
+ * The pinned dev tenant, or null when the escape hatch is off.
+ *
+ * A UUID or the name `local-dev`. When set, the product skips Clerk entirely. When unset, the
+ * product path refuses to serve tenant data without a resolved org, by design.
+ */
+export function devTenant(): string | null {
+  const v = process.env.TALLY_DEV_TENANT;
+  return v && v.trim() ? v.trim() : null;
+}
+
+/**
+ * The control-plane service-token header (§6). The web server is the only legitimate caller of the
+ * gateway control plane and authenticates with a server-only shared secret. Empty when unset (local
+ * dev with auth off), so `make up` is unaffected. The token never reaches a client bundle.
+ */
+export function serviceTokenHeader(): Record<string, string> {
+  const token = process.env.GATEWAY_SERVICE_TOKEN;
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Headers for a control-plane call: the resolved tenant UUID plus the service token (when set).
+ * `extra` merges in per-call headers such as `content-type`.
+ */
+export function controlPlaneHeaders(
+  tenantId: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  return { "x-tenant-id": tenantId, ...serviceTokenHeader(), ...(extra ?? {}) };
+}
+
+const _orgCache = new Map<string, { tenantId: string; plan: string; at: number }>();
+
+async function resolveOrgToTenant(orgId: string): Promise<{ tenantId: string; plan: string }> {
+  const cached = _orgCache.get(orgId);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return { tenantId: cached.tenantId, plan: cached.plan };
+  }
+  const res = await fetch(
+    `${GATEWAY_URL}/v1/tenant/by-clerk-org/${encodeURIComponent(orgId)}`,
+    { headers: serviceTokenHeader(), cache: "no-store", signal: AbortSignal.timeout(2000) },
+  );
+  if (!res.ok) {
+    throw new Error(`by-clerk-org resolve failed: HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as { tenant_id: string; plan: string };
+  const resolved = { tenantId: body.tenant_id, plan: body.plan };
+  _orgCache.set(orgId, { ...resolved, at: Date.now() });
+  return resolved;
+}
+
+/**
+ * Resolve the caller's active tenant. See the module docstring for the two modes.
+ *
+ * Throws {@link NoActiveOrgError} on the product path when there is no active org, and never falls
+ * back to `local-dev` unless the dev escape hatch is set.
+ */
+export async function getTenant(): Promise<ResolvedTenant> {
+  const dev = devTenant();
+  if (dev) {
+    return { tenantId: dev, orgId: null, orgRole: null };
+  }
+  const { auth } = await import("@clerk/nextjs/server");
+  const { orgId, orgRole } = await auth();
+  if (!orgId) {
+    throw new NoActiveOrgError();
+  }
+  const { tenantId } = await resolveOrgToTenant(orgId);
+  return { tenantId, orgId, orgRole: orgRole ?? null };
+}
+
+/** Convenience: just the tenant UUID. The common case for a read or a control-plane call. */
+export async function resolveTenantId(): Promise<string> {
+  return (await getTenant()).tenantId;
+}

--- a/web/lib/getTenant.ts
+++ b/web/lib/getTenant.ts
@@ -51,8 +51,14 @@ export class NoActiveOrgError extends Error {
 /**
  * The pinned dev tenant, or null when the escape hatch is off.
  *
- * A UUID or the name `local-dev`. When set, the product skips Clerk entirely. When unset, the
- * product path refuses to serve tenant data without a resolved org, by design.
+ * When set, the product skips Clerk entirely. When unset, the product path refuses to serve tenant
+ * data without a resolved org, by design.
+ *
+ * Use the tenant UUID, not the name `local-dev`: this value is bound directly into the ClickHouse
+ * read filter (TenantId = ...), and the demo backfill tags spans with the tenant UUID, so a bare
+ * name matches no rows and renders an empty dashboard. `make seed` prints the UUID to use. A name
+ * still resolves for gateway control-plane calls (the gateway folds name onto UUID), but reads need
+ * the UUID.
  */
 export function devTenant(): string | null {
   const v = process.env.TALLY_DEV_TENANT;

--- a/web/lib/getTenant.ts
+++ b/web/lib/getTenant.ts
@@ -120,3 +120,29 @@ export async function getTenant(): Promise<ResolvedTenant> {
 export async function resolveTenantId(): Promise<string> {
   return (await getTenant()).tenantId;
 }
+
+/** Clerk's admin role in an org. Key and member writes require it (§9). */
+export const ORG_ADMIN_ROLE = "org:admin";
+
+/**
+ * Whether a resolved tenant may perform admin-only control-plane writes (mint/rotate/revoke keys,
+ * manage members). On the dev escape hatch there is no Clerk role, so local dev is treated as admin;
+ * on the product path only ``org:admin`` qualifies (§9). This is the single web-side policy point
+ * the gateway trusts (§6): the gateway sees only the service token and the resolved tenant.
+ */
+export function canManage(tenant: ResolvedTenant): boolean {
+  if (devTenant() !== null) {
+    return true;
+  }
+  return tenant.orgRole === ORG_ADMIN_ROLE;
+}
+
+/** The active Clerk user id (for key `created_by` audit), or null on the dev escape hatch. */
+export async function currentUserId(): Promise<string | null> {
+  if (devTenant() !== null) {
+    return null;
+  }
+  const { auth } = await import("@clerk/nextjs/server");
+  const { userId } = await auth();
+  return userId ?? null;
+}

--- a/web/lib/getTenant.ts
+++ b/web/lib/getTenant.ts
@@ -21,20 +21,24 @@
 // Server-only. Imported by Route Handlers and server components; Clerk is loaded lazily so this
 // module (and the dev path) never pulls Clerk into a context that has no keys, including the vitest
 // suite, which sets `TALLY_DEV_TENANT` so the short-circuit is taken.
+//
+// The `server-only` guard makes the boundary fail loudly at the source: a client module that reaches
+// this file (directly or transitively) breaks the build here instead of surfacing as an opaque Clerk
+// `server-only` error several imports away (CTO-259). Client-safe constants, types and pure helpers
+// that a client legitimately needs live in `tenantShared.ts` and are re-exported below for server
+// callers, so a client never has to import this module to get them.
+import "server-only";
+
+import { ORG_ADMIN_ROLE, type ResolvedTenant } from "./tenantShared";
+
+// Re-exported so server callers keep a single import site (`@/lib/getTenant`). Clients import these
+// from `@/lib/tenantShared` directly, never from here.
+export { ORG_ADMIN_ROLE, type ResolvedTenant };
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 /** Short TTL so switching orgs re-scopes within a minute without a per-request gateway round-trip. */
 const CACHE_TTL_MS = 60_000;
-
-export interface ResolvedTenant {
-  /** The canonical `tenants.id` UUID that scopes every read and write. */
-  tenantId: string;
-  /** The active Clerk org id, or null on the dev escape hatch. */
-  orgId: string | null;
-  /** The caller's Clerk role in the active org (`org:admin` / `org:member`), or null in dev. */
-  orgRole: string | null;
-}
 
 /** No active organization on the Clerk session. Callers redirect to select-or-create-org (§7). */
 export class NoActiveOrgError extends Error {
@@ -120,9 +124,6 @@ export async function getTenant(): Promise<ResolvedTenant> {
 export async function resolveTenantId(): Promise<string> {
   return (await getTenant()).tenantId;
 }
-
-/** Clerk's admin role in an org. Key and member writes require it (§9). */
-export const ORG_ADMIN_ROLE = "org:admin";
 
 /**
  * Whether a resolved tenant may perform admin-only control-plane writes (mint/rotate/revoke keys,

--- a/web/lib/revenueSources.ts
+++ b/web/lib/revenueSources.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Which business events count as revenue, per tenant (CTO-194).
 //
 // The attribution revenue sum used to be gated on a hardcoded `business_events.Source = 'stripe'`.
@@ -87,7 +88,6 @@ export function revenueSourceFilter(
 }
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 /**
  * Fetch the tenant's revenue policy. Never throws and never returns null: a tenant with no row or
@@ -97,7 +97,7 @@ const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 export async function queryRevenuePolicy(): Promise<RevenuePolicy> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-sources/config`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/lib/revenueUpload.ts
+++ b/web/lib/revenueUpload.ts
@@ -17,168 +17,23 @@ import { resolveTenantId } from "./getTenant";
 //
 // The dashboard never touches Postgres: reads and writes go through the gateway's
 // /v1/tenant/revenue-uploads endpoints (same rule as lib/costConnectors.ts).
+//
+// Client-safe types, constants and the pure freshness/format helpers live in revenueUploadShared.ts
+// (CTO-259) so the client `RevenueUpload` card can import them without reaching this server-only
+// module. They are re-exported below so existing server call sites keep importing from
+// "@/lib/revenueUpload".
 
-import { asOfLabel, isStale, relativeAge } from "./dataState";
+import {
+  type RevenueSnapshot,
+  type SnapshotWire,
+  type UploadResult,
+  type UploadRowError,
+  fromWire,
+} from "./revenueUploadShared";
+
+export * from "./revenueUploadShared";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-
-/** business_events.Source stamped on uploaded rows. Matches gateway.revenue_upload.UPLOAD_SOURCE. */
-export const UPLOAD_SOURCE = "csv_upload";
-
-/**
- * Freshness window for an uploaded snapshot: 35 days.
- *
- * Deliberately not the 2h telemetry window from spec 13.8. Revenue is refreshed when finance
- * closes a month, so a monthly cadence is healthy and judging it against two hours would leave
- * every well-run tenant permanently amber — a badge that is always on is a badge nobody reads. A
- * month plus a few days of grace flags exactly the case that matters: the upload nobody came back
- * to. The staleness logic itself is shared with every other surface (see lib/dataState.ts).
- */
-export const SNAPSHOT_STALE_AFTER_MS = 35 * 24 * 60 * 60 * 1000;
-
-/**
- * How far behind the current month the newest uploaded period may sit before it counts as stale.
- *
- * The month in progress is not closable yet and the one just ended may not be closed either, so
- * two months behind is the first genuinely missing period rather than a normal accounting lag.
- */
-export const MAX_MONTHS_BEHIND = 2;
-
-export interface RevenueSnapshot {
-  /** Calendar month the snapshot covers, `YYYY-MM`. */
-  period: string;
-  source: string;
-  accountCount: number;
-  totalAmountMicro: number;
-  currency: string;
-  filename: string | null;
-  /** When this period was last uploaded. The "as of" the badge is derived from. */
-  uploadedAt: string;
-  uploadedBy: string | null;
-}
-
-interface SnapshotWire {
-  period: string;
-  source: string;
-  account_count: number;
-  total_amount_micro: number;
-  currency: string;
-  filename: string | null;
-  uploaded_at: string;
-  uploaded_by: string | null;
-}
-
-function fromWire(s: SnapshotWire): RevenueSnapshot {
-  return {
-    period: s.period,
-    source: s.source,
-    accountCount: s.account_count,
-    totalAmountMicro: s.total_amount_micro,
-    currency: s.currency,
-    filename: s.filename,
-    uploadedAt: s.uploaded_at,
-    uploadedBy: s.uploaded_by,
-  };
-}
-
-/** Months from `period` (YYYY-MM) to the month containing `now`. Null if unparseable. */
-export function monthsBehind(period: string, now: number = Date.now()): number | null {
-  const m = /^(\d{4})-(\d{2})$/.exec(period);
-  if (!m) return null;
-  const year = Number(m[1]);
-  const month = Number(m[2]);
-  if (month < 1 || month > 12) return null;
-  const d = new Date(now);
-  return (d.getUTCFullYear() - year) * 12 + (d.getUTCMonth() + 1 - month);
-}
-
-/** The freshness verdict for a tenant's uploaded revenue, and the reason behind it. */
-export interface UploadFreshness {
-  /** Newest upload timestamp across all periods, or null when nothing has been uploaded. */
-  asOf: string | null;
-  /** Compact relative age of `asOf`, or null. */
-  age: string | null;
-  /** Newest period covered, or null. */
-  latestPeriod: string | null;
-  stale: boolean;
-  /**
-   * Why the verdict is what it is, in plain words. Null when nothing has been uploaded — an
-   * absent snapshot is an invitation to upload one, not a warning about a number we are showing.
-   */
-  reason: string | null;
-}
-
-/**
- * Derive the "as of" + staleness verdict from the manifest rows.
- *
- * Two independent ways an upload goes stale, because they catch different mistakes:
- *
- *  1. **Nobody came back.** The newest upload is older than the freshness window. Catches the
- *     tenant who uploaded once during onboarding and never again.
- *  2. **A period is missing.** The newest period covered is more than `MAX_MONTHS_BEHIND` behind
- *     the current month. Catches the tenant who re-uploads January's file every month: the upload
- *     timestamp looks fresh while the revenue it describes is a year old.
- */
-export function deriveUploadFreshness(
-  snapshots: readonly RevenueSnapshot[],
-  now: number = Date.now(),
-): UploadFreshness {
-  if (snapshots.length === 0) {
-    return { asOf: null, age: null, latestPeriod: null, stale: false, reason: null };
-  }
-  const newestUpload = snapshots.reduce((a, b) => (a.uploadedAt >= b.uploadedAt ? a : b));
-  const latestPeriod = snapshots.reduce((a, b) => (a.period >= b.period ? a : b)).period;
-  const asOf = asOfLabel(newestUpload.uploadedAt);
-  if (asOf === null) {
-    // An unparseable or sentinel timestamp is not evidence of freshness. Say so rather than
-    // letting the absence of a date read as "current".
-    return {
-      asOf: null,
-      age: null,
-      latestPeriod,
-      stale: true,
-      reason: "The upload carries no readable timestamp, so its age cannot be checked",
-    };
-  }
-  const age = relativeAge(asOf, now);
-  const behind = monthsBehind(latestPeriod, now);
-  const tooOld = isStale(asOf, now, SNAPSHOT_STALE_AFTER_MS);
-  const missingPeriod = behind !== null && behind >= MAX_MONTHS_BEHIND;
-  if (tooOld) {
-    return {
-      asOf,
-      age,
-      latestPeriod,
-      stale: true,
-      reason: `Last uploaded ${age}. Revenue changes monthly, so margin is being computed from a snapshot that has not been refreshed.`,
-    };
-  }
-  if (missingPeriod) {
-    return {
-      asOf,
-      age,
-      latestPeriod,
-      stale: true,
-      reason: `The newest period covered is ${latestPeriod}, ${behind} months behind. Upload the missing months or margin will keep reading an old one.`,
-    };
-  }
-  return {
-    asOf,
-    age,
-    latestPeriod,
-    stale: false,
-    reason: `Covering periods through ${latestPeriod}.`,
-  };
-}
-
-/** Micro-units of a currency to a display string. Never rounds a real figure away to zero. */
-export function formatSnapshotAmount(micro: number, currency: string): string {
-  const units = micro / 1_000_000;
-  return `${units.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })} ${currency}`;
-}
 
 /** Uploaded snapshots for the tenant. `null` means the gateway is unreachable, NOT "none". */
 export async function queryRevenueUploads(): Promise<RevenueSnapshot[] | null> {
@@ -195,16 +50,6 @@ export async function queryRevenueUploads(): Promise<RevenueSnapshot[] | null> {
     return null;
   }
 }
-
-/** One rejected CSV line. The line number is the point: nothing is ever silently skipped. */
-export interface UploadRowError {
-  line: number;
-  message: string;
-}
-
-export type UploadResult =
-  | { ok: true; acceptedRows: number; snapshots: RevenueSnapshot[]; note: string | null }
-  | { ok: false; error: string; rowErrors: UploadRowError[] };
 
 /**
  * Send a CSV to the gateway. All-or-nothing: on 422 nothing was written and `rowErrors` names

--- a/web/lib/revenueUpload.ts
+++ b/web/lib/revenueUpload.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Uploaded revenue snapshots (CTO-198, plan item E5).
 //
 // For tenants whose revenue lives in Chargebee, Recurly, Zuora, NetSuite or a spreadsheet rather
@@ -19,7 +20,6 @@
 
 import { asOfLabel, isStale, relativeAge } from "./dataState";
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 /** business_events.Source stamped on uploaded rows. Matches gateway.revenue_upload.UPLOAD_SOURCE. */
@@ -184,7 +184,7 @@ export function formatSnapshotAmount(micro: number, currency: string): string {
 export async function queryRevenueUploads(): Promise<RevenueSnapshot[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-uploads`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -217,7 +217,7 @@ export async function uploadRevenueCsv(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-uploads`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": TENANT },
+      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
       body: JSON.stringify({
         csv,
         filename: opts.filename,
@@ -256,7 +256,7 @@ export async function deleteRevenueUpload(
       `${GATEWAY_URL}/v1/tenant/revenue-uploads/${encodeURIComponent(period)}`,
       {
         method: "DELETE",
-        headers: { "x-tenant-id": TENANT },
+        headers: { "x-tenant-id": await resolveTenantId() },
         cache: "no-store",
         signal: AbortSignal.timeout(4000),
       },

--- a/web/lib/revenueUploadShared.ts
+++ b/web/lib/revenueUploadShared.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Client-safe uploaded-revenue shapes and freshness logic (CTO-198, E5; boundary split CTO-259).
+//
+// The transport half (`revenueUpload.ts`) resolves the tenant via the server-only `getTenant`, so a
+// Client Component cannot import from it without dragging the server graph in. The types, constants
+// and the pure freshness/format helpers here carry no such dependency (only lib/dataState, which is
+// itself client-safe), so `RevenueUpload` imports them from here while `revenueUpload.ts` re-exports
+// them for server callers.
+
+import { asOfLabel, isStale, relativeAge } from "./dataState";
+
+/** business_events.Source stamped on uploaded rows. Matches gateway.revenue_upload.UPLOAD_SOURCE. */
+export const UPLOAD_SOURCE = "csv_upload";
+
+/**
+ * Freshness window for an uploaded snapshot: 35 days.
+ *
+ * Deliberately not the 2h telemetry window from spec 13.8. Revenue is refreshed when finance
+ * closes a month, so a monthly cadence is healthy and judging it against two hours would leave
+ * every well-run tenant permanently amber, and a badge that is always on is a badge nobody reads. A
+ * month plus a few days of grace flags exactly the case that matters: the upload nobody came back
+ * to. The staleness logic itself is shared with every other surface (see lib/dataState.ts).
+ */
+export const SNAPSHOT_STALE_AFTER_MS = 35 * 24 * 60 * 60 * 1000;
+
+/**
+ * How far behind the current month the newest uploaded period may sit before it counts as stale.
+ *
+ * The month in progress is not closable yet and the one just ended may not be closed either, so
+ * two months behind is the first genuinely missing period rather than a normal accounting lag.
+ */
+export const MAX_MONTHS_BEHIND = 2;
+
+export interface RevenueSnapshot {
+  /** Calendar month the snapshot covers, `YYYY-MM`. */
+  period: string;
+  source: string;
+  accountCount: number;
+  totalAmountMicro: number;
+  currency: string;
+  filename: string | null;
+  /** When this period was last uploaded. The "as of" the badge is derived from. */
+  uploadedAt: string;
+  uploadedBy: string | null;
+}
+
+export interface SnapshotWire {
+  period: string;
+  source: string;
+  account_count: number;
+  total_amount_micro: number;
+  currency: string;
+  filename: string | null;
+  uploaded_at: string;
+  uploaded_by: string | null;
+}
+
+export function fromWire(s: SnapshotWire): RevenueSnapshot {
+  return {
+    period: s.period,
+    source: s.source,
+    accountCount: s.account_count,
+    totalAmountMicro: s.total_amount_micro,
+    currency: s.currency,
+    filename: s.filename,
+    uploadedAt: s.uploaded_at,
+    uploadedBy: s.uploaded_by,
+  };
+}
+
+/** Months from `period` (YYYY-MM) to the month containing `now`. Null if unparseable. */
+export function monthsBehind(period: string, now: number = Date.now()): number | null {
+  const m = /^(\d{4})-(\d{2})$/.exec(period);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  if (month < 1 || month > 12) return null;
+  const d = new Date(now);
+  return (d.getUTCFullYear() - year) * 12 + (d.getUTCMonth() + 1 - month);
+}
+
+/** The freshness verdict for a tenant's uploaded revenue, and the reason behind it. */
+export interface UploadFreshness {
+  /** Newest upload timestamp across all periods, or null when nothing has been uploaded. */
+  asOf: string | null;
+  /** Compact relative age of `asOf`, or null. */
+  age: string | null;
+  /** Newest period covered, or null. */
+  latestPeriod: string | null;
+  stale: boolean;
+  /**
+   * Why the verdict is what it is, in plain words. Null when nothing has been uploaded, because an
+   * absent snapshot is an invitation to upload one, not a warning about a number we are showing.
+   */
+  reason: string | null;
+}
+
+/**
+ * Derive the "as of" + staleness verdict from the manifest rows.
+ *
+ * Two independent ways an upload goes stale, because they catch different mistakes:
+ *
+ *  1. **Nobody came back.** The newest upload is older than the freshness window. Catches the
+ *     tenant who uploaded once during onboarding and never again.
+ *  2. **A period is missing.** The newest period covered is more than `MAX_MONTHS_BEHIND` behind
+ *     the current month. Catches the tenant who re-uploads January's file every month: the upload
+ *     timestamp looks fresh while the revenue it describes is a year old.
+ */
+export function deriveUploadFreshness(
+  snapshots: readonly RevenueSnapshot[],
+  now: number = Date.now(),
+): UploadFreshness {
+  if (snapshots.length === 0) {
+    return { asOf: null, age: null, latestPeriod: null, stale: false, reason: null };
+  }
+  const newestUpload = snapshots.reduce((a, b) => (a.uploadedAt >= b.uploadedAt ? a : b));
+  const latestPeriod = snapshots.reduce((a, b) => (a.period >= b.period ? a : b)).period;
+  const asOf = asOfLabel(newestUpload.uploadedAt);
+  if (asOf === null) {
+    // An unparseable or sentinel timestamp is not evidence of freshness. Say so rather than
+    // letting the absence of a date read as "current".
+    return {
+      asOf: null,
+      age: null,
+      latestPeriod,
+      stale: true,
+      reason: "The upload carries no readable timestamp, so its age cannot be checked",
+    };
+  }
+  const age = relativeAge(asOf, now);
+  const behind = monthsBehind(latestPeriod, now);
+  const tooOld = isStale(asOf, now, SNAPSHOT_STALE_AFTER_MS);
+  const missingPeriod = behind !== null && behind >= MAX_MONTHS_BEHIND;
+  if (tooOld) {
+    return {
+      asOf,
+      age,
+      latestPeriod,
+      stale: true,
+      reason: `Last uploaded ${age}. Revenue changes monthly, so margin is being computed from a snapshot that has not been refreshed.`,
+    };
+  }
+  if (missingPeriod) {
+    return {
+      asOf,
+      age,
+      latestPeriod,
+      stale: true,
+      reason: `The newest period covered is ${latestPeriod}, ${behind} months behind. Upload the missing months or margin will keep reading an old one.`,
+    };
+  }
+  return {
+    asOf,
+    age,
+    latestPeriod,
+    stale: false,
+    reason: `Covering periods through ${latestPeriod}.`,
+  };
+}
+
+/** Micro-units of a currency to a display string. Never rounds a real figure away to zero. */
+export function formatSnapshotAmount(micro: number, currency: string): string {
+  const units = micro / 1_000_000;
+  return `${units.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} ${currency}`;
+}
+
+/** One rejected CSV line. The line number is the point: nothing is ever silently skipped. */
+export interface UploadRowError {
+  line: number;
+  message: string;
+}
+
+export type UploadResult =
+  | { ok: true; acceptedRows: number; snapshots: RevenueSnapshot[]; note: string | null }
+  | { ok: false; error: string; rowErrors: UploadRowError[] };

--- a/web/lib/stripeConnector.ts
+++ b/web/lib/stripeConnector.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Per-tenant Stripe connector config (CTO-110).
 //
 // Mirrors lib/tenant.ts: the dashboard never talks to Postgres directly — it goes through the
 // gateway's /v1/tenant/stripe + /v1/tenant/stripe/connect endpoints. Failure modes fall back
 // gracefully so a /connectors page render never breaks because the gateway is briefly down.
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 export interface StripeConfigView {
@@ -33,7 +33,7 @@ interface StripeGetResponse {
 export async function queryStripeConfig(): Promise<StripeConfigView | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/stripe`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -64,7 +64,7 @@ export async function connectStripe(
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-tenant-id": TENANT,
+        "x-tenant-id": await resolveTenantId(),
       },
       body: JSON.stringify({
         webhook_secret: webhookSecret,
@@ -87,8 +87,8 @@ export async function connectStripe(
 }
 
 /** Public URL the tenant configures in their Stripe dashboard. */
-export function webhookUrl(): string {
-  const tenant = TENANT;
+export async function webhookUrl(): Promise<string> {
+  const tenant = await resolveTenantId();
   // The gateway is reachable at the same URL we use server-side; the tenant runs the curl
   // documented in RUNNING.md → `stripe listen --forward-to <this URL>` for local testing.
   return `${GATEWAY_URL}/v1/stripe/webhook?tenant=${encodeURIComponent(tenant)}`;

--- a/web/lib/tenant.ts
+++ b/web/lib/tenant.ts
@@ -11,7 +11,9 @@ import { resolveTenantId } from "./getTenant";
 // config — we never read Postgres directly from the dashboard. Failures fall back to ["llm"] so
 // demos and CI (where the gateway may be unreachable) keep working and the banner stays quiet.
 //
-// Tenant scoping mirrors web/lib/clickhouse.ts: TALLY_TENANT_ID || "local-dev".
+// Tenant scoping mirrors web/lib/clickhouse.ts: the active tenant is resolved per call via
+// resolveTenantId() (the Clerk org, or the TALLY_DEV_TENANT escape hatch), never a module-level
+// constant.
 import { LAYERS, type Layer } from "./cost";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";

--- a/web/lib/tenant.ts
+++ b/web/lib/tenant.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Per-tenant cost-layer connector declarations (CTO-107).
 //
 // The "Partial data" banner used to fire whenever any cost layer reported zero, which made it
@@ -13,7 +14,6 @@
 // Tenant scoping mirrors web/lib/clickhouse.ts: TALLY_TENANT_ID || "local-dev".
 import { LAYERS, type Layer } from "./cost";
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 interface TenantConnectorsResponse {
@@ -48,7 +48,7 @@ function asLayer(s: string): Layer | null {
 export async function queryEnabledConnectors(): Promise<Layer[]> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/connectors`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       // Short timeout: a slow gateway shouldn't block every page render.
       signal: AbortSignal.timeout(2000),
@@ -93,7 +93,7 @@ export async function setConnectorEnabled(
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-tenant-id": TENANT,
+        "x-tenant-id": await resolveTenantId(),
       },
       body: JSON.stringify({ layer, enabled }),
       cache: "no-store",

--- a/web/lib/tenantBudgetsClient.ts
+++ b/web/lib/tenantBudgetsClient.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Read this tenant's budgets from the gateway (CTO-209, F5; endpoint from CTO-205, F1).
 //
 // Server-only, imported by Route Handlers. The dashboard never touches Postgres directly, same rule
@@ -14,7 +15,6 @@
 
 import type { TenantBudget } from "./budgetVsActual";
 
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
 /** A slow control plane must not hold a page render open. Matches `lib/tenant.ts`. */
@@ -35,7 +35,7 @@ export type TenantBudgetsResult =
 export async function fetchTenantBudgets(): Promise<TenantBudgetsResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });

--- a/web/lib/tenantShared.ts
+++ b/web/lib/tenantShared.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Client-safe tenant constants and types (Initiative 1, §9; CTO-259).
+//
+// `getTenant.ts` is server-only: it imports `server-only` and lazily loads Clerk, so any client
+// module that reaches it breaks the build. The symbols here carry no server dependency (no Clerk, no
+// gateway fetch, no `server-only`) and are the pieces a Client Component may legitimately need. They
+// live in this separate module so a client can import them without dragging the server graph in;
+// `getTenant.ts` re-exports them so server callers keep a single import site.
+
+/**
+ * The active Clerk organization resolved to its ai-tally tenant, as returned by the server-only
+ * `getTenant()`. Declared here (not in `getTenant.ts`) so a Client Component that only needs the
+ * shape can type against it without importing the server module.
+ */
+export interface ResolvedTenant {
+  /** The canonical `tenants.id` UUID that scopes every read and write. */
+  tenantId: string;
+  /** The active Clerk org id, or null on the dev escape hatch. */
+  orgId: string | null;
+  /** The caller's Clerk role in the active org (`org:admin` / `org:member`), or null in dev. */
+  orgRole: string | null;
+}
+
+/** Clerk's admin role in an org. Key and member writes require it (§9). */
+export const ORG_ADMIN_ROLE = "org:admin";

--- a/web/lib/unitEconomicsConfig.ts
+++ b/web/lib/unitEconomicsConfig.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolveTenantId } from "./getTenant";
 // Per-tenant LTV/CAC band threshold overrides, read via the gateway (CTO-126).
 //
 // The band cutoffs used to be hardcoded B2B-SaaS defaults inline in unitEconomics.ts. They are now
@@ -10,7 +11,6 @@
 import type { UnitEconomicsThresholdOverrides } from "./unitEconomics";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
-const TENANT = process.env.TALLY_TENANT_ID ?? "local-dev";
 
 /** Wire shape of the gateway's config object (snake_case, matching the Postgres columns). */
 export interface UnitEconomicsConfigApi {
@@ -43,7 +43,7 @@ export function overridesFromApi(
 export async function queryUnitEconomicsConfig(): Promise<UnitEconomicsThresholdOverrides | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/unit-economics/config`, {
-      headers: { "x-tenant-id": TENANT },
+      headers: { "x-tenant-id": await resolveTenantId() },
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Clerk request middleware (Initiative 1, §7). Protects every app route, leaves the sign-in,
+// sign-up, and Clerk provisioning webhook public, and pushes a signed-in user with no active org to
+// the select-or-create-org screen (the product has no personal workspace).
+//
+// Dev escape hatch (§10): when TALLY_DEV_TENANT is set, this is a NO-OP so `make up` and CI reach
+// every route with no Clerk session and no Clerk keys. The product path (flag unset) requires a
+// session, exactly as intended.
+
+import {
+  clerkMiddleware,
+  createRouteMatcher,
+} from "@clerk/nextjs/server";
+import { NextResponse, type NextRequest } from "next/server";
+
+const DEV_TENANT = process.env.TALLY_DEV_TENANT?.trim();
+
+// Public routes carry no Clerk session: the sign-in / sign-up flows, and the provisioning webhook,
+// which is svix-authenticated inside its own route (§4), not by a Clerk session.
+const isPublicRoute = createRouteMatcher([
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/api/webhooks/clerk",
+]);
+
+// The screen where a signed-in user with no active org lands. Excluded from the org requirement so
+// the redirect below cannot loop.
+const isOrgSelectionRoute = createRouteMatcher(["/select-org(.*)"]);
+
+const clerkGuard = clerkMiddleware(async (auth, req: NextRequest) => {
+  if (isPublicRoute(req)) {
+    return;
+  }
+  const { userId, orgId } = await auth.protect();
+  // Signed in but in no organization: send them to create or pick one before any data page renders.
+  if (userId && !orgId && !isOrgSelectionRoute(req)) {
+    return NextResponse.redirect(new URL("/select-org", req.url));
+  }
+});
+
+// A no-op middleware for the dev escape hatch. Typed to match clerkMiddleware's return.
+function devPassThrough(): NextResponse {
+  return NextResponse.next();
+}
+
+export default DEV_TENANT ? devPassThrough : clerkGuard;
+
+export const config = {
+  // Run on everything except Next internals and static files, plus API routes. Standard Clerk
+  // matcher.
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,13 +9,16 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@clerk/nextjs": "^6.9.6",
         "@clickhouse/client": "^1.19.0",
         "next": "^15.5.18",
         "react": "19.0.0",
-        "react-dom": "19.0.0"
+        "react-dom": "19.0.0",
+        "svix": "^1.42.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.1.0",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
@@ -355,6 +358,108 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "2.33.6",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.6.tgz",
+      "integrity": "sha512-5foMmTHEQFt4mDv7AN0RDwUHZhGcg/JYe5hnl9SU/LFS8ZHY29Z2HDtIBmzKgjRfOJTMKj1AM81LgK2UFsGm9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.8",
+        "@clerk/types": "^4.101.26",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.61.9",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.9.tgz",
+      "integrity": "sha512-PRIodE1QVem/eV3wrjicJJiJ2pkGiZfI6t1vekE/+04cIHciXyvUezQ/468gGPl31xd7BiCNO3uKNM14TXEKZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.8",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/nextjs": {
+      "version": "6.39.6",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.6.tgz",
+      "integrity": "sha512-bfB1mt1kFdlV2khNdJPP4Zynrz6XfXjqiJogEHWpeK0ch46uWX7lNN9wrstkokDMHTmvpVkDZPAKkncdK3vZ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^2.33.6",
+        "@clerk/clerk-react": "^5.61.9",
+        "@clerk/shared": "^3.47.8",
+        "@clerk/types": "^4.101.26",
+        "server-only": "0.0.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.47.8",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.8.tgz",
+      "integrity": "sha512-cPURU1it/Eal4uXO9SOcHzw9sfE6Opi21W8EJUg+Ri80Q6JKtK8qBmyOpIyqgf09EanexhTzS4xrmYlvn2p7Iw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/shared/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.101.26",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.26.tgz",
+      "integrity": "sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.8"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@clickhouse/client": {
@@ -2321,6 +2426,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2336,7 +2447,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2395,8 +2505,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3322,7 +3431,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3384,7 +3492,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4215,9 +4322,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4264,8 +4369,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5023,6 +5127,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5302,6 +5412,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -6023,6 +6139,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6270,7 +6395,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7072,7 +7196,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7088,7 +7211,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7172,8 +7294,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -7481,6 +7602,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -7717,11 +7844,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -7944,6 +8080,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.99.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.99.1.tgz",
+      "integrity": "sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -8477,6 +8645,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,13 +12,16 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@clerk/nextjs": "^6.9.6",
     "@clickhouse/client": "^1.19.0",
     "next": "^15.5.18",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "svix": "^1.42.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.1.0",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,5 +11,10 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    // The dev escape hatch (Initiative 1, §10). Tests run with no Clerk account, so `getTenant()`
+    // short-circuits to a pinned tenant instead of consulting Clerk. This mirrors how `make up` and
+    // CI run the product with no Clerk keys, and keeps the tenant scoping in the fetch-shaped tests
+    // exactly what it was before Clerk (`local-dev`).
+    env: { TALLY_DEV_TENANT: "local-dev" },
   },
 });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -6,7 +6,15 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: { "@": resolve(__dirname, ".") },
+    alias: {
+      "@": resolve(__dirname, "."),
+      // `getTenant.ts` imports `server-only` (CTO-259), whose default export throws by design so a
+      // client bundle cannot pull in a server module. Vitest runs in Node, not the RSC/client
+      // bundler, and legitimately imports server modules under test (getTenant, route handlers), so
+      // point the marker at its empty build to make it a no-op here. This is exactly the shim Next's
+      // bundler applies via the `react-server` export condition.
+      "server-only": resolve(__dirname, "node_modules/server-only/empty.js"),
+    },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
Implements **Initiative 1: Organizations, users & access (Clerk)** in the areas this PR owns: `web/`, `infra/gateway/`, `db/postgres/`, `infra/docker-compose.yml`, `infra/Makefile`. Draft; do not merge. (The Initiative 2 gateway endpoints `hmac-key` / `edge/keys`, the SDK, and the edge proxy are out of scope and untouched.)

## What is built (spec §3–§13)

**Data model (§3).** `db/postgres/0029_orgs_and_access.sql` (all additive/nullable): `tenants.clerk_org_id` with a partial unique index `uq_tenants_clerk_org_id`, and `api_keys` display metadata `name` / `token_prefix` / `created_by` / `last_used_at`. Compose mount added alongside 0001..0028.

**Provisioning (§4).** `gateway/tenant_provisioning.py`: `POST /v1/tenant/provision`, idempotent and race-safe (`INSERT ... ON CONFLICT (clerk_org_id) WHERE clerk_org_id IS NOT NULL DO NOTHING RETURNING`), per-org HMAC key set minted through a `KeyMaterialProvider` (local dev impl) with only a reference stored in `hash_salt_kek_ref` honoring the `no_raw_secret` CHECK, and orphan-key cleanup on a lost race. A redelivery mints nothing.

**Gateway endpoints (§5).** `GET /v1/tenant/by-clerk-org/{org_id}`; keys CRUD (`GET/POST /v1/tenant/keys`, `POST /v1/tenant/keys/{id}/rotate`, `DELETE /v1/tenant/keys/{id}`) in `gateway/tenant_api_keys.py`, minting `tally_sk_live_...` returned once and hashed with the existing `auth.py::hash_key`; list returns metadata only. `resolve_tenant_uuid` extended to also match `clerk_org_id`.

**Control-plane auth gate (§6).** New `TALLY_GATEWAY_SERVICE_TOKEN` setting; `_require_service_token` gates the new endpoints, active only when `require_api_key` is on AND a token is set (constant-time compare), so local dev with auth off is unaffected.

**Dashboard (§7).** `@clerk/nextjs` + `ClerkProvider`, `clerkMiddleware()` (public: sign-in, sign-up, `/api/webhooks/clerk`), `OrganizationSwitcher` + `UserButton` in the shell, require-active-org redirect to `/select-org`, `web/app/api/webhooks/clerk/route.ts` (svix verify then forward to the gateway with the service token), `web/lib/getTenant.ts` resolving the Clerk orgId to the tenant UUID (cached per-org), and every `TALLY_TENANT_ID ?? "local-dev"` occurrence replaced with the resolved tenant (17 files). Admin-gated key-management UI (list, create-once-token modal, rotate, revoke) via `/api/keys` proxy handlers; member management via Clerk `OrganizationProfile`.

**Canonical TenantId = UUID (§8).** Makefile resolves the seeded tenant UUID and passes it to the demo backfill; `make seed` and `getTenant()` reconcile the dashboard onto the UUID.

**Dev escape hatch (§10).** `TALLY_DEV_TENANT` makes `getTenant()` short-circuit and the Clerk middleware a no-op; `ClerkProvider` is skipped and org controls are hidden. The product path refuses to fall back to `local-dev` when the flag is unset.

## Run without Clerk (dev flag)

`make up && make seed` (prints the tenant UUID), then run the web app with `TALLY_DEV_TENANT=<that uuid>` (or `local-dev`). No Clerk account, keys, or login needed. The vitest suite sets `TALLY_DEV_TENANT` so tests never require Clerk.

## CI commands run

- gateway: `uv run --extra dev pytest -q` -> **854 passed**; `uv run ruff check .` -> **All checks passed**.
- web: `tsc --noEmit` -> **clean**; `next lint` -> **clean** (only a pre-existing `useLivePoll.ts` warning); `vitest run` -> **684 passed, 1 failed** — the failure is the known `GET /api/attribution falls back to mock when ClickHouse is unreachable` case (passes in CI; fails locally because ClickHouse is up), per CLAUDE.md. No new failures.

Tests added: gateway provision idempotency/race + orphan cleanup, resolver extension, keys CRUD, service-token gate; web getTenant dev short-circuit + header helpers, and the Clerk webhook route (svix mocked).

Not built (out of scope for this PR): Initiative 2 endpoints (`hmac-key`, `edge/keys`), SDK, edge proxy. `last_used_at` is left null (best-effort off-hot-path stamping is a follow-up, honest-null until then). Existing control-plane fetches send the resolved tenant; wiring the service-token header onto every one of them beyond the new key/webhook paths is a small follow-up (CI runs auth-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
