### PR TITLE
fix(edge-proxy): costable Gemini spans, visible telemetry loss (PR #284 review)

### DIFF
--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -58,7 +58,7 @@ These are enforced by tests, not just documented:
 | `EDGE_PROXY_BROKER_TTL` | `5m` | how long a minted credential is reused before re-minting |
 | `EDGE_PROXY_SELF_HOSTED` | `false` | label emitted telemetry as `self-host` vs `cloud` |
 | `EDGE_PROXY_TELEMETRY_URL` | — | gateway ingest endpoint (`https://gateway/v1/batches`) the proxy POSTs metadata-only spans to; empty disables shipping |
-| `EDGE_PROXY_INGEST_TOKEN` | — | **fallback** bearer for those POSTs, used only for records that carry no tenant key of their own (single-tenant self-host without `EDGE_PROXY_REQUIRE_TENANT`); normally the presented `X-Tenant-Key` authenticates |
+| `EDGE_PROXY_INGEST_TOKEN` | — | **fallback** bearer for those POSTs, used for every record whose `X-Tenant-Key` the edge-key cache did not resolve; normally a resolved `X-Tenant-Key` authenticates. Set it on any self-host without `EDGE_PROXY_KEYS_URL`, or telemetry is shed |
 | `EDGE_PROXY_ROUTES` | — | hosted multi-provider route table (see below); empty keeps single-origin `EDGE_PROXY_UPSTREAM` |
 | `EDGE_PROXY_ROUTE_MODE` | `host` | `host` (match on hostname, hosted default) or `path` (match+strip a leading prefix) |
 | `EDGE_PROXY_KEYS_URL` | — | gateway delta feed `GET /v1/edge/keys?since={cursor}` for key-to-tenant resolution; empty disables it |
@@ -217,20 +217,43 @@ traffic does and lands in the same `otel_spans` columns:
 Method, path, byte counts, upstream-failure flag and the deployment label ride along as span
 attributes and land in `SpanAttributes`, so nothing about this needed a schema change.
 
-**Auth.** Each POST carries `Authorization: Bearer <the tenant key the caller presented>`. That key
-is the caller's own ai-tally api key, so the gateway resolves it to the same tenant the proxy did
-and every batch is authenticated by the tenant it belongs to, which is what makes the hosted
-multi-tenant deployment correct by construction. The key travels on the header only; it is never a
-field in the body and never logged. `EDGE_PROXY_INGEST_TOKEN` is the fallback for a deployment
-whose requests carry no tenant key at all. With neither available the record is shed and counted
-(`HTTPSink.Unauthenticated()`) rather than posted unattributable.
+The route's provider label is mapped to the `gen_ai.system` value the rest of the product uses:
+`gemini` ships as **`google`**, because that is the provider string the price catalog keys Google
+models under and it compares by exact equality. Without the mapping every hosted Gemini span would
+be permanently uncostable and would aggregate separately from the same org's SDK Gemini spans.
+(`TestGeminiShipsAsGoogleSystem`.)
 
-**Unknown stays unknown.** Token counts are nullable end to end: a streamed response, a body past
-the metadata scan cap, and an error response all leave them absent from the JSON, so they reach
-storage as NULL. A `0` would read downstream as a real call that consumed nothing. Same for the
-model and the provider: omitted when they could not be extracted, which makes the span honestly
-unpriceable rather than priced against a guess. (`TestUnknownTokensSerializeAsNullNeverZero`,
+**Auth.** Each POST carries `Authorization: Bearer <the tenant key the caller presented>`, but only
+when the edge-key cache actually **resolved** that key. A resolved key is the caller's own ai-tally
+api key, so the gateway resolves it to the same tenant the proxy did and every batch is
+authenticated by the tenant it belongs to, which is what makes the hosted multi-tenant deployment
+correct by construction. An unresolved `X-Tenant-Key` is just a client-controlled string, not a
+credential, so it never becomes an outgoing bearer: `EDGE_PROXY_INGEST_TOKEN` is used instead. With
+neither available the record is shed and counted (`HTTPSink.Unauthenticated()`) rather than posted
+unattributable. The key travels on the header only; it is never a field in the body and never
+logged.
+
+**Failure is never silent.** A config that can authenticate nothing (`EDGE_PROXY_TELEMETRY_URL` set,
+no `EDGE_PROXY_INGEST_TOKEN`, no `EDGE_PROXY_KEYS_URL`) is warned about at startup rather than
+logging a destination the proxy will never write to (`Config.Warnings()`). At runtime the sink
+reports what it shed once a minute and again at shutdown, and stays silent when it shed nothing.
+Per-item refusals count too: the gateway reports validation failures as `partial_errors` inside an
+HTTP **200** body, so the sink parses the ack and counts any span the gateway did not accept
+(`HTTPSink.Rejected()`), logging the error codes but never the gateway's per-item messages, which
+can echo request detail.
+
+**Unknown stays unknown on the wire.** A streamed response, a body past the metadata scan cap, and
+an error response all leave the token counts absent from the emitted JSON rather than serialized as
+`0`, which would read downstream as a real call that consumed nothing. Same for the model and the
+provider: omitted when they could not be extracted, which makes the span honestly unpriceable rather
+than priced against a guess. (`TestUnknownTokensSerializeAsNullNeverZero`,
 `TestZeroTokensStillSerialize`.)
+
+That guarantee currently ends at the proxy's outbound wire. The gateway's mapping coerces a missing
+count to `0` and the `otel_spans` token columns are non-nullable `UInt32`, so an omitted count still
+lands as `0` in storage today. Carrying the unknown through as a real `NULL` needs a gateway and
+schema change tracked separately; what the proxy guarantees is that it is not the place the `0` is
+invented.
 
 ### Container image
 

--- a/infra/edge-proxy/cmd/edge-proxy/main.go
+++ b/infra/edge-proxy/cmd/edge-proxy/main.go
@@ -22,10 +22,21 @@ import (
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/telemetry"
 )
 
+// telemetryReportInterval is how often the sink summarizes shed records. A minute is frequent
+// enough to notice a broken pipeline in the first alert window and quiet enough that a healthy
+// proxy (which logs nothing, since the report is silent when nothing was shed) stays quiet.
+const telemetryReportInterval = time.Minute
+
 func main() {
 	cfg, err := config.FromEnv(os.Getenv)
 	if err != nil {
 		log.Fatalf("edge-proxy: config error: %v", err)
+	}
+
+	// A config can parse cleanly and still ship nothing (telemetry with no usable credential). Say so
+	// loudly at boot rather than logging a destination the proxy will never successfully write to.
+	for _, w := range cfg.Warnings() {
+		log.Printf("edge-proxy: WARNING: %s", w)
 	}
 
 	var opts []proxy.Option
@@ -55,6 +66,10 @@ func main() {
 			URL:         cfg.TelemetryURL,
 			Deployment:  dep,
 			IngestToken: cfg.IngestToken,
+			// Shed records are the only evidence of a telemetry pipeline that is failing without
+			// erroring (no credential, every span rejected per item). Report them on a cadence so the
+			// operator finds out from the proxy's own log instead of from a missing dashboard.
+			ReportInterval: telemetryReportInterval,
 		})
 		opts = append(opts, proxy.WithSink(sink))
 		log.Printf("edge-proxy: telemetry -> %s (deployment=%s)", cfg.TelemetryURL, dep)
@@ -139,7 +154,9 @@ func main() {
 		log.Printf("edge-proxy: graceful shutdown failed: %v", err)
 	}
 	if sink != nil {
-		sink.Close() // flush any buffered telemetry before exit
+		// Flush buffered telemetry, then report anything that was shed: a proxy that shipped nothing
+		// at all must say so before it exits.
+		sink.Close()
 	}
 	log.Printf("edge-proxy: stopped")
 }

--- a/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
+++ b/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
@@ -45,10 +45,11 @@ proxy:
   # /v1/batches requests (e.g. https://ingest.ai-tally.com/v1/batches). Empty disables telemetry
   # shipping entirely (the proxy still works; it just emits nothing).
   #
-  # Each batch is authenticated by the tenant key the caller presented, so no credential is
-  # configured here. A single-tenant install whose callers send no tenant key needs the
-  # EDGE_PROXY_INGEST_TOKEN fallback instead; that is a secret, so set it on the Deployment from
-  # your own Secret rather than through this chart's ConfigMap.
+  # Each batch is authenticated by the tenant key the caller presented, provided the edge-key cache
+  # resolved it, so a deployment with keysURL set needs no credential here. Any other install (no
+  # key feed, or callers that send no tenant key) needs the EDGE_PROXY_INGEST_TOKEN fallback, or its
+  # telemetry is shed unauthenticated and the proxy warns about it at startup. That token is a
+  # secret, so set it on the Deployment from your own Secret rather than through this ConfigMap.
   telemetryURL: ""
 
 # --- key broker (broker mode only) -------------------------------------------------------------

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -133,10 +133,11 @@ type Config struct {
 	// single-span batches (the gateway's POST /v1/batches). Empty disables telemetry shipping
 	// (NopSink), as in the CTO-39 core.
 	TelemetryURL string
-	// IngestToken is the fallback bearer for those POSTs, used only when a record carries no tenant
-	// key of its own. Normally the presented X-Tenant-Key authenticates the batch, which is what
-	// keeps the hosted multi-tenant deployment attributing each batch to its own tenant; a
-	// single-tenant self-host that runs without RequireTenant sets this instead. It is a reference
+	// IngestToken is the fallback bearer for those POSTs, used for every record that did not present
+	// a tenant key the edge-key cache resolved. Normally the presented X-Tenant-Key authenticates the
+	// batch, which is what keeps the hosted multi-tenant deployment attributing each batch to its own
+	// tenant; a self-host with no edge-key feed, or one running without RequireTenant, sets this
+	// instead and Warnings() says so at startup when it is missing. It is a reference
 	// to a deployment secret (env var rendered from Secret Manager / KMS), never a key we mint.
 	IngestToken string
 
@@ -323,6 +324,34 @@ func FromEnv(lookup Env) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// Warnings returns operator-facing problems with a configuration that parses cleanly but will not
+// behave as the operator intends. They are warnings rather than errors because none of them is
+// wrong for every deployment, and refusing to boot would break a proxy that is deliberately running
+// without telemetry.
+//
+// The case that motivated this: the default self-host config (EDGE_PROXY_TELEMETRY_URL set, no
+// EDGE_PROXY_INGEST_TOKEN, RequireTenant off, no edge-key feed) ships exactly zero telemetry, since
+// no record can produce a credential, while startup still logs a cheerful "telemetry -> <url>". A
+// total, permanent failure must not be silent.
+func (c Config) Warnings() []string {
+	var out []string
+	if c.TelemetryURL == "" || c.IngestToken != "" {
+		return out
+	}
+	// Only a key the edge-key cache resolved is used as a bearer, so with no feed configured no
+	// record can ever authenticate itself and the ingest token is the only possible credential.
+	if c.KeysURL == "" {
+		out = append(out, "EDGE_PROXY_TELEMETRY_URL is set but EDGE_PROXY_INGEST_TOKEN is empty and "+
+			"EDGE_PROXY_KEYS_URL is unset: no record can be authenticated, so every span will be shed "+
+			"and NO telemetry will reach ingest")
+	} else if !c.RequireTenant {
+		out = append(out, "EDGE_PROXY_TELEMETRY_URL is set but EDGE_PROXY_INGEST_TOKEN is empty and "+
+			"EDGE_PROXY_REQUIRE_TENANT is off: telemetry for any request that arrives without a "+
+			"resolvable tenant key will be shed unauthenticated")
+	}
+	return out
 }
 
 // parseRoutes builds the route table from EDGE_PROXY_ROUTES. Two wire forms are accepted:

--- a/infra/edge-proxy/internal/config/config_test.go
+++ b/infra/edge-proxy/internal/config/config_test.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -226,5 +227,65 @@ func TestAccountIdHashHeaderOverride(t *testing.T) {
 	}
 	if cfg.AccountIdHashHeader != "X-Acct" {
 		t.Errorf("AccountIdHashHeader = %q", cfg.AccountIdHashHeader)
+	}
+}
+
+// TestWarningsOnSilentlyUndeliverableTelemetry: the default self-host shape (a telemetry URL, no
+// ingest token, no edge-key feed) can authenticate nothing, so it ships zero telemetry while
+// startup logs a destination. That must be warned about, not discovered from an empty dashboard.
+func TestWarningsOnSilentlyUndeliverableTelemetry(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_TELEMETRY_URL": "https://ingest.example.com/v1/batches",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	warnings := cfg.Warnings()
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "NO telemetry") {
+		t.Fatalf("want a loud no-telemetry warning, got %v", warnings)
+	}
+}
+
+// TestWarningsOnOpenModeWithoutIngestToken: with a key feed configured, only a request carrying a
+// resolvable key can authenticate its own telemetry. In open mode the rest are shed, which is a
+// real (partial) loss the operator should hear about.
+func TestWarningsOnOpenModeWithoutIngestToken(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_TELEMETRY_URL": "https://ingest.example.com/v1/batches",
+		"EDGE_PROXY_KEYS_URL":      "https://gw.example.com/v1/edge/keys",
+		"EDGE_PROXY_SERVICE_TOKEN": "svc",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	warnings := cfg.Warnings()
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "shed unauthenticated") {
+		t.Fatalf("want a partial-loss warning, got %v", warnings)
+	}
+}
+
+// TestNoWarningsOnHealthyConfigs: a proxy with no telemetry at all, and a fully configured one, are
+// both correct. A warning that fires on a healthy config trains operators to ignore warnings.
+func TestNoWarningsOnHealthyConfigs(t *testing.T) {
+	for name, env := range map[string]map[string]string{
+		"telemetry off": nil,
+		"ingest token set": {
+			"EDGE_PROXY_TELEMETRY_URL": "https://ingest.example.com/v1/batches",
+			"EDGE_PROXY_INGEST_TOKEN":  "svc_token",
+		},
+		"require tenant with key feed": {
+			"EDGE_PROXY_TELEMETRY_URL":  "https://ingest.example.com/v1/batches",
+			"EDGE_PROXY_KEYS_URL":       "https://gw.example.com/v1/edge/keys",
+			"EDGE_PROXY_SERVICE_TOKEN":  "svc",
+			"EDGE_PROXY_REQUIRE_TENANT": "true",
+		},
+	} {
+		cfg, err := FromEnv(envMap(env))
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+		if got := cfg.Warnings(); len(got) != 0 {
+			t.Errorf("%s: unexpected warnings %v", name, got)
+		}
 	}
 }

