### PR TITLE
fix(web): scale Model Comparison candidate cost to full traffic (kills the bogus 100% reduction)

### DIFF
--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -88,6 +88,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -98,7 +99,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: corpus cost over 50 replayed traces. $0.0015/call → $3.00/mo at 2000 calls.
+          projected_monthly_cost_micro_usd: 75_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -108,7 +110,8 @@ describe("/api/compare", () => {
         {
           provider: "openai",
           model: "gpt-5-mini",
-          projected_monthly_cost_micro_usd: 4_000_000,
+          // $0.002/call → $4.00/mo at 2000 calls.
+          projected_monthly_cost_micro_usd: 100_000,
           p50_latency_ms: 900,
           p95_latency_ms: 1700,
           error_rate: 0.02,
@@ -127,10 +130,13 @@ describe("/api/compare", () => {
     expect(body.replay_source).toBe("replay");
     expect(body.current.model).toBe("claude-sonnet-4-5");
     expect(body.candidates).toHaveLength(2);
-    // Costs come straight from the projection, not the rescaled mock.
+    // CTO-231: cost is rescaled onto the current model's full-traffic basis (per-call cost ×
+    // 2000 monthly calls), NOT the raw 75_000 corpus projection. This is what stops the bogus
+    // "100% reduction": $3.00/mo candidate vs $10.00/mo current is a believable 70% cut.
     const haiku = body.candidates.find((c: { model: string }) => c.model === "claude-haiku-4-5");
     expect(haiku.monthlyCostMicroUsd).toBe(3_000_000);
-    // Savings recomputed off the cheapest candidate.
+    expect(haiku.monthlyCostMicroUsd).not.toBe(75_000);
+    // Savings recomputed off the cheapest candidate on the corrected basis.
     expect(body.recommendation.projectedSavingsMicroUsd).toBe(7_000_000);
     // Diagnostics reflect the real samples_available + replay cost.
     expect(body.diagnostics.samplesAvailable).toBe(50);
@@ -144,6 +150,102 @@ describe("/api/compare", () => {
     expect(haiku.errorRate).toBeCloseTo(0.01, 6);
   });
 
+  // CTO-231: the candidate's reported monthly cost is the replayed-corpus cost rescaled to the
+  // current model's FULL-TRAFFIC monthly call volume, not the raw corpus projection. This is the
+  // fix for the bogus "100% reduction": before, a ~150-trace corpus cost was compared against a
+  // full month of incumbent spend, so the candidate looked ~$8/mo against a ~$72K/mo current and
+  // deriveRecommendation reported a nonsense ~100% cut. Here the current model runs 300_000
+  // monthly calls, so a $0.088/call candidate projects to ~$26.4K/mo (about 63% cheaper), NOT the
+  // 13_200 corpus figure.
+  it("CTO-231: scales candidate cost to the current model's full call volume, not the raw corpus projection", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 72_000_000_000, // $72K/mo real full-traffic incumbent spend
+      monthlyCalls: 300_000, // real full-traffic monthly call volume
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 70_000,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 150,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          // Corpus cost of $13.20 over 150 replayed traces = $0.088/call.
+          projected_monthly_cost_micro_usd: 13_200_000,
+          p50_latency_ms: 800,
+          p95_latency_ms: 1500,
+          error_rate: 0.01,
+          samples_replayed: 150,
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 13_200_000,
+      },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    const haiku = body.candidates.find((c: { model: string }) => c.model === "claude-haiku-4-5");
+    // $0.088/call × 300_000 monthly calls = $26,400/mo full-traffic, on the SAME basis as current.
+    expect(haiku.monthlyCostMicroUsd).toBe(26_400_000_000);
+    // NOT the raw corpus projection the gateway returned.
+    expect(haiku.monthlyCostMicroUsd).not.toBe(13_200_000);
+    // Savings are believable (~63%), never the bogus ~100% the un-rescaled corpus cost produced.
+    expect(body.recommendation.projectedSavingsMicroUsd).toBe(45_600_000_000);
+    expect(body.recommendation.projectedSavingsPct).toBeCloseTo(0.6333, 3);
+    expect(body.recommendation.projectedSavingsPct).toBeLessThan(1);
+  });
+
+  // CTO-231: a candidate with zero replayed responses has no per-call cost to scale. We must not
+  // divide by zero or fabricate a figure; the candidate is dropped (honest-null) and, with no
+  // alternative clearing replay, the recommendation is the honest insufficient-data result.
+  it("CTO-231: samples_replayed === 0 yields the honest insufficient-data result (no divide-by-zero)", async () => {
+    queryCurrentModel.mockResolvedValueOnce({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      monthlyCostMicroUsd: 72_000_000_000,
+      monthlyCalls: 300_000,
+      latencyP95Ms: 2400,
+      errorRate: 0.004,
+      sampleCount: 70_000,
+    });
+    queryReplayCandidates.mockResolvedValueOnce({
+      samples_available: 0,
+      per_candidate: [
+        {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          projected_monthly_cost_micro_usd: 13_200_000,
+          p50_latency_ms: null,
+          p95_latency_ms: null,
+          error_rate: null,
+          samples_replayed: 0, // nothing replayed → no per-call cost to scale
+          excluded_budget_count: 0,
+        },
+      ],
+      diagnostics: {
+        context_fidelity: "resolved-context replay (no live retrieval)",
+        replay_cost_micro_usd: 0,
+      },
+    });
+
+    const res = await CompareGET(new Request("http://test/api/compare") as never);
+    const body = await res.json();
+    expect(body.replay_source).toBe("replay");
+    // The zero-sample candidate is dropped rather than shown with a fabricated / NaN cost.
+    expect(body.candidates).toHaveLength(0);
+    // No candidate cleared replay → honest insufficient-data recommendation, never the fixture prose.
+    expect(body.recommendation.summary).toMatch(/no alternative candidate cleared replay/i);
+    expect(body.recommendation.summary).not.toBe(comparison.recommendation.summary);
+    // Savings default to 0 when there is no candidate to project (never a fabricated figure).
+    expect(body.recommendation.projectedSavingsMicroUsd).toBe(0);
+  });
+
   // CTO-123: a candidate with fewer than 50 replayed responses gets null latency/error —
   // the same honest-null floor the `current` row uses (CTO-115) — so the page renders "—"
   // rather than a noisy number or a borrowed mock.
@@ -152,6 +254,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -162,7 +265,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: 73_500 over 49 replayed traces → $3.00/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 73_500,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -172,7 +276,7 @@ describe("/api/compare", () => {
         {
           provider: "openai",
           model: "gpt-5-mini",
-          projected_monthly_cost_micro_usd: 4_000_000,
+          projected_monthly_cost_micro_usd: 100_000,
           p50_latency_ms: 900,
           p95_latency_ms: 1700,
           error_rate: 0.02,
@@ -204,6 +308,7 @@ describe("/api/compare", () => {
       model: "claude-haiku-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 1_000_000,
+      monthlyCalls: 400,
       latencyP95Ms: 1500,
       errorRate: 0.005,
       sampleCount: 100,
@@ -247,6 +352,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
     });
     queryReplayCandidates.mockResolvedValueOnce({
       samples_available: 50,
@@ -254,7 +360,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: 75_000 over 50 replayed traces → $3.00/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 75_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -301,6 +408,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
     });
     queryReplayCandidates.mockResolvedValueOnce({
       samples_available: 50,
@@ -308,7 +416,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: 75_000 over 50 replayed traces → $3.00/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 75_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -353,6 +462,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
     });
     queryReplayCandidates.mockResolvedValueOnce({
       samples_available: 50,
@@ -360,7 +470,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: 75_000 over 50 replayed traces → $3.00/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 75_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -388,6 +499,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -398,7 +510,8 @@ describe("/api/compare", () => {
         {
           provider: "google",
           model: "gemini-3-flash",
-          projected_monthly_cost_micro_usd: 2_400_000,
+          // CTO-231: 72_000 over 60 replayed traces → $2.40/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 72_000,
           p50_latency_ms: 700,
           p95_latency_ms: 1400,
           error_rate: 0.012,
@@ -451,6 +564,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -461,7 +575,8 @@ describe("/api/compare", () => {
         {
           provider: "google",
           model: "gemini-3-flash",
-          projected_monthly_cost_micro_usd: 2_400_000,
+          // CTO-231: 36_000 over 30 replayed traces → $2.40/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 36_000,
           p50_latency_ms: 700,
           p95_latency_ms: 1400,
           error_rate: 0.012,
@@ -514,6 +629,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -524,7 +640,9 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000, // 70% cheaper than current
+          // CTO-231: 90_000 over 60 replayed traces → $3.00/mo scaled to 2000 monthly calls,
+          // i.e. 70% cheaper than the $10.00/mo current model.
+          projected_monthly_cost_micro_usd: 90_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -585,6 +703,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -595,7 +714,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: 90_000 over 60 replayed traces → $3.00/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 90_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,
@@ -622,6 +742,7 @@ describe("/api/compare", () => {
       model: "claude-sonnet-4-5",
       provider: "anthropic",
       monthlyCostMicroUsd: 10_000_000,
+      monthlyCalls: 2000,
       latencyP95Ms: 2400,
       errorRate: 0.004,
       sampleCount: 500,
@@ -632,7 +753,8 @@ describe("/api/compare", () => {
         {
           provider: "anthropic",
           model: "claude-haiku-4-5",
-          projected_monthly_cost_micro_usd: 3_000_000,
+          // CTO-231: 30_000 over 20 replayed traces → $3.00/mo scaled to 2000 monthly calls.
+          projected_monthly_cost_micro_usd: 30_000,
           p50_latency_ms: 800,
           p95_latency_ms: 1500,
           error_rate: 0.01,

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
-import { comparison, deriveRecommendation, deriveWorkload } from "@/lib/compare";
+import {
+  comparison,
+  deriveRecommendation,
+  deriveWorkload,
+  scaleCandidateMonthlyCost,
+} from "@/lib/compare";
 import {
   queryCurrentModel,
   queryEvalCandidates,
@@ -85,12 +90,26 @@ export async function GET(req: Request) {
 
   if (replay) {
     // Real replay data — drop the mock rescaling entirely. Each candidate row is built from
-    // the gateway's projection (per-candidate average cost × matched corpus size). The current
-    // model still comes from queryCurrentModel because v1 replay doesn't re-replay the current
-    // model against itself.
+    // the gateway's projection. The current model still comes from queryCurrentModel because v1
+    // replay doesn't re-replay the current model against itself.
     const candidates = replay.per_candidate
       .filter((c) => c.model !== live.model)
-      .map((c) => {
+      .flatMap((c) => {
+        // CTO-231: the gateway's projected_monthly_cost_micro_usd is the candidate's cost over the
+        // REPLAYED CORPUS (per-candidate average cost × matched corpus size), NOT a full month of
+        // traffic. Shipping it as-is against the incumbent's real full-month spend made the
+        // candidate look ~$8/mo next to a ~$72K/mo current model, so deriveRecommendation reported
+        // a nonsense "100% reduction". Rescale it onto the SAME full-traffic monthly basis as
+        // `current`: per-call cost (corpus cost / samples replayed) × the current model's
+        // full-traffic monthly call count. A candidate with no replayed responses has no per-call
+        // cost, so scaleCandidateMonthlyCost returns null and we emit nothing for it (honest-null)
+        // rather than divide by zero; its absence surfaces as the insufficient-data verdict below.
+        const monthlyCostMicroUsd = scaleCandidateMonthlyCost(
+          c.projected_monthly_cost_micro_usd,
+          c.samples_replayed,
+          live.monthlyCalls,
+        );
+        if (monthlyCostMicroUsd === null) return [];
         // CTO-114: real pairwise-LLM-judge win-rate when ≥10 samples have been judged for this
         // candidate. Below the floor, qualityScore is null — the page renders "—". We never
         // fall back to a mock number; that would have been the previous workaround and the
@@ -101,15 +120,17 @@ export async function GET(req: Request) {
         // rate computed from fewer than 50 replayed responses is too noisy to present, so we emit
         // null and the page renders "—" rather than a number or a borrowed mock.
         const enoughReplayed = c.samples_replayed >= MIN_REPLAYED_SAMPLES;
-        return {
-          model: c.model,
-          provider: c.provider,
-          monthlyCostMicroUsd: c.projected_monthly_cost_micro_usd,
-          qualityScore: quality?.qualityScore ?? null,
-          ...(quality ? { qualityCi: quality.qualityCi } : {}),
-          latencyP95Ms: enoughReplayed ? c.p95_latency_ms : null,
-          errorRate: enoughReplayed ? c.error_rate : null,
-        };
+        return [
+          {
+            model: c.model,
+            provider: c.provider,
+            monthlyCostMicroUsd,
+            qualityScore: quality?.qualityScore ?? null,
+            ...(quality ? { qualityCi: quality.qualityCi } : {}),
+            latencyP95Ms: enoughReplayed ? c.p95_latency_ms : null,
+            errorRate: enoughReplayed ? c.error_rate : null,
+          },
+        ];
       });
     // CTO-168: verdict + summary + projected savings are all generated from the REAL replayed
     // deltas here — cost savings %, pairwise-judge quality, latency — never the fixture prose.

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -83,6 +83,8 @@ describe("queryCurrentModel — latency/error suppression (CTO-115)", () => {
     expect(out!.latencyP95Ms).toBe(2401);
     expect(out!.errorRate).toBeCloseTo(0.004, 6);
     expect(out!.sampleCount).toBe(500);
+    // CTO-231: the 7-day call count projected to a 30-day month, same basis as the cost.
+    expect(out!.monthlyCalls).toBe(Math.round((500 * 30) / 7));
   });
 
   it("handles ClickHouse string-encoded numerics", async () => {
@@ -99,6 +101,8 @@ describe("queryCurrentModel — latency/error suppression (CTO-115)", () => {
     expect(out!.latencyP95Ms).toBe(1800);
     expect(out!.errorRate).toBeCloseTo(0.01, 6);
     expect(out!.sampleCount).toBe(75);
+    // CTO-231: string-encoded sampleCount still yields an integer monthly call projection.
+    expect(out!.monthlyCalls).toBe(Math.round((75 * 30) / 7));
   });
 });
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -2927,6 +2927,12 @@ export async function queryCurrentModel(): Promise<{
   model: string;
   provider: string;
   monthlyCostMicroUsd: number;
+  // CTO-231: the current model's full-traffic call count over the same window, projected to a
+  // 30-day month exactly like monthlyCostMicroUsd. The /api/compare route needs a full-traffic
+  // call volume to rescale each candidate's replayed-corpus cost onto the incumbent's basis
+  // (candidate per-call cost × this figure). Without it the route could only weigh a ~150-trace
+  // replay corpus against a full month of incumbent spend, which reported a bogus ~100% reduction.
+  monthlyCalls: number;
   // null when sampleCount < MIN_SPANS_FOR_LATENCY_ERROR — the route surfaces these as "—" on the
   // page rather than fabricating numbers off a too-small window.
   latencyP95Ms: number | null;
@@ -2983,6 +2989,10 @@ export async function queryCurrentModel(): Promise<{
       typeof out[0].sampleCount === "number"
         ? out[0].sampleCount
         : parseInt(out[0].sampleCount, 10) || 0;
+    // CTO-231: project the 7-day call count to a 30-day month on the SAME basis as the cost sum
+    // above, so the /api/compare route can put candidate costs on the incumbent's full-traffic
+    // basis. Rounded to an integer call count.
+    const monthlyCalls = Math.round((sampleCount * 30) / 7);
     const enoughSamples = sampleCount >= MIN_SPANS_FOR_LATENCY_ERROR;
     const p95Raw = out[0].p95Ms;
     const errRaw = out[0].errRate;
@@ -3008,6 +3018,7 @@ export async function queryCurrentModel(): Promise<{
       model: out[0].model,
       provider: out[0].provider || "unknown",
       monthlyCostMicroUsd,
+      monthlyCalls,
       latencyP95Ms,
       errorRate,
       sampleCount,

--- a/web/lib/compare.test.ts
+++ b/web/lib/compare.test.ts
@@ -6,6 +6,7 @@ import {
   deriveRecommendation,
   deriveWorkload,
   MIN_SAMPLES_TO_RECOMMEND,
+  scaleCandidateMonthlyCost,
   type RecommendationCandidate,
 } from "./compare";
 
@@ -31,6 +32,30 @@ describe("compare", () => {
   it("diagnostics excludes throttled samples from headline metrics (modeled)", () => {
     expect(comparison.diagnostics.excludedRateLimited).toBeGreaterThan(0);
     expect(comparison.diagnostics.contextFidelity).toMatch(/resolved-context/);
+  });
+});
+
+// CTO-231: the rescale that puts a candidate's replayed-corpus cost on the incumbent's
+// full-traffic monthly basis, killing the bogus "100% reduction".
+describe("scaleCandidateMonthlyCost", () => {
+  it("scales the replayed-corpus cost by full monthly calls / samples replayed", () => {
+    // Corpus cost $0.075 over 50 replayed traces = $0.0015/call; at 2000 monthly calls that is
+    // $3.00/mo full-traffic (3_000_000 micro-USD), NOT the raw 75_000 corpus projection.
+    expect(scaleCandidateMonthlyCost(75_000, 50, 2000)).toBe(3_000_000);
+  });
+
+  it("is the identity when monthly calls equals samples replayed", () => {
+    expect(scaleCandidateMonthlyCost(4_000_000, 150, 150)).toBe(4_000_000);
+  });
+
+  it("keeps money integer micro-USD (rounds half-up, no float dollars)", () => {
+    // 1_000_000 * 3 / 7 = 428571.42... → rounds to 428_571.
+    expect(scaleCandidateMonthlyCost(1_000_000, 7, 3)).toBe(428_571);
+  });
+
+  it("returns null (never divides by zero or fabricates) when no samples were replayed", () => {
+    expect(scaleCandidateMonthlyCost(3_000_000, 0, 2000)).toBeNull();
+    expect(scaleCandidateMonthlyCost(3_000_000, -5, 2000)).toBeNull();
   });
 });
 

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -100,6 +100,35 @@ export function deltaPct(current: number, candidate: number): number {
   return (candidate - current) / current;
 }
 
+/**
+ * Rescale a candidate's replayed-corpus cost onto the current model's full-traffic monthly basis
+ * (CTO-231). The gateway's `projected_monthly_cost_micro_usd` is the candidate's cost over the
+ * REPLAYED CORPUS (per-candidate average cost × matched corpus size), NOT a full month of traffic.
+ * Comparing that raw corpus figure against the incumbent's real full-month spend made a ~150-trace
+ * replay look like ~$8/mo against a ~$72K/mo incumbent, so the page reported a bogus "100%
+ * reduction". Here we recover the candidate's per-call cost (corpus cost / samples replayed) and
+ * multiply by the current model's full-traffic monthly call count, so both sides of the comparison
+ * sit on one basis and the savings % is believable (e.g. ~89%, not 100%).
+ *
+ * Money stays integer micro-USD: the multiply/divide runs in BigInt and rounds half-up at the end,
+ * so no float dollars enter the math. Returns `null` when `samplesReplayed <= 0`: a per-call cost
+ * is undefined without a replayed sample, so we emit nothing rather than divide by zero or
+ * fabricate a figure (honest-under-uncertainty). Callers drop the null candidate.
+ */
+export function scaleCandidateMonthlyCost(
+  projectedCorpusCostMicroUsd: MicroUSD,
+  samplesReplayed: number,
+  currentMonthlyCalls: number,
+): MicroUSD | null {
+  if (samplesReplayed <= 0) return null;
+  const numer =
+    BigInt(Math.round(projectedCorpusCostMicroUsd)) * BigInt(Math.round(currentMonthlyCalls));
+  const denom = BigInt(Math.round(samplesReplayed));
+  // Round half-up in integer space (denom/2n truncates toward zero, matching non-negative money).
+  const scaled = (numer + denom / 2n) / denom;
+  return Number(scaled);
+}
+
 // Compare fixture for the research_agent workload — the dominant cost driver from cost.ts
 // ($19.1K LLM spend on this workload alone over 30 days, ≈ $4.5K/week).
 //


### PR DESCRIPTION
## The bug

On the Model Comparison page, a candidate model showed a **"100% reduction"** in cost, with a nonsense savings figure.

## Root cause: a basis mismatch

In `web/app/api/compare/route.ts`, the live replay path built each candidate row with:

```ts
monthlyCostMicroUsd: c.projected_monthly_cost_micro_usd
```

Per the gateway, that value is "per-candidate average cost x matched corpus size", i.e. the candidate's cost **over the replayed corpus** (e.g. 150 traces), not a full month of traffic. Meanwhile the `current` model's `monthlyCostMicroUsd` comes from `queryCurrentModel()` and is **real full-traffic monthly spend**.

Comparing those two different bases made the candidate look ~$8/mo against a ~$72K/mo incumbent, so `deriveRecommendation` computed a ~100% savings and a meaningless dollar figure. (The separate fallback-mock path already rescaled via `scale = live.monthlyCostMicroUsd / mockCurrentCost`; only the live path was left unscaled.)

## The fix

Put each candidate's monthly cost on the **same full-traffic basis** as `current`:

- **Candidate per-call cost** = `projected_monthly_cost_micro_usd / samples_replayed`.
- **Scale to full traffic** by multiplying by the current model's full-traffic monthly call count: `candidateMonthly = round(perCall * currentMonthlyCalls)`.
- `queryCurrentModel()` now also returns `monthlyCalls` (the 7-day call count projected to a 30-day month, on the same basis as the cost it already returns), threaded into the route.
- New pure helper `scaleCandidateMonthlyCost()` in `web/lib/compare.ts` does the rescale in **BigInt** (money stays integer micro-USD, no float dollars), rounding half-up at the boundary.
- Savings %, "cheapest candidate", and the verdict are all recomputed on the corrected basis, so a candidate now reads e.g. ~89% cheaper, never 100%.

## Honest-under-uncertainty preserved

- A candidate with `samples_replayed <= 0` has no per-call cost, so it is **dropped (honest-null)** rather than divided by zero or fabricated; with no candidate clearing replay the recommendation falls to the honest insufficient-data result.
- Quality is never fabricated (real judge win-rate or null), and latency/error stay null below their sample floors. The insufficient-replay-data path is unchanged.

## Tests

- `web/lib/compare.test.ts`: unit tests for `scaleCandidateMonthlyCost` (scaling, identity, half-up rounding, and the zero-samples null guard).
- `web/app/api/compare/route.test.ts`: fixtures updated so candidate costs reflect the scaled basis; a new test proves a candidate's reported cost is scaled to the current model's full call volume (not the raw corpus projection) with believable (~63%) savings, and a new test proves `samples_replayed === 0` yields the honest insufficient-data result with no divide-by-zero.
- `web/lib/clickhouse.test.ts`: asserts the new `monthlyCalls` projection.

Web CI green locally: `npm run typecheck`, `npm run lint`, and the compare/clickhouse suites all pass. The two known `api.test.ts` "falls back to mock when ClickHouse is unreachable" cases were not touched and no new failures were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)