### PR TITLE
feat: Onboarding agent recipe catalog and MCP server

### DIFF
--- a/sdk/python/onboarding_mcp/__init__.py
+++ b/sdk/python/onboarding_mcp/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ai-tally onboarding MCP server (CTO-261 section 4.2).
+
+A thin server over the recipe catalog (``sdk/python/recipes/``) and the real SDK
+surface. The developer's own coding agent (Claude Code, Cursor) connects to it and
+applies what it returns locally; source never leaves the developer's machine
+(section 9 security posture). The server holds only recipes and generated code,
+never a repo.
+
+The MCP tools (section 4.2) are exposed as plain, importable functions here so they
+are unit-testable without an MCP transport; :mod:`onboarding_mcp.server` binds them
+to the MCP protocol.
+"""
+
+from onboarding_mcp.catalog import Recipe, RecipeCatalog, get_catalog
+from onboarding_mcp.detect import detect_stack
+from onboarding_mcp.generate import (
+    coverage_report,
+    explain_layer,
+    generate_middleware,
+    get_recipe,
+    instrument_call_site,
+)
+
+__all__ = [
+    "Recipe",
+    "RecipeCatalog",
+    "get_catalog",
+    "detect_stack",
+    "get_recipe",
+    "generate_middleware",
+    "instrument_call_site",
+    "explain_layer",
+    "coverage_report",
+]

--- a/sdk/python/onboarding_mcp/catalog.py
+++ b/sdk/python/onboarding_mcp/catalog.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Recipe catalog loader (CTO-261 section 5.1).
+
+Reads ``sdk/python/recipes/`` (data, not code): one YAML file per recipe plus
+``index.yaml`` and ``schema.json``. Kept beside the SDK so a recipe and the method
+it targets move together (section 5.1). This module is the single in-process view of
+the catalog that every MCP tool reads.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# recipes/ sits next to onboarding_mcp/ under sdk/python/.
+RECIPES_DIR = Path(__file__).resolve().parent.parent / "recipes"
+
+
+@dataclass(frozen=True)
+class Recipe:
+    """One parsed recipe. ``raw`` is the full document; the rest are convenience views."""
+
+    id: str
+    kind: str
+    title: str
+    detect: dict[str, Any]
+    sdk_surface: dict[str, Any]
+    edit: dict[str, Any]
+    verify: dict[str, Any]
+    notes: str
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_doc(cls, doc: dict[str, Any]) -> Recipe:
+        return cls(
+            id=doc["id"],
+            kind=doc["kind"],
+            title=doc["title"],
+            detect=doc.get("detect", {}),
+            sdk_surface=doc.get("sdk_surface", {}),
+            edit=doc.get("edit", {}),
+            verify=doc.get("verify", {}),
+            notes=doc.get("notes", ""),
+            raw=doc,
+        )
+
+    @property
+    def imports(self) -> list[str]:
+        return list(self.detect.get("imports", []))
+
+    @property
+    def call_patterns(self) -> list[str]:
+        return list(self.detect.get("call_patterns", []))
+
+    @property
+    def layer(self) -> str:
+        return str(self.sdk_surface.get("layer", ""))
+
+
+class RecipeCatalog:
+    """In-memory catalog: id -> Recipe, plus lookups the MCP tools need."""
+
+    def __init__(self, recipes: list[Recipe], schema: dict[str, Any]):
+        self._by_id = {r.id: r for r in recipes}
+        self.schema = schema
+
+    @property
+    def recipes(self) -> list[Recipe]:
+        return list(self._by_id.values())
+
+    def get(self, recipe_id: str) -> Recipe | None:
+        return self._by_id.get(recipe_id)
+
+    def by_kind(self, kind: str) -> list[Recipe]:
+        return [r for r in self._by_id.values() if r.kind == kind]
+
+    def resolve_alias(self, name: str) -> Recipe | None:
+        """Resolve a recipe by id, or by a framework / provider name in its id or detect imports.
+
+        Lets ``get_recipe`` take a friendly name ("pinecone", "fastapi") as section 4.2 allows,
+        not only the dotted id.
+        """
+        exact = self.get(name)
+        if exact is not None:
+            return exact
+        needle = name.lower()
+        for recipe in self._by_id.values():
+            if needle in recipe.id.lower():
+                return recipe
+            if any(needle == imp.lower() for imp in recipe.imports):
+                return recipe
+            if needle == str(recipe.detect.get("web_framework", "")).lower():
+                return recipe
+        return None
+
+
+def _load_index(recipes_dir: Path) -> list[str]:
+    index = yaml.safe_load((recipes_dir / "index.yaml").read_text())
+    return [entry["file"] for entry in index["recipes"]]
+
+
+@lru_cache(maxsize=1)
+def get_catalog() -> RecipeCatalog:
+    """Load and cache the catalog from ``RECIPES_DIR``."""
+    return load_catalog(RECIPES_DIR)
+
+
+def load_catalog(recipes_dir: Path) -> RecipeCatalog:
+    """Load a catalog from an explicit directory (used by tests and by ``get_catalog``)."""
+    schema = json.loads((recipes_dir / "schema.json").read_text())
+    recipes: list[Recipe] = []
+    for filename in _load_index(recipes_dir):
+        doc = yaml.safe_load((recipes_dir / filename).read_text())
+        recipes.append(Recipe.from_doc(doc))
+    return RecipeCatalog(recipes, schema)

--- a/sdk/python/onboarding_mcp/detect.py
+++ b/sdk/python/onboarding_mcp/detect.py
@@ -3,7 +3,7 @@
 
 Reads dependency-manifest contents (and optional import-site excerpts the developer's
 agent chooses to pass, section 4.2) and reports the detected providers, frameworks,
-vector DBs, and web framework, plus the recipe ids that match. Detection is grounded
+vector DBs, and web frameworks, plus the recipe ids that match. Detection is grounded
 on the catalog's ``detect`` blocks: a component with no recipe is reported as a gap,
 never filled by guessing (section 2 decision 2).
 """
