### PR TITLE
fix(deploy): resolve the tenant UUID in the demo kit, not the name (CTO-243)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -10,13 +10,20 @@ ingest, not mock data.
                                                  │  validate → enrich cost → map to row
                                                  ▼
                                             ClickHouse  otel_spans
-                                            (:8123, db=default, TenantId=local-dev)
+                                            (:8123, db=default, TenantId=<tenant UUID>)
                                                  ▲
-   browser ──▶ Next.js web (:3000) ──Route Handler──┘  (web/lib/clickhouse.ts, tenant=local-dev)
+   browser ──▶ Next.js web (:3000) ──Route Handler──┘  (web/lib/clickhouse.ts, TALLY_DEV_TENANT)
 ```
 
-Everything is keyed to the **`local-dev`** tenant: the demo batch writes as `local-dev`, and the
-web UI reads `local-dev` by default — they line up with zero configuration.
+Everything is keyed to the tenant `make seed` creates, and the key is its **UUID**, not the name
+`local-dev` (Initiative 1 §8). Ingest writes `TenantId` verbatim from the batch and the dashboard
+binds `TALLY_DEV_TENANT` straight into the read filter (`TenantId = ...`), so the two only line up
+when both carry the UUID. Send a batch under the name and it lands in ClickHouse and never appears
+on screen: no error anywhere, just an empty dashboard. `make seed` prints the UUID; `make demo`
+resolves it for you and refuses to send without it.
+
+(Control-plane calls are the exception: `/v1/tenant/*` accepts either, because the gateway folds a
+name onto the UUID. Reads do not.)
 
 ## Prerequisites
 
@@ -79,20 +86,25 @@ Ingest (`/v1/batches`) is unchanged: it still authenticates with the ingest API 
 
 ## 3. Push telemetry through the gateway
 
-Easiest — the built-in demo batch (writes as tenant `local-dev`, and re-sends once to demonstrate
-idempotent replay):
+Easiest: the built-in demo batch (resolves the seeded tenant's UUID and writes under it, then
+re-sends once to demonstrate idempotent replay):
 
 ```bash
 make demo            # run it a few times for more rows
 ```
 
-Or fire your own burst (note `tenant_id` **must** be `local-dev` for the UI to show it):
+Or fire your own burst. `tenant_id` **must** be the tenant UUID for the UI to show it, so grab it
+first (this is the same lookup `make demo` and the demo-deploy kit do):
 
 ```bash
+TENANT=$(docker compose exec -T postgres \
+  psql -U tally -d tally -tAc "SELECT id FROM tenants WHERE name='local-dev' LIMIT 1" | tr -d '[:space:]')
+test -n "$TENANT" || echo "not seeded, run 'make seed' first"
+
 for i in $(seq 1 40); do
   curl -s -X POST localhost:8080/v1/batches \
     -H 'content-type: application/json' \
-    -d '{"tenant_id":"local-dev","sdk_version":"test","resource_spans":[
+    -d '{"tenant_id":"'"$TENANT"'","sdk_version":"test","resource_spans":[
           {"trace_id":"tr'$i'","span_id":"s'$i'","gen_ai.system":"openai",
            "gen_ai.operation.name":"chat","gen_ai.request.model":"gpt-4o",
            "gen_ai.usage.input_tokens":1200,"gen_ai.usage.output_tokens":350}]}' >/dev/null
@@ -103,11 +115,13 @@ Verify the rows landed (and carry enriched cost):
 
 ```bash
 curl -s 'http://localhost:8123/?user=tally&password=tally&database=default' \
-  --data "SELECT count(), round(sum(EstimatedCost),4) FROM otel_spans WHERE TenantId='local-dev'"
+  --data "SELECT count(), round(sum(EstimatedCost),4) FROM otel_spans WHERE TenantId='$TENANT'"
 ```
 
 or open a SQL shell with `make ch` and run
-`SELECT FeatureTag, count(), sum(EstimatedCost) FROM otel_spans WHERE TenantId='local-dev' GROUP BY FeatureTag`.
+`SELECT TenantId, FeatureTag, count(), sum(EstimatedCost) FROM otel_spans GROUP BY TenantId, FeatureTag`.
+A `TenantId` that reads `local-dev` rather than a UUID is a batch that the dashboard will not
+render: re-send it under the UUID.
 
 ## 4. Run the web dashboard
 
@@ -121,11 +135,23 @@ npm run dev
 
 Open **http://localhost:3000**.
 
-No env config is needed: `web/lib/clickhouse.ts` defaults to exactly what the stack uses —
-`http://localhost:8123`, database `default`, tenant `local-dev`. Each Route Handler queries
-ClickHouse live and falls back to mock data **only** if ClickHouse is unreachable. With the stack up
-and a batch sent, the **Cost**, **Features**, **Agents**, and **Data Quality** pages render your
-ingested `local-dev` spans.
+The ClickHouse connection needs no config: `web/lib/clickhouse.ts` defaults to exactly what the
+stack uses: `http://localhost:8123`, database `default`. The **tenant** does need one variable.
+There is no pinned default any more: on the product path the dashboard resolves the caller's Clerk
+organization, so to run locally with no Clerk account set the dev escape hatch to the UUID that
+`make seed` printed (Initiative 1 §10):
+
+```bash
+export TALLY_DEV_TENANT=<the UUID make seed printed>
+npm run dev
+```
+
+Use the UUID, not `local-dev`: the value is bound into the ClickHouse read filter and a name matches
+no rows. Leave it unset and the dashboard errors rather than guessing a tenant.
+
+Each Route Handler queries ClickHouse live and falls back to mock data **only** if ClickHouse is
+unreachable. With the stack up and a batch sent, the **Cost**, **Features**, **Agents**, and **Data
+Quality** pages render your ingested spans.
 
 ---
 

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -320,10 +320,28 @@ rows land in ClickHouse. Finally open the web URL — the **Cost**, **Features**
 
 ## 9. Point the dashboard at production tenants
 
-The web tier defaults to tenant `local-dev`. For real tenants, set `web.config.tenantId` (EKS) or the
-`TALLY_TENANT_ID` env (ECS `web.taskdef.json`), and keep `gateway.config.requireApiKey=true` (the
-cloud default) so ingest requires `Authorization: Bearer <key>` — seed keys with the gateway's
-`seed.py` against RDS.
+On the product path the dashboard does not pin a tenant at all: it resolves the caller's Clerk
+organization to a tenant UUID through the gateway control plane. So leave `web.config.devTenant`
+(EKS) and the `TALLY_DEV_TENANT` env (ECS `web.taskdef.json`) **empty**, and keep
+`gateway.config.requireApiKey=true` (the cloud default) so ingest requires
+`Authorization: Bearer <key>`. Seed keys with the gateway's `seed.py` against RDS.
+
+Two things follow from that, and both bite silently if you get them wrong:
+
+- **Control-plane calls need the service token.** Every `/v1/tenant/*` request carries
+  `Authorization: Bearer $TALLY_GATEWAY_SERVICE_TOKEN`, and with `requireApiKey` on the gateway
+  refuses to boot when the token is empty rather than serve an open control plane. The gateway
+  reads it as `TALLY_GATEWAY_SERVICE_TOKEN` and the web tier reads the same secret as
+  `GATEWAY_SERVICE_TOKEN`; both taskdefs and both charts reference the
+  `ai-tally-gateway-service-token` Secrets Manager entry, so put a real value in it
+  (`openssl rand -hex 32`) and never a committed literal. A mismatch surfaces as a `401` on every
+  dashboard control-plane write.
+
+- **If you do pin a tenant, pin the UUID.** `TALLY_DEV_TENANT` / `web.config.devTenant` is a
+  single-tenant demo escape hatch, and its value is bound straight into the ClickHouse read filter
+  (`TenantId = ...`) while spans are tagged with the tenant UUID. The name `local-dev` therefore
+  matches no rows: the stack comes up green and the dashboard renders empty. `make seed` prints the
+  UUID to use. The older `TALLY_TENANT_ID` env is no longer read by the web tier at all.
 
 ## 10. Teardown
 

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -21,7 +21,7 @@
       "environment": [
         { "name": "PORT", "value": "3000" },
         { "name": "TALLY_GATEWAY_URL", "value": "REPLACE_GATEWAY_URL" },
-        { "name": "TALLY_TENANT_ID", "value": "local-dev" },
+        { "name": "TALLY_DEV_TENANT", "value": "" },
         { "name": "TALLY_CLICKHOUSE_URL", "value": "REPLACE_CLICKHOUSE_URL" },
         { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
         { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },

--- a/deploy/aws/helm/ai-tally-eks/templates/web-configmap.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/web-configmap.yaml
@@ -11,7 +11,10 @@ data:
   # the gateway (TALLY_GATEWAY_URL). The ClickHouse password comes from the synced Secret.
   PORT: {{ .Values.web.service.port | quote }}
   TALLY_GATEWAY_URL: {{ include "ai-tally.gatewayUrl" . | quote }}
-  TALLY_TENANT_ID: {{ .Values.web.config.tenantId | quote }}
+  # Initiative 1 §10: dev escape hatch. Empty on the product path (tenant comes from the
+  # caller's Clerk org). When pinned it must be the tenant UUID, not a name: the value is
+  # bound into the ClickHouse read filter (TenantId = ...), so a name matches no rows.
+  TALLY_DEV_TENANT: {{ .Values.web.config.devTenant | quote }}
   TALLY_CLICKHOUSE_URL: {{ printf "%s://%s:%d" .Values.clickhouse.scheme (include "ai-tally.clickhouseHost" .) (int .Values.clickhouse.httpPort) | quote }}
   TALLY_CLICKHOUSE_DB: {{ .Values.web.config.clickhouseDb | quote }}
   TALLY_CLICKHOUSE_USER: {{ .Values.web.config.clickhouseUser | quote }}

--- a/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
@@ -54,4 +54,6 @@ web:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/ai-tally/web
     tag: "1.0.0"
   config:
-    tenantId: local-dev
+    # Empty: the tenant comes from the caller's Clerk org. To pin one for a demo, use its
+    # UUID (`make seed` prints it), never the name `local-dev`.
+    devTenant: ""

--- a/deploy/aws/helm/ai-tally-eks/values.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values.yaml
@@ -131,7 +131,10 @@ web:
     # The dashboard queries ClickHouse directly AND calls the gateway. The gateway URL defaults to
     # the in-cluster Service; leave blank to auto-derive it from the release name.
     gatewayUrl: ""
-    tenantId: local-dev
+    # Initiative 1 §10: pin a tenant and skip Clerk. Leave EMPTY on the product path. For a
+    # single-tenant demo set the tenant UUID (`make seed` prints it), never the name
+    # `local-dev`: this is bound into the ClickHouse read filter and a name matches no rows.
+    devTenant: ""
     clickhouseDb: default
     clickhouseUser: tally
     dashboardRefreshMs: "5000"   # NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS

--- a/deploy/demo/.env.example
+++ b/deploy/demo/.env.example
@@ -26,16 +26,28 @@ MINIO_ROOT_USER=tally
 MINIO_ROOT_PASSWORD=tally-minio
 
 # --- Tenant the dashboard renders --------------------------------------------------------------
-# PINNED, not a free knob. The demo data is seeded under `local-dev`: `gateway.seed` (make seed)
-# creates the `local-dev` tenant and deploy.sh/reseed.sh backfill under it. The dashboard queries
-# whatever tenant NAME is set here, so it MUST stay `local-dev` to match the seeded data. Changing
-# it points the dashboard at a tenant that has no demo data and renders an empty dashboard with no
-# error. Leave as-is.
-TALLY_TENANT_ID=local-dev
+# NOT set here. The dashboard reads TALLY_DEV_TENANT, and that value must be the demo tenant's
+# UUID, not the name `local-dev`: the web binds it straight into the ClickHouse read filter
+# (TenantId = ...) and the backfill tags spans with the UUID, so a name matches no rows and gives
+# you an empty dashboard with no error.
+#
+# The UUID does not exist until `make seed` has run, so deploy.sh resolves it from Postgres after
+# seeding, hands it to the backfill, and recreates the web service with it. reseed.sh does the same.
+# Neither ever falls back to a name: if resolution fails they abort with the reason.
+#
+# Only override this if you seeded under a different tenant name:
+# DEMO_TENANT_NAME=local-dev
 
 # --- Control-plane service token (Initiative 1 §6) ----------------------------------------------
-# The web server presents this as a bearer token on every gateway /v1/tenant/* call. The gateway
-# enforces it only when TALLY_REQUIRE_API_KEY is true, which this demo VM leaves off, so it can
-# stay unset here. If you do turn gateway auth on, set a long random value: the gateway then
-# refuses to boot without it rather than come up with an unauthenticated control plane.
+# One secret, read by the gateway as TALLY_GATEWAY_SERVICE_TOKEN and by the web server as
+# GATEWAY_SERVICE_TOKEN; the compose overlay wires both from this single key, so they cannot
+# disagree. The web presents it as a bearer token on every /v1/tenant/* control-plane call.
+#
+# The gateway enforces it only when TALLY_REQUIRE_API_KEY is true, which this demo VM leaves off,
+# so it may stay unset. Turn auth on and it becomes mandatory: the gateway refuses to boot with an
+# empty token rather than come up with an unauthenticated control plane, and deploy.sh/reseed.sh
+# stop up front with that message instead of letting you wait out a health-check timeout.
+#
+# Generate a real one (never commit it, and never reuse the infra/.env.example placeholder):
+#   echo "TALLY_GATEWAY_SERVICE_TOKEN=$(openssl rand -hex 32)" >> deploy/demo/.env
 # TALLY_GATEWAY_SERVICE_TOKEN=

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -23,9 +23,10 @@ keep talking to each other over the compose network but are not reachable from t
 | `web.Dockerfile` | Multi-stage build of the Next.js dashboard (standalone, `node:22`), root build context. |
 | `docker-compose.prod.yml` | Overlay: adds `web` + `caddy`, strips host ports off the base services. |
 | `Caddyfile` | `${DOMAIN}` site: automatic TLS, basic-auth, `reverse_proxy web:3000`. Commented gateway-ingest and local-HTTP variants. |
-| `.env.example` | Per-host config: domain, basic-auth user + bcrypt hash, stack creds, tenant. |
+| `.env.example` | Per-host config: domain, basic-auth user + bcrypt hash, stack creds, service token. |
 | `deploy.sh` | Bring the stack up, wait for health, apply DDL, seed + backfill, print the link. |
 | `reseed.sh` | Reset + re-seed the synthetic data (run nightly via cron). |
+| `lib-tenant.sh` | Sourced by both scripts: tenant-UUID resolution and the service-token preflight. |
 
 ## Operator runbook
 
@@ -70,6 +71,25 @@ Edit `deploy/demo/.env`:
   Store only the `$2a$...` hash in `.env`; keep the plaintext to share with testers. `.env` is
   host-specific and is git-ignored - do not commit it.
 
+- Leave `TALLY_GATEWAY_SERVICE_TOKEN` commented out unless you also turn gateway auth on
+  (`TALLY_REQUIRE_API_KEY=true`). If you do turn it on, generate a real token and never commit it:
+
+  ```
+  echo "TALLY_GATEWAY_SERVICE_TOKEN=$(openssl rand -hex 32)" >> deploy/demo/.env
+  ```
+
+  One key covers both tiers: the compose overlay hands the same value to the gateway as
+  `TALLY_GATEWAY_SERVICE_TOKEN` and to the web server as `GATEWAY_SERVICE_TOKEN`. With auth on and
+  the token empty the gateway refuses to boot rather than serve an open control plane, so
+  `deploy.sh` and `reseed.sh` stop up front and say so.
+
+- Do **not** set the tenant by hand. The dashboard reads `TALLY_DEV_TENANT`, and it must hold the
+  tenant **UUID**, not the name `local-dev`: the web binds that value straight into the ClickHouse
+  read filter (`TenantId = ...`) and the backfill tags spans with the UUID, so a name matches no
+  rows and you get an empty dashboard with no error. The UUID only exists after seeding, so
+  `deploy.sh` resolves it from Postgres, hands it to the backfill, and recreates the web service
+  with it. If resolution ever fails, both scripts abort with the reason instead of falling back.
+
 ### 4. Deploy
 
 ```
@@ -77,8 +97,8 @@ Edit `deploy/demo/.env`:
 ```
 
 This builds the images, starts the stack, waits for the gateway to be healthy, applies the
-ClickHouse DDL (including `replay_samples`), seeds the tenant, and backfills 30 days of synthetic
-spans. When it finishes it prints:
+ClickHouse DDL (including `replay_samples`), seeds the tenant, resolves that tenant's UUID and
+points the dashboard at it, then backfills 30 days of synthetic spans. When it finishes it prints:
 
 ```
 URL:   https://demo.example.com
@@ -145,6 +165,33 @@ docker run --rm -v "$PWD/deploy/demo/Caddyfile:/etc/caddy/Caddyfile:ro" \
 For an end-to-end auth check, run Caddy with the commented `:8088` HTTP block from the `Caddyfile`
 proxying to a `web` container on a spare port and `curl` it: no creds -> `401`, correct creds ->
 `200`.
+
+## Troubleshooting
+
+**The dashboard renders but every panel is empty.** Almost always a tenant mismatch: the spans were
+written under one `TenantId` and the dashboard is reading another. Check the two ends agree:
+
+```
+# What the control plane says the tenant UUID is:
+docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml \
+  exec -T postgres psql -U tally -d tally -tAc "SELECT id, name FROM tenants"
+
+# What the web tier is actually reading:
+docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml \
+  exec -T web printenv TALLY_DEV_TENANT
+
+# What ClickHouse actually holds:
+docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml \
+  exec -T clickhouse clickhouse-client -u tally --password tally -d default \
+  --query "SELECT TenantId, count() FROM otel_spans GROUP BY TenantId"
+```
+
+All three must show the same **UUID**. A `local-dev` (the name) in either of the last two means
+something bypassed `deploy.sh`; re-running `./deploy/demo/reseed.sh` re-resolves and repairs it.
+
+**A control-plane write from the dashboard returns 401.** Gateway auth is on and the two tiers hold
+different tokens. They come from the single `TALLY_GATEWAY_SERVICE_TOKEN` key in `.env`, so confirm
+`.env` has it and re-run `deploy.sh`; a hand-edited container env is the usual cause.
 
 ## Feedback
 

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -41,6 +41,13 @@ set +a
 # Compose reads the same .env for base-stack defaults; pass it explicitly so both files see it.
 COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
 
+# Tenant-UUID resolution and the service-token preflight, shared with reseed.sh.
+# shellcheck source=deploy/demo/lib-tenant.sh
+source "${SCRIPT_DIR}/lib-tenant.sh"
+
+# Cheap check first: a missing service token with auth on means the gateway never boots.
+require_service_token_if_auth_on
+
 echo "==> Building images and starting the stack"
 "${COMPOSE[@]}" up -d --build
 
@@ -66,10 +73,20 @@ echo "==> Applying ClickHouse DDL (make ch-migrate)"
 make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" ch-migrate
 
 # --- Load the SYNTHETIC demo dataset ------------------------------------------------------------
-# seed: creates the local-dev tenant + API key + price catalog.
+# seed: creates the `local-dev` tenant + API key + price catalog, and prints the tenant UUID.
 # chatbot-demo-backfill: POSTs 30 days of backdated synthetic spans ($0, no LLM calls, no API keys).
 echo "==> Seeding the demo tenant (make seed)"
 make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" seed
+
+# --- Point the dashboard at the tenant that was just seeded -------------------------------------
+# The UUID only exists after `make seed`, so the web container above started without it. Resolve it
+# now and recreate just the web service with TALLY_DEV_TENANT set. Exported so Compose interpolation
+# picks it up: a host env var wins over the same key in --env-file.
+echo "==> Resolving the demo tenant UUID"
+TENANT_UUID="$(resolve_tenant_uuid)"
+echo "    ${DEMO_TENANT_NAME} = ${TENANT_UUID}"
+export TALLY_DEV_TENANT="${TENANT_UUID}"
+"${COMPOSE[@]}" up -d web
 
 echo "==> Backfilling 30 days of SYNTHETIC demo spans"
 # The `make chatbot-demo-backfill` target runs on the HOST and POSTs to localhost:8080 - neither
@@ -80,16 +97,16 @@ echo "==> Backfilling 30 days of SYNTHETIC demo spans"
 # COMPOSE_NETWORK is `<project>_default`; the project name is `ai-tally` (infra/docker-compose.yml
 # `name:`). Override COMPOSE_NETWORK in the environment if you renamed the project.
 #
-# Backfill under the SAME tenant the dashboard renders (TALLY_TENANT_ID). `gateway.seed` creates the
-# demo tenant as `local-dev`, so this is pinned to local-dev in .env.example; passing it here keeps
-# the seeded data and the dashboard's tenant from drifting into an empty dashboard (CTO-243).
+# Backfill under the SAME tenant UUID the dashboard was just pointed at. Both sides come from the
+# one resolve_tenant_uuid call above, so the seeded data and the rendered tenant cannot drift into
+# an empty dashboard (CTO-243).
 COMPOSE_NETWORK="${COMPOSE_NETWORK:-ai-tally_default}"
 docker run --rm \
   --network "${COMPOSE_NETWORK}" \
   -v "${REPO_ROOT}/examples/vercel-chatbot/scripts:/scripts:ro" \
   -e TALLY_GATEWAY_URL="http://gateway:8080/v1/batches" \
   node:22-bookworm-slim \
-  npx --yes tsx /scripts/backfill-spans.ts --tenant "${TALLY_TENANT_ID:-local-dev}"
+  npx --yes tsx /scripts/backfill-spans.ts --tenant "${TENANT_UUID}"
 
 # --- Done ---------------------------------------------------------------------------------------
 cat <<EOF

--- a/deploy/demo/docker-compose.prod.yml
+++ b/deploy/demo/docker-compose.prod.yml
@@ -51,10 +51,20 @@ services:
       TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
       TALLY_CLICKHOUSE_DB: default
       TALLY_GATEWAY_URL: http://gateway:8080
-      TALLY_TENANT_ID: ${TALLY_TENANT_ID:-local-dev}
-      # Initiative 1 §6: the control-plane service token. Empty here because the demo VM runs
-      # with TALLY_REQUIRE_API_KEY off, which makes the gateway gate a no-op. Set it in .env
-      # (same value as the gateway's TALLY_GATEWAY_SERVICE_TOKEN) if you turn auth on.
+      # Initiative 1 §10: the dev escape hatch that pins the tenant, so the demo VM needs no Clerk
+      # account. It MUST be the tenant UUID, not the name `local-dev`: the web binds this value
+      # straight into the ClickHouse read filter (TenantId = ...) and the backfill tags spans with
+      # the UUID, so a name matches no rows and renders an empty dashboard.
+      #
+      # Not settable by hand in .env: the UUID only exists once `make seed` has run. deploy.sh
+      # resolves it from Postgres after seeding and exports it, then recreates this service. Left
+      # empty on the very first `up` (before seeding), where the dashboard errors loudly rather
+      # than rendering a blank page for an unknown tenant.
+      TALLY_DEV_TENANT: ${TALLY_DEV_TENANT:-}
+      # Initiative 1 §6: the control-plane service token, the same secret the gateway reads as
+      # TALLY_GATEWAY_SERVICE_TOKEN (the gateway picks it up from the base compose file and the
+      # same .env, so the two cannot disagree). The gateway's gate is a no-op while the demo VM
+      # runs with TALLY_REQUIRE_API_KEY off; turn auth on and it is mandatory on both sides.
       GATEWAY_SERVICE_TOKEN: ${TALLY_GATEWAY_SERVICE_TOKEN:-}
     # No host port: the browser reaches the dashboard only through Caddy (caddy -> web:3000).
     depends_on:

--- a/deploy/demo/lib-tenant.sh
+++ b/deploy/demo/lib-tenant.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# ai-tally demo-deploy-kit - shared preflight helpers for deploy.sh and reseed.sh (CTO-243).
+#
+# WHY this file exists: both scripts need the SAME tenant-UUID resolution and the SAME service-token
+# preflight, and a copy-paste divergence between them is exactly the failure mode that produces a
+# blank demo dashboard. Keeping one definition means deploy and the nightly reseed cannot drift.
+#
+# Sourced, never executed. The caller must already have sourced deploy/demo/.env and populated the
+# COMPOSE array, e.g.
+#
+#   COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
+#   source deploy/demo/lib-tenant.sh
+
+# The tenant NAME `gateway.seed` creates. Only the name is knowable ahead of time; the UUID is
+# generated at seed time, which is why it has to be read back out of Postgres.
+DEMO_TENANT_NAME="${DEMO_TENANT_NAME:-local-dev}"
+
+# Resolve the demo tenant's UUID from the control plane, printing it on stdout.
+#
+# WHY the UUID and not the name (Initiative 1, §8): the canonical TenantId is the tenant UUID. The
+# backfill tags every span with whatever `--tenant` it is handed, and the dashboard binds
+# TALLY_DEV_TENANT straight into the ClickHouse read filter (`TenantId = ...`). Feed a NAME to
+# either side and it matches no rows: the stack comes up green and the dashboard renders empty with
+# no error anywhere. Mirrors the TENANT_UUID recipe in infra/Makefile.
+#
+# Honest under uncertainty: on any failure this returns non-zero with a real reason instead of
+# falling back to `local-dev` or to an empty string, both of which would silently produce that empty
+# dashboard.
+resolve_tenant_uuid() {
+  # The name is interpolated into SQL, so refuse anything that is not a plain identifier rather than
+  # hand an operator typo (or worse) to psql.
+  if [[ ! "${DEMO_TENANT_NAME}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "ERROR: DEMO_TENANT_NAME='${DEMO_TENANT_NAME}' is not a plain identifier ([A-Za-z0-9_-]+)." >&2
+    return 1
+  fi
+
+  local uuid
+  uuid="$("${COMPOSE[@]}" exec -T postgres \
+    psql -U "${POSTGRES_USER:-tally}" -d "${POSTGRES_DB:-tally}" -tAc \
+    "SELECT id FROM tenants WHERE name='${DEMO_TENANT_NAME}' LIMIT 1" 2>/dev/null \
+    | tr -d '[:space:]')"
+
+  if [[ ! "${uuid}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    cat >&2 <<ERR
+ERROR: could not resolve the '${DEMO_TENANT_NAME}' tenant UUID from Postgres.
+       Got: '${uuid:-<empty>}'
+
+       The dashboard reads spans by tenant UUID, so there is no safe fallback here: continuing
+       with the tenant NAME (or with nothing) would leave you with a green stack and an empty
+       dashboard. Fix the cause and re-run.
+
+       Check, in order:
+         1. Postgres is up:   ${COMPOSE[*]} ps postgres
+         2. The tenant exists: ${COMPOSE[*]} exec -T postgres \\
+              psql -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally} -c 'SELECT id, name FROM tenants'
+         3. If it is missing, the seed step did not run or failed:
+              make -C infra seed
+ERR
+    return 1
+  fi
+
+  printf '%s\n' "${uuid}"
+}
+
+# Fail before the stack is touched when gateway auth is on but no service token was supplied.
+#
+# WHY up front (Initiative 1, §6): with TALLY_REQUIRE_API_KEY on and TALLY_GATEWAY_SERVICE_TOKEN
+# empty, the gateway deliberately REFUSES TO BOOT rather than expose an unauthenticated control
+# plane. Without this check that surfaces two minutes later as an opaque health-check timeout.
+require_service_token_if_auth_on() {
+  local auth_on="${TALLY_REQUIRE_API_KEY:-false}"
+  case "${auth_on}" in
+    true|TRUE|True|1|yes|on) ;;
+    *) return 0 ;;
+  esac
+
+  if [[ -z "${TALLY_GATEWAY_SERVICE_TOKEN:-}" ]]; then
+    cat >&2 <<ERR
+ERROR: TALLY_REQUIRE_API_KEY is on but TALLY_GATEWAY_SERVICE_TOKEN is empty.
+
+       The gateway refuses to boot in that state rather than come up with an open control plane,
+       and every dashboard control-plane write would fail. Generate a real token and put it in
+       deploy/demo/.env:
+
+         echo "TALLY_GATEWAY_SERVICE_TOKEN=\$(openssl rand -hex 32)" >> deploy/demo/.env
+
+       The same value reaches the gateway as TALLY_GATEWAY_SERVICE_TOKEN and the web tier as
+       GATEWAY_SERVICE_TOKEN (see deploy/demo/docker-compose.prod.yml); they must match.
+ERR
+    return 1
+  fi
+}

--- a/deploy/demo/reseed.sh
+++ b/deploy/demo/reseed.sh
@@ -48,6 +48,12 @@ set +a
 
 COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
 
+# Tenant-UUID resolution and the service-token preflight, shared with deploy.sh.
+# shellcheck source=deploy/demo/lib-tenant.sh
+source "${SCRIPT_DIR}/lib-tenant.sh"
+
+require_service_token_if_auth_on
+
 CH_USER="${CLICKHOUSE_USER:-tally}"
 CH_PASSWORD="${CLICKHOUSE_PASSWORD:-tally}"
 
@@ -68,6 +74,13 @@ TABLES=(
   replay_samples
 )
 
+# Resolve the tenant BEFORE truncating. If the control plane cannot answer, a nightly run must abort
+# with the old data still on screen rather than empty the tables and then discover it has no tenant
+# to repost under (CTO-243).
+echo "==> Resolving the demo tenant UUID"
+TENANT_UUID="$(resolve_tenant_uuid)"
+echo "    ${DEMO_TENANT_NAME} = ${TENANT_UUID}"
+
 echo "==> Truncating ClickHouse telemetry tables"
 for t in "${TABLES[@]}"; do
   echo "    TRUNCATE ${t}"
@@ -83,7 +96,8 @@ echo "==> Re-backfilling 30 days of SYNTHETIC demo spans"
 # Same throwaway-container approach as deploy.sh: no host Node, reaches the gateway internally.
 # --seed: a per-run nonce so batch_ids are fresh and the gateway's 24h dedup never drops a reseed
 #         (see the WHY block above). Override with BACKFILL_SEED if you need a reproducible run.
-# --tenant: pin to the dashboard's tenant so seed data and the rendered tenant cannot drift.
+# --tenant: the resolved tenant UUID, the value the dashboard binds into its ClickHouse read filter,
+#         so seed data and the rendered tenant cannot drift (a NAME here matches no rows).
 COMPOSE_NETWORK="${COMPOSE_NETWORK:-ai-tally_default}"
 BACKFILL_SEED="${BACKFILL_SEED:-$(date +%s)}"
 docker run --rm \
@@ -91,6 +105,12 @@ docker run --rm \
   -v "${REPO_ROOT}/examples/vercel-chatbot/scripts:/scripts:ro" \
   -e TALLY_GATEWAY_URL="http://gateway:8080/v1/batches" \
   node:22-bookworm-slim \
-  npx --yes tsx /scripts/backfill-spans.ts --seed "${BACKFILL_SEED}" --tenant "${TALLY_TENANT_ID:-local-dev}"
+  npx --yes tsx /scripts/backfill-spans.ts --seed "${BACKFILL_SEED}" --tenant "${TENANT_UUID}"
+
+# Repair the web tier if it is running without TALLY_DEV_TENANT (for example after a bare
+# `docker compose up` that bypassed deploy.sh). Compose recreates only when the value actually
+# changes, so on a normal nightly run this is a no-op.
+export TALLY_DEV_TENANT="${TENANT_UUID}"
+"${COMPOSE[@]}" up -d web
 
 echo "==> Demo data reset. The dashboard now shows a fresh synthetic 30-day window."

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -273,14 +273,31 @@ curl -s localhost:8080/healthz                      # {"status":"ok"}
 
 Then send a batch (the same payload as `RUNNING.md` step 3, pointed at your gateway URL) and confirm
 rows land in ClickHouse. Finally open the web service URL — the **Cost**, **Features**, **Agents**,
-and **Data Quality** pages should render your ingested `local-dev` spans.
+and **Data Quality** pages should render your ingested spans.
 
 ## 9. Point the dashboard at production tenants
 
-The web tier defaults to tenant `local-dev` (matching local dev). For real tenants, set
-`web.config.tenantId` (GKE) or the `TALLY_TENANT_ID` env (Cloud Run), and enable
+On the product path the dashboard does not pin a tenant at all: it resolves the caller's Clerk
+organization to a tenant UUID through the gateway control plane. So leave `web.config.devTenant`
+(GKE) and the `TALLY_DEV_TENANT` env (Cloud Run) **empty**, and keep
 `gateway.config.requireApiKey=true` (the cloud default) so ingest requires
-`Authorization: Bearer <key>` — seed keys with the gateway's `seed.py` against Cloud SQL.
+`Authorization: Bearer <key>`. Seed keys with the gateway's `seed.py` against Cloud SQL.
+
+Two things follow from that, and both bite silently if you get them wrong:
+
+- **Control-plane calls need the service token.** Every `/v1/tenant/*` request carries
+  `Authorization: Bearer $TALLY_GATEWAY_SERVICE_TOKEN`, and with `requireApiKey` on the gateway
+  refuses to boot when the token is empty rather than serve an open control plane. The gateway
+  reads it as `TALLY_GATEWAY_SERVICE_TOKEN` and the web tier reads the same secret as
+  `GATEWAY_SERVICE_TOKEN`; both are wired here as Secret Manager references, so put a real value in
+  the `ai-tally-gateway-service-token` secret (`openssl rand -hex 32`) and never a committed
+  literal. A mismatch surfaces as a `401` on every dashboard control-plane write.
+
+- **If you do pin a tenant, pin the UUID.** `TALLY_DEV_TENANT` / `web.config.devTenant` is a
+  single-tenant demo escape hatch, and its value is bound straight into the ClickHouse read filter
+  (`TenantId = ...`) while spans are tagged with the tenant UUID. The name `local-dev` therefore
+  matches no rows: the stack comes up green and the dashboard renders empty. `make seed` prints the
+  UUID to use. The older `TALLY_TENANT_ID` env is no longer read by the web tier at all.
 
 ---
 

--- a/deploy/gcp/cloudrun/web.service.yaml
+++ b/deploy/gcp/cloudrun/web.service.yaml
@@ -35,7 +35,12 @@ spec:
             - containerPort: 8080
           env:
             - { name: TALLY_GATEWAY_URL,    value: "REPLACE_GATEWAY_URL" }
-            - { name: TALLY_TENANT_ID,      value: "local-dev" }
+            # Initiative 1 §10: the dev escape hatch that pins a tenant and skips Clerk. Leave it
+            # EMPTY on the product path, where the tenant comes from the caller's Clerk org. Set it
+            # only for a single-tenant demo, and then to the tenant UUID (`make seed` prints it),
+            # never to a name: the value is bound into the ClickHouse read filter (TenantId = ...),
+            # so a name matches no rows and renders an empty dashboard.
+            - { name: TALLY_DEV_TENANT,     value: "" }
             - { name: TALLY_CLICKHOUSE_URL, value: "REPLACE_CLICKHOUSE_URL" }
             - { name: TALLY_CLICKHOUSE_DB,  value: "default" }
             - { name: TALLY_CLICKHOUSE_USER, value: "tally" }

--- a/deploy/gcp/helm/ai-tally/templates/web-configmap.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/web-configmap.yaml
@@ -11,7 +11,10 @@ data:
   # the gateway (TALLY_GATEWAY_URL). The ClickHouse password comes from the synced Secret.
   PORT: {{ .Values.web.service.port | quote }}
   TALLY_GATEWAY_URL: {{ include "ai-tally.gatewayUrl" . | quote }}
-  TALLY_TENANT_ID: {{ .Values.web.config.tenantId | quote }}
+  # Initiative 1 §10: dev escape hatch. Empty on the product path (tenant comes from the
+  # caller's Clerk org). When pinned it must be the tenant UUID, not a name: the value is
+  # bound into the ClickHouse read filter (TenantId = ...), so a name matches no rows.
+  TALLY_DEV_TENANT: {{ .Values.web.config.devTenant | quote }}
   TALLY_CLICKHOUSE_URL: {{ printf "%s://%s:%d" .Values.clickhouse.scheme (include "ai-tally.clickhouseHost" .) (int .Values.clickhouse.httpPort) | quote }}
   TALLY_CLICKHOUSE_DB: {{ .Values.web.config.clickhouseDb | quote }}
   TALLY_CLICKHOUSE_USER: {{ .Values.web.config.clickhouseUser | quote }}

--- a/deploy/gcp/helm/ai-tally/values-gke.example.yaml
+++ b/deploy/gcp/helm/ai-tally/values-gke.example.yaml
@@ -46,4 +46,6 @@ web:
     repository: us-central1-docker.pkg.dev/MY_PROJECT/ai-tally/web
     tag: "1.0.0"
   config:
-    tenantId: local-dev
+    # Empty: the tenant comes from the caller's Clerk org. To pin one for a demo, use its
+    # UUID (`make seed` prints it), never the name `local-dev`.
+    devTenant: ""

--- a/deploy/gcp/helm/ai-tally/values.yaml
+++ b/deploy/gcp/helm/ai-tally/values.yaml
@@ -120,7 +120,10 @@ web:
     # The dashboard queries ClickHouse directly AND calls the gateway. The gateway URL defaults to
     # the in-cluster Service; leave blank to auto-derive it from the release name.
     gatewayUrl: ""
-    tenantId: local-dev
+    # Initiative 1 §10: pin a tenant and skip Clerk. Leave EMPTY on the product path. For a
+    # single-tenant demo set the tenant UUID (`make seed` prints it), never the name
+    # `local-dev`: this is bound into the ClickHouse read filter and a name matches no rows.
+    devTenant: ""
     clickhouseDb: default
     clickhouseUser: tally
     dashboardRefreshMs: "5000"   # NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -69,7 +69,20 @@ fallback — the dashboard boots without any of them (it just renders the mock/`
 | `TALLY_CLICKHOUSE_PASSWORD` | ClickHouse password | `••••••••` | **Encrypted / Sensitive** |
 | `TALLY_CLICKHOUSE_DB` | ClickHouse database | `default` | Plain env |
 | `TALLY_GATEWAY_URL` | Ingest gateway base URL | `https://gateway.example.com` | Plain env |
-| `TALLY_TENANT_ID` | Tenant the dashboard reads | `local-dev` (prod: your tenant) | Plain env |
+| `GATEWAY_SERVICE_TOKEN` | Bearer token on every gateway `/v1/tenant/*` call | `openssl rand -hex 32` output | **Encrypted / Sensitive** |
+| `TALLY_DEV_TENANT` | Dev escape hatch: pin a tenant, skip Clerk | unset in prod (demo: the tenant **UUID**) | Plain env |
+
+`GATEWAY_SERVICE_TOKEN` must be the exact same string the gateway holds as
+`TALLY_GATEWAY_SERVICE_TOKEN`. The gateway rejects every control-plane call without it once
+`TALLY_REQUIRE_API_KEY` is on, so a mismatch shows up as a `401` on key management and connector
+config. Generate a real value (`openssl rand -hex 32`) and store it Sensitive; never commit one.
+
+`TALLY_DEV_TENANT` should be **unset** on a production deployment: the tenant then comes from the
+caller's Clerk organization. Set it only for a single-tenant demo, and set it to the tenant **UUID**
+(`make seed` prints it), never to a name like `local-dev`. The value is bound directly into the
+ClickHouse read filter (`TenantId = ...`) and spans are tagged with the UUID, so a name matches no
+rows and the dashboard renders empty with no error. The older `TALLY_TENANT_ID` variable is gone;
+delete it from any project that still has it.
 
 **Optional UI/build knobs (`NEXT_PUBLIC_*` are inlined at build time — non-secret by definition):**
 

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -62,7 +62,13 @@ seed: ## Create a local tenant + API key + feature tags in Postgres
 	@echo "  export TALLY_DEV_TENANT=$(TENANT_UUID)"
 
 demo: ## Send a sample batch through the gateway into ClickHouse
-	$(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py
+	@# send_batch.py defaults to the tenant NAME, but ingest writes TenantId verbatim while the
+	@# dashboard reads by UUID (Initiative 1, §8), so the default would land rows the UI never shows.
+	@# Fail loudly rather than write invisible rows: an empty UUID means the tenant is not seeded.
+	@test -n "$(strip $(TENANT_UUID))" || { \
+	  echo "cannot resolve the local-dev tenant UUID from Postgres; run 'make up && make seed' first"; \
+	  exit 1; }
+	$(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py --tenant $(TENANT_UUID)
 
 aider-demo: ## Run Aider against a fixture repo through the edge proxy (needs OPENAI_API_KEY)
 	@curl -sf http://localhost:8080/healthz >/dev/null || { \


### PR DESCRIPTION
Stacked on `feat/i1-close-control-plane-auth-gap`. Review that one first; this PR targets it as its base.

## The bug

`deploy/demo` pinned `TALLY_TENANT_ID=local-dev`. Two things wrong with it:

1. The web tier no longer reads `TALLY_TENANT_ID` at all. It reads `TALLY_DEV_TENANT` (`web/lib/getTenant.ts`), so the kit was setting a variable nothing consumes.
2. `local-dev` is a tenant NAME, but the canonical `TenantId` is the UUID. Ingest writes `TenantId` verbatim from the batch and the dashboard binds its tenant straight into the ClickHouse read filter (`TenantId = ...`), so a name matches no rows.

Net effect: the demo kit brought up a green stack and an empty dashboard, with no error anywhere.

## The fix

`deploy.sh` and `reseed.sh` resolve the UUID from Postgres after seeding, mirroring the `TENANT_UUID` recipe in `infra/Makefile`, and thread it into both ends: `TALLY_DEV_TENANT` for the web tier (exported, then `up -d web` recreates that one service) and `--tenant` for the backfill. Both come from one `resolve_tenant_uuid` call, so they cannot drift.

The resolution lives in a new sourced `deploy/demo/lib-tenant.sh` so the deploy path and the nightly reseed cannot diverge by copy-paste.

Honest under uncertainty: there is no fallback. If resolution fails, the scripts abort and print what to check. A silent fallback to the name or to an empty string is precisely what produced the blank dashboard. `reseed.sh` also resolves *before* it truncates, so a failed nightly run leaves the old data on screen instead of emptying the tables and then discovering it has no tenant to repost under.

## Service token

The base branch already wired `TALLY_GATEWAY_SERVICE_TOKEN` through the demo compose overlay to both tiers (gateway reads it under that name, web as `GATEWAY_SERVICE_TOKEN`, from the single `.env` key), so that part was not redone. Added here:

- A preflight in the shared helper: with `TALLY_REQUIRE_API_KEY` on and the token empty, the gateway deliberately refuses to boot, and without this check that surfaced two minutes later as an opaque health-check timeout. Now both scripts stop up front with the reason and the `openssl rand -hex 32` recipe.
- `deploy/demo/.env.example` documents generating a real one. No literal token is committed anywhere.

## Other targets

The same stale variable was set everywhere, so the grep-and-fix pass covered them:

- Cloud Run `web.service.yaml` and ECS `web.taskdef.json`: `TALLY_TENANT_ID: "local-dev"` becomes `TALLY_DEV_TENANT: ""`. Empty is correct on the product path, where the tenant comes from the caller's Clerk org.
- Both Helm charts: `web.config.tenantId` becomes `web.config.devTenant`, emitted as `TALLY_DEV_TENANT`, defaulting to empty.
- `infra/Makefile`: `make demo` was sending under the name too. It now sends under the resolved UUID and refuses to send without one, rather than writing rows the dashboard will never show.

## Docs

`RUNNING.md`, `deploy/demo/README.md`, `deploy/gcp/README.md`, `deploy/aws/README.md`, `deploy/vercel/README.md`. Appended to what the base branch wrote rather than restating it: generating a real service token, control-plane calls needing the bearer, and UUID-not-name. The demo README gains a troubleshooting section for the two failure modes this class of bug produces (empty dashboard, 401 on control-plane writes) with the three commands that localise a tenant mismatch.

`infra/.env.example` already covered the token on the base branch and needed nothing.

## Verified

- `bash -n` clean on `deploy.sh`, `reseed.sh`, `lib-tenant.sh`. `shellcheck` is not installed on this machine, so it was not run.
- `resolve_tenant_uuid` exercised against the running local Postgres via a shim harness: returns the real UUID `38a6c264-...` for `local-dev`; returns non-zero with the diagnostic (and prints nothing on stdout) for a missing tenant and for a non-identifier name. The service-token preflight verified in all three states.
- `docker compose config` renders the demo overlay cleanly: no `TALLY_TENANT_ID` remains, both `GATEWAY_SERVICE_TOKEN` and `TALLY_DEV_TENANT` are present, and an exported `TALLY_DEV_TENANT` correctly overrides the `--env-file` value, which is the mechanism `deploy.sh` relies on.
- `make -n demo` expands to the real UUID and the guard.
- `web.taskdef.json` parses as JSON.

## Not verified from here

- No cloud deploy was attempted. The Cloud Run, ECS and Helm changes are reviewed by eye only: `helm template` and `yamllint` are not installed on this machine, and the Helm value rename was applied identically to both charts.
- `deploy.sh` / `reseed.sh` were not run end to end. That needs a VM with DNS and a real `.env`; the pieces they compose (the UUID lookup, the compose interpolation, the preflight) were each exercised individually as above.

## Deliberately left out

- `chatbot-demo-backfill` in `infra/Makefile` still falls back silently to no `--tenant` when the UUID is empty. That is the same honesty gap, but the target belongs to in-flight work on another branch and touching it invites a conflict. Worth a follow-up.
- No changes under `infra/gateway/src/gateway/app.py`, `web/`, `sdk/python/` or `infra/edge-proxy/`.
- The local ClickHouse currently holds only name-keyed rows (`TenantId = 'local-dev'`), so any existing local data predates the UUID switch and will need a re-backfill to render. Not something a deploy script should migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
