### PR TITLE
fix(sdk): review fixes for coverage_report MCP wiring (CTO-261)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -207,7 +207,7 @@ things from the environment:
 
 | Variable | What it is |
 |---|---|
-| `TALLY_GATEWAY_URL` | base URL of the gateway that holds your telemetry |
+| `TALLY_GATEWAY_URL` | base URL of the gateway that holds your telemetry. Must be `https://`, because the request carries the service token; plain `http://` is accepted only for `localhost`, `127.0.0.1` or `::1` so local dev still works |
 | `TALLY_TENANT_ID` | your tenant UUID, sent as `x-tenant-id` |
 | `GATEWAY_SERVICE_TOKEN` | the control-plane service token. Set `TALLY_GATEWAY_SERVICE_TOKEN_ENV` to read it from a differently named variable instead |
 
@@ -215,9 +215,15 @@ The token is held by reference: the tool reads the variable at the moment it cal
 never stores, echoes or logs the value. The `tenant_key` argument is likewise reported only as
 present or absent, never sent onward.
 
+The token is also never carried off the origin you configured: a redirect to a different scheme,
+host or port is refused rather than followed, so a load balancer that 301s elsewhere cannot be
+handed your service token.
+
 Leave these unset and the tool answers `probe_available: false` with every layer `unknown` and
-the reason attached. That is also what you get if the gateway is unreachable, answers an error,
-times out, or returns something unreadable. None of those ever turns into "this layer is not
+the reason attached. That is also what you get if `TALLY_GATEWAY_URL` is rejected as unsafe, or
+if the gateway is unreachable, answers an error, times out, redirects off-origin, or returns
+something unreadable or oversized. The result shape is the same on both paths, so `reason` is
+always present (empty when the probe answered). None of those ever turns into "this layer is not
 wired": a layer is reported covered only when the probe returns a span count above zero to prove
 it, re-derived from that count rather than taken on the wire's word, so a payload claiming
 coverage with no evidence is downgraded back to `unknown`.

--- a/sdk/python/onboarding_mcp/coverage_client.py
+++ b/sdk/python/onboarding_mcp/coverage_client.py
@@ -44,7 +44,20 @@ TENANT_ID_ENV = "TALLY_TENANT_ID"
 DEFAULT_TOKEN_ENV = "GATEWAY_SERVICE_TOKEN"
 TOKEN_ENV_REF = "TALLY_GATEWAY_SERVICE_TOKEN_ENV"
 
-DEFAULT_TIMEOUT_SECONDS = 5.0
+# The probe does two ClickHouse reads, one of them a grouped pass over ``otel_spans`` that gets no
+# key-prefix benefit, so a large or cold tenant can sit well past a few seconds. A short timeout
+# would report every layer unknown for a tenant that is in fact fully instrumented, so this matches
+# the 30s the sibling ``onboarding_bot/github_pr.py`` transport allows (CTO-261).
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+# A coverage payload is five small rows. Anything past this is not our endpoint answering, and
+# reading it unbounded would let a wrong or hostile host sit on the tool's memory (CTO-261).
+MAX_RESPONSE_BYTES = 1_048_576
+
+# Schemes we will send a bearer token over. Plain http is allowed only to a loopback host, where
+# there is no network to sniff, so local dev against ``http://localhost:8080`` keeps working while
+# a real deployment cannot ship the service token in cleartext (CTO-261).
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
 
 # The layer names the gateway speaks, keyed by the names this package has always used. The MCP
 # surface says "tool" (it mirrors ``tally.record_tool_call``); the probe says "tools". Translating
@@ -115,7 +128,49 @@ def config_from_env(env: Mapping[str, str] | None = None) -> tuple[CoverageConfi
             f"${token_env} with the control-plane service token. Nothing is being claimed about "
             f"your instrumentation."
         )
+    scheme_reason = _reject_unsafe_base(gateway_url)
+    if scheme_reason:
+        return None, scheme_reason
+
     return CoverageConfig(gateway_url=gateway_url, tenant_id=tenant_id, token_env=token_env), ""
