### PR TITLE
fix(gateway): persist replay bodies + fail-soft on missing body (restart no longer blanks Recoverable Cost)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -151,6 +151,23 @@ services:
       timeout: 3s
       retries: 20
 
+  # --- MinIO bucket bootstrap (CTO-241) --------------------------------------------------------
+  # One-shot: create the replay-body bucket before the gateway boots so the s3 backend has a
+  # target. Persistent MinIO storage is what stops a gateway restart from wiping replay bodies and
+  # blanking the Recoverable Cost page. Idempotent (mb --ignore-existing), then exits 0.
+  minio-setup:
+    image: minio/mc:RELEASE.2024-09-16T17-43-14Z
+    container_name: ai-tally-minio-setup
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-tally} ${MINIO_ROOT_PASSWORD:-tally-minio} &&
+      mc mb --ignore-existing local/${TALLY_REPLAY_S3_BUCKET:-tally-replay} &&
+      echo 'replay bucket ready';
+      "
+
   # --- Ingest gateway (SDK batch -> enrich -> ClickHouse) --------------------------------------
   gateway:
     build:
@@ -165,6 +182,16 @@ services:
       TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
       TALLY_POSTGRES_DSN: postgresql://${POSTGRES_USER:-tally}:${POSTGRES_PASSWORD:-tally}@postgres:5432/${POSTGRES_DB:-tally}
       TALLY_REQUIRE_API_KEY: ${TALLY_REQUIRE_API_KEY:-false}
+      # CTO-241: persist replay sample bodies in MinIO (S3-compatible) instead of the in-process
+      # dict, so a gateway restart no longer wipes them and blanks the Recoverable Cost page. The
+      # AWS_* creds are the local MinIO root user/password; the endpoint targets the in-network
+      # MinIO S3 API on 9000. Region is nominal (MinIO ignores it, boto3 still wants one).
+      TALLY_REPLAY_BLOB_BACKEND: ${TALLY_REPLAY_BLOB_BACKEND:-s3}
+      TALLY_REPLAY_S3_BUCKET: ${TALLY_REPLAY_S3_BUCKET:-tally-replay}
+      TALLY_REPLAY_S3_ENDPOINT: http://minio:9000
+      TALLY_REPLAY_S3_REGION: ${TALLY_REPLAY_S3_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-tally}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-tally-minio}
     ports:
       - "${GATEWAY_PORT:-8080}:8080"
     depends_on:
@@ -172,6 +199,10 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-setup:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/healthz').status==200 else 1)"]
       interval: 10s

--- a/infra/gateway/Dockerfile
+++ b/infra/gateway/Dockerfile
@@ -13,8 +13,10 @@ COPY sdk/python /app/sdk/python
 COPY infra/gateway /app/infra/gateway
 
 # Install the SDK, then the gateway. We resolve `tally` from the local path rather than PyPI.
+# CTO-241: install the [s3] extra so boto3 is present for the s3 replay-blob backend the
+# docker-compose stack selects by default (persisting replay bodies in MinIO across restarts).
 RUN pip install /app/sdk/python \
- && pip install /app/infra/gateway
+ && pip install "/app/infra/gateway[s3]"
 
 EXPOSE 8080
 

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -251,6 +251,8 @@ def _build_replay_blob_store(settings) -> ReplayBlobStore:
             bucket=settings.replay_s3_bucket,
             prefix=settings.replay_s3_prefix,
             region=settings.replay_s3_region or None,
