### PR TITLE
feat(edge-proxy): close the P1 telemetry gap so proxy traffic reaches storage (Initiative 2 §6.3/§8)

### DIFF
--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -25,10 +25,12 @@ These are enforced by tests, not just documented:
 1. **Bodies are never mutated.** Request and response bodies stream straight through
    `httputil.ReverseProxy`. We never buffer, rewrite, or persist them.
    (`TestTransparentForwarding`, `TestLargeBodyForwardedByteForByte` — 1 MiB exact-echo.)
-2. **Telemetry is metadata only.** `TraceRecord` carries tenant key, method, path, status, byte
-   *counts*, and timing — never content. Byte counts come from counting readers/writers that tally
-   as bytes pass, without copying them. There is structurally no field that could hold a prompt,
-   completion, or provider key. (`TestTraceRecordCarriesNoBodyContent`.)
+2. **Telemetry is metadata only.** `TraceRecord` carries method, path, status, byte *counts*,
+   timing, and the resolved tenant/model/token scalars — never content. The tenant key it holds
+   authenticates the ingest POST and is never a field in the emitted payload. Byte counts come from
+   counting readers/writers that tally as bytes pass, without copying them. There is structurally no
+   field that could hold a prompt, completion, or provider key.
+   (`TestTraceRecordCarriesNoBodyContent`, `TestEncodeCarriesNoBodyContent`.)
 3. **The customer's provider key is in-flight only.** The inbound `Authorization` header is
    forwarded to the upstream unchanged and is never read into any struct, log, or sink. Our own
    `X-Tenant-Key` control header is *stripped* before the request leaves for the provider.
@@ -55,7 +57,8 @@ These are enforced by tests, not just documented:
 | `EDGE_PROXY_BROKER_FILE` | — | path to the KMS-export JSON; **required** when `EDGE_PROXY_MODE=broker` |
 | `EDGE_PROXY_BROKER_TTL` | `5m` | how long a minted credential is reused before re-minting |
 | `EDGE_PROXY_SELF_HOSTED` | `false` | label emitted telemetry as `self-host` vs `cloud` |
-| `EDGE_PROXY_TELEMETRY_URL` | — | collector endpoint for metadata-only `TraceRecord`s; empty disables shipping |
+| `EDGE_PROXY_TELEMETRY_URL` | — | gateway ingest endpoint (`https://gateway/v1/batches`) the proxy POSTs metadata-only spans to; empty disables shipping |
+| `EDGE_PROXY_INGEST_TOKEN` | — | **fallback** bearer for those POSTs, used only for records that carry no tenant key of their own (single-tenant self-host without `EDGE_PROXY_REQUIRE_TENANT`); normally the presented `X-Tenant-Key` authenticates |
 | `EDGE_PROXY_ROUTES` | — | hosted multi-provider route table (see below); empty keeps single-origin `EDGE_PROXY_UPSTREAM` |
 | `EDGE_PROXY_ROUTE_MODE` | `host` | `host` (match on hostname, hosted default) or `path` (match+strip a leading prefix) |
 | `EDGE_PROXY_KEYS_URL` | — | gateway delta feed `GET /v1/edge/keys?since={cursor}` for key-to-tenant resolution; empty disables it |
@@ -110,8 +113,10 @@ no Postgres or gateway call sits in the request path. The feed ships only creati
 revocations since the persisted cursor; a revoked key arrives with `revoked_at` set and is
 dropped, so revocation propagates within one refresh interval (the documented proxy-path
 revocation SLA). The resolved UUID is stamped on `TraceRecord.TenantId` (a UUID is metadata, not
-content), so proxy and SDK traffic for one org share a single `TenantId` and one Cost Explorer
-view. An unknown or revoked key is rejected with `403` when `EDGE_PROXY_REQUIRE_TENANT=true`,
+content) and shipped as the batch's `tenant_id`, so proxy and SDK traffic for one org share a
+single `TenantId` and one Cost Explorer view, provided `EDGE_PROXY_TELEMETRY_URL` is set. With
+telemetry shipping off, resolution still gates the request (the `403` below) but nothing reaches
+storage. An unknown or revoked key is rejected with `403` when `EDGE_PROXY_REQUIRE_TENANT=true`,
 never forwarded unauthenticated; a brand-new key can miss the cache until the next refresh, which
 is honest and bounded, not a fabricated success. A transient feed error keeps the last good map:
 resolution never fails open. `GET /v1/edge/keys` is delivered by a separate gateway PR; only the
@@ -187,11 +192,45 @@ go run ./cmd/edge-proxy
 ### Telemetry parity
 
 A self-hosted proxy emits the **same** metadata-only records as the cloud proxy — same fields, same
-wire shape — differing only in a `deployment` label (`self-host` vs `cloud`). Set
-`EDGE_PROXY_TELEMETRY_URL` to your ai-tally collector to enable shipping; leave it empty to run the
-proxy fully dark. Parity is guaranteed by a single serialization path (`telemetry.Encode`) asserted
-by `TestParitySelfHostMatchesCloud`; `TestEncodeCarriesNoBodyContent` whitelists the allowed fields
-so no prompt/completion/key field can ever sneak into the envelope.
+wire shape, differing only in a `tally.deployment` label (`self-host` vs `cloud`). Set
+`EDGE_PROXY_TELEMETRY_URL` to your gateway's `/v1/batches` to enable shipping; leave it empty to run
+the proxy fully dark. Parity is guaranteed by a single serialization path (`telemetry.Encode`)
+asserted by `TestParitySelfHostMatchesCloud`; `TestEncodeCarriesNoBodyContent` whitelists the
+allowed fields so no prompt/completion/key field can ever sneak into the envelope.
+
+### Where telemetry goes (Initiative 2 sec 6.3 / sec 8)
+
+The destination is the gateway's existing ingest endpoint, not a proxy-only collector. Each
+`TraceRecord` is encoded as a one-span `POST /v1/batches` body (`tally.wire.BatchRequest`), so
+proxied traffic runs the same authenticated, validated, cost-enriched, idempotent write path SDK
+traffic does and lands in the same `otel_spans` columns:
+
+| record field | span field | column |
+|---|---|---|
+| `TenantId` | envelope `tenant_id` | `TenantId` |
+| `Provider` | `gen_ai.system` | `GenAiSystem` |
+| `Model` | `gen_ai.response.model` | `GenAiResponseModel` |
+| `PromptTokens` / `CompletionTokens` | `gen_ai.usage.input_tokens` / `.output_tokens` | `InputTokens` / `OutputTokens` |
+| `FeatureTag` | `gen_ai.feature_tag` | `FeatureTag` |
+| `AccountIdHash` | `gen_ai.account_id_hash` | `AccountIdHash` |
+
+Method, path, byte counts, upstream-failure flag and the deployment label ride along as span
+attributes and land in `SpanAttributes`, so nothing about this needed a schema change.
+
+**Auth.** Each POST carries `Authorization: Bearer <the tenant key the caller presented>`. That key
+is the caller's own ai-tally api key, so the gateway resolves it to the same tenant the proxy did
+and every batch is authenticated by the tenant it belongs to, which is what makes the hosted
+multi-tenant deployment correct by construction. The key travels on the header only; it is never a
+field in the body and never logged. `EDGE_PROXY_INGEST_TOKEN` is the fallback for a deployment
+whose requests carry no tenant key at all. With neither available the record is shed and counted
+(`HTTPSink.Unauthenticated()`) rather than posted unattributable.
+
+**Unknown stays unknown.** Token counts are nullable end to end: a streamed response, a body past
+the metadata scan cap, and an error response all leave them absent from the JSON, so they reach
+storage as NULL. A `0` would read downstream as a real call that consumed nothing. Same for the
+model and the provider: omitted when they could not be extracted, which makes the span honestly
+unpriceable rather than priced against a guess. (`TestUnknownTokensSerializeAsNullNeverZero`,
+`TestZeroTokensStillSerialize`.)
 
 ### Container image
 
@@ -216,14 +255,14 @@ from either an inline value (dev) or — recommended — a Secret you render fro
 ```bash
 # dev / quick trial: inline keys (renders a Secret for you)
 helm install edge-proxy infra/edge-proxy/deploy/helm/edge-proxy \
-  --set proxy.telemetryURL=https://ingest.ai-tally.com/v1/traces \
+  --set proxy.telemetryURL=https://ingest.ai-tally.com/v1/batches \
   --set-file broker.inline=infra/edge-proxy/deploy/keys.example.json
 
 # production: reference a Secret you manage (provider keys never touch values.yaml or git)
 kubectl create secret generic edge-proxy-broker --from-file=keys.json=./from-kms.json
 helm install edge-proxy infra/edge-proxy/deploy/helm/edge-proxy \
   --set broker.existingSecret=edge-proxy-broker \
-  --set proxy.telemetryURL=https://ingest.ai-tally.com/v1/traces
+  --set proxy.telemetryURL=https://ingest.ai-tally.com/v1/batches
 ```
 
 Every `proxy.*` value maps onto one `EDGE_PROXY_*` env var from the table above; see