+
+
+def _reject_unsafe_base(gateway_url: str) -> str:
+    """Say why ``gateway_url`` is not somewhere we will send a service token, or "" if it is.
+
+    A reason rather than an exception: a base URL we refuse is one more thing we do not know the
+    coverage for, and the caller turns it into the honest gap shape (CLAUDE.md, honest under
+    uncertainty). We check the scheme here rather than at call time so the refusal happens before
+    the token is ever read out of the environment (CTO-261).
+    """
+    try:
+        parsed = urllib.parse.urlsplit(gateway_url)
+    except ValueError:
+        return (
+            f"${GATEWAY_URL_ENV} is not a URL we can parse, so the coverage probe was not called. "
+            f"Nothing is being claimed about your instrumentation."
+        )
+
+    scheme = parsed.scheme.lower()
+    if scheme not in ("http", "https"):
+        return (
+            f"${GATEWAY_URL_ENV} must be an http or https URL (got "
+            f"{scheme or 'no scheme'!r}), so the coverage probe was not called. Nothing is being "
+            f"claimed about your instrumentation."
+        )
+    if not parsed.hostname:
+        return (
+            f"${GATEWAY_URL_ENV} has no host, so the coverage probe was not called. Nothing is "
+            f"being claimed about your instrumentation."
+        )
+    if scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+        return (
+            f"${GATEWAY_URL_ENV} uses plain http to a non-loopback host, which would send the "
+            f"control-plane service token in cleartext. Use https (plain http is allowed only for "
+            f"localhost). The coverage probe was not called and nothing is being claimed about "
+            f"your instrumentation."
+        )
+    return ""
 
 
 def resolve_token(config: CoverageConfig, env: Mapping[str, str] | None = None) -> str:
@@ -130,12 +185,71 @@ def resolve_token(config: CoverageConfig, env: Mapping[str, str] | None = None) 
     return token
 
 
+class _SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """A redirect handler that will not carry the service token to another origin (CTO-261).
+
+    ``HTTPRedirectHandler.redirect_request`` strips only ``content-length`` and ``content-type``
+    and re-sends every other header, ``authorization`` included, at whatever host the 30x names.
+    A gateway behind a load balancer that 301s elsewhere would therefore hand
+    ``$GATEWAY_SERVICE_TOKEN`` to that host. So a redirect that leaves the origin (scheme, host or
+    port) is refused outright rather than silently followed without the header: the tool's answer
+    is then an honest unknown, which is the correct outcome for "we could not safely ask"
+    (CLAUDE.md, credentials by reference).
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        if _origin(newurl) != _origin(req.full_url):
+            raise urllib.error.HTTPError(
+                req.full_url,
+                code,
+                "cross-origin redirect refused: the control-plane service token is not "
+                "forwarded off the configured gateway origin",
+                headers,
+                fp,
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    """(scheme, host, port) for same-origin comparison. Unparseable compares equal to nothing."""
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        port = parsed.port
+    except ValueError:
+        return ("", "", None)
+    default = {"http": 80, "https": 443}.get(parsed.scheme.lower())
+    return (parsed.scheme.lower(), (parsed.hostname or "").lower(), port or default)
+
+
+def _build_opener() -> urllib.request.OpenerDirector:
+    """An opener whose redirect handling cannot leak the token to another host (CTO-261)."""
+    return urllib.request.build_opener(_SameOriginRedirectHandler())
+
+
 def _urllib_transport(
     url: str, headers: dict[str, str], timeout: float
 ) -> str:  # pragma: no cover - exercised only against a real gateway
     request = urllib.request.Request(url, headers=headers, method="GET")
-    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 - configured base
-        return response.read().decode("utf-8")
+    # Never the module-level ``urlopen``: its default opener follows cross-host redirects with the
+    # authorization header attached (CTO-261).
+    with _build_opener().open(request, timeout=timeout) as response:  # noqa: S310 - scheme checked in config_from_env
+        return _read_capped(response)
+
+
+def _read_capped(response: Any) -> str:
+    """Read at most :data:`MAX_RESPONSE_BYTES`, refusing anything longer (CTO-261).
+
+    ``errors="replace"`` matches ``onboarding_bot/github_pr.py``: a non-UTF-8 error page from some
+    proxy in the path must not become a ``UnicodeDecodeError`` escaping the failure funnel. The
+    body is decoded only to be JSON-parsed, and never lands in an error message.
+    """
+    raw = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise CoverageUnavailable(
+            f"the coverage probe returned more than {MAX_RESPONSE_BYTES} bytes, which is not a "
+            f"coverage payload, so we could not read your coverage"
+        )
+    return raw.decode("utf-8", errors="replace")
 
 
 def fetch_coverage(
@@ -165,7 +279,18 @@ def fetch_coverage(
         raise CoverageUnavailable(
             f"the coverage probe answered HTTP {exc.code}, so we could not read your coverage"
         ) from None
-    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+    except CoverageUnavailable:
+        # The transport already produced a reason fit to show a developer (an oversized body, for
+        # one). Let it through rather than relabelling it.
+        raise
+    except Exception as exc:
+        # Deliberately everything else (CTO-261). The tool's contract is that no failure escapes as
+        # a crash: a scheme-less base makes ``urlopen`` raise a bare ``ValueError`` ("unknown url
+        # type"), ``http.client`` raises ``IncompleteRead`` / ``BadStatusLine``, and a non-UTF-8
+        # body raises ``UnicodeDecodeError``, none of which is an OSError. Every one of them means
+        # the same thing to a developer: we could not read your coverage. Only the exception CLASS
+        # NAME reaches the message, never ``str(exc)``, so neither the token nor a URL nor a
+        # response body can ride out in the reason (CLAUDE.md, no bodies in telemetry).
         raise CoverageUnavailable(
             f"the coverage probe could not be reached ({type(exc).__name__}), so we could not "
             f"read your coverage"
@@ -241,6 +366,38 @@ def derive_layer(row: Mapping[str, Any] | None, *, wired: bool = False) -> dict[
 
     if claimed == "covered" and derived != "covered":
         return {"status": "unknown", "reason": NO_EVIDENCE, "proving_spans": None}
+    if derived != claimed:
+        # The wire's prose describes the wire's state, so once we have re-derived a different one
+        # the two contradict each other and the prose is the half that is wrong. A row claiming
+        # ``not_wired`` with 5 proving spans would otherwise be reported covered while carrying
+        # "not wired: no span with GenAiOperation = 'tool'", and an unreadable count under
+        # ``not_wired`` would deliver a fabricated negative as text. Neither is honest, so we say
+        # what we derived and why (CTO-261).
+        return {
+            "status": derived,
+            "reason": _derived_reason(derived, spans),
+            "proving_spans": spans,
+        }
     if derived == "unknown":
         return {"status": "unknown", "reason": reason, "proving_spans": None}
     return {"status": derived, "reason": reason, "proving_spans": spans}
+
+
+def _derived_reason(derived: str, spans: int | None) -> str:
+    """The reason for a status we derived ourselves, used when the wire's prose disagrees."""
+    if derived == "covered":
+        return (
+            f"{spans} span(s) prove this layer is flowing, though the probe described it "
+            f"differently; we report what the evidence shows"
+        )
+    if derived == "awaiting_first_event":
+        return (
+            "this layer is wired but no span has arrived yet, though the probe described it "
+            "differently; we report what the evidence shows"
+        )
+    if derived == "not_wired":
+        return (
+            "no span proves this layer is flowing and it was not reported as newly wired, though "
+            "the probe described it differently; we report what the evidence shows"
+        )
+    return UNREADABLE

