### PR TITLE
feat: configurable dev-mode organization name

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -16,8 +16,12 @@ export const metadata: Metadata = {
 // entirely (mounting it with no keys would throw) and hide the org controls in the shell. On the
 // product path ClerkProvider wraps the tree and the shell shows the org switcher.
 export default function RootLayout({ children }: { children: ReactNode }) {
-  const devLabel = devTenant();
-  const dev = devLabel !== null;
+  const devTenantId = devTenant();
+  const dev = devTenantId !== null;
+  // In the dev escape hatch there is no Clerk org to read, so the shell names the tenant. Let a demo
+  // or local deployment show a friendly organization name instead of the raw tenant id via
+  // TALLY_DEV_ORG_NAME (CTO-262); falls back to the tenant value when unset.
+  const devLabel = process.env.TALLY_DEV_ORG_NAME ?? devTenantId;
 
   const body = (
     <html lang="en">


### PR DESCRIPTION
Follow-up to #267. In the dev escape hatch there is no Clerk organization to read, so the shell showed the raw tenant id (`local-dev`) as the org name, which reads as a missing/placeholder name on a demo.

The root layout now shows `TALLY_DEV_ORG_NAME` when set, falling back to the tenant id, so a local/demo deployment displays a friendly organization name in the shell's ORGANIZATION box (e.g. "Northwind"). The product (Clerk) path is unchanged: with no dev tenant, `ClerkProvider` wraps the tree and the shell reads the active org name from Clerk via `useOrganization()`.

Verified live: the shell now renders `ORGANIZATION · Northwind [DEV]` in dev mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)