### PR TITLE
feat: Initiative 2 gateway endpoints and first-data onboarding

### DIFF
--- a/db/postgres/0030_edge_keys_watermark_index.sql
+++ b/db/postgres/0030_edge_keys_watermark_index.sql
@@ -1,0 +1,17 @@
+-- 0030_edge_keys_watermark_index.sql
+-- Edge-key delta feed supporting index (Initiative 2 §6.2 review).
+--
+-- The /v1/edge/keys feed (gateway.edge_keys.EdgeKeyStore) pages api_keys by a keyset watermark over
+-- (GREATEST(created_at, COALESCE(revoked_at, created_at)), id), filtering
+--   WHERE (watermark, id) > (cursor_wm, cursor_id)
+--     AND watermark <= now() - safe_lag
+--   ORDER BY watermark, id
+-- Without an index on that exact expression tuple every poll is a full sequential scan of api_keys
+-- plus an in-memory sort, which grows with total key count and runs every proxy refresh interval.
+-- This expression index makes each poll an index range scan in watermark/id order, so the feed reads
+-- only the changed tail. The index expression MUST match the query's watermark expression byte for
+-- byte (including COALESCE(revoked_at, created_at)) or the planner will not use it.
+--
+-- IF NOT EXISTS so replaying the whole migration set stays idempotent, matching the rest of db/postgres.
+CREATE INDEX IF NOT EXISTS idx_api_keys_edge_watermark
+    ON api_keys (GREATEST(created_at, COALESCE(revoked_at, created_at)), id);

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       # re-pulls the provider's whole window, 96 times a day per tenant per connector.
       - ../db/postgres/0028_tenant_ingest_cursors.sql:/docker-entrypoint-initdb.d/0028_tenant_ingest_cursors.sql:ro
       - ../db/postgres/0029_orgs_and_access.sql:/docker-entrypoint-initdb.d/0029_orgs_and_access.sql:ro
+      - ../db/postgres/0030_edge_keys_watermark_index.sql:/docker-entrypoint-initdb.d/0030_edge_keys_watermark_index.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -136,7 +136,9 @@ from gateway.tenant_api_keys import (
     TenantNotFound as ApiKeyTenantNotFound,
 )
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
-from gateway.tenant_provisioning import ProvisionError, TenantProvisioner
+from gateway.edge_keys import EdgeKeyStore
+from gateway.tenant_hmac_key import HmacKeyUnavailableError, TenantHmacKeyStore
+from gateway.tenant_provisioning import LocalDevKeyProvider, ProvisionError, TenantProvisioner
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
 from gateway.tenant_identity import TenantIdentityResolver
@@ -349,8 +351,17 @@ async def lifespan(app: FastAPI):
     # Organizations, users & access (Initiative 1). Provisioning turns a Clerk org into a tenant with
     # its own per-org HMAC key reference; the keys store is self-serve ingest-key management. Both go
     # through the service-token-authed control plane; the web server is their only caller.
-    app.state.tenant_provisioner = TenantProvisioner(settings)
+    # One key provider shared by the provisioner and the HMAC bootstrap store (Initiative 2, §3.2):
+    # the provisioner mints a per-org HMAC key set into tenants.hash_salt_kek_ref and the bootstrap
+    # store reads the active material back through the SAME provider, so a tenant provisioned in this
+    # process resolves to the very bytes minted for it. Prod backs this with KMS/Secret Manager.
+    hmac_key_provider = LocalDevKeyProvider()
+    app.state.tenant_provisioner = TenantProvisioner(settings, key_provider=hmac_key_provider)
     app.state.tenant_api_keys = TenantApiKeyStore(settings)
+    # Initiative 2: the SDK's in-process HMAC bootstrap (GET /v1/tenant/hmac-key, §3.2) and the edge
+    # proxy's key-cache delta feed (GET /v1/edge/keys, §6.2).
+    app.state.tenant_hmac_keys = TenantHmacKeyStore(settings, hmac_key_provider)
+    app.state.edge_keys = EdgeKeyStore(settings)
     # In-process dedup set for Stripe webhook redeliveries. ClickHouse's ReplacingMergeTree
     # will collapse late duplicates at merge time, but this short-circuits the second insert
     # so the 200 stays well under Stripe's 30s timeout window.