--- a/sdk/python/onboarding_mcp/generate.py
+++ b/sdk/python/onboarding_mcp/generate.py
@@ -298,6 +298,11 @@ def coverage_report(
     return {
         "tenant_key_present": bool(tenant_key),
         "probe_available": True,
+        # Present on both branches so the shape is stable: a caller reading ``result["reason"]``
+        # unconditionally used to get a KeyError exactly when the probe succeeded (CTO-261). The
+        # top-level reason explains why the probe as a whole did not answer, so on success it is
+        # empty; the per-layer reasons carry the detail.
+        "reason": "",
         "layers": [
             {
                 "layer": name,

--- a/sdk/python/tests/test_onboarding_mcp_coverage.py
+++ b/sdk/python/tests/test_onboarding_mcp_coverage.py
@@ -8,15 +8,21 @@ instrumentation is missing. The transport is a fake throughout, so no test opens
 
 from __future__ import annotations
 
+import http.client
 import json
 import urllib.error
+import urllib.request
 from typing import Any
 
 import pytest
 from onboarding_mcp import coverage_report
 from onboarding_mcp.coverage_client import (
+    MAX_RESPONSE_BYTES,
     CoverageConfig,
     CoverageUnavailable,
+    _build_opener,
+    _read_capped,
+    _SameOriginRedirectHandler,
     config_from_env,
     derive_layer,
     fetch_coverage,
@@ -252,3 +258,214 @@ def test_fetch_coverage_error_text_carries_no_token_and_no_body():
         fetch_coverage(CONFIG, transport=_raising(exc), env=ENV)
     assert "svc-token-value" not in str(caught.value)
     assert "internal" not in str(caught.value)
+
+
+# ---------------------------------------------------------------------------------------------
+# Review fixes (CTO-261): the token never crosses an origin, every failure stays a gap, and a
+# derived status never carries prose that contradicts it.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_scheme_less_url_is_a_gap_not_a_crash():
+    """``urlopen`` raises a bare ValueError ("unknown url type"), which is not an OSError."""
+    config = CoverageConfig(gateway_url="gateway.example", tenant_id="t")
+    boom = ValueError("unknown url type: 'gateway.example'")
+    with pytest.raises(CoverageUnavailable) as caught:
+        fetch_coverage(config, transport=_raising(boom), env=ENV)
+    assert "could not" in str(caught.value)
+
+    result = coverage_report("k", transport=_raising(boom), config=config, env=ENV)
+    _assert_all_unknown_with_reason(result, "ValueError")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        http.client.IncompleteRead(b""),
+        http.client.BadStatusLine("garbage"),
+        UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        RuntimeError("something nobody predicted"),
+    ],
+)
+def test_every_transport_failure_resolves_to_the_gap_shape(exc):
+    result = coverage_report("k", transport=_raising(exc), config=CONFIG, env=ENV)
+    assert result["probe_available"] is False
+    for layer in result["layers"]:
+        assert layer["status"] == "unknown"
+        assert layer["proving_spans"] is None
+        assert layer["reason"].strip()
+    # Only the class name travels: no token, no body.
+    assert "svc-token-value" not in json.dumps(result)
+
+
+def test_an_oversized_body_is_a_gap_not_an_unbounded_read():
+    class _Fat:
+        def __init__(self) -> None:
+            self.asked: int | None = None
+
+        def read(self, n: int | None = None) -> bytes:
+            self.asked = n
+            return b"x" * (MAX_RESPONSE_BYTES + 1)
+
+    fat = _Fat()
+    with pytest.raises(CoverageUnavailable) as caught:
+        _read_capped(fat)
+    # Capped at the source: the reader never pulls an unbounded stream into memory.
+    assert fat.asked == MAX_RESPONSE_BYTES + 1
+    assert "xxxx" not in str(caught.value)
+
+
+def test_a_non_utf8_body_decodes_instead_of_raising():
+    class _Mojibake:
+        def read(self, n: int | None = None) -> bytes:
+            return b'{"layers": []} \xff\xfe'
+
+    assert "layers" in _read_capped(_Mojibake())
+
+
+@pytest.mark.parametrize(
+    "base",
+    ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080", "https://gw.example"],
+)
+def test_a_safe_base_url_is_accepted(base):
+    config, reason = config_from_env({"TALLY_GATEWAY_URL": base, "TALLY_TENANT_ID": "abc"})
+    assert reason == ""
+    assert config is not None and config.gateway_url == base
+
+
+@pytest.mark.parametrize(
+    "base",
+    [
+        "http://gw.example",
+        "http://10.0.0.5:8080",
+        "ftp://gw.example",
+        "gateway.example",
+        "https://",
+    ],
+)
+def test_an_unsafe_base_url_is_a_reasoned_gap_not_an_exception(base):
+    config, reason = config_from_env({"TALLY_GATEWAY_URL": base, "TALLY_TENANT_ID": "abc"})
+    assert config is None
+    assert "TALLY_GATEWAY_URL" in reason
+    assert "othing is being claimed" in reason
+
+
+def test_a_cleartext_base_is_refused_before_the_token_is_read():
+    env = {
+        "TALLY_GATEWAY_URL": "http://gw.example",
+        "TALLY_TENANT_ID": "abc",
+        "GATEWAY_SERVICE_TOKEN": "svc-token-value",
+    }
+    result = coverage_report("k", config=None, env=env, transport=_transport(_payload()))
+    _assert_all_unknown_with_reason(result, "https")
+    assert "svc-token-value" not in json.dumps(result)
+
+
+class _FakeResponse:
+    """Enough of a response object for ``HTTPRedirectHandler.redirect_request``.
+
+    ``HTTPError`` adopts the fp it is handed, so it needs ``close`` as well as ``read``.
+    """
+
+    def read(self, n: int | None = None) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        return None
+
+
+def _redirect(from_url: str, to_url: str):
+    handler = _SameOriginRedirectHandler()
+    request = urllib.request.Request(from_url, headers={"authorization": "Bearer svc-token-value"})
+    return handler.redirect_request(
+        request, _FakeResponse(), 301, "Moved", {"location": to_url}, to_url
+    )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "https://evil.example/v1/tenant/onboarding/coverage",
+        "http://gateway.example/v1/tenant/onboarding/coverage",
+        "https://gateway.example:8443/v1/tenant/onboarding/coverage",
+    ],
+)
+def test_a_cross_origin_redirect_never_forwards_the_authorization_header(target):
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        _redirect("https://gateway.example/v1/tenant/onboarding/coverage", target)
+    assert "svc-token-value" not in str(caught.value)
+    assert "cross-origin redirect refused" in str(caught.value)
+
+
+def test_a_same_origin_redirect_is_still_followed():
+    redirected = _redirect(
+        "https://gateway.example/v1/tenant/onboarding/coverage",
+        "https://gateway.example/v2/tenant/onboarding/coverage",
+    )
+    assert redirected is not None
+    assert redirected.full_url == "https://gateway.example/v2/tenant/onboarding/coverage"
+
+
+def test_the_transport_opener_carries_the_same_origin_redirect_handler():
+    opener = _build_opener()
+    assert any(isinstance(handler, _SameOriginRedirectHandler) for handler in opener.handlers)
+
+
+def test_the_default_timeout_allows_for_a_cold_clickhouse_read():
+    assert CoverageConfig(gateway_url="https://gw.example", tenant_id="t").timeout >= 30.0
+
+
+def test_a_drifted_row_reason_matches_the_status_we_derived():
+    """A ``not_wired`` row with real spans must not carry "not wired" prose under ``covered``."""
+    row = {
+        "layer": "tools",
+        "state": "not_wired",
+        "proving_spans": 5,
+        "reason": "not wired: no span with GenAiOperation = 'tool'",
+    }
+    derived = derive_layer(row)
+    assert derived["status"] == "covered"
+    assert derived["proving_spans"] == 5
+    assert "not wired" not in derived["reason"]
+
+
+def test_an_unreadable_count_never_delivers_a_fabricated_negative_as_prose():
+    row = {
+        "layer": "tools",
+        "state": "not_wired",
+        "proving_spans": "many",
+        "reason": "not wired: no span found",
+    }
+    derived = derive_layer(row)
+    assert derived["status"] == "unknown"
+    assert derived["proving_spans"] is None
+    assert "not wired" not in derived["reason"]
+
+
+def test_an_agreeing_row_keeps_the_probes_own_prose():
+    derived = derive_layer(_row("llm", "covered", 12))
+    assert derived["status"] == "covered"
+    assert derived["reason"] == "llm: covered"
+
+
+def test_a_drifted_awaiting_row_says_it_is_awaiting_not_what_the_wire_said():
+    row = {
+        "layer": "vector",
+        "state": "not_wired",
+        "proving_spans": 0,
+        "reason": "not wired at all",
+    }
+    derived = derive_layer(row, wired=True)
+    assert derived["status"] == "awaiting_first_event"
+    assert "not wired at all" not in derived["reason"]
+
+
+def test_the_success_path_carries_a_reason_key_too():
+    result = coverage_report(
+        "k", transport=_transport(_payload(_row("llm", "covered", 3))), config=CONFIG, env=ENV
+    )
+    assert result["probe_available"] is True
+    # Reading result["reason"] unconditionally must not raise on the success branch.
+    assert result["reason"] == ""
+    failed = coverage_report("k", transport=_raising(TimeoutError()), config=CONFIG, env=ENV)
+    assert set(failed) == set(result)


### PR DESCRIPTION
Review fixes for #288. Base is `feat/i3-p3-coverage-report-mcp` so the stack stays intact. All changes are under `sdk/python/`; SDK runtime dependencies stay empty (stdlib `urllib` only).

## Finding 1 (MUST FIX, security): token forwarded across redirects, scheme unvalidated

`_urllib_transport` used the module-level `urllib.request.urlopen`, whose default opener follows 30x with the `authorization` header attached: `HTTPRedirectHandler.redirect_request` strips only `content-length` and `content-type`. A gateway behind an LB that 301s to another host would have been handed `$GATEWAY_SERVICE_TOKEN`.

- Added `_SameOriginRedirectHandler`, which raises rather than following any redirect that changes scheme, host or port. `_build_opener()` installs it and the transport uses `opener.open`, never the module-level `urlopen`.
- Added `_reject_unsafe_base` in `config_from_env`: `https` is required, plain `http` is allowed only for `localhost` / `127.0.0.1` / `::1` so local dev keeps working. Anything else (bad scheme, no host, unparseable) returns `(None, reason)`, which the caller turns into the honest gap shape. No exception escapes, and the base is checked before the token is ever read out of the environment.

## Finding 2 (MUST FIX): except clauses too narrow

`fetch_coverage` guarded only `HTTPError`, `TimeoutError`, `URLError`, `OSError`. A scheme-less base such as `gateway.example` makes `urlopen` raise a bare `ValueError`, and `http.client.IncompleteRead` / `BadStatusLine` and `UnicodeDecodeError` escaped the same way, crashing the MCP tool.

- The guard is now a deliberate catch-all after the two specific clauses, so every failure resolves to `probe_available: false` with a reason. Only the exception class name reaches the message, never `str(exc)`, so no token, URL or body can ride out.
- The body decodes with `errors="replace"`, matching `onboarding_bot/github_pr.py`.

## Finding 3 (SHOULD FIX): derived status carried the wire's contradicting reason

`derive_layer` re-derived the status but passed the wire's `reason` through, so a drifted row `{"state": "not_wired", "proving_spans": 5}` reported `covered` while carrying "not wired: no span with GenAiOperation = 'tool'", and an unreadable count under `not_wired` delivered a fabricated negative as prose.

- Whenever the derived status differs from the claimed one, a derived reason is substituted (`_derived_reason`). An agreeing row still keeps the probe's own prose, and the existing `covered`-without-evidence downgrade is untouched.

## Finding 4 (MINOR): unstable result shape

`generate.py` emitted a top-level `reason` only on the failure path, so `result["reason"]` raised `KeyError` exactly when the probe succeeded. The success branch now emits `"reason": ""`.

## Finding 5 (MINOR): default timeout

Raised from 5s to 30s, matching the sibling `onboarding_bot/github_pr.py` transport, with a comment on why (the endpoint does two ClickHouse reads, one a grouped pass over `otel_spans` with no key-prefix benefit, so a cold tenant would otherwise report every layer unknown while fully instrumented).

## Finding 6 (MINOR): unbounded read

`response.read()` is now `_read_capped`, reading at most `MAX_RESPONSE_BYTES` (1 MiB) + 1 and treating anything longer as the honest gap shape with a reason. The cap is applied at the read call, so an oversized stream is never pulled into memory whole.

## Regression tests

All in `sdk/python/tests/test_onboarding_mcp_coverage.py`, all with fakes; no test opens a socket.

- `test_a_scheme_less_url_is_a_gap_not_a_crash` (finding 2)
- `test_every_transport_failure_resolves_to_the_gap_shape`, parametrized over `IncompleteRead`, `BadStatusLine`, `UnicodeDecodeError` and an unforeseen `RuntimeError` (finding 2)
- `test_a_cross_origin_redirect_never_forwards_the_authorization_header`, parametrized over a different host, a different scheme and a different port; plus `test_a_same_origin_redirect_is_still_followed` and `test_the_transport_opener_carries_the_same_origin_redirect_handler` (finding 1)
- `test_a_safe_base_url_is_accepted` / `test_an_unsafe_base_url_is_a_reasoned_gap_not_an_exception` / `test_a_cleartext_base_is_refused_before_the_token_is_read` (finding 1)
- `test_a_drifted_row_reason_matches_the_status_we_derived`, `test_an_unreadable_count_never_delivers_a_fabricated_negative_as_prose`, `test_a_drifted_awaiting_row_says_it_is_awaiting_not_what_the_wire_said`, `test_an_agreeing_row_keeps_the_probes_own_prose` (finding 3)
- `test_the_success_path_carries_a_reason_key_too`, which also asserts both branches have identical key sets (finding 4)
- `test_the_default_timeout_allows_for_a_cold_clickhouse_read` (finding 5)
- `test_an_oversized_body_is_a_gap_not_an_unbounded_read`, `test_a_non_utf8_body_decodes_instead_of_raising` (finding 6)

The honesty contract is preserved: no layer reaches `covered` without a positive proving-span count, and every failure mode is unknown-with-reason with `proving_spans` null, never 0. The anti-hallucination guard in `sdk_surface.py` is untouched.

`README.md` documents the new https requirement, the off-origin redirect refusal and the stable `reason` key.

## Verification

```
cd sdk/python && uv run --extra dev pytest -q   # 1231 passed
cd sdk/python && uv run ruff check .            # All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