--- a/infra/edge-proxy/internal/proxy/provider.go
+++ b/infra/edge-proxy/internal/proxy/provider.go
@@ -22,8 +22,10 @@ import (
 //
 // The token counts are pointers, not plain int64s, because "the provider did not report usage"
 // (streaming, an error response, a body past the scan cap) and "the provider reported zero" are
-// different facts and telemetry must not conflate them. A nil count stays NULL all the way to
-// storage; a fabricated 0 would read downstream as a real, free call.
+// different facts and telemetry must not conflate them. A nil count is omitted from the emitted
+// wire rather than serialized, so the proxy never invents the number; a fabricated 0 would read
+// downstream as a real, free call. (Storage does not yet preserve the distinction: see the note in
+// internal/telemetry on the pending gateway and schema change.)
 type responseMeta struct {
 	Model            string
 	PromptTokens     *int64

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -47,10 +47,13 @@ type TraceRecord struct {
 	// PromptTokens / CompletionTokens are the input/output token counts reported by the provider in
 	// the response usage block (OpenAI usage.prompt_tokens/completion_tokens, Anthropic
 	// usage.input_tokens/output_tokens, Gemini usageMetadata.promptTokenCount/candidatesTokenCount).
-	// They are pointers so unknown stays NULL: pass-through mode, a stream past the scan cap, and an
-	// error response all leave them nil, and nil is omitted from the wire rather than serialized as
-	// 0. A fabricated 0 would read downstream as a real call that cost nothing, which the
-	// honest-under-uncertainty invariant forbids. These are scalar counts only, and extracting them
+	// They are pointers so unknown stays unknown on the wire: pass-through mode, a stream past the
+	// scan cap, and an error response all leave them nil, and nil is omitted from the emitted JSON
+	// rather than serialized as 0. A fabricated 0 would read downstream as a real call that cost
+	// nothing, which the honest-under-uncertainty invariant forbids. Storage does not yet preserve
+	// that distinction (the gateway coerces a missing count to 0 into a non-nullable column); the
+	// end-to-end NULL depends on a separately tracked gateway/schema change, and the proxy's job is
+	// to stop being the place the 0 is invented. These are scalar counts only, and extracting them
 	// never persists or logs the body they came from.
 	PromptTokens     *int64
 	CompletionTokens *int64

--- a/infra/edge-proxy/internal/telemetry/telemetry.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry.go
@@ -25,11 +25,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/proxy"
 )
 
@@ -86,8 +88,14 @@ type wireSpan struct {
 	System        string `json:"gen_ai.system,omitempty"`
 	ResponseModel string `json:"gen_ai.response.model,omitempty"`
 	// InputTokens / OutputTokens are pointers so an unknown count is omitted from the JSON entirely
-	// and reaches storage as NULL. A count the provider genuinely reported as 0 still serializes as
-	// 0, because omitempty on a pointer keys off nil, not off the pointed-to value.
+	// rather than serialized as a fabricated 0. A count the provider genuinely reported as 0 still
+	// serializes as 0, because omitempty on a pointer keys off nil, not off the pointed-to value.
+	//
+	// What the proxy guarantees is the wire: unknown is absent, never 0. It does NOT currently
+	// guarantee a NULL in storage. The gateway's mapping coerces a missing count to 0 and the
+	// ClickHouse columns are non-nullable UInt32, so today an omitted count still lands as 0 in
+	// otel_spans. Making unknown survive as NULL end to end needs a gateway + schema change that is
+	// tracked separately; this encoder is the half of it that can be honest without one.
 	InputTokens  *int64 `json:"gen_ai.usage.input_tokens,omitempty"`
 	OutputTokens *int64 `json:"gen_ai.usage.output_tokens,omitempty"`
 	// FeatureTag / AccountIdHash mirror the same span attributes the Python SDK emits, so a proxied
@@ -138,14 +146,31 @@ func defaultIds() ids {
 
 // randomHex returns nBytes of crypto-random data as lowercase hex. Trace and span ids only need to
 // be unique; they carry no meaning and must not encode anything about the request.
+//
+// There is deliberately no error branch: crypto/rand.Read never returns an error and always fills
+// the buffer entirely (it panics rather than degrading), so there is no partial-success case to
+// handle. An earlier version returned the same all-zeros encoding on both paths, which would have
+// been actively harmful here: batch_id also comes from this function, and a run of zero batch ids
+// would collide on the gateway's (tenant_id, batch_id) idempotency key so every batch after the
+// first is discarded as a replay for the cache TTL.
 func randomHex(nBytes int) string {
 	b := make([]byte, nBytes)
-	if _, err := rand.Read(b); err != nil {
-		// crypto/rand does not fail in practice; a degraded id is still better than dropping the
-		// span, and the gateway dedupes on (trace_id, span_id) within a batch of one.
-		return hex.EncodeToString(b)
-	}
+	rand.Read(b) //nolint:errcheck // documented never to fail; see above
 	return hex.EncodeToString(b)
+}
+
+// genAISystem maps the proxy's route protocol label to the gen_ai.system value the rest of the
+// product uses. openai and anthropic are already the catalog's provider strings, but Google models
+// are catalogued under "google" (sdk/python/src/tally/pricing.py, where the comment states the
+// catalog string IS the gen_ai.system value), and PriceCatalog._best compares the provider by exact
+// string equality. Shipping the route label "gemini" verbatim would therefore miss the catalog and
+// leave every hosted Gemini span permanently uncostable, and would split the provider dimension so
+// one org's SDK Gemini spans and its proxy Gemini spans never aggregate together.
+func genAISystem(provider string) string {
+	if provider == string(config.ProviderGemini) {
+		return "google"
+	}
+	return provider
 }
 
 func toWire(dep Deployment, rec proxy.TraceRecord, id ids) wireBatch {
@@ -164,7 +189,7 @@ func toWire(dep Deployment, rec proxy.TraceRecord, id ids) wireBatch {
 		StatusCode:     status,
 		DurationNs:     rec.Duration.Nanoseconds(),
 		Operation:      "chat",
-		System:         rec.Provider,
+		System:         genAISystem(rec.Provider),
 		ResponseModel:  rec.Model,
 		InputTokens:    rec.PromptTokens,
 		OutputTokens:   rec.CompletionTokens,
@@ -208,17 +233,41 @@ type HTTPSink struct {
 	ingestToken string
 	client      *http.Client
 	ch          chan proxy.TraceRecord
+	logf        func(format string, args ...any)
 
 	wg       sync.WaitGroup
 	closeOne sync.Once
+	done     chan struct{}
 
 	// dropped counts records shed because the buffer was full, unauthenticated counts records shed
-	// because no ingest credential was available for them (observability for the operator: both are
-	// real telemetry loss and neither is silently papered over).
+	// because no ingest credential was available for them, and rejected counts spans the gateway
+	// declined per item (observability for the operator: all three are real telemetry loss and none
+	// is silently papered over).
 	mu              sync.Mutex
 	dropped         int64
 	unauthenticated int64
+	rejected        int64
+	// reported is the last snapshot logged, so a periodic report says what changed rather than
+	// re-reporting a total that has stopped moving.
+	reported Stats
 }
+
+// Stats is a snapshot of the sink's telemetry-loss counters.
+type Stats struct {
+	// Dropped is records shed because the buffer was full (collector down or slow).
+	Dropped int64
+	// Unauthenticated is records shed because no credential was available to authenticate them.
+	Unauthenticated int64
+	// Rejected is spans the gateway declined per item, reported as partial_errors. The gateway
+	// reports per-item validation failures inside an HTTP 200 body, so without this counter a
+	// deployment whose every span is refused (PII_DETECTED, PAYLOAD_TOO_LARGE, load shedding) looks
+	// perfectly healthy from here.
+	Rejected int64
+}
+
+// Any reports whether anything at all has been shed. An operator only needs to hear from the sink
+// when the answer is yes.
+func (s Stats) Any() bool { return s.Dropped > 0 || s.Unauthenticated > 0 || s.Rejected > 0 }
 
 // Options configures an HTTPSink.
 type Options struct {
@@ -234,6 +283,12 @@ type Options struct {
 	Buffer int
 	// Client overrides the HTTP client (mainly for tests); defaults to a short-timeout client.
 	Client *http.Client
+	// ReportInterval, when > 0, starts a ticker that logs newly shed records at that cadence. The
+	// counters are otherwise unreachable from outside the process, so a total telemetry failure (a
+	// misconfigured credential, a gateway rejecting every span) would be completely silent.
+	ReportInterval time.Duration
+	// Logf overrides where the sink logs (tests); defaults to log.Printf.
+	Logf func(format string, args ...any)
 }
 
 // NewHTTPSink builds and starts an HTTPSink. Call Close to flush and stop the worker.
@@ -250,15 +305,25 @@ func NewHTTPSink(o Options) *HTTPSink {
 	if dep == "" {
 		dep = DeploymentCloud
 	}
+	logf := o.Logf
+	if logf == nil {
+		logf = log.Printf
+	}
 	s := &HTTPSink{
 		url:         o.URL,
 		deployment:  dep,
 		ingestToken: o.IngestToken,
 		client:      client,
 		ch:          make(chan proxy.TraceRecord, buf),
+		logf:        logf,
+		done:        make(chan struct{}),
 	}
 	s.wg.Add(1)
 	go s.run()
+	if o.ReportInterval > 0 {
+		s.wg.Add(1)
+		go s.reportLoop(o.ReportInterval)
+	}
 	return s
 }
 
@@ -280,12 +345,66 @@ func (s *HTTPSink) Dropped() int64 {
 	return s.dropped
 }
 
-// Unauthenticated returns the number of records shed because neither the record's tenant key nor a
+// Unauthenticated returns the number of records shed because neither a resolved tenant key nor a
 // configured ingest token was available to authenticate the POST.
 func (s *HTTPSink) Unauthenticated() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.unauthenticated
+}
+
+// Rejected returns the number of spans the gateway declined per item (partial_errors).
+func (s *HTTPSink) Rejected() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rejected
+}
+
+// Stats snapshots all three loss counters at once, so an operator report cannot mix reads from
+// different instants.
+func (s *HTTPSink) Stats() Stats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Stats{Dropped: s.dropped, Unauthenticated: s.unauthenticated, Rejected: s.rejected}
+}
+
+// ReportLoss logs what has been shed since the previous report and stays silent when nothing has.
+// It is exported so the binary can also report once at shutdown, which is the only chance a
+// short-lived process gets to say that it shipped nothing.
+func (s *HTTPSink) ReportLoss() {
+	s.mu.Lock()
+	delta := Stats{
+		Dropped:         s.dropped - s.reported.Dropped,
+		Unauthenticated: s.unauthenticated - s.reported.Unauthenticated,
+		Rejected:        s.rejected - s.reported.Rejected,
+	}
+	total := Stats{Dropped: s.dropped, Unauthenticated: s.unauthenticated, Rejected: s.rejected}
+	s.reported = total
+	s.mu.Unlock()
+
+	if !delta.Any() {
+		return
+	}
+	s.logf(
+		"edge-proxy telemetry: shed since last report: %d buffer-full, %d unauthenticated, "+
+			"%d rejected by ingest (totals: %d / %d / %d)",
+		delta.Dropped, delta.Unauthenticated, delta.Rejected,
+		total.Dropped, total.Unauthenticated, total.Rejected,
+	)
+}
+
+func (s *HTTPSink) reportLoop(every time.Duration) {
+	defer s.wg.Done()
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			s.ReportLoss()
+		case <-s.done:
+			return
+		}
+	}
 }
 
 func (s *HTTPSink) run() {
@@ -297,14 +416,19 @@ func (s *HTTPSink) run() {
 
 // credentialFor picks the bearer that authenticates this record's batch.
 //
-// The record's own tenant key wins: it is the ai-tally api key the caller presented, the gateway
-// resolves it to the same tenant the proxy did, and it makes the hosted multi-tenant deployment
-// correct by construction, since every batch is authenticated by the tenant it belongs to. The
-// configured IngestToken is only a fallback for a deployment where requests carry no tenant key.
+// The record's own tenant key wins, but ONLY when the edge-key cache actually resolved it, which is
+// exactly the condition TenantId being non-empty encodes (proxy.ServeHTTP sets TenantId only for a
+// key found in the cache with write scope). The header value is client-controlled, so an unresolved
+// one is not a credential, it is an arbitrary string: a value carrying bytes Go refuses in a header
+// (a newline, DEL) makes client.Do fail on every proxied request, which an attacker can trigger at
+// will to flood the log. Falling back to the configured IngestToken for anything unresolved keeps
+// that string off the wire entirely. The gateway independently validates the token and enforces
+// TENANT_MISMATCH, so this was never a cross-tenant write risk, only a self-inflicted one.
+//
 // The key is read here and put on a header; it is never written into the batch body and never
 // logged.
 func (s *HTTPSink) credentialFor(rec proxy.TraceRecord) string {
-	if rec.TenantKey != "" {
+	if rec.TenantKey != "" && rec.TenantId != "" {
 		return rec.TenantKey
 	}
 	return s.ingestToken
@@ -343,18 +467,78 @@ func (s *HTTPSink) post(rec proxy.TraceRecord) {
 		log.Printf("edge-proxy telemetry: post failed: %v", err)
 		return
 	}
+	// Read a bounded prefix of the body, then drain the remainder and close, so the connection goes
+	// back to the pool for reuse (net/http only reuses a connection whose body was read to EOF).
+	ackBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxAckBytes))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
 	if resp.StatusCode >= 400 {
-		// Status only: the response body may echo request detail, and telemetry failures must not
-		// become their own leak. A 401/403 here is the operator's signal that the ingest credential
-		// or the key's scope is wrong.
+		// A 401/403 here is the operator's signal that the ingest credential or the key's scope is
+		// wrong.
 		log.Printf("edge-proxy telemetry: ingest rejected batch with status %d", resp.StatusCode)
 	}
-	// Drain and close so the connection can be reused from the pool.
-	_ = resp.Body.Close()
+	s.recordAck(resp.StatusCode, ackBody)
 }
 
-// Close stops accepting records and waits for the worker to drain the buffer.
+// maxAckBytes bounds how much of the ingest response is read. The ack is a small JSON object; the
+// cap is only there so a misconfigured URL pointing at something that streams cannot make the sink
+// buffer without limit.
+const maxAckBytes = 64 << 10
+
+// ingestAck is the subset of the gateway's BatchResponse the sink needs (gateway/app.py
+// _response_dict). Deliberately partial: `message` is not decoded at all, because it can echo
+// request detail and a telemetry failure must not become its own leak.
+type ingestAck struct {
+	Status        string `json:"status"`
+	AcceptedSpans int    `json:"accepted_spans"`
+	PartialErrors []struct {
+		ItemId string `json:"item_id"`
+		Code   string `json:"code"`
+	} `json:"partial_errors"`
+}
+
+// recordAck accounts for per-item outcomes the gateway reports INSIDE a 200 body.
+//
+// The gateway answers a batch whose items were validated away with HTTP 200 and status "partial"
+// (or "accepted" when the only entries are non-fatal flags), listing each refusal as a
+// partial_errors entry. Only a batch where every item was rejected becomes a 422. So a status check
+// alone hides the interesting failures: a caller sending a non-hex X-Tally-Account-Id-Hash
+// (PII_DETECTED), an oversized span (PAYLOAD_TOO_LARGE), or ingest shedding under load would all
+// read as success here. Count the shortfall against what was sent, and log the codes (never the
+// messages) so the operator can act.
+func (s *HTTPSink) recordAck(status int, body []byte) {
+	var ack ingestAck
+	if len(body) == 0 || json.Unmarshal(body, &ack) != nil {
+		return
+	}
+	// The proxy sends exactly one span per batch, so the shortfall is exact rather than inferred.
+	notAccepted := spansPerBatch - ack.AcceptedSpans
+	if notAccepted <= 0 {
+		return
+	}
+	s.mu.Lock()
+	s.rejected += int64(notAccepted)
+	s.mu.Unlock()
+	codes := make([]string, 0, len(ack.PartialErrors))
+	for _, e := range ack.PartialErrors {
+		codes = append(codes, e.Code)
+	}
+	s.logf("edge-proxy telemetry: ingest accepted %d/%d spans (http %d, status %q, codes %v)",
+		ack.AcceptedSpans, spansPerBatch, status, ack.Status, codes)
+}
+
+// spansPerBatch is the batch size the encoder emits: one record, one span, one batch.
+const spansPerBatch = 1
+
+// Close stops accepting records, waits for the worker to drain the buffer, and reports any
+// telemetry that never made it. The final report matters most for a short-lived process: without it
+// a proxy that shipped nothing at all for its whole life would exit without ever saying so.
 func (s *HTTPSink) Close() {
-	s.closeOne.Do(func() { close(s.ch) })
+	s.closeOne.Do(func() {
+		close(s.ch)
+		close(s.done)
+	})
 	s.wg.Wait()
+	s.ReportLoss()
 }

--- a/infra/edge-proxy/internal/telemetry/telemetry_test.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry_test.go
@@ -187,8 +187,10 @@ func TestEncodeCarriesResolvedFields(t *testing.T) {
 }
 
 // TestUnknownTokensSerializeAsNullNeverZero is the honest-under-uncertainty guard. A streamed
-// response (or one past the metadata scan cap) reports no usage; that span must reach storage with
-// NULL token counts. Emitting 0 would read downstream as a real call that consumed nothing.
+// response (or one past the metadata scan cap) reports no usage; that span must leave the proxy
+// with the counts absent, never as 0, which would read downstream as a real call that consumed
+// nothing. Whether the absence survives as a NULL in storage is a separate, pending gateway and
+// schema change; this test pins the half the proxy owns.
 func TestUnknownTokensSerializeAsNullNeverZero(t *testing.T) {
 	rec := sampleRecord()
 	rec.PromptTokens = nil
@@ -231,6 +233,62 @@ func TestZeroTokensStillSerialize(t *testing.T) {
 	}
 	if v, ok := span["gen_ai.usage.output_tokens"]; !ok || v != float64(0) {
 		t.Errorf("a reported 0 must serialize, got %#v (present=%v)", v, ok)
+	}
+}
+
+// TestGeminiShipsAsGoogleSystem: the route protocol label is "gemini", but the price catalog keys
+// Google models under "google" and matches the provider by exact string equality. Shipping the
+// route label verbatim left every hosted Gemini span uncostable and split the provider dimension
+// away from the same org's SDK spans, so the mapping happens at the encoder boundary.
+func TestGeminiShipsAsGoogleSystem(t *testing.T) {
+	for _, tc := range []struct{ provider, want string }{
+		{"gemini", "google"},
+		{"openai", "openai"},
+		{"anthropic", "anthropic"},
+	} {
+		rec := sampleRecord()
+		rec.Provider = tc.provider
+		body, err := Encode(DeploymentCloud, rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := decodeSpan(t, body)["gen_ai.system"]; got != tc.want {
+			t.Errorf("provider %q shipped gen_ai.system %v, want %q", tc.provider, got, tc.want)
+		}
+	}
+}
+
+// TestEmptyProviderStaysOmitted: pure pass-through extracts no provider, and the mapping must not
+// turn that unknown into a value.
+func TestEmptyProviderStaysOmitted(t *testing.T) {
+	rec := sampleRecord()
+	rec.Provider = ""
+	body, err := Encode(DeploymentCloud, rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, present := decodeSpan(t, body)["gen_ai.system"]; present {
+		t.Errorf("gen_ai.system present as %#v for an unextracted provider", v)
+	}
+}
+
+// TestRandomHexIsUnique guards the batch_id path: identical ids across batches would collide on the
+// gateway's (tenant_id, batch_id) idempotency key and every batch after the first would be dropped
+// as a replay.
+func TestRandomHexIsUnique(t *testing.T) {
+	seen := make(map[string]bool, 128)
+	for i := 0; i < 128; i++ {
+		v := randomHex(16)
+		if len(v) != 32 {
+			t.Fatalf("randomHex(16) = %q, want 32 hex chars", v)
+		}
+		if v == strings.Repeat("0", 32) {
+			t.Fatal("randomHex returned an all-zeros id")
+		}
+		if seen[v] {
+			t.Fatalf("randomHex repeated %q", v)
+		}
+		seen[v] = true
 	}
 }
 
@@ -343,6 +401,180 @@ func TestHTTPSinkShedsUnauthenticatedRecords(t *testing.T) {
 	}
 	if got := sink.Unauthenticated(); got != 1 {
 		t.Fatalf("Unauthenticated() = %d, want 1", got)
+	}
+}
+
+// TestHTTPSinkIgnoresUnresolvedTenantKey: the X-Tenant-Key header is client-controlled, and a value
+// the edge-key cache never resolved is not a credential. Sending it anyway lets a caller put bytes
+// Go refuses in a header (a newline here) into every outgoing request, failing client.Do once per
+// proxied call: an attacker-triggerable log flood. An unresolved key must fall back to the
+// configured ingest token and must never reach the wire.
+func TestHTTPSinkIgnoresUnresolvedTenantKey(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotAuth string
+		hits    int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rec := sampleRecord()
+	rec.TenantKey = "tk_live_bogus\nX-Injected: 1"
+	rec.TenantId = "" // the cache did not resolve it
+
+	sink := NewHTTPSink(Options{URL: srv.URL, Deployment: DeploymentCloud, IngestToken: "svc_token"})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("collector got %d posts, want 1 (the unresolved key must not break the request)", hits)
+	}
+	if gotAuth != "Bearer svc_token" {
+		t.Fatalf("Authorization = %q, want the configured ingest token", gotAuth)
+	}
+}
+
+// TestHTTPSinkShedsUnresolvedKeyWithoutToken: with an unresolved key and no ingest token there is
+// still nothing that can authenticate the batch, so it is shed and counted rather than posted with
+// an arbitrary caller-supplied string as the bearer.
+func TestHTTPSinkShedsUnresolvedKeyWithoutToken(t *testing.T) {
+	var mu sync.Mutex
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rec := sampleRecord()
+	rec.TenantId = ""
+	sink := NewHTTPSink(Options{URL: srv.URL, Deployment: DeploymentCloud})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 0 {
+		t.Fatalf("posted %d batches with an unresolved key, want 0", hits)
+	}
+	if got := sink.Unauthenticated(); got != 1 {
+		t.Fatalf("Unauthenticated() = %d, want 1", got)
+	}
+}
+
+// TestHTTPSinkCountsPartialRejection is the visibility fix: the gateway reports per-item validation
+// failures as partial_errors inside an HTTP 200 body, so a status check alone reads a batch whose
+// only span was thrown away (PII_DETECTED here) as a success.
+func TestHTTPSinkCountsPartialRejection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"batch_id":"b1","status":"partial","accepted_spans":0,` +
+			`"partial_errors":[{"item_id":"#0","code":"PII_DETECTED",` +
+			`"message":"account_id_hash is not hex"}],"replayed":false}`))
+	}))
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var lines []string
+	sink := NewHTTPSink(Options{
+		URL: srv.URL, Deployment: DeploymentCloud,
+		Logf: func(format string, args ...any) {
+			mu.Lock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		},
+	})
+	sink.Record(sampleRecord())
+	sink.Close()
+
+	if got := sink.Rejected(); got != 1 {
+		t.Fatalf("Rejected() = %d, want 1", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "PII_DETECTED") {
+		t.Fatalf("rejection code not logged: %q", joined)
+	}
+	// The gateway's per-item message can echo request detail, so a telemetry failure must not become
+	// its own leak: codes are logged, messages never are.
+	if strings.Contains(joined, "account_id_hash is not hex") {
+		t.Fatalf("gateway message echoed into the proxy log: %q", joined)
+	}
+}
+
+// TestHTTPSinkCountsNothingOnCleanAck: a fully accepted batch must not be counted as loss, and a
+// healthy sink must stay silent.
+func TestHTTPSinkCountsNothingOnCleanAck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"batch_id":"b1","status":"accepted","accepted_spans":1,` +
+			`"partial_errors":[]}`))
+	}))
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var lines int
+	sink := NewHTTPSink(Options{
+		URL: srv.URL, Deployment: DeploymentCloud,
+		Logf: func(string, ...any) { mu.Lock(); lines++; mu.Unlock() },
+	})
+	sink.Record(sampleRecord())
+	sink.Close()
+
+	if got := sink.Stats(); got.Any() {
+		t.Fatalf("clean ack counted as loss: %+v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if lines != 0 {
+		t.Fatalf("healthy sink logged %d lines, want silence", lines)
+	}
+}
+
+// TestReportLossSpeaksOnlyWhenSomethingWasShed: the counters are otherwise unreachable outside
+// tests, which is how a total telemetry failure stayed silent. A report names the delta once and
+// does not repeat itself while the totals hold still.
+func TestReportLossSpeaksOnlyWhenSomethingWasShed(t *testing.T) {
+	var lines []string
+	sink := NewHTTPSink(Options{
+		URL: "http://127.0.0.1:1", Deployment: DeploymentCloud,
+		Logf: func(format string, args ...any) { lines = append(lines, fmt.Sprintf(format, args...)) },
+	})
+	defer sink.Close()
+
+	sink.ReportLoss()
+	if len(lines) != 0 {
+		t.Fatalf("reported %v with nothing shed", lines)
+	}
+
+	rec := sampleRecord()
+	rec.TenantId = ""
+	rec.TenantKey = ""
+	sink.Record(rec)
+	// Drain deterministically: Close is the flush barrier, so use a second sink-free wait instead.
+	for sink.Unauthenticated() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	sink.ReportLoss()
+	if len(lines) != 1 || !strings.Contains(lines[0], "1 unauthenticated") {
+		t.Fatalf("want one report naming the unauthenticated shed, got %v", lines)
+	}
+	sink.ReportLoss()
+	if len(lines) != 1 {
+		t.Fatalf("repeated a report with no new loss: %v", lines)
 	}
 }
 


