### PR TITLE
perf(waste): opt-in query cache for the heavy detector scans (test-safe redo of #270)

### DIFF
--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -182,6 +182,52 @@ export async function rowsP<T>(
   return rs.json<T>();
 }
 
+// Cached variant of rowsP for the EXPENSIVE, repeatedly-issued analytical reads (the waste detectors,
+// CTO-234 perf). Several detectors scan the same otel_spans rows in one /api/waste request, and
+// useLivePoll re-issues the whole set every few seconds; this collapses that. An identical IN-FLIGHT
+// query is coalesced to one round-trip, and an identical query within a short TTL is served from
+// memory. It is deliberately SEPARATE from rowsP: the state probes (queryAccountDetailResult /
+// queryExcludedInfraCost) must distinguish "unreachable" from "unknown" on EVERY call, so they stay on
+// the uncached rowsP (this is what a cache on rowsP broke). A failed query is evicted immediately so an
+// error is never cached, each caller gets a copy so an in-place sort can't corrupt the shared array,
+// and resetQueryCache() clears it for test isolation. TTL is short: a cost dashboard tolerates a few
+// seconds of staleness, a slightly delayed real value, never a fabricated one.
+const CACHED_QUERY_TTL_MS = 8_000;
+const _cachedQueries = new Map<string, { at: number; promise: Promise<unknown[]> }>();
+
+/** Clear the rowsPCached cache. Call from test setup so a cached result never leaks across cases. */
+export function resetQueryCache(): void {
+  _cachedQueries.clear();
+}
+
+export async function rowsPCached<T>(
+  db: ClickHouseClient,
+  query: string,
+  params: Record<string, unknown>,
+): Promise<T[]> {
+  const key = `${query} ${JSON.stringify(params)}`;
+  const now = Date.now();
+  const hit = _cachedQueries.get(key);
+  if (hit && now - hit.at < CACHED_QUERY_TTL_MS) {
+    return [...(await (hit.promise as Promise<T[]>))];
+  }
+  const promise = db
+    .query({ query, query_params: params, format: "JSONEachRow" })
+    .then((rs) => rs.json<T>()) as Promise<unknown[]>;
+  _cachedQueries.set(key, { at: now, promise });
+  // Never cache a rejection: evict so the next caller retries rather than replaying the error.
+  promise.catch(() => {
+    if (_cachedQueries.get(key)?.promise === promise) _cachedQueries.delete(key);
+  });
+  // Bound memory: sweep expired entries when the map grows (cheap, amortized).
+  if (_cachedQueries.size > 256) {
+    for (const [k, v] of _cachedQueries) {
+      if (now - v.at >= CACHED_QUERY_TTL_MS) _cachedQueries.delete(k);
+    }
+  }
+  return [...(await (promise as Promise<T[]>))];
+}
+
 function median(xs: number[]): number {
   if (xs.length === 0) return 0;
   const s = [...xs].sort((a, b) => a - b);

--- a/web/lib/waste/duplicated-work.ts
+++ b/web/lib/waste/duplicated-work.ts
@@ -27,7 +27,7 @@
 import type { WasteFinding } from "../waste";
 import type { DimensionFilters } from "../filters";
 import { clampWindowDays } from "../explore";
-import { tryLive, rowsP, micro } from "../clickhouse";
+import { tryLive, rowsPCached, micro } from "../clickhouse";
 
 // --- Named thresholds (WHY, not magic numbers) --------------------------------------------------
 
@@ -281,7 +281,7 @@ export async function collectDuplicatedWork(
     // change feature/agent/model/user mid-trace); its timestamp is the last span's, its cost the
     // trace sum, and its outcome the worst StatusCode (2 == error => failed). compute/egress spans
     // are tenant-level infra rows, not agent runs, so they are excluded exactly as queryAgents does.
-    const rows = await rowsP<RunRow>(
+    const rows = await rowsPCached<RunRow>(
       db,
       `SELECT TraceId AS traceId,
               any(FeatureTag) AS feature,

--- a/web/lib/waste/no-measured-return.ts
+++ b/web/lib/waste/no-measured-return.ts
@@ -22,7 +22,7 @@ import type { MicroUSD } from "@/lib/types";
 import type { WasteConfidence, WasteFinding, WasteScopeKind } from "@/lib/waste";
 import { clampWindowDays } from "@/lib/explore";
 import type { DimensionFilters } from "@/lib/filters";
-import { micro, queryFeatureEconomics, rowsP, tryLive } from "@/lib/clickhouse";
+import { micro, queryFeatureEconomics, rowsPCached, tryLive } from "@/lib/clickhouse";
 
 // At or below this attribution rate a scope has, for our purposes, NO measured return: in practice
 // `queryFeatureEconomics` returns either ~1.0 (conversions attributed) or null (none), but a small
@@ -166,7 +166,7 @@ export async function collectNoMeasuredReturn(
   const live = await tryLive(async (db, tenant) => {
     // Per-feature windowed spend. `w` is a clamped int, so interpolating it is injection-safe (same
     // pattern as the sibling queries in lib/clickhouse.ts). `filters.feature` binds as an array param.
-    const spendRows = await rowsP<FeatureSpendRow>(
+    const spendRows = await rowsPCached<FeatureSpendRow>(
       db,
       `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost
        FROM otel_spans
@@ -181,7 +181,7 @@ export async function collectNoMeasuredReturn(
     // Tenant-wide attribution rate: distinct business events that got an attribution record over the
     // window / all business events over the window. This is the honesty discriminator -- 0 (or no
     // events at all) means the tenant has no revenue source wired, and the detector then emits [].
-    const [attrRow] = await rowsP<TenantAttributionRow>(
+    const [attrRow] = await rowsPCached<TenantAttributionRow>(
       db,
       `SELECT
          uniqExact(BusinessEventId) AS total_events,

--- a/web/lib/waste/paid-for-nothing.ts
+++ b/web/lib/waste/paid-for-nothing.ts
@@ -19,7 +19,7 @@
 
 import type { WasteFinding } from "@/lib/waste";
 import type { DimensionFilters } from "@/lib/filters";
-import { tryLive, rowsP, micro } from "@/lib/clickhouse";
+import { tryLive, rowsPCached, micro } from "@/lib/clickhouse";
 import { clampWindowDays } from "@/lib/explore";
 
 /**
@@ -241,7 +241,7 @@ export async function collectPaidForNothing(
       GROUP BY scopeKind, scopeValue
       HAVING sum(m.5) > 0`;
 
-    const raw = await rowsP<PaidForNothingRow>(db, sql, { tenant, ...params });
+    const raw = await rowsPCached<PaidForNothingRow>(db, sql, { tenant, ...params });
     return detectPaidForNothing(raw);
   });
 

--- a/web/lib/waste/wrong-sized-model.collect.test.ts
+++ b/web/lib/waste/wrong-sized-model.collect.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/clickhouse", async (importOriginal) => {
     queryReplayCandidates: vi.fn(),
     queryEvalCandidates: vi.fn(),
     tryLive: vi.fn(),
-    rowsP: vi.fn(),
+    rowsPCached: vi.fn(),
   };
 });
 
@@ -38,7 +38,7 @@ import type { DimensionFilters } from "@/lib/filters";
 const queryReplayCandidates = ch.queryReplayCandidates as unknown as ReturnType<typeof vi.fn>;
 const queryEvalCandidates = ch.queryEvalCandidates as unknown as ReturnType<typeof vi.fn>;
 const tryLive = ch.tryLive as unknown as ReturnType<typeof vi.fn>;
-const rowsP = ch.rowsP as unknown as ReturnType<typeof vi.fn>;
+const rowsP = ch.rowsPCached as unknown as ReturnType<typeof vi.fn>;
 
 function filters(over: Partial<DimensionFilters> = {}): DimensionFilters {
   return { feature: [], model: [], layer: [], provider: [], account: [], agent: [], ...over };

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -52,7 +52,7 @@ import {
   micro,
   queryEvalCandidates,
   queryReplayCandidates,
-  rowsP,
+  rowsPCached,
   tryLive,
 } from "@/lib/clickhouse";
 
@@ -275,7 +275,7 @@ interface FeatureIncumbent {
 async function queryFeatureIncumbents(windowDays: number): Promise<FeatureIncumbent[] | null> {
   const w = clampWindowDays(windowDays);
   return tryLive(async (db, tenant) => {
-    const out = await rowsP<{ feature: string; model: string; spend: string; calls: string | number }>(
+    const out = await rowsPCached<{ feature: string; model: string; spend: string; calls: string | number }>(
       db,
       `SELECT FeatureTag AS feature,
               if(GenAiResponseModel != '', GenAiResponseModel,


### PR DESCRIPTION
Redo of #270 (reverted), **test-safe** this time.

## Why #270 broke
#270 cached `rows()`/`rowsP()` globally. The state probes (`queryAccountDetailResult`, `queryExcludedInfraCost`) must distinguish **unreachable** from **unknown** on every call, and a cached success from one test leaked into the next, so `clickhouse.test.ts` went red. I also should not have merged over that red check.

## This version
- New, **separate** `rowsPCached` (in-flight coalescing + 8s TTL; errors never cached; `resetQueryCache()` for tests).
- Only the four expensive waste detectors use it: `paid-for-nothing`, `duplicated-work`, `wrong-sized-model` (incumbents), `no-measured-return`.
- The state probes stay on the **untouched, uncached** `rowsP`, so their unknown/unreachable contract holds and `clickhouse.test.ts` passes.
- The one detector test that mocks `rowsP` now mocks `rowsPCached`.

## Effect
The same `otel_spans` scan issued by concurrent detectors in one request runs once, and a live-poll re-issue within the TTL is served from memory. 8s staleness is within the honesty bar for a cost dashboard.

## Verified
Full web CI green locally: `typecheck`, `lint`, `build` all pass; the only failing test is the documented ClickHouse-reachability case that fails only with a local ClickHouse running and passes in CI. Dev-mode wall-clock is noisy; the win is clearer in a prod build. `structural-inefficiency` and any `rows`-based scans are still uncached and could be added for more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)