### PR TITLE
fix(gateway,deploy): address code-review findings on PR #283

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -75,7 +75,28 @@ when auth is on and no service token is set, rather than coming up with an open 
 `curl … -H 'x-tenant-id: …'` examples below work as written only while auth is off; with auth on, add
 `-H "Authorization: Bearer $TALLY_GATEWAY_SERVICE_TOKEN"`.
 
-Ingest (`/v1/batches`) is unchanged: it still authenticates with the ingest API key above.
+Ingest (`/v1/batches`) is unchanged: it still authenticates with the ingest API key above. So is
+`POST /v1/revenue/events` (`docs/revenue-api.md`), which a customer's billing job posts to with an
+ingest key: it takes a write-scoped ingest key **or** the service token, never the service token
+alone.
+
+**The two token settings are a pair.** `infra/.env.example` and `web/.env.example` both leave the
+token commented, because setting only one is worse than setting neither:
+
+| gateway `TALLY_GATEWAY_SERVICE_TOKEN` | web `GATEWAY_SERVICE_TOKEN` | result with auth on |
+| --- | --- | --- |
+| unset | unset | gateway refuses to boot (fail closed, by design) |
+| set | unset | dashboard sends no `Authorization`; every control-plane read 401s and the settings pages go blank |
+| unset | set | gateway refuses to boot |
+| set, same value | set, same value | working |
+
+Generate the value once and paste it into both files:
+
+```bash
+openssl rand -hex 32
+```
+
+Never reuse a value from an example file. Anything checked into this repo is public.
 
 ## 3. Push telemetry through the gateway
 

--- a/db/postgres/0031_api_keys_display_bounds.sql
+++ b/db/postgres/0031_api_keys_display_bounds.sql
@@ -22,11 +22,17 @@
 -- NOT VALID + VALIDATE is deliberately NOT used: these are additive constraints on columns that only
 -- 0029 could have populated, and the table is small. A plain ADD CONSTRAINT takes a brief ACCESS
 -- EXCLUSIVE lock, which is acceptable on api_keys.
+--
+-- The idempotency guards below qualify on conrelid as well as conname. Constraint names are unique
+-- per TABLE, not per database, so matching on conname alone would let a same-named constraint on
+-- some other table make this migration skip a bound and still report success: the column would go
+-- unbounded while the run looked clean.
 
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_name_len'
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'api_keys_name_len' AND conrelid = 'api_keys'::regclass
     ) THEN
         ALTER TABLE api_keys
             ADD CONSTRAINT api_keys_name_len
@@ -34,7 +40,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_token_prefix_len'
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'api_keys_token_prefix_len' AND conrelid = 'api_keys'::regclass
     ) THEN
         ALTER TABLE api_keys
             ADD CONSTRAINT api_keys_token_prefix_len