@@ -2001,6 +2012,74 @@ def revoke_tenant_key(
     except ApiKeyTenantNotFound as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return Response(status_code=204)
+
+
+@app.get("/v1/tenant/hmac-key")
+def get_tenant_hmac_key(
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    """Return the caller tenant's active HMAC key material + version (Initiative 2, §3.2).
+
+    Authenticated by the INGEST KEY itself (``ApiKeyAuth.authenticate``), not the service token: the
+    SDK holds no service token, and the key is tenant-bound, so one org can never fetch another's key
+    material (the tenant is the key's tenant, there is no ``x-tenant-id`` input). A ``write`` or
+    ``admin`` scope is REQUIRED, never ``read``: this hands back hashing key material, so a read-only
+    key (which may be handed to less-trusted readers) must not unlock it. Auth runs independent of
+    ``require_api_key``: this endpoint always demands a valid key, because there is no other way to
+    know the tenant and the material is sensitive.
+
+    The response body carries the tenant's active symmetric HMAC key. It is TREATED AS A SECRET: the
+    gateway logs no response bodies, it is never placed on a span, and it is served TLS-only in the
+    hosted deployment. It is the tenant's own key, delivered only to a process already holding that
+    tenant's ingest key, used only to hash that tenant's own account/user ids in that process. It is
+    never a KEK, never a raw provider credential, never another tenant's key (§3.2).
+    """
+    auth: ApiKeyAuth = app.state.auth
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise _error(401, ErrorCode.UNAUTHENTICATED, "missing bearer token")
+    token = authorization.split(" ", 1)[1].strip()
+    result = auth.authenticate(token)
+    if result is None:
+        raise _error(401, ErrorCode.UNAUTHENTICATED, "invalid or revoked api key")
+    if not result.can_write:
+        # A read-only key authenticates but must not unlock key material (spec §3.2, WRITE_SCOPES).
+        raise _error(403, ErrorCode.FORBIDDEN_SCOPE, f"scope '{result.scope}' cannot fetch hmac key material")
+    store: TenantHmacKeyStore = app.state.tenant_hmac_keys
+    if store.export_disabled(result.tenant_id):
+        # Per-tenant kill switch (spec §12 Q1). Default-on today; the check is wired so a
+        # high-security tenant can be pinned proxy-only without an endpoint change.
+        raise _error(403, ErrorCode.HMAC_EXPORT_DISABLED, "hmac key export is disabled for this tenant")
+    try:
+        material = store.active_key(result.tenant_id)
+    except HmacKeyUnavailableError as exc:
+        # Honest under uncertainty: no fabricated bytes. The SDK degrades to unattributed (§3.3).
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    # No log line here: the only interesting thing to report is the material, which must not be
+    # recorded. The access log may keep the request line; the body never appears in a log.
+    return JSONResponse(material.as_dict(), status_code=200)
+
+
+@app.get("/v1/edge/keys")
+def get_edge_keys(
+    since: str | None = None,
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    """Delta feed of api-key changes for the edge proxy's key cache (Initiative 2, §6.2).
+
+    Authenticated by the ``GATEWAY_SERVICE_TOKEN`` gate (Initiative 1, §6): the proxy is a server,
+    not a tenant, and holds no human session. Returns ``{changes, cursor}`` where each change is
+    ``{key_hash, tenant_id, scope, revoked_at}`` (metadata only, never a raw or reversible token) and
+    ``cursor`` is a monotonic watermark the proxy persists and passes back as ``?since=`` next tick.
+    An empty cursor pages the full active set once (cold start); the steady state ships only what
+    changed. Revoked keys arrive with ``revoked_at`` set so the proxy drops them within one refresh
+    interval.
+    """
+    _require_service_token(authorization)
+    store: EdgeKeyStore = app.state.edge_keys
+    changes, cursor = store.changes_since(since)
+    return JSONResponse(
+        {"changes": [c.as_dict() for c in changes], "cursor": cursor}, status_code=200
+    )
 
 
 @app.post("/v1/stripe/webhook")

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -138,7 +138,7 @@ from gateway.tenant_api_keys import (
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.edge_keys import EdgeKeyStore
 from gateway.tenant_hmac_key import HmacKeyUnavailableError, TenantHmacKeyStore
-from gateway.tenant_provisioning import LocalDevKeyProvider, ProvisionError, TenantProvisioner
+from gateway.tenant_provisioning import ProvisionError, TenantProvisioner, build_key_provider
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
 from gateway.tenant_identity import TenantIdentityResolver
@@ -362,8 +362,10 @@ async def lifespan(app: FastAPI):
     # One key provider shared by the provisioner and the HMAC bootstrap store (Initiative 2, §3.2):
     # the provisioner mints a per-org HMAC key set into tenants.hash_salt_kek_ref and the bootstrap
     # store reads the active material back through the SAME provider, so a tenant provisioned in this
-    # process resolves to the very bytes minted for it. Prod backs this with KMS/Secret Manager.
-    hmac_key_provider = LocalDevKeyProvider()
+    # process resolves to the very bytes minted for it. Settings-selectable (TALLY_HMAC_KEY_PROVIDER):
+    # the default 'local' provider derives material deterministically from the durable reference, so a
+    # provisioned tenant's hmac-key survives a gateway restart; prod selects KMS / Secret Manager.
+    hmac_key_provider = build_key_provider(settings)
     app.state.tenant_provisioner = TenantProvisioner(settings, key_provider=hmac_key_provider)
     app.state.tenant_api_keys = TenantApiKeyStore(settings)
     # Initiative 2: the SDK's in-process HMAC bootstrap (GET /v1/tenant/hmac-key, §3.2) and the edge

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -31,6 +31,21 @@ class Settings(BaseSettings):
     # must carry `Authorization: Bearer <key>` whose SHA-256 is registered in api_keys.
     require_api_key: bool = False
 
+    # Per-org HMAC key-material provider (Initiative 2, §3.2). Selects HOW the provisioner mints, and
+    # the /v1/tenant/hmac-key bootstrap reads back, a tenant's active HMAC key set:
+    #   * ``local`` (default): dev provider with NO cloud dependency. The material is DERIVED
+    #     deterministically from the durable reference stored in ``tenants.hash_salt_kek_ref`` and the
+    #     root secret below, so a tenant provisioned before a gateway restart still resolves to the
+    #     same bytes afterwards (the old in-memory-only provider 404'd the hmac-key after a restart).
+    #   * ``kms`` / ``secret-manager``: the production seam, backed by KMS / Secret Manager. Selectable
+    #     here so a deployment can turn it on; the concrete client is wired by the deployment (the raw
+    #     key set is never persisted to Postgres, only its reference is).
+    hmac_key_provider: str = "local"
+    # Dev-only root secret the ``local`` provider derives per-tenant HMAC material from. Deterministic
+    # across restarts (that is the point), so it must be overridden in any shared/staging environment
+    # and is NEVER used by the ``kms`` provider. Not a production key.
+    hmac_local_root_secret: str = "tally-local-dev-hmac-root-secret-do-not-use-in-prod"
+
     # Control-plane service token (Initiative 1, §6). The web server is the ONLY legitimate caller of
     # the control-plane endpoints (`/v1/tenant/*`); it authenticates with this server-only shared
     # secret as `Authorization: Bearer <token>` and passes the resolved tenant UUID in `x-tenant-id`.
@@ -41,6 +56,17 @@ class Settings(BaseSettings):
 
     # Idempotency window (seconds) for (tenant_id, batch_id) dedup.
     idempotency_ttl_s: int = 24 * 3600
+
+    # Edge-key delta feed safe-lag window, in seconds (Initiative 2 §6.2 review). The /v1/edge/keys
+    # cursor is a keyset watermark over (GREATEST(created_at, revoked_at), id). created_at/revoked_at
+    # are stamped at statement time, not commit time, so a slow transaction can commit a row whose
+    # watermark is BELOW a cursor a later-but-faster commit already advanced past, and that row would
+    # be skipped forever. The feed therefore refuses to advance the cursor past `now() - this margin`,
+    # so any transaction that commits within the margin is still picked up on a later poll. Size it
+    # above the longest expected api_keys write transaction plus app<->DB clock skew; a few seconds is
+    # ample for single-row inserts/revokes. The cost is that a brand-new key takes up to this long to
+    # appear in the feed, which is well within the proxy's refresh budget.
+    edge_key_safe_lag_seconds: float = 5.0
 
     # Per-tenant rate limit (token bucket) + monthly span quota (CTO-33). Process-local enforcement;
     # cluster-wide fairness is a later concern (CTO-30). Defaults are generous for local dev.

--- a/infra/gateway/src/gateway/edge_keys.py
+++ b/infra/gateway/src/gateway/edge_keys.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Delta feed of api-key changes for the edge proxy's local cache (Initiative 2, §6.2).
+
+WHY this exists. The hosted proxy resolves a real ``X-Tenant-Key`` (``tally_sk_live_...``) to a
+tenant UUID on every request, and must do it without a per-request gateway round-trip to hold its
+p99 < 3ms budget. So it keeps an in-memory ``sha256(key) -> {tenant_uuid, scope, revoked}`` map and
+refreshes it by polling this endpoint. This module is the gateway half: it returns the key-hash to
+tenant/scope changes (creations and revocations) since a caller-held cursor.
+
+DELTA, NOT DUMP. The feed is incremental so it scales as tenants and keys grow: the steady state
+ships only what changed since ``cursor``; a cold start (empty cursor) pages the full set once. The
+cursor is a monotonic keyset watermark over ``(greatest(created_at, revoked_at), id)``. A revoke
+stamps ``revoked_at = now()``, which raises the row's watermark above any prior cursor, so the row
+reappears in the feed with its ``revoked_at`` set and the proxy drops it: revocation propagates
+within one refresh interval, the proxy-path revocation SLA (spec §6.2). Keyset pagination on the
+compound ``(watermark, id)`` means no row is skipped when two share a watermark, and delta
+application at the proxy is idempotent, so a boundary re-send is harmless.
+
+METADATA ONLY. Every change carries ``key_hash`` (the SHA-256 hex already stored, never reversible),
+``tenant_id``, ``scope`` and ``revoked_at``. Never a raw or reversible token, never ``token_prefix``
+(Initiative 1 §11). The proxy computes ``sha256`` of the presented key with the same transform
+(``gateway.auth.hash_key``) and looks it up locally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import psycopg
+
+#: The row's change watermark: the later of creation and revocation. A live key sits at its
+#: ``created_at``; a revoked key rises to its ``revoked_at`` so the revoke re-enters the feed.
+_WATERMARK_SQL = "GREATEST(created_at, COALESCE(revoked_at, created_at))"
+
+#: Max changes returned per call. The proxy pages with the returned cursor until a short page. Large
+#: enough that a cold start is a handful of round-trips, bounded so one call is never unbounded.
+DEFAULT_LIMIT = 1000
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+#: The all-zero UUID: the low bound of the id tiebreak, so an empty cursor pages from the very start.
+_ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+@dataclass(frozen=True, slots=True)
+class KeyChange:
+    """One key's current metadata. Deliberately carries no token or reversible material."""
+
+    key_hash: str
+    tenant_id: str
+    scope: str
+    revoked_at: datetime | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "key_hash": self.key_hash,
+            "tenant_id": self.tenant_id,
+            "scope": self.scope,
+            # null means live; a timestamp means revoked. The proxy drops any row with a timestamp.
+            "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+        }
+
+
+def _encode_cursor(watermark: datetime, key_id: str) -> str:
+    """Encode ``(watermark, id)`` as an opaque ``<epoch_micros>:<id>`` string."""
+    micros = int((watermark - _EPOCH) // timedelta(microseconds=1))
+    return f"{micros}:{key_id}"
+
+
+def _decode_cursor(cursor: str | None) -> tuple[datetime, str]:
+    """Decode a cursor into ``(watermark, id)``. An absent or malformed cursor starts from the top.
+
+    A malformed cursor degrades to a cold start rather than raising: the proxy re-pages the full set
+    (idempotent) instead of the feed 500-ing on a bad watermark.
+    """
+    if not cursor:
+        return _EPOCH, _ZERO_UUID
+    micros_str, _, key_id = cursor.partition(":")
+    if not micros_str.isdigit() or not key_id:
+        return _EPOCH, _ZERO_UUID
+    return _EPOCH + timedelta(microseconds=int(micros_str)), key_id
+
+
+class EdgeKeyStore:
+    """Postgres-backed delta feed over ``api_keys`` for the edge proxy's key cache."""
+
+    def __init__(self, settings, *, limit: int = DEFAULT_LIMIT) -> None:
+        self._dsn = settings.postgres_dsn
+        self._limit = limit
+
+    def changes_since(self, cursor: str | None) -> tuple[list[KeyChange], str]:
+        """Return ``(changes, next_cursor)`` for key rows changed since ``cursor``.
+
+        ``next_cursor`` advances to the last row's watermark when anything is returned, and is the
+        input cursor unchanged when nothing changed (so a steady-state poll ships an empty list and
+        the same cursor).
+        """
+        after_wm, after_id = _decode_cursor(cursor)
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT key_hash, tenant_id, scope, revoked_at, {_WATERMARK_SQL} AS wm, id
+                FROM api_keys
+                WHERE ({_WATERMARK_SQL}, id) > (%s, %s)
+                ORDER BY wm, id
+                LIMIT %s
+                """,
+                (after_wm, after_id, self._limit),
+            )
+            rows = cur.fetchall()
+        if not rows:
+            # Nothing changed: echo the caller's cursor (normalized empty -> "") so it can persist it.
+            return [], (cursor or "")
+        changes = [
+            KeyChange(
+                key_hash=str(row[0]),
+                tenant_id=str(row[1]),
+                scope=str(row[2]),
+                revoked_at=row[3],
+            )
+            for row in rows
+        ]
+        last = rows[-1]
+        return changes, _encode_cursor(last[4], str(last[5]))

--- a/infra/gateway/src/gateway/edge_keys.py
+++ b/infra/gateway/src/gateway/edge_keys.py
@@ -16,6 +16,16 @@ within one refresh interval, the proxy-path revocation SLA (spec §6.2). Keyset 
 compound ``(watermark, id)`` means no row is skipped when two share a watermark, and delta
 application at the proxy is idempotent, so a boundary re-send is harmless.
 
+SAFE-LAG WINDOW (Initiative 2 §6.2 review). ``created_at`` / ``revoked_at`` are stamped at statement
+time, NOT commit time, so a slow transaction can commit a row whose watermark is BELOW a cursor that
+a later-but-faster commit already advanced past. Under plain keyset pagination that row is invisible
+forever (its watermark is not ``> cursor``), so the proxy never caches the key and the customer's
+first proxy events never land. A monotonic sequence would not help: a sequence value is also assigned
+before commit, so it can commit out of order the same way. The fix is time-based: the feed never
+returns (and so never advances the cursor past) a row whose watermark is newer than ``now() - lag``.
+Any transaction that commits within ``lag`` is therefore still ahead of the cursor on the next poll
+and gets picked up. See ``Settings.edge_key_safe_lag_seconds`` for how the margin is sized.
+
 METADATA ONLY. Every change carries ``key_hash`` (the SHA-256 hex already stored, never reversible),
 ``tenant_id``, ``scope`` and ``revoked_at``. Never a raw or reversible token, never ``token_prefix``
 (Initiative 1 §11). The proxy computes ``sha256`` of the presented key with the same transform
@@ -87,6 +97,10 @@ class EdgeKeyStore:
     def __init__(self, settings, *, limit: int = DEFAULT_LIMIT) -> None:
         self._dsn = settings.postgres_dsn
         self._limit = limit
+        # Safe-lag margin (seconds): the feed never advances the cursor past ``now() - this``, so a
+        # row committed out of watermark order (a slow transaction) is still picked up on a later
+        # poll. See the module docstring and Settings.edge_key_safe_lag_seconds.
+        self._safe_lag_seconds = float(getattr(settings, "edge_key_safe_lag_seconds", 5.0))
 
     def changes_since(self, cursor: str | None) -> tuple[list[KeyChange], str]:
         """Return ``(changes, next_cursor)`` for key rows changed since ``cursor``.
@@ -94,6 +108,10 @@ class EdgeKeyStore:
         ``next_cursor`` advances to the last row's watermark when anything is returned, and is the
         input cursor unchanged when nothing changed (so a steady-state poll ships an empty list and
         the same cursor).
+
+        Only rows whose watermark is at least ``edge_key_safe_lag_seconds`` old (per the DATABASE
+        clock, not the app's) are eligible, so a row that commits out of watermark order within the
+        lag window is never stranded below an already-advanced cursor.
         """
         after_wm, after_id = _decode_cursor(cursor)
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
@@ -102,10 +120,11 @@ class EdgeKeyStore:
                 SELECT key_hash, tenant_id, scope, revoked_at, {_WATERMARK_SQL} AS wm, id
                 FROM api_keys
                 WHERE ({_WATERMARK_SQL}, id) > (%s, %s)
+                  AND {_WATERMARK_SQL} <= now() - make_interval(secs => %s)
                 ORDER BY wm, id
                 LIMIT %s
                 """,
-                (after_wm, after_id, self._limit),
+                (after_wm, after_id, self._safe_lag_seconds, self._limit),
             )
             rows = cur.fetchall()
         if not rows:

--- a/infra/gateway/src/gateway/errors.py
+++ b/infra/gateway/src/gateway/errors.py
@@ -15,6 +15,7 @@ class ErrorCode(str, Enum):
     UNAUTHENTICATED = "UNAUTHENTICATED"        # missing/invalid/revoked bearer key
     FORBIDDEN_SCOPE = "FORBIDDEN_SCOPE"        # key lacks the scope for this operation
     TENANT_MISMATCH = "TENANT_MISMATCH"        # body claims a tenant the key isn't bound to
+    HMAC_EXPORT_DISABLED = "HMAC_EXPORT_DISABLED"  # per-tenant policy forbids HMAC key export (Init 2 §3.2)
     QUOTA_EXCEEDED = "QUOTA_EXCEEDED"          # monthly tenant quota spent
     RATE_LIMITED = "RATE_LIMITED"              # short-term per-tenant rate cap hit
 

--- a/infra/gateway/src/gateway/tenant_hmac_key.py
+++ b/infra/gateway/src/gateway/tenant_hmac_key.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serve a tenant's active HMAC key material for in-process hashing (Initiative 2, §3.2).
+
+WHY this exists. The SDK's one-line ``tally.init(key)`` needs to hash account and user ids inside
+the customer process so a raw id never leaves it (CLAUDE.md: identifiers by hash). To hash, it needs
+the tenant's active HMAC key material and its version. This module is the gateway half of the
+``GET /v1/tenant/hmac-key`` bootstrap: it resolves the caller's tenant onto ``tenants.id``, reads the
+per-org HMAC key reference Initiative 1 provisioned into ``tenants.hash_salt_kek_ref``, and returns
+the active key bytes (base64) plus the version parsed from that reference.
+
+WHAT IT IS NOT. It is not a general KMS proxy. It returns exactly one tenant's one active symmetric
+key, resolved through the same :class:`gateway.tenant_provisioning.KeyMaterialProvider` seam that
+minted it. It never returns a KEK, never another tenant's key, never a raw provider credential. The
+endpoint gates on the caller's own ingest key with a ``write``/``admin`` scope and is TLS-only, so
+the exported bytes only ever reach a process already holding that tenant's ingest key (spec §3.2).
+
+THE VERSION. The reference carries a trailing version selector (``.../v1``, see
+``tenant_provisioning._LOCAL_KEK_SCHEME``). We surface it as ``key_version`` so the SDK stamps new
+spans with the active version and a server-side rotation (a higher version on a later fetch) is
+carried forward without orphaning historical hashes (spec §3.2, Option B rotation).
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+
+import psycopg
+
+from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
+
+#: Re-exported so a caller catching a store failure catches one name (matches the sibling stores).
+TenantNotFound = TenantNotFoundError
+
+#: The only algorithm this endpoint speaks. Named on the wire so the SDK need not assume it.
+ALGORITHM = "HMAC-SHA256"
+
+#: Default version when a reference carries no explicit ``v<n>`` selector. The provisioner always
+#: appends one, so this only backstops a hand-written or legacy reference.
+_DEFAULT_VERSION = "v1"
+
+
+class HmacKeyUnavailableError(RuntimeError):
+    """The tenant resolves but its active HMAC material cannot be produced.
+
+    Honest under uncertainty: the endpoint turns this into a 404 rather than returning fabricated
+    bytes. In local dev this is the normal state for a tenant whose material was minted in a prior
+    process (the local key provider holds material in memory only); the SDK then degrades to
+    unattributed accounts, never a raw id (spec §3.3).
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class HmacKeyMaterial:
+    """One tenant's active HMAC key material and version. Sensitive: never log ``key_material_b64``."""
+
+    tenant_id: str
+    key_version: str
+    key_material_b64: str
+    algorithm: str = ALGORITHM
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tenant_id": self.tenant_id,
+            "key_version": self.key_version,
+            "key_material_b64": self.key_material_b64,
+            "algorithm": self.algorithm,
+        }
+
+
+def _version_from_ref(ref: str) -> str:
+    """Parse the trailing ``v<n>`` selector from a key reference (``local://hmac/<uuid>/v1``)."""
+    tail = ref.rstrip("/").rsplit("/", 1)[-1]
+    if tail.startswith("v") and tail[1:].isdigit():
+        return tail
+    return _DEFAULT_VERSION
+
+
+class TenantHmacKeyStore:
+    """Reads a tenant's active HMAC key material through the provisioning key-provider seam.
+
+    The store shares the SAME :class:`KeyMaterialProvider` instance the provisioner mints into, so a
+    tenant provisioned in this process resolves to the very bytes that were minted for it. Every
+    method resolves the caller's tenant onto ``tenants.id`` first, so the SQL never crosses tenants.
+    """
+
+    def __init__(self, settings, key_provider) -> None:
+        self._dsn = settings.postgres_dsn
+        self._keys = key_provider
+
+    def export_disabled(self, tenant_id: str) -> bool:
+        """Per-tenant HMAC-export kill switch (spec §12 Q1).
+
+        Wired now, default-on (returns False for every tenant), so the highest-security tenants can
+        later be pinned proxy-only (no client-side hashing) by flipping this without touching the
+        endpoint. The seam exists deliberately even though nothing flips it yet: the blast radius of
+        exporting key material (spec §3.2) is exactly what such a flag would contain.
+        """
+        return False
+
+    def active_key(self, tenant_id: str) -> HmacKeyMaterial:
+        """Return the caller tenant's active HMAC key material + version.
+
+        Raises :class:`TenantNotFoundError` when the identifier resolves to no tenant and
+        :class:`HmacKeyUnavailableError` when the tenant has no usable material.
+        """
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute("SELECT hash_salt_kek_ref FROM tenants WHERE id = %s", (resolved,))
+            row = cur.fetchone()
+        if row is None or not row[0]:
+            raise HmacKeyUnavailableError(f"tenant {resolved} has no HMAC key reference")
+        ref = str(row[0])
+        try:
+            material = self._keys.material(ref)
+        except KeyError as exc:
+            raise HmacKeyUnavailableError(
+                f"active HMAC material for tenant {resolved} is unavailable"
+            ) from exc
+        return HmacKeyMaterial(
+            tenant_id=resolved,
+            key_version=_version_from_ref(ref),
+            key_material_b64=base64.b64encode(material).decode("ascii"),
+        )

--- a/infra/gateway/src/gateway/tenant_provisioning.py
+++ b/infra/gateway/src/gateway/tenant_provisioning.py
@@ -24,7 +24,8 @@ THE TWO INVARIANTS THIS MODULE HOLDS.
 
 from __future__ import annotations
 
-import secrets
+import hashlib
+import hmac
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -74,45 +75,105 @@ class KeyMaterialProvider(Protocol):
 class LocalDevKeyProvider:
     """Local-dev HMAC key provider: no cloud KMS, no cloud dependency for ``make up``.
 
-    Generates a 256-bit random key set from a CSPRNG, holds the material in-process keyed by its
-    reference, and returns a reference string that satisfies the ``no_raw_secret`` CHECK. ``delete``
-    removes the material so a lost provision race cleans up its orphaned key set. This is the local
-    analog of Secret Manager / KMS; the raw bytes never touch Postgres or a log.
+    DURABLE ACROSS RESTARTS (Initiative 2 §3.2 review). The material is DERIVED deterministically from
+    the durable reference (``tenants.hash_salt_kek_ref``) and a process root secret, so a tenant
+    provisioned before a restart resolves to the SAME bytes afterwards. The previous version held the
+    bytes in an in-process dict only, so ``GET /v1/tenant/hmac-key`` 404'd for a durably-provisioned
+    tenant after any gateway restart. Deriving from the stored reference removes that failure without
+    persisting raw key material anywhere: the reference is durable, the root secret is config, and the
+    32-byte key set is HMAC-SHA256(root, ref). This is the local analog of Secret Manager / KMS; the
+    raw bytes never touch Postgres or a log.
+
+    ``mint`` still returns a fresh, unique reference, so distinct tenants derive distinct material.
+    ``delete`` / ``has`` track a minted-set purely for the provisioner's orphan-cleanup bookkeeping on
+    a lost race; they do NOT gate ``material``, which derives from the reference alone so it survives a
+    restart that empties the set.
     """
 
-    _material: dict[str, bytes] = field(default_factory=dict)
+    #: Root secret material is derived under. Deterministic across restarts by design (dev-only).
+    root_secret: bytes = b"tally-local-dev-hmac-root-secret-do-not-use-in-prod"
+    _minted: set[str] = field(default_factory=set)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
     def mint(self) -> str:
-        material = secrets.token_bytes(32)  # 256-bit key set from a CSPRNG (§4.1)
         ref = f"{_LOCAL_KEK_SCHEME}://hmac/{uuid.uuid4()}/v1"
         with self._lock:
-            self._material[ref] = material
+            self._minted.add(ref)
         return ref
 
     def delete(self, ref: str) -> None:
         with self._lock:
-            self._material.pop(ref, None)
+            self._minted.discard(ref)
 
     def has(self, ref: str) -> bool:
-        """Whether a reference still resolves to material. For orphan-cleanup tests."""
-        with self._lock:
-            return ref in self._material
+        """Whether this process minted ``ref`` and has not deleted it. For orphan-cleanup tests.
 
-    def material(self, ref: str) -> bytes:
-        """Return the active key bytes for ``ref``, or raise ``KeyError`` when it is not held.
-
-        The bytes are the tenant's own active HMAC key set. They are handed only to the HMAC
-        bootstrap endpoint under the tenant's own ingest key (spec §3.2) and are never logged. A ref
-        this process never minted (for example the seeded ``local-dev`` key, or any tenant minted in
-        a prior process) is a miss, not a fabricated key: the endpoint turns that into an honest
-        "material unavailable" rather than returning bytes that would hash to nothing real.
+        Note this is bookkeeping, NOT material availability: ``material`` derives from the reference
+        and so resolves any well-formed reference, including one minted in a prior process.
         """
         with self._lock:
-            material = self._material.get(ref)
-        if material is None:
-            raise KeyError(f"no key material held for reference {ref!r}")
-        return material
+            return ref in self._minted
+
+    def material(self, ref: str) -> bytes:
+        """Return the active key bytes for ``ref``, derived deterministically from the root secret.
+
+        The bytes are the tenant's own active HMAC key set. They are handed only to the HMAC
+        bootstrap endpoint under the tenant's own ingest key (spec §3.2) and are never logged. Because
+        the material is HMAC-SHA256(root, ref), a durably-stored reference (the seeded ``local-dev``
+        key, or any tenant provisioned in a prior process) resolves to the same 32 bytes after a
+        restart, rather than 404-ing. An empty reference is still a miss (``KeyError``): there is no
+        material to derive from nothing.
+        """
+        if not ref:
+            raise KeyError("no key material for an empty reference")
+        return hmac.new(self.root_secret, ref.encode("utf-8"), hashlib.sha256).digest()
+
+
+class SecretManagerKeyProvider:
+    """Production HMAC key provider seam, backed by KMS / Secret Manager (Initiative 2 §3.2).
+
+    This is the prod path selected by ``TALLY_HMAC_KEY_PROVIDER=kms``. The raw key set lives in the
+    cloud secret store; only its resource reference is persisted to ``tenants.hash_salt_kek_ref``, and
+    ``material`` fetches the active version back through the cloud client. The concrete client is
+    supplied by the deployment (Workload Identity / IAM, never a raw credential in config), so it is
+    injected rather than constructed here; selecting this provider without wiring a client fails fast
+    instead of silently falling back to dev-derived material.
+    """
+
+    def __init__(self, client: object | None = None) -> None:
+        if client is None:
+            raise ProvisionError(
+                "hmac_key_provider='kms' selected but no Secret Manager / KMS client was wired. "
+                "Inject the deployment's client; do not fall back to the local dev provider in prod."
+            )
+        self._client = client
+
+    def mint(self) -> str:  # pragma: no cover - exercised only in a cloud deployment
+        raise NotImplementedError("wire the deployment's Secret Manager / KMS client")
+
+    def delete(self, ref: str) -> None:  # pragma: no cover - cloud-only
+        raise NotImplementedError("wire the deployment's Secret Manager / KMS client")
+
+    def material(self, ref: str) -> bytes:  # pragma: no cover - cloud-only
+        raise NotImplementedError("wire the deployment's Secret Manager / KMS client")
+
+
+def build_key_provider(settings: Settings) -> KeyMaterialProvider:
+    """Select the HMAC key-material provider from settings (Initiative 2 §3.2 review).
+
+    ``local`` (default) returns the restart-durable dev provider; ``kms`` / ``secret-manager`` selects
+    the production seam. An unknown value fails fast rather than guessing, so a typo in a prod
+    deployment cannot silently drop to dev-derived material.
+    """
+    choice = (getattr(settings, "hmac_key_provider", "local") or "local").strip().lower()
+    if choice == "local":
+        root = getattr(settings, "hmac_local_root_secret", "") or ""
+        return LocalDevKeyProvider(root_secret=root.encode("utf-8"))
+    if choice in ("kms", "secret-manager", "secretmanager"):
+        # The concrete client is injected by the deployment (see SecretManagerKeyProvider); this
+        # factory does not construct cloud credentials.
+        return SecretManagerKeyProvider()
+    raise ProvisionError(f"unknown hmac_key_provider {choice!r} (expected 'local' or 'kms')")
 
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/src/gateway/tenant_provisioning.py
+++ b/infra/gateway/src/gateway/tenant_provisioning.py
@@ -55,11 +55,19 @@ class KeyMaterialProvider(Protocol):
     Production backs this with Secret Manager / KMS and returns its resource reference; local dev
     uses :class:`LocalDevKeyProvider`. The application never persists raw key material to Postgres:
     only the reference is stored, in ``tenants.hash_salt_kek_ref``.
+
+    ``material`` resolves a reference back to the active key bytes. It is the seam the Initiative 2
+    HMAC bootstrap (``GET /v1/tenant/hmac-key``, spec §3.2) reads through so the SDK can hash account
+    and user ids in the customer process. In prod that is a KMS/Secret Manager fetch; here it is the
+    in-process map below. It returns one tenant's active symmetric key only, never a KEK and never
+    another tenant's material.
     """
 
     def mint(self) -> str: ...
 
     def delete(self, ref: str) -> None: ...
+
+    def material(self, ref: str) -> bytes: ...
 
 
 @dataclass
@@ -90,6 +98,21 @@ class LocalDevKeyProvider:
         """Whether a reference still resolves to material. For orphan-cleanup tests."""
         with self._lock:
             return ref in self._material
+
+    def material(self, ref: str) -> bytes:
+        """Return the active key bytes for ``ref``, or raise ``KeyError`` when it is not held.
+
+        The bytes are the tenant's own active HMAC key set. They are handed only to the HMAC
+        bootstrap endpoint under the tenant's own ingest key (spec §3.2) and are never logged. A ref
+        this process never minted (for example the seeded ``local-dev`` key, or any tenant minted in
+        a prior process) is a miss, not a fabricated key: the endpoint turns that into an honest
+        "material unavailable" rather than returning bytes that would hash to nothing real.
+        """
+        with self._lock:
+            material = self._material.get(ref)
+        if material is None:
+            raise KeyError(f"no key material held for reference {ref!r}")
+        return material
 
 
 @dataclass(frozen=True, slots=True)

--- a/infra/gateway/tests/test_app_hmac_and_edge_keys.py
+++ b/infra/gateway/tests/test_app_hmac_and_edge_keys.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Initiative 2 gateway endpoints: GET /v1/tenant/hmac-key and GET /v1/edge/keys.
+
+These use ``TestClient`` with in-memory fakes injected into ``app.state`` so no Postgres is needed,
+matching ``test_app_orgs_access.py``. They assert the contracts the task calls out:
+
+* hmac-key: write/admin scope required (read is 403), tenant isolation (the key's tenant decides),
+  and one tenant never receives another tenant's material.
+* edge/keys: the delta advances by cursor, the payload is metadata-only (never a raw token), and the
+  service-token gate protects it.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.auth import AuthResult
+from gateway.edge_keys import KeyChange
+from gateway.tenant_hmac_key import HmacKeyMaterial, HmacKeyUnavailableError
+
+SERVICE_TOKEN = "svc-secret-token"
+TENANT_A = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+TENANT_B = "1d2e3f4a-5b6c-7d8e-9f01-234567890abc"
+
+
+class FakeAuth:
+    """Maps a token to an :class:`AuthResult`. Unknown token -> None (invalid key)."""
+
+    def __init__(self, tokens: dict[str, AuthResult]) -> None:
+        self._tokens = tokens
+
+    def authenticate(self, token: str) -> AuthResult | None:
+        return self._tokens.get(token)
+
+
+class FakeHmacStore:
+    """Serves per-tenant material and honors the export kill switch, without Postgres."""
+
+    def __init__(self) -> None:
+        self._material = {
+            TENANT_A: b"AAAA-tenant-a-key-bytes-000000000",
+            TENANT_B: b"BBBB-tenant-b-key-bytes-111111111",
+        }
+        self.disabled: set[str] = set()
+
+    def export_disabled(self, tenant_id: str) -> bool:
+        return tenant_id in self.disabled
+
+    def active_key(self, tenant_id: str) -> HmacKeyMaterial:
+        material = self._material.get(tenant_id)
+        if material is None:
+            raise HmacKeyUnavailableError(f"tenant {tenant_id} has no HMAC key reference")
+        return HmacKeyMaterial(
+            tenant_id=tenant_id,
+            key_version="v1",
+            key_material_b64=base64.b64encode(material).decode("ascii"),
+        )
+
+
+class FakeEdgeStore:
+    """A tiny in-memory delta feed: an ordered list of (cursor, change) entries."""
+
+    def __init__(self) -> None:
+        # (watermark index, KeyChange). Cursor is the string index of the last delivered row.
+        self._rows: list[KeyChange] = []
+
+    def add(self, change: KeyChange) -> None:
+        self._rows.append(change)
+
+    def changes_since(self, cursor: str | None) -> tuple[list[KeyChange], str]:
+        start = int(cursor) if cursor and cursor.isdigit() else 0
+        rows = self._rows[start:]
+        if not rows:
+            return [], (cursor or "")
+        return rows, str(len(self._rows))
+
+
+@contextmanager
+def _client(
+    *,
+    auth_on: bool,
+    tokens: dict[str, AuthResult] | None = None,
+    hmac: FakeHmacStore | None = None,
+    edge: FakeEdgeStore | None = None,
+) -> Iterator[tuple[TestClient, FakeHmacStore, FakeEdgeStore]]:
+    with TestClient(app) as client:
+        # Snapshot the global app.state we mutate so this module never pollutes another (the tests
+        # share one process-global ``app``). Restored in the finally below.
+        saved = (
+            app.state.settings.require_api_key,
+            app.state.settings.gateway_service_token,
+            app.state.auth,
+            app.state.tenant_hmac_keys,
+            app.state.edge_keys,
+        )
+        app.state.settings.require_api_key = auth_on
+        app.state.settings.gateway_service_token = SERVICE_TOKEN if auth_on else ""
+        app.state.auth = FakeAuth(tokens or {})
+        hmac = hmac or FakeHmacStore()
+        edge = edge or FakeEdgeStore()
+        app.state.tenant_hmac_keys = hmac
+        app.state.edge_keys = edge
+        try:
+            yield client, hmac, edge
+        finally:
+            (
+                app.state.settings.require_api_key,
+                app.state.settings.gateway_service_token,
+                app.state.auth,
+                app.state.tenant_hmac_keys,
+                app.state.edge_keys,
+            ) = saved
+
+
+def _write(tenant: str) -> AuthResult:
+    return AuthResult(tenant_id=tenant, scope="write")
+
+
+def _read(tenant: str) -> AuthResult:
+    return AuthResult(tenant_id=tenant, scope="read")
+
+
+# --- /v1/tenant/hmac-key ------------------------------------------------------------------------
+
+
+def test_hmac_key_requires_bearer() -> None:
+    with _client(auth_on=True) as (c, _h, _e):
+        r = c.get("/v1/tenant/hmac-key")
+        assert r.status_code == 401
+
+
+def test_hmac_key_rejects_invalid_key() -> None:
+    with _client(auth_on=True, tokens={}) as (c, _h, _e):
+        r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer nope"})
+        assert r.status_code == 401
+
+
+def test_hmac_key_rejects_read_scope() -> None:
+    # A read-only key authenticates but must NOT unlock hashing key material (spec §3.2).
+    with _client(auth_on=True, tokens={"ro": _read(TENANT_A)}) as (c, _h, _e):
+        r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer ro"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "FORBIDDEN_SCOPE"
+
+
+def test_hmac_key_returns_active_material_for_write_scope() -> None:
+    with _client(auth_on=True, tokens={"wk": _write(TENANT_A)}) as (c, _h, _e):
+        r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer wk"})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["tenant_id"] == TENANT_A
+        assert body["key_version"] == "v1"
+        assert body["algorithm"] == "HMAC-SHA256"
+        # Round-trips to real bytes; never a raw token.
+        assert base64.b64decode(body["key_material_b64"]) == b"AAAA-tenant-a-key-bytes-000000000"
+
+
+def test_hmac_key_is_tenant_isolated_never_another_tenant() -> None:
+    # Two keys, two tenants: each key gets ONLY its own tenant's material, decided by the key.
+    tokens = {"ka": _write(TENANT_A), "kb": _write(TENANT_B)}
+    with _client(auth_on=True, tokens=tokens) as (c, _h, _e):
+        ra = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer ka"}).json()
+        rb = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer kb"}).json()
+        assert ra["tenant_id"] == TENANT_A
+        assert rb["tenant_id"] == TENANT_B
+        assert ra["key_material_b64"] != rb["key_material_b64"]
+        # There is no x-tenant-id input, so a header cannot coax tenant B's key out of tenant A's key.
+        spoof = c.get(
+            "/v1/tenant/hmac-key",
+            headers={"Authorization": "Bearer ka", "X-Tenant-Id": TENANT_B},
+        ).json()
+        assert spoof["tenant_id"] == TENANT_A
+
+
+def test_hmac_key_honors_export_kill_switch() -> None:
+    store = FakeHmacStore()
+    store.disabled.add(TENANT_A)
+    with _client(auth_on=True, tokens={"wk": _write(TENANT_A)}, hmac=store) as (c, _h, _e):
+        r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer wk"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "HMAC_EXPORT_DISABLED"
+
+
+def test_hmac_key_404_when_material_unavailable() -> None:
+    with _client(auth_on=True, tokens={"wk": _write("cafef00d-0000-0000-0000-000000000000")}) as (
+        c,
+        _h,
+        _e,
+    ):
+        r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer wk"})
+        assert r.status_code == 404
+
+
+# --- /v1/edge/keys ------------------------------------------------------------------------------
+
+
+def _change(key_hash: str, tenant: str, scope: str = "write", revoked: bool = False) -> KeyChange:
+    at = datetime(2026, 9, 1, tzinfo=timezone.utc) if revoked else None
+    return KeyChange(key_hash=key_hash, tenant_id=tenant, scope=scope, revoked_at=at)
+
+
+def test_edge_keys_gate_rejects_missing_token_when_auth_on() -> None:
+    with _client(auth_on=True) as (c, _h, _e):
+        assert c.get("/v1/edge/keys").status_code == 401
+
+
+def test_edge_keys_gate_rejects_wrong_token_when_auth_on() -> None:
+    with _client(auth_on=True) as (c, _h, _e):
+        r = c.get("/v1/edge/keys", headers={"Authorization": "Bearer wrong"})
+        assert r.status_code == 401
+
+
+def test_edge_keys_gate_is_noop_when_auth_off() -> None:
+    with _client(auth_on=False) as (c, _h, _e):
+        assert c.get("/v1/edge/keys").status_code == 200
+
+
+def test_edge_keys_delta_advances_by_cursor() -> None:
+    edge = FakeEdgeStore()
+    edge.add(_change("hashA", TENANT_A))
+    with _client(auth_on=True, edge=edge) as (c, _h, _e):
+        headers = {"Authorization": f"Bearer {SERVICE_TOKEN}"}
+        first = c.get("/v1/edge/keys", headers=headers).json()
+        assert [ch["key_hash"] for ch in first["changes"]] == ["hashA"]
+        cursor = first["cursor"]
+
+        # Nothing new: empty changes, same cursor.
+        second = c.get(f"/v1/edge/keys?since={cursor}", headers=headers).json()
+        assert second["changes"] == []
+        assert second["cursor"] == cursor
+
+        # A revocation arrives as a change with revoked_at set; the proxy drops it.
+        edge.add(_change("hashA", TENANT_A, revoked=True))
+        third = c.get(f"/v1/edge/keys?since={cursor}", headers=headers).json()
+        assert len(third["changes"]) == 1
+        assert third["changes"][0]["revoked_at"] is not None
+
+
+def test_edge_keys_payload_is_metadata_only() -> None:
+    edge = FakeEdgeStore()
+    edge.add(_change("hash123", TENANT_A, scope="admin"))
+    with _client(auth_on=True, edge=edge) as (c, _h, _e):
+        r = c.get("/v1/edge/keys", headers={"Authorization": f"Bearer {SERVICE_TOKEN}"})
+        change = r.json()["changes"][0]
+        # Exactly the metadata contract, and no token/token_prefix/secret leaks in.
+        assert set(change.keys()) == {"key_hash", "tenant_id", "scope", "revoked_at"}
+        assert change["key_hash"] == "hash123"
+        assert "token" not in change

--- a/infra/gateway/tests/test_edge_keys_store.py
+++ b/infra/gateway/tests/test_edge_keys_store.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for :class:`gateway.edge_keys.EdgeKeyStore.changes_since` (Initiative 2 §6.2 review).
+
+The delta feed pages api-key changes by a keyset watermark over ``(GREATEST(created_at, revoked_at),
+id)``. Because those timestamps are stamped at STATEMENT time, not commit time, a slow transaction
+can commit a row whose watermark sits below a cursor that a later-but-faster commit already advanced
+past. Under plain keyset pagination that row is skipped forever. The store guards against this with a
+safe-lag window: it never returns (and so never advances the cursor past) a row whose watermark is
+newer than ``now() - edge_key_safe_lag_seconds``.
+
+These tests drive the real store SQL through a fake psycopg cursor that models the api_keys table,
+the DATABASE clock (``now()``), and per-row commit visibility, so the skip scenario is reproduced
+deterministically without a live Postgres.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from gateway import edge_keys
+from gateway.edge_keys import EdgeKeyStore
+
+_EPOCH = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def _ts(seconds: int) -> dt.datetime:
+    """A DB timestamp `seconds` after the epoch. Keeps the arithmetic obvious in the assertions."""
+    return _EPOCH + dt.timedelta(seconds=seconds)
+
+
+@dataclass
+class Row:
+    key_hash: str
+    tenant_id: str
+    scope: str
+    created_at: dt.datetime
+    revoked_at: dt.datetime | None
+    row_id: str
+    visible_at: dt.datetime  # models commit time: the row is invisible to reads before this
+
+    def watermark(self) -> dt.datetime:
+        return max(self.created_at, self.revoked_at or self.created_at)
+
+
+class FakeCursor:
+    """Emulates the store's single keyset query against an in-memory, clock-and-commit-aware table."""
+
+    def __init__(self, table: "FakeTable") -> None:
+        self._table = table
+        self._result: list[tuple] = []
+
+    def execute(self, sql: str, params: tuple) -> None:
+        after_wm, after_id, lag_seconds, limit = params
+        boundary = self._table.now - dt.timedelta(seconds=float(lag_seconds))
+        visible = [r for r in self._table.rows if r.visible_at <= self._table.now]
+        matched = [
+            r
+            for r in visible
+            if (r.watermark(), r.row_id) > (after_wm, after_id) and r.watermark() <= boundary
+        ]
+        matched.sort(key=lambda r: (r.watermark(), r.row_id))
+        self._result = [
+            (r.key_hash, r.tenant_id, r.scope, r.revoked_at, r.watermark(), r.row_id)
+            for r in matched[:limit]
+        ]
+
+    def fetchall(self) -> list[tuple]:
+        return self._result
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConn:
+    def __init__(self, table: "FakeTable") -> None:
+        self._table = table
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self._table)
+
+    def __enter__(self) -> "FakeConn":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeTable:
+    def __init__(self) -> None:
+        self.rows: list[Row] = []
+        self.now = _EPOCH
+
+
+def _store(monkeypatch, table: FakeTable, *, lag_seconds: float) -> EdgeKeyStore:
+    monkeypatch.setattr(edge_keys.psycopg, "connect", lambda _dsn: FakeConn(table))
+    settings = SimpleNamespace(
+        postgres_dsn="postgresql://ignored", edge_key_safe_lag_seconds=lag_seconds
+    )
+    return EdgeKeyStore(settings)
+
+
+def _build_out_of_commit_order_table() -> FakeTable:
+    """Key B is created after key A but commits FIRST; A's slow transaction commits later.
+
+    A: created at t=99, commits (visible) at t=104.  watermark 99.
+    B: created at t=100, commits (visible) at t=100. watermark 100.
+    """
+    table = FakeTable()
+    table.rows = [
+        Row("hashA", "tenantA", "write", _ts(99), None, "keyA", visible_at=_ts(104)),
+        Row("hashB", "tenantB", "write", _ts(100), None, "keyB", visible_at=_ts(100)),
+    ]
+    return table
+
+
+def test_out_of_commit_order_row_is_not_skipped_with_safe_lag(monkeypatch) -> None:
+    table = _build_out_of_commit_order_table()
+    store = _store(monkeypatch, table, lag_seconds=5.0)
+
+    # Poll 1 at t=101: B has committed (wm 100) but is still inside the 5s lag window (boundary 96),
+    # so the feed holds it back and does NOT advance the cursor past it.
+    table.now = _ts(101)
+    changes, cursor = store.changes_since(None)
+    assert changes == []
+    assert cursor == ""  # unchanged: no row was safe to emit yet
+
+    # Poll 2 at t=110: A's slow transaction has now committed (wm 99), and both rows are outside the
+    # lag window (boundary 105). Both are delivered, ordered by watermark, so A is NOT skipped.
+    table.now = _ts(110)
+    changes, cursor = store.changes_since(cursor)
+    assert [c.key_hash for c in changes] == ["hashA", "hashB"]
+
+
+def test_without_safe_lag_the_late_commit_is_skipped(monkeypatch) -> None:
+    # The regression itself: with NO safe-lag window (lag 0) the exact scenario strands key A.
+    table = _build_out_of_commit_order_table()
+    store = _store(monkeypatch, table, lag_seconds=0.0)
+
+    # Poll 1 at t=101: only B is visible; it is emitted immediately and the cursor advances past it.
+    table.now = _ts(101)
+    changes, cursor = store.changes_since(None)
+    assert [c.key_hash for c in changes] == ["hashB"]
+
+    # Poll 2 at t=110: A has committed but its watermark (99) is below the cursor (100, keyB), so the
+    # keyset predicate excludes it forever. This asserts the bug the safe-lag window fixes.
+    table.now = _ts(110)
+    changes, _ = store.changes_since(cursor)
+    assert changes == []
+
+
+def test_revocation_propagates_once_outside_the_lag_window(monkeypatch) -> None:
+    table = FakeTable()
+    table.rows = [Row("hashA", "tenantA", "write", _ts(10), None, "keyA", visible_at=_ts(10))]
+    store = _store(monkeypatch, table, lag_seconds=5.0)
+
+    table.now = _ts(30)
+    changes, cursor = store.changes_since(None)
+    assert [c.key_hash for c in changes] == ["hashA"]
+    assert changes[0].revoked_at is None
+
+    # Revoke at t=40 (watermark rises to 40). Visible immediately; picked up once past the lag window.
+    table.rows[0].revoked_at = _ts(40)
+    table.rows[0].visible_at = _ts(40)
+    table.now = _ts(50)
+    changes, _ = store.changes_since(cursor)
+    assert len(changes) == 1
+    assert changes[0].revoked_at == _ts(40)

--- a/infra/gateway/tests/test_tenant_hmac_key_store.py
+++ b/infra/gateway/tests/test_tenant_hmac_key_store.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Restart-durability of the HMAC bootstrap store (Initiative 2 §3.2 review).
+
+``GET /v1/tenant/hmac-key`` used to 404 for a durably-provisioned tenant after a gateway restart,
+because the in-memory-only key provider lost the bytes while ``tenants.hash_salt_kek_ref`` survived.
+The provider now derives material deterministically from that durable reference, so a fresh provider
+(a simulated restart) resolves the same tenant's material rather than raising. This drives the real
+:class:`TenantHmacKeyStore` through a fake psycopg cursor so no Postgres is needed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway import tenant_hmac_key
+from gateway.tenant_hmac_key import TenantHmacKeyStore
+from gateway.tenant_provisioning import LocalDevKeyProvider
+
+TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
+
+
+class FakeCursor:
+    """Resolves the tenant UUID (pass-through) and returns its stored hash_salt_kek_ref."""
+
+    def __init__(self, ref: str | None) -> None:
+        self._ref = ref
+        self._result: tuple | None = None
+
+    def execute(self, sql: str, params: tuple) -> None:
+        if "hash_salt_kek_ref" in sql:
+            self._result = (self._ref,) if self._ref is not None else None
+        else:  # pragma: no cover - resolve_tenant_uuid takes the UUID fast-path, no lookup
+            self._result = None
+
+    def fetchone(self) -> tuple | None:
+        return self._result
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConn:
+    def __init__(self, ref: str | None) -> None:
+        self._ref = ref
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self._ref)
+
+    def __enter__(self) -> "FakeConn":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def _store(monkeypatch, ref: str | None, provider: LocalDevKeyProvider) -> TenantHmacKeyStore:
+    monkeypatch.setattr(tenant_hmac_key.psycopg, "connect", lambda _dsn: FakeConn(ref))
+    return TenantHmacKeyStore(SimpleNamespace(postgres_dsn="postgresql://ignored"), provider)
+
+
+def test_hmac_key_resolves_after_a_simulated_restart(monkeypatch) -> None:
+    root = b"dev-root"
+    # Provision under one provider instance; capture the durable reference the tenant row would hold.
+    before = LocalDevKeyProvider(root_secret=root)
+    ref = before.mint()
+    material_before = _store(monkeypatch, ref, before).active_key(TENANT_UUID)
+
+    # Simulated restart: a brand-new provider instance (empty minted set), same durable reference in
+    # the tenant row. The store must return the SAME material, not a 404 (HmacKeyUnavailableError).
+    after = LocalDevKeyProvider(root_secret=root)
+    material_after = _store(monkeypatch, ref, after).active_key(TENANT_UUID)
+
+    assert material_after.tenant_id == TENANT_UUID
+    assert material_after.key_material_b64 == material_before.key_material_b64
+    assert material_after.key_version == "v1"

--- a/infra/gateway/tests/test_tenant_provisioning.py
+++ b/infra/gateway/tests/test_tenant_provisioning.py
@@ -20,12 +20,16 @@ import uuid
 
 import pytest
 
+from types import SimpleNamespace
+
 from gateway import tenant_provisioning
 from gateway.tenant_lookup import TenantNotFoundError, resolve_tenant_uuid
 from gateway.tenant_provisioning import (
     LocalDevKeyProvider,
     ProvisionError,
+    SecretManagerKeyProvider,
     TenantProvisioner,
+    build_key_provider,
 )
 
 
@@ -194,6 +198,57 @@ def test_local_dev_provider_mint_is_unique_and_check_safe() -> None:
     provider.delete(ref_a)
     assert not provider.has(ref_a)
     assert provider.has(ref_b)
+
+
+def test_local_dev_provider_material_survives_a_restart() -> None:
+    # Initiative 2 §3.2 regression: after a gateway restart the in-memory-only provider lost the
+    # bytes and /v1/tenant/hmac-key 404'd for a durably-provisioned tenant. Material is now derived
+    # from the durable reference + root secret, so a FRESH provider instance (a simulated restart)
+    # resolves the same reference to the same 32 bytes.
+    root = b"root-secret-value"
+    before = LocalDevKeyProvider(root_secret=root)
+    ref = before.mint()
+    material_before = before.material(ref)
+    assert len(material_before) == 32
+
+    after = LocalDevKeyProvider(root_secret=root)  # simulated restart: empty minted set
+    assert not after.has(ref)  # bookkeeping is gone...
+    assert after.material(ref) == material_before  # ...but the material still resolves
+
+    # Distinct references derive distinct material (tenant isolation), and an empty ref is a miss.
+    assert after.material(before.mint()) != material_before
+    with pytest.raises(KeyError):
+        after.material("")
+
+
+def test_build_key_provider_selects_by_setting() -> None:
+    local = build_key_provider(
+        SimpleNamespace(hmac_key_provider="local", hmac_local_root_secret="rs")
+    )
+    assert isinstance(local, LocalDevKeyProvider)
+    # Two local providers built from the same root secret agree on material (restart-durable).
+    other = build_key_provider(
+        SimpleNamespace(hmac_key_provider="local", hmac_local_root_secret="rs")
+    )
+    ref = local.mint()
+    assert local.material(ref) == other.material(ref)
+
+    # The prod seam is selectable but fails fast without a wired client, never silently local.
+    with pytest.raises(ProvisionError):
+        build_key_provider(
+            SimpleNamespace(hmac_key_provider="kms", hmac_local_root_secret="rs")
+        )
+    with pytest.raises(ProvisionError):
+        build_key_provider(
+            SimpleNamespace(hmac_key_provider="bogus", hmac_local_root_secret="rs")
+        )
+
+
+def test_secret_manager_provider_requires_a_client() -> None:
+    with pytest.raises(ProvisionError):
+        SecretManagerKeyProvider()
+    # With a client wired it constructs; the concrete cloud calls are a deployment concern.
+    assert SecretManagerKeyProvider(client=object()) is not None
 
 
 # --- resolver extension ---------------------------------------------------------------------------

--- a/web/app/api/onboarding/first-event/route.ts
+++ b/web/app/api/onboarding/first-event/route.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// First-data onboarding probe endpoint (Initiative 2, §9). The onboarding panel polls this to flip
+// from "waiting for your first event" to "connected". It runs a tenant-scoped existence check
+// against ClickHouse (SELECT 1 FROM otel_spans WHERE TenantId = {tenant} LIMIT 1) using the canonical
+// tenant UUID from getTenant(), and returns the honest state only: connected / waiting / unknown.
+//
+// Server-only (nodejs runtime): it reaches ClickHouse through the same lib the dashboard reads use,
+// and the tenant resolves from Clerk (or the dev escape hatch) exactly as every other read does.
+import { NextResponse } from "next/server";
+
+import { queryFirstEventSeen } from "@/lib/clickhouse";
+import type { FirstEventStatus } from "@/lib/firstEvent";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export interface FirstEventPayload {
+  status: FirstEventStatus;
+}
+
+// GET /api/onboarding/first-event — has any span landed for the caller's tenant yet?
+export async function GET(): Promise<NextResponse<FirstEventPayload>> {
+  const status = await queryFirstEventSeen();
+  return NextResponse.json({ status });
+}

--- a/web/app/settings/keys/ConnectPanel.test.tsx
+++ b/web/app/settings/keys/ConnectPanel.test.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Initiative 2 §9 review: the Copy button must report success ONLY on a real copy (finding #10) and
+// the first-event badge must stop polling once connected (finding #11).
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectPanel } from "./ConnectPanel";
+
+// The badge polls /api/onboarding/first-event. Default the fetch to "waiting" so a test that only
+// cares about the Copy button is not perturbed by the poll; individual tests override it.
+function stubFetch(status: "waiting" | "connected" | "unknown") {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function setClipboard(value: unknown) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("ConnectPanel Copy button (finding #10)", () => {
+  it("reports Copied only after writeText resolves", async () => {
+    stubFetch("waiting");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+
+    render(<ConnectPanel token="tally_sk_live_test" />);
+    const copy = screen.getAllByRole("button", { name: "Copy" })[0];
+    fireEvent.click(copy);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Copied" })).toBeTruthy());
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("tally_sk_live_test"));
+  });
+
+  it("reports Copy failed when the Clipboard API is absent", async () => {
+    stubFetch("waiting");
+    setClipboard(undefined);
+
+    render(<ConnectPanel token="tally_sk_live_test" />);
+    const copy = screen.getAllByRole("button", { name: "Copy" })[0];
+    fireEvent.click(copy);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copy failed" })).toBeTruthy(),
+    );
+    // The false-success claim must never appear on this path.
+    expect(screen.queryByRole("button", { name: "Copied" })).toBeNull();
+  });
+
+  it("reports Copy failed when writeText rejects", async () => {
+    stubFetch("waiting");
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error("denied")) });
+
+    render(<ConnectPanel token="tally_sk_live_test" />);
+    const copy = screen.getAllByRole("button", { name: "Copy" })[0];
+    fireEvent.click(copy);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copy failed" })).toBeTruthy(),
+    );
+  });
+});
+
+describe("ConnectPanel first-event badge (finding #11)", () => {
+  it("stops polling once the status is connected", async () => {
+    vi.useFakeTimers();
+    const fetchMock = stubFetch("connected");
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+
+    render(<ConnectPanel token="tally_sk_live_test" />);
+
+    // First run is SSR-only (no immediate fetch); the first poll fires one interval in and resolves
+    // to "connected", which latches the badge and disables further polling.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(screen.getByText(/We received your first event\./i)).toBeTruthy();
+    const callsAtConnect = fetchMock.mock.calls.length;
+    expect(callsAtConnect).toBeGreaterThan(0);
+
+    // Well past several more intervals: no additional polls once connected.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000 * 5);
+    });
+    expect(fetchMock.mock.calls.length).toBe(callsAtConnect);
+  });
+});

