### PR TITLE
feat(gateway,web): close the control-plane auth gap on the legacy /v1/tenant/* endpoints (Initiative 1 §6)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -65,6 +65,18 @@ make seed     # creates the `local-dev` tenant + API key + feature tags in Postg
 This prints a one-time API key (`tally_sk_…`). Only its SHA-256 is stored — copy it if you plan to
 enable auth. For local testing auth is **off** by default (`TALLY_REQUIRE_API_KEY=false`).
 
+### Control-plane auth when you flip `TALLY_REQUIRE_API_KEY=true`
+
+The `/v1/tenant/*` control plane is authenticated separately from ingest (Initiative 1 §6). With auth
+on, every control-plane call needs a bearer **service token** (`TALLY_GATEWAY_SERVICE_TOKEN` on the
+gateway, `GATEWAY_SERVICE_TOKEN` on the web server, same value) plus an `x-tenant-id` header naming
+the tenant. An ingest API key does **not** open the control plane, and the gateway refuses to boot
+when auth is on and no service token is set, rather than coming up with an open control plane. So the
+`curl … -H 'x-tenant-id: …'` examples below work as written only while auth is off; with auth on, add
+`-H "Authorization: Bearer $TALLY_GATEWAY_SERVICE_TOKEN"`.
+
+Ingest (`/v1/batches`) is unchanged: it still authenticates with the ingest API key above.
+
 ## 3. Push telemetry through the gateway
 
 Easiest — the built-in demo batch (writes as tenant `local-dev`, and re-sends once to demonstrate

--- a/db/postgres/0031_api_keys_display_bounds.sql
+++ b/db/postgres/0031_api_keys_display_bounds.sql
@@ -1,0 +1,52 @@
+-- 0031_api_keys_display_bounds.sql
+-- Length-bounded CHECKs on the api_keys display columns (Initiative 1 §11 hardening).
+--
+-- 0029_orgs_and_access.sql added name / token_prefix / created_by as unbounded TEXT. The gateway
+-- store (gateway/tenant_api_keys.py: normalize_name, normalize_created_by) already caps name at 120
+-- and created_by at 255 before insert, but that is application-side only: anything that writes
+-- api_keys outside that path (a fixture, a repair script, a future endpoint) can still park an
+-- unbounded blob in a column the dashboard renders. The CLAUDE.md invariant is that credential-
+-- adjacent metadata is bounded by a CHECK, the same way tenants.hash_salt_kek_ref already is, so the
+-- database enforces it rather than trusting every caller.
+--
+-- These bound DISPLAY metadata only. The secret is still stored solely as key_hash (SHA-256) and is
+-- untouched here. token_prefix is a non-secret leading slice (TOKEN_PREFIX + 6 suffix chars = 20
+-- characters today); 64 leaves room to lengthen the display slice without another migration, while
+-- still refusing a blob. NULL passes every CHECK: all three columns are legitimately absent on the
+-- pre-existing local-dev keys, and an unknown value stays NULL rather than being back-filled with a
+-- fabricated one.
+--
+-- Bounds match the gateway constants exactly. If MAX_KEY_NAME_CHARS / MAX_CREATED_BY_CHARS move,
+-- move them here too, or the store will accept a value the database then rejects.
+--
+-- NOT VALID + VALIDATE is deliberately NOT used: these are additive constraints on columns that only
+-- 0029 could have populated, and the table is small. A plain ADD CONSTRAINT takes a brief ACCESS
+-- EXCLUSIVE lock, which is acceptable on api_keys.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_name_len'
+    ) THEN
+        ALTER TABLE api_keys
+            ADD CONSTRAINT api_keys_name_len
+            CHECK (name IS NULL OR length(name) <= 120);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_token_prefix_len'
+    ) THEN
+        ALTER TABLE api_keys
+            ADD CONSTRAINT api_keys_token_prefix_len
+            CHECK (token_prefix IS NULL OR length(token_prefix) <= 64);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_created_by_len'
+    ) THEN
+        ALTER TABLE api_keys
+            ADD CONSTRAINT api_keys_created_by_len
+            CHECK (created_by IS NULL OR length(created_by) <= 255);
+    END IF;
+END
+$$;

--- a/deploy/aws/ecs/gateway.taskdef.json
+++ b/deploy/aws/ecs/gateway.taskdef.json
@@ -30,6 +30,7 @@
       "secrets": [
         { "name": "TALLY_POSTGRES_DSN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-postgres-dsn" },
         { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" },
+        { "name": "TALLY_GATEWAY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" },
         { "name": "OPENAI_API_KEY", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-openai-api-key" },
         { "name": "ANTHROPIC_API_KEY", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-anthropic-api-key" }
       ],

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -28,7 +28,8 @@
         { "name": "NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS", "value": "5000" }
       ],
       "secrets": [
-        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" }
+        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" },
+        { "name": "GATEWAY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/ || exit 1"],

--- a/deploy/aws/helm/ai-tally-eks/templates/secretproviderclass.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/secretproviderclass.yaml
@@ -16,6 +16,9 @@ No secret value is present here — only Secrets Manager names/ARNs from .Values
 {{- if $secrets.clickhousePassword }}{{ $mappings = append $mappings (dict "sm" $secrets.clickhousePassword "env" "TALLY_CLICKHOUSE_PASSWORD") }}{{- end -}}
 {{- if $secrets.openaiApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.openaiApiKey "env" "OPENAI_API_KEY") }}{{- end -}}
 {{- if $secrets.anthropicApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.anthropicApiKey "env" "ANTHROPIC_API_KEY") }}{{- end -}}
+{{- /* Initiative 1 §6: the control-plane service token. The gateway envFrom picks it up as
+     TALLY_GATEWAY_SERVICE_TOKEN; the web Deployment pulls the same key as GATEWAY_SERVICE_TOKEN. */ -}}
+{{- if $secrets.gatewayServiceToken }}{{ $mappings = append $mappings (dict "sm" $secrets.gatewayServiceToken "env" "TALLY_GATEWAY_SERVICE_TOKEN") }}{{- end -}}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:

--- a/deploy/aws/helm/ai-tally-eks/templates/web-deployment.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/web-deployment.yaml
@@ -54,6 +54,16 @@ spec:
                   name: {{ include "ai-tally.secretName" . }}
                   key: TALLY_CLICKHOUSE_PASSWORD
             {{- end }}
+            # Initiative 1 §6: the web server is the only legitimate caller of the gateway
+            # control plane and authenticates with this shared secret. Same Secret key the
+            # gateway reads as TALLY_GATEWAY_SERVICE_TOKEN; the web code reads it unprefixed.
+            {{- if .Values.secretsManager.secrets.gatewayServiceToken }}
+            - name: GATEWAY_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-tally.secretName" . }}
+                  key: TALLY_GATEWAY_SERVICE_TOKEN
+            {{- end }}
           {{- if eq .Values.secretsManager.mode "csi" }}
           volumeMounts:
             - name: secrets-store

--- a/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
@@ -23,6 +23,7 @@ secretsManager:
     clickhousePassword: ai-tally-clickhouse-password
     openaiApiKey: ai-tally-openai-api-key
     anthropicApiKey: ai-tally-anthropic-api-key
+    gatewayServiceToken: ai-tally-gateway-service-token
 
 rds:
   endpoint: ai-tally-pg.abcdefghijkl.us-east-1.rds.amazonaws.com   # informational

--- a/deploy/aws/helm/ai-tally-eks/values.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values.yaml
@@ -64,6 +64,11 @@ secretsManager:
     # to the IRSA role (the SDK uses the role, not a key).
     openaiApiKey: ai-tally-openai-api-key
     anthropicApiKey: ai-tally-anthropic-api-key