@@ -249,14 +288,16 @@ go test -bench=ProxyOverhead -benchmem ./internal/proxy/
 
 `TestOverheadBudget` runs on every `go test`: it measures p99 added latency against a loopback
 upstream and fails if it crosses 3ms, so a hot-path regression (an accidental body buffer, a new
-sync allocation) trips CI rather than shipping silently.
+sync allocation) trips CI rather than shipping silently. It budgets **both** deployment shapes,
+because they do different per-request work: `single-origin` (the CTO-39 core) and `hosted` (the
+Initiative 2 shape the cloud runs: route-table scan, key sha256 plus cache lookup, and provider
+response-metadata extraction).
 
 ### Measured (Apple M-series, loopback, Go 1.26)
 
 ```
-direct  p50=29µs   p99=62µs
-proxied p50=63µs   p99=129µs
-added overhead p99 ≈ 100µs            (budget 3ms)
+single-origin  direct p50=29µs  proxied p99=153µs  added overhead p99 ≈ 124µs   (budget 3ms)
+hosted         direct p50=28µs  proxied p99=182µs  added overhead p99 ≈ 153µs   (budget 3ms)
 BenchmarkProxyOverhead   ~64µs/op
 ```
 

--- a/infra/edge-proxy/cmd/edge-proxy/main.go
+++ b/infra/edge-proxy/cmd/edge-proxy/main.go
@@ -42,14 +42,20 @@ func main() {
 	}
 
 	// Telemetry shipping: a self-hosted proxy emits the same metadata-only records as the cloud
-	// proxy, labeled by deployment. Empty URL keeps the CTO-39 NopSink (no telemetry).
+	// proxy, labeled by deployment. Records go to the gateway's POST /v1/batches as single-span
+	// batches, authenticated per record by the presented tenant key (Initiative 2 sec 6.3 / sec 8).
+	// Empty URL keeps the CTO-39 NopSink (no telemetry).
 	var sink *telemetry.HTTPSink
 	if cfg.TelemetryURL != "" {
 		dep := telemetry.DeploymentCloud
 		if cfg.SelfHosted {
 			dep = telemetry.DeploymentSelfHost
 		}
-		sink = telemetry.NewHTTPSink(telemetry.Options{URL: cfg.TelemetryURL, Deployment: dep})
+		sink = telemetry.NewHTTPSink(telemetry.Options{
+			URL:         cfg.TelemetryURL,
+			Deployment:  dep,
+			IngestToken: cfg.IngestToken,
+		})
 		opts = append(opts, proxy.WithSink(sink))
 		log.Printf("edge-proxy: telemetry -> %s (deployment=%s)", cfg.TelemetryURL, dep)
 	}

--- a/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
+++ b/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
@@ -41,8 +41,14 @@ proxy:
   # collector can distinguish self-hosted ingest from cloud. Leave true for self-hosted installs.
   selfHosted: true
 
-  # Collector endpoint the proxy POSTs metadata-only TraceRecords to. Empty disables telemetry
+  # Gateway ingest endpoint the proxy POSTs metadata-only spans to, as single-span
+  # /v1/batches requests (e.g. https://ingest.ai-tally.com/v1/batches). Empty disables telemetry
   # shipping entirely (the proxy still works; it just emits nothing).
+  #
+  # Each batch is authenticated by the tenant key the caller presented, so no credential is
+  # configured here. A single-tenant install whose callers send no tenant key needs the
+  # EDGE_PROXY_INGEST_TOKEN fallback instead; that is a secret, so set it on the Deployment from
+  # your own Secret rather than through this chart's ConfigMap.
   telemetryURL: ""
 
 # --- key broker (broker mode only) -------------------------------------------------------------

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -129,9 +129,16 @@ type Config struct {
 	// SelfHosted marks this as a customer-VPC deployment; it labels emitted telemetry so the cloud
 	// can distinguish self-hosted ingest. Defaults to false (cloud).
 	SelfHosted bool
-	// TelemetryURL, if set, is the collector endpoint the proxy POSTs metadata-only TraceRecords
-	// to. Empty disables telemetry shipping (NopSink), as in the CTO-39 core.
+	// TelemetryURL, if set, is the ingest endpoint the proxy POSTs metadata-only TraceRecords to as
+	// single-span batches (the gateway's POST /v1/batches). Empty disables telemetry shipping
+	// (NopSink), as in the CTO-39 core.
 	TelemetryURL string
+	// IngestToken is the fallback bearer for those POSTs, used only when a record carries no tenant
+	// key of its own. Normally the presented X-Tenant-Key authenticates the batch, which is what
+	// keeps the hosted multi-tenant deployment attributing each batch to its own tenant; a
+	// single-tenant self-host that runs without RequireTenant sets this instead. It is a reference
+	// to a deployment secret (env var rendered from Secret Manager / KMS), never a key we mint.
+	IngestToken string
 
 	// --- Hosted multi-provider routing (Initiative 2 sec 6.1) ---
 
@@ -192,6 +199,7 @@ func FromEnv(lookup Env) (Config, error) {
 		Mode:            ModePassthrough,
 		BrokerTTL:       DefaultBrokerTTL,
 		TelemetryURL:    lookup("EDGE_PROXY_TELEMETRY_URL"),
+		IngestToken:     lookup("EDGE_PROXY_INGEST_TOKEN"),
 	}
 
 	// Provider is orthogonal to upstream selection but changes the default upstream: a gemini proxy

--- a/infra/edge-proxy/internal/proxy/overhead_test.go
+++ b/infra/edge-proxy/internal/proxy/overhead_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/edgekeys"
 )
 
 // tinyUpstream returns a fixed small JSON body, the shape of a cheap models/health call. We want