@@ -71,12 +71,29 @@ def detect_stack(
     # A gap is a detected component category that surfaced no matching recipe.
     gaps: list[str] = []
     matched_kinds = {cat.get(rid).kind for rid in matched}
-    if vector and not any(cat.get(rid).kind == "vector" for rid in matched):
+    if vector and "vector" not in matched_kinds:
         gaps.append("vector: detected a vector DB but no recipe matched")
-    if web and "middleware" not in matched_kinds:
-        gaps.append("account: detected a web framework but no middleware recipe matched")
+
+    # Check each detected web framework against a matched middleware recipe for that framework, not
+    # just whether *some* middleware matched: with two frameworks present (e.g. flask + fastapi) a
+    # blanket "middleware in matched_kinds" check would report the whole stack handled while the
+    # framework with no recipe was silently dropped (CTO-261 §4.2, review finding).
+    matched_web_frameworks = {
+        str(cat.get(rid).detect.get("web_framework", "")).lower()
+        for rid in matched
+        if cat.get(rid).kind == "middleware"
+    }
+    unhandled_web = [f for f in web if f not in matched_web_frameworks]
+    if unhandled_web:
+        gaps.append(
+            "account: detected web framework(s) "
+            f"{', '.join(unhandled_web)} but no middleware recipe matched"
+        )
 
     return {
+        # All detected web frameworks, so a second framework is never dropped. web_framework keeps
+        # the single-framework field prior callers read (the first, alphabetically).
+        "web_frameworks": web,
         "web_framework": web[0] if web else None,
         "llm_providers": llm,
         "agent_frameworks": agents,

--- a/sdk/python/onboarding_mcp/detect.py
+++ b/sdk/python/onboarding_mcp/detect.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``detect_stack`` MCP tool (CTO-261 sections 3 step 1, 4.2).
+
+Reads dependency-manifest contents (and optional import-site excerpts the developer's
+agent chooses to pass, section 4.2) and reports the detected providers, frameworks,
+vector DBs, and web framework, plus the recipe ids that match. Detection is grounded
+on the catalog's ``detect`` blocks: a component with no recipe is reported as a gap,
+never filled by guessing (section 2 decision 2).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+
+# Classification tokens for the human-facing summary. LLM providers appear here even
+# though P1 ships no manual LLM recipe: they are auto-instrumented by tally.init
+# (CTO-260 section 4), so detecting them tells the developer "already covered", not a gap.
+_LLM_PROVIDERS = {"openai", "anthropic", "google", "cohere", "mistralai", "vertexai"}
+_WEB_FRAMEWORKS = {"fastapi", "flask", "django"}
+_AGENT_FRAMEWORKS = {"langchain", "langchain_core", "agents", "mcp", "llama_index"}
+_VECTOR_DBS = {"pinecone", "weaviate", "qdrant_client", "chromadb", "pgvector"}
+
+_TOKEN_RE = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+
+
+def _tokens(text: str) -> set[str]:
+    return {t.lower() for t in _TOKEN_RE.findall(text)}
+
+
+def _classify(tokens: set[str], vocabulary: set[str]) -> list[str]:
+    return sorted(tokens & vocabulary)
+
+
+def detect_stack(
+    manifest: str = "",
+    import_excerpts: str = "",
+    *,
+    catalog: RecipeCatalog | None = None,
+) -> dict[str, Any]:
+    """Detect the stack from a manifest and optional import-site excerpts.
+
+    Args:
+        manifest: contents of ``requirements.txt`` / ``pyproject.toml`` / a lockfile.
+        import_excerpts: optional source excerpts; only these are matched against
+            ``call_patterns`` (section 4.2: manifests are the cheap default, excerpts opt-in).
+        catalog: override for tests; defaults to the in-tree catalog.
+
+    Returns a dict of detected components plus ``matched_recipes`` (recipe ids that apply)
+    and ``gaps`` (detected components with no recipe).
+    """
+    cat = catalog or get_catalog()
+    manifest_tokens = _tokens(manifest)
+    excerpt_tokens = _tokens(import_excerpts)
+    all_tokens = manifest_tokens | excerpt_tokens
+
+    matched: list[str] = []
+    for recipe in cat.recipes:
+        import_hit = any(_tokens(imp) & all_tokens for imp in recipe.imports)
+        pattern_hit = any(pat in import_excerpts for pat in recipe.call_patterns)
+        if import_hit or pattern_hit:
+            matched.append(recipe.id)
+
+    web = _classify(all_tokens, _WEB_FRAMEWORKS)
+    vector = _classify(all_tokens, _VECTOR_DBS)
+    agents = _classify(all_tokens, _AGENT_FRAMEWORKS)
+    llm = _classify(all_tokens, _LLM_PROVIDERS)
+
+    # A gap is a detected component category that surfaced no matching recipe.
+    gaps: list[str] = []
+    matched_kinds = {cat.get(rid).kind for rid in matched}
+    if vector and not any(cat.get(rid).kind == "vector" for rid in matched):
+        gaps.append("vector: detected a vector DB but no recipe matched")
+    if web and "middleware" not in matched_kinds:
+        gaps.append("account: detected a web framework but no middleware recipe matched")
+
+    return {
+        "web_framework": web[0] if web else None,
+        "llm_providers": llm,
+        "agent_frameworks": agents,
+        "vector_dbs": vector,
+        "matched_recipes": sorted(matched),
+        "gaps": gaps,
+    }

--- a/sdk/python/onboarding_mcp/generate.py
+++ b/sdk/python/onboarding_mcp/generate.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The code-returning MCP tools (CTO-261 section 4.2).
+
+``get_recipe``, ``generate_middleware``, ``instrument_call_site``, ``explain_layer``,
+and a ``coverage_report`` stub. Each returns recipes or generated code, never an edit
+applied to a repo (section 4.2). Every path is honest under uncertainty: a stack with
+no recipe returns a reported gap, never a fabricated ``record_*`` call (section 2
+decision 2, section 9).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+from onboarding_mcp.sdk_surface import emitted_tally_calls, layer_grounding
+
+_HOLE_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+def _gap(reason: str, **extra: Any) -> dict[str, Any]:
+    """A reported gap. The one shape every no-recipe / unanswered path returns."""
+    return {"gap": True, "reason": reason, **extra}
+
+
+def _holes(template: str) -> list[str]:
+    """Distinct ``{hole}`` names in a template, in first-seen order."""
+    seen: list[str] = []
+    for name in _HOLE_RE.findall(template):
+        if name not in seen:
+            seen.append(name)
+    return seen
+
+
+def _fill(template: str, values: dict[str, str]) -> str:
+    """Replace ``{hole}`` tokens from ``values``; leave unknown holes as a clear FILL marker."""
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        return values[name] if name in values else f"<FILL:{name}>"
+
+    return _HOLE_RE.sub(repl, template)
+
+
+def get_recipe(name: str, *, catalog: RecipeCatalog | None = None) -> dict[str, Any]:
+    """Return the machine-readable recipe for a recipe id or framework / provider name.
+
+    A name that matches no recipe is a reported gap, not a guess (section 2 decision 2).
+    """
+    cat = catalog or get_catalog()
+    recipe = cat.resolve_alias(name)
+    if recipe is None:
+        return _gap(
+            f"no recipe for {name!r}",
+            requested=name,
+            known_recipes=[r.id for r in cat.recipes],
+        )
+    return dict(recipe.raw)
+
+
+def generate_middleware(
+    web_framework: str,
+    account_source: str,
+    feature_tag: str | None = None,
+    *,
+    catalog: RecipeCatalog | None = None,
+) -> dict[str, Any]:
+    """Generate drop-in account / feature middleware bound to the developer's answer (section 6).
+
+    ``account_source`` is the confirmed resolver expression (an ``X-Customer-Id`` header, an
+    auth dependency); it is injected verbatim, never inferred. Without an answer the account
+    layer stays unattributed, so an empty ``account_source`` is a reported gap, not a guess.
+    """
+    cat = catalog or get_catalog()
+    if not account_source.strip():
+        return _gap(
+            "the account-identity question is unanswered; middleware not generated "
+            "(section 6). The account layer stays UNATTRIBUTED until a resolver is confirmed.",
+            web_framework=web_framework,
+        )
+    recipe = None
+    for candidate in cat.by_kind("middleware"):
+        if str(candidate.detect.get("web_framework", "")).lower() == web_framework.lower():
+            recipe = candidate
+            break
+    if recipe is None:
+        return _gap(
+            f"no middleware recipe for web framework {web_framework!r}",
+            web_framework=web_framework,
+            known_frameworks=[
+                r.detect.get("web_framework") for r in cat.by_kind("middleware")
+            ],
+        )
+
+    feature_expr = repr(feature_tag) if feature_tag else "None"
+    code = _fill(
+        recipe.edit["template"],
+        {"account_source": account_source, "feature_tag": feature_expr},
+    )
+    return {
+        "recipe_id": recipe.id,
+        "web_framework": web_framework,
+        "imports_to_add": recipe.edit["imports_to_add"],
+        "code": code,
+        "placement": recipe.edit["placement"],
+        "bound_account_source": account_source,
+        "feature_tag": feature_tag,
+    }
+
+
+def instrument_call_site(
+    call_site: str,
+    recipe_id: str,
+    *,
+    holes: dict[str, str] | None = None,
+    catalog: RecipeCatalog | None = None,
+) -> dict[str, Any]:
+    """Adapt a recipe's ``record_*`` edit to a concrete call site (section 4.2).
+
+    ``holes`` lets the caller supply values it derived from the call site; anything
+    unfilled is surfaced as a FILL marker plus a ``holes_to_fill`` list, so the tool
+    never invents an index name or a count. An unknown ``recipe_id``, or a recipe that
+    emits no SDK call (the otel-ingest recipe), is a reported gap.
+    """
+    cat = catalog or get_catalog()
+    recipe = cat.resolve_alias(recipe_id)
+    if recipe is None:
+        return _gap(
+            f"no recipe {recipe_id!r}; cannot instrument this call site",
+            requested=recipe_id,
+            call_site=call_site,
+        )
+    if not recipe.sdk_surface.get("call"):
+        return _gap(
+            f"recipe {recipe.id!r} emits config, not an SDK call; nothing to instrument here",
+            recipe_id=recipe.id,
+        )
+
+    supplied = dict(holes or {})
+    supplied.update(_autofill_from_call_site(call_site, recipe))
+    template = recipe.edit["template"]
+    code = _fill(template, supplied)
+    remaining = [h for h in _holes(template) if h not in supplied]
+    emitted = emitted_tally_calls(template)
+    return {
+        "recipe_id": recipe.id,
+        "sdk_call": recipe.sdk_surface["call"],
+        "emitted_calls": [c.name for c in emitted],
+        "imports_to_add": recipe.edit["imports_to_add"],
+        "code": code,
+        "placement": recipe.edit["placement"],
+        "holes_to_fill": remaining,
+    }
+
+
+# Cheap, honest autofill: derive a result count from an obvious limit kwarg. Anything
+# not confidently derivable is left as a FILL marker (never guessed).
+_COUNT_HOLES = {"n_results", "row_count"}
+_COUNT_RE = re.compile(r"\b(?:top_k|limit|k)\s*=\s*(\d+)")
+
+
+def _autofill_from_call_site(call_site: str, recipe) -> dict[str, str]:
+    filled: dict[str, str] = {}
+    count_match = _COUNT_RE.search(call_site)
+    if count_match:
+        for hole in _holes(recipe.edit["template"]):
+            if hole in _COUNT_HOLES:
+                filled[hole] = count_match.group(1)
+    return filled
+
+
+def explain_layer(query: str, *, catalog: RecipeCatalog | None = None) -> dict[str, Any]:
+    """Explain which ``record_*`` method covers a layer, grounded on the SDK surface (section 4.2).
+
+    ``query`` is a layer name ("vector") or a call-site excerpt ("what records this
+    pinecone call?"). For an excerpt, the matching recipe's layer is used.
+    """
+    cat = catalog or get_catalog()
+    facts = layer_grounding(query.strip().lower())
+    matched_recipe = None
+    if facts is None:
+        # Not a bare layer name: try to match the excerpt to a recipe by its detect block.
+        for recipe in cat.recipes:
+            if any(pat in query for pat in recipe.call_patterns) or any(
+                imp in query for imp in recipe.imports
+            ):
+                facts = layer_grounding(recipe.verify.get("layer", ""))
+                matched_recipe = recipe.id
+                break
+    if facts is None:
+        return _gap(
+            f"no known layer or recipe matches {query!r}",
+            query=query,
+            known_layers=["llm", "tool", "vector", "embeddings", "account"],
+        )
+    result = dict(facts)
+    if matched_recipe:
+        result["matched_recipe"] = matched_recipe
+    return result
+
+
+def coverage_report(tenant_key: str, *, layers: list[str] | None = None) -> dict[str, Any]:
+    """Per-layer coverage (section 7). Stubbed against the spec contract for P1.
+
+    The real ClickHouse per-layer existence probe is the gateway's work in a later PR
+    (section 12 P3). Until then this reports each layer as not-yet-probed rather than
+    fabricating a covered / dark verdict, honoring "honest under uncertainty": a layer
+    is never marked covered without a span to prove it (section 7, CLAUDE.md).
+    """
+    layer_names = layers or ["llm", "tool", "vector", "embeddings", "account"]
+    return {
+        "tenant_key_present": bool(tenant_key),
+        "probe_available": False,
+        "note": (
+            "Per-layer coverage probe ships in a later PR (CTO-261 section 7 / P3). "
+            "No layer is reported as covered without a proving span."
+        ),
+        "layers": [
+            {
+                "layer": name,
+                "signal": (grounding or {}).get("signal", ""),
+                "status": "not_probed",
+            }
+            for name in layer_names
+            for grounding in [layer_grounding(name)]
+        ],
+    }

--- a/sdk/python/onboarding_mcp/sdk_surface.py
+++ b/sdk/python/onboarding_mcp/sdk_surface.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Grounding on the real SDK surface (CTO-261 sections 5.2, 5.3).
+
+This is the anti-hallucination core. A recipe's ``sdk_surface.call`` is the
+module-level convenience form the template emits (``tally.record_vector_call``);
+``delegates_to`` is the ``TallyClient`` method it wraps. Checking only that the named
+method exists would still pass a template that called a nonexistent
+``tally.record_vector_call`` (section 5.2), so the guard here parses ``edit.template``,
+finds every ``tally.<name>(...)`` call it actually emits, resolves each against the
+live SDK, and binds the passed arguments against the real signature. A template that
+calls a function that does not exist, or passes a kwarg the real signature does not
+accept, fails.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import re
+from dataclasses import dataclass
+
+# A template hole is a bare {snake_case} token the agent fills from the call site.
+# Replace holes with a placeholder name so the template parses as real Python.
+_HOLE_RE = re.compile(r"\{[a-zA-Z_][a-zA-Z0-9_]*\}")
+_HOLE_PLACEHOLDER = "_TALLY_HOLE"
+
+# The module the recipes' module-level convenience calls live on.
+_MODULE_ROOT = "tally"
+
+
+class SurfaceError(Exception):
+    """A recipe references an SDK symbol or argument that does not exist. Fails CI."""
+
+
+@dataclass(frozen=True)
+class EmittedCall:
+    """A ``tally.<name>(...)`` call found in a recipe template."""
+
+    name: str
+    n_positional: int
+    kwargs: tuple[str, ...]
+
+
+def render_template(template: str) -> str:
+    """Substitute ``{hole}`` tokens with a placeholder so the template parses as Python."""
+    return _HOLE_RE.sub(_HOLE_PLACEHOLDER, template)
+
+
+def emitted_tally_calls(template: str) -> list[EmittedCall]:
+    """Parse ``template`` and return every ``tally.<name>(...)`` call it emits."""
+    tree = ast.parse(render_template(template))
+    calls: list[EmittedCall] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == _MODULE_ROOT
+        ):
+            kwargs = tuple(kw.arg for kw in node.keywords if kw.arg is not None)
+            n_positional = sum(1 for a in node.args if not isinstance(a, ast.Starred))
+            calls.append(EmittedCall(func.attr, n_positional, kwargs))
+    return calls
+
+
+def resolve_dotted(dotted: str):
+    """Resolve a dotted path (module + attribute chain) to the live object.
+
+    Imports the longest importable module prefix, then walks the remaining attributes,
+    so ``tally.client.TallyClient.record_vector_call`` resolves the method object.
+    """
+    parts = dotted.split(".")
+    module = None
+    split_at = 0
+    for i in range(len(parts), 0, -1):
+        try:
+            module = importlib.import_module(".".join(parts[:i]))
+            split_at = i
+            break
+        except ImportError:
+            continue
+    if module is None:
+        raise SurfaceError(f"no importable module in {dotted!r}")
+    obj = module
+    for attr in parts[split_at:]:
+        try:
+            obj = getattr(obj, attr)
+        except AttributeError as exc:
+            raise SurfaceError(f"{dotted!r} does not resolve: {exc}") from exc
+    return obj
+
+
+def _signature_without_self(fn) -> inspect.Signature:
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    if params and params[0].name == "self":
+        return sig.replace(parameters=params[1:])
+    return sig
+
+
+def _is_bare_var_keyword(sig: inspect.Signature) -> bool:
+    """True for a ``def f(**kwargs)`` wrapper whose real signature lives on ``delegates_to``."""
+    params = list(sig.parameters.values())
+    return len(params) == 1 and params[0].kind is inspect.Parameter.VAR_KEYWORD
+
+
+def module_symbol(name: str):
+    """Return the public ``tally.<name>`` symbol, or raise if it does not exist."""
+    root = importlib.import_module(_MODULE_ROOT)
+    if not hasattr(root, name):
+        raise SurfaceError(f"tally.{name} does not exist on the SDK surface")
+    return getattr(root, name)
+
+
+def validate_recipe_surface(recipe) -> None:
+    """The resolve-the-call guard for one recipe. Raises :class:`SurfaceError` on any mismatch.
+
+    Steps (section 5.2):
+      1. The otel recipe emits config, not an SDK call: nothing to resolve.
+      2. The declared ``call`` must be a real ``tally.<name>`` symbol.
+      3. ``delegates_to`` must resolve, and every ``required_args`` must be a real
+         parameter of it.
+      4. Every ``tally.<name>(...)`` the template emits must resolve; the declared
+         call is bound against ``delegates_to``'s real signature, so an unknown kwarg
+         or a missing required arg fails.
+    """
+    surface = recipe.sdk_surface
+    call = surface.get("call")
+    delegates_to = surface.get("delegates_to")
+
+    if call is None:
+        # otel-ingest: config only, no SDK call to resolve. Guarded by schema elsewhere.
+        return
+
+    if not call.startswith(f"{_MODULE_ROOT}."):
+        raise SurfaceError(f"{recipe.id}: sdk_surface.call {call!r} must be a tally.* convenience")
+    call_name = call[len(_MODULE_ROOT) + 1 :]
+
+    # (2) The module-level convenience must exist and be callable.
+    conv = module_symbol(call_name)
+    if not callable(conv):
+        raise SurfaceError(f"{recipe.id}: {call} is not callable")
+
+    # (3) Resolve the delegate and check the recipe's declared required_args are real.
+    bind_sig: inspect.Signature | None = None
+    if delegates_to:
+        delegate = resolve_dotted(delegates_to)
+        if not callable(delegate):
+            raise SurfaceError(f"{recipe.id}: delegates_to {delegates_to} is not callable")
+        bind_sig = _signature_without_self(delegate)
+        for arg in surface.get("required_args", []):
+            if arg not in bind_sig.parameters:
+                raise SurfaceError(
+                    f"{recipe.id}: required_arg {arg!r} is not a parameter of {delegates_to}"
+                )
+
+    # (4) Resolve every tally.* call the template actually emits and bind the declared one.
+    emitted = emitted_tally_calls(recipe.edit["template"])
+    declared = [c for c in emitted if c.name == call_name]
+    if not declared:
+        raise SurfaceError(
+            f"{recipe.id}: template does not emit the declared call tally.{call_name}(...)"
+        )
+
+    for emitted_call in emitted:
+        # Existence guard for secondary calls too (e.g. start_trace in a middleware template).
+        symbol = module_symbol(emitted_call.name)
+        target_sig: inspect.Signature | None
+        if emitted_call.name == call_name and bind_sig is not None:
+            target_sig = bind_sig
+        else:
+            sig = _signature_without_self(symbol)
+            # A bare **kwargs wrapper carries no real signature to bind against; the
+            # declared call is the one pinned via delegates_to, so skip binding here.
+            target_sig = None if _is_bare_var_keyword(sig) else sig
+        if target_sig is None:
+            continue
+        placeholder = object()
+        try:
+            target_sig.bind(
+                *([placeholder] * emitted_call.n_positional),
+                **{k: placeholder for k in emitted_call.kwargs},
+            )
+        except TypeError as exc:
+            raise SurfaceError(
+                f"{recipe.id}: tally.{emitted_call.name}(...) does not match the real "
+                f"signature: {exc}"
+            ) from exc
+
+
+# --------------------------------------------------------------------------- #
+# Layer grounding for explain_layer (section 4.2). Each entry is pinned to a real
+# SDK symbol resolved at call time, never a hand-written method name.
+# --------------------------------------------------------------------------- #
+_LAYER_GROUNDING = {
+    "llm": {
+        "call": "tally.record_llm_call",
+        "delegates_to": "tally.client.TallyClient.record_llm_call",
+        "operation_name": "chat",
+        "signal": "GenAiOperation = 'chat'",
+        "why": "LLM chat completions land with gen_ai.operation.name = 'chat'.",
+    },
+    "tool": {
+        "call": "tally.record_tool_call",
+        "delegates_to": "tally.client.TallyClient.record_tool_call",
+        "operation_name": "tool",
+        "signal": "GenAiOperation = 'tool'",
+        "why": "An app's own billable tool call is bucketed on gen_ai.operation.name = 'tool'.",
+    },
+    "vector": {
+        "call": "tally.record_vector_call",
+        "delegates_to": "tally.client.TallyClient.record_vector_call",
+        "operation_name": "vector",
+        "signal": "GenAiOperation = 'vector'",
+        "why": "A vector-DB call is bucketed on gen_ai.operation.name = 'vector'.",
+    },
+    "embeddings": {
+        "call": "tally.record_embedding_call",
+        "delegates_to": "tally.client.TallyClient.record_embedding_call",
+        "operation_name": "embeddings",
+        "signal": "GenAiOperation = 'embeddings'",
+        "why": "An embedding call is bucketed on gen_ai.operation.name = 'embeddings'.",
+    },
+    "account": {
+        "call": "tally.with_account",
+        "delegates_to": "tally.context.with_account",
+        "operation_name": "",
+        "signal": "AccountIdHash != ''",
+        "why": "Per-customer attribution is set by with_account and rides as the HMAC'd "
+        "AccountIdHash column, not a gen_ai.operation.name value.",
+    },
+}
+
+# Some callers name the layer "embedding" (kind) vs "embeddings" (coverage). Accept both.
+_LAYER_ALIASES = {"embedding": "embeddings", "chat": "llm", "llm": "llm"}
+
+
+def layer_grounding(layer: str) -> dict[str, str] | None:
+    """Return the SDK-grounded facts for a coverage layer, or None for an unknown layer."""
+    key = _LAYER_ALIASES.get(layer, layer)
+    facts = _LAYER_GROUNDING.get(key)
+    if facts is None:
+        return None
+    # Resolve the pinned symbol now so a drifted method name would surface as an error,
+    # not stale prose.
+    resolve_dotted(facts["delegates_to"])
+    return dict(facts, layer=key)

--- a/sdk/python/onboarding_mcp/server.py
+++ b/sdk/python/onboarding_mcp/server.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MCP protocol binding for the onboarding tools (CTO-261 section 4.2).
+
+Thin: it maps the plain functions in this package onto MCP tools. The tools are fully
+usable and testable without this module (they are ordinary functions); this only wires
+them to an MCP transport for a developer's coding agent to call. The ``mcp`` package is
+an optional runtime dependency, imported lazily so the SDK test suite needs no MCP stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from onboarding_mcp import (
+    coverage_report,
+    detect_stack,
+    explain_layer,
+    generate_middleware,
+    get_recipe,
+    instrument_call_site,
+)
+
+SERVER_NAME = "ai-tally-onboarding"
+
+
+def build_server() -> Any:
+    """Build the FastMCP server with the section 4.2 tools registered.
+
+    Raises a clear error if the optional ``mcp`` package is not installed, rather than
+    failing at import time (so importing this module for its tool wiring stays cheap).
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover - exercised only without the mcp extra
+        raise RuntimeError(
+            "the 'mcp' package is required to run the onboarding MCP server; install it "
+            "with `pip install mcp`. The tools themselves are importable without it."
+        ) from exc
+
+    server = FastMCP(SERVER_NAME)
+
+    @server.tool()
+    def detect_stack_tool(manifest: str = "", import_excerpts: str = "") -> dict[str, Any]:
+        """Detect providers, frameworks, vector DBs, and web framework from a manifest."""
+        return detect_stack(manifest, import_excerpts)
+
+    @server.tool()
+    def get_recipe_tool(name: str) -> dict[str, Any]:
+        """Return the machine-readable recipe for a recipe id or framework / provider name."""
+        return get_recipe(name)
+
+    @server.tool()
+    def generate_middleware_tool(
+        web_framework: str, account_source: str, feature_tag: str | None = None
+    ) -> dict[str, Any]:
+        """Generate account / feature middleware bound to the confirmed account resolver."""
+        return generate_middleware(web_framework, account_source, feature_tag)
+
+    @server.tool()
+    def instrument_call_site_tool(call_site: str, recipe_id: str) -> dict[str, Any]:
+        """Adapt a recipe's record_* edit to a concrete call site."""
+        return instrument_call_site(call_site, recipe_id)
+
+    @server.tool()
+    def explain_layer_tool(query: str) -> dict[str, Any]:
+        """Explain which record_* method covers a layer, grounded on the SDK surface."""
+        return explain_layer(query)
+
+    @server.tool()
+    def coverage_report_tool(tenant_key: str) -> dict[str, Any]:
+        """Per-layer coverage (stubbed against the spec contract; probe ships later)."""
+        return coverage_report(tenant_key)
+
+    return server
+
+
+def main() -> None:  # pragma: no cover - entrypoint
+    build_server().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -8,9 +8,14 @@ license = { text = "Apache-2.0" }
 dependencies = []
 
 [project.optional-dependencies]
+# CTO-261: the onboarding-agent recipe catalog is YAML; jsonschema backs the
+# schema-validation guard in tests/test_recipes.py. Kept dev-only so the SDK
+# runtime stays dependency-free (see `dependencies = []` above).
 dev = [
     "pytest>=8.0",
     "ruff>=0.12,<0.16",
+    "pyyaml>=6.0",
+    "jsonschema>=4.0",
 ]
 
 [build-system]
@@ -29,5 +34,6 @@ select = ["E", "F", "I", "UP", "B"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+# "." makes the onboarding_mcp component (CTO-261) importable alongside the SDK's src tree.
+pythonpath = ["src", "."]
 addopts = "-q"

--- a/sdk/python/recipes/embedding.generic.call.yaml
+++ b/sdk/python/recipes/embedding.generic.call.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5: an embedding call not made through the patched client -> record_embedding_call.
+id: embedding.generic.call
+kind: embedding
+title: "Embedding call (unpatched path) -> tally.record_embedding_call"
+detect:
+  imports: ["openai", "cohere", "sentence_transformers", "voyageai"]
+  call_patterns: [".embeddings.create(", ".embed(", ".encode("]
+sdk_surface:
+  call: "tally.record_embedding_call"
+  delegates_to: "tally.client.TallyClient.record_embedding_call"
+  required_args: [provider, model, input_tokens]
+  layer: embedding
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # After the embedding call returns. Use this only for embedding calls the
+    # patched openai / anthropic client does not already capture (CTO-260 auto-instrument).
+    tally.record_embedding_call(
+        provider={embedding_provider},
+        model={embedding_model},
+        input_tokens={input_tokens},
+    )
+  placement: after_call
+verify:
+  layer: embeddings
+  operation_name: "embeddings"
+notes: "Cost is estimated input-side only, under PriceType.EMBEDDING. Unknown (provider, model) keeps cost None/0 with a one-time WARN."

--- a/sdk/python/recipes/index.yaml
+++ b/sdk/python/recipes/index.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5.1: the recipe catalog index. Single source of truth all three
+# delivery forms read (dashboard Q&A, MCP server, hosted PR bot). Each entry names
+# a recipe file in this directory; the file is validated against recipes/schema.json
+# and, where it emits an SDK call, against the real SDK surface (tests/test_recipes.py).
+version: 1
+recipes:
+  - id: middleware.fastapi.account
+    file: middleware.fastapi.account.yaml
+    kind: middleware
+  - id: middleware.flask.account
+    file: middleware.flask.account.yaml
+    kind: middleware
+  - id: middleware.django.account
+    file: middleware.django.account.yaml
+    kind: middleware
+  - id: vector.pinecone.query
+    file: vector.pinecone.query.yaml
+    kind: vector
+  - id: vector.weaviate.query
+    file: vector.weaviate.query.yaml
+    kind: vector
+  - id: vector.qdrant.search
+    file: vector.qdrant.search.yaml
+    kind: vector
+  - id: vector.pgvector.query
+    file: vector.pgvector.query.yaml
+    kind: vector
+  - id: tool.generic.call
+    file: tool.generic.call.yaml
+    kind: tool
+  - id: embedding.generic.call
+    file: embedding.generic.call.yaml
+    kind: embedding
+  - id: otel.ingest.gen_ai
+    file: otel.ingest.yaml
+    kind: otel

--- a/sdk/python/recipes/middleware.django.account.yaml
+++ b/sdk/python/recipes/middleware.django.account.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 sections 5 and 6: Django account + feature middleware bound to the developer's answer.
+id: middleware.django.account
+kind: middleware
+title: "Django middleware class -> with_account / start_trace"
+detect:
+  imports: ["django"]
+  call_patterns: ["MIDDLEWARE", "get_response", "django.urls"]
+  web_framework: django
+sdk_surface:
+  call: "tally.with_account"
+  delegates_to: "tally.context.with_account"
+  required_args: [account_id]
+  layer: account
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # Add "myapp.tally_mw.TallyAccountMiddleware" to settings.MIDDLEWARE.
+    # {account_source} is the header / resolver you confirmed (section 6).
+    class TallyAccountMiddleware:
+        def __init__(self, get_response):
+            self.get_response = get_response
+
+        def __call__(self, request):
+            account_id = {account_source}
+            with tally.start_trace(feature_tag={feature_tag}):
+                with tally.with_account(account_id):
+                    return self.get_response(request)
+  placement: wrap_handler
+verify:
+  layer: account
+  operation_name: ""
+notes: "account attribution lights up when AccountIdHash != '' for the tenant (section 7)."

--- a/sdk/python/recipes/middleware.fastapi.account.yaml
+++ b/sdk/python/recipes/middleware.fastapi.account.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 sections 5 and 6: FastAPI account + feature middleware bound to the developer's answer.
+id: middleware.fastapi.account
+kind: middleware
+title: "FastAPI request middleware -> with_account / start_trace"
+detect:
+  imports: ["fastapi"]
+  call_patterns: ["FastAPI(", "@app.get(", "@app.post(", "APIRouter("]
+  web_framework: fastapi
+sdk_surface:
+  # The account floor (section 6): with_account is the pinned symbol; start_trace
+  # adds the feature dimension in the same scope.
+  call: "tally.with_account"
+  delegates_to: "tally.context.with_account"
+  required_args: [account_id]
+  layer: account
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # Resolve the customer once per request and scope every span to it.
+    # {account_source} is the header / resolver you confirmed (section 6): the agent
+    # never guesses it. The raw id is HMAC'd in-process and never travels raw.
+    @app.middleware("http")
+    async def tally_account_middleware(request, call_next):
+        account_id = {account_source}
+        with tally.start_trace(feature_tag={feature_tag}):
+            with tally.with_account(account_id):
+                return await call_next(request)
+  placement: wrap_handler
+verify:
+  layer: account
+  operation_name: ""
+notes: "account attribution lights up when AccountIdHash != '' for the tenant (section 7). If the developer cannot answer the account question, this recipe is not wired and the account layer stays UNATTRIBUTED, reported as still dark."

--- a/sdk/python/recipes/middleware.flask.account.yaml
+++ b/sdk/python/recipes/middleware.flask.account.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 sections 5 and 6: Flask account + feature middleware bound to the developer's answer.
+id: middleware.flask.account
+kind: middleware
+title: "Flask view wrapper -> with_account / start_trace"
+detect:
+  imports: ["flask"]
+  call_patterns: ["Flask(", "@app.route(", "Blueprint("]
+  web_framework: flask
+sdk_surface:
+  call: "tally.with_account"
+  delegates_to: "tally.context.with_account"
+  required_args: [account_id]
+  layer: account
+edit:
+  imports_to_add: ["import tally", "from functools import wraps"]
+  template: |
+    # Flask has no async middleware hook that spans a `with` block cleanly, so wrap
+    # the view. Apply @tally_account to your views (or wrap app.dispatch_request).
+    # {account_source} is the header / resolver you confirmed (section 6).
+    def tally_account(view):
+        @wraps(view)
+        def _wrapped(*args, **kwargs):
+            account_id = {account_source}
+            with tally.start_trace(feature_tag={feature_tag}):
+                with tally.with_account(account_id):
+                    return view(*args, **kwargs)
+        return _wrapped
+  placement: wrap_handler
+verify:
+  layer: account
+  operation_name: ""
+notes: "account attribution lights up when AccountIdHash != '' for the tenant (section 7)."

--- a/sdk/python/recipes/otel.ingest.yaml
+++ b/sdk/python/recipes/otel.ingest.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5.3 (lever 2): a team already emitting gen_ai.* OTel spans points
+# its exporter at the gateway's OTLP endpoint; no ai-tally-specific code is needed.
+id: otel.ingest.gen_ai
+kind: otel
+title: "Point an existing OTLP exporter at the ai-tally gateway"
+detect:
+  imports: ["opentelemetry", "opentelemetry-sdk", "opentelemetry-exporter-otlp"]
+  call_patterns: ["OTLPSpanExporter(", "TracerProvider(", "gen_ai."]
+sdk_surface:
+  # No SDK call: this recipe emits config, so call / delegates_to are null and the
+  # resolve-the-call guard skips it (tests/test_recipes.py). It still validates
+  # against the schema like every other recipe.
+  call: null
+  delegates_to: null
+  required_args: []
+  layer: otel
+edit:
+  imports_to_add: []
+  template: |
+    # If the app already emits OpenTelemetry gen_ai.* spans, point the OTLP exporter
+    # at the ai-tally gateway instead of adding SDK calls. The gateway ingests OTLP
+    # traces at ingest_otlp_traces (infra/gateway/src/gateway/app.py).
+    export OTEL_EXPORTER_OTLP_ENDPOINT="{gateway_otlp_endpoint}"
+    export OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer {tally_key}"
+  placement: config
+verify:
+  layer: otel
+  operation_name: ""
+notes: "The gateway buckets each span by gen_ai.operation.name into the same coverage layers (chat / tool / vector / embeddings), so an OTel-native app needs no record_* calls."

--- a/sdk/python/recipes/schema.json
+++ b/sdk/python/recipes/schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ai-tally.dev/schemas/onboarding-recipe.json",
+  "title": "ai-tally onboarding instrumentation recipe",
+  "description": "CTO-261 section 5.2. One machine-readable recipe per framework / provider. The recipe catalog is the reliability mechanism: the onboarding agent retrieves and adapts a known-good recipe rather than hand-writing the SDK API. Every recipe with an sdk_surface.call is additionally checked by tests/test_recipes.py, which resolves the emitted call against the real SDK surface.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "kind", "title", "detect", "sdk_surface", "edit", "verify"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable dotted-namespace id, e.g. vector.pinecone.query.",
+      "pattern": "^[a-z0-9]+(\\.[a-z0-9_]+)+$"
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["vector", "tool", "embedding", "llm", "middleware", "otel"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "detect": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How the agent knows this recipe applies (section 3 step 1).",
+      "properties": {
+        "imports": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Import names or dependency-manifest tokens that signal this component."
+        },
+        "call_patterns": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Call-site substrings that mark a candidate edit point."
+        },
+        "web_framework": {
+          "type": "string",
+          "description": "For middleware recipes: the web framework this middleware targets."
+        }
+      }
+    },
+    "sdk_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Pins the recipe to a real SDK symbol. Recipes emit the module-level convenience form; delegates_to records the instance method it wraps (section 5.2, 5.3).",
+      "required": ["layer"],
+      "properties": {
+        "call": {
+          "type": ["string", "null"],
+          "description": "The module-level convenience form the edit.template emits, e.g. tally.record_vector_call. Null only for the otel-ingest recipe, which emits config, not an SDK call."
+        },
+        "delegates_to": {
+          "type": ["string", "null"],
+          "description": "Fully-qualified instance method the module-level convenience wraps, e.g. tally.client.TallyClient.record_vector_call."
+        },
+        "required_args": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Arguments the emitted call must carry. Validated to be real parameters of delegates_to."
+        },
+        "layer": {
+          "type": "string",
+          "enum": ["vector", "tool", "embedding", "llm", "account", "otel"],
+          "description": "Gateway cost-layer / coverage bucket this recipe lands in."
+        }
+      }
+    },
+    "edit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["imports_to_add", "template", "placement"],
+      "properties": {
+        "imports_to_add": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "template": {
+          "type": "string",
+          "description": "The adaptable code template. Named holes are {snake_case} and are filled from the concrete call site by the agent.",
+          "minLength": 1
+        },
+        "placement": {
+          "type": "string",
+          "enum": ["after_call", "before_call", "replace_call", "wrap_handler", "startup", "config"]
+        }
+      }
+    },
+    "verify": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layer"],
+      "description": "Names the coverage layer that must light up (section 7).",
+      "properties": {
+        "layer": {
+          "type": "string",
+          "enum": ["vector", "tool", "embeddings", "llm", "account", "otel"]
+        },
+        "operation_name": {
+          "type": "string",
+          "description": "Value of the GenAiOperation column the gateway buckets on (tool, vector, embeddings, chat)."
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/sdk/python/recipes/tool.generic.call.yaml
+++ b/sdk/python/recipes/tool.generic.call.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5: an app's own billable tool call -> record_tool_call.
+id: tool.generic.call
+kind: tool
+title: "App tool / function call -> tally.record_tool_call"
+detect:
+  # No single import marks "a tool": the agent surfaces candidate functions the
+  # developer confirms. LangChain / Agents-SDK tool decorators are strong hints.
+  imports: ["langchain", "langchain_core", "agents"]
+  call_patterns: ["@tool", "Tool(", "function_call", "tool_call"]
+sdk_surface:
+  call: "tally.record_tool_call"
+  delegates_to: "tally.client.TallyClient.record_tool_call"
+  required_args: [provider, tool]
+  layer: tool
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # After the tool runs. provider identifies the tool's vendor / backend;
+    # tool is the tool's name. Pass cost_micro_usd only when you know it;
+    # otherwise the versioned catalog resolves the rate under PriceType.TOOL_CALL.
+    tally.record_tool_call(
+        provider={tool_provider},
+        tool={tool_name},
+    )
+  placement: after_call
+verify:
+  layer: tool
+  operation_name: "tool"
+notes: "cost_micro_usd is optional; when omitted, an unknown (provider, tool) pair defaults to 0 with a one-time WARN. A caller-supplied cost always overrides."

--- a/sdk/python/recipes/vector.pgvector.query.yaml
+++ b/sdk/python/recipes/vector.pgvector.query.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5: pgvector similarity query -> record_vector_call.
+id: vector.pgvector.query
+kind: vector
+title: "pgvector ORDER BY embedding <-> query -> tally.record_vector_call"
+detect:
+  # pgvector rides on the Postgres driver; the operator in the SQL is the real signal.
+  imports: ["pgvector", "psycopg", "psycopg2", "sqlalchemy"]
+  call_patterns: ["<->", "<=>", "<#>", "l2_distance(", "cosine_distance("]
+sdk_surface:
+  call: "tally.record_vector_call"
+  delegates_to: "tally.client.TallyClient.record_vector_call"
+  required_args: [provider, index, operation]
+  layer: vector
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # After executing the pgvector similarity query. The table (or index) name maps to index.
+    tally.record_vector_call(
+        provider="pgvector",
+        index={table_name},
+        operation="query",
+        record_count={row_count},
+    )
+  placement: after_call
+verify:
+  layer: vector
+  operation_name: "vector"
+notes: "pgvector has no per-call vendor price; cost resolves to 0 with a one-time WARN unless the tenant seeds a (pgvector, query) rate. The layer still lights up in coverage."

--- a/sdk/python/recipes/vector.pinecone.query.yaml
+++ b/sdk/python/recipes/vector.pinecone.query.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5: Pinecone index.query -> record_vector_call.
+id: vector.pinecone.query
+kind: vector
+title: "Pinecone index.query / upsert -> tally.record_vector_call"
+detect:
+  imports: ["pinecone"]
+  call_patterns: [".query(", ".upsert("]
+sdk_surface:
+  call: "tally.record_vector_call"
+  delegates_to: "tally.client.TallyClient.record_vector_call"
+  required_args: [provider, index, operation]
+  layer: vector
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # After the Pinecone call returns, record the vector-search cost layer.
+    # index / operation / record_count are filled from the concrete call site.
+    tally.record_vector_call(
+        provider="pinecone",
+        index={index_name},
+        operation="query",
+        record_count={n_results},
+    )
+  placement: after_call
+verify:
+  layer: vector
+  operation_name: "vector"
+notes: "record_count is accepted by record_vector_call for API symmetry; cost resolves from the versioned catalog under PriceType.VECTOR_CALL keyed by (provider, operation)."

--- a/sdk/python/recipes/vector.qdrant.search.yaml
+++ b/sdk/python/recipes/vector.qdrant.search.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5: Qdrant search -> record_vector_call.
+id: vector.qdrant.search
+kind: vector
+title: "Qdrant search / query_points -> tally.record_vector_call"
+detect:
+  imports: ["qdrant_client"]
+  call_patterns: [".search(", ".query_points(", ".upsert("]
+sdk_surface:
+  call: "tally.record_vector_call"
+  delegates_to: "tally.client.TallyClient.record_vector_call"
+  required_args: [provider, index, operation]
+  layer: vector
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # After the Qdrant search returns. The Qdrant "collection_name" maps to index.
+    tally.record_vector_call(
+        provider="qdrant",
+        index={collection_name},
+        operation="search",
+        record_count={n_results},
+    )
+  placement: after_call
+verify:
+  layer: vector
+  operation_name: "vector"
+notes: "operation is the Qdrant method name (search / query_points / upsert); cost resolves per (provider, operation)."

--- a/sdk/python/recipes/vector.weaviate.query.yaml
+++ b/sdk/python/recipes/vector.weaviate.query.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5: Weaviate collection query -> record_vector_call.
+id: vector.weaviate.query
+kind: vector
+title: "Weaviate near_text / query -> tally.record_vector_call"
+detect:
+  imports: ["weaviate"]
+  call_patterns: [".query.near_text(", ".query.near_vector(", ".query.fetch_objects("]
+sdk_surface:
+  call: "tally.record_vector_call"
+  delegates_to: "tally.client.TallyClient.record_vector_call"
+  required_args: [provider, index, operation]
+  layer: vector
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # After the Weaviate query returns. The Weaviate "collection" maps to index.
+    tally.record_vector_call(
+        provider="weaviate",
+        index={collection_name},
+        operation="query",
+        record_count={n_results},
+    )
+  placement: after_call
+verify:
+  layer: vector
+  operation_name: "vector"
+notes: "Weaviate collections are the index slot; the tool-name slot encodes {provider}.{index}.{operation}."

--- a/sdk/python/tests/test_onboarding_mcp.py
+++ b/sdk/python/tests/test_onboarding_mcp.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Onboarding MCP tool tests (CTO-261 sections 4.2, 13).
+
+Detection on sample manifests, recipe retrieval, middleware generation bound to a given
+header, call-site adaptation, and the no-recipe gap path (a reported gap, never a
+fabricated record).
+"""
+
+from __future__ import annotations
+
+import ast
+
+from onboarding_mcp import (
+    coverage_report,
+    detect_stack,
+    explain_layer,
+    generate_middleware,
+    get_recipe,
+    instrument_call_site,
+)
+from onboarding_mcp.sdk_surface import emitted_tally_calls
+
+# A representative P1 stack: FastAPI + Pinecone + openai (section 12 "Done when").
+SAMPLE_MANIFEST = """
+fastapi==0.115.0
+uvicorn==0.30.0
+openai==1.40.0
+pinecone-client==5.0.0
+"""
+
+SAMPLE_IMPORTS = """
+import openai
+from pinecone import Pinecone
+from fastapi import FastAPI, Request
+results = index.query(vector=embedding, top_k=5)
+"""
+
+
+def test_detect_stack_on_sample_manifest():
+    result = detect_stack(SAMPLE_MANIFEST, SAMPLE_IMPORTS)
+    assert result["web_framework"] == "fastapi"
+    assert "openai" in result["llm_providers"]
+    assert "pinecone" in result["vector_dbs"]
+    assert "vector.pinecone.query" in result["matched_recipes"]
+    assert "middleware.fastapi.account" in result["matched_recipes"]
+
+
+def test_detect_stack_manifest_only_still_matches():
+    # Manifests are the cheap default (section 4.2); detection works without excerpts.
+    result = detect_stack(SAMPLE_MANIFEST)
+    assert "vector.pinecone.query" in result["matched_recipes"]
+    assert "middleware.fastapi.account" in result["matched_recipes"]
+
+
+def test_get_recipe_by_id_and_by_alias():
+    by_id = get_recipe("vector.pinecone.query")
+    assert by_id["id"] == "vector.pinecone.query"
+    assert by_id["sdk_surface"]["call"] == "tally.record_vector_call"
+    # Section 4.2 allows a friendly framework / provider name.
+    by_alias = get_recipe("pinecone")
+    assert by_alias["id"] == "vector.pinecone.query"
+    by_framework = get_recipe("fastapi")
+    assert by_framework["kind"] == "middleware"
+
+
+def test_get_recipe_unknown_is_a_reported_gap():
+    result = get_recipe("cassandra")
+    assert result["gap"] is True
+    assert "cassandra" in result["reason"]
+    # Honest: it names what it knows instead of inventing a recipe.
+    assert result["known_recipes"]
+
+
+def test_generate_middleware_is_bound_to_the_given_header():
+    account_source = 'request.headers.get("X-Customer-Id")'
+    result = generate_middleware("fastapi", account_source, feature_tag="chatbot")
+    assert result["recipe_id"] == "middleware.fastapi.account"
+    assert account_source in result["code"]
+    assert "chatbot" in result["code"]
+    # The generated code parses and actually emits with_account / start_trace.
+    ast.parse(result["code"])
+    emitted = {c.name for c in emitted_tally_calls(result["code"])}
+    assert "with_account" in emitted
+    assert "start_trace" in emitted
+    assert "<FILL:" not in result["code"]  # both holes were bound
+
+
+def test_generate_middleware_without_an_answer_is_a_gap_not_a_guess():
+    result = generate_middleware("fastapi", "   ")
+    assert result["gap"] is True
+    assert "unanswered" in result["reason"]
+
+
+def test_generate_middleware_unknown_framework_is_a_gap():
+    result = generate_middleware("tornado", 'request.headers["X-Customer-Id"]')
+    assert result["gap"] is True
+    assert "tornado" in result["reason"]
+
+
+def test_instrument_call_site_adapts_the_record_call_and_autofills_count():
+    call_site = "results = index.query(vector=embedding, top_k=5)"
+    result = instrument_call_site(call_site, "vector.pinecone.query")
+    assert result["sdk_call"] == "tally.record_vector_call"
+    assert "record_vector_call" in result["emitted_calls"]
+    # top_k=5 fills the record_count hole; the index name is left to fill, never guessed.
+    assert "record_count=5" in result["code"]
+    assert "index_name" in result["holes_to_fill"]
+
+
+def test_instrument_call_site_unknown_recipe_returns_a_gap_not_a_record():
+    result = instrument_call_site("some.call()", "vector.milvus.query")
+    assert result["gap"] is True
+    assert "code" not in result  # no fabricated record emitted
+
+
+def test_instrument_call_site_on_otel_recipe_is_a_gap():
+    # The otel-ingest recipe emits config, not an SDK call: nothing to instrument.
+    result = instrument_call_site("...", "otel.ingest.gen_ai")
+    assert result["gap"] is True
+
+
+def test_explain_layer_by_name_is_grounded_on_the_sdk():
+    result = explain_layer("vector")
+    assert result["call"] == "tally.record_vector_call"
+    assert result["operation_name"] == "vector"
+    assert result["signal"] == "GenAiOperation = 'vector'"
+
+
+def test_explain_layer_by_excerpt_maps_to_a_recipe_layer():
+    result = explain_layer("index.query(vector=v, top_k=5)")
+    assert result["call"] == "tally.record_vector_call"
+    assert result.get("matched_recipe") == "vector.pinecone.query"
+
+
+def test_explain_layer_account_layer():
+    result = explain_layer("account")
+    assert result["call"] == "tally.with_account"
+    assert result["signal"] == "AccountIdHash != ''"
+
+
+def test_explain_layer_unknown_is_a_gap():
+    result = explain_layer("quantum")
+    assert result["gap"] is True
+
+
+def test_coverage_report_is_honest_and_not_fabricated():
+    result = coverage_report("tally_sk_live_deadbeef")
+    assert result["probe_available"] is False
+    statuses = {layer["status"] for layer in result["layers"]}
+    assert statuses == {"not_probed"}
+    # No layer is claimed covered without a proving span (section 7, CLAUDE.md).
+    assert all(layer["status"] != "covered" for layer in result["layers"])

--- a/sdk/python/tests/test_onboarding_mcp.py
+++ b/sdk/python/tests/test_onboarding_mcp.py
@@ -52,6 +52,42 @@ def test_detect_stack_manifest_only_still_matches():
     assert "middleware.fastapi.account" in result["matched_recipes"]
 
 
+def test_detect_stack_reports_all_web_frameworks():
+    # Two web frameworks in one stack: both must be reported, not just the alphabetically-first,
+    # and web_framework (singular) stays the first for prior callers (finding #8).
+    manifest = "django==5.0\nfastapi==0.115.0\nuvicorn==0.30.0\n"
+    result = detect_stack(manifest)
+    assert result["web_frameworks"] == ["django", "fastapi"]
+    assert result["web_framework"] == "django"
+
+
+def test_detect_stack_no_gap_when_every_web_framework_is_handled():
+    result = detect_stack(SAMPLE_MANIFEST, SAMPLE_IMPORTS)
+    assert not [g for g in result["gaps"] if g.startswith("account:")]
+
+
+def test_detect_stack_gap_names_the_unhandled_web_framework():
+    # The account gap is checked per detected framework, not "did any middleware match", so a
+    # framework whose middleware recipe was dropped is named rather than masked by another that
+    # matched (CTO-261 §4.2, finding #8). Use a catalog with only the fastapi middleware recipe so
+    # a detected flask has no recipe to match.
+    from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+
+    full = get_catalog()
+    only_fastapi = RecipeCatalog(
+        [r for r in full.recipes if r.detect.get("web_framework") != "flask"],
+        full.schema,
+    )
+    manifest = "fastapi==0.115.0\nflask==3.0.0\n"
+    imports = "from fastapi import FastAPI\nfrom flask import Flask\n"
+    result = detect_stack(manifest, imports, catalog=only_fastapi)
+    assert result["web_frameworks"] == ["fastapi", "flask"]
+    account_gaps = [g for g in result["gaps"] if g.startswith("account:")]
+    # flask is detected but unhandled and named; fastapi matched so is not in the gap.
+    assert account_gaps and "flask" in account_gaps[0]
+    assert "fastapi" not in account_gaps[0]
+
+
 def test_get_recipe_by_id_and_by_alias():
     by_id = get_recipe("vector.pinecone.query")
     assert by_id["id"] == "vector.pinecone.query"

--- a/sdk/python/tests/test_recipes.py
+++ b/sdk/python/tests/test_recipes.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Recipe catalog validation (CTO-261 sections 5.2, 5.3, 13).
+
+The anti-hallucination guard. Every recipe is validated against ``recipes/schema.json``,
+then each ``edit.template``'s emitted ``tally.*`` call is resolved against the real SDK
+public surface (the module-level convenience plus its ``delegates_to`` method) and the
+passed kwargs are bound to the real signature. A template that calls a nonexistent
+function, or passes an unknown kwarg, fails here rather than shipping a bad edit.
+"""
+
+from __future__ import annotations
+
+import jsonschema
+import pytest
+import yaml
+from onboarding_mcp.catalog import RECIPES_DIR, Recipe, load_catalog
+from onboarding_mcp.sdk_surface import SurfaceError, validate_recipe_surface
+
+CATALOG = load_catalog(RECIPES_DIR)
+
+
+def test_catalog_is_non_empty_and_covers_the_p1_stack():
+    ids = {r.id for r in CATALOG.recipes}
+    # Section 12 P1: FastAPI / Flask / Django middleware; Pinecone / Weaviate / Qdrant /
+    # pgvector vector calls; a tool and an embedding recipe; the OTel-ingest recipe.
+    expected = {
+        "middleware.fastapi.account",
+        "middleware.flask.account",
+        "middleware.django.account",
+        "vector.pinecone.query",
+        "vector.weaviate.query",
+        "vector.qdrant.search",
+        "vector.pgvector.query",
+        "tool.generic.call",
+        "embedding.generic.call",
+        "otel.ingest.gen_ai",
+    }
+    assert expected <= ids
+
+
+@pytest.mark.parametrize("recipe", CATALOG.recipes, ids=lambda r: r.id)
+def test_recipe_matches_schema(recipe: Recipe):
+    jsonschema.validate(instance=recipe.raw, schema=CATALOG.schema)
+
+
+@pytest.mark.parametrize("recipe", CATALOG.recipes, ids=lambda r: r.id)
+def test_recipe_emitted_call_resolves_against_the_real_sdk(recipe: Recipe):
+    # The core guard: resolve the emitted call, bind the kwargs to the real signature.
+    validate_recipe_surface(recipe)
+
+
+def test_index_and_files_agree():
+    index = yaml.safe_load((RECIPES_DIR / "index.yaml").read_text())
+    index_files = {entry["file"] for entry in index["recipes"]}
+    on_disk = {p.name for p in RECIPES_DIR.glob("*.yaml") if p.name != "index.yaml"}
+    assert index_files == on_disk, "every recipe file must be listed in index.yaml and vice versa"
+
+
+# --------------------------------------------------------------------------- #
+# The guard must actually reject bad recipes, not just pass the good ones.
+# --------------------------------------------------------------------------- #
+def _doc(**overrides):
+    base = {
+        "id": "vector.fake.query",
+        "kind": "vector",
+        "title": "fake",
+        "detect": {"imports": ["fake"]},
+        "sdk_surface": {
+            "call": "tally.record_vector_call",
+            "delegates_to": "tally.client.TallyClient.record_vector_call",
+            "required_args": ["provider", "index", "operation"],
+            "layer": "vector",
+        },
+        "edit": {
+            "imports_to_add": ["import tally"],
+            "template": (
+                "tally.record_vector_call(provider='fake', index='i', operation='query')\n"
+            ),
+            "placement": "after_call",
+        },
+        "verify": {"layer": "vector", "operation_name": "vector"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_guard_passes_a_well_formed_synthetic_recipe():
+    validate_recipe_surface(Recipe.from_doc(_doc()))
+
+
+def test_guard_rejects_a_nonexistent_function():
+    doc = _doc(
+        sdk_surface={
+            "call": "tally.record_bogus_call",
+            "delegates_to": None,
+            "required_args": [],
+            "layer": "vector",
+        },
+        edit={
+            "imports_to_add": ["import tally"],
+            "template": "tally.record_bogus_call(provider='fake')\n",
+            "placement": "after_call",
+        },
+    )
+    with pytest.raises(SurfaceError):
+        validate_recipe_surface(Recipe.from_doc(doc))
+
+
+def test_guard_rejects_an_unknown_kwarg():
+    doc = _doc(
+        edit={
+            "imports_to_add": ["import tally"],
+            "template": (
+                "tally.record_vector_call(provider='fake', index='i', "
+                "operation='query', bogus_kwarg=1)\n"
+            ),
+            "placement": "after_call",
+        }
+    )
+    with pytest.raises(SurfaceError):
+        validate_recipe_surface(Recipe.from_doc(doc))
+
+
+def test_guard_rejects_a_required_arg_that_is_not_a_real_parameter():
+    doc = _doc(
+        sdk_surface={
+            "call": "tally.record_vector_call",
+            "delegates_to": "tally.client.TallyClient.record_vector_call",
+            "required_args": ["provider", "not_a_real_param"],
+            "layer": "vector",
+        }
+    )
+    with pytest.raises(SurfaceError):
+        validate_recipe_surface(Recipe.from_doc(doc))
+
+
+def test_guard_rejects_a_template_that_never_emits_the_declared_call():
+    doc = _doc(
+        edit={
+            "imports_to_add": ["import tally"],
+            "template": "tally.record_tool_call(provider='fake', tool='t')\n",
+            "placement": "after_call",
+        }
+    )
+    with pytest.raises(SurfaceError):
+        validate_recipe_surface(Recipe.from_doc(doc))


### PR DESCRIPTION
## What this builds

The independent part of the Onboarding agent initiative (spec `docs/specs/initiative-onboarding-agent.md`, sections 5 and 4.2): the in-tree recipe catalog and the onboarding MCP server. Stacks on the Initiative 2 SDK PR (#263, base `feat/260-sdk-connect`), which provides `tally.init`, the module-level `record_*` convenience, and the `TallyClient` methods the recipes validate against.

### Recipe catalog (`sdk/python/recipes/`, section 5)
- `schema.json`: the recipe schema (section 5.2).
- `index.yaml` plus one machine-readable YAML recipe per common component:
  - FastAPI / Flask / Django account + feature middleware
  - Pinecone / Weaviate / Qdrant / pgvector vector calls
  - a tool-call recipe and an embedding recipe
  - the OTel-ingest recipe
- Each recipe's `sdk_surface` carries `call` (the module-level `tally.record_*` convenience form) and `delegates_to` (the `TallyClient` method it wraps), per the spec fix.

### Anti-hallucination guard (`tests/test_recipes.py`, `onboarding_mcp/sdk_surface.py`)
Validates every recipe against the schema, then **resolves the emitted call, not just a method name**: it parses each `edit.template`, finds every `tally.*(...)` call it actually emits, resolves each against the real SDK public surface, and binds the passed kwargs to the delegate's real signature (from `sdk/python/src/tally/client.py` and `context.py`). A template that calls a nonexistent function, passes an unknown kwarg, omits a required arg, or declares a bogus `required_arg` fails. Negative tests prove the guard rejects each of those.

### MCP server (`sdk/python/onboarding_mcp/`, section 4.2)
Exposes `detect_stack`, `get_recipe`, `generate_middleware`, `instrument_call_site`, and `explain_layer` over the catalog and the SDK surface; `coverage_report` is stubbed against the spec contract. Honest under uncertainty: the no-recipe path and the unanswered-account path return a reported gap, never a fabricated `record_*` call. The tools are plain importable functions; `server.py` binds them to MCP lazily, so the SDK test suite needs no MCP stack and the SDK runtime stays dependency-free (`pyyaml` / `jsonschema` are dev-only).

The server holds only recipes and generated code, never a repo.

## Follow-up (separate PR, not built here)
- The gateway per-layer coverage probe (section 7 / P3).
- The web dashboard Q&A snippet + coverage panel (section 4.1).

## CI

```
cd sdk/python && uv run --extra dev pytest -q      # 1104 passed
cd sdk/python && uv run ruff check .               # All checks passed!
```

The new suites: `tests/test_recipes.py` (schema + resolve-the-call guard, all recipes and negative cases) and `tests/test_onboarding_mcp.py` (detection on a sample FastAPI + Pinecone + openai manifest, recipe retrieval by id and alias, middleware generation bound to a given header, call-site adaptation with count autofill, and the no-recipe / unanswered-account / otel-config gap paths).

Draft: do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