+    # Control-plane service token (Initiative 1 §6). The web server presents it as a bearer token
+    # on every /v1/tenant/* call and the gateway refuses to boot without it when
+    # gateway.config.requireApiKey is true. Consumed as TALLY_GATEWAY_SERVICE_TOKEN (gateway)
+    # and GATEWAY_SERVICE_TOKEN (web).
+    gatewayServiceToken: ai-tally-gateway-service-token
   # NOTE on Stripe + HMAC: the Stripe webhook *signing secret* is NOT a gateway env var — it is
   # pasted per-tenant in the dashboard and persisted in Postgres (see db/postgres/0003_*.sql), so it
   # is protected by protecting RDS. Per-tenant HMAC user-id keys (CTO-74) live in the gateway's

--- a/deploy/demo/.env.example
+++ b/deploy/demo/.env.example
@@ -32,3 +32,10 @@ MINIO_ROOT_PASSWORD=tally-minio
 # it points the dashboard at a tenant that has no demo data and renders an empty dashboard with no
 # error. Leave as-is.
 TALLY_TENANT_ID=local-dev
+
+# --- Control-plane service token (Initiative 1 §6) ----------------------------------------------
+# The web server presents this as a bearer token on every gateway /v1/tenant/* call. The gateway
+# enforces it only when TALLY_REQUIRE_API_KEY is true, which this demo VM leaves off, so it can
+# stay unset here. If you do turn gateway auth on, set a long random value: the gateway then
+# refuses to boot without it rather than come up with an unauthenticated control plane.
+# TALLY_GATEWAY_SERVICE_TOKEN=

--- a/deploy/demo/docker-compose.prod.yml
+++ b/deploy/demo/docker-compose.prod.yml
@@ -52,6 +52,10 @@ services:
       TALLY_CLICKHOUSE_DB: default
       TALLY_GATEWAY_URL: http://gateway:8080
       TALLY_TENANT_ID: ${TALLY_TENANT_ID:-local-dev}
+      # Initiative 1 §6: the control-plane service token. Empty here because the demo VM runs
+      # with TALLY_REQUIRE_API_KEY off, which makes the gateway gate a no-op. Set it in .env
+      # (same value as the gateway's TALLY_GATEWAY_SERVICE_TOKEN) if you turn auth on.
+      GATEWAY_SERVICE_TOKEN: ${TALLY_GATEWAY_SERVICE_TOKEN:-}
     # No host port: the browser reaches the dashboard only through Caddy (caddy -> web:3000).
     depends_on:
       clickhouse:

--- a/deploy/gcp/cloudrun/gateway.service.yaml
+++ b/deploy/gcp/cloudrun/gateway.service.yaml
@@ -56,6 +56,12 @@ spec:
             - name: TALLY_CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef: { name: ai-tally-clickhouse-password, key: latest }
+            # Initiative 1 §6: the control-plane service token the web server presents on every
+            # /v1/tenant/* call. REQUIRED here, because with TALLY_REQUIRE_API_KEY=true the gateway
+            # refuses to boot rather than come up with an unauthenticated control plane.
+            - name: TALLY_GATEWAY_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef: { name: ai-tally-gateway-service-token, key: latest }
             # Provider keys are OPTIONAL — the gateway boots fail-soft without them (CTO-109).
             # Remove these two blocks if you have not created the secrets.
             - name: OPENAI_API_KEY

--- a/deploy/gcp/cloudrun/web.service.yaml
+++ b/deploy/gcp/cloudrun/web.service.yaml
@@ -43,6 +43,11 @@ spec:
             - name: TALLY_CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef: { name: ai-tally-clickhouse-password, key: latest }
+            # Initiative 1 §6: same secret the gateway reads as TALLY_GATEWAY_SERVICE_TOKEN. The web
+            # server is the only legitimate caller of the gateway control plane.
+            - name: GATEWAY_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef: { name: ai-tally-gateway-service-token, key: latest }
           resources:
             limits:
               cpu: "1"

--- a/deploy/gcp/helm/ai-tally/templates/secretproviderclass.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/secretproviderclass.yaml
@@ -16,6 +16,9 @@ No secret value is present here — only Secret Manager resource names from .Val
 {{- if $secrets.clickhousePassword }}{{ $mappings = append $mappings (dict "sm" $secrets.clickhousePassword "env" "TALLY_CLICKHOUSE_PASSWORD") }}{{- end -}}
 {{- if $secrets.openaiApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.openaiApiKey "env" "OPENAI_API_KEY") }}{{- end -}}
 {{- if $secrets.anthropicApiKey }}{{ $mappings = append $mappings (dict "sm" $secrets.anthropicApiKey "env" "ANTHROPIC_API_KEY") }}{{- end -}}
+{{- /* Initiative 1 §6: the control-plane service token. The gateway envFrom picks it up as
+     TALLY_GATEWAY_SERVICE_TOKEN; the web Deployment pulls the same key as GATEWAY_SERVICE_TOKEN. */ -}}
+{{- if $secrets.gatewayServiceToken }}{{ $mappings = append $mappings (dict "sm" $secrets.gatewayServiceToken "env" "TALLY_GATEWAY_SERVICE_TOKEN") }}{{- end -}}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:

--- a/deploy/gcp/helm/ai-tally/templates/web-deployment.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/web-deployment.yaml
@@ -54,6 +54,16 @@ spec:
                   name: {{ include "ai-tally.secretName" . }}
                   key: TALLY_CLICKHOUSE_PASSWORD
             {{- end }}
+            # Initiative 1 §6: the web server is the only legitimate caller of the gateway
+            # control plane and authenticates with this shared secret. Same Secret key the
+            # gateway reads as TALLY_GATEWAY_SERVICE_TOKEN; the web code reads it unprefixed.
+            {{- if .Values.secretManager.secrets.gatewayServiceToken }}
+            - name: GATEWAY_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-tally.secretName" . }}
+                  key: TALLY_GATEWAY_SERVICE_TOKEN
+            {{- end }}
           {{- if eq .Values.secretManager.mode "csi" }}
           volumeMounts:
             - name: secrets-store

--- a/deploy/gcp/helm/ai-tally/values-gke.example.yaml
+++ b/deploy/gcp/helm/ai-tally/values-gke.example.yaml
@@ -16,6 +16,7 @@ secretManager:
     clickhousePassword: ai-tally-clickhouse-password
     openaiApiKey: ai-tally-openai-api-key
     anthropicApiKey: ai-tally-anthropic-api-key
+    gatewayServiceToken: ai-tally-gateway-service-token
 
 cloudSql:
   enabled: true

--- a/deploy/gcp/helm/ai-tally/values.yaml
+++ b/deploy/gcp/helm/ai-tally/values.yaml
@@ -57,6 +57,11 @@ secretManager:
     # fail-soft without them (CTO-109). Consumed as OPENAI_API_KEY / ANTHROPIC_API_KEY.
     openaiApiKey: ai-tally-openai-api-key
     anthropicApiKey: ai-tally-anthropic-api-key
+    # Control-plane service token (Initiative 1 §6). The web server presents it as a bearer token
+    # on every /v1/tenant/* call and the gateway refuses to boot without it when
+    # gateway.config.requireApiKey is true. Consumed as TALLY_GATEWAY_SERVICE_TOKEN (gateway)
+    # and GATEWAY_SERVICE_TOKEN (web).
+    gatewayServiceToken: ai-tally-gateway-service-token
   # NOTE on Stripe + HMAC: the Stripe webhook *signing secret* is NOT a gateway env var — it is
   # pasted per-tenant in the dashboard and persisted in Postgres (see db/postgres/0003_*.sql), so
   # it is protected by protecting Cloud SQL. Per-tenant HMAC user-id keys (CTO-74) live in the

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -30,7 +30,13 @@ GATEWAY_PORT=8080
 TALLY_REQUIRE_API_KEY=false
 
 # --- Organizations, users & access (Initiative 1) ---