--- a/web/app/settings/keys/ConnectPanel.tsx
+++ b/web/app/settings/keys/ConnectPanel.tsx
@@ -9,7 +9,7 @@
 //      reports the honest state only (connected / waiting / unknown), never a fabricated success.
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { connectSnippets, type ConnectPath, type Snippet } from "@/lib/connectSnippets";
 import type { FirstEventPayload } from "@/app/api/onboarding/first-event/route";
@@ -21,7 +21,24 @@ const PATH_LABELS: Record<ConnectPath, string> = {
 };
 
 function CodeBlock({ snippet }: { snippet: Snippet }) {
-  const [copied, setCopied] = useState(false);
+  // "idle" until a copy actually resolves. We report "Copied" ONLY on a real success and "Copy failed"
+  // when the Clipboard API is missing (insecure context / older browser) or writeText() rejects
+  // (permission denied), never an unconditional success (Initiative 2 §9 review).
+  const [state, setState] = useState<"idle" | "copied" | "failed">("idle");
+
+  async function copy() {
+    try {
+      const clipboard = navigator.clipboard;
+      if (!clipboard?.writeText) throw new Error("clipboard unavailable");
+      await clipboard.writeText(snippet.code);
+      setState("copied");
+    } catch {
+      setState("failed");
+    }
+    setTimeout(() => setState("idle"), 1500);
+  }
+
+  const label = state === "copied" ? "Copied" : state === "failed" ? "Copy failed" : "Copy";
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between">
@@ -29,13 +46,11 @@ function CodeBlock({ snippet }: { snippet: Snippet }) {
         <button
           type="button"
           onClick={() => {
-            void navigator.clipboard?.writeText(snippet.code);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
+            void copy();
           }}
           className="rounded border border-edge px-2 py-0.5 text-xs text-fg"
         >
-          {copied ? "Copied" : "Copy"}
+          {label}
         </button>
       </div>
       <pre className="overflow-x-auto rounded border border-edge bg-transparent p-3 text-xs text-fg">
@@ -49,12 +64,21 @@ function CodeBlock({ snippet }: { snippet: Snippet }) {
 function FirstEventBadge() {
   // Poll the tenant-scoped probe. Start from "unknown" so the first paint makes no claim before the
   // first fetch resolves.
+  //
+  // The first event only ever arrives ONCE, so once we see "connected" we stop polling: continuing
+  // to hit the ClickHouse probe every 4s forever is pure waste (Initiative 2 §9 review). "connected"
+  // is terminal, so `done` latches and the interval never restarts, even if a later reset were to
+  // momentarily blank the data.
+  const [done, setDone] = useState(false);
   const { data } = useLivePoll<FirstEventPayload>(
     "/api/onboarding/first-event",
     { status: "unknown" },
-    { intervalMs: 4000 },
+    { intervalMs: 4000, enabled: !done },
   );
   const status = data.status;
+  useEffect(() => {
+    if (status === "connected") setDone(true);
+  }, [status]);
   if (status === "connected") {
     return (
       <div className="rounded-md border border-accent bg-panel px-3 py-2 text-sm text-fg">

--- a/web/app/settings/keys/ConnectPanel.tsx
+++ b/web/app/settings/keys/ConnectPanel.tsx
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// First-data onboarding surface (Initiative 2, §9), shown right after a key is minted. Two halves:
+//
+//   1. A per-path, per-language snippet generator with the REAL key inlined. The key comes from the
+//      one-time mint response and is never stored: this component only renders while the parent still
+//      holds that response, so nothing has to be re-fetched to show it later.
+//   2. A live "we received your first event" indicator that polls the tenant-scoped ClickHouse probe
+//      (/api/onboarding/first-event) and flips from waiting to connected when the first span lands. It
+//      reports the honest state only (connected / waiting / unknown), never a fabricated success.
+"use client";
+
+import { useState } from "react";
+
+import { connectSnippets, type ConnectPath, type Snippet } from "@/lib/connectSnippets";
+import type { FirstEventPayload } from "@/app/api/onboarding/first-event/route";
+import { useLivePoll } from "@/lib/useLivePoll";
+
+const PATH_LABELS: Record<ConnectPath, string> = {
+  proxy: "Proxy (zero-code)",
+  sdk: "SDK (deep context)",
+};
+
+function CodeBlock({ snippet }: { snippet: Snippet }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs uppercase tracking-wider text-muted">{snippet.language}</span>
+        <button
+          type="button"
+          onClick={() => {
+            void navigator.clipboard?.writeText(snippet.code);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+          className="rounded border border-edge px-2 py-0.5 text-xs text-fg"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="overflow-x-auto rounded border border-edge bg-transparent p-3 text-xs text-fg">
+        <code>{snippet.code}</code>
+      </pre>
+      {snippet.note && <p className="text-xs text-muted">{snippet.note}</p>}
+    </div>
+  );
+}
+
+function FirstEventBadge() {
+  // Poll the tenant-scoped probe. Start from "unknown" so the first paint makes no claim before the
+  // first fetch resolves.
+  const { data } = useLivePoll<FirstEventPayload>(
+    "/api/onboarding/first-event",
+    { status: "unknown" },
+    { intervalMs: 4000 },
+  );
+  const status = data.status;
+  if (status === "connected") {
+    return (
+      <div className="rounded-md border border-accent bg-panel px-3 py-2 text-sm text-fg">
+        <span className="font-semibold">We received your first event.</span>{" "}
+        <a className="underline" href="/explore">
+          View Cost Explorer
+        </a>
+      </div>
+    );
+  }
+  if (status === "waiting") {
+    return (
+      <div className="rounded-md border border-edge bg-panel px-3 py-2 text-sm text-muted">
+        Waiting for your first event. Run the snippet above and it appears here.
+      </div>
+    );
+  }
+  // unknown: the probe could not reach ClickHouse. Honest, not a fabricated waiting/connected.
+  return (
+    <div className="rounded-md border border-edge bg-panel px-3 py-2 text-sm text-muted">
+      Checking for your first event…
+    </div>
+  );
+}
+
+export function ConnectPanel({ token }: { token: string }) {
+  const [path, setPath] = useState<ConnectPath>("proxy");
+  const snippets = connectSnippets(token);
+  const [active, setActive] = useState(0);
+  const current = snippets[path];
+  const shown = current[Math.min(active, current.length - 1)];
+
+  return (
+    <div className="space-y-3 rounded-md border border-edge bg-panel p-4">
+      <div className="text-sm font-semibold text-fg">Connect your app</div>
+      <div className="flex gap-2">
+        {(Object.keys(PATH_LABELS) as ConnectPath[]).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => {
+              setPath(p);
+              setActive(0);
+            }}
+            className={
+              "rounded px-2 py-1 text-xs " +
+              (path === p ? "bg-accent text-white" : "border border-edge text-fg")
+            }
+          >
+            {PATH_LABELS[p]}
+          </button>
+        ))}
+      </div>
+      {current.length > 1 && (
+        <div className="flex gap-2">
+          {current.map((s, i) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => setActive(i)}
+              className={
+                "rounded px-2 py-0.5 text-xs " +
+                (i === active ? "bg-fg text-panel" : "border border-edge text-muted")
+              }
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <CodeBlock snippet={shown} />
+      <FirstEventBadge />
+    </div>
+  );
+}

--- a/web/app/settings/keys/KeyManager.tsx
+++ b/web/app/settings/keys/KeyManager.tsx
@@ -7,6 +7,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { ConnectPanel } from "./ConnectPanel";
+
 interface KeyMeta {
   id: string;
   name: string | null;
@@ -179,6 +181,10 @@ export function KeyManager({ canManage }: { canManage: boolean }) {
               Dismiss
             </button>
           </div>
+          {/* One-step connect (Initiative 2, §9): snippets with the real key inlined into this
+              one-time view, plus the live first-event indicator. The key is never stored to render
+              this later; it lives only in `minted` until dismissed. */}
+          <ConnectPanel token={minted.token} />
         </div>
       )}
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -92,6 +92,7 @@ import {
 // module-level `local-dev` constant (Initiative 1, §7/§8). The ClickHouse read filter binds this
 // UUID, so a UUID-scoped read matches UUID-tagged ingest.
 import { resolveTenantId } from "./getTenant";
+import { firstEventStatus, type FirstEventStatus } from "./firstEvent";
 
 let _client: ClickHouseClient | null = null;
 
@@ -116,6 +117,24 @@ export async function tryLive<T>(fn: (db: ClickHouseClient, tenant: string) => P
     console.warn("[clickhouse] live query failed, falling back to mock:", (err as Error).message);
     return null;
   }
+}
+
+// First-data onboarding probe (Initiative 2, §9). A single-row existence check scoped to the tenant
+// UUID from getTenant(): does ANY span exist for this tenant yet? It is the cheapest possible query
+// (LIMIT 1, no scan of history) so the onboarding panel can poll it. `tryLive` returns null when
+// ClickHouse is unreachable, which the caller maps to the honest "unknown" state rather than a
+// fabricated "waiting" (see firstEvent.ts). This is the only place the raw probe lives; the status
+// mapping is the pure `firstEventStatus`.
+export async function queryFirstEventSeen(): Promise<FirstEventStatus> {
+  const seen = await tryLive(async (db, tenant) => {
+    const r = await rows<{ one: number }>(
+      db,
+      "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1",
+      tenant,
+    );
+    return r.length > 0;
+  });
+  return firstEventStatus(seen);
 }
 
 // Decimal string (USD) -> integer micro-USD. Exported so sibling lib modules (e.g. the waste

--- a/web/lib/connectSnippets.test.ts
+++ b/web/lib/connectSnippets.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// One-step-connect snippet generator (Initiative 2, §9).
+import { describe, expect, it } from "vitest";
+
+import { connectSnippets, defaultEndpoints } from "./connectSnippets";
+
+const KEY = "tally_sk_live_TESTKEY123";
+
+describe("connectSnippets", () => {
+  it("inlines the real key into every path and provider", () => {
+    const s = connectSnippets(KEY);
+    const all = [...s.proxy, ...s.sdk];
+    // Every snippet carries the key: the one-time creation view is the only place it appears.
+    for (const snip of all) {
+      expect(snip.code).toContain(KEY);
+    }
+    // Both proxy providers plus the SDK python one-liner.
+    expect(s.proxy.map((x) => x.id)).toEqual(["proxy-openai", "proxy-anthropic"]);
+    expect(s.sdk.map((x) => x.id)).toEqual(["sdk-python"]);
+  });
+
+  it("proxy snippets send the key as X-Tenant-Key, never as the provider credential", () => {
+    const s = connectSnippets(KEY);
+    const openai = s.proxy.find((x) => x.id === "proxy-openai")!;
+    expect(openai.code).toContain(`X-Tenant-Key: ${KEY}`);
+    // The provider key stays the provider's own env var, never the tally key.
+    expect(openai.code).toContain("Authorization: Bearer $OPENAI_API_KEY");
+    expect(openai.code).not.toContain(`Authorization: Bearer ${KEY}`);
+
+    const anthropic = s.proxy.find((x) => x.id === "proxy-anthropic")!;
+    expect(anthropic.code).toContain(`X-Tenant-Key: ${KEY}`);
+    expect(anthropic.code).toContain("x-api-key: $ANTHROPIC_API_KEY");
+    expect(anthropic.code).toContain("anthropic-version");
+  });
+
+  it("the SDK snippet is a tally.init one-liner with the key", () => {
+    const python = connectSnippets(KEY).sdk[0];
+    expect(python.code).toContain(`tally.init("${KEY}")`);
+    expect(python.language).toBe("python");
+  });
+
+  it("threads a custom SDK endpoint into init() when configured", () => {
+    const endpoints = { ...defaultEndpoints(), sdkEndpoint: "https://ingest.example.com" };
+    const python = connectSnippets(KEY, endpoints).sdk[0];
+    expect(python.code).toContain(`tally.init("${KEY}", endpoint="https://ingest.example.com")`);
+  });
+
+  it("proxy snippets carry the refresh-window note; the SDK one does not", () => {
+    const s = connectSnippets(KEY);
+    expect(s.proxy.every((x) => x.note && x.note.includes("few seconds"))).toBe(true);
+    expect(s.sdk[0].note).not.toContain("few seconds");
+  });
+
+  it("defaults to the hosted proxy hostnames", () => {
+    const e = defaultEndpoints();
+    expect(e.openaiProxyBaseUrl).toContain("openai.proxy.ai-tally.com");
+    expect(e.anthropicProxyBaseUrl).toContain("anthropic.proxy.ai-tally.com");
+  });
+});

--- a/web/lib/connectSnippets.ts
+++ b/web/lib/connectSnippets.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// One-step-connect snippet generator (Initiative 2, §9). Shown right after a key is minted, with the
+// real token inlined into that ONE-TIME creation view. No secret is stored to render it later: the
+// key is passed in from the mint response and lives only in the client component that shows it once.
+//
+// Two paths, both keyed by the same per-org ingest key (Initiative 2, Decision 2):
+//   * Proxy (zero-code): point the provider base URL at the hosted ai-tally proxy and send the key
+//     as the X-Tenant-Key header. Any language; shown here as a shell/curl block per provider.
+//   * SDK (deep context): `pip install tally` then `tally.init(key)` auto-instruments the official
+//     openai / anthropic clients.
+//
+// Pure and framework-free so it is unit-tested directly; the React view maps over the result.
+
+/** The hosted endpoints the snippets point at. Overridable per deployment via NEXT_PUBLIC_* env. */
+export interface ConnectEndpoints {
+  openaiProxyBaseUrl: string;
+  anthropicProxyBaseUrl: string;
+  /** The SDK ingest endpoint. Empty string means "use the SDK default" and is omitted from init(). */
+  sdkEndpoint: string;
+}
+
+/** Read the hosted endpoints from NEXT_PUBLIC_* env, falling back to the spec's §6.4 hostnames. */
+export function defaultEndpoints(): ConnectEndpoints {
+  return {
+    openaiProxyBaseUrl:
+      process.env.NEXT_PUBLIC_TALLY_OPENAI_PROXY_URL ?? "https://openai.proxy.ai-tally.com/v1",
+    anthropicProxyBaseUrl:
+      process.env.NEXT_PUBLIC_TALLY_ANTHROPIC_PROXY_URL ?? "https://anthropic.proxy.ai-tally.com",
+    sdkEndpoint: process.env.NEXT_PUBLIC_TALLY_INGEST_URL ?? "",
+  };
+}
+
+export type ConnectPath = "proxy" | "sdk";
+
+export interface Snippet {
+  /** Stable id for the tab/key. */
+  id: string;
+  /** Human label for the tab, e.g. "OpenAI" or "Python". */
+  label: string;
+  /** Syntax hint for the code block, e.g. "bash" or "python". */
+  language: string;
+  /** The copy-paste body, with the real key already inlined. */
+  code: string;
+  /** An honest caveat rendered under the block, or null. */
+  note: string | null;
+}
+
+// The proxy path attributes a brand-new key only after the edge cache picks it up, up to one refresh
+// interval (Initiative 2, §6.2/§9). Stated so a first event that lags a few seconds reads as expected,
+// not broken. The SDK path has no such delay: the gateway resolves the key directly per request.
+const PROXY_REFRESH_NOTE =
+  "A brand-new key can take a few seconds to attribute while the proxy picks it up. Your provider key is unchanged and never sent to ai-tally.";
+
+function proxyOpenAi(key: string, e: ConnectEndpoints): Snippet {
+  return {
+    id: "proxy-openai",
+    label: "OpenAI",
+    language: "bash",
+    code: [
+      "# Point the OpenAI SDK at the ai-tally proxy",
+      `export OPENAI_BASE_URL="${e.openaiProxyBaseUrl}"`,
+      "",
+      "# ai-tally identifies your org by this ingest key, sent as the X-Tenant-Key header:",
+      `#   X-Tenant-Key: ${key}`,
+      "# e.g. a raw request:",
+      `curl "${e.openaiProxyBaseUrl}/chat/completions" \\`,
+      '  -H "Authorization: Bearer $OPENAI_API_KEY" \\',
+      `  -H "X-Tenant-Key: ${key}" \\`,
+      '  -H "Content-Type: application/json" \\',
+      `  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'`,
+    ].join("\n"),
+    note: PROXY_REFRESH_NOTE,
+  };
+}
+
+function proxyAnthropic(key: string, e: ConnectEndpoints): Snippet {
+  return {
+    id: "proxy-anthropic",
+    label: "Anthropic",
+    language: "bash",
+    code: [
+      "# Point the Anthropic SDK at the ai-tally proxy",
+      `export ANTHROPIC_BASE_URL="${e.anthropicProxyBaseUrl}"`,
+      "",
+      "# Send your ai-tally ingest key as the X-Tenant-Key header:",
+      `#   X-Tenant-Key: ${key}`,
+      "# e.g. a raw request (your x-api-key and anthropic-version pass through untouched):",
+      `curl "${e.anthropicProxyBaseUrl}/v1/messages" \\`,
+      '  -H "x-api-key: $ANTHROPIC_API_KEY" \\',
+      '  -H "anthropic-version: 2023-06-01" \\',
+      `  -H "X-Tenant-Key: ${key}" \\`,
+      '  -H "Content-Type: application/json" \\',
+      `  -d '{"model":"claude-3-5-haiku-latest","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'`,
+    ].join("\n"),
+    note: PROXY_REFRESH_NOTE,
+  };
+}
+
+function sdkPython(key: string, e: ConnectEndpoints): Snippet {
+  const initArgs = e.sdkEndpoint
+    ? `"${key}", endpoint="${e.sdkEndpoint}"`
+    : `"${key}"`;
+  return {
+    id: "sdk-python",
+    label: "Python",
+    language: "python",
+    code: [
+      "# pip install tally",
+      "import tally",
+      "",
+      `tally.init(${initArgs})`,
+      "# From here your unmodified openai / anthropic calls are auto-instrumented:",
+      "# model, tokens, and cost land in ai-tally with no per-call record_* code.",
+    ].join("\n"),
+    note: "Set with_account(...) once per request to unlock cost per customer; start_trace(feature_tag=...) for cost per feature.",
+  };
+}
+
+/**
+ * Build the connect snippets for a freshly minted key. The key is inlined into every snippet, so this
+ * is only ever called from the one-time key-creation view (spec §9).
+ */
+export function connectSnippets(
+  key: string,
+  endpoints: ConnectEndpoints = defaultEndpoints(),
+): Record<ConnectPath, Snippet[]> {
+  return {
+    proxy: [proxyOpenAi(key, endpoints), proxyAnthropic(key, endpoints)],
+    sdk: [sdkPython(key, endpoints)],
+  };
+}

--- a/web/lib/firstEvent.test.ts
+++ b/web/lib/firstEvent.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// First-data onboarding status mapper (Initiative 2, §9).
+import { describe, expect, it } from "vitest";
+
+import { firstEventStatus } from "./firstEvent";
+
+describe("firstEventStatus", () => {
+  it("maps a found row to connected", () => {
+    expect(firstEventStatus(true)).toBe("connected");
+  });
+
+  it("maps a ran-but-empty probe to waiting", () => {
+    expect(firstEventStatus(false)).toBe("waiting");
+  });
+
+  it("maps an unrunnable probe to unknown, never a fabricated waiting", () => {
+    // null = ClickHouse unreachable. Honest under uncertainty: not collapsed into a definite "no".
+    expect(firstEventStatus(null)).toBe("unknown");
+  });
+});

--- a/web/lib/firstEvent.ts
+++ b/web/lib/firstEvent.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// First-data onboarding status (Initiative 2, §9). The onboarding panel flips from "waiting" to
+// "connected" when the first span for the tenant lands, and reports the honest state only: it never
+// claims data that is not there.
+//
+// Three states, deliberately: a ClickHouse existence probe can come back "yes a row exists"
+// (connected), "no rows yet" (waiting), or "we could not reach ClickHouse" (unknown). The last is
+// NOT collapsed into "waiting": that would fabricate a definite negative from an actual absence of
+// knowledge, against "honest under uncertainty" (CLAUDE.md). The pure mapper here is unit-tested;
+// the live probe that produces its input lives in clickhouse.ts.
+
+export type FirstEventStatus = "connected" | "waiting" | "unknown";
+
+/**
+ * Map a probe result to a status. `true` = a row exists (connected); `false` = the probe ran and
+ * found none (waiting); `null` = the probe could not run (unknown), never a fabricated "waiting".
+ */
+export function firstEventStatus(seen: boolean | null): FirstEventStatus {
+  if (seen === null) return "unknown";
+  return seen ? "connected" : "waiting";
+}


### PR DESCRIPTION
## What this builds

Initiative 2 (real one-step connect), the gateway endpoints and web first-data onboarding deferred from the foundation PRs. Stacks on Initiative 1 (base branch `feat/259-orgs-access`, PR #264). Scope is strictly the gateway endpoints and the web onboarding surface; `sdk/python` and `infra/edge-proxy` are untouched.

### Gateway (spec 3.2, 6.2)

- **`GET /v1/tenant/hmac-key`** — returns the caller tenant's active HMAC key material + version for in-process hashing. Authenticated by the **ingest key itself** (`ApiKeyAuth.authenticate`), requiring **write or admin** scope (reuses `WRITE_SCOPES`), never `read`, since it hands back hashing key material. The tenant is the key's tenant (no `x-tenant-id` input), so one org can never fetch another's material. Reads the active bytes through the same `KeyMaterialProvider` seam Initiative 1 provisions into `tenants.hash_salt_kek_ref`. Treated as sensitive: never logged (the gateway logs no response bodies), never on a span, TLS-only. A per-tenant export kill switch is wired default-on (spec §12 Q1). Response `{tenant_id, key_version, key_material_b64, algorithm}`; an honest 404 when material is unavailable rather than fabricated bytes.
- **`GET /v1/edge/keys?since={cursor}`** — metadata-only delta feed `{changes: [{key_hash, tenant_id, scope, revoked_at}], cursor}`, gated by the `GATEWAY_SERVICE_TOKEN` (the same gate Initiative 1 added). The cursor is a monotonic keyset watermark over `greatest(created_at, revoked_at)` with an id tiebreak: the steady state ships only what changed, a cold start pages the full active set, and a revoke re-enters the feed with `revoked_at` set so the proxy drops it within one refresh interval. Never a raw or reversible token.
- New `HMAC_EXPORT_DISABLED` error code (additive).

### Web (spec 9)

- **Snippet generator** (`connectSnippets`) shown right after key creation, per path and language: proxy shell/curl for OpenAI and Anthropic (base URL + `X-Tenant-Key` header, the provider credential passed through untouched) and a Python `tally.init(key)` one-liner. The real key is inlined into the one-time creation view only; no secret is stored to render it later.
- **Live "we received your first event" state**: a tenant-scoped ClickHouse existence probe (`SELECT 1 FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1`) on the `getTenant()` UUID, mapped to `connected` / `waiting` / `unknown`. ClickHouse unreachable is `unknown`, never a fabricated `waiting`. Exposed at `GET /api/onboarding/first-event` and polled by a `ConnectPanel` that flips the panel from waiting to connected.

## How it completes the mocked PRs

The SDK PR (#263) and edge-proxy PR (#262) built their sides against mocks of exactly these two endpoints. `/v1/tenant/hmac-key` is the real in-process HMAC bootstrap the SDK's `tally.init` calls to hash account/user ids client-side; `/v1/edge/keys` is the real delta feed the edge proxy polls to resolve `X-Tenant-Key` to a tenant UUID without a per-request round-trip. The web onboarding is the P3 surface those two paths land data into.

## CI

- gateway: `uv run --extra dev pytest -q` -> **866 passed**; `uv run ruff check .` -> **clean**. New tests cover hmac-key scope enforcement + tenant isolation (never returns another tenant) and the edge/keys delta + metadata-only payload + service-token gate.
- web: `npm run typecheck` -> clean; `npm run lint` -> clean (one pre-existing warning in `useLivePoll.ts`); `npm run test` -> passes except the one documented ClickHouse-reachability case in `api.test.ts` (fails only when a local ClickHouse is running; passes in CI). New tests: `connectSnippets.test.ts`, `firstEvent.test.ts`.

Draft, do not merge. Base is `feat/259-orgs-access` so this stacks on Initiative 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