### PR DESCRIPTION
Review fixes for #284, scoped entirely to `infra/edge-proxy/`. Stacked on `feat/i2-p1-proxy-telemetry-exit`.

## Findings addressed

**1. MUST FIX: `gemini` made every Gemini span uncostable.** `telemetry.go` shipped `System: rec.Provider` verbatim, so a hosted Gemini route sent `gen_ai.system: "gemini"` while the price catalog keys Google models under `"google"` and `PriceCatalog._best` compares the provider by exact string equality. Result: a permanent catalog miss, plus a split provider dimension (the same org's SDK Gemini spans under `google`, its proxy spans under `gemini`). Mapped at the encoder boundary in `genAISystem`; `openai` and `anthropic` already matched. Test: `TestGeminiShipsAsGoogleSystem`, plus `TestEmptyProviderStaysOmitted` so the mapping cannot turn an unextracted provider into a value.

**2. SHOULD FIX: the default self-host shipped zero telemetry, silently.** With no `EDGE_PROXY_INGEST_TOKEN` and no edge-key feed, nothing can authenticate a batch, so every record was shed while startup still logged `telemetry -> <url>`, and `Dropped()` / `Unauthenticated()` were unreachable outside tests. Two changes: `Config.Warnings()` warns loudly at boot (a hard "NO telemetry will reach ingest" for the can-never-authenticate case, a softer partial-loss warning for open mode with a key feed), and the sink now surfaces its loss counters, reporting on a one-minute ticker and once more at shutdown, silent when nothing was shed. Tests: `TestWarningsOnSilentlyUndeliverableTelemetry`, `TestWarningsOnOpenModeWithoutIngestToken`, `TestNoWarningsOnHealthyConfigs`, `TestReportLossSpeaksOnlyWhenSomethingWasShed`.

**3. SHOULD FIX: per-item rejections were invisible.** The gateway reports validation failures as `partial_errors` inside an HTTP **200** body (`status: "partial"`; only an all-rejected batch becomes a 422), and the sink only logged at `>= 400`. So `PII_DETECTED` from a non-hex `X-Tally-Account-Id-Hash`, `PAYLOAD_TOO_LARGE`, and load shedding were all silent. The sink now parses the ack (shape taken from `_response_dict` in `gateway/app.py`: `status`, `accepted_spans`, `partial_errors[].{item_id,code}` — note the field is `partial_errors`, not `errors`), counts the shortfall against the one span it sent, and logs the codes. The per-item `message` is deliberately not decoded at all: it can echo request detail, and a telemetry failure must not become its own leak. Tests: `TestHTTPSinkCountsPartialRejection` (including a no-message-leak assertion), `TestHTTPSinkCountsNothingOnCleanAck`.

**4. FIX: `randomHex`'s no-op error branch.** Both branches returned `hex.EncodeToString(b)` on the same buffer, so a failure would have yielded an all-zeros id, and since `batch_id` comes from the same function every later batch would have collided on the gateway's `(tenant_id, batch_id)` idempotency key and been dropped as a replay for the cache TTL. `crypto/rand.Read` never returns an error and always fills the buffer, so the dead branch is removed and the comment now says that plus why the old behavior would have been actively harmful. Test: `TestRandomHexIsUnique`.

**5. FIX: unvalidated client header became an outgoing bearer.** `credentialFor` returned whatever the caller put in `X-Tenant-Key`; a value with bytes Go rejects in a header (`\n`, DEL) made `client.Do` fail once per proxied request, an attacker-triggerable log flood. Now only a key the edge-key cache actually resolved is used, which is exactly what a non-empty `TenantId` encodes (`proxy.ServeHTTP` sets it only for a cached key with write scope); anything else falls back to `IngestToken`, or is shed and counted. Not a cross-tenant write risk before or after, since the gateway validates the token and enforces `TENANT_MISMATCH`. Tests: `TestHTTPSinkIgnoresUnresolvedTenantKey`, `TestHTTPSinkShedsUnresolvedKeyWithoutToken`.

Note the behavior change this implies: a self-host that presents tenant keys but runs no edge-key feed must now set `EDGE_PROXY_INGEST_TOKEN`. That is exactly the case finding 2's startup warning names, and the README and Helm values say so.

**6. NIT: comment claimed a drain that never happened.** The response body is now read (bounded at 64KB) and drained before `Close`, which is what net/http needs to return the connection to the pool. Code and comment agree, and the read is what feeds finding 3.

**7. Corrected the branch's own claims.** This branch asserted that unknown token counts "reach storage as NULL". They do not: `mapping.py` coerces `None` to 0 and the ClickHouse token columns are non-nullable `UInt32`. The prose in `README.md`, `internal/telemetry/telemetry.go`, `internal/proxy/trace.go` and `internal/proxy/provider.go` now states the guarantee the proxy actually delivers (unknown is omitted from the emitted wire, never serialized as 0, so the proxy is not the place the 0 is invented) and notes that end-to-end NULL semantics depend on a pending gateway and schema change.

## Deliberately not fixed

The two findings about token counts and cost being stored as a fabricated 0 need a gateway and ClickHouse schema change and are being handled separately as a product decision. Nothing here attempts them; the prose above is the honest interim statement rather than a claim the code does not deliver.

## Verification

```
go build ./...   ok
go vet ./...     ok
gofmt -l .       (no output)
go test ./...        all pass except TestOverheadBudget
go test -race ./...  all pass except TestOverheadBudget
```

`TestOverheadBudget` is a wall-clock p99 latency budget against a loopback server and fails identically on the base branch on this machine (confirmed by stashing the change and rerunning). Nothing here touches the request hot path. Every other proxy test passes: `go test -run 'Test[^O]' ./internal/proxy/` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