-# Control-plane service token (§6). The web server sends this as a bearer token on every
-# control-plane call; the gateway enforces it only when TALLY_REQUIRE_API_KEY is true AND this is
-# set, so local dev with auth off is unaffected. Set a long random value in any real deployment.
-# TALLY_GATEWAY_SERVICE_TOKEN=change-me-in-real-deployments
+# Control-plane service token (§6). The web server sends this as a bearer token on EVERY
+# /v1/tenant/* call; the gateway rejects control-plane requests without it once
+# TALLY_REQUIRE_API_KEY is true. The gate is a no-op while auth is off, so local dev is unaffected,
+# but the gateway REFUSES TO BOOT when auth is on and this is empty rather than come up with an
+# open control plane. The web server reads the same secret as GATEWAY_SERVICE_TOKEN
+# (see web/.env.example); the two values must match.
+#
+# The value below is a local placeholder only. Generate a long random value for any real
+# deployment, for example `openssl rand -hex 32`.
+TALLY_GATEWAY_SERVICE_TOKEN=local-dev-service-token-change-me

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - ../db/postgres/0028_tenant_ingest_cursors.sql:/docker-entrypoint-initdb.d/0028_tenant_ingest_cursors.sql:ro
       - ../db/postgres/0029_orgs_and_access.sql:/docker-entrypoint-initdb.d/0029_orgs_and_access.sql:ro
       - ../db/postgres/0030_edge_keys_watermark_index.sql:/docker-entrypoint-initdb.d/0030_edge_keys_watermark_index.sql:ro
+      - ../db/postgres/0031_api_keys_display_bounds.sql:/docker-entrypoint-initdb.d/0031_api_keys_display_bounds.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s
@@ -182,6 +183,10 @@ services:
       TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
       TALLY_POSTGRES_DSN: postgresql://${POSTGRES_USER:-tally}:${POSTGRES_PASSWORD:-tally}@postgres:5432/${POSTGRES_DB:-tally}
       TALLY_REQUIRE_API_KEY: ${TALLY_REQUIRE_API_KEY:-false}