@@ -37,27 +38,62 @@ func percentile(sorted []time.Duration, p float64) time.Duration {
 // setup to the steady-state measurement — exactly how the proxy runs in production (hot pool).
 func measure(t testing.TB, client *http.Client, url string, warmup, n int) []time.Duration {
 	t.Helper()
-	for i := 0; i < warmup; i++ {
-		resp, err := client.Get(url)
+	return measureWith(t, client, url, nil, warmup, n)
+}
+
+// measureWith is measure plus per-request headers, so the hosted path can be measured carrying the
+// X-Tenant-Key that triggers the sha256 + cache lookup it pays for in production.
+func measureWith(
+	t testing.TB, client *http.Client, url string, header http.Header, warmup, n int,
+) []time.Duration {
+	t.Helper()
+	do := func() {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
-			t.Fatalf("warmup request: %v", err)
+			t.Fatalf("build request: %v", err)
 		}
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}
-	out := make([]time.Duration, 0, n)
-	for i := 0; i < n; i++ {
-		start := time.Now()
-		resp, err := client.Get(url)
+		for k, vs := range header {
+			for _, v := range vs {
+				req.Header.Add(k, v)
+			}
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			t.Fatalf("request: %v", err)
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
+	}
+	for i := 0; i < warmup; i++ {
+		do()
+	}
+	out := make([]time.Duration, 0, n)
+	for i := 0; i < n; i++ {
+		start := time.Now()
+		do()
 		out = append(out, time.Since(start))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 	return out
+}
+
+// checkBudget reports the measured overhead and fails when it crosses the CTO-39 budget.
+func checkBudget(t *testing.T, label string, direct, proxied []time.Duration) {
+	t.Helper()
+	// Overhead = proxied tail minus the direct typical service time.
+	overheadP99 := percentile(proxied, 99) - percentile(direct, 50)
+	if overheadP99 < 0 {
+		overheadP99 = 0
+	}
+
+	t.Logf("%s: direct  p50=%s p99=%s", label, percentile(direct, 50), percentile(direct, 99))
+	t.Logf("%s: proxied p50=%s p99=%s", label, percentile(proxied, 50), percentile(proxied, 99))
+	t.Logf("%s: added overhead p99=%s (budget 3ms)", label, overheadP99)
+
+	const budget = 3 * time.Millisecond
+	if overheadP99 >= budget {
+		t.Errorf("%s: p99 added overhead %s exceeds budget %s", label, overheadP99, budget)
+	}
 }
 
 // TestOverheadBudget enforces the CTO-39 acceptance criterion: p99 added latency < 3ms.
@@ -65,49 +101,79 @@ func measure(t testing.TB, client *http.Client, url string, warmup, n int) []tim
 // Both paths hit the same loopback upstream, so subtracting the direct baseline isolates the
 // proxy's own processing. This runs on every `go test`, so a regression that fattens the hot path
 // (e.g. buffering a body, adding a sync allocation) trips CI rather than shipping silently.
+//
+// Two configurations are measured, because they do measurably different work per request:
+//
+//   - single-origin: the CTO-39 core, one upstream, no routing and no key resolution.
+//   - hosted: the Initiative 2 shape the cloud actually runs (sec 6.1/6.2): a route table the
+//     router scans per request, a sha256 of the presented key plus a cache lookup, and a provider
+//     protocol whose response scanner tees the body aside. Budgeting only the single-origin path
+//     would leave the deployment customers touch unmeasured.
 func TestOverheadBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping latency budget in -short mode")
 	}
 
-	origin := httptest.NewServer(tinyUpstream())
-	defer origin.Close()
-
-	cfg, err := config.FromEnv(func(k string) string {
-		if k == "EDGE_PROXY_UPSTREAM" {
-			return origin.URL
-		}
-		return ""
-	})
-	if err != nil {
-		t.Fatalf("config: %v", err)
-	}
-	front := httptest.NewServer(New(cfg)) // NopSink: zero telemetry overhead on the hot path
-	defer front.Close()
-
 	const (
 		warmup = 200
 		n      = 3000
 	)
-	client := &http.Client{Transport: &http.Transport{MaxIdleConnsPerHost: 4}}
 
-	direct := measure(t, client, origin.URL+"/v1/models", warmup, n)
-	proxied := measure(t, client, front.URL+"/v1/models", warmup, n)
+	t.Run("single-origin", func(t *testing.T) {
+		origin := httptest.NewServer(tinyUpstream())
+		defer origin.Close()
 
-	// Overhead = proxied tail minus the direct typical service time.
-	overheadP99 := percentile(proxied, 99) - percentile(direct, 50)
-	if overheadP99 < 0 {
-		overheadP99 = 0
-	}
+		cfg, err := config.FromEnv(func(k string) string {
+			if k == "EDGE_PROXY_UPSTREAM" {
+				return origin.URL
+			}
+			return ""
+		})
+		if err != nil {
+			t.Fatalf("config: %v", err)
+		}
+		front := httptest.NewServer(New(cfg)) // NopSink: zero telemetry overhead on the hot path
+		defer front.Close()
 
-	t.Logf("direct  p50=%s p99=%s", percentile(direct, 50), percentile(direct, 99))
-	t.Logf("proxied p50=%s p99=%s", percentile(proxied, 50), percentile(proxied, 99))
-	t.Logf("added overhead p99=%s (budget 3ms)", overheadP99)
+		client := &http.Client{Transport: &http.Transport{MaxIdleConnsPerHost: 4}}
+		direct := measure(t, client, origin.URL+"/v1/models", warmup, n)
+		proxied := measure(t, client, front.URL+"/v1/models", warmup, n)
+		checkBudget(t, "single-origin", direct, proxied)
+	})
 
-	const budget = 3 * time.Millisecond
-	if overheadP99 >= budget {
-		t.Errorf("p99 added overhead %s exceeds budget %s", overheadP99, budget)
-	}
+	t.Run("hosted", func(t *testing.T) {
+		origin := httptest.NewServer(tinyUpstream())
+		defer origin.Close()
+
+		// The loopback host the test client will send, placed last in the table so the router pays a
+		// full scan past the decoy routes on every request, as it does behind real hostnames.
+		const tenantKey = "tally_sk_live_overhead"
+		cfg := config.Config{
+			TenantHeader:        "X-Tenant-Key",
+			FeatureTagHeader:    "X-Tally-Feature-Tag",
+			AccountIdHashHeader: "X-Tally-Account-Id-Hash",
+			RequireTenant:       true,
+			RouteMode:           config.RouteModeHost,
+			Routes: []config.Route{
+				{Match: "openai.proxy.test", Upstream: mustURL(t, origin.URL), Provider: config.ProviderOpenAI},
+				{Match: "anthropic.proxy.test", Upstream: mustURL(t, origin.URL), Provider: config.ProviderAnthropic},
+				{Match: "gemini.proxy.test", Upstream: mustURL(t, origin.URL), Provider: config.ProviderGemini},
+				{Match: "127.0.0.1", Upstream: mustURL(t, origin.URL), Provider: config.ProviderOpenAI},
+			},
+		}
+		resolver := staticResolver{edgekeys.HashKey(tenantKey): "uuid-overhead"}
+		front := httptest.NewServer(New(cfg, WithKeyResolver(resolver)))
+		defer front.Close()
+
+		header := http.Header{}
+		header.Set("X-Tenant-Key", tenantKey)
+		header.Set("X-Tally-Feature-Tag", "overhead-probe")
+
+		client := &http.Client{Transport: &http.Transport{MaxIdleConnsPerHost: 4}}
+		direct := measure(t, client, origin.URL+"/v1/models", warmup, n)
+		proxied := measureWith(t, client, front.URL+"/v1/models", header, warmup, n)
+		checkBudget(t, "hosted", direct, proxied)
+	})
 }
 
 // BenchmarkProxyOverhead reports ns/op for a single proxied round-trip against a loopback upstream.

--- a/infra/edge-proxy/internal/proxy/provider.go
+++ b/infra/edge-proxy/internal/proxy/provider.go
@@ -19,10 +19,15 @@ import (
 // (empty Provider) none of this runs and the hot path is byte-identical to CTO-39.
 
 // responseMeta holds the scalar metadata pulled from one response. It never carries content.
+//
+// The token counts are pointers, not plain int64s, because "the provider did not report usage"
+// (streaming, an error response, a body past the scan cap) and "the provider reported zero" are
+// different facts and telemetry must not conflate them. A nil count stays NULL all the way to
+// storage; a fabricated 0 would read downstream as a real, free call.
 type responseMeta struct {
 	Model            string
-	PromptTokens     int64
-	CompletionTokens int64
+	PromptTokens     *int64
+	CompletionTokens *int64
 }
 
 // metaCaptureCap bounds how many response bytes we tee aside for parsing. A generateContent /
@@ -49,47 +54,51 @@ func extractMeta(p config.Provider, path string, body []byte) responseMeta {
 }
 
 func openAIMeta(body []byte) responseMeta {
+	// Pointer fields throughout: an absent "usage" object, or an absent count inside it, must stay
+	// absent rather than decode to 0 (see responseMeta).
 	var r struct {
 		Model string `json:"model"`
-		Usage struct {
-			PromptTokens     int64 `json:"prompt_tokens"`
-			CompletionTokens int64 `json:"completion_tokens"`
+		Usage *struct {
+			PromptTokens     *int64 `json:"prompt_tokens"`
+			CompletionTokens *int64 `json:"completion_tokens"`
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
 		return responseMeta{}
 	}
-	return responseMeta{
-		Model:            r.Model,
-		PromptTokens:     r.Usage.PromptTokens,
-		CompletionTokens: r.Usage.CompletionTokens,
+	m := responseMeta{Model: r.Model}
+	if r.Usage != nil {
+		m.PromptTokens = r.Usage.PromptTokens
+		m.CompletionTokens = r.Usage.CompletionTokens
 	}
+	return m
 }
 
 func anthropicMeta(body []byte) responseMeta {
 	var r struct {
 		Model string `json:"model"`
-		Usage struct {
-			InputTokens  int64 `json:"input_tokens"`
-			OutputTokens int64 `json:"output_tokens"`
+		Usage *struct {
+			InputTokens  *int64 `json:"input_tokens"`
+			OutputTokens *int64 `json:"output_tokens"`
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
 		return responseMeta{}
 	}
-	return responseMeta{
-		Model:            r.Model,
-		PromptTokens:     r.Usage.InputTokens,
-		CompletionTokens: r.Usage.OutputTokens,
+	m := responseMeta{Model: r.Model}
+	if r.Usage != nil {
+		m.PromptTokens = r.Usage.InputTokens
+		m.CompletionTokens = r.Usage.OutputTokens
 	}
+	return m
 }
 
 func geminiMeta(path string, body []byte) responseMeta {
 	var r struct {
 		ModelVersion  string `json:"modelVersion"`
-		UsageMetadata struct {
-			PromptTokenCount     int64 `json:"promptTokenCount"`
-			CandidatesTokenCount int64 `json:"candidatesTokenCount"`
+		UsageMetadata *struct {
+			PromptTokenCount     *int64 `json:"promptTokenCount"`
+			CandidatesTokenCount *int64 `json:"candidatesTokenCount"`
 		} `json:"usageMetadata"`
 	}
 	// The body may be missing/unparseable (e.g. an error response); still return the path-derived
@@ -100,11 +109,12 @@ func geminiMeta(path string, body []byte) responseMeta {
 	if model == "" {
 		model = r.ModelVersion
 	}
-	return responseMeta{
-		Model:            model,
-		PromptTokens:     r.UsageMetadata.PromptTokenCount,
-		CompletionTokens: r.UsageMetadata.CandidatesTokenCount,
+	m := responseMeta{Model: model}
+	if r.UsageMetadata != nil {
+		m.PromptTokens = r.UsageMetadata.PromptTokenCount
+		m.CompletionTokens = r.UsageMetadata.CandidatesTokenCount
 	}
+	return m
 }
 
 // geminiModelFromPath pulls the model id out of a Generative Language request path of the form

--- a/infra/edge-proxy/internal/proxy/provider_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_test.go
@@ -6,11 +6,25 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
 )
+
+// tokensEq reports whether a nullable token count is present and equal to want. A nil count means
+// the provider never reported usage, which is never equal to a number.
+func tokensEq(got *int64, want int64) bool { return got != nil && *got == want }
+
+// tokensStr renders a nullable count for test failure messages, so an unknown reads as "unknown"
+// rather than as a misleading 0.
+func tokensStr(got *int64) string {
+	if got == nil {
+		return "unknown"
+	}
+	return strconv.FormatInt(*got, 10)
+}
 
 // recordedGeminiResponse is a real-shape generateContent response body (content elided): the parts
 // text is irrelevant to metadata — only usageMetadata and, via the path, the model matter.
@@ -36,11 +50,11 @@ func TestGeminiMetaFromRecordedResponse(t *testing.T) {
 	if meta.Model != "gemini-2.5-flash" {
 		t.Errorf("Model = %q, want gemini-2.5-flash", meta.Model)
 	}
-	if meta.PromptTokens != 259 {
-		t.Errorf("PromptTokens = %d, want 259", meta.PromptTokens)
+	if !tokensEq(meta.PromptTokens, 259) {
+		t.Errorf("PromptTokens = %s, want 259", tokensStr(meta.PromptTokens))
 	}
-	if meta.CompletionTokens != 73 {
-		t.Errorf("CompletionTokens = %d, want 73", meta.CompletionTokens)
+	if !tokensEq(meta.CompletionTokens, 73) {
+		t.Errorf("CompletionTokens = %s, want 73", tokensStr(meta.CompletionTokens))
 	}
 }
 
@@ -71,13 +85,15 @@ func TestGeminiMetaFallsBackToModelVersion(t *testing.T) {
 func TestOpenAIAndAnthropicMeta(t *testing.T) {
 	openai := extractMeta(config.ProviderOpenAI, "/v1/chat/completions",
 		[]byte(`{"model":"gpt-4o-2024-08-06","usage":{"prompt_tokens":12,"completion_tokens":34}}`))
-	if openai.Model != "gpt-4o-2024-08-06" || openai.PromptTokens != 12 || openai.CompletionTokens != 34 {
+	if openai.Model != "gpt-4o-2024-08-06" || !tokensEq(openai.PromptTokens, 12) ||
+		!tokensEq(openai.CompletionTokens, 34) {
 		t.Errorf("openai meta = %+v", openai)
 	}
 
 	anthropic := extractMeta(config.ProviderAnthropic, "/v1/messages",
 		[]byte(`{"model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":200}}`))
-	if anthropic.Model != "claude-sonnet-4-5" || anthropic.PromptTokens != 100 || anthropic.CompletionTokens != 200 {
+	if anthropic.Model != "claude-sonnet-4-5" || !tokensEq(anthropic.PromptTokens, 100) ||
+		!tokensEq(anthropic.CompletionTokens, 200) {
 		t.Errorf("anthropic meta = %+v", anthropic)
 	}
 }
@@ -152,8 +168,8 @@ func TestGeminiProxyRecordsMetadataAndHidesKey(t *testing.T) {
 	if rec.Model != "gemini-2.5-flash" {
 		t.Errorf("trace Model = %q", rec.Model)
 	}
-	if rec.PromptTokens != 259 || rec.CompletionTokens != 73 {
-		t.Errorf("trace tokens = %d/%d, want 259/73", rec.PromptTokens, rec.CompletionTokens)
+	if !tokensEq(rec.PromptTokens, 259) || !tokensEq(rec.CompletionTokens, 73) {
+		t.Errorf("trace tokens = %s/%s, want 259/73", tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
 	}
 	if rec.StatusCode != http.StatusOK {
 		t.Errorf("trace status = %d", rec.StatusCode)
@@ -191,7 +207,10 @@ func TestGeminiProxyStreamingModelFromPath(t *testing.T) {
 	if rec.Model != "gemini-1.5-pro" {
 		t.Errorf("trace Model = %q, want gemini-1.5-pro", rec.Model)
 	}
-	if rec.PromptTokens != 0 || rec.CompletionTokens != 0 {
-		t.Errorf("expected zero tokens when usage absent, got %d/%d", rec.PromptTokens, rec.CompletionTokens)
+	// Honest under uncertainty: usage the provider never reported stays nil (NULL downstream). A 0
+	// here would claim the call really used no tokens, which is a fabricated fact.
+	if rec.PromptTokens != nil || rec.CompletionTokens != nil {
+		t.Errorf("expected unknown tokens when usage absent, got %s/%s",
+			tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
 	}
 }

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -310,6 +310,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AccountIdHash:    accountIdHash,
 		Method:           r.Method,
 		Path:             r.URL.Path,
+		Provider:         string(route.provider),
 		Model:            meta.Model,
 		PromptTokens:     meta.PromptTokens,
 		CompletionTokens: meta.CompletionTokens,

--- a/infra/edge-proxy/internal/proxy/routing_test.go
+++ b/infra/edge-proxy/internal/proxy/routing_test.go
@@ -88,7 +88,8 @@ func TestHostRoutingSelectsOrigin(t *testing.T) {
 		t.Fatalf("host routing wrong: openaiHit=%v anthropicHit=%v", openaiHit.Load(), anthropicHit.Load())
 	}
 	sink.waitFor(t, 1)
-	if got := sink.last(); got.Model != "gpt-5" || got.PromptTokens != 11 || got.CompletionTokens != 7 {
+	if got := sink.last(); got.Model != "gpt-5" || !tokensEq(got.PromptTokens, 11) ||
+		!tokensEq(got.CompletionTokens, 7) {
 		t.Errorf("openai route trace = %+v, want gpt-5 11/7", got)
 	}
 
@@ -106,7 +107,8 @@ func TestHostRoutingSelectsOrigin(t *testing.T) {
 		t.Fatalf("host routing wrong on 2nd: openaiHit=%v anthropicHit=%v", openaiHit.Load(), anthropicHit.Load())
 	}
 	sink.waitFor(t, 2)
-	if got := sink.last(); got.Model != "claude" || got.PromptTokens != 3 || got.CompletionTokens != 9 {
+	if got := sink.last(); got.Model != "claude" || !tokensEq(got.PromptTokens, 3) ||
+		!tokensEq(got.CompletionTokens, 9) {
 		t.Errorf("anthropic route trace = %+v, want claude 3/9", got)
 	}
 }

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -34,18 +34,26 @@ type TraceRecord struct {
 	AccountIdHash string
 	Method        string
 	Path          string
+	// Provider is the route's protocol label (openai / anthropic / gemini), empty in pure
+	// pass-through mode. It ships as gen_ai.system, which is half of the (system, model) pair the
+	// gateway prices against: without it an ingested proxy span can never be costed.
+	Provider string
 	// Model is the model id for the request, extracted from the response (or request path for
 	// Gemini) when a provider protocol is configured (CTO-167). Empty in pure pass-through mode or
 	// when the response carried no recognizable model. It is a short identifier
-	// (e.g. "gemini-2.5-flash"), never request/response content.
+	// (e.g. "gemini-2.5-flash"), never request/response content. An empty Model is omitted from the
+	// wire rather than shipped as "": an unextracted model is unknown, not a model named "".
 	Model string
 	// PromptTokens / CompletionTokens are the input/output token counts reported by the provider in
 	// the response usage block (OpenAI usage.prompt_tokens/completion_tokens, Anthropic
 	// usage.input_tokens/output_tokens, Gemini usageMetadata.promptTokenCount/candidatesTokenCount).
-	// Zero when unknown (pass-through mode, streaming past the scan cap, or an error response). These
-	// are scalar counts only — extracting them never persists or logs the body they came from.
-	PromptTokens     int64
-	CompletionTokens int64
+	// They are pointers so unknown stays NULL: pass-through mode, a stream past the scan cap, and an
+	// error response all leave them nil, and nil is omitted from the wire rather than serialized as
+	// 0. A fabricated 0 would read downstream as a real call that cost nothing, which the
+	// honest-under-uncertainty invariant forbids. These are scalar counts only, and extracting them
+	// never persists or logs the body they came from.
+	PromptTokens     *int64
+	CompletionTokens *int64
 	// StatusCode is the upstream response status relayed to the client (0 if the upstream failed
 	// before any status, e.g. connection refused — see Failed).
 	StatusCode int

--- a/infra/edge-proxy/internal/telemetry/telemetry.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Package telemetry ships the proxy's metadata-only TraceRecords to an ai-tally collector.
+// Package telemetry ships the proxy's metadata-only TraceRecords to the ai-tally ingest gateway.
 //
 // This is the real Sink that CTO-39 left as a NopSink. It exists here (rather than in package
 // proxy) so the self-hostable binary (CTO-43) and the cloud binary share one wire format: a
@@ -7,13 +7,23 @@
 // only in the `deployment` label. Encode is the single source of truth for that format, so the
 // parity guarantee is structural — both deployments call the same encoder.
 //
+// Initiative 2 sec 6.3 / sec 8: the destination is the gateway's existing POST /v1/batches, and the
+// payload is a tally.wire.BatchRequest carrying one span. Reusing the SDK's ingest contract rather
+// than inventing a proxy-only collector endpoint means proxied traffic runs the same authenticated,
+// validated, cost-enriched, idempotent write path SDK traffic does, and lands in the same
+// otel_spans columns. Nothing new is needed on the gateway side.
+//
 // Like the rest of the proxy, the record carries only metadata + byte counts, never request or
-// response content and never the customer's provider key.
+// response content and never the customer's provider key. The tenant's own ai-tally key
+// authenticates the POST as an Authorization bearer and is deliberately NOT a body field: a
+// credential travels by reference, never inside telemetry.
 package telemetry
 
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -31,49 +41,161 @@ const (
 	DeploymentSelfHost Deployment = "self-host"
 )
 
-// wireRecord is the JSON envelope posted to the collector. The field set is the full TraceRecord
-// plus the deployment label; nothing else. Durations are serialized as integer nanoseconds and
-// timestamps as Unix nanoseconds so the format is language-neutral and stable.
-type wireRecord struct {
-	Deployment Deployment `json:"deployment"`
-	TenantKey  string     `json:"tenant_key"`
-	FeatureTag string     `json:"feature_tag"`
-	// AccountIdHash mirrors the gen_ai.account_id_hash span attribute so a proxied request lands in
-	// the same ClickHouse AccountIdHash column a Python-SDK span does (CTO-182). Empty means
-	// unattributed.
-	AccountIdHash string `json:"account_id_hash"`
-	Method        string `json:"method"`
-	Path          string `json:"path"`
-	StatusCode    int    `json:"status_code"`
-	ReqBytes      int64  `json:"req_bytes"`
-	RespBytes     int64  `json:"resp_bytes"`
-	DurationNs    int64  `json:"duration_ns"`
-	StartedAtNs   int64  `json:"started_at_ns"`
-	Failed        bool   `json:"failed"`
+// SDKVersion identifies the producer in the batch envelope, so ingest can tell proxy-emitted spans
+// from SDK-emitted ones without inspecting the span.
+const SDKVersion = "edge-proxy/1"
+
+// ServiceName is the ServiceName column value for every proxy-emitted span.
+const ServiceName = "edge-proxy"
+
+// IngestProtocol is the X-Ingest-Protocol version this encoder speaks (gateway/protocol.py).
+const IngestProtocol = "ingest-v1"
+
+// OTel status codes (semconv): the StatusCode column is 0=Unset, 1=Ok, 2=Error, which is what the
+// dashboard's failure queries read (web/lib/clickhouse.ts). It is NOT the HTTP status; that ships
+// separately as an attribute.
+const (
+	statusOk    = 1
+	statusError = 2
+)
+
+// wireSpan is one span in the batch's resource_spans list. Field names are the gateway's ingest
+// contract (gateway/mapping.py): structural keys plus gen_ai.* attributes, which the mapper
+// promotes to typed otel_spans columns. Anything not promoted lands in the SpanAttributes map, so
+// the proxy-only fields below (deployment, method, path, byte counts) are preserved without a
+// schema change.
+//
+// Every optional field is omitempty on purpose. The gateway's validator rejects a known gen_ai
+// string key present but empty, and more importantly an omitted field reads back as "unknown"
+// while an empty or zero one would read back as a fact. Unknown must stay unknown.
+type wireSpan struct {
+	TimestampNs int64  `json:"timestamp_ns"`
+	TraceId     string `json:"trace_id"`
+	SpanId      string `json:"span_id"`
+	ServiceName string `json:"service_name"`
+	SpanName    string `json:"span_name"`
+	StatusCode  int    `json:"status_code"`
+	DurationNs  int64  `json:"duration_ns"`
+
+	// Operation is always "chat": the proxy meters LLM API calls, and the value is lowercase because
+	// the gateway's validator requires it.
+	Operation string `json:"gen_ai.operation.name"`
+	// System / ResponseModel are the (provider, model) pair the gateway prices against. Both are
+	// omitted when unextracted (pure pass-through, streamed response) so the span is honestly
+	// unpriceable rather than priced against a guess.
+	System        string `json:"gen_ai.system,omitempty"`
+	ResponseModel string `json:"gen_ai.response.model,omitempty"`
+	// InputTokens / OutputTokens are pointers so an unknown count is omitted from the JSON entirely
+	// and reaches storage as NULL. A count the provider genuinely reported as 0 still serializes as
+	// 0, because omitempty on a pointer keys off nil, not off the pointed-to value.
+	InputTokens  *int64 `json:"gen_ai.usage.input_tokens,omitempty"`
+	OutputTokens *int64 `json:"gen_ai.usage.output_tokens,omitempty"`
+	// FeatureTag / AccountIdHash mirror the same span attributes the Python SDK emits, so a proxied
+	// request lands in the same FeatureTag / AccountIdHash columns (CTO-104, CTO-182). Omitted when
+	// the caller did not tag or attribute the request: the unattributed bucket, not a customer
+	// named "unknown".
+	FeatureTag    string `json:"gen_ai.feature_tag,omitempty"`
+	AccountIdHash string `json:"gen_ai.account_id_hash,omitempty"`
+
+	// Long-tail attributes: not promoted to columns, kept in SpanAttributes. Counts and labels only.
+	Deployment Deployment `json:"tally.deployment"`
+	Method     string     `json:"http.request.method"`
+	Path       string     `json:"url.path"`
+	HTTPStatus int        `json:"http.response.status_code,omitempty"`
+	ReqBytes   int64      `json:"http.request.body.size"`
+	RespBytes  int64      `json:"http.response.body.size"`
+	// UpstreamFailed marks a request the upstream never answered (the synthesized 502). Such a span
+	// carries no HTTP status and no usage, which is the honest record of a call that produced
+	// nothing, not a zero-cost success.
+	UpstreamFailed bool `json:"tally.upstream_failed,omitempty"`
 }
 
-func toWire(dep Deployment, rec proxy.TraceRecord) wireRecord {
-	return wireRecord{
-		Deployment:    dep,
-		TenantKey:     rec.TenantKey,
-		FeatureTag:    rec.FeatureTag,
-		AccountIdHash: rec.AccountIdHash,
-		Method:        rec.Method,
-		Path:          rec.Path,
-		StatusCode:    rec.StatusCode,
-		ReqBytes:      rec.ReqBytes,
-		RespBytes:     rec.RespBytes,
-		DurationNs:    rec.Duration.Nanoseconds(),
-		StartedAtNs:   rec.StartedAt.UnixNano(),
-		Failed:        rec.Failed,
+// wireBatch is the POST /v1/batches envelope (tally.wire.BatchRequest). The proxy sends one span
+// per batch: records arrive one at a time off the async channel, and a per-record batch keeps the
+// tenant boundary trivially correct, since a batch belongs to exactly one tenant.
+type wireBatch struct {
+	// TenantId is the UUID the edge key cache resolved (sec 6.3). The gateway treats the
+	// authenticating key's tenant as authoritative and refuses a batch claiming a different one, so
+	// this is a claim it verifies, never a way to write into another tenant. Empty (no resolver
+	// configured) is accepted: the key still decides.
+	TenantId       string     `json:"tenant_id"`
+	SdkVersion     string     `json:"sdk_version"`
+	ResourceSpans  []wireSpan `json:"resource_spans"`
+	BatchId        string     `json:"batch_id"`
+	ClientSendTsNs int64      `json:"client_send_ts_ns"`
+}
+
+// ids supplies the identifiers and send timestamp that vary per batch. It is injectable so the
+// parity test can encode the same record twice and compare byte for byte.
+type ids struct {
+	newHex func(nBytes int) string
+	nowNs  func() int64
+}
+
+func defaultIds() ids {
+	return ids{newHex: randomHex, nowNs: func() int64 { return time.Now().UnixNano() }}
+}
+
+// randomHex returns nBytes of crypto-random data as lowercase hex. Trace and span ids only need to
+// be unique; they carry no meaning and must not encode anything about the request.
+func randomHex(nBytes int) string {
+	b := make([]byte, nBytes)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand does not fail in practice; a degraded id is still better than dropping the
+		// span, and the gateway dedupes on (trace_id, span_id) within a batch of one.
+		return hex.EncodeToString(b)
+	}
+	return hex.EncodeToString(b)
+}
+
+func toWire(dep Deployment, rec proxy.TraceRecord, id ids) wireBatch {
+	// OTel status: a 4xx/5xx or an unreachable upstream is an Error span, everything else Ok. The
+	// raw HTTP status rides along as an attribute rather than being crammed into this column.
+	status := statusOk
+	if rec.Failed || rec.StatusCode >= 400 {
+		status = statusError
+	}
+	span := wireSpan{
+		TimestampNs:    rec.StartedAt.UnixNano(),
+		TraceId:        id.newHex(16),
+		SpanId:         id.newHex(8),
+		ServiceName:    ServiceName,
+		SpanName:       "llm.call",
+		StatusCode:     status,
+		DurationNs:     rec.Duration.Nanoseconds(),
+		Operation:      "chat",
+		System:         rec.Provider,
+		ResponseModel:  rec.Model,
+		InputTokens:    rec.PromptTokens,
+		OutputTokens:   rec.CompletionTokens,
+		FeatureTag:     rec.FeatureTag,
+		AccountIdHash:  rec.AccountIdHash,
+		Deployment:     dep,
+		Method:         rec.Method,
+		Path:           rec.Path,
+		HTTPStatus:     rec.StatusCode,
+		ReqBytes:       rec.ReqBytes,
+		RespBytes:      rec.RespBytes,
+		UpstreamFailed: rec.Failed,
+	}
+	return wireBatch{
+		TenantId:       rec.TenantId,
+		SdkVersion:     SDKVersion,
+		ResourceSpans:  []wireSpan{span},
+		BatchId:        id.newHex(16),
+		ClientSendTsNs: id.nowNs(),
 	}
 }
 
-// Encode serializes one record to its canonical wire JSON. Both the cloud and self-hosted proxy
-// call this, so given identical inputs the output differs only in the deployment field — which is
-// exactly the parity property CTO-43 requires.
+// Encode serializes one record to its canonical wire JSON: a single-span POST /v1/batches request.
+// Both the cloud and self-hosted proxy call this, so given identical inputs the output differs only
+// in the deployment label, which is exactly the parity property CTO-43 requires.
 func Encode(dep Deployment, rec proxy.TraceRecord) ([]byte, error) {
-	return json.Marshal(toWire(dep, rec))
+	return encode(dep, rec, defaultIds())
+}
+
+func encode(dep Deployment, rec proxy.TraceRecord, id ids) ([]byte, error) {
+	return json.Marshal(toWire(dep, rec, id))
 }
 
 // HTTPSink is a proxy.Sink that batches records and POSTs them to a collector URL out of band of
@@ -81,17 +203,21 @@ func Encode(dep Deployment, rec proxy.TraceRecord) ([]byte, error) {
 // background worker flushes. If the buffer is full (collector down / slow), records are dropped
 // rather than back-pressuring customer traffic — telemetry must never degrade the proxied call.
 type HTTPSink struct {
-	url        string
-	deployment Deployment
-	client     *http.Client
-	ch         chan proxy.TraceRecord
+	url         string
+	deployment  Deployment
+	ingestToken string
+	client      *http.Client
+	ch          chan proxy.TraceRecord
 
 	wg       sync.WaitGroup
 	closeOne sync.Once
 
-	// dropped counts records shed because the buffer was full (observability for the operator).
-	mu      sync.Mutex
-	dropped int64
+	// dropped counts records shed because the buffer was full, unauthenticated counts records shed
+	// because no ingest credential was available for them (observability for the operator: both are
+	// real telemetry loss and neither is silently papered over).
+	mu              sync.Mutex
+	dropped         int64
+	unauthenticated int64
 }
 
 // Options configures an HTTPSink.
@@ -100,6 +226,10 @@ type Options struct {
 	URL string
 	// Deployment labels every record (cloud vs self-host).
 	Deployment Deployment
+	// IngestToken is the fallback bearer used when a record carries no tenant key of its own (a
+	// single-tenant self-host running with EDGE_PROXY_REQUIRE_TENANT unset). In the hosted
+	// multi-tenant deployment the per-request tenant key is what authenticates, so this stays empty.
+	IngestToken string
 	// Buffer is the channel depth; defaults to 1024.
 	Buffer int
 	// Client overrides the HTTP client (mainly for tests); defaults to a short-timeout client.
@@ -121,10 +251,11 @@ func NewHTTPSink(o Options) *HTTPSink {
 		dep = DeploymentCloud
 	}
 	s := &HTTPSink{
-		url:        o.URL,
-		deployment: dep,
-		client:     client,
-		ch:         make(chan proxy.TraceRecord, buf),
+		url:         o.URL,
+		deployment:  dep,
+		ingestToken: o.IngestToken,
+		client:      client,
+		ch:          make(chan proxy.TraceRecord, buf),
 	}
 	s.wg.Add(1)
 	go s.run()
@@ -149,6 +280,14 @@ func (s *HTTPSink) Dropped() int64 {
 	return s.dropped
 }
 
+// Unauthenticated returns the number of records shed because neither the record's tenant key nor a
+// configured ingest token was available to authenticate the POST.
+func (s *HTTPSink) Unauthenticated() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.unauthenticated
+}
+
 func (s *HTTPSink) run() {
 	defer s.wg.Done()
 	for rec := range s.ch {
@@ -156,7 +295,31 @@ func (s *HTTPSink) run() {
 	}
 }
 
+// credentialFor picks the bearer that authenticates this record's batch.
+//
+// The record's own tenant key wins: it is the ai-tally api key the caller presented, the gateway
+// resolves it to the same tenant the proxy did, and it makes the hosted multi-tenant deployment
+// correct by construction, since every batch is authenticated by the tenant it belongs to. The
+// configured IngestToken is only a fallback for a deployment where requests carry no tenant key.
+// The key is read here and put on a header; it is never written into the batch body and never
+// logged.
+func (s *HTTPSink) credentialFor(rec proxy.TraceRecord) string {
+	if rec.TenantKey != "" {
+		return rec.TenantKey
+	}
+	return s.ingestToken
+}
+
 func (s *HTTPSink) post(rec proxy.TraceRecord) {
+	token := s.credentialFor(rec)
+	if token == "" {
+		// Nothing can authenticate this batch. Shed it and count it rather than POSTing an
+		// unauthenticated body the gateway will reject anyway.
+		s.mu.Lock()
+		s.unauthenticated++
+		s.mu.Unlock()
+		return
+	}
 	body, err := Encode(s.deployment, rec)
 	if err != nil {
 		return
@@ -168,10 +331,23 @@ func (s *HTTPSink) post(rec proxy.TraceRecord) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// The ingest protocol the gateway negotiates against (gateway/protocol.py). Sending it
+	// explicitly means a future protocol bump is a clean 400 here rather than a silent
+	// misinterpretation of our payload.
+	req.Header.Set("X-Ingest-Protocol", IngestProtocol)
+	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := s.client.Do(req)
 	if err != nil {
+		// The error can name the collector host but never the credential (it is only ever a header
+		// value, which net/http does not include in its error strings).
 		log.Printf("edge-proxy telemetry: post failed: %v", err)
 		return
+	}
+	if resp.StatusCode >= 400 {
+		// Status only: the response body may echo request detail, and telemetry failures must not
+		// become their own leak. A 401/403 here is the operator's signal that the ingest credential
+		// or the key's scope is wrong.
+		log.Printf("edge-proxy telemetry: ingest rejected batch with status %d", resp.StatusCode)
 	}
 	// Drain and close so the connection can be reused from the pool.
 	_ = resp.Body.Close()

--- a/infra/edge-proxy/internal/telemetry/telemetry_test.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry_test.go
@@ -3,9 +3,11 @@ package telemetry
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,82 +15,222 @@ import (
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/proxy"
 )
 
+func i64(v int64) *int64 { return &v }
+
 func sampleRecord() proxy.TraceRecord {
 	return proxy.TraceRecord{
-		TenantKey:  "tk_live_acme",
-		Method:     "POST",
-		Path:       "/v1/chat/completions",
-		StatusCode: 200,
-		ReqBytes:   512,
-		RespBytes:  4096,
-		Duration:   1500 * time.Millisecond,
-		StartedAt:  time.Unix(1_700_000_000, 123),
-		Failed:     false,
+		TenantKey:        "tk_live_acme",
+		TenantId:         "7f1c3a2e-0000-4000-8000-000000000001",
+		FeatureTag:       "support-bot",
+		AccountIdHash:    "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+		Method:           "POST",
+		Path:             "/v1/chat/completions",
+		Provider:         "openai",
+		Model:            "gpt-4o-2024-08-06",
+		PromptTokens:     i64(12),
+		CompletionTokens: i64(34),
+		StatusCode:       200,
+		ReqBytes:         512,
+		RespBytes:        4096,
+		Duration:         1500 * time.Millisecond,
+		StartedAt:        time.Unix(1_700_000_000, 123),
+		Failed:           false,
 	}
+}
+
+// fixedIds pins the per-batch identifiers and send timestamp so two encodings of the same record
+// are comparable byte for byte.
+func fixedIds() ids {
+	n := 0
+	return ids{
+		newHex: func(nBytes int) string {
+			n++
+			return fmt.Sprintf("%0*d", nBytes*2, n)
+		},
+		nowNs: func() int64 { return 1_700_000_001_000_000_000 },
+	}
+}
+
+// decodeSpan pulls the single span out of an encoded batch.
+func decodeSpan(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var batch map[string]any
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatalf("bad batch json: %v", err)
+	}
+	spans, ok := batch["resource_spans"].([]any)
+	if !ok || len(spans) != 1 {
+		t.Fatalf("want exactly one resource span, got %v", batch["resource_spans"])
+	}
+	span, ok := spans[0].(map[string]any)
+	if !ok {
+		t.Fatalf("span is not an object: %v", spans[0])
+	}
+	return span
 }
 
 // TestParitySelfHostMatchesCloud is the CTO-43 acceptance test: a self-hosted proxy must emit
 // telemetry identical to the cloud proxy. We encode the same record under both deployment labels
-// and assert every field matches except `deployment`.
+// and assert every field matches except the deployment label on the span.
 func TestParitySelfHostMatchesCloud(t *testing.T) {
 	rec := sampleRecord()
 
-	cloud, err := Encode(DeploymentCloud, rec)
+	cloud, err := encode(DeploymentCloud, rec, fixedIds())
 	if err != nil {
 		t.Fatalf("encode cloud: %v", err)
 	}
-	self, err := Encode(DeploymentSelfHost, rec)
+	self, err := encode(DeploymentSelfHost, rec, fixedIds())
 	if err != nil {
 		t.Fatalf("encode self-host: %v", err)
 	}
 
-	var cloudMap, selfMap map[string]any
-	if err := json.Unmarshal(cloud, &cloudMap); err != nil {
-		t.Fatal(err)
-	}
-	if err := json.Unmarshal(self, &selfMap); err != nil {
-		t.Fatal(err)
+	cloudSpan := decodeSpan(t, cloud)
+	selfSpan := decodeSpan(t, self)
+
+	if cloudSpan["tally.deployment"] != "cloud" || selfSpan["tally.deployment"] != "self-host" {
+		t.Fatalf("deployment labels wrong: %v / %v",
+			cloudSpan["tally.deployment"], selfSpan["tally.deployment"])
 	}
 
-	if cloudMap["deployment"] != "cloud" || selfMap["deployment"] != "self-host" {
-		t.Fatalf("deployment labels wrong: %v / %v", cloudMap["deployment"], selfMap["deployment"])
+	delete(cloudSpan, "tally.deployment")
+	delete(selfSpan, "tally.deployment")
+	if len(cloudSpan) != len(selfSpan) {
+		t.Fatalf("field count differs: cloud %d, self-host %d", len(cloudSpan), len(selfSpan))
 	}
-
-	delete(cloudMap, "deployment")
-	delete(selfMap, "deployment")
-	if len(cloudMap) != len(selfMap) {
-		t.Fatalf("field count differs: cloud %d, self-host %d", len(cloudMap), len(selfMap))
-	}
-	for k, v := range cloudMap {
-		if selfMap[k] != v {
-			t.Fatalf("field %q differs: cloud %v, self-host %v", k, v, selfMap[k])
+	for k, v := range cloudSpan {
+		if selfSpan[k] != v {
+			t.Fatalf("field %q differs: cloud %v, self-host %v", k, v, selfSpan[k])
 		}
 	}
 }
 
 // TestEncodeCarriesNoBodyContent guards the metadata-only invariant: the wire format must not grow
-// a field that could carry a prompt, completion, or provider key.
+// a field that could carry a prompt, completion, or a credential. The tenant key in particular is
+// an ai-tally credential and belongs on the Authorization header, never in the payload.
 func TestEncodeCarriesNoBodyContent(t *testing.T) {
 	body, err := Encode(DeploymentCloud, sampleRecord())
 	if err != nil {
 		t.Fatal(err)
 	}
-	var m map[string]any
-	if err := json.Unmarshal(body, &m); err != nil {
+	var batch map[string]any
+	if err := json.Unmarshal(body, &batch); err != nil {
 		t.Fatal(err)
 	}
-	allowed := map[string]bool{
-		"deployment": true, "tenant_key": true, "feature_tag": true,
-		// account_id_hash is a hash, not an identifier: it cannot carry a name or a body (CTO-182).
-		"account_id_hash": true,
-		"method":          true, "path": true,
-		"status_code": true, "req_bytes": true, "resp_bytes": true,
-		"duration_ns": true, "started_at_ns": true, "failed": true,
+	allowedEnvelope := map[string]bool{
+		"tenant_id": true, "sdk_version": true, "resource_spans": true,
+		"batch_id": true, "client_send_ts_ns": true,
 	}
-	for k := range m {
-		if !allowed[k] {
-			t.Fatalf("unexpected field %q in telemetry wire format", k)
+	for k := range batch {
+		if !allowedEnvelope[k] {
+			t.Fatalf("unexpected envelope field %q in telemetry wire format", k)
 		}
+	}
+
+	allowedSpan := map[string]bool{
+		"timestamp_ns": true, "trace_id": true, "span_id": true,
+		"service_name": true, "span_name": true, "status_code": true, "duration_ns": true,
+		"gen_ai.operation.name": true, "gen_ai.system": true, "gen_ai.response.model": true,
+		"gen_ai.usage.input_tokens": true, "gen_ai.usage.output_tokens": true,
+		"gen_ai.feature_tag": true,
+		// account_id_hash is a hash, not an identifier: it cannot carry a name or a body (CTO-182).
+		"gen_ai.account_id_hash": true,
+		"tally.deployment":       true,
+		"http.request.method":    true, "url.path": true, "http.response.status_code": true,
+		"http.request.body.size": true, "http.response.body.size": true,
+		"tally.upstream_failed": true,
+	}
+	for k := range decodeSpan(t, body) {
+		if !allowedSpan[k] {
+			t.Fatalf("unexpected span field %q in telemetry wire format", k)
+		}
+	}
+
+	if string(body) == "" {
+		t.Fatal("empty payload")
+	}
+	if got := batch["tenant_id"]; got != "7f1c3a2e-0000-4000-8000-000000000001" {
+		t.Fatalf("tenant_id = %v, want the resolved UUID", got)
+	}
+}
+
+// TestEncodeCarriesResolvedFields is the Initiative 2 sec 6.3 regression: the fields the request
+// path resolves (tenant UUID, model, token counts) must actually reach the wire. Before this they
+// were computed and thrown away, so no proxy traffic could ever be costed or attributed.
+func TestEncodeCarriesResolvedFields(t *testing.T) {
+	body, err := Encode(DeploymentCloud, sampleRecord())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var batch map[string]any
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatal(err)
+	}
+	if batch["tenant_id"] != "7f1c3a2e-0000-4000-8000-000000000001" {
+		t.Errorf("tenant_id = %v", batch["tenant_id"])
+	}
+	span := decodeSpan(t, body)
+	if span["gen_ai.response.model"] != "gpt-4o-2024-08-06" {
+		t.Errorf("model = %v", span["gen_ai.response.model"])
+	}
+	if span["gen_ai.system"] != "openai" {
+		t.Errorf("system = %v", span["gen_ai.system"])
+	}
+	if span["gen_ai.usage.input_tokens"] != float64(12) {
+		t.Errorf("input tokens = %v, want 12", span["gen_ai.usage.input_tokens"])
+	}
+	if span["gen_ai.usage.output_tokens"] != float64(34) {
+		t.Errorf("output tokens = %v, want 34", span["gen_ai.usage.output_tokens"])
+	}
+	if span["gen_ai.feature_tag"] != "support-bot" {
+		t.Errorf("feature tag = %v", span["gen_ai.feature_tag"])
+	}
+}
+
+// TestUnknownTokensSerializeAsNullNeverZero is the honest-under-uncertainty guard. A streamed
+// response (or one past the metadata scan cap) reports no usage; that span must reach storage with
+// NULL token counts. Emitting 0 would read downstream as a real call that consumed nothing.
+func TestUnknownTokensSerializeAsNullNeverZero(t *testing.T) {
+	rec := sampleRecord()
+	rec.PromptTokens = nil
+	rec.CompletionTokens = nil
+	rec.Model = "" // model extraction can fail on the same responses
+
+	body, err := Encode(DeploymentCloud, rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	span := decodeSpan(t, body)
+
+	for _, k := range []string{"gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens", "gen_ai.response.model"} {
+		v, present := span[k]
+		if present {
+			t.Errorf("%s present as %#v; unknown must be omitted (NULL), never a value", k, v)
+		}
+	}
+	// Belt and braces against a future struct-tag slip: the raw JSON must not contain a zeroed count.
+	if s := string(body); strings.Contains(s, `"gen_ai.usage.input_tokens":0`) ||
+		strings.Contains(s, `"gen_ai.usage.output_tokens":0`) {
+		t.Fatalf("unknown token count serialized as 0: %s", s)
+	}
+}
+
+// TestZeroTokensStillSerialize: a count the provider genuinely reported as 0 is a fact and must
+// survive. This is the other half of the nullable contract: omitempty keys off nil, not off 0.
+func TestZeroTokensStillSerialize(t *testing.T) {
+	rec := sampleRecord()
+	rec.PromptTokens = i64(0)
+	rec.CompletionTokens = i64(0)
+
+	body, err := Encode(DeploymentCloud, rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	span := decodeSpan(t, body)
+	if v, ok := span["gen_ai.usage.input_tokens"]; !ok || v != float64(0) {
+		t.Errorf("a reported 0 must serialize, got %#v (present=%v)", v, ok)
+	}
+	if v, ok := span["gen_ai.usage.output_tokens"]; !ok || v != float64(0) {
+		t.Errorf("a reported 0 must serialize, got %#v (present=%v)", v, ok)
 	}
 }
 
@@ -96,6 +238,8 @@ func TestHTTPSinkPostsRecord(t *testing.T) {
 	var (
 		mu       sync.Mutex
 		received [][]byte
+		gotAuth  string
+		gotProto string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Type") != "application/json" {
@@ -104,6 +248,8 @@ func TestHTTPSinkPostsRecord(t *testing.T) {
 		b, _ := io.ReadAll(r.Body)
 		mu.Lock()
 		received = append(received, b)
+		gotAuth = r.Header.Get("Authorization")
+		gotProto = r.Header.Get("X-Ingest-Protocol")
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -122,8 +268,81 @@ func TestHTTPSinkPostsRecord(t *testing.T) {
 	if err := json.Unmarshal(received[0], &m); err != nil {
 		t.Fatalf("bad json: %v", err)
 	}
-	if m["deployment"] != "self-host" || m["tenant_key"] != "tk_live_acme" {
+	if m["sdk_version"] != SDKVersion {
 		t.Fatalf("unexpected payload: %v", m)
+	}
+	if gotAuth != "Bearer tk_live_acme" {
+		t.Fatalf("Authorization = %q, want the record's tenant key as a bearer", gotAuth)
+	}
+	if gotProto != IngestProtocol {
+		t.Fatalf("X-Ingest-Protocol = %q, want %q", gotProto, IngestProtocol)
+	}
+	// The credential authenticates the POST and must never appear in the body.
+	if strings.Contains(string(received[0]), "tk_live_acme") {
+		t.Fatalf("tenant key leaked into the telemetry body: %s", received[0])
+	}
+}
+
+// TestHTTPSinkFallsBackToIngestToken covers the single-tenant self-host where requests carry no
+// tenant key: the configured ingest credential authenticates instead.
+func TestHTTPSinkFallsBackToIngestToken(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotAuth string
+		hits    int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rec := sampleRecord()
+	rec.TenantKey = ""
+	sink := NewHTTPSink(Options{URL: srv.URL, Deployment: DeploymentSelfHost, IngestToken: "svc_token"})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("collector got %d posts, want 1", hits)
+	}
+	if gotAuth != "Bearer svc_token" {
+		t.Fatalf("Authorization = %q, want the configured ingest token", gotAuth)
+	}
+}
+
+// TestHTTPSinkShedsUnauthenticatedRecords: with no tenant key and no configured token there is
+// nothing to authenticate with. The sink counts the loss honestly instead of POSTing a batch that
+// cannot be attributed.
+func TestHTTPSinkShedsUnauthenticatedRecords(t *testing.T) {
+	var hits int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rec := sampleRecord()
+	rec.TenantKey = ""
+	sink := NewHTTPSink(Options{URL: srv.URL, Deployment: DeploymentCloud})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 0 {
+		t.Fatalf("posted %d unauthenticated batches, want 0", hits)
+	}
+	if got := sink.Unauthenticated(); got != 1 {
+		t.Fatalf("Unauthenticated() = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## The gap

Initiative 2 §6.3 says proxy traffic and SDK traffic for one org share a single `TenantId` and one Cost Explorer view. §8 wants proxied calls costed. Neither was true end to end.

The proxy's request path was already correct and complete: route table, edge key cache, fail-closed unknown-key handling, tenant-UUID resolution, model and token extraction. It then threw the results away.

- `TenantId`, `Model`, `PromptTokens`, `CompletionTokens` were resolved onto `TraceRecord` and were **absent from the emitted wire format**.
- `HTTPSink.post` sent **no `Authorization` header at all**, so the sink could not authenticate anywhere.

Net effect: no proxy telemetry could ever reach ClickHouse. The one env var a customer sets bought them a working reverse proxy and an empty dashboard.

## The fix

**1. Unknown stays NULL, never 0.**

`PromptTokens` / `CompletionTokens` were non-pointer `int64` documented as "Zero when unknown". Serializing that as-is would have emitted a fabricated `0` for every streamed response, every body past the metadata scan cap, and every error response, reading downstream as a real call that consumed nothing. They are now `*int64` through `responseMeta` and `TraceRecord`, with `omitempty` on the wire, so unknown is omitted and lands as NULL. A count the provider genuinely reported as `0` still serializes, because `omitempty` on a pointer keys off nil rather than the pointed-to value. `Model` is handled the same way by omission, not empty-string-as-fact.

**2. A real destination, reusing the tested ingest path.**

The sink now encodes each record as a one-span `tally.wire.BatchRequest` and POSTs it to the gateway's existing `POST /v1/batches`. **No new gateway surface, no gateway change.** Proxied traffic runs the same authenticated, validated, cost-enriched, idempotent write path SDK traffic runs and lands in the same `otel_spans` columns:

| record field | span field | column |
|---|---|---|
| `TenantId` | envelope `tenant_id` | `TenantId` |
| `Provider` | `gen_ai.system` | `GenAiSystem` |
| `Model` | `gen_ai.response.model` | `GenAiResponseModel` |
| `PromptTokens` / `CompletionTokens` | `gen_ai.usage.input_tokens` / `.output_tokens` | `InputTokens` / `OutputTokens` |
| `FeatureTag` | `gen_ai.feature_tag` | `FeatureTag` |
| `AccountIdHash` | `gen_ai.account_id_hash` | `AccountIdHash` |

Method, path, byte counts, upstream-failure flag and the deployment label ride along as span attributes into `SpanAttributes`. No schema change.

**Auth.** Each POST carries `Authorization: Bearer <the tenant key the caller presented>`. That key is the caller's own ai-tally api key, so the gateway resolves it to the same tenant the proxy did, and every batch is authenticated by the tenant it belongs to. That makes the hosted multi-tenant deployment correct by construction rather than by a claimed `tenant_id` the gateway would have to trust. `EDGE_PROXY_INGEST_TOKEN` (new, documented) is the fallback for a deployment whose requests carry no tenant key. With neither available the record is shed and counted via `HTTPSink.Unauthenticated()` rather than POSTed unattributable.

Side effect worth calling out: the old wire format carried the raw tenant key as a `tenant_key` body field. That is a credential sitting inside telemetry. It now travels on the header only, and a test asserts it never appears in the body.

**3. `TraceRecord` gains `Provider`.**

The gateway prices against the `(gen_ai.system, model)` pair; without the system half `enrich_cost` takes the catalog-miss branch and the span is never costed. The route already knows its protocol label, so this is one field copied from `route.provider`. An ingested-but-uncostable span would not have satisfied §8.

## Tests

- `TestEncodeCarriesResolvedFields` — round-trips `tenant_id`, `gen_ai.system`, model, both token counts, feature tag.
- `TestUnknownTokensSerializeAsNullNeverZero` — an unknown count is omitted, and the raw JSON is additionally asserted not to contain `"gen_ai.usage.input_tokens":0`, so a future struct-tag slip trips CI.
- `TestZeroTokensStillSerialize` — the other half of the contract: a genuinely reported 0 survives.
- `TestHTTPSinkPostsRecord` — asserts `Authorization: Bearer <tenant key>` and `X-Ingest-Protocol`, and that the key does not appear in the body.
- `TestHTTPSinkFallsBackToIngestToken`, `TestHTTPSinkShedsUnauthenticatedRecords`.
- `TestEncodeCarriesNoBodyContent` — allowlists every envelope and span field, so no prompt/completion/credential field can sneak in.

`TestOverheadBudget` previously built config from an env stub with no routes and no key resolver, so the p99 budget was only proven for the single-origin path. It now measures both shapes, including the hosted one (route-table scan, key sha256 plus cache lookup, provider response scan):

```
single-origin: added overhead p99 = 124µs   (budget 3ms)
hosted:        added overhead p99 = 153µs   (budget 3ms)
```

## Housekeeping

- README §6.3 claimed the resolved UUID reaches storage; it now says that holds provided `EDGE_PROXY_TELEMETRY_URL` is set, and documents where telemetry goes, how it authenticates, and the nullable contract.
- Helm `values.yaml` telemetry comment corrected; the chart deliberately does **not** plumb `EDGE_PROXY_INGEST_TOKEN`, since a token belongs in a Secret, not the ConfigMap.
- Deleted the empty tracked file `keys` at the repo root (confirmed empty blob via `git ls-files -s`).

## Scope

Changes are confined to `infra/edge-proxy/` plus that one root file deletion. Nothing under `infra/gateway/`, `web/`, or `db/` is touched.

## Verification

```
cd infra/edge-proxy && go build ./... && go test ./... && gofmt -l .
```

All packages pass; `gofmt` lists nothing. `go test -race ./...` also passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
