### PR TITLE
feat(gateway,web): per-layer coverage probe and honest coverage panel (CTO-261)

### DIFF
--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -48,6 +48,7 @@ from gateway.auth import ApiKeyAuth
 from gateway.backpressure import Backpressure
 from gateway.config import get_settings
 from gateway.cost_connector_job import register_cost_connector_job
+from gateway.coverage_probe import AccountSignal, build_coverage, parse_wired_param
 from gateway.errors import ErrorCode
 from gateway.ingest_buffer import AsyncIngestBuffer
 from gateway.mapping import span_to_row
@@ -2335,6 +2336,56 @@ async def stripe_webhook(
             "account_attributed": resolution.is_attributed,
             "account_inferred": resolution.inferred,
         },
+        status_code=200,
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# Onboarding: per-layer instrumentation coverage (CTO-261, onboarding-agent §7).
+# --------------------------------------------------------------------------------------------
+
+
+@app.get("/v1/tenant/onboarding/coverage")
+def tenant_coverage(
+    wired: str | None = None,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Per-layer coverage for the caller's tenant: which layers a real span proves are flowing.
+
+    Widens Initiative 2 §9's single existence probe across LLM, tools, vector, embeddings and
+    per-customer attribution (§7). ``wired`` is an optional comma-separated list of layers the
+    onboarding agent reports it instrumented; it only distinguishes "wired, awaiting first event"
+    from "not wired" for a dark layer, and can never produce coverage (``coverage_probe``).
+
+    A ClickHouse failure returns 200 with the affected layers ``unknown``, not a 5xx and not a row
+    of zeroes. The caller polls this during onboarding, and a transient outage must read as "we
+    could not tell", never as "your instrumentation is missing" (CLAUDE.md, honest under
+    uncertainty). The two probes are caught separately so an unreadable rollup does not blank out
+    the four layers the span probe answered.
+    """
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    store: ClickHouseStore = app.state.store
+
+    try:
+        operation_counts: dict[str, int] | None = store.coverage_operation_counts(tenant_id)
+    except Exception:  # noqa: BLE001 — an unreachable store is "unknown", never "not covered"
+        logger.exception("coverage span probe failed for tenant %s", tenant_id)
+        operation_counts = None
+
+    try:
+        total, attributed = store.coverage_account_rows(tenant_id)
+        account: AccountSignal | None = AccountSignal(
+            total_rows=total, attributed_rows=attributed
+        )
+    except Exception:  # noqa: BLE001 — same rule for the rollup read
+        logger.exception("coverage account probe failed for tenant %s", tenant_id)
+        account = None
+
+    layers = build_coverage(operation_counts, account, parse_wired_param(wired))
+    return JSONResponse(
+        {"tenant_id": tenant_id, "layers": [layer.as_dict() for layer in layers]},
         status_code=200,
     )
 

--- a/infra/gateway/src/gateway/coverage_probe.py
+++ b/infra/gateway/src/gateway/coverage_probe.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer instrumentation coverage (CTO-261, Initiative onboarding-agent §7).
+
+WHAT THIS IS. Initiative 2 §9 gave onboarding one binary signal: has ANY span landed for this
+tenant yet. That answers "are you connected" and nothing else, so a developer who wired the LLM
+one-liner and stopped there sees a green tick while tools, vector, embeddings and per-customer
+attribution are all still dark. This module widens that single existence check into one check per
+layer, so the onboarding agent can say which layers are proven flowing and name every layer that
+is not, with the reason.
+
+THE HONESTY RULE, which is the whole point (§7). A layer is reported ``covered`` only when a real
+span proves it. There is no path in :func:`build_coverage` that reaches ``covered`` from anything
+but a positive span count, and a probe that could not run yields ``unknown`` rather than the
+definite negative ``not_wired``. Collapsing "we could not reach ClickHouse" into "you have not
+wired tools" would be inventing a negative fact out of an absence of knowledge, which is the same
+sin as rendering a fabricated zero (CLAUDE.md, "honest under uncertainty").
+
+FOUR STATES, not three, because "not covered" is really two different situations and the developer
+needs to tell them apart:
+
+  * ``covered``               a span exists for the layer. Proven, with the count that proves it.
+  * ``awaiting_first_event``  the onboarding agent wired this layer, but the code path has not run
+                              yet. Nothing is wrong; the developer has to exercise it.
+  * ``not_wired``             no span, and nothing claims to have wired it. This is the real gap.
+  * ``unknown``               the probe did not run. We say so instead of guessing.
+
+Which layers were wired is an INPUT, never an inference: only the agent that proposed the diff
+knows what it wired, and ClickHouse cannot tell a layer that was never wired from one that was
+wired and never exercised. An unwired-but-firing layer still reports ``covered``, because the span
+is the proof and it outranks the claim.
+
+THE ACCOUNT LAYER IS DIFFERENT and reads a different table. See :func:`build_coverage`.
+
+No bodies, no identifiers: this module handles operation names and row counts only. The account
+signal is a count of rows whose ``AccountIdHash`` is non-empty, never a hash.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal, Mapping
+
+CoverageState = Literal["covered", "awaiting_first_event", "not_wired", "unknown"]
+
+# The four layers whose signal is an operation on the span itself (§7's table). The value is the
+# `GenAiOperation` promoted column, which is `gen_ai.operation.name` (db/clickhouse/otel_spans.sql).
+LAYER_OPERATIONS: Mapping[str, str] = {
+    "llm": "chat",
+    "tools": "tool",
+    "vector": "vector",
+    "embeddings": "embeddings",
+}
+
+# The attribution layer. Not an operation: a span of ANY operation proves it, as long as it carries
+# an account hash. Kept separate from LAYER_OPERATIONS because it is read from a different table.
+ACCOUNT_LAYER = "account"
+
+# Report order. Deliberately the order a developer wires things in: the one-liner first, then the
+# explicit records, then attribution, which is the layer that needs the question only they can
+# answer (§6).
+LAYERS: tuple[str, ...] = ("llm", "tools", "vector", "embeddings", ACCOUNT_LAYER)
+
+_LAYER_LABELS: Mapping[str, str] = {
+    "llm": "LLM calls",
+    "tools": "tool calls",
+    "vector": "vector search",
+    "embeddings": "embeddings",
+    ACCOUNT_LAYER: "per-customer attribution",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AccountSignal:
+    """What the per-account rollup says about attribution for one tenant.
+
+    ``total_rows`` is carried alongside ``attributed_rows`` because a rollup that is empty for a
+    tenant is ambiguous and must not be read as "no attribution". ``daily_account_rollup`` is a
+    materialized view, an INSERT trigger that captures nothing that predates it, and a deployment
+    that created it without running the documented backfill has a legitimately empty table under a
+    tenant with millions of attributed spans (db/clickhouse/account_rollups.sql). Reporting
+    ``not_wired`` off that would tell the developer their instrumentation is missing when it is
+    ours that is. So an empty rollup for a tenant that HAS spans resolves to ``unknown``.
+    """
+
+    total_rows: int
+    attributed_rows: int
+
+
+@dataclass(frozen=True, slots=True)
+class LayerCoverage:
+    """One layer's honest state, the reason for it, and the evidence behind ``covered``."""
+
+    layer: str
+    state: CoverageState
+    reason: str
+    # Spans that prove the layer, or None when we could not count them. Never 0-as-a-fact under
+    # `unknown`: an unknown count is null, not zero (CLAUDE.md).
+    proving_spans: int | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "layer": self.layer,
+            "state": self.state,
+            "reason": self.reason,
+            "proving_spans": self.proving_spans,
+        }
+
+
+def normalize_wired(values: Iterable[object] | None) -> frozenset[str]:
+    """Accept a caller's claim about which layers it wired, keeping only real layer names.
+
+    An unrecognised name is dropped rather than rejected: the claim only ever softens a dark layer's
+    wording from ``not_wired`` to ``awaiting_first_event``, so a typo costs the developer a slightly
+    blunter message and nothing else. It can never manufacture coverage.
+    """
+    if values is None:
+        return frozenset()
+    return frozenset(v for v in values if isinstance(v, str) and v in LAYERS)
+
+
+def parse_wired_param(raw: str | None) -> frozenset[str]:
+    """Parse the ``wired=tools,vector`` query parameter."""
+    if not raw:
+        return frozenset()
+    return normalize_wired(part.strip() for part in raw.split(","))
+
+
+def _dark(layer: str, wired: frozenset[str], detail: str) -> LayerCoverage:
+    """The two flavours of "no span proves this layer", which are not the same news."""
+    if layer in wired:
+        return LayerCoverage(
+            layer=layer,
+            state="awaiting_first_event",
+            reason=(
+                f"wired, awaiting first event: {detail}. Exercise the code path that "
+                f"records {_LAYER_LABELS[layer]} and this flips on its own."
+            ),
+            proving_spans=0,
+        )
+    return LayerCoverage(
+        layer=layer,
+        state="not_wired",
+        reason=f"not wired: {detail}, and no instrumentation for this layer was reported.",
+        proving_spans=0,
+    )
+
+
+def build_coverage(
+    operation_counts: Mapping[str, int] | None,
+    account: AccountSignal | None,
+    wired: frozenset[str] = frozenset(),
+) -> list[LayerCoverage]:
+    """Turn two raw probe results into the per-layer report.
+
+    ``operation_counts`` maps ``GenAiOperation`` to a span count for the tenant, or is None when the
+    span probe could not run. ``account`` is the rollup signal, or None when that probe could not
+    run. The two are separate inputs because they read different tables and can fail independently:
+    an unreadable rollup must not blank out the four layers the span probe answered fine.
+
+    WHY THE ACCOUNT LAYER READS THE ROLLUP. On ``otel_spans`` the ORDER BY is
+    (TenantId, FeatureTag, ServiceName, SpanName, Timestamp), so ``AccountIdHash`` is not in the key
+    at all and "does any attributed span exist" degrades into a scan of the tenant's whole history
+    every time the answer is no, which is exactly the case onboarding polls. ``daily_account_rollup``
+    is ordered (TenantId, AccountIdHash, Day, ...), so the same question is a key-prefix range read
+    over a table that holds one row per account per day per feature per operation instead of one row
+    per span. That is the one genuinely cheaper rollup read here; the four operation layers get no
+    such benefit (GenAiOperation is the LAST key column there) and are answered in a single grouped
+    pass over the spans, which is also what supplies the proving counts.
+    """
+    out: list[LayerCoverage] = []
+
+    for layer in LAYER_OPERATIONS:
+        operation = LAYER_OPERATIONS[layer]
+        if operation_counts is None:
+            out.append(
+                LayerCoverage(
+                    layer=layer,
+                    state="unknown",
+                    reason=(
+                        "could not read otel_spans, so we cannot tell whether this layer is "
+                        "flowing. This is not a report that it is dark."
+                    ),
+                    proving_spans=None,
+                )
+            )
+            continue
+        count = int(operation_counts.get(operation, 0))
+        if count > 0:
+            out.append(
+                LayerCoverage(
+                    layer=layer,
+                    state="covered",
+                    reason=(
+                        f"{count} span(s) with GenAiOperation = '{operation}' prove this layer "
+                        "is flowing."
+                    ),
+                    proving_spans=count,
+                )
+            )
+        else:
+            out.append(_dark(layer, wired, f"no span with GenAiOperation = '{operation}'"))
+
+    out.append(_account_coverage(operation_counts, account, wired))
+    return out
+
+
+def _account_coverage(
+    operation_counts: Mapping[str, int] | None,
+    account: AccountSignal | None,
+    wired: frozenset[str],
+) -> LayerCoverage:
+    if account is None:
+        return LayerCoverage(
+            layer=ACCOUNT_LAYER,
+            state="unknown",
+            reason=(
+                "could not read daily_account_rollup, so we cannot tell whether spans carry an "
+                "account. This is not a report that attribution is missing."
+            ),
+            proving_spans=None,
+        )
+    if account.attributed_rows > 0:
+        return LayerCoverage(
+            layer=ACCOUNT_LAYER,
+            state="covered",
+            reason=(
+                f"{account.attributed_rows} rollup row(s) carry a non-empty AccountIdHash, so "
+                "spend is attributed to a customer."
+            ),
+            proving_spans=account.attributed_rows,
+        )
+    spans_seen = operation_counts is not None and any(v > 0 for v in operation_counts.values())
+    if account.total_rows == 0 and spans_seen:
+        # Spans exist but the rollup has nothing for this tenant. That is a rollup that was never
+        # backfilled, not an app that never called with_account(), and we must not blame the
+        # developer for our own missing migration step (see AccountSignal).
+        return LayerCoverage(
+            layer=ACCOUNT_LAYER,
+            state="unknown",
+            reason=(
+                "spans exist for this tenant but daily_account_rollup has no rows for it, so the "
+                "rollup is behind (see the backfill note in db/clickhouse/account_rollups.sql) "
+                "and cannot answer this."
+            ),
+            proving_spans=None,
+        )
+    return _dark(ACCOUNT_LAYER, wired, "no span carries an account hash")