+      # Initiative 1 §6: the shared secret the web server presents on every /v1/tenant/* call. The
+      # gate is a no-op while TALLY_REQUIRE_API_KEY is false (the `make up` default), but the gateway
+      # refuses to BOOT when auth is on and this is empty, so it has to be pass-through-able here.
+      TALLY_GATEWAY_SERVICE_TOKEN: ${TALLY_GATEWAY_SERVICE_TOKEN:-}
       # CTO-241: persist replay sample bodies in MinIO (S3-compatible) instead of the in-process
       # dict, so a gateway restart no longer wipes them and blanks the Recoverable Cost page. The
       # AWS_* creds are the local MinIO root user/password; the endpoint targets the in-network

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -1001,29 +1001,6 @@ def get_usage(
     return JSONResponse(record.as_dict(), status_code=200)
 
 
-def _resolve_tenant_for_control_plane(
-    authorization: str | None, x_tenant_id: str | None
-) -> str:
-    """Shared tenant-resolution for read/write control-plane endpoints.
-
-    Same pattern as :func:`get_usage`: bearer key when auth is on, ``X-Tenant-Id`` header in dev.
-    Refuses ambiguity so the caller can never accidentally cross tenants.
-    """
-    settings = app.state.settings
-    auth: ApiKeyAuth = app.state.auth
-    if settings.require_api_key:
-        if not authorization or not authorization.lower().startswith("bearer "):
-            raise HTTPException(status_code=401, detail="missing bearer token")
-        token = authorization.split(" ", 1)[1].strip()
-        tenant_id = auth.tenant_for_key(token)
-        if tenant_id is None:
-            raise HTTPException(status_code=403, detail="invalid api key")
-        return tenant_id
-    if not x_tenant_id:
-        raise HTTPException(status_code=422, detail="X-Tenant-Id required when auth is disabled")
-    return x_tenant_id
-
-
 def _require_service_token(authorization: str | None) -> None:
     """Gate a control-plane endpoint on the ``GATEWAY_SERVICE_TOKEN`` (Initiative 1, §6).
 
@@ -1093,7 +1070,8 @@ def list_tenant_connectors(
     *enabled* layers count as a real gap when they report zero. Layers the tenant never enabled
     don't appear in the response and don't contribute to partiality.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantConnectorStore = app.state.tenant_connectors
     rows = store.list(tenant_id)
     return JSONResponse(
@@ -1117,7 +1095,8 @@ async def set_tenant_connector(
     Body: ``{"layer": "vector", "enabled": true, "notes": "optional"}``. Idempotent — re-enabling an
     already-enabled connector is a no-op, disabling an absent one stamps a tombstone row.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1150,7 +1129,8 @@ def list_cost_connectors(
     Safe view only: every ``*_ref`` returned is a secret-manager REFERENCE, which is all the column
     ever holds. No raw credential exists to leak here.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     admin: CostConnectorAdmin = app.state.cost_connector_admin
     try:
         rows = admin.list_configs(tenant_id)
@@ -1174,7 +1154,8 @@ async def upsert_cost_connector(
     required fields are enforced in :mod:`gateway.connectors.config_admin`, which also rejects
     anything shaped like a raw credential before it can reach Postgres.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1202,7 +1183,8 @@ def delete_cost_connector(
     x_tenant_id: str | None = Header(default=None),
 ) -> JSONResponse:
     """Disconnect one cloud cost connector. Idempotent: deleting an absent row is a 200."""
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     admin: CostConnectorAdmin = app.state.cost_connector_admin
     try:
         deleted = admin.delete(tenant_id, connector)
@@ -1224,7 +1206,8 @@ def list_tenant_guardrails(
     Rules in 'shadow' state are evaluated and observed but never alter agent behavior — that's the
     safe staging step before flipping to 'enabled'.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantGuardrailStore = app.state.tenant_guardrails
     rules = store.list(tenant_id)
     return JSONResponse({
@@ -1244,7 +1227,8 @@ async def upsert_tenant_guardrail(
     Body: ``{rule_id, kind, params, state, change_id, actor?, notes?}``. Replaying the same
     change_id is a no-op (returns the existing rule unchanged).
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1294,7 +1278,8 @@ def list_tenant_guardrail_audit(
     x_tenant_id: str | None = Header(default=None),
 ) -> JSONResponse:
     """Recent guardrail rule changes for the caller's tenant (CTO-116)."""
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantGuardrailStore = app.state.tenant_guardrails
     changes = store.audit(tenant_id, rule_id=rule_id)
     return JSONResponse({
@@ -1314,7 +1299,8 @@ def list_tenant_feature_value_events(
     The /features page reads this to overlay the configured value event onto each feature row and
     to decide whether the onboarding "Finish setup" banner should still show.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantFeatureValueEventStore = app.state.tenant_feature_value_events
     events = store.list(tenant_id)
     return JSONResponse({
@@ -1334,7 +1320,8 @@ async def upsert_tenant_feature_value_event(
     Body: ``{feature_tag, event_name, change_id, actor?, notes?}``. Replaying the same change_id is
     a no-op (returns the existing mapping unchanged).
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1379,7 +1366,8 @@ async def delete_tenant_feature_value_event(
     Body: ``{feature_tag, change_id, actor?}``. Deleting an absent mapping (or replaying a change_id)
     is a no-op that still returns 200.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1412,7 +1400,8 @@ async def connect_tenant_stripe(
     a *fingerprint* of the secret (last 4 chars) so the dashboard can show "connected" — the raw
     secret is never re-exposed.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1442,7 +1431,8 @@ def get_tenant_stripe(
     x_tenant_id: str | None = Header(default=None),
 ) -> JSONResponse:
     """Read the safe (no-secret) view of a tenant's Stripe config — used by the connectors tile."""
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantStripeStore = app.state.tenant_stripe
     cfg = store.get(tenant_id)
     return JSONResponse(
@@ -1462,7 +1452,8 @@ def list_tenant_integration_status(
     merges this against its static catalog of supported third-party integrations and renders
     catalog-entries-without-a-row as "Not connected" (the honest default for fresh tenants).
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantIntegrationStore = app.state.tenant_integrations
     rows = store.get_status(tenant_id)
     return JSONResponse(
@@ -1483,7 +1474,8 @@ def get_tenant_reconciliation_status(
     tenant — the honest first-render state, which the web fn turns into a null so the route falls
     back to its mock.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: ReconciliationStore = app.state.reconciliation
     run = store.get_latest(tenant_id)
     return JSONResponse(
@@ -1532,7 +1524,8 @@ async def lookup_account_id(
     :mod:`gateway.tenant_identity`): the tenant name and the ``tenants.id`` UUID derive different
     HMAC keys, so callers should match spans against the whole set rather than assume a spelling.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1627,7 +1620,8 @@ def list_tenant_account_labels(
     design, and the tab falls back to a shortened hash. A tenant that wants no customer names in
     our system sets none and everything still works.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantAccountLabelStore = app.state.tenant_account_labels
     try:
         labels = store.list(tenant_id)
@@ -1660,7 +1654,8 @@ async def upsert_tenant_account_label(
     The label is written to Postgres and joined at render time. It is never stamped onto a span,
     so ClickHouse never holds a customer name. See ``db/postgres/0023_tenant_account_labels.sql``.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         raw = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1705,7 +1700,8 @@ async def delete_tenant_account_label(
     Deleting an already-unlabelled account returns 200 with ``removed: false`` rather than 404. The
     end state the caller asked for is the end state they get, and a double-click is not an error.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         raw = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1750,7 +1746,8 @@ def get_tenant_allocation_config(
     A tenant with no ``tenants`` row is 404, not a silent default: that is a misrouted request, and
     inventing an allocation rule for a tenant we do not know is not a recovery.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantAllocationStore = app.state.tenant_allocation
     try:
         config = store.get(tenant_id)
@@ -1784,7 +1781,8 @@ async def upsert_tenant_allocation_config(
     another would leave the page naming a rule that did not produce its numbers, which is exactly
     the invisible assumption this config exists to remove.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1839,7 +1837,8 @@ def list_tenant_budgets(
     An unknown tenant is 404 rather than an empty list. A misrouted request is not a tenant who has
     set no budgets, and answering "no budget set" for a tenant we do not know would hide the bug.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantBudgetStore = app.state.tenant_budgets
     try:
         budgets = store.list(tenant_id)
@@ -1886,7 +1885,8 @@ async def upsert_tenant_budget(
     a budget, either POST the same ``budget_id`` (which edits in place) or close the old one by
     setting its ``ends_on`` first.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -1943,7 +1943,8 @@ async def delete_tenant_budget(
     account-labels control plane: the end state the caller asked for is the end state they get, and
     a double-click is not an error.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     if budget_id is None:
         try:
             body = await request.json()
@@ -2349,7 +2350,8 @@ def list_tenant_cac(
     x_tenant_id: str | None = Header(default=None),
 ) -> JSONResponse:
     """List monthly CAC periods for the caller's tenant, newest first."""
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantCacStore = app.state.tenant_cac
     rows = store.list(tenant_id)
     return JSONResponse(
@@ -2369,7 +2371,8 @@ async def upsert_tenant_cac(
     Rejects rows whose ``period_start`` is already closed (the successor month exists). Rejects
     rows whose ``new_customers_total < new_customers_paid`` (sanity guard).
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -2391,7 +2394,8 @@ async def upload_tenant_cac_csv(
     x_tenant_id: str | None = Header(default=None),
 ) -> JSONResponse:
     """Bulk-upsert CAC periods from a CSV body (fixed column order)."""
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     body = (await request.body()).decode("utf-8", errors="replace")
     try:
         forms = parse_csv(body)
@@ -2418,7 +2422,8 @@ def download_tenant_cac_template(
     """Return the CSV template (header + example row). Used by the upload UI."""
     from fastapi.responses import PlainTextResponse
 
-    _ = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    _ = _service_token_tenant(x_tenant_id)
     return PlainTextResponse(
         csv_template(),
         media_type="text/csv",
@@ -2436,7 +2441,8 @@ def get_tenant_unit_economics_config(
     Returns ``config: null`` when the tenant has no row — the web classify helpers then fall back to
     the hardcoded B2B-SaaS defaults. Same per-tenant auth as the CAC route.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantUnitEconomicsStore = app.state.tenant_unit_economics
     config = store.get(tenant_id)
     return JSONResponse(
@@ -2457,7 +2463,8 @@ async def upsert_tenant_unit_economics_config(
     payback_months_yellow, change_id, updated_by?}``. Replaying the same change_id is a no-op
     (returns the existing config unchanged). Rejects inverted bands (422).
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -2493,7 +2500,8 @@ def get_tenant_revenue_source_config(
     (every source counts; ValueType monetary + mrr are revenue; refunds net off). Same per-tenant
     auth as the unit-economics route.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: TenantRevenueSourceStore = app.state.tenant_revenue_sources
     try:
         config = store.get(tenant_id)
@@ -2519,7 +2527,8 @@ async def upsert_tenant_revenue_source_config(
     ``revenue_sources: null`` means every source counts. An empty array is rejected (422) because
     "nothing is revenue" silently blanks the dashboard and is never what a caller means.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -2579,7 +2588,8 @@ def list_revenue_uploads(
     The dashboard derives its "as of" date and staleness badge from ``uploaded_at``. An empty list
     means nothing has ever been uploaded, which the UI renders as an invitation rather than a zero.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     store: RevenueUploadStore = app.state.revenue_uploads
     try:
         rows = store.list(tenant_id)
@@ -2637,7 +2647,8 @@ async def upload_revenue_csv(
     ``BusinessEventId`` of every row is derived from ``(period, account hash)``. Re-uploading the
     same file leaves exactly the same rows behind.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -2728,7 +2739,8 @@ def delete_revenue_upload(
     manifest row (or the other way round) would leave the dashboard claiming a freshness it cannot
     back, so both go in one call.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     if normalize_period(period) is None:
         raise HTTPException(status_code=422, detail="period must be a YYYY-MM calendar month")
     store: ClickHouseStore = app.state.store
@@ -2775,7 +2787,8 @@ async def ingest_revenue_event(
     the response reports whether the tenant's own configured revenue sources (CTO-194) will count
     it, so a narrowed policy shows up on the first request rather than as a blank dashboard later.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -2882,7 +2895,8 @@ def get_tenant_replay_config(
 
     Defaults to ``enabled=false`` when the tenant has no row yet — sampling is opt-in.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     cfg = app.state.tenant_replay.get(tenant_id)
     return JSONResponse({"tenant_id": tenant_id, "config": cfg.as_dict()})
 
@@ -2898,7 +2912,8 @@ async def set_tenant_replay_config(
     Body fields (all optional — only what changes is updated):
     ``{enabled?: bool, sample_rate?: 0..1, retention_days?: int>0, daily_budget_usd?: number>=0}``.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -3043,6 +3058,7 @@ async def project_replay(
     client; with a real provider client the executor's concurrency limit (5 per tenant) keeps
     things bounded.
     """
+    _require_service_token(authorization)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -3050,9 +3066,7 @@ async def project_replay(
     if not isinstance(body, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")
 
-    tenant_id = body.get("tenant_id") or _resolve_tenant_for_control_plane(
-        authorization, x_tenant_id
-    )
+    tenant_id = body.get("tenant_id") or _service_token_tenant(x_tenant_id)
     feature_tag = body.get("feature_tag")
     candidates = body.get("candidate_models") or []
     if not isinstance(candidates, list) or not all(
@@ -3240,6 +3254,7 @@ async def project_replay_estimate(
     honesty/diagnostics block. Like ``/v1/replay``, the candidate client is injectable via
     ``app.state.replay_candidate_client`` (a deterministic mock by default).
     """
+    _require_service_token(authorization)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -3247,9 +3262,7 @@ async def project_replay_estimate(
     if not isinstance(body, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")
 
-    tenant_id = body.get("tenant_id") or _resolve_tenant_for_control_plane(
-        authorization, x_tenant_id
-    )
+    tenant_id = body.get("tenant_id") or _service_token_tenant(x_tenant_id)
     feature_tag = body.get("feature_tag")
     candidate = body.get("candidate_model")
     if not isinstance(candidate, dict) or "provider" not in candidate or "model" not in candidate:
@@ -3455,7 +3468,8 @@ def get_tenant_eval_config(
     Defaults to ``enabled=false`` when the tenant has no row yet — eval is opt-in (judge calls
     burn real provider budget).
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     cfg = app.state.tenant_eval.get(tenant_id)
     return JSONResponse({"tenant_id": tenant_id, "config": cfg.as_dict()})
 
@@ -3471,7 +3485,8 @@ async def set_tenant_eval_config(
     Body fields (all optional — only what changes is updated):
     ``{enabled?: bool, judge_model?: str, daily_budget_usd?: number>=0}``.
     """
-    tenant_id = _resolve_tenant_for_control_plane(authorization, x_tenant_id)
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -3527,6 +3542,7 @@ async def project_eval(
     fits inside a 10-minute timeout for typical 50-sample × 3-candidate passes against the
     in-memory mock judge.
     """
+    _require_service_token(authorization)
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -3534,9 +3550,7 @@ async def project_eval(
     if not isinstance(body, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")
 
-    tenant_id = body.get("tenant_id") or _resolve_tenant_for_control_plane(
-        authorization, x_tenant_id
-    )
+    tenant_id = body.get("tenant_id") or _service_token_tenant(x_tenant_id)
     feature_tag = body.get("feature_tag")
     candidates = body.get("candidate_models") or []
     if not isinstance(candidates, list) or not all(

--- a/infra/gateway/tests/test_app_auth.py
+++ b/infra/gateway/tests/test_app_auth.py
@@ -7,6 +7,7 @@ limiter/mapping tests plus the live smoke in the PR description.
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -14,6 +15,7 @@ from fastapi.testclient import TestClient
 
 from gateway.app import app
 from gateway.auth import AuthResult
+from gateway.mapping import COLUMNS
 from gateway.ratelimit import RateLimiter
 
 
@@ -42,17 +44,45 @@ def _batch(tenant_id: str, n_spans: int = 1) -> dict:
     }
 
 
+class RecordingStore:
+    """Captures the row tuples the ingest path would insert, so no ClickHouse is needed."""
+
+    def __init__(self) -> None:
+        self.spans: list[tuple] = []
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        self.spans.extend(rows)
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
 @contextmanager
 def _client(
-    *, keys: dict[str, AuthResult] | None = None, limiter: RateLimiter | None = None
+    *,
+    keys: dict[str, AuthResult] | None = None,
+    limiter: RateLimiter | None = None,
+    store: RecordingStore | None = None,
 ) -> Iterator[TestClient]:
     # `with TestClient(app)` runs the lifespan exactly once; we then override the infra-touching
-    # bits (auth → in-memory, optionally the limiter) before yielding.
+    # bits (auth → in-memory, optionally the limiter or the store) before yielding.
     with TestClient(app) as client:
         app.state.settings.require_api_key = True
         app.state.auth = FakeAuth(keys or {})
         if limiter is not None:
             app.state.limiter = limiter
+        if store is not None:
+            app.state.store = store
         yield client
 
 
@@ -84,6 +114,32 @@ def test_tenant_a_key_cannot_write_tenant_b() -> None:
         r = c.post("/v1/batches", json=_batch(TENANT_B), headers={"Authorization": "Bearer wk"})
         assert r.status_code == 403
         assert r.json()["detail"]["code"] == "TENANT_MISMATCH"
+
+
+def test_ingest_stamps_the_tenant_uuid_on_every_span() -> None:
+    """Canonical TenantId is the tenant UUID (Initiative 1, §8, Decision 4).
+
+    ``db/clickhouse/otel_spans.sql`` orders by ``TenantId`` first and the dashboard binds the UUID
+    into its read filter, so a span stamped with anything else (a tenant NAME, say) is invisible to
+    every read. The key's tenant is authoritative and it is a UUID, so this pins the written value
+    rather than trusting the ingest path to keep agreeing with the reader by coincidence.
+    """
+    keys = {"wk": AuthResult(tenant_id=TENANT_A, scope="write")}
+    store = RecordingStore()
+    with _client(keys=keys, store=store) as c:
+        r = c.post(
+            "/v1/batches",
+            json=_batch(TENANT_A, n_spans=2),
+            headers={"Authorization": "Bearer wk"},
+        )
+        assert r.status_code == 200
+
+    assert len(store.spans) == 2
+    tenant_col = COLUMNS.index("TenantId")
+    written = {row[tenant_col] for row in store.spans}
+    assert written == {TENANT_A}
+    # Guard against a future refactor that stamps a name: parseable as a UUID, not a label.
+    uuid.UUID(written.pop())
 
 
 def test_rate_limit_exceeded_returns_429_with_retry_after() -> None:

--- a/infra/gateway/tests/test_app_orgs_access.py
+++ b/infra/gateway/tests/test_app_orgs_access.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import date
 
 from fastapi.testclient import TestClient
 
 from gateway.app import app
 from gateway.config import get_settings
 from gateway.tenant_api_keys import ApiKeyMeta, MintedKey
+from gateway.tenant_budgets import Budget
 from gateway.tenant_provisioning import ProvisionResult
 
 TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
@@ -256,3 +258,94 @@ def test_revoke_key_returns_204() -> None:
             headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
         )
         assert r.status_code == 204
+
+
+# --- legacy control-plane endpoints ----------------------------------------------------------------
+#
+# Initiative 1 §6 closed the gap on the PRE-EXISTING /v1/tenant/* handlers too, not just the ones
+# this initiative added. Those used to resolve the tenant from an INGEST api key when auth was on,
+# so any holder of a write key could read and edit the control plane, and with auth off they trusted
+# a bare x-tenant-id from anyone who could reach the gateway. They now take the same service-token
+# gate and read the tenant from x-tenant-id. Budgets stands in for the whole set: a plain
+# store-backed read and write with no ingest coupling.
+
+
+class FakeBudgetStore:
+    """Minimal stand-in for TenantBudgetStore: enough for the auth assertions, no Postgres."""
+
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str]] = []
+
+    def upsert(self, tenant_id: str, **kw: object) -> Budget:
+        self.writes.append((tenant_id, str(kw.get("budget_id"))))
+        return Budget(
+            budget_id=str(kw.get("budget_id")),
+            period=str(kw.get("period")),
+            # Integer micro-USD, echoed back exactly as given: never a float, never defaulted to 0.
+            amount_micro=int(kw["amount_micro"]),  # type: ignore[arg-type]
+            scope_kind=str(kw.get("scope_kind")),
+            scope_value=str(kw.get("scope_value") or ""),
+            starts_on=date(2026, 1, 1),
+            ends_on=None,
+            created_at=None,
+            updated_at=None,
+        )
+
+    def list(self, tenant_id: str) -> list[Budget]:
+        return []
+
+
+_BUDGET_BODY = {
+    "budget_id": "research-agent-2026",
+    "period": "month",
+    "amount_micro": 30_000_000_000,
+    "scope_kind": "feature",
+    "scope_value": "research-agent",
+    "starts_on": "2026-01-01",
+}
+
+
+def test_legacy_budgets_write_rejected_without_service_token() -> None:
+    with _client(auth_on=True) as c:
+        store = FakeBudgetStore()
+        app.state.tenant_budgets = store
+        r = c.post(
+            "/v1/tenant/budgets",
+            json=_BUDGET_BODY,
+            headers={"X-Tenant-Id": TENANT_UUID},
+        )
+        assert r.status_code == 401
+        # The gate runs BEFORE the store, so an unauthenticated caller never reaches the write.
+        assert store.writes == []
+
+        wrong = c.post(
+            "/v1/tenant/budgets",
+            json=_BUDGET_BODY,
+            headers={"Authorization": "Bearer nope", "X-Tenant-Id": TENANT_UUID},
+        )
+        assert wrong.status_code == 401
+        assert store.writes == []
+
+
+def test_legacy_budgets_write_succeeds_with_service_token() -> None:
+    with _client(auth_on=True) as c:
+        store = FakeBudgetStore()
+        app.state.tenant_budgets = store
+        r = c.post(
+            "/v1/tenant/budgets",
+            json=_BUDGET_BODY,
+            headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}),
+        )
+        assert r.status_code == 200
+        # The tenant comes from x-tenant-id, not from an ingest key: the service token authenticates
+        # the web SERVER, never a tenant (§6).
+        assert store.writes == [(TENANT_UUID, "research-agent-2026")]
+        assert r.json()["budget"]["amount_micro"] == 30_000_000_000
+
+
+def test_legacy_budgets_read_rejected_without_service_token() -> None:
+    with _client(auth_on=True) as c:
+        app.state.tenant_budgets = FakeBudgetStore()
+        assert c.get("/v1/tenant/budgets", headers={"X-Tenant-Id": TENANT_UUID}).status_code == 401
+        ok = c.get("/v1/tenant/budgets", headers=_svc_headers({"X-Tenant-Id": TENANT_UUID}))
+        assert ok.status_code == 200

--- a/web/app/api/features/value-events/route.ts
+++ b/web/app/api/features/value-events/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "@/lib/getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "@/lib/getTenant";
 import { NextResponse } from "next/server";
 
 import { queryDistinctBusinessEventNames, queryFeatureValueEvents } from "@/lib/clickhouse";
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/feature-value-events`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify(payload),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
@@ -94,7 +94,7 @@ export async function DELETE(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/feature-value-events`, {
       method: "DELETE",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify({ feature_tag: feature, change_id: changeId }),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/app/api/guardrails/route.ts
+++ b/web/app/api/guardrails/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "@/lib/getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "@/lib/getTenant";
 import { NextResponse } from "next/server";
 
 import {
@@ -42,7 +42,7 @@ export async function GET(req: Request) {
     try {
       const qs = ruleId ? `?rule_id=${encodeURIComponent(ruleId)}` : "";
       const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails/audit${qs}`, {
-        headers: { "x-tenant-id": await resolveTenantId() },
+        headers: controlPlaneHeaders(await resolveTenantId()),
         cache: "no-store",
         signal: AbortSignal.timeout(2000),
       });
@@ -102,7 +102,7 @@ export async function POST(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify(payload),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/app/api/keys/route.test.ts
+++ b/web/app/api/keys/route.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Admin gating on the /api/keys proxy (Initiative 1, §6/§9). The gateway sees only the service token
+// and a resolved tenant; it does not know the human's role. That makes the web server the single
+// policy enforcement point, so these tests pin it: a `member` must not be able to mint an ingest key,
+// and no request must reach the gateway when the role check fails.
+//
+// Clerk is mocked and TALLY_DEV_TENANT is cleared per test, because the dev escape hatch treats the
+// local developer as an admin by design and would hide the check the product path relies on.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+vi.mock("@clerk/nextjs/server", () => ({ auth: authMock }));
+
+const TENANT_UUID = "3f8c1c2a-0b7e-4d3a-9a1b-77c0d5e2f011";
+const ORG_ID = "org_test";
+
+const originalDevTenant = process.env.TALLY_DEV_TENANT;
+const originalToken = process.env.GATEWAY_SERVICE_TOKEN;
+
+/** Gateway responses the route's own fetch calls consume. Recorded so we can assert none happened. */
+let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+beforeEach(() => {
+  vi.resetModules();
+  // Leave the escape hatch OFF so getTenant() takes the product path through Clerk.
+  delete process.env.TALLY_DEV_TENANT;
+  process.env.GATEWAY_SERVICE_TOKEN = "svc-token";
+  fetchCalls = [];
+  vi.stubGlobal("fetch", (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    fetchCalls.push({ url, init });
+    if (url.includes("/v1/tenant/by-clerk-org/")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ tenant_id: TENANT_UUID, plan: "free" }), { status: 200 }),
+      );
+    }
+    if (init?.method === "POST") {
+      return Promise.resolve(
+        new Response(JSON.stringify({ id: "key-1", token: "tally_sk_live_secret" }), {
+          status: 201,
+        }),
+      );
+    }
+    return Promise.resolve(new Response(JSON.stringify({ keys: [] }), { status: 200 }));
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  authMock.mockReset();
+  if (originalDevTenant === undefined) delete process.env.TALLY_DEV_TENANT;
+  else process.env.TALLY_DEV_TENANT = originalDevTenant;
+  if (originalToken === undefined) delete process.env.GATEWAY_SERVICE_TOKEN;
+  else process.env.GATEWAY_SERVICE_TOKEN = originalToken;
+});
+
+function mintRequest(): Request {
+  return new Request("http://localhost/api/keys", {
+    method: "POST",
+    body: JSON.stringify({ name: "prod ingest", scope: "write" }),
+  });
+}
+
+describe("POST /api/keys admin gating", () => {
+  it("refuses a member with 403 and never calls the gateway keys endpoint", async () => {
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:member", userId: "user_1" });
+    const { POST } = await import("./route");
+
+    const res = await POST(mintRequest());
+
+    expect(res.status).toBe(403);
+    // The org resolve is allowed; the MINT must not have been attempted.
+    expect(fetchCalls.some((c) => c.init?.method === "POST")).toBe(false);
+  });
+
+  it("lets an admin mint and forwards the service token plus the resolved tenant UUID", async () => {
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:admin", userId: "user_1" });
+    const { POST } = await import("./route");
+
+    const res = await POST(mintRequest());
+
+    expect(res.status).toBe(201);
+    const mint = fetchCalls.find((c) => c.init?.method === "POST");
+    expect(mint).toBeDefined();
+    const headers = mint?.init?.headers as Record<string, string>;
+    expect(headers["x-tenant-id"]).toBe(TENANT_UUID);
+    expect(headers.authorization).toBe("Bearer svc-token");
+    expect(headers["x-clerk-user-id"]).toBe("user_1");
+  });
+});
+
+describe("GET /api/keys", () => {
+  it("is readable by a member: key metadata carries no secret (§9)", async () => {
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:member", userId: "user_1" });
+    const { GET } = await import("./route");
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const listed = fetchCalls.find((c) => c.url.endsWith("/v1/tenant/keys"));
+    expect(listed).toBeDefined();
+    expect((listed?.init?.headers as Record<string, string>)["x-tenant-id"]).toBe(TENANT_UUID);
+  });
+});

--- a/web/app/api/revenue-uploads/template/route.ts
+++ b/web/app/api/revenue-uploads/template/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "@/lib/getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "@/lib/getTenant";
 // Serves the revenue-upload CSV template (CTO-198).
 //
 // A thin proxy rather than a copy of the header string: the gateway owns what the columns are, and
@@ -15,7 +15,7 @@ const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 export async function GET() {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-uploads/template`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/app/api/unit-economics/config/route.ts
+++ b/web/app/api/unit-economics/config/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "@/lib/getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "@/lib/getTenant";
 import { NextResponse } from "next/server";
 
 import {
@@ -87,7 +87,7 @@ export async function POST(req: Request) {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/unit-economics/config`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify(payload),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/lib/accountLabels.ts
+++ b/web/lib/accountLabels.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Dashboard client for the account control plane (CTO-188, plan D2).
 //
 // Two gateway endpoints, one module, because they answer the two halves of the same question "which
@@ -52,7 +52,7 @@ interface AccountLookupResponse {
 export async function queryAccountLabels(): Promise<Map<string, string> | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/account-labels`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });
@@ -101,7 +101,7 @@ export async function lookupAccountHashes(accountId: string): Promise<AccountLoo
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/account-lookup`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify({ account_id: trimmed }),
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),

--- a/web/lib/allocationConfig.ts
+++ b/web/lib/allocationConfig.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Per-tenant shared-cost allocation rule, read via the gateway (CTO-193, plan C2).
 //
 // The rule decides how compute and egress are split across accounts on /cost-per-customer, which on
@@ -91,7 +91,7 @@ export function settingFromApi(body: AllocationConfigApi | null): AllocationRule
 export async function queryAllocationRule(): Promise<AllocationRuleSetting> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/allocation-config`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });

--- a/web/lib/budgets.ts
+++ b/web/lib/budgets.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Typed client for the tenant budget control plane (CTO-208, F4).
 //
 // CTO-205 built the storage and the rules (`db/postgres/0026_tenant_budgets.sql`,
@@ -78,7 +78,7 @@ export async function queryBudgets(): Promise<BudgetList> {
   };
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(4000),
     });
@@ -116,7 +116,7 @@ export async function saveBudget(input: BudgetInput): Promise<SaveResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify({
         budget_id: input.budgetId,
         period: input.period,
@@ -147,7 +147,7 @@ export async function deleteBudget(budgetId: string): Promise<DeleteResult> {
       `${GATEWAY_URL}/v1/tenant/budgets?budget_id=${encodeURIComponent(budgetId)}`,
       {
         method: "DELETE",
-        headers: { "x-tenant-id": await resolveTenantId() },
+        headers: controlPlaneHeaders(await resolveTenantId()),
         cache: "no-store",
         signal: AbortSignal.timeout(5000),
       },

--- a/web/lib/cac.ts
+++ b/web/lib/cac.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // CAC period type + gateway-backed fetch (CTO-111).
 //
 // Shapes match the gateway's /v1/tenant/cac response. Money is micro-USD on the wire (matching
@@ -73,7 +73,7 @@ export interface CacQueryResult {
 export async function queryCacPeriods(): Promise<CacQueryResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cac`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -94,7 +94,7 @@ import {
 // The active tenant is resolved per call from the Clerk org (or the dev escape hatch), not a
 // module-level `local-dev` constant (Initiative 1, §7/§8). The ClickHouse read filter binds this
 // UUID, so a UUID-scoped read matches UUID-tagged ingest.
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 import { firstEventStatus, type FirstEventStatus } from "./firstEvent";
 
 let _client: ClickHouseClient | null = null;
@@ -1866,7 +1866,7 @@ interface ReconciliationRun {
 async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/reconciliation/status`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -2391,7 +2391,7 @@ export interface IntegrationStatusRow {
 export async function queryIntegrationStatus(): Promise<IntegrationStatusRow[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/integrations/status`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -2518,7 +2518,7 @@ export async function queryGuardrailActivity(): Promise<Map<string, GuardrailAct
 export async function queryGuardrailRules(): Promise<GuardrailRule[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/guardrails`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -2563,7 +2563,7 @@ export interface FeatureValueEventConfig {
 export async function queryFeatureValueEvents(): Promise<FeatureValueEventConfig[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/feature-value-events`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -3128,7 +3128,7 @@ export async function queryReplayCandidates(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/replay`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": tenant },
+      headers: controlPlaneHeaders(tenant, { "content-type": "application/json" }),
       body: JSON.stringify({
         tenant_id: tenant,
         feature_tag: featureTag,
@@ -3182,7 +3182,7 @@ export async function queryReplayEstimate(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/replay/estimate`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": tenant },
+      headers: controlPlaneHeaders(tenant, { "content-type": "application/json" }),
       body: JSON.stringify({
         tenant_id: tenant,
         feature_tag: req.featureTag,
@@ -3260,7 +3260,7 @@ export async function queryEvalCandidates(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/eval`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": tenant },
+      headers: controlPlaneHeaders(tenant, { "content-type": "application/json" }),
       body: JSON.stringify({
         tenant_id: tenant,
         feature_tag: featureTag,

--- a/web/lib/costConnectors.ts
+++ b/web/lib/costConnectors.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Cloud cost-connector configuration (CTO-176).
 //
 // Mirrors lib/stripeConnector.ts: the dashboard never talks to Postgres directly, it goes through
@@ -34,7 +34,7 @@ interface ConfigWire {
 export async function queryCostConnectorConfigs(): Promise<CostConnectorConfig[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -67,7 +67,7 @@ export async function connectCostConnector(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify({ connector, ...fields }),
       cache: "no-store",
       signal: AbortSignal.timeout(4000),
@@ -95,7 +95,7 @@ export async function disconnectCostConnector(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/cost-connectors/${connector}`, {
       method: "DELETE",
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(4000),
     });

--- a/web/lib/getTenant.test.ts
+++ b/web/lib/getTenant.test.ts
@@ -15,10 +15,13 @@ import {
 
 describe("getTenant dev escape hatch", () => {
   it("short-circuits to the pinned dev tenant without consulting Clerk", async () => {
-    expect(devTenant()).toBe("local-dev");
+    // Pinned in vitest.config.ts. A UUID, not the name `local-dev`: the canonical TenantId is the
+    // tenant UUID (Initiative 1, §8) and this value is bound into the ClickHouse read filter.
+    const DEV_TENANT = "00000000-0000-0000-0000-000000000000";
+    expect(devTenant()).toBe(DEV_TENANT);
     const t = await getTenant();
-    expect(t).toEqual({ tenantId: "local-dev", orgId: null, orgRole: null });
-    expect(await resolveTenantId()).toBe("local-dev");
+    expect(t).toEqual({ tenantId: DEV_TENANT, orgId: null, orgRole: null });
+    expect(await resolveTenantId()).toBe(DEV_TENANT);
   });
 
   it("treats dev as admin so local key management works", async () => {

--- a/web/lib/revenueSources.ts
+++ b/web/lib/revenueSources.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Which business events count as revenue, per tenant (CTO-194).
 //
 // The attribution revenue sum used to be gated on a hardcoded `business_events.Source = 'stripe'`.
@@ -97,7 +97,7 @@ const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 export async function queryRevenuePolicy(): Promise<RevenuePolicy> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-sources/config`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/lib/revenueUpload.ts
+++ b/web/lib/revenueUpload.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Uploaded revenue snapshots (CTO-198, plan item E5).
 //
 // For tenants whose revenue lives in Chargebee, Recurly, Zuora, NetSuite or a spreadsheet rather
@@ -39,7 +39,7 @@ const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 export async function queryRevenueUploads(): Promise<RevenueSnapshot[] | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-uploads`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -62,7 +62,7 @@ export async function uploadRevenueCsv(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/revenue-uploads`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId(), { "content-type": "application/json" }),
       body: JSON.stringify({
         csv,
         filename: opts.filename,
@@ -101,7 +101,7 @@ export async function deleteRevenueUpload(
       `${GATEWAY_URL}/v1/tenant/revenue-uploads/${encodeURIComponent(period)}`,
       {
         method: "DELETE",
-        headers: { "x-tenant-id": await resolveTenantId() },
+        headers: controlPlaneHeaders(await resolveTenantId()),
         cache: "no-store",
         signal: AbortSignal.timeout(4000),
       },

--- a/web/lib/stripeConnector.ts
+++ b/web/lib/stripeConnector.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Per-tenant Stripe connector config (CTO-110).
 //
 // Mirrors lib/tenant.ts: the dashboard never talks to Postgres directly — it goes through the
@@ -33,7 +33,7 @@ interface StripeGetResponse {
 export async function queryStripeConfig(): Promise<StripeConfigView | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/stripe`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });
@@ -62,10 +62,9 @@ export async function connectStripe(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/stripe/connect`, {
       method: "POST",
-      headers: {
+      headers: controlPlaneHeaders(await resolveTenantId(), {
         "content-type": "application/json",
-        "x-tenant-id": await resolveTenantId(),
-      },
+      }),
       body: JSON.stringify({
         webhook_secret: webhookSecret,
         stripe_account_id: stripeAccountId || undefined,

--- a/web/lib/tenant.ts
+++ b/web/lib/tenant.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Per-tenant cost-layer connector declarations (CTO-107).
 //
 // The "Partial data" banner used to fire whenever any cost layer reported zero, which made it
@@ -50,7 +50,7 @@ function asLayer(s: string): Layer | null {
 export async function queryEnabledConnectors(): Promise<Layer[]> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/connectors`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       // Short timeout: a slow gateway shouldn't block every page render.
       signal: AbortSignal.timeout(2000),
@@ -93,10 +93,9 @@ export async function setConnectorEnabled(
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/connectors`, {
       method: "POST",
-      headers: {
+      headers: controlPlaneHeaders(await resolveTenantId(), {
         "content-type": "application/json",
-        "x-tenant-id": await resolveTenantId(),
-      },
+      }),
       body: JSON.stringify({ layer, enabled }),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),

--- a/web/lib/tenantBudgetsClient.ts
+++ b/web/lib/tenantBudgetsClient.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Read this tenant's budgets from the gateway (CTO-209, F5; endpoint from CTO-205, F1).
 //
 // Server-only, imported by Route Handlers. The dashboard never touches Postgres directly, same rule
@@ -35,7 +35,7 @@ export type TenantBudgetsResult =
 export async function fetchTenantBudgets(): Promise<TenantBudgetsResult> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/budgets`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });

--- a/web/lib/unitEconomicsConfig.ts
+++ b/web/lib/unitEconomicsConfig.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { resolveTenantId } from "./getTenant";
+import { controlPlaneHeaders, resolveTenantId } from "./getTenant";
 // Per-tenant LTV/CAC band threshold overrides, read via the gateway (CTO-126).
 //
 // The band cutoffs used to be hardcoded B2B-SaaS defaults inline in unitEconomics.ts. They are now
@@ -43,7 +43,7 @@ export function overridesFromApi(
 export async function queryUnitEconomicsConfig(): Promise<UnitEconomicsThresholdOverrides | null> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/unit-economics/config`, {
-      headers: { "x-tenant-id": await resolveTenantId() },
+      headers: controlPlaneHeaders(await resolveTenantId()),
       cache: "no-store",
       signal: AbortSignal.timeout(2000),
     });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,8 +21,13 @@ export default defineConfig({
     globals: true,
     // The dev escape hatch (Initiative 1, §10). Tests run with no Clerk account, so `getTenant()`
     // short-circuits to a pinned tenant instead of consulting Clerk. This mirrors how `make up` and
-    // CI run the product with no Clerk keys, and keeps the tenant scoping in the fetch-shaped tests
-    // exactly what it was before Clerk (`local-dev`).
-    env: { TALLY_DEV_TENANT: "local-dev" },
+    // CI run the product with no Clerk keys.
+    //
+    // The pinned value is a UUID, not the name `local-dev`, because the canonical TenantId is the
+    // tenant UUID (§8) and this value is bound straight into the ClickHouse read filter. Pinning a
+    // name here would let a read path that only works for names pass in CI and then render an empty
+    // dashboard against real data. The all-zero UUID is deliberately not a real tenant; it matches
+    // the placeholder in web/.env.example.
+    env: { TALLY_DEV_TENANT: "00000000-0000-0000-0000-000000000000" },
   },
 });


### PR DESCRIPTION
## The gap

Initiative 1 §6 landed the control-plane service-token gate, but only on the endpoints the initiative itself added. The ~40 pre-existing `/v1/tenant/*` handlers still resolved their tenant through `_resolve_tenant_for_control_plane`, which:

- with auth **off**, trusted a bare `x-tenant-id` from anyone who could reach the gateway, and
- with auth **on**, derived the tenant from a bearer **ingest** API key.

Both are holes once organizations are real. An ingest write key is minted so an SDK can post telemetry; it should not also open a tenant's budgets, guardrails, cost connectors, allocation config, CAC, revenue sources, unit-economics config and replay/eval settings. And the endpoints that were left ungated are exactly the ones that carry the control-plane writes.

## The fix

**Gateway** (`infra/gateway/src/gateway/app.py`). Every remaining call site now uses `_require_service_token(authorization)` + `_service_token_tenant(x_tenant_id)`, the same pattern the Initiative-1 endpoints use: the token authenticates the **web server**, and the tenant always comes from `x-tenant-id` (the UUID the web server resolved from the Clerk org). `_resolve_tenant_for_control_plane` is deleted rather than left behind as a second, weaker door.

On the three replay/eval handlers that accept a body-level `tenant_id` (`/v1/replay`, `/v1/replay/estimate`, `/v1/eval`) the gate is hoisted above the body parse, so an unauthenticated caller is refused before anything is read.

Untouched by design: `/v1/batches` and the whole ingest hot path, the edge-key delta feed (already gated), and the health endpoints.

**Web.** The legacy clients sent only `{"x-tenant-id": ...}`, so they would have started 401ing the moment auth was flipped on. Items 1 and 2 have to land together for that reason. All 33 call sites across `web/lib` and `web/app/api` now go through the existing `controlPlaneHeaders()`, which attaches the service token when one is configured and is a no-op locally when it is not.

**Deploy.** `TALLY_GATEWAY_SERVICE_TOKEN` is wired into the compose gateway, `deploy/gcp/cloudrun`, `deploy/aws/ecs`, and both Helm charts as a Secret Manager / Secrets Manager **reference**, never a literal. The web tier reads the same value as `GATEWAY_SERVICE_TOKEN`. This matters operationally: `app.py` already refuses to boot when auth is on and the token is empty, so without this a real deployment could not start.

## Also in this PR

- **Regression tests** (`test_app_orgs_access.py`): `POST /v1/tenant/budgets` is 401 without the service token *and never reaches the store*, and succeeds with a valid one under the tenant from `x-tenant-id`. The read is covered too.
- **§8 ingest test** (`test_app_auth.py`): the `TenantId` `/v1/batches` writes is the key's tenant UUID, asserted against the real column ordering and parsed as a UUID so a future refactor cannot quietly stamp a name.
- **Dev tenant value.** `web/vitest.config.ts` pinned the tenant NAME `local-dev`. Canonical `TenantId` is the UUID (§8, Decision 4), and that value is bound into the ClickHouse read filter, so a name-pinned suite could pass in CI and then render an empty dashboard against real data. Pinned to the placeholder UUID that `web/.env.example` already documents. `web/.env.local` is empty in this checkout and was not touched.
- **Migration 0031** (new number, compose mount added; 0029 not edited): length-bounded CHECKs on the `api_keys` display columns 0029 added as unbounded `TEXT`. `gateway/tenant_api_keys.py` already caps `name` at 120 and `created_by` at 255 (verified), but that is application-side only; this puts the same bound in the database, matching how `tenants.hash_salt_kek_ref` is already protected. NULL passes every CHECK, so an unknown value stays null and is never back-filled.
- **Web test for `/api/keys` admin gating**: a `member` gets 403 and no mint request reaches the gateway; an `admin` mints and the forwarded headers carry the resolved tenant UUID, the service token and the Clerk user id for audit.
- **RUNNING.md**: documents that control-plane curls need the bearer service token once `TALLY_REQUIRE_API_KEY=true`, and that an ingest key does not open the control plane.

## Verification

- `infra/gateway`: **899 passed**, `ruff check` clean.
- `web`: `typecheck` clean, `lint` clean (one pre-existing warning in `lib/useLivePoll.ts`), **707 passed / 61 files**.
- `infra/edge-proxy`: `go build` + `go test` all ok, `gofmt -l` lists nothing.

No new failures. The two known `web/app/api/api.test.ts` ClickHouse-unreachable cases passed here because no local ClickHouse was running.

## Not done

- The `deploy/demo` kit still pins `TALLY_TENANT_ID=local-dev`, which the web no longer reads (it reads `TALLY_DEV_TENANT`) and which is a name rather than the seeded UUID. `deploy.sh` / `reseed.sh` need the same UUID resolution `infra/Makefile` already does. That is a separate, untestable-from-here change and is left out deliberately; the service-token pass-through for that kit **is** included.
- `last_used_at` stamping is still unimplemented, as §5 intends (off the hot path; null is honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