@@ -42,7 +49,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint WHERE conname = 'api_keys_created_by_len'
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'api_keys_created_by_len' AND conrelid = 'api_keys'::regclass
     ) THEN
         ALTER TABLE api_keys
             ADD CONSTRAINT api_keys_created_by_len

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -185,6 +185,41 @@ aws secretsmanager create-secret --name ai-tally-openai-api-key    --secret-stri
 aws secretsmanager create-secret --name ai-tally-anthropic-api-key --secret-string 'sk-ant-...'
 ```
 
+### The control-plane service token, and when to create it
+
+The `/v1/tenant/*` control plane is gated on a shared **service token** (Initiative 1 §6) whenever
+`gateway.config.requireApiKey` / `TALLY_REQUIRE_API_KEY` is true. The gateway refuses to boot with
+the gate on and no token, so **the secret has to exist before the upgrade that turns the gate on**,
+not after:
+
+```bash
+openssl rand -hex 32 | tr -d '\n' | \
+  xargs -0 -I{} aws secretsmanager create-secret --name ai-tally-gateway-service-token \
+    --secret-string {}
+```
+
+Then, and only then, point the chart at it:
+
+```yaml
+secretsManager:
+  secrets:
+    gatewayServiceToken: ai-tally-gateway-service-token
+```
+
+It ships **empty** in `values.yaml` on purpose. A non-empty default makes an ordinary `helm upgrade`
+of an existing release mount a secret that does not exist yet, and the pods sit in
+`ContainerCreating` with nothing in the logs to explain it. Left empty with `requireApiKey: true`,
+the chart instead fails to render with a message naming this value. The **web tier does not need the
+token at all** while the gate is off, which is why the ECS `web.taskdef.json` does not list it: add
+
+```json
+{ "name": "GATEWAY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" }
+```
+
+to that task def's `secrets` block in the same change that turns the gate on. The gateway reads the
+same value as `TALLY_GATEWAY_SERVICE_TOKEN`; the two must match exactly, or the dashboard sends no
+`Authorization` and every control-plane read 401s.
+
 > **Not deploy-time secrets:** the **Stripe** webhook signing secret is pasted per-tenant in the
 > dashboard and persisted in Postgres (`db/postgres/0003_tenant_stripe_config.sql`) — protect it by
 > protecting RDS, not via an env var. Per-tenant **HMAC** user-id keys (CTO-74) live in the gateway's

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -28,8 +28,7 @@
         { "name": "NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS", "value": "5000" }
       ],
       "secrets": [
-        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" },
-        { "name": "GATEWAY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" }
+        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/ || exit 1"],

--- a/deploy/aws/helm/ai-tally-eks/templates/gateway-deployment.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/gateway-deployment.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.gateway.enabled }}
+{{- /* Initiative 1 §6: fail at TEMPLATE time, not as a CrashLoop, when the control-plane gate is
+     switched on without a service token. The gateway refuses to boot in that state (fail closed),
+     and this turns a mystery restart loop into an actionable `helm upgrade` error. Sequencing:
+     create the secret FIRST, then set secretsManager.secrets.gatewayServiceToken. */ -}}
+{{- if and .Values.gateway.config.requireApiKey (not .Values.secretsManager.secrets.gatewayServiceToken) }}
+{{- fail "gateway.config.requireApiKey is true but secretsManager.secrets.gatewayServiceToken is empty: create the control-plane service-token secret in your secret manager, then set that value to its name (see the deploy README)." }}
+{{- end }}
 {{- $tier := "gateway" -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/aws/helm/ai-tally-eks/values.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values.yaml
@@ -68,7 +68,11 @@ secretsManager:
     # on every /v1/tenant/* call and the gateway refuses to boot without it when
     # gateway.config.requireApiKey is true. Consumed as TALLY_GATEWAY_SERVICE_TOKEN (gateway)
     # and GATEWAY_SERVICE_TOKEN (web).
-    gatewayServiceToken: ai-tally-gateway-service-token
+    # DEFAULTED OFF so an existing release can be upgraded before the secret exists: with a value
+    # here the web pods mount a secret that is not there yet and sit in ContainerCreating, and the
+    # web tier does not need the token at all while gateway.config.requireApiKey is false. Create
+    # the Secrets Manager entry FIRST, then set this (see the deploy README).
+    gatewayServiceToken: ""
   # NOTE on Stripe + HMAC: the Stripe webhook *signing secret* is NOT a gateway env var — it is
   # pasted per-tenant in the dashboard and persisted in Postgres (see db/postgres/0003_*.sql), so it
   # is protected by protecting RDS. Per-tenant HMAC user-id keys (CTO-74) live in the gateway's

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -163,6 +163,34 @@ printf 'sk-...'      | gcloud secrets create ai-tally-openai-api-key    --data-f
 printf 'sk-ant-...'  | gcloud secrets create ai-tally-anthropic-api-key --data-file=-
 ```
 
+### The control-plane service token, and when to create it
+
+The `/v1/tenant/*` control plane is gated on a shared **service token** (Initiative 1 §6) whenever
+`gateway.config.requireApiKey` / `TALLY_REQUIRE_API_KEY` is true. The gateway refuses to boot with
+the gate on and no token, so **the secret has to exist before the upgrade that turns the gate on**,
+not after:
+
+```bash
+openssl rand -hex 32 | tr -d '\n' | gcloud secrets create ai-tally-gateway-service-token --data-file=-
+```
+
+Then, and only then, point the chart at it:
+
+```yaml
+secretManager:
+  secrets:
+    gatewayServiceToken: ai-tally-gateway-service-token
+```
+
+It ships **empty** in `values.yaml` on purpose. A non-empty default makes an ordinary `helm upgrade`
+of an existing release mount a secret that does not exist yet, and the pods sit in
+`ContainerCreating` with nothing in the logs to explain it. Left empty with `requireApiKey: true`,
+the chart instead fails to render with a message naming this value. The web tier does not need the
+token at all while the gate is off. The gateway reads the same value as
+`TALLY_GATEWAY_SERVICE_TOKEN` and the web tier as `GATEWAY_SERVICE_TOKEN`; the two must match
+exactly, or the dashboard sends no `Authorization` and every control-plane read 401s.
+
+
 > **Not deploy-time secrets:** the **Stripe** webhook signing secret is pasted per-tenant in the
 > dashboard and persisted in Postgres (`db/postgres/0003_tenant_stripe_config.sql`) — protect it by
 > protecting Cloud SQL, not via an env var. Per-tenant **HMAC** user-id keys (CTO-74) live in the

--- a/deploy/gcp/helm/ai-tally/templates/gateway-deployment.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/gateway-deployment.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.gateway.enabled }}
+{{- /* Initiative 1 §6: fail at TEMPLATE time, not as a CrashLoop, when the control-plane gate is
+     switched on without a service token. The gateway refuses to boot in that state (fail closed),
+     and this turns a mystery restart loop into an actionable `helm upgrade` error. Sequencing:
+     create the secret FIRST, then set secretManager.secrets.gatewayServiceToken. */ -}}
+{{- if and .Values.gateway.config.requireApiKey (not .Values.secretManager.secrets.gatewayServiceToken) }}
+{{- fail "gateway.config.requireApiKey is true but secretManager.secrets.gatewayServiceToken is empty: create the control-plane service-token secret in your secret manager, then set that value to its name (see the deploy README)." }}
+{{- end }}
 {{- $tier := "gateway" -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/gcp/helm/ai-tally/values.yaml
+++ b/deploy/gcp/helm/ai-tally/values.yaml
@@ -61,7 +61,11 @@ secretManager:
     # on every /v1/tenant/* call and the gateway refuses to boot without it when
     # gateway.config.requireApiKey is true. Consumed as TALLY_GATEWAY_SERVICE_TOKEN (gateway)
     # and GATEWAY_SERVICE_TOKEN (web).
-    gatewayServiceToken: ai-tally-gateway-service-token
+    # DEFAULTED OFF so an existing release can be upgraded before the secret exists: with a value
+    # here the web pods mount a secret that is not there yet and sit in ContainerCreating, and the
+    # web tier does not need the token at all while gateway.config.requireApiKey is false. Create
+    # the Secret Manager entry FIRST, then set this (see the deploy README).
+    gatewayServiceToken: ""
   # NOTE on Stripe + HMAC: the Stripe webhook *signing secret* is NOT a gateway env var — it is
   # pasted per-tenant in the dashboard and persisted in Postgres (see db/postgres/0003_*.sql), so
   # it is protected by protecting Cloud SQL. Per-tenant HMAC user-id keys (CTO-74) live in the

--- a/docs/hosted-version-scope.md
+++ b/docs/hosted-version-scope.md
@@ -43,9 +43,11 @@ Hosted multi-tenancy requires the tenant to come from the authenticated session 
 instead. That is a change to the signature of essentially every query function in `web/lib`, and it
 has to be done in a way where forgetting it is impossible rather than merely discouraged.
 
-The gateway is in better shape. It already resolves tenants per request from a bearer key or header
-(`_resolve_tenant_for_control_plane`), stamps `TenantId` on every row, and holds per-tenant HMAC key
-versions for user hashing. The backend was built multi-tenant. The dashboard was not.
+The gateway is in better shape. It already resolves tenants per request: ingest from the bearer api
+key's own tenant, and the control plane from the `x-tenant-id` the web server resolved, behind the
+service-token gate (`_require_service_token` / `_service_token_tenant` in `gateway/app.py`). It
+stamps `TenantId` on every row and holds per-tenant HMAC key versions for user hashing. The backend
+was built multi-tenant. The dashboard was not.
 
 ## Isolation, and the thing that will keep you up at night
 

--- a/docs/revenue-api.md
+++ b/docs/revenue-api.md
@@ -22,6 +22,17 @@ Authorization: Bearer <tenant api key>     # or X-Tenant-Id when auth is disable
 Content-Type: application/json
 ```
 
+This is an **ingest** endpoint, not part of the `/v1/tenant/*` control plane, so with
+`TALLY_REQUIRE_API_KEY=true` it accepts either credential:
+
+- a **tenant api key** with `write` or `admin` scope. This is the normal path: your billing job
+  holds an api key. The tenant comes from the key itself, so `X-Tenant-Id` is neither needed nor
+  trusted, and one tenant can never post as another. A `read`-scoped key gets a 403.
+- the **control-plane service token** plus `X-Tenant-Id`, for a first-party server calling on a
+  tenant's behalf.
+
+With auth off (local dev), `X-Tenant-Id` alone is enough, as everywhere else.
+
 | Field         | Required | Type   | Notes                                                                           |
 | ------------- | -------- | ------ | ------------------------------------------------------------------------------- |
 | `event_id`    | yes      | string | Your stable id for this event. The idempotency key. Max 200 chars.              |

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -37,6 +37,13 @@ TALLY_REQUIRE_API_KEY=false
 # open control plane. The web server reads the same secret as GATEWAY_SERVICE_TOKEN
 # (see web/.env.example); the two values must match.
 #
-# The value below is a local placeholder only. Generate a long random value for any real
-# deployment, for example `openssl rand -hex 32`.
-TALLY_GATEWAY_SERVICE_TOKEN=local-dev-service-token-change-me
+# LEFT COMMENTED ON PURPOSE. A checked-in placeholder is not a secret: if this were set, copying
+# .env.example to .env and flipping TALLY_REQUIRE_API_KEY=true would boot a gateway that looks
+# secured while accepting a token anyone can read out of this repo, granting read/write on every
+# tenant's budgets, guardrails, cost connectors, Stripe config and CAC. Commented, the fail-closed
+# boot guard fires instead and the gateway refuses to start until a real value is set.
+#
+# Generate one with `openssl rand -hex 32` and set it here AND as GATEWAY_SERVICE_TOKEN in
+# web/.env (see web/.env.example) - the two values must match, or the dashboard sends no
+# Authorization and every control-plane read 401s.
+# TALLY_GATEWAY_SERVICE_TOKEN=

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -1045,6 +1045,72 @@ def _service_token_tenant(x_tenant_id: str | None) -> str:
     return x_tenant_id
 
 
+def _service_token_or_ingest_key_tenant(
+    authorization: str | None, x_tenant_id: str | None, *, action: str
+) -> str:
+    """Resolve the tenant for an endpoint a CUSTOMER calls directly, not only the web server.
+
+    The ``/v1/tenant/*`` control plane is service-token only (Initiative 1 §6) because the web
+    server is its only legitimate caller. A tenant-facing INGEST endpoint is different: the caller
+    is the customer's own billing integration, which holds an ingest api key and will never hold
+    the shared service token. Gating such an endpoint on the service token alone turns every
+    automated post into a 401 the moment ``TALLY_REQUIRE_API_KEY`` is flipped on.
+
+    So both doors are open, and both authenticate:
+
+    * the service token plus ``x-tenant-id`` (the dashboard / any first-party server path), and
+    * the tenant's own ingest key, whose ``AuthResult`` carries the tenant, so no header is
+      trusted and one tenant can never post as another.
+
+    A ``write`` or ``admin`` scope is REQUIRED on the ingest-key path: this writes rows. This is
+    the same shape ``GET /v1/tenant/hmac-key`` uses for the same reason (the caller holds no
+    service token). With auth OFF the dev escape hatch (§10) applies exactly as elsewhere: the
+    tenant comes from ``x-tenant-id`` and an absent header is refused rather than guessed.
+    """
+    settings = app.state.settings
+    if not settings.require_api_key:
+        return _service_token_tenant(x_tenant_id)
+
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise _error(401, ErrorCode.UNAUTHENTICATED, "missing bearer token")
+    presented = authorization.split(" ", 1)[1].strip()
+
+    service_token = settings.gateway_service_token
+    if service_token and secrets.compare_digest(presented, service_token):
+        # Constant-time compare, then the tenant comes from the header: the service token
+        # authenticates the SERVER, never a tenant.
+        return _service_token_tenant(x_tenant_id)
+
+    auth: ApiKeyAuth = app.state.auth
+    result = auth.authenticate(presented)
+    if result is None:
+        raise _error(401, ErrorCode.UNAUTHENTICATED, "invalid or revoked api key")
+    if not result.can_write:
+        raise _error(403, ErrorCode.FORBIDDEN_SCOPE, f"scope '{result.scope}' cannot {action}")
+    return result.tenant_id
+
+
+def _body_tenant(body: dict, x_tenant_id: str | None) -> str:
+    """Tenant for a service-token endpoint that also accepts a body ``tenant_id``.
+
+    Only a service-token holder reaches these handlers and the web server always sends the tenant
+    it resolved server-side, so there is no live IDOR here. Letting the body silently OUTRANK the
+    header is still the wrong default: it means the one field an attacker would control is the one
+    that wins if the gate is ever loosened. A mismatch is refused instead of picking a winner, and
+    the body is accepted only when it agrees with the header or the header is absent.
+    """
+    body_tenant = body.get("tenant_id")
+    if body_tenant is not None and not isinstance(body_tenant, str):
+        raise HTTPException(status_code=422, detail="tenant_id must be a string")
+    body_tenant = (body_tenant or "").strip()
+    header_tenant = (x_tenant_id or "").strip()
+    if body_tenant and header_tenant and body_tenant != header_tenant:
+        raise HTTPException(
+            status_code=403, detail="tenant_id in body does not match the x-tenant-id header"
+        )
+    return body_tenant or _service_token_tenant(x_tenant_id)
+
+
 @app.exception_handler(TenantNotFoundError)
 def _tenant_not_found_handler(_request: Request, exc: TenantNotFoundError) -> JSONResponse:
     """Map an unresolved tenant identifier onto a clean 404 (CTO-201).
@@ -2786,9 +2852,17 @@ async def ingest_revenue_event(
     Nothing here bypasses the revenue policy. The row is an ordinary ``business_events`` row, and
     the response reports whether the tenant's own configured revenue sources (CTO-194) will count
     it, so a narrowed policy shows up on the first request rather than as a blank dashboard later.
+
+    Authenticated by the tenant's own INGEST KEY (write or admin scope) OR by the control-plane
+    service token, not the service token alone: this is a tenant-facing ingest endpoint that a
+    customer's Chargebee / Recurly / Zuora job posts to with an api key, exactly as
+    ``docs/revenue-api.md`` documents. Service-token-only would 401 every one of those jobs the
+    moment auth is switched on and blank the LTV / CAC / margin views. See
+    ``_service_token_or_ingest_key_tenant``.
     """
-    _require_service_token(authorization)
-    tenant_id = _service_token_tenant(x_tenant_id)
+    tenant_id = _service_token_or_ingest_key_tenant(
+        authorization, x_tenant_id, action="post revenue events"
+    )
     try:
         body = await request.json()
     except Exception as exc:  # noqa: BLE001
@@ -3066,7 +3140,7 @@ async def project_replay(
     if not isinstance(body, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")
 
-    tenant_id = body.get("tenant_id") or _service_token_tenant(x_tenant_id)
+    tenant_id = _body_tenant(body, x_tenant_id)
     feature_tag = body.get("feature_tag")
     candidates = body.get("candidate_models") or []
     if not isinstance(candidates, list) or not all(
@@ -3262,7 +3336,7 @@ async def project_replay_estimate(
     if not isinstance(body, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")
 
-    tenant_id = body.get("tenant_id") or _service_token_tenant(x_tenant_id)
+    tenant_id = _body_tenant(body, x_tenant_id)
     feature_tag = body.get("feature_tag")
     candidate = body.get("candidate_model")
     if not isinstance(candidate, dict) or "provider" not in candidate or "model" not in candidate:
@@ -3550,7 +3624,7 @@ async def project_eval(
     if not isinstance(body, dict):
         raise HTTPException(status_code=422, detail="body must be a JSON object")
 
-    tenant_id = body.get("tenant_id") or _service_token_tenant(x_tenant_id)
+    tenant_id = _body_tenant(body, x_tenant_id)
     feature_tag = body.get("feature_tag")
     candidates = body.get("candidate_models") or []
     if not isinstance(candidates, list) or not all(

--- a/infra/gateway/tests/test_app_auth.py
+++ b/infra/gateway/tests/test_app_auth.py
@@ -77,13 +77,28 @@ def _client(
     # `with TestClient(app)` runs the lifespan exactly once; we then override the infra-touching
     # bits (auth → in-memory, optionally the limiter or the store) before yielding.
     with TestClient(app) as client:
-        app.state.settings.require_api_key = True
-        app.state.auth = FakeAuth(keys or {})
-        if limiter is not None:
-            app.state.limiter = limiter
-        if store is not None:
-            app.state.store = store
-        yield client
+        # `app` is module-level and shared by every test in the run, so each override is put back on
+        # the way out. Leaving a RecordingStore (or a FakeAuth) parked on app.state leaks into
+        # whatever runs next and makes failures depend on test order.
+        previous = {
+            "require_api_key": app.state.settings.require_api_key,
+            "auth": app.state.auth,
+            "limiter": app.state.limiter,
+            "store": app.state.store,
+        }
+        try:
+            app.state.settings.require_api_key = True
+            app.state.auth = FakeAuth(keys or {})
+            if limiter is not None:
+                app.state.limiter = limiter
+            if store is not None:
+                app.state.store = store
+            yield client
+        finally:
+            app.state.settings.require_api_key = previous["require_api_key"]
+            app.state.auth = previous["auth"]
+            app.state.limiter = previous["limiter"]
+            app.state.store = previous["store"]
 
 
 def test_missing_bearer_is_unauthenticated() -> None:

--- a/infra/gateway/tests/test_app_replay_estimate.py
+++ b/infra/gateway/tests/test_app_replay_estimate.py
@@ -208,3 +208,33 @@ def test_estimate_uses_injected_candidate_client(client: TestClient) -> None:
     # The override must have reached the injected client's envelope.
     assert seen
     assert all(c.envelope.get("system_prompt") == "x" * 2000 for c in seen)
+
+
+def test_body_tenant_that_disagrees_with_the_header_is_refused(client: TestClient) -> None:
+    """Defence in depth: the body must never silently outrank the header.
+
+    Only a service-token holder reaches this handler and the web server always sends the tenant it
+    resolved server-side, so this is not a live IDOR. It is refused anyway, because a body field is
+    the one input an attacker would control, and "the body wins" is the wrong thing to have already
+    written down if the gate is ever loosened. A matching body tenant_id still works.
+    """
+    r = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": "some-other-tenant",
+            "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+        },
+    )
+    assert r.status_code == 403
+    assert "does not match" in r.json()["detail"]
+
+    r = client.post(
+        "/v1/replay/estimate",
+        headers={"X-Tenant-Id": T},
+        json={
+            "tenant_id": T,
+            "candidate_model": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+        },
+    )
+    assert r.status_code == 200

--- a/infra/gateway/tests/test_app_revenue_api.py
+++ b/infra/gateway/tests/test_app_revenue_api.py
@@ -13,6 +13,8 @@ from contextlib import contextmanager
 from fastapi.testclient import TestClient
 
 from gateway.app import app
+from gateway.auth import AuthResult
+from gateway.config import get_settings
 from gateway.revenue_api import counts_as_revenue
 from gateway.tenant_revenue_sources import RevenueSourceConfig
 from tally.cdp_connectors import WebhookIngestor
@@ -313,3 +315,110 @@ def test_counts_as_revenue_mirrors_the_reader_defaults():
     assert counts_as_revenue(_config(None, include_mrr=False), "revenue-api", "monetary") is True
     # Source comparison is case-insensitive, matching lower(Source) in the reader.
     assert counts_as_revenue(_config(("Revenue-API",)), "revenue-api", "monetary") is True
+
+
+# ----------------------------------------------------------------------------------------------
+# Auth with TALLY_REQUIRE_API_KEY on: this is tenant-facing INGEST, not the control plane.
+#
+# Two doors, both authenticated: the customer's own ingest key (all a Chargebee / Recurly / Zuora
+# job ever holds, and what docs/revenue-api.md documents) and the control-plane service token.
+# Service-token-only would 401 every automated revenue post the moment auth is switched on, and
+# silently blank the LTV / CAC / margin views.
+# ----------------------------------------------------------------------------------------------
+
+SERVICE_TOKEN = "svc-token-for-tests"
+
+
+class FakeAuth:
+    """Token -> AuthResult, standing in for the Postgres api-key lookup."""
+
+    def __init__(self, mapping: dict[str, AuthResult]) -> None:
+        self._mapping = mapping
+
+    def authenticate(self, token: str) -> AuthResult | None:
+        return self._mapping.get(token)
+
+    def ping(self) -> bool:
+        return True
+
+
+@contextmanager
+def _authed_client(keys: dict[str, AuthResult]) -> Iterator[tuple[TestClient, FakeCHStore]]:
+    # Boot with auth OFF so the fail-closed boot guard cannot trip on leftover singleton state, then
+    # apply the per-test auth config, which is what the request-time path actually reads. Restored
+    # on the way out: app is module-level and shared with every other test in the run.
+    boot = get_settings()
+    boot.require_api_key = False
+    boot.gateway_service_token = ""
+    with TestClient(app) as client:
+        previous_auth = app.state.auth
+        try:
+            app.state.settings.require_api_key = True
+            app.state.settings.gateway_service_token = SERVICE_TOKEN
+            app.state.auth = FakeAuth(keys)
+            ch = FakeCHStore()
+            app.state.store = ch
+            app.state.tenant_revenue_sources = FakeRevenueSourceStore()
+            app.state.revenue_ingestor = WebhookIngestor()
+            yield client, ch
+        finally:
+            app.state.settings.require_api_key = False
+            app.state.settings.gateway_service_token = ""
+            app.state.auth = previous_auth
+
+
+def _written_tenants(ch: FakeCHStore) -> set[str]:
+    return {tenant for tenant, _ in ch.existing}
+
+
+def test_ingest_key_still_works_when_auth_is_on():
+    """The regression this guards: a billing integration holds an ingest key, never the service
+    token. The tenant comes from the KEY, so no header is trusted and no cross-tenant post is
+    possible."""
+    keys = {"wk": AuthResult(tenant_id=TENANT, scope="write")}
+    with _authed_client(keys) as (client, ch):
+        res = client.post(
+            "/v1/revenue/events", json=_payload(), headers={"Authorization": "Bearer wk"}
+        )
+        assert res.status_code == 201
+        assert len(ch.events) == 1
+        assert _written_tenants(ch) == {TENANT}
+
+
+def test_service_token_plus_tenant_header_also_works_when_auth_is_on():
+    with _authed_client({}) as (client, ch):
+        res = client.post(
+            "/v1/revenue/events",
+            json=_payload(),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}", "X-Tenant-Id": TENANT},
+        )
+        assert res.status_code == 201
+        assert len(ch.events) == 1
+        assert _written_tenants(ch) == {TENANT}
+
+
+def test_neither_credential_is_rejected_when_auth_is_on():
+    with _authed_client({}) as (client, ch):
+        # No Authorization at all: a bare x-tenant-id must not be enough once auth is on.
+        res = client.post("/v1/revenue/events", json=_payload(), headers={"X-Tenant-Id": TENANT})
+        assert res.status_code == 401
+        # A token that is neither the service token nor a live api key.
+        res = client.post(
+            "/v1/revenue/events",
+            json=_payload(),
+            headers={"Authorization": "Bearer nope", "X-Tenant-Id": TENANT},
+        )
+        assert res.status_code == 401
+        assert ch.events == []
+
+
+def test_read_scoped_ingest_key_cannot_post_revenue():
+    """A read-only key authenticates but must not write rows, matching /v1/tenant/hmac-key."""
+    keys = {"rk": AuthResult(tenant_id=TENANT, scope="read")}
+    with _authed_client(keys) as (client, ch):
+        res = client.post(
+            "/v1/revenue/events", json=_payload(), headers={"Authorization": "Bearer rk"}
+        )
+        assert res.status_code == 403
+        assert res.json()["detail"]["code"] == "FORBIDDEN_SCOPE"
+        assert ch.events == []

--- a/web/.env.example
+++ b/web/.env.example
@@ -16,10 +16,15 @@
 # --- Gateway ---
 # Where the control-plane gateway lives (server-side only).
 TALLY_GATEWAY_URL=http://localhost:8080
-# Control-plane service token (§6). Must match the gateway's TALLY_GATEWAY_SERVICE_TOKEN. Sent as a
-# bearer token on every control-plane call; server-side only, never in a client bundle. Optional in
-# local dev with gateway auth off.
-# GATEWAY_SERVICE_TOKEN=change-me-in-real-deployments
+# Control-plane service token (§6). Must match the gateway's TALLY_GATEWAY_SERVICE_TOKEN exactly.
+# Sent as a bearer token on every control-plane call; server-side only, never in a client bundle.
+# Optional in local dev with gateway auth off.
+#
+# LEFT COMMENTED ON PURPOSE, and infra/.env.example leaves its half commented too. The two are a
+# PAIR: set one without the other and you get a gateway that enforces the gate against a dashboard
+# that sends no Authorization, so every control-plane read 401s and the settings surface goes blank.
+# Generate one value with `openssl rand -hex 32` and set it in BOTH files, or set it in neither.
+# GATEWAY_SERVICE_TOKEN=
 
 # --- Clerk (product path only; not needed when TALLY_DEV_TENANT is set) ---
 # NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...


### PR DESCRIPTION
Stacked on `feat/i1-close-control-plane-auth-gap`. Do not merge to `main`.

Each change below maps to a review finding on #283.

## 1. MUST FIX (regression): `/v1/revenue/events` is tenant-facing ingest, and the gate broke it

`docs/revenue-api.md` documents this endpoint as `Authorization: Bearer <tenant api key>`. A customer's Chargebee / Recurly / Zuora integration holds an ingest key and will never hold the shared web-server service token, so gating it on the service token alone means every automated revenue post 401s the moment `TALLY_REQUIRE_API_KEY` is flipped on, and the dashboard's LTV / CAC / margin views silently blank.

New `_service_token_or_ingest_key_tenant` in `infra/gateway/src/gateway/app.py` opens both doors, and both authenticate:

- a `write`/`admin`-scoped ingest key, with the tenant taken from the key's own `AuthResult`, so no header is trusted and one tenant cannot post as another. A `read`-scoped key gets a 403.
- the service token plus `x-tenant-id`, so any first-party server path keeps working.

This is the same shape `GET /v1/tenant/hmac-key` already uses, for the same "the caller holds no service token" reason, including the write-scope check. With auth off the dev escape hatch is unchanged. `docs/revenue-api.md` now spells out both credentials.

**No genuine control-plane endpoint had its auth model changed.**

## 2. MUST FIX (security posture): uncommented placeholder token

`infra/.env.example` had `TALLY_GATEWAY_SERVICE_TOKEN=local-dev-service-token-change-me` set. Copy to `.env`, enable auth, and you get a gateway that boots "secured" while accepting a value anyone can read out of this repo, granting read/write on every tenant's budgets, guardrails, cost connectors, Stripe config and CAC. Re-commented, so the fail-closed boot guard fires instead, with a loud note on generating a real one.

## 3. Asymmetry footgun

`infra/.env.example` and `web/.env.example` now both leave the token commented, each pointing at the other. `RUNNING.md` gains a table of what each half-configured combination actually does (set on the gateway only means every control-plane read 401s and the settings surface goes blank) and the `openssl rand -hex 32` recipe. Appended to the base branch's section, not a restatement of it.

## 4. Migration idempotency guard under-qualified

`db/postgres/0031_api_keys_display_bounds.sql` matched on `conname` alone. Constraint names are unique per table, not per database, so a same-named constraint on another table could make the migration skip a bound and still report success. All three checks now add `AND conrelid = 'api_keys'::regclass`. No renumbering, no other semantics touched.

## 5. Docs: dangling reference

`docs/hosted-version-scope.md` cited `_resolve_tenant_for_control_plane`, deleted on this branch. Rewritten to describe what the gateway does now (ingest from the key's tenant, control plane from `x-tenant-id` behind `_require_service_token`).

## 6. Ops sequencing: the new secret was mandatory with no opt-out

- `deploy/aws/ecs/web.taskdef.json` no longer names `ai-tally-gateway-service-token`. The web tier does not need the token at all while gateway auth is off; `deploy/aws/README.md` gives the exact JSON line to add back in the same change that turns the gate on.
- Both Helm charts default `gatewayServiceToken` to `""` (the templates were already conditional). A non-empty default makes an ordinary `helm upgrade` of an existing release mount a secret that does not exist yet, and the pods sit in `ContainerCreating` with nothing in the logs.
- Because the chart defaults `requireApiKey: true`, both gateway deployment templates now `fail` at **template** time when the gate is on and no token is set, naming the value. That turns a silent restart loop into an actionable `helm upgrade` error, and matches the gateway's own fail-closed boot guard. The `values-*.example.yaml` files set the token, so example installs render unchanged.
- Both deploy READMEs get a "create it before the upgrade that turns the gate on" section.

## 7. Defence in depth: body `tenant_id` outranked the header

`/v1/replay`, `/v1/replay/estimate` and `/v1/eval` used `body.get("tenant_id") or _service_token_tenant(...)`. Only a service-token holder reaches them and the web always sends the server-resolved tenant, so there is no IDOR today. Replaced with `_body_tenant`, which refuses a body/header mismatch with a 403 instead of letting the body win, and type-checks the field. A matching body `tenant_id` still works, so no caller changes.

## 8. NIT: test hygiene

`infra/gateway/tests/test_app_auth.py` swapped the store, auth, limiter and `require_api_key` on the module-level app and never restored them, leaking into whatever ran next. All four are captured and restored in a `finally`.

## Tests added

- `test_app_revenue_api.py`: ingest-key path works with auth on and stamps the key's tenant; service token plus `x-tenant-id` works; neither credential (bare `x-tenant-id`, and a bogus bearer) is 401 with nothing written; a `read`-scoped key is 403 `FORBIDDEN_SCOPE`.
- `test_app_replay_estimate.py`: a body `tenant_id` disagreeing with `x-tenant-id` is 403, and a matching one still succeeds.

## Verification

```
cd infra/gateway && uv run --extra dev pytest -q   ->  904 passed
cd infra/gateway && uv run ruff check .            ->  All checks passed!
cd web && npm run typecheck                        ->  clean
cd web && npm run lint                             ->  1 pre-existing warning (lib/useLivePoll.ts unused eslint-disable)
cd web && npm run test                             ->  61 files, 707 tests passed
```

No new failures. The two known `web/app/api/api.test.ts` ClickHouse-unreachable cases passed here because no local ClickHouse was running.

## Not fixed / notes

- Helm rendering was not executed: `helm` is not installed in this environment. The two guards are plain `if`/`fail` Go template blocks and the referenced values keys were verified to exist in both charts.
- The `values-*.example.yaml` files still set `gatewayServiceToken`. That is intentional: they describe a fresh install where the operator creates the secrets from the README first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