--- a/infra/gateway/src/gateway/store.py
+++ b/infra/gateway/src/gateway/store.py
@@ -211,6 +211,51 @@ class ClickHouseStore:
             )
         return out
 
+    def coverage_operation_counts(self, tenant_id: str) -> dict[str, int]:
+        """Span count per ``GenAiOperation`` for one tenant, for the per-layer probe (CTO-261).
+
+        ONE grouped pass, not one existence probe per layer. Four separate ``LIMIT 1`` checks would
+        each read the same tenant range, and each would read it in full whenever the answer is no,
+        which is precisely the case onboarding polls. Grouping reads a single LowCardinality column
+        over that range once and answers all four layers, and the counts double as the evidence the
+        report shows for a covered layer.
+
+        Tenant-scoped, so this stays inside the leading key column on a shared cluster (CTO-18).
+        Counts only: no identifier and no body leaves this query.
+        """
+        result = self.client.query(
+            "SELECT GenAiOperation, count() FROM otel_spans WHERE TenantId = %(t)s "
+            "GROUP BY GenAiOperation",
+            parameters={"t": tenant_id},
+        )
+        return {str(r[0]): int(r[1]) for r in result.result_rows}
+
+    def coverage_account_rows(self, tenant_id: str) -> tuple[int, int]:
+        """``(total_rows, attributed_rows)`` from ``daily_account_rollup`` for one tenant (CTO-261).
+
+        Reads the rollup rather than the spans because ``AccountIdHash`` leads that table's key and
+        appears nowhere in the raw table's (see ``coverage_probe.build_coverage``).
+
+        ``notEmpty`` rather than a length test, and this matters. ``AccountIdHash`` is
+        ``FixedString(64) DEFAULT ''``: ClickHouse pads a FixedString to width with NUL bytes, so the
+        unattributed default is 64 NULs and ``length(AccountIdHash) > 0`` is TRUE for every row,
+        including the unattributed ones. Verified against ClickHouse 24.8 on a column declared
+        exactly this way: ``length`` is 64 for both, while ``notEmpty`` (and ``!= ''``, which pads
+        the literal) is 0 for the default and 1 for a real hash. Getting this wrong would report
+        every tenant as attributed, which is the failure mode this whole probe exists to prevent.
+
+        ``total_rows`` comes back with it so the caller can tell an unattributed tenant from a
+        rollup that was never backfilled; conflating the two would blame the developer for our own
+        missing migration step.
+        """
+        result = self.client.query(
+            "SELECT count(), countIf(notEmpty(AccountIdHash)) FROM daily_account_rollup "
+            "WHERE TenantId = %(t)s",
+            parameters={"t": tenant_id},
+        )
+        row = result.result_rows[0]
+        return int(row[0]), int(row[1])
+
     def close(self) -> None:
         if self._client is not None:
             self._client.close()