+            # CTO-241: point at MinIO in local dev; empty -> real AWS (or AWS_ENDPOINT_URL_S3).
+            endpoint_url=settings.replay_s3_endpoint or None,
         )
     raise ValueError(
         f"unknown TALLY_REPLAY_BLOB_BACKEND: {backend!r} (expected 'memory', 'gcs', or 's3')"
@@ -3009,11 +3011,19 @@ async def project_replay(
 
     per_candidate = []
     total_replay_cost = 0
+    # CTO-241: projection-scope tallies to decide, honestly, whether ANY captured body was still
+    # present. A restart can leave the durable index pointing at bodies the in-memory dev store no
+    # longer holds; those samples are skipped (excluded_missing_body) rather than 500-ing the
+    # request. If nothing at all could be replayed because every body was gone, we fall through to
+    # the same "insufficient corpus" shape the no-corpus branch returns, never a guessed number.
+    projection_replayed = 0
+    projection_missing_body = 0
     for cand in candidates:
         provider = str(cand["provider"])
         model = str(cand["model"])
         results = []
         excluded_budget = 0
+        excluded_missing_body = 0
         latencies: list[int] = []
         errors = 0
         cost_sum = 0
@@ -3038,6 +3048,10 @@ async def project_replay(
             if result.excluded_budget:
                 excluded_budget += 1
                 continue
+            if result.excluded_missing_body:
+                # CTO-241: body gone from the store; skip it, count it, fabricate nothing.
+                excluded_missing_body += 1
+                continue
             if result.row is not None:
                 latencies.append(result.row.latency_ms)
                 cost_sum += result.row.cost_micro_usd
@@ -3047,7 +3061,9 @@ async def project_replay(
         # Project per-sample cost into a monthly figure by scaling to the *corpus* size.
         # `samples_available` is the matched corpus (after filter); we treat it as a
         # representative slice of the tenant's monthly volume on that feature_tag.
-        replayed = len(results) - excluded_budget
+        replayed = len(results) - excluded_budget - excluded_missing_body
+        projection_replayed += replayed
+        projection_missing_body += excluded_missing_body
         avg_cost = (cost_sum / replayed) if replayed > 0 else 0
         # Honest extrapolation: avg cost per call × corpus size, scaled by a 30/sample-window-days
         # factor of 30 — we don't track window days yet, so v1 just reports avg × corpus.
@@ -3065,6 +3081,24 @@ async def project_replay(
             "error_rate": error_rate,
             "samples_replayed": replayed,
             "excluded_budget_count": excluded_budget,
+            "excluded_missing_body_count": excluded_missing_body,
+        })
+
+    # CTO-241: every selected body was gone (nothing replayed, and the reason was missing bodies,
+    # not the budget cap). Return the same honest "insufficient corpus" shape as the no-corpus
+    # branch rather than a page full of zeros, so Recoverable Cost shows a blank with a reason.
+    if projection_replayed == 0 and projection_missing_body > 0:
+        return JSONResponse({
+            "tenant_id": tenant_id,
+            "feature_tag": feature_tag,
+            "samples_available": samples_available,
+            "per_candidate": [],
+            "diagnostics": {
+                "context_fidelity": "resolved-context replay (no live retrieval)",
+                "replay_cost_micro_usd": 0,
+                "samples_replayed": 0,
+                "missing_body_count": projection_missing_body,
+            },
         })
 
     return JSONResponse({
@@ -3174,6 +3208,7 @@ async def project_replay_estimate(
     model = str(candidate["model"])
     results = []
     excluded_budget = 0
+    excluded_missing_body = 0
     latencies: list[int] = []
     errors = 0
     cost_sum = 0
@@ -3198,13 +3233,31 @@ async def project_replay_estimate(
         if result.excluded_budget:
             excluded_budget += 1
             continue
+        if result.excluded_missing_body:
+            # CTO-241: index row without a body (e.g. a restart wiped the dev store). Skip it and
+            # fabricate nothing rather than 500-ing the what-if.
+            excluded_missing_body += 1
+            continue
         if result.row is not None:
             latencies.append(result.row.latency_ms)
             cost_sum += result.row.cost_micro_usd
             if result.row.error_msg:
                 errors += 1
 
-    replayed = len(results) - excluded_budget
+    replayed = len(results) - excluded_budget - excluded_missing_body
+
+    # CTO-241: nothing left to replay because every selected body was gone — return the honest
+    # "insufficient corpus" shape (empty per_candidate) instead of a zero-filled projection.
+    if replayed == 0 and excluded_missing_body > 0:
+        diagnostics["missing_body_count"] = excluded_missing_body
+        return JSONResponse({
+            "tenant_id": tenant_id,
+            "feature_tag": feature_tag,
+            "samples_available": samples_available,
+            "per_candidate": [],
+            "diagnostics": diagnostics,
+        })
+
     avg_cost = (cost_sum / replayed) if replayed > 0 else 0
     projected_monthly_cost = int(round(avg_cost * samples_available))
     sorted_lat = sorted(latencies)
@@ -3227,6 +3280,7 @@ async def project_replay_estimate(
             "error_rate": error_rate,
             "samples_replayed": replayed,
             "excluded_budget_count": excluded_budget,
+            "excluded_missing_body_count": excluded_missing_body,
         }],
         "diagnostics": diagnostics,
     })

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -105,6 +105,12 @@ class Settings(BaseSettings):
     replay_s3_bucket: str = ""
     replay_s3_prefix: str = ""
     replay_s3_region: str = ""
+    # CTO-241: S3 endpoint override so the ``s3`` backend can target an S3-compatible service
+    # (MinIO in the local docker-compose stack) instead of real AWS. Empty means "use the regional
+    # AWS endpoint". boto3 also honours ``AWS_ENDPOINT_URL_S3`` from the environment when this is
+    # empty. Wiring the dev gateway to MinIO here is what stops a restart from wiping replay bodies
+    # and blanking the Recoverable Cost page.
+    replay_s3_endpoint: str = ""
 
     # BigQuery export sink (CTO-154). OPTIONAL, additive analytics mirror that copies
     # spans / business_events / attribution / daily rollups into a tenant's OWN BigQuery

--- a/infra/gateway/src/gateway/replay_errors.py
+++ b/infra/gateway/src/gateway/replay_errors.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed errors for the replay path (CTO-241).
+
+Kept in a tiny standalone module on purpose: the exception's class identity must be STABLE across
+an ``importlib.reload`` of :mod:`gateway.replay_store` (that module's optional-dependency tests
+reload it to prove it imports without boto3 / google-cloud-storage). If ``ReplayBodyMissing`` were
+defined inside ``replay_store`` itself, a reload would rebind it to a fresh class object, and the
+``except ReplayBodyMissing`` clause in :mod:`gateway.replay_executor` (bound against the pre-reload
+class) would silently stop catching it, turning a benign skip back into the uncaught 500 this ticket
+set out to kill. Defining it here, in a module nothing reloads, keeps that identity fixed.
+"""
+
+from __future__ import annotations
+
+
+class ReplayBodyMissing(KeyError):
+    """A replay sample's INDEX row exists but its scrubbed BODY is absent from the blob store.
+
+    CTO-241: the ClickHouse ``replay_samples`` index is durable and is re-hydrated on boot, but the
+    body blobs are not always co-durable. In local dev the blob store is
+    ``InMemoryReplayBlobStore`` (a plain in-process dict), so a gateway restart wipes every body
+    while the index still points at them. A bare dict/``KeyError`` lookup then surfaced as an HTTP
+    500 out of ``/v1/replay`` and blanked the Recoverable Cost page.
+
+    A ``ReplayBlobStore.get_bytes`` raises this typed exception instead, so a missing body is a
+    KNOWN, non-fatal condition the executor can skip over rather than an uncaught error. It
+    subclasses ``KeyError`` so any legacy caller that caught the old bare-dict ``KeyError`` keeps
+    working. ``key`` is the object key that missed (safe to log: it carries no body, only the
+    deterministic ``tenants/.../{sample_id}.json`` path).
+    """
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key)
+        self.key = key

--- a/infra/gateway/src/gateway/replay_executor.py
+++ b/infra/gateway/src/gateway/replay_executor.py
@@ -39,7 +39,7 @@ from uuid import UUID, uuid4
 
 from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
 
-from gateway.replay_store import ReplayBlobStore, ReplayRunRow
+from gateway.replay_store import ReplayBlobStore, ReplayBodyMissing, ReplayRunRow
 
 UTC = timezone.utc
 logger = logging.getLogger("tally.gateway.replay_executor")
@@ -87,6 +87,11 @@ class ReplayResult:
     candidate_provider: str
     candidate_model: str
     excluded_budget: bool = False
+    # CTO-241: the sample's index row existed but its scrubbed body was gone from the blob store
+    # (e.g. a restart wiped the in-memory dev store). The sample is skipped, not replayed, and MUST
+    # NOT contribute a fabricated cost/latency to the projection. Distinct from ``excluded_budget``
+    # so the caller can report the two skip reasons separately and stay honest under uncertainty.
+    excluded_missing_body: bool = False
     error_msg: str = ""
     row: ReplayRunRow | None = None
 
@@ -158,7 +163,22 @@ class ReplayExecutor:
             )
 
         async with self._semaphore(tenant_id):
-            envelope_bytes = self.blob_store.get_bytes(object_key)
+            try:
+                envelope_bytes = self.blob_store.get_bytes(object_key)
+            except ReplayBodyMissing:
+                # CTO-241: index row without a body. Skip the sample rather than 500 the whole
+                # /v1/replay request; the projection is computed over the bodies that ARE present.
+                # We emit nothing for it (no guessed cost) to preserve honesty under uncertainty.
+                logger.info(
+                    "replay: body missing for sample=%s key=%s — skipping",
+                    sample_id, object_key,
+                )
+                return ReplayResult(
+                    sample_id=sample_id,
+                    candidate_provider=candidate_provider,
+                    candidate_model=candidate_model,
+                    excluded_missing_body=True,
+                )
             envelope = json.loads(envelope_bytes.decode("utf-8"))
             if envelope_transform is not None:
                 envelope = envelope_transform(envelope)

--- a/infra/gateway/src/gateway/replay_store.py
+++ b/infra/gateway/src/gateway/replay_store.py
@@ -21,6 +21,13 @@ from uuid import UUID
 
 from gateway.replay_sampler import ReplaySamplePayload
 
+# CTO-241: ReplayBodyMissing is defined in gateway.replay_errors (a module nothing reloads) so its
+# class identity stays stable across an importlib.reload of this module. The optional-dependency
+# tests reload gateway.replay_store; if the exception were defined here, a reload would rebind it to
+# a fresh class the executor's ``except`` clause would stop catching. Re-exported so callers keep
+# importing it from gateway.replay_store alongside the stores.
+from gateway.replay_errors import ReplayBodyMissing
+
 UTC = timezone.utc
 
 
@@ -57,7 +64,13 @@ class InMemoryReplayBlobStore:
         self._objects[key] = body
 
     def get_bytes(self, key: str) -> bytes:
-        return self._objects[key]
+        # CTO-241: a bare ``self._objects[key]`` raised a plain KeyError that bubbled out of
+        # /v1/replay as a 500 after a restart wiped this in-process dict. Translate the miss into
+        # the typed, non-fatal ReplayBodyMissing so the executor can skip the sample instead.
+        try:
+            return self._objects[key]
+        except KeyError:
+            raise ReplayBodyMissing(key) from None
 
     def __len__(self) -> int:
         return len(self._objects)
@@ -113,7 +126,14 @@ class GCSReplayBlobStore:
         blob.upload_from_string(body, content_type=content_type)
 
     def get_bytes(self, key: str) -> bytes:
-        return self._bucket.blob(key).download_as_bytes()
+        # CTO-241: mirror the in-memory/S3 path — a missing blob is the typed, non-fatal
+        # ReplayBodyMissing, not a raw google-cloud NotFound that would 500 /v1/replay.
+        try:
+            return self._bucket.blob(key).download_as_bytes()
+        except Exception as exc:  # noqa: BLE001 — normalise google-cloud NotFound (404) to a miss.
+            if _is_gcs_not_found(exc):
+                raise ReplayBodyMissing(key) from exc
+            raise
 
 
 class S3ReplayBlobStore:
@@ -155,6 +175,7 @@ class S3ReplayBlobStore:
         *,
         prefix: str = "",
         region: str | None = None,
+        endpoint_url: str | None = None,
         client: object | None = None,
     ) -> None:
         if not bucket:
@@ -165,7 +186,12 @@ class S3ReplayBlobStore:
             # instance profile / env / shared file) automatically — we never handle a raw key here.
             import boto3  # type: ignore[import-not-found]
 
-            client = boto3.client("s3", region_name=region)
+            # CTO-241: ``endpoint_url`` points the client at an S3-compatible service (MinIO in the
+            # local docker-compose stack) so replay bodies survive a gateway restart instead of
+            # living only in an in-process dict. Left None for real AWS, boto3 resolves the regional
+            # AWS endpoint itself. boto3 also honours AWS_ENDPOINT_URL_S3 from the environment when
+            # this arg is None, so the compose env can set it either way.
+            client = boto3.client("s3", region_name=region, endpoint_url=endpoint_url or None)
         self._client = client
         self._bucket = bucket
         # Normalise prefix to a bare, slash-terminated segment (or empty) so key joins are clean.
@@ -183,7 +209,14 @@ class S3ReplayBlobStore:
         )
 
     def get_bytes(self, key: str) -> bytes:
-        resp = self._client.get_object(Bucket=self._bucket, Key=self._full_key(key))
+        # CTO-241: a body that was indexed but never landed (or aged out of the bucket) must be a
+        # typed, non-fatal miss like the in-memory path, not a raw botocore 404 that 500s /v1/replay.
+        try:
+            resp = self._client.get_object(Bucket=self._bucket, Key=self._full_key(key))
+        except Exception as exc:  # noqa: BLE001 — normalise botocore ClientError (404/NoSuchKey).
+            if _is_s3_not_found(exc):
+                raise ReplayBodyMissing(key) from exc
+            raise
         return resp["Body"].read()
 
     def exists(self, key: str) -> bool:
@@ -211,6 +244,16 @@ def _is_s3_not_found(exc: BaseException) -> bool:
         if status == 404:
             return True
     return False
+
+
+def _is_gcs_not_found(exc: BaseException) -> bool:
+    """Return True for a google-cloud 'blob not found' error (HTTP 404 / NotFound).
+
+    Kept structural (duck-typed on ``code`` / class name) so the module never needs
+    ``google-cloud-storage`` imported to interpret the error and tests can raise a stand-in."""
+    if getattr(exc, "code", None) == 404:
+        return True
+    return type(exc).__name__ == "NotFound"
 
 
 # --- ClickHouse-side index rows --------------------------------------------------------------

--- a/infra/gateway/tests/test_app_replay.py
+++ b/infra/gateway/tests/test_app_replay.py
@@ -182,6 +182,63 @@ def test_replay_projection_returns_per_candidate_rows(client: TestClient) -> Non
     assert diag["replay_cost_micro_usd"] >= 0
 
 
+def test_replay_projection_skips_missing_bodies_thinner(client: TestClient) -> None:
+    """CTO-241: some bodies gone (index rows survive), the rest present. /v1/replay must return a
+    valid projection over the bodies that ARE present, never a 500, and report the skip count."""
+    _seed_samples(client, n=10)
+    index = app.state.replay_sample_index
+    blob_store = app.state.replay_blob_store
+    # Simulate a partial body loss: drop 4 of the 10 bodies while their index rows remain.
+    for row in index[:4]:
+        blob_store._objects.pop(row.s3_object_key, None)
+
+    r = client.post(
+        "/v1/replay",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_models": [{"provider": "anthropic", "model": "claude-haiku-4-5"}],
+            "sample_size": 10,  # >= n so every sample is selected -> deterministic 6 present / 4 gone
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["samples_available"] == 10
+    assert len(body["per_candidate"]) == 1
+    cand = body["per_candidate"][0]
+    assert cand["samples_replayed"] == 6
+    assert cand["excluded_missing_body_count"] == 4
+    # Thinner projection is still a real, positive number computed off the present bodies.
+    assert cand["projected_monthly_cost_micro_usd"] > 0
+
+
+def test_replay_projection_all_bodies_missing_returns_insufficient_corpus(
+    client: TestClient,
+) -> None:
+    """CTO-241: the exact restart bug — durable index re-hydrated, in-memory bodies wiped. Every
+    body is gone, so /v1/replay returns the honest insufficient-corpus shape (empty per_candidate),
+    NOT a 500 and NOT a page of fabricated zeros."""
+    _seed_samples(client, n=5)
+    # Restart simulation: the index survives (durable ClickHouse re-hydrate) but the in-process
+    # blob store comes back empty.
+    app.state.replay_blob_store = InMemoryReplayBlobStore()
+
+    r = client.post(
+        "/v1/replay",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_models": [{"provider": "anthropic", "model": "claude-haiku-4-5"}],
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["per_candidate"] == []
+    assert body["samples_available"] == 5
+    assert body["diagnostics"]["missing_body_count"] == 5
+    assert body["diagnostics"]["samples_replayed"] == 0
+
+
 def test_replay_projection_filters_by_feature_tag(client: TestClient) -> None:
     _seed_samples(client, n=30, feature_tag="chat")
     _seed_samples(client, n=20, feature_tag="research")

--- a/infra/gateway/tests/test_replay_executor.py
+++ b/infra/gateway/tests/test_replay_executor.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import uuid4
 
+import pytest
 
 from tally.pricing import seed_catalog
 
@@ -19,6 +20,7 @@ from gateway.replay_executor import (
 )
 from gateway.replay_store import (
     InMemoryReplayBlobStore,
+    ReplayBodyMissing,
     ReplayRunRow,
     build_replay_object_key,
 )
@@ -115,6 +117,41 @@ def test_replay_persists_candidate_response_text() -> None:
     ch = row.as_clickhouse_row()
     assert ch[-2] == "The candidate's actual answer is 42."
     assert ch[-1] == "stop"
+
+
+# --- Missing body (CTO-241) ---------------------------------------------------
+
+def test_replay_skips_when_body_missing() -> None:
+    """A durable index row whose body is gone from the store (e.g. a restart wiped the in-memory
+    dev store) must be skipped, not 500. The executor emits no row and fabricates no cost."""
+    exec_, rows = _make_executor()
+    sid = uuid4()
+    # Intentionally do NOT seed the blob: the object_key points at a body that is not present.
+    missing_key = build_replay_object_key("t1", sid, datetime.now(timezone.utc))
+
+    result = asyncio.run(exec_.replay_sample(
+        tenant_id="t1",
+        sample_id=sid,
+        object_key=missing_key,
+        candidate_provider="anthropic",
+        candidate_model="claude-haiku-4-5",
+        daily_budget_usd=Decimal("5.00"),
+    ))
+
+    assert result.excluded_missing_body is True
+    assert result.excluded_budget is False
+    assert result.row is None
+    assert result.succeeded is False
+    assert rows == []  # nothing written; no guessed figure
+
+
+def test_in_memory_store_raises_typed_missing() -> None:
+    """The typed miss is what makes the skip a KNOWN condition (and it stays a KeyError subclass
+    so any legacy bare-except-KeyError caller keeps working)."""
+    store = InMemoryReplayBlobStore()
+    with pytest.raises(ReplayBodyMissing):
+        store.get_bytes("tenants/t1/replay_samples/2026/01/01/nope.json")
+    assert issubclass(ReplayBodyMissing, KeyError)
 
 
 # --- Budget cap ---------------------------------------------------------------

--- a/infra/gateway/tests/test_replay_store_s3.py
+++ b/infra/gateway/tests/test_replay_store_s3.py
@@ -19,6 +19,7 @@ from gateway.config import Settings
 from gateway.replay_sampler import ReplaySamplePayload
 from gateway.replay_store import (
     InMemoryReplayBlobStore,
+    ReplayBodyMissing,
     S3ReplayBlobStore,
     build_replay_object_key,
     persist_sample,
@@ -126,6 +127,48 @@ def test_content_type_passed_and_bucket_used() -> None:
     assert "my-bucket" in client.buckets_used
 
 
+# --- Missing body (CTO-241) ------------------------------------------------------------------
+
+def test_get_bytes_raises_typed_missing_on_nosuchkey() -> None:
+    """A 404 / NoSuchKey out of S3 becomes the typed, non-fatal ReplayBodyMissing so /v1/replay
+    can skip the sample instead of 500-ing (mirrors the in-memory backend)."""
+    store = S3ReplayBlobStore(bucket="b", client=_FakeS3Client())
+    with pytest.raises(ReplayBodyMissing):
+        store.get_bytes("tenants/t/gone.json")
+
+
+def test_get_bytes_reraises_non_404_errors() -> None:
+    class _BoomClient(_FakeS3Client):
+        def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+            raise _FakeClientError("AccessDenied", status=403)
+
+    store = S3ReplayBlobStore(bucket="b", client=_BoomClient())
+    with pytest.raises(_FakeClientError):
+        store.get_bytes("tenants/t/x.json")
+
+
+def test_endpoint_url_forwarded_to_boto3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CTO-241: when no client is injected, the endpoint override reaches boto3.client so the store
+    can point at MinIO. Uses a fake boto3 module so the real dependency is not required."""
+    captured: dict[str, object] = {}
+
+    class _FakeBoto3:
+        @staticmethod
+        def client(service: str, *, region_name=None, endpoint_url=None):
+            captured["service"] = service
+            captured["region_name"] = region_name
+            captured["endpoint_url"] = endpoint_url
+            return _FakeS3Client()
+
+    monkeypatch.setitem(sys.modules, "boto3", _FakeBoto3)
+    S3ReplayBlobStore(bucket="b", region="us-east-1", endpoint_url="http://minio:9000")
+    assert captured == {
+        "service": "s3",
+        "region_name": "us-east-1",
+        "endpoint_url": "http://minio:9000",
+    }
+
+
 # --- exists() --------------------------------------------------------------------------------
 
 def test_exists_true_after_put_and_false_when_absent() -> None:
@@ -182,10 +225,18 @@ def test_backend_selection_picks_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
     class _StubS3:
-        def __init__(self, bucket: str, *, prefix: str = "", region: str | None = None) -> None:
+        def __init__(
+            self,
+            bucket: str,
+            *,
+            prefix: str = "",
+            region: str | None = None,
+            endpoint_url: str | None = None,
+        ) -> None:
             captured["bucket"] = bucket
             captured["prefix"] = prefix
             captured["region"] = region
+            captured["endpoint_url"] = endpoint_url
 
     monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)
     settings = Settings(
@@ -200,7 +251,35 @@ def test_backend_selection_picks_s3(monkeypatch: pytest.MonkeyPatch) -> None:
         "bucket": "tally-replay-prod",
         "prefix": "env/prod",
         "region": "us-east-1",
+        # No endpoint set -> None so boto3 resolves the real regional AWS endpoint.
+        "endpoint_url": None,
     }
+
+
+def test_backend_selection_passes_endpoint_from_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CTO-241: TALLY_REPLAY_S3_ENDPOINT threads through to the store so the s3 backend can target
+    MinIO (or any S3-compatible endpoint) in local dev."""
+    from gateway.app import _build_replay_blob_store
+
+    captured: dict[str, object] = {}
+
+    class _StubS3:
+        def __init__(
+            self, bucket: str, *, prefix: str = "", region: str | None = None,
+            endpoint_url: str | None = None,
+        ) -> None:
+            captured["endpoint_url"] = endpoint_url
+
+    monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)
+    settings = Settings(
+        replay_blob_backend="s3",
+        replay_s3_bucket="tally-replay",
+        replay_s3_endpoint="http://minio:9000",
+    )
+    _build_replay_blob_store(settings)
+    assert captured["endpoint_url"] == "http://minio:9000"
 
 
 def test_s3_empty_region_resolves_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -209,7 +288,10 @@ def test_s3_empty_region_resolves_to_none(monkeypatch: pytest.MonkeyPatch) -> No
     captured: dict[str, object] = {}
 
     class _StubS3:
-        def __init__(self, bucket: str, *, prefix: str = "", region: str | None = None) -> None:
+        def __init__(
+            self, bucket: str, *, prefix: str = "", region: str | None = None,
+            endpoint_url: str | None = None,
+        ) -> None:
             captured["region"] = region
 
     monkeypatch.setattr("gateway.app.S3ReplayBlobStore", _StubS3)


### PR DESCRIPTION
## Root cause

A gateway restart blanked the **Recoverable Cost** dashboard page.

The wrong-sized-model waste detector calls the gateway `/v1/replay`, which re-executes captured replay samples. Each sample has a durable **INDEX** row in ClickHouse `replay_samples` plus a scrubbed **BODY** in a blob store. In local dev the blob store is `InMemoryReplayBlobStore` (a plain in-process dict), so a gateway restart wipes every body. On boot the gateway re-hydrates the index from ClickHouse (so it *thinks* the samples exist) but the bodies are gone, and `replay_store.py` `get_bytes` did a bare dict / `KeyError` lookup that surfaced as an **HTTP 500** from `/v1/replay`:

```
app.py project_replay -> replay_executor.replay_sample -> replay_store.py get_bytes -> KeyError
```

The detector then honestly emitted nothing and Recoverable Cost rendered blank.

## Part A — fail-soft on a missing body

- `get_bytes` now raises a typed **`ReplayBodyMissing`** (a `KeyError` subclass, so any legacy `except KeyError` keeps working) on a miss, for the in-memory, S3, and GCS backends. It lives in a tiny `gateway.replay_errors` module so its class identity survives the optional-dependency `importlib.reload` tests (a reloaded `replay_store` would otherwise rebind the class and the executor's `except` would stop catching it).
- `replay_executor.replay_sample` catches it and returns a **skipped** result (`excluded_missing_body`) instead of propagating.
- `project_replay` / `project_replay_estimate` exclude skipped samples from the projection and report `excluded_missing_body_count`, computing a valid **thinner** projection over the bodies that ARE present. When **every** selected body is gone they return the same honest **"insufficient corpus"** shape the endpoints already use for an empty corpus — never a 500, never a fabricated zero. Existing honest-null / PII-scrub behavior is untouched.

## Part B — persistent blob backend for local dev

- `S3ReplayBlobStore` gains an `endpoint_url` override (new `TALLY_REPLAY_S3_ENDPOINT` setting, threaded through `Settings` and `_build_replay_blob_store`; boto3's `AWS_ENDPOINT_URL_S3` is also honored) so the `s3` backend can target the **MinIO** already running in `docker-compose`.
- The gateway image installs the `[s3]` extra so `boto3` is present when the `s3` backend is selected.
- `docker-compose.yml` wires the gateway to MinIO (`TALLY_REPLAY_BLOB_BACKEND=s3`, bucket, endpoint, `AWS_*` creds from the MinIO service) with a one-shot `mc` bucket-bootstrap service. **The `Settings` default stays `memory`, so tests/CI are unaffected.**

## Tests

- Executor: a missing body yields a skipped sample (no row, no exception); the typed miss is a `KeyError` subclass.
- App: a partial body loss yields a valid thinner projection with `excluded_missing_body_count`; the full-loss (restart) case returns the insufficient-corpus shape rather than a 500.
- S3 store: honors the `endpoint_url` override (forwarded to `boto3.client`), `_build_replay_blob_store` selects it from settings, and a 404/NoSuchKey becomes `ReplayBodyMissing`.

Gateway CI green locally: `uv run --extra dev pytest -q` (887 passed) and `uv run ruff check .` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)