### PR TITLE
feat(sdk): make the onboarding MCP server connectable, add init + llm recipes (CTO-261)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -133,3 +133,77 @@ and does not write it to the span row, so no customer name lands in the telemetr
 are optional per account: set none and the dashboard falls back to a shortened hash, which is a
 supported way to run. A label with no account id alongside it is dropped, since there is nothing
 to key it on.
+
+## Onboarding MCP server (CTO-261)
+
+`tally.init()` meters the LLM layer on its own, but the other layers need app code: the
+vector, tool and embedding `record_*` calls, and the per-customer attribution only your app
+can resolve. The onboarding MCP server hands your own coding agent the maintained recipes and
+generated snippets for that wiring. Your source never leaves your machine: the server holds
+only the recipe catalog and the SDK surface, and it returns code, never an applied edit.
+
+Install the extra (it is optional, the SDK runtime itself has no dependencies):
+
+```bash
+pip install 'tally-sdk[mcp]'
+```
+
+That installs the `tally-onboarding-mcp` console script, which speaks MCP over stdio.
+
+### Claude Code
+
+```bash
+claude mcp add ai-tally-onboarding -- tally-onboarding-mcp
+```
+
+Or add it to `.mcp.json` in your project root so your team picks it up too:
+
+```json
+{
+  "mcpServers": {
+    "ai-tally-onboarding": {
+      "command": "tally-onboarding-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Cursor
+
+Add the same stanza to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "ai-tally-onboarding": {
+      "command": "tally-onboarding-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+If `tally-onboarding-mcp` is not on your agent's PATH, point `command` at the interpreter that
+has it installed instead: `"command": "/path/to/.venv/bin/tally-onboarding-mcp"`.
+
+### The tools
+
+| Tool | What it returns |
+|---|---|
+| `detect_stack` | providers, agent frameworks, vector DBs and web frameworks found in a manifest, plus the recipe ids that match and the gaps that matched nothing |
+| `get_recipe` | one machine-readable recipe, by id or by a friendly name (`pinecone`, `fastapi`) |
+| `generate_startup` | the `tally.init()` line for application startup |
+| `generate_middleware` | account / feature middleware bound to the resolver you confirm, bundled with the startup line |
+| `instrument_call_site` | the adapted `record_*` edit for one concrete call site |
+| `explain_layer` | which `record_*` method covers a layer and why, grounded on the live SDK surface |
+| `coverage_report` | per-layer coverage; reports `not_probed` until the probe ships, never a guessed verdict |
+
+Two things the server will not do. It never guesses which customer a request belongs to: pass
+`generate_middleware` the header or resolver you confirmed, and with no answer it returns a
+reported gap and the account layer stays unattributed. And it never invents an SDK call: a
+stack with no recipe comes back as a gap, and every hole it cannot fill from the call site you
+passed is left as a visible `<FILL:...>` marker for you to complete.
+
+Both mcp 1.x (`FastMCP`) and mcp 2.x (`MCPServer`) are supported. Without the extra installed,
+launching the server fails with a clear error rather than starting a server that does nothing.

--- a/sdk/python/onboarding_mcp/__init__.py
+++ b/sdk/python/onboarding_mcp/__init__.py
@@ -18,6 +18,7 @@ from onboarding_mcp.generate import (
     coverage_report,
     explain_layer,
     generate_middleware,
+    generate_startup,
     get_recipe,
     instrument_call_site,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "detect_stack",
     "get_recipe",
     "generate_middleware",
+    "generate_startup",
     "instrument_call_site",
     "explain_layer",
     "coverage_report",

--- a/sdk/python/onboarding_mcp/catalog.py
+++ b/sdk/python/onboarding_mcp/catalog.py
@@ -17,8 +17,15 @@ from typing import Any
 
 import yaml
 
-# recipes/ sits next to onboarding_mcp/ under sdk/python/.
-RECIPES_DIR = Path(__file__).resolve().parent.parent / "recipes"
+# In-tree, recipes/ sits next to onboarding_mcp/ under sdk/python/. In an installed
+# wheel the catalog is force-included at onboarding_mcp/recipes/ so the console
+# entrypoint finds it without a source checkout (CTO-261 section 4.2).
+_INSTALLED_RECIPES = Path(__file__).resolve().parent / "recipes"
+RECIPES_DIR = (
+    _INSTALLED_RECIPES
+    if _INSTALLED_RECIPES.is_dir()
+    else Path(__file__).resolve().parent.parent / "recipes"
+)
 
 
 @dataclass(frozen=True)

--- a/sdk/python/onboarding_mcp/generate.py
+++ b/sdk/python/onboarding_mcp/generate.py
@@ -97,6 +97,10 @@ def generate_middleware(
         recipe.edit["template"],
         {"account_source": account_source, "feature_tag": feature_expr},
     )
+    # Section 3 step 4 describes the proposed diff as "tally.init() at startup +
+    # middleware + record_*". Returning the startup snippet alongside the middleware is
+    # what makes the bundle complete: the developer's agent would otherwise wire
+    # with_account into a process that never called init.
     return {
         "recipe_id": recipe.id,
         "web_framework": web_framework,
@@ -104,6 +108,41 @@ def generate_middleware(
         "code": code,
         "placement": recipe.edit["placement"],
         "bound_account_source": account_source,
+        "feature_tag": feature_tag,
+        "startup": generate_startup(feature_tag, catalog=cat),
+    }
+
+
+STARTUP_RECIPE_ID = "startup.tally.init"
+
+
+def generate_startup(
+    feature_tag: str | None = None,
+    *,
+    catalog: RecipeCatalog | None = None,
+) -> dict[str, Any]:
+    """Generate the ``tally.init()`` startup snippet (section 3 step 4).
+
+    The proposed diff is "init at startup + middleware + record_*"; without the init line
+    the other two edits run in a process that was never connected. A catalog with no
+    startup recipe is a reported gap, not an invented init line.
+    """
+    cat = catalog or get_catalog()
+    recipe = cat.get(STARTUP_RECIPE_ID)
+    if recipe is None:
+        return _gap(
+            f"no startup recipe {STARTUP_RECIPE_ID!r} in the catalog",
+            known_recipes=[r.id for r in cat.recipes],
+        )
+    code = _fill(
+        recipe.edit["template"],
+        {"feature_tag": repr(feature_tag) if feature_tag else "None"},
+    )
+    return {
+        "recipe_id": recipe.id,
+        "imports_to_add": recipe.edit["imports_to_add"],
+        "code": code,
+        "placement": recipe.edit["placement"],
         "feature_tag": feature_tag,
     }
 

--- a/sdk/python/onboarding_mcp/server.py
+++ b/sdk/python/onboarding_mcp/server.py
@@ -16,57 +16,98 @@ from onboarding_mcp import (
     detect_stack,
     explain_layer,
     generate_middleware,
+    generate_startup,
     get_recipe,
     instrument_call_site,
 )
 
 SERVER_NAME = "ai-tally-onboarding"
 
+# The section 4.2 tool names, in registration order. Kept as data so the wiring is
+# assertable without an MCP transport installed (tests/test_onboarding_mcp_server.py).
+TOOL_NAMES = (
+    "detect_stack",
+    "get_recipe",
+    "generate_startup",
+    "generate_middleware",
+    "instrument_call_site",
+    "explain_layer",
+    "coverage_report",
+)
 
-def build_server() -> Any:
-    """Build the FastMCP server with the section 4.2 tools registered.
 
-    Raises a clear error if the optional ``mcp`` package is not installed, rather than
-    failing at import time (so importing this module for its tool wiring stays cheap).
+_MISSING_MCP = (
+    "the 'mcp' package is required to run the onboarding MCP server; install it with "
+    "`pip install 'tally-sdk[mcp]'`. The tools themselves are importable without it."
+)
+
+
+def load_server_class() -> Any:
+    """Return the MCP server class from whichever ``mcp`` generation is installed.
+
+    mcp 2.x renamed FastMCP to MCPServer, so pinning either name alone leaves half the
+    installed base unable to launch the server. Both expose the ``tool()`` decorator and
+    ``run()`` this module uses, so trying 2.x first and falling back to 1.x is enough.
+    Neither present is an honest RuntimeError, never a degraded no-op server.
     """
     try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError as exc:  # pragma: no cover - exercised only without the mcp extra
-        raise RuntimeError(
-            "the 'mcp' package is required to run the onboarding MCP server; install it "
-            "with `pip install mcp`. The tools themselves are importable without it."
-        ) from exc
+        from mcp.server.mcpserver import MCPServer  # mcp >= 2
 
-    server = FastMCP(SERVER_NAME)
+        return MCPServer
+    except ImportError:
+        pass
+    try:
+        from mcp.server.fastmcp import FastMCP  # mcp 1.x
 
-    @server.tool()
+        return FastMCP
+    except ImportError as exc:
+        raise RuntimeError(_MISSING_MCP) from exc
+
+
+def build_server(server_class: Any = None) -> Any:
+    """Build the MCP server with the section 4.2 tools registered.
+
+    ``server_class`` is an injection seam for tests: the registration wiring is the part
+    worth asserting, and it must be assertable without an MCP transport installed.
+    Tool names are pinned to the section 4.2 table (``TOOL_NAMES``) rather than taken
+    from the Python function names, so the surface a coding agent sees matches the spec.
+    """
+    cls = server_class or load_server_class()
+    server = cls(SERVER_NAME)
+
+    @server.tool(name="detect_stack")
     def detect_stack_tool(manifest: str = "", import_excerpts: str = "") -> dict[str, Any]:
         """Detect providers, frameworks, vector DBs, and web framework from a manifest."""
         return detect_stack(manifest, import_excerpts)
 
-    @server.tool()
+    @server.tool(name="get_recipe")
     def get_recipe_tool(name: str) -> dict[str, Any]:
         """Return the machine-readable recipe for a recipe id or framework / provider name."""
         return get_recipe(name)
 
-    @server.tool()
+    @server.tool(name="generate_startup")
+    def generate_startup_tool(feature_tag: str | None = None) -> dict[str, Any]:
+        """Generate the tally.init() startup snippet the proposed diff opens with."""
+        return generate_startup(feature_tag)
+
+    @server.tool(name="generate_middleware")
     def generate_middleware_tool(
         web_framework: str, account_source: str, feature_tag: str | None = None
     ) -> dict[str, Any]:
-        """Generate account / feature middleware bound to the confirmed account resolver."""
+        """Generate account / feature middleware plus the startup snippet, bound to the answer."""
         return generate_middleware(web_framework, account_source, feature_tag)
 
-    @server.tool()
+    @server.tool(name="instrument_call_site")
     def instrument_call_site_tool(call_site: str, recipe_id: str) -> dict[str, Any]:
         """Adapt a recipe's record_* edit to a concrete call site."""
         return instrument_call_site(call_site, recipe_id)
 
-    @server.tool()
+    @server.tool(name="explain_layer")
     def explain_layer_tool(query: str) -> dict[str, Any]:
         """Explain which record_* method covers a layer, grounded on the SDK surface."""
         return explain_layer(query)
 
-    @server.tool()
+    @server.tool(name="coverage_report")
     def coverage_report_tool(tenant_key: str) -> dict[str, Any]:
         """Per-layer coverage (stubbed against the spec contract; probe ships later)."""
         return coverage_report(tenant_key)
@@ -74,7 +115,8 @@ def build_server() -> Any:
     return server
 
 
-def main() -> None:  # pragma: no cover - entrypoint
+def main() -> None:  # pragma: no cover - entrypoint, exercised by launching the server
+    """Console entrypoint (``tally-onboarding-mcp``). Runs the server over stdio."""
     build_server().run()
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -17,13 +17,29 @@ dev = [
     "pyyaml>=6.0",
     "jsonschema>=4.0",
 ]
+# CTO-261 section 4.2: the onboarding MCP server. Optional so the SDK runtime stays
+# dependency-free; a developer connecting their coding agent installs this extra.
+# pyyaml is a real runtime need here (the recipe catalog is YAML), which is why it is
+# listed again rather than borrowed from dev.
+mcp = [
+    "mcp>=1.0",
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+# The stdio entrypoint a coding agent's MCP config launches (see README "Connect your
+# coding agent"). Fails with a clear RuntimeError when the mcp extra is absent.
+tally-onboarding-mcp = "onboarding_mcp.server:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/tally"]
+# onboarding_mcp ships in the wheel so the console entrypoint above resolves for an
+# installed SDK; recipes/ is the data the server reads and is forced in below.
+packages = ["src/tally", "onboarding_mcp"]
+force-include = { "recipes" = "onboarding_mcp/recipes" }
 
 [tool.ruff]
 line-length = 100

--- a/sdk/python/recipes/index.yaml
+++ b/sdk/python/recipes/index.yaml
@@ -35,3 +35,11 @@ recipes:
   - id: otel.ingest.gen_ai
     file: otel.ingest.yaml
     kind: otel
+  # Appended last on purpose: excerpt matching (explain_layer) resolves in index order,
+  # and these two are the broadest detect blocks in the catalog.
+  - id: startup.tally.init
+    file: startup.tally.init.yaml
+    kind: llm
+  - id: llm.generic.call
+    file: llm.generic.call.yaml
+    kind: llm

--- a/sdk/python/recipes/llm.generic.call.yaml
+++ b/sdk/python/recipes/llm.generic.call.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 5.3: LLM call sites CTO-260 auto-instrumentation does not cover
+# (a self-hosted or gateway-fronted model, a raw HTTP call, a provider with no patch).
+# The patched openai / anthropic clients need no edit; this recipe is for the rest.
+id: llm.generic.call
+kind: llm
+title: "Unpatched LLM call site -> tally.record_llm_call"
+detect:
+  imports: ["httpx", "requests", "boto3", "ollama", "vllm", "together", "groq"]
+  call_patterns: [".chat.completions.create(", "messages.create(", "/v1/chat/completions"]
+sdk_surface:
+  call: "tally.record_llm_call"
+  delegates_to: "tally.client.TallyClient.record_llm_call"
+  required_args: [provider, model, usage]
+  layer: llm
+edit:
+  imports_to_add: ["import tally", "from tally.pricing import Usage"]
+  template: |
+    # After the LLM call returns. Use this only where the patched openai / anthropic
+    # client does not already capture the call (CTO-260 auto-instrument), otherwise the
+    # same call is metered twice. Token counts come from the provider's own usage block:
+    # counts only, never the prompt or the completion.
+    tally.record_llm_call(
+        provider={llm_provider},
+        model={llm_model},
+        usage=Usage(
+            input_tokens={input_tokens},
+            output_tokens={output_tokens},
+        ),
+    )
+  placement: after_call
+verify:
+  layer: llm
+  operation_name: "chat"
+notes: "Cost resolves from the versioned catalog keyed by (provider, model); an unpriced pair keeps cost unknown with a one-time WARN rather than reporting a fabricated zero. Pass cached_input_tokens on Usage where the provider reports it."

--- a/sdk/python/recipes/startup.tally.init.yaml
+++ b/sdk/python/recipes/startup.tally.init.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# CTO-261 section 3 step 4: the tally.init() line the proposed diff always opens with.
+# Without this recipe the agent wires middleware and record_* calls into a process that
+# was never connected, so nothing ships.
+id: startup.tally.init
+kind: llm
+title: "Application startup -> tally.init()"
+detect:
+  # init applies to any metered app; the LLM clients are the strongest manifest signal
+  # that there is something to meter at all (CTO-260 auto-instruments them from here).
+  imports: ["openai", "anthropic", "langchain", "llama_index"]
+  call_patterns: ["if __name__ ==", "def create_app(", "FastAPI(", "Flask("]
+sdk_surface:
+  call: "tally.init"
+  delegates_to: "tally.init.init"
+  required_args: [feature_tag]
+  layer: llm
+edit:
+  imports_to_add: ["import tally"]
+  template: |
+    # Once at process startup, before the first LLM call. init is idempotent and
+    # non-blocking, and it patches the openai / anthropic clients in this process so
+    # the LLM layer needs no per-call-site edit (CTO-260).
+    # The key is read from the TALLY_KEY environment variable: it is a credential and
+    # is supplied by reference (env / secret manager), never committed to the repo.
+    tally.init(feature_tag={feature_tag})
+  placement: startup
+verify:
+  layer: llm
+  operation_name: "chat"
+notes: "feature_tag sets the process-wide default feature dimension; the middleware recipe overrides it per request via start_trace. Passing no key degrades to a disabled client with one warning rather than raising, so a missing TALLY_KEY is visible in logs and never silently fabricates telemetry."

--- a/sdk/python/tests/test_onboarding_mcp.py
+++ b/sdk/python/tests/test_onboarding_mcp.py
@@ -15,6 +15,7 @@ from onboarding_mcp import (
     detect_stack,
     explain_layer,
     generate_middleware,
+    generate_startup,
     get_recipe,
     instrument_call_site,
 )
@@ -119,6 +120,58 @@ def test_generate_middleware_is_bound_to_the_given_header():
     assert "with_account" in emitted
     assert "start_trace" in emitted
     assert "<FILL:" not in result["code"]  # both holes were bound
+
+
+def test_generate_middleware_bundles_the_startup_snippet():
+    # Section 3 step 4: the proposed diff is init + middleware + record_*. Middleware
+    # without the init line wires a process that was never connected.
+    result = generate_middleware("fastapi", 'request.headers["X-Customer-Id"]', "chatbot")
+    startup = result["startup"]
+    assert startup["recipe_id"] == "startup.tally.init"
+    assert startup["placement"] == "startup"
+    assert "tally.init(" in startup["code"]
+    ast.parse(startup["code"])
+    assert {c.name for c in emitted_tally_calls(startup["code"])} == {"init"}
+
+
+def test_generate_startup_binds_the_feature_tag_and_never_inlines_a_key():
+    result = generate_startup("chatbot")
+    assert "feature_tag='chatbot'" in result["code"]
+    assert "<FILL:" not in result["code"]
+    # Credentials by reference (CLAUDE.md): the key comes from the environment, so no
+    # snippet ever puts a tally_sk_live_ secret into the developer's diff.
+    assert "tally_sk_live_" not in result["code"]
+    assert "TALLY_KEY" in result["code"]
+
+
+def test_generate_startup_without_a_feature_tag_is_none_not_invented():
+    result = generate_startup()
+    assert "feature_tag=None" in result["code"]
+
+
+def test_generate_startup_without_the_recipe_is_a_gap():
+    # A catalog missing the startup recipe reports a gap rather than hand-writing init.
+    from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+
+    full = get_catalog()
+    without = RecipeCatalog(
+        [r for r in full.recipes if r.id != "startup.tally.init"], full.schema
+    )
+    result = generate_startup("chatbot", catalog=without)
+    assert result["gap"] is True
+    assert "code" not in result
+
+
+def test_instrument_call_site_adapts_the_llm_recipe():
+    # Section 5.3: LLM call sites CTO-260 auto-instrumentation does not cover.
+    result = instrument_call_site(
+        'r = httpx.post("/v1/chat/completions", json=payload)', "llm.generic.call"
+    )
+    assert result["sdk_call"] == "tally.record_llm_call"
+    assert "record_llm_call" in result["emitted_calls"]
+    # Token counts are left to fill from the provider's usage block, never guessed.
+    assert "input_tokens" in result["holes_to_fill"]
+    assert "<FILL:input_tokens>" in result["code"]
 
 
 def test_generate_middleware_without_an_answer_is_a_gap_not_a_guess():

--- a/sdk/python/tests/test_onboarding_mcp_server.py
+++ b/sdk/python/tests/test_onboarding_mcp_server.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MCP protocol binding tests (CTO-261 sections 4.2, 12 P1).
+
+The P1 "Done when" is a developer's coding agent actually connecting to the server, so
+the wiring itself has to be covered: every section 4.2 tool registered under its spec
+name, each delegating to the plain function, the declared console entrypoint resolving,
+and an honest RuntimeError (never a degraded no-op server) when ``mcp`` is absent.
+
+The registration assertions run without an MCP transport installed by injecting a
+recording stand-in for the server class, which is why ``build_server`` takes one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tomllib
+from onboarding_mcp import server as server_mod
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+class RecordingServer:
+    """Stand-in for FastMCP / MCPServer: records what ``build_server`` registers."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str | None = None):
+        def decorator(fn):
+            self.tools[name or fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+@pytest.fixture()
+def built() -> RecordingServer:
+    return server_mod.build_server(server_class=RecordingServer)
+
+
+def test_server_registers_every_section_4_2_tool(built: RecordingServer):
+    assert built.name == server_mod.SERVER_NAME
+    # Registered under the spec's names, not the Python function names.
+    assert tuple(built.tools) == server_mod.TOOL_NAMES
+
+
+def test_every_registered_tool_has_a_docstring(built: RecordingServer):
+    # MCP clients show the docstring as the tool description; a blank one is unusable.
+    assert all(fn.__doc__ for fn in built.tools.values())
+
+
+def test_registered_tools_delegate_to_the_plain_functions(built: RecordingServer):
+    detect = built.tools["detect_stack"]("fastapi==0.115.0\npinecone-client==5.0.0\n")
+    assert "vector.pinecone.query" in detect["matched_recipes"]
+
+    recipe = built.tools["get_recipe"]("vector.pinecone.query")
+    assert recipe["sdk_surface"]["call"] == "tally.record_vector_call"
+
+    startup = built.tools["generate_startup"]("chatbot")
+    assert "tally.init(" in startup["code"]
+
+    middleware = built.tools["generate_middleware"](
+        "fastapi", 'request.headers.get("X-Customer-Id")', "chatbot"
+    )
+    assert "with_account" in middleware["code"]
+    assert "tally.init(" in middleware["startup"]["code"]
+
+    site = built.tools["instrument_call_site"](
+        "index.query(vector=v, top_k=5)", "vector.pinecone.query"
+    )
+    assert site["sdk_call"] == "tally.record_vector_call"
+
+    assert built.tools["explain_layer"]("vector")["operation_name"] == "vector"
+    assert built.tools["coverage_report"]("tally_sk_live_x")["probe_available"] is False
+
+
+def test_unknown_input_stays_a_gap_through_the_tool_layer(built: RecordingServer):
+    # The honesty invariant must survive the protocol binding, not only the plain call.
+    assert built.tools["get_recipe"]("cassandra")["gap"] is True
+    assert built.tools["generate_middleware"]("fastapi", "  ")["gap"] is True
+
+
+def test_missing_mcp_dependency_raises_a_clear_runtime_error(monkeypatch):
+    # Blocking both module paths in sys.modules makes the import fail the same way an
+    # uninstalled extra does, whether or not mcp happens to be present in this env.
+    monkeypatch.setitem(sys.modules, "mcp.server.mcpserver", None)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", None)
+    with pytest.raises(RuntimeError) as excinfo:
+        server_mod.load_server_class()
+    message = str(excinfo.value)
+    assert "mcp" in message
+    assert "tally-sdk[mcp]" in message
+
+
+def test_build_server_propagates_the_missing_dependency_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mcp.server.mcpserver", None)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", None)
+    with pytest.raises(RuntimeError):
+        server_mod.build_server()
+
+
+def test_declared_console_entrypoint_resolves():
+    # The P1 blocker was a server with no way to launch it. Resolve exactly what
+    # pyproject declares, so a renamed main() or a dropped script fails here.
+    pyproject = tomllib.loads(PYPROJECT.read_text())
+    target = pyproject["project"]["scripts"]["tally-onboarding-mcp"]
+    module_path, _, attr = target.partition(":")
+    module = __import__(module_path, fromlist=[attr])
+    assert callable(getattr(module, attr))
+
+
+def test_onboarding_mcp_is_packaged_in_the_wheel():
+    # Without this the console entrypoint above cannot import at install time.
+    pyproject = tomllib.loads(PYPROJECT.read_text())
+    packages = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    assert "onboarding_mcp" in packages
+    assert "mcp" in pyproject["project"]["optional-dependencies"]
+    # The catalog is data the server reads, so it has to ship too (catalog.py resolves
+    # the installed location first, the in-tree one second).
+    force_include = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    assert force_include["recipes"] == "onboarding_mcp/recipes"

--- a/sdk/python/tests/test_recipes.py
+++ b/sdk/python/tests/test_recipes.py
@@ -10,11 +10,18 @@ function, or passes an unknown kwarg, fails here rather than shipping a bad edit
 
 from __future__ import annotations
 
+import inspect
+
 import jsonschema
 import pytest
 import yaml
 from onboarding_mcp.catalog import RECIPES_DIR, Recipe, load_catalog
-from onboarding_mcp.sdk_surface import SurfaceError, validate_recipe_surface
+from onboarding_mcp.sdk_surface import (
+    SurfaceError,
+    emitted_tally_calls,
+    resolve_dotted,
+    validate_recipe_surface,
+)
 
 CATALOG = load_catalog(RECIPES_DIR)
 
@@ -34,6 +41,10 @@ def test_catalog_is_non_empty_and_covers_the_p1_stack():
         "tool.generic.call",
         "embedding.generic.call",
         "otel.ingest.gen_ai",
+        # Section 3 step 4 / section 5.3: the startup line the proposed diff opens with,
+        # and the LLM call sites CTO-260 auto-instrumentation does not reach.
+        "startup.tally.init",
+        "llm.generic.call",
     }
     assert expected <= ids
 
@@ -47,6 +58,39 @@ def test_recipe_matches_schema(recipe: Recipe):
 def test_recipe_emitted_call_resolves_against_the_real_sdk(recipe: Recipe):
     # The core guard: resolve the emitted call, bind the kwargs to the real signature.
     validate_recipe_surface(recipe)
+
+
+def test_startup_recipe_binds_the_real_tally_init_signature():
+    # The parametrized guard above covers this recipe too; this pins the specific claim
+    # that matters for the startup line: the emitted call is tally.init and its kwargs
+    # bind against the live init signature, not a look-alike.
+    recipe = CATALOG.get("startup.tally.init")
+    validate_recipe_surface(recipe)
+    emitted = {c.name for c in emitted_tally_calls(recipe.edit["template"])}
+    assert emitted == {"init"}
+    assert recipe.sdk_surface["delegates_to"] == "tally.init.init"
+    assert "feature_tag" in inspect.signature(resolve_dotted("tally.init.init")).parameters
+
+
+def test_llm_call_site_recipe_binds_the_real_record_llm_call_signature():
+    recipe = CATALOG.get("llm.generic.call")
+    validate_recipe_surface(recipe)
+    calls = emitted_tally_calls(recipe.edit["template"])
+    emitted = [c for c in calls if c.name == "record_llm_call"]
+    assert emitted, "the llm recipe must emit tally.record_llm_call(...)"
+    sig = inspect.signature(resolve_dotted("tally.client.TallyClient.record_llm_call"))
+    for kwarg in emitted[0].kwargs:
+        assert kwarg in sig.parameters
+
+
+def test_recipe_templates_carry_no_prompt_or_completion_text():
+    # "No bodies in telemetry" (CLAUDE.md) applies to what the recipes tell an app to
+    # emit: counts and names only, never a prompt, a completion, or retrieved text.
+    forbidden = ("prompt=", "completion=", "messages=", "input_text", "response_text", "text=")
+    for recipe in CATALOG.recipes:
+        template = recipe.edit["template"]
+        for token in forbidden:
+            assert token not in template, f"{recipe.id} template passes {token!r}"
 
 
 def test_index_and_files_agree():


### PR DESCRIPTION
Closes the three remaining P1 gaps in the onboarding-agent initiative (`docs/specs/initiative-onboarding-agent.md`, CTO-261). Changes are confined to `sdk/python/`. The recipe catalog and the MCP tool logic were already built; this makes them shippable.

## 1. The MCP server is actually connectable (the §12 P1 blocker)

`onboarding_mcp/server.py` existed but nothing could launch it: the wheel packaged only `src/tally`, there was no `mcp` extra, and no console entrypoint.

- `mcp` optional-dependency extra, `onboarding_mcp` added to the hatch wheel `packages`, and a `tally-onboarding-mcp` console script.
- The recipe catalog is force-included at `onboarding_mcp/recipes` so an installed server finds its data; `catalog.py` resolves the installed location first and the in-tree one second.
- **mcp 2.x renamed `FastMCP` to `MCPServer`.** The server pinned `mcp.server.fastmcp` only, so `pip install mcp` today would have produced a `ModuleNotFoundError` at launch. `load_server_class()` now tries 2.x, falls back to 1.x, and keeps the honest `RuntimeError` when neither is installed.
- Tools register under the §4.2 names (`detect_stack`, `get_recipe`, ...) rather than the Python function names, so the surface a coding agent sees matches the spec.
- `sdk/python/README.md` documents registration for Claude Code (`claude mcp add`, `.mcp.json`) and Cursor (`.cursor/mcp.json`), with the exact JSON stanza and install command.

## 2. Startup and LLM recipes

§3 step 4 describes the proposed diff as `tally.init()` + middleware + `record_*`, but no recipe emitted an init line.

- `recipes/startup.tally.init.yaml`: the `tally.init()` line at startup (`placement: startup`). The key stays a `TALLY_KEY` environment reference and is never inlined into a developer's diff (credentials by reference).
- `recipes/llm.generic.call.yaml`: `record_llm_call` for the LLM call sites CTO-260 auto-instrumentation does not reach (§5.3). Token counts only, never a prompt or completion.
- Both registered in `recipes/index.yaml`. No schema change was needed: `kind: llm` and `placement: startup` were already in the enums.
- `generate_middleware` now returns the startup snippet alongside the middleware, via a new `generate_startup` tool, so the bundle is complete. A catalog missing the startup recipe returns the existing `_gap()` shape rather than a hand-written init line.

## 3. Tests

`onboarding_mcp/server.py` had zero coverage. New `tests/test_onboarding_mcp_server.py` covers tool registration and delegation (via an injected recording server class, so it runs without an MCP transport installed), the gap paths surviving the protocol binding, the declared console entrypoint resolving, wheel packaging, and the missing-`mcp` `RuntimeError`.

`tests/test_recipes.py` picks up both new recipes through the existing parametrized schema and `sdk_surface` guards, with targeted tests that genuinely bind `tally.init` and `TallyClient.record_llm_call` against the live SDK signatures. The anti-hallucination guard in `sdk_surface.py` is unchanged and nothing is special-cased around it. Added a no-bodies check asserting no template passes a prompt, completion, or retrieved text.

## Verification

```
cd sdk/python && uv run --extra dev pytest -q   -> 1137 passed
                 uv run --extra dev ruff check . -> All checks passed!
```

End to end, beyond the test suite: built the wheel, installed it with the `mcp` extra into a clean venv, and drove the `tally-onboarding-mcp` console script over stdio through a real `initialize` / `tools/list` / `tools/call` handshake. All seven tools listed, and `generate_startup` returned the init snippet.

## Deliberately not done

- No `infra/`, `web/` or `db/` changes (another agent is working there).
- No `coverage_report` probe: that is P3 and still honestly reports `not_probed`.
- No schema changes to `recipes/schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)