--- a/infra/gateway/tests/test_app_coverage_probe.py
+++ b/infra/gateway/tests/test_app_coverage_probe.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer instrumentation coverage (CTO-261, onboarding-agent §7).
+
+The tests that matter are the honesty ones: a layer with no span is never ``covered``, and an
+unreachable ClickHouse reads as ``unknown`` rather than as a report that the layer is dark.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.app import app
+from gateway.coverage_probe import (
+    AccountSignal,
+    LAYERS,
+    build_coverage,
+    normalize_wired,
+    parse_wired_param,
+)
+
+T = "t-acme"
+
+
+class FakeStore:
+    """Stands in for ClickHouseStore. ``raise_*`` simulates an unreachable store."""
+
+    def __init__(
+        self,
+        operation_counts: dict[str, int] | None = None,
+        account_rows: tuple[int, int] = (0, 0),
+        raise_spans: bool = False,
+        raise_account: bool = False,
+    ) -> None:
+        self._operation_counts = operation_counts or {}
+        self._account_rows = account_rows
+        self._raise_spans = raise_spans
+        self._raise_account = raise_account
+
+    def coverage_operation_counts(self, tenant_id: str) -> dict[str, int]:
+        if self._raise_spans:
+            raise RuntimeError("clickhouse unreachable")
+        return dict(self._operation_counts)
+
+    def coverage_account_rows(self, tenant_id: str) -> tuple[int, int]:
+        if self._raise_account:
+            raise RuntimeError("clickhouse unreachable")
+        return self._account_rows
+
+    def close(self) -> None:
+        """The app's shutdown hook closes the store; the fake has nothing to close."""
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+def _states(body: dict) -> dict[str, str]:
+    return {row["layer"]: row["state"] for row in body["layers"]}
+
+
+def _reasons(body: dict) -> dict[str, str]:
+    return {row["layer"]: row["reason"] for row in body["layers"]}
+
+
+# --------------------------------------------------------------------------------------------
+# The pure mapper.
+# --------------------------------------------------------------------------------------------
+
+
+def test_every_layer_is_reported() -> None:
+    rows = build_coverage({}, AccountSignal(0, 0))
+    assert [r.layer for r in rows] == list(LAYERS)
+
+
+def test_a_layer_with_a_span_is_covered_with_the_proving_count() -> None:
+    rows = {r.layer: r for r in build_coverage({"tool": 3}, AccountSignal(0, 0))}
+    assert rows["tools"].state == "covered"
+    assert rows["tools"].proving_spans == 3
+    assert "GenAiOperation = 'tool'" in rows["tools"].reason
+
+
+def test_a_layer_with_no_span_is_never_covered() -> None:
+    """The central rule of §7: no proving span, no coverage. Not even when the caller claims it."""
+    rows = {
+        r.layer: r
+        for r in build_coverage({"chat": 12}, AccountSignal(0, 0), normalize_wired(LAYERS))
+    }
+    for layer in ("tools", "vector", "embeddings", "account"):
+        assert rows[layer].state != "covered", layer
+    for layer in ("tools", "vector", "embeddings"):
+        assert rows[layer].proving_spans == 0, layer
+
+
+def test_wired_but_unexercised_is_distinct_from_not_wired() -> None:
+    rows = {
+        r.layer: r
+        for r in build_coverage({"chat": 1}, AccountSignal(2, 0), normalize_wired(["vector"]))
+    }
+    assert rows["vector"].state == "awaiting_first_event"
+    assert "awaiting first event" in rows["vector"].reason
+    assert rows["tools"].state == "not_wired"
+
+
+def test_an_unreadable_span_probe_is_unknown_not_not_covered() -> None:
+    rows = {r.layer: r for r in build_coverage(None, AccountSignal(5, 5))}
+    for layer in ("llm", "tools", "vector", "embeddings"):
+        assert rows[layer].state == "unknown", layer
+        # An unknown count is null, never 0 (CLAUDE.md).
+        assert rows[layer].proving_spans is None
+        assert "cannot tell" in rows[layer].reason
+    # The rollup answered, so attribution is still reported rather than blanked with it.
+    assert rows["account"].state == "covered"
+
+
+def test_an_unreadable_rollup_leaves_the_span_layers_intact() -> None:
+    rows = {r.layer: r for r in build_coverage({"chat": 4}, None)}
+    assert rows["llm"].state == "covered"
+    assert rows["account"].state == "unknown"
+    assert rows["account"].proving_spans is None
+
+
+def test_attributed_rollup_rows_prove_the_account_layer() -> None:
+    rows = {r.layer: r for r in build_coverage({"chat": 4}, AccountSignal(9, 2))}
+    assert rows["account"].state == "covered"
+    assert rows["account"].proving_spans == 2
+
+
+def test_an_empty_rollup_under_a_tenant_with_spans_is_unknown() -> None:
+    """A never-backfilled materialized view is our gap, not the developer's (CTO-261)."""
+    rows = {r.layer: r for r in build_coverage({"chat": 40}, AccountSignal(0, 0))}
+    assert rows["account"].state == "unknown"
+    assert "rollup is behind" in rows["account"].reason
+
+
+def test_an_empty_rollup_under_a_tenant_with_no_spans_is_a_real_gap() -> None:
+    rows = {r.layer: r for r in build_coverage({}, AccountSignal(0, 0))}
+    assert rows["account"].state == "not_wired"
+
+
+def test_wired_claim_cannot_manufacture_coverage_from_garbage() -> None:
+    assert parse_wired_param("tools, vector,nonsense,") == frozenset({"tools", "vector"})
+    assert parse_wired_param(None) == frozenset()
+    assert normalize_wired([1, None, "llm"]) == frozenset({"llm"})
+
+
+# --------------------------------------------------------------------------------------------
+# The endpoint.
+# --------------------------------------------------------------------------------------------
+
+
+def test_endpoint_reports_covered_and_dark_layers(client: TestClient) -> None:
+    app.state.store = FakeStore(operation_counts={"chat": 7, "vector": 1}, account_rows=(3, 1))
+    r = client.get(
+        "/v1/tenant/onboarding/coverage?wired=tools", headers={"X-Tenant-Id": T}
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tenant_id"] == T
+    assert _states(body) == {
+        "llm": "covered",
+        "tools": "awaiting_first_event",
+        "vector": "covered",
+        "embeddings": "not_wired",
+        "account": "covered",
+    }
+    # Every dark layer is named with a reason, per §7.
+    assert all(reason for reason in _reasons(body).values())
+
+
+def test_endpoint_maps_an_unreachable_clickhouse_to_unknown(client: TestClient) -> None:
+    """Never a 5xx, and never a row of zeroes passed off as "not covered"."""
+    app.state.store = FakeStore(raise_spans=True, raise_account=True)
+    r = client.get("/v1/tenant/onboarding/coverage", headers={"X-Tenant-Id": T})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert set(_states(body).values()) == {"unknown"}
+    assert all(row["proving_spans"] is None for row in body["layers"])
+
+
+def test_endpoint_requires_a_tenant_header(client: TestClient) -> None:
+    app.state.store = FakeStore()
+    assert client.get("/v1/tenant/onboarding/coverage").status_code == 422
+
+
+def test_endpoint_is_gated_on_the_service_token(client: TestClient) -> None:
+    """Initiative 1 §6: the control plane answers the web server, not the internet."""
+    app.state.store = FakeStore()
+    settings = app.state.settings
+    settings.require_api_key = True
+    settings.gateway_service_token = "svc-secret"
+    try:
+        assert client.get(
+            "/v1/tenant/onboarding/coverage", headers={"X-Tenant-Id": T}
+        ).status_code == 401
+        assert client.get(
+            "/v1/tenant/onboarding/coverage",
+            headers={"X-Tenant-Id": T, "Authorization": "Bearer wrong"},
+        ).status_code == 401
+        assert client.get(
+            "/v1/tenant/onboarding/coverage",
+            headers={"X-Tenant-Id": T, "Authorization": "Bearer svc-secret"},
+        ).status_code == 200
+    finally:
+        settings.require_api_key = False
+        settings.gateway_service_token = ""

--- a/web/app/api/onboarding/coverage/route.test.ts
+++ b/web/app/api/onboarding/coverage/route.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Coverage proxy route (CTO-261, onboarding-agent §7). The gateway owns the probe; this handler is
+// the service-token seam. What is tested here is what happens when that call does NOT go well,
+// because the answer must be "we could not tell", never "your instrumentation is missing".
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+import type { LayerCoverage } from "@/lib/firstEvent";
+
+function reply(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function call(url = "http://test/api/onboarding/coverage"): Promise<LayerCoverage[]> {
+  const res = await GET(new Request(url));
+  return ((await res.json()) as { layers: LayerCoverage[] }).layers;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/onboarding/coverage", () => {
+  it("passes the gateway's per-layer report through", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      reply({
+        layers: [
+          { layer: "llm", state: "covered", reason: "4 spans", proving_spans: 4 },
+          { layer: "tools", state: "not_wired", reason: "no tool span", proving_spans: 0 },
+          { layer: "vector", state: "not_wired", reason: "no vector span", proving_spans: 0 },
+          {
+            layer: "embeddings",
+            state: "not_wired",
+            reason: "no embeddings span",
+            proving_spans: 0,
+          },
+          { layer: "account", state: "covered", reason: "2 rollup rows", proving_spans: 2 },
+        ],
+      }),
+    );
+    const layers = await call();
+    expect(layers.map((l) => l.state)).toEqual([
+      "covered",
+      "not_wired",
+      "not_wired",
+      "not_wired",
+      "covered",
+    ]);
+  });
+
+  it("forwards the wired claim and softens a dark layer with it", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      reply({
+        layers: [{ layer: "tools", state: "not_wired", reason: "no tool span", proving_spans: 0 }],
+      }),
+    );
+    const layers = await call("http://test/api/onboarding/coverage?wired=tools");
+    expect(String(fetchMock.mock.calls[0][0])).toContain("wired=tools");
+    expect(layers.find((l) => l.layer === "tools")?.state).toBe("awaiting_first_event");
+  });
+
+  it("reports unknown, not not-wired, when the gateway errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(reply({ detail: "boom" }, 503));
+    const layers = await call();
+    expect(layers.every((l) => l.state === "unknown" && l.provingSpans === null)).toBe(true);
+    expect(layers[0].reason).toMatch(/HTTP 503/);
+  });
+
+  it("reports unknown when the gateway cannot be reached at all", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const layers = await call();
+    expect(layers.every((l) => l.state === "unknown")).toBe(true);
+    expect(layers[0].reason).toMatch(/could not be reached/);
+  });
+
+  it("never lights a layer green on a covered claim with no proving span", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      reply({
+        layers: [{ layer: "llm", state: "covered", reason: "trust me", proving_spans: 0 }],
+      }),
+    );
+    expect((await call())[0].state).toBe("unknown");
+  });
+});

--- a/web/app/api/onboarding/coverage/route.ts
+++ b/web/app/api/onboarding/coverage/route.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Per-layer coverage proxy (CTO-261, onboarding-agent §7). The coverage panel polls this to see
+// which instrumentation layers a real span proves are flowing, and which are still dark and why.
+//
+// The probe itself lives in the gateway (§13): it reads otel_spans and daily_account_rollup, and
+// the browser must never hold the control-plane service token, so this server-side handler is the
+// seam. It resolves the active tenant from Clerk exactly as every other read does and forwards to
+// the gateway's service-token-authed endpoint.
+//
+// A gateway that is down yields an all-unknown report with the reason attached, never a row of
+// "not covered". Telling a developer their tools layer is unwired because OUR gateway blipped is
+// the fabricated-negative this initiative exists to avoid (CLAUDE.md, honest under uncertainty).
+import { NextResponse } from "next/server";
+
+import { controlPlaneHeaders, getTenant } from "@/lib/getTenant";
+import { type LayerCoverage, parseCoverage, unknownCoverage } from "@/lib/firstEvent";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export interface CoveragePayload {
+  layers: LayerCoverage[];
+}
+
+// GET /api/onboarding/coverage?wired=tools,vector returns per-layer coverage for the tenant.
+// `wired` passes the onboarding agent's claim about what it instrumented straight through; it only
+// separates "wired, awaiting first event" from "not wired" and can never manufacture coverage.
+export async function GET(req: Request): Promise<NextResponse<CoveragePayload>> {
+  const wiredParam = new URL(req.url).searchParams.get("wired") ?? "";
+  const wired = wiredParam
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const tenant = await getTenant();
+  const qs = wiredParam ? `?wired=${encodeURIComponent(wiredParam)}` : "";
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/onboarding/coverage${qs}`, {
+      headers: controlPlaneHeaders(tenant.tenantId),
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      return NextResponse.json({
+        layers: unknownCoverage(
+          `the coverage probe answered HTTP ${res.status}, so we could not read this layer`,
+        ),
+      });
+    }
+    return NextResponse.json({ layers: parseCoverage(await res.json(), wired) });
+  } catch {
+    return NextResponse.json({
+      layers: unknownCoverage(
+        "the coverage probe could not be reached, so we could not read this layer",
+      ),
+    });
+  }
+}

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { CoveragePanel } from "@/components/CoveragePanel";
 import { apiGet } from "@/lib/api";
 import type { FunnelEvent, OnboardingProgress, TenantProxyCredentials } from "@/lib/onboarding";
 
@@ -24,6 +25,11 @@ export default async function OnboardingPage() {
         </p>
       </div>
       <Onboarding initialProgress={progress} creds={creds} />
+      {/* Per-layer coverage (CTO-261, §4.1). Sits under the connect steps because it answers the
+          question that comes NEXT: the steps above get the LLM layer flowing, and this says which
+          of the remaining layers a span actually proves. It polls on the client, so the page does
+          not block on the probe. */}
+      <CoveragePanel />
     </div>
   );
 }

--- a/web/components/CoveragePanel.test.tsx
+++ b/web/components/CoveragePanel.test.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Coverage panel (CTO-261, onboarding-agent §4.1 / §7). The assertions that matter are the honest
+// ones: a dark layer is named with its reason, and a layer we could not read renders the blank with
+// that reason rather than a zero.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BLANK } from "./HonestValue";
+import { CoveragePanel } from "./CoveragePanel";
+import type { LayerCoverage } from "@/lib/firstEvent";
+
+function layers(overrides: Partial<Record<string, Partial<LayerCoverage>>> = {}): LayerCoverage[] {
+  const base: LayerCoverage[] = [
+    { layer: "llm", state: "covered", reason: "12 spans prove this layer", provingSpans: 12 },
+    {
+      layer: "tools",
+      state: "awaiting_first_event",
+      reason: "wired, awaiting first event: no span with GenAiOperation = 'tool'",
+      provingSpans: 0,
+    },
+    {
+      layer: "vector",
+      state: "not_wired",
+      reason: "not wired: no span with GenAiOperation = 'vector'",
+      provingSpans: 0,
+    },
+    {
+      layer: "embeddings",
+      state: "not_wired",
+      reason: "not wired: no span with GenAiOperation = 'embeddings'",
+      provingSpans: 0,
+    },
+    {
+      layer: "account",
+      state: "unknown",
+      reason: "could not read daily_account_rollup, so we cannot tell",
+      provingSpans: null,
+    },
+  ];
+  return base.map((l) => ({ ...l, ...(overrides[l.layer] ?? {}) }));
+}
+
+describe("CoveragePanel", () => {
+  it("shows each layer with its state badge", () => {
+    render(<CoveragePanel initialLayers={layers()} poll={false} />);
+    expect(screen.getByText("LLM calls")).toBeTruthy();
+    expect(screen.getByText("Flowing")).toBeTruthy();
+    expect(screen.getByText("Wired, awaiting first event")).toBeTruthy();
+    expect(screen.getAllByText("Not wired")).toHaveLength(2);
+    expect(screen.getByText("Unknown")).toBeTruthy();
+  });
+
+  it("names every dark layer with its reason", () => {
+    render(<CoveragePanel initialLayers={layers()} poll={false} />);
+    expect(screen.getByText(/no span with GenAiOperation = 'vector'/)).toBeTruthy();
+    expect(screen.getByText(/wired, awaiting first event/)).toBeTruthy();
+  });
+
+  it("renders a blank with the reason, not a zero, for a layer it could not read", () => {
+    const { container } = render(<CoveragePanel initialLayers={layers()} poll={false} />);
+    const blank = container.querySelector("[title*='could not read daily_account_rollup']");
+    expect(blank).toBeTruthy();
+    expect(blank?.textContent).toContain(BLANK);
+    // Only the three layers whose count is a KNOWN zero print one. The unknown layer prints no
+    // number at all, because a zero there would be a fabricated fact rather than a measured one.
+    expect(screen.getAllByText("0 spans")).toHaveLength(3);
+  });
+
+  it("shows the proving span count behind a covered layer", () => {
+    render(<CoveragePanel initialLayers={layers()} poll={false} />);
+    expect(screen.getByText("12 spans")).toBeTruthy();
+  });
+
+  it("counts only span-proven layers in the summary", () => {
+    render(<CoveragePanel initialLayers={layers()} poll={false} />);
+    expect(screen.getByText(/1\/5 layers proven by a span/)).toBeTruthy();
+    expect(screen.getByText(/1 could not be read/)).toBeTruthy();
+  });
+
+  it("starts unknown rather than claiming anything before the probe answers", () => {
+    render(<CoveragePanel poll={false} />);
+    expect(screen.getAllByText("Unknown")).toHaveLength(5);
+    expect(screen.getByText(/0\/5 layers proven by a span/)).toBeTruthy();
+  });
+});

--- a/web/components/CoveragePanel.tsx
+++ b/web/components/CoveragePanel.tsx
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Per-layer coverage panel (CTO-261, onboarding-agent §4.1 / §7).
+//
+// What the developer needs to see after a wired change runs is not "connected", it is WHICH of the
+// five layers is actually flowing and, for every layer that is not, why. So each row states its
+// case: a covered layer shows the span count that proves it, a dark layer says whether it is
+// awaiting its first event or simply unwired, and a layer we could not read renders the honest
+// blank with the reason on hover rather than a zero (CLAUDE.md).
+//
+// The proving-span count goes through `Blank` for exactly that reason: an unknown count is a blank
+// with a reason, never the number 0, which would read as "this layer fired nothing" when the truth
+// is "we could not look".
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Blank } from "@/components/HonestValue";
+import {
+  COVERAGE_LAYER_LABELS,
+  type LayerCoverage,
+  type LayerCoverageState,
+  unknownCoverage,
+} from "@/lib/firstEvent";
+
+const POLL_MS = 5000;
+
+/** One row's badge. Wording is the developer-facing half of §7's honesty rule. */
+const STATE_COPY: Record<LayerCoverageState, { label: string; className: string }> = {
+  covered: { label: "Flowing", className: "border-good/40 bg-good/10 text-good" },
+  awaiting_first_event: {
+    label: "Wired, awaiting first event",
+    className: "border-warn/40 bg-warn/10 text-warn",
+  },
+  not_wired: { label: "Not wired", className: "border-edge bg-ink text-muted" },
+  unknown: { label: "Unknown", className: "border-edge bg-ink text-muted" },
+};
+
+export function CoveragePanel({
+  initialLayers,
+  wired = [],
+  poll = true,
+}: {
+  /** Server-rendered first answer, so the panel never flashes an empty state it has to correct. */
+  initialLayers?: LayerCoverage[];
+  /** Layers the onboarding agent reports it wired. Only ever softens a dark layer's wording. */
+  wired?: readonly string[];
+  poll?: boolean;
+}) {
+  const [layers, setLayers] = useState<LayerCoverage[]>(
+    initialLayers ??
+      unknownCoverage("the coverage probe has not answered yet, so we cannot tell yet"),
+  );
+
+  useEffect(() => {
+    if (!poll) return;
+    const qs = wired.length ? `?wired=${encodeURIComponent(wired.join(","))}` : "";
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/onboarding/coverage${qs}`, { cache: "no-store" });
+        const data = (await res.json()) as { layers?: LayerCoverage[] };
+        // Keep the last honest answer on a failed poll rather than blanking a proven layer: a
+        // dropped request is not evidence that instrumentation stopped.
+        if (!cancelled && Array.isArray(data.layers) && data.layers.length) {
+          setLayers(data.layers);
+        }
+      } catch {
+        /* keep the last answer and try again */
+      }
+    };
+    void tick();
+    const id = setInterval(tick, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+    // `wired` is a prop array; join it so a re-render with an equal list does not restart the poll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poll, wired.join(",")]);
+
+  const covered = layers.filter((l) => l.state === "covered").length;
+  const unknown = layers.filter((l) => l.state === "unknown").length;
+
+  return (
+    <section className="rounded-xl border border-edge bg-panel p-5">
+      <h2 className="mb-1 text-sm font-medium uppercase tracking-wide text-muted">
+        Instrumentation coverage
+      </h2>
+      <p className="mb-4 text-sm text-muted">
+        A layer counts as flowing only when a real span proves it. Layers we have no span for are
+        named with the reason, and a layer we could not read is left blank rather than called dark.
+      </p>
+
+      <ul className="space-y-2">
+        {layers.map((layer) => {
+          const copy = STATE_COPY[layer.state];
+          return (
+            <li
+              key={layer.layer}
+              className="flex items-center justify-between gap-4 rounded-lg border border-edge bg-ink px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="text-sm text-fg">{COVERAGE_LAYER_LABELS[layer.layer]}</div>
+                <div className="mt-0.5 text-xs text-muted">{layer.reason}</div>
+              </div>
+              <div className="flex shrink-0 items-center gap-3">
+                <span className="text-xs text-muted" title="spans proving this layer">
+                  {layer.provingSpans === null ? (
+                    <Blank reason={layer.reason} />
+                  ) : (
+                    `${layer.provingSpans.toLocaleString()} spans`
+                  )}
+                </span>
+                <span
+                  className={`rounded-md border px-2 py-1 text-xs ${copy.className}`}
+                >
+                  {copy.label}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="mt-4 border-t border-edge pt-3 text-xs text-muted">
+        {covered}/{layers.length} layers proven by a span
+        {unknown > 0 ? `, ${unknown} could not be read` : ""}
+      </div>
+    </section>
+  );
+}

--- a/web/lib/firstEvent.test.ts
+++ b/web/lib/firstEvent.test.ts
@@ -2,7 +2,13 @@
 // First-data onboarding status mapper (Initiative 2, §9).
 import { describe, expect, it } from "vitest";
 
-import { firstEventStatus } from "./firstEvent";
+import {
+  COVERAGE_LAYERS,
+  firstEventStatus,
+  layerCoverageState,
+  parseCoverage,
+  unknownCoverage,
+} from "./firstEvent";
 
 describe("firstEventStatus", () => {
   it("maps a found row to connected", () => {
@@ -16,5 +22,92 @@ describe("firstEventStatus", () => {
   it("maps an unrunnable probe to unknown, never a fabricated waiting", () => {
     // null = ClickHouse unreachable. Honest under uncertainty: not collapsed into a definite "no".
     expect(firstEventStatus(null)).toBe("unknown");
+  });
+});
+
+describe("per-layer coverage (CTO-261)", () => {
+  it("derives covered only from a positive proving-span count", () => {
+    expect(layerCoverageState(3)).toBe("covered");
+    expect(layerCoverageState(1, true)).toBe("covered");
+  });
+
+  it("separates a wired-but-unexercised layer from an unwired one", () => {
+    expect(layerCoverageState(0, true)).toBe("awaiting_first_event");
+    expect(layerCoverageState(0, false)).toBe("not_wired");
+  });
+
+  it("maps an uncountable layer to unknown, never a fabricated not-wired", () => {
+    expect(layerCoverageState(null)).toBe("unknown");
+    expect(layerCoverageState(null, true)).toBe("unknown");
+  });
+
+  it("parses the gateway payload into one row per layer, in order", () => {
+    const layers = parseCoverage({
+      layers: [
+        { layer: "llm", state: "covered", reason: "7 spans", proving_spans: 7 },
+        { layer: "tools", state: "not_wired", reason: "no tool span", proving_spans: 0 },
+        { layer: "account", state: "unknown", reason: "rollup is behind", proving_spans: null },
+      ],
+    });
+    expect(layers.map((l) => l.layer)).toEqual([...COVERAGE_LAYERS]);
+    expect(layers[0]).toMatchObject({ state: "covered", provingSpans: 7 });
+    expect(layers[1]).toMatchObject({ state: "not_wired", provingSpans: 0 });
+    // vector and embeddings were absent from the payload: reported unknown, never dropped.
+    expect(layers[2]).toMatchObject({ state: "unknown", provingSpans: null });
+    expect(layers[2].reason).toBeTruthy();
+    expect(layers[4]).toMatchObject({ state: "unknown", provingSpans: null });
+  });
+
+  it("refuses a covered claim that carries no proving span", () => {
+    const [llm] = parseCoverage({
+      layers: [{ layer: "llm", state: "covered", reason: "trust me", proving_spans: 0 }],
+    });
+    expect(llm.state).toBe("unknown");
+    expect(llm.provingSpans).toBeNull();
+    expect(llm.reason).toMatch(/no span to prove it/);
+  });
+
+  it("refuses a covered claim with a missing or malformed span count", () => {
+    for (const proving_spans of [null, undefined, "many", -1, Number.NaN]) {
+      const [llm] = parseCoverage({
+        layers: [{ layer: "llm", state: "covered", reason: "trust me", proving_spans }],
+      });
+      expect(llm.state).toBe("unknown");
+    }
+  });
+
+  it("softens a dark layer the caller says it wired, without ever granting coverage", () => {
+    const [, tools] = parseCoverage(
+      {
+        layers: [{ layer: "tools", state: "not_wired", reason: "no tool span", proving_spans: 0 }],
+      },
+      ["tools"],
+    );
+    expect(tools.state).toBe("awaiting_first_event");
+    const [, alsoTools] = parseCoverage({ layers: [] }, ["tools"]);
+    expect(alsoTools.state).toBe("unknown");
+  });
+
+  it("treats an unrecognised state as unknown rather than trusting it", () => {
+    const [llm] = parseCoverage({
+      layers: [{ layer: "llm", state: "definitely_fine", reason: "hi", proving_spans: 9 }],
+    });
+    expect(llm.state).toBe("unknown");
+  });
+
+  it("survives a garbage payload with an all-unknown report", () => {
+    for (const raw of [null, undefined, {}, { layers: "nope" }, { layers: [1, 2] }]) {
+      const layers = parseCoverage(raw);
+      expect(layers).toHaveLength(COVERAGE_LAYERS.length);
+      expect(layers.every((l) => l.state === "unknown" && l.reason)).toBe(true);
+    }
+  });
+
+  it("builds an all-unknown report with the reason attached", () => {
+    const layers = unknownCoverage("gateway unreachable");
+    expect(layers).toHaveLength(COVERAGE_LAYERS.length);
+    expect(
+      layers.every((l) => l.reason === "gateway unreachable" && l.provingSpans === null),
+    ).toBe(true);
   });
 });

--- a/web/lib/firstEvent.ts
+++ b/web/lib/firstEvent.ts
@@ -19,3 +19,144 @@ export function firstEventStatus(seen: boolean | null): FirstEventStatus {
   if (seen === null) return "unknown";
   return seen ? "connected" : "waiting";
 }
+
+// --------------------------------------------------------------------------------------------
+// Per-layer coverage (CTO-261, onboarding-agent §7).
+//
+// The binary status above answers "are you connected" and stops there, so a developer who wired the
+// LLM one-liner sees a green tick while tools, vector, embeddings and per-customer attribution are
+// all still dark. The gateway's per-layer probe widens it; this is the client-side view of that
+// answer. `firstEventStatus` and its three states are untouched, because the connect panel still
+// asks exactly the binary question and its callers should not have to care about layers.
+//
+// A dark layer splits in two, which is the distinction the whole panel exists to draw: a layer the
+// onboarding agent wired but the app has not exercised yet ("wired, awaiting first event") is not
+// the same news as a layer nothing instruments. And neither is `unknown`, which means the probe did
+// not run. `covered` requires a proving span and is not reachable any other way, here or in the
+// gateway.
+// --------------------------------------------------------------------------------------------
+
+/** The five layers §7 reports on, in the order a developer wires them. */
+export const COVERAGE_LAYERS = ["llm", "tools", "vector", "embeddings", "account"] as const;
+export type CoverageLayer = (typeof COVERAGE_LAYERS)[number];
+
+export type LayerCoverageState = "covered" | "awaiting_first_event" | "not_wired" | "unknown";
+
+export interface LayerCoverage {
+  layer: CoverageLayer;
+  state: LayerCoverageState;
+  /** Why this layer is in this state. Always present: a dark or unknown layer is never unexplained. */
+  reason: string;
+  /** Spans proving the layer, or null when we could not count them. Never 0 standing in for null. */
+  provingSpans: number | null;
+}
+
+/** Human labels for the layer names the wire speaks. */
+export const COVERAGE_LAYER_LABELS: Record<CoverageLayer, string> = {
+  llm: "LLM calls",
+  tools: "Tool calls",
+  vector: "Vector search",
+  embeddings: "Embeddings",
+  account: "Per-customer attribution",
+};
+
+/**
+ * Map one layer's raw probe result to a state.
+ *
+ * `provingSpans` is the count of spans that prove the layer, or null when the probe could not run.
+ * `wired` is the onboarding agent's claim that it instrumented this layer, which only ever softens
+ * the wording of a dark layer. It cannot produce coverage: the only route to `covered` is a
+ * positive span count, so a claim without a span still reads as awaiting.
+ */
+export function layerCoverageState(
+  provingSpans: number | null,
+  wired = false,
+): LayerCoverageState {
+  if (provingSpans === null) return "unknown";
+  if (provingSpans > 0) return "covered";
+  return wired ? "awaiting_first_event" : "not_wired";
+}
+
+/** Whether a state means "we have proof", for a caller counting covered layers. */
+export function isCovered(state: LayerCoverageState): boolean {
+  return state === "covered";
+}
+
+const _STATES: readonly LayerCoverageState[] = [
+  "covered",
+  "awaiting_first_event",
+  "not_wired",
+  "unknown",
+];
+
+const UNREADABLE =
+  "the coverage probe did not return a usable answer for this layer, so we cannot tell whether it is flowing";
+
+/** An all-unknown report, for when the probe itself could not be reached. `reason` says why. */
+export function unknownCoverage(reason: string): LayerCoverage[] {
+  return COVERAGE_LAYERS.map((layer) => ({
+    layer,
+    state: "unknown" as const,
+    reason,
+    provingSpans: null,
+  }));
+}
+
+/**
+ * Parse the gateway's coverage payload into the panel's shape, defensively.
+ *
+ * Defensive because this is the last gate before a claim reaches a developer's screen. Anything the
+ * gateway sends that does not carry BOTH a `covered` state and a positive proving-span count is
+ * downgraded to `unknown` with a reason rather than trusted, so no wire-shape drift, no partial
+ * deploy and no future refactor can light a layer green without evidence behind it. A missing layer
+ * is reported unknown too, never silently dropped from the panel.
+ */
+export function parseCoverage(raw: unknown, wired: readonly string[] = []): LayerCoverage[] {
+  const rows = new Map<string, Record<string, unknown>>();
+  const list = (raw as { layers?: unknown } | null)?.layers;
+  if (Array.isArray(list)) {
+    for (const row of list) {
+      if (row && typeof row === "object" && typeof (row as { layer?: unknown }).layer === "string") {
+        rows.set((row as { layer: string }).layer, row as Record<string, unknown>);
+      }
+    }
+  }
+
+  return COVERAGE_LAYERS.map((layer) => {
+    const row = rows.get(layer);
+    if (!row) {
+      return { layer, state: "unknown" as const, reason: UNREADABLE, provingSpans: null };
+    }
+    const spansRaw = row.proving_spans;
+    const spans =
+      typeof spansRaw === "number" && Number.isFinite(spansRaw) && spansRaw >= 0
+        ? Math.floor(spansRaw)
+        : null;
+    const reason = typeof row.reason === "string" && row.reason.trim() ? row.reason : UNREADABLE;
+    const claimed = row.state;
+    if (
+      typeof claimed !== "string" ||
+      !(_STATES as readonly string[]).includes(claimed) ||
+      claimed === "unknown"
+    ) {
+      return { layer, state: "unknown" as const, reason, provingSpans: null };
+    }
+    // The evidence gate, and the reason this re-derives rather than trusting the wire: the state
+    // shown comes from the span count, so `covered` is structurally unreachable without one. A
+    // payload that claims coverage with nothing behind it reads as unknown, not as a green tick.
+    const state = layerCoverageState(
+      spans,
+      claimed === "awaiting_first_event" || wired.includes(layer),
+    );
+    if (claimed === "covered" && state !== "covered") {
+      return {
+        layer,
+        state: "unknown" as const,
+        reason:
+          "the probe reported this layer covered but returned no span to prove it, so we are not claiming it",
+        provingSpans: null,
+      };
+    }
+    return { layer, state, reason, provingSpans: spans };
+  });
+}


### PR DESCRIPTION
P3 of the onboarding-agent initiative: the verification loop and per-layer coverage reporting (spec §4.1, §7, §12 P3, §13). Stacked on `feat/i1-close-control-plane-auth-gap`, whose service-token gate the new control-plane endpoint uses.

## The problem

Initiative 2 §9 gave onboarding one binary signal: has any span landed for this tenant. That answers "are you connected" and nothing else, so a developer who wired the LLM one-liner and stopped there sees a green tick while tools, vector, embeddings and per-customer attribution are all still dark.

## What this adds

**Gateway** (`gateway/coverage_probe.py`, `GET /v1/tenant/onboarding/coverage`, service-token gated)

- The four operation layers come from ONE grouped pass over `otel_spans` (`GROUP BY GenAiOperation`), not four `LIMIT 1` probes over the same tenant range. The counts double as the evidence a covered layer displays.
- Attribution reads `daily_account_rollup` instead. That is the one read where a rollup is genuinely cheaper: `AccountIdHash` leads its key `(TenantId, AccountIdHash, Day, ...)` and is absent from `otel_spans`' ORDER BY entirely, so on the raw table the question degrades into a full tenant scan exactly when the answer is no, which is the case onboarding polls. The operation layers get no such benefit (`GenAiOperation` is that table's LAST key column), so they stay on the spans.
- The account check is `notEmpty(AccountIdHash)`, **verified against ClickHouse 24.8** on a column declared `FixedString(64) DEFAULT ''`: FixedString pads to width with NUL bytes, so `length(AccountIdHash) > 0` is true for every row including the unattributed ones and would have reported every tenant as fully attributed. `notEmpty` (and `!= ''`, which pads the literal) is 0 for the default and 1 for a real hash.

**Honest three-way state**, which is the point of §7

| state | meaning |
| --- | --- |
| `covered` | a real span proves it, with the count |
| `awaiting_first_event` | wired by the agent, code path not yet exercised |
| `not_wired` | no span and nothing claims to have wired it |
| `unknown` | the probe did not run, so we do not say |

Enforced in two places. In the gateway, `covered` is reachable only from a positive count. In the web mapper, `parseCoverage` re-derives the state from the count rather than trusting the wire, so a payload claiming coverage with nothing behind it renders `unknown`, not a green tick. Which layers are "wired" is an INPUT from the agent that proposed the diff (ClickHouse cannot tell unwired from unexercised); it only softens a dark layer's wording and can never manufacture coverage. An unreachable ClickHouse, an erroring gateway, an unparseable payload and a `daily_account_rollup` that was never backfilled all resolve to `unknown` with the reason attached, never to a report that the developer's instrumentation is missing. The two ClickHouse probes are caught separately so an unreadable rollup does not blank out the four layers the span probe answered.

**Web**

- `lib/firstEvent.ts` grows the per-layer types, mapper and defensive parser alongside its untouched binary `firstEventStatus` and its existing callers/tests.
- `app/api/onboarding/coverage/route.ts`: the service-token seam, so the browser never holds the control-plane token.
- `components/CoveragePanel.tsx` on the onboarding page: every dark layer names its reason, and a layer we could not read renders `Blank` with the reason on hover rather than a zero.

## Tests

Gateway `tests/test_app_coverage_probe.py` (14) covers: a layer with no span is never `covered` even when the caller claims it wired; an unreachable ClickHouse yields `unknown` with a null count, not `not_covered` and not a 5xx; an empty rollup under a tenant that has spans is `unknown` (our missing backfill, not their missing code); the service-token gate. Web: 13 mapper cases, 5 route cases (gateway 5xx, unreachable, covered-without-proof), 6 panel cases.

## Verification

- `infra/gateway`: 913 passed, `ruff check` clean.
- `web`: typecheck clean, lint clean (one pre-existing unrelated warning), 728 tests in 63 files passed. The two known ClickHouse-reachability cases passed locally too; no new failures.

## Deliberately out of scope

Wiring the MCP `coverage_report` tool (§4.2) to this endpoint: `sdk/python/onboarding_mcp/` is being changed concurrently and that hookup is the agreed follow-up. No change under `sdk/python/` or `infra/edge-proxy/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
