### PR TITLE
fix(sdk): correct placement, allowlisting and honesty in the onboarding PR bot (CTO-261)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -262,8 +262,23 @@ not merely promised here:
   (and `rebase`, `cherry-pick`, `reset`) is on neither, so no code path reaches one. The PR
   waits for a human.
 - **It keeps no source.** The clone is shallow, lives in a temporary directory, and is
-  deleted in a `finally` on every exit path including a refused run. What the run returns is
-  paths, counts, generated code and gaps, never your source.
+  deleted in a `finally` on every exit path including a refused run, and by a SIGTERM /
+  SIGINT handler so a runner that stops the job does not leave the clone behind either. A
+  `SIGKILL` cannot be caught by anything, so the promise is every exit path the process
+  controls. A cleanup that fails is reported in `cleanup_error`, never swallowed. What the
+  run returns is paths, counts, generated code and gaps, never your source.
 - **It invents nothing.** Every line it writes comes from the recipe catalog. A value it
   cannot derive from the call site stays a visible `<FILL:...>` hole, and a block with a hole
   is inserted commented out so nothing runs on a guessed value.
+- **It claims nothing it did not do.** `layers_wired` (in the JSON result, the commit
+  subject and the PR table) lists only blocks that actually meter. A block inserted
+  commented out is reported separately as inactive.
+- **It never commits code that does not compile.** Every block goes in at a statement
+  boundary resolved from the parsed file, and every patched Python file is run through
+  `compile()` before anything is written. A file it cannot patch cleanly is left untouched
+  and reported as a gap.
+
+Each run gets its own branch (`tally/onboarding/<run id>`); pass `--branch-suffix` to name
+it yourself. If the branch is already on the remote the run stops and says so instead of
+failing at push. If the push succeeds but the PR call does not, the exit is non-zero and the
+printed result carries `orphan_branch` so you can find the branch it left.

--- a/sdk/python/onboarding_bot/__init__.py
+++ b/sdk/python/onboarding_bot/__init__.py
@@ -19,13 +19,14 @@ Two properties hold the whole component together:
   * The section 9 posture is code, not prose: :mod:`onboarding_bot.guards` refuses a push to
     a default branch, refuses every git subcommand and GitHub endpoint outside the narrow
     set a reviewed PR needs (merge is on neither list), and redacts the token from anything
-    the component emits. The working clone is deleted in a ``finally``.
+    the component emits. The working clone is deleted in a ``finally`` and by a SIGTERM /
+    SIGINT handler, so a stopped hosted run leaves no clone behind either.
 """
 
 from .config import DEFAULT_TOKEN_ENV, BotConfig, resolve_token
 from .guards import SecurityViolation
 from .propose import ACCOUNT_QUESTION, Proposal, ProposedEdit, account_question, build_proposal
-from .run import RunResult, pr_body, run_bot
+from .run import RunFailed, RunResult, pr_body, run_bot
 
 __all__ = [
     "BotConfig",
@@ -38,6 +39,7 @@ __all__ = [
     "account_question",
     "build_proposal",
     "RunResult",
+    "RunFailed",
     "run_bot",
     "pr_body",
 ]

--- a/sdk/python/onboarding_bot/config.py
+++ b/sdk/python/onboarding_bot/config.py
@@ -17,12 +17,29 @@ same settings page when the run is done.
 from __future__ import annotations
 
 import os
+import secrets
+import time
 from dataclasses import dataclass, field
 
-from .guards import SecurityViolation
+from .guards import (
+    SecurityViolation,
+    assert_repo_part_allowed,
+    assert_token_env_name_allowed,
+)
 
 DEFAULT_TOKEN_ENV = "TALLY_ONBOARDING_GITHUB_TOKEN"
 DEFAULT_BRANCH_PREFIX = "tally/onboarding"
+
+
+def new_run_id() -> str:
+    """A per-run branch suffix: a UTC date plus random hex.
+
+    A fixed suffix makes the second run against a repo collide with the first branch and
+    die at push with a bare non-fast-forward error and no PR (CTO-261). A run id is the
+    smallest thing that makes two runs two branches; the date keeps the name readable for
+    the developer who has to find it.
+    """
+    return f"{time.strftime('%Y%m%d', time.gmtime())}-{secrets.token_hex(3)}"
 
 
 @dataclass(frozen=True)
@@ -45,22 +62,36 @@ class BotConfig:
     feature_tag: str | None = None
     branch_prefix: str = DEFAULT_BRANCH_PREFIX
     branch_suffix: str = ""
-    """Appended to the generated branch name; a run id in production, fixed in tests."""
+    """Appended to the generated branch name; a run id in production, fixed in tests.
+
+    Left empty it is filled once, at construction, with :func:`new_run_id`, so two runs
+    against the same repo are two branches rather than a push collision."""
 
     labels: list[str] = field(default_factory=list)
     max_call_sites: int = 25
     """Cap on instrumented call sites so one run stays a reviewable diff, not a rewrite."""
 
+    def __post_init__(self) -> None:
+        # Validated here rather than at the point of use so a malformed run refuses before
+        # it clones anything, and so no unchecked operator string reaches the credential
+        # helper or the endpoint allowlist (CTO-261 section 9).
+        assert_token_env_name_allowed(self.token_env)
+        _owner, _name = self.owner_and_name
+        if not self.branch_suffix:
+            object.__setattr__(self, "branch_suffix", new_run_id())
+
     def branch_name(self) -> str:
-        suffix = self.branch_suffix or "wire-tally"
-        return f"{self.branch_prefix}/{suffix}"
+        return f"{self.branch_prefix}/{self.branch_suffix}"
 
     @property
     def owner_and_name(self) -> tuple[str, str]:
         parts = self.repo.split("/")
         if len(parts) != 2 or not all(parts):
             raise SecurityViolation(f"repo must be 'owner/name', got {self.repo!r}")
-        return parts[0], parts[1]
+        owner, name = parts
+        assert_repo_part_allowed(owner, field="owner")
+        assert_repo_part_allowed(name, field="name")
+        return owner, name
 
 
 def resolve_token(config: BotConfig) -> str:

--- a/sdk/python/onboarding_bot/git_ops.py
+++ b/sdk/python/onboarding_bot/git_ops.py
@@ -25,6 +25,7 @@ from .guards import (
     assert_git_subcommand_allowed,
     assert_push_flags_allowed,
     assert_push_target_allowed,
+    assert_token_env_name_allowed,
     redact,
 )
 
@@ -67,6 +68,10 @@ class GitRunner:
 
     def _askpass_path(self) -> Path:
         if self._askpass is None:
+            # Re-checked at the point of interpolation, not only at config construction: this
+            # is the one place an operator string becomes shell source, so the refusal lives
+            # next to the substitution (CTO-261 section 9).
+            assert_token_env_name_allowed(self.config.token_env)
             path = self.workdir / "askpass.sh"
             path.write_text(_ASKPASS_TEMPLATE.replace("${token_env}", f"${self.config.token_env}"))
             path.chmod(path.stat().st_mode | stat.S_IXUSR)
@@ -150,8 +155,24 @@ class GitRunner:
         self.run("add", "-A", cwd=repo_dir)
         self.run("commit", "-m", message, cwd=repo_dir)
 
-    def push_branch(self, repo_dir: Path, branch: str, default_branch: str) -> None:
+    def remote_branch_exists(self, repo_dir: Path, branch: str) -> bool:
+        """Ask the remote whether the branch is already there.
+
+        A branch that exists means an earlier run got this far. Reporting that by name beats
+        the bare non-fast-forward error git would otherwise raise at push time (CTO-261).
+        """
+        result = self.run(
+            "ls-remote", "--heads", "origin", branch, cwd=repo_dir, with_credentials=True
+        )
+        return bool(result.stdout.strip())
+
+    def push_branch(
+        self, repo_dir: Path, branch: str, default_branch: str, *, flags: tuple[str, ...] = ()
+    ) -> None:
         """Push the new branch. The single push path in the component, and it is guarded."""
         assert_push_target_allowed(branch, default_branch)
-        assert_push_flags_allowed([])
-        self.run("push", "origin", f"{branch}:{branch}", cwd=repo_dir, with_credentials=True)
+        argv = ["push", *flags, "origin", f"{branch}:{branch}"]
+        # The flags actually in the argv, not a hard-coded empty list: a refusal that
+        # inspects nothing reads like enforcement and enforces nothing (CTO-261 section 9).
+        assert_push_flags_allowed([arg for arg in argv if arg.startswith("-")])
+        self.run(*argv, cwd=repo_dir, with_credentials=True)

--- a/sdk/python/onboarding_bot/guards.py
+++ b/sdk/python/onboarding_bot/guards.py
@@ -57,9 +57,64 @@ _ALLOWED_ENDPOINTS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("POST", re.compile(r"^/repos/[^/]+/[^/]+/pulls$")),
 )
 
+# GitHub's own owner / repository character set. Anything else (a `?`, a `#`, a `/`) makes
+# the path the allowlist approves differ from the path urllib actually requests: `?ref=x`
+# in the name turns POST /repos/o/n%3Fref%3Dx/pulls into POST /repos/o/n with a query
+# string, so the allowlist would have approved a request that was never sent (CTO-261
+# section 9).
+_REPO_PART_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Environment variable names, as the shell defines them. The name is interpolated into the
+# GIT_ASKPASS helper, so an unconstrained name is a shell expression in a module whose whole
+# thesis is allowlisting (CTO-261 section 9).
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 class SecurityViolation(Exception):
     """A refused action under the section 9 posture. Never caught internally."""
+
+
+def assert_repo_part_allowed(part: str, *, field: str) -> None:
+    """Refuse an owner or repository name that is not what GitHub would accept.
+
+    The endpoint allowlist matches on the path the bot builds. A name carrying a query or
+    a path separator makes that path a different request than the one urllib sends, so the
+    only safe check is on the parts before the path exists.
+    """
+    if not _REPO_PART_RE.match(part) or part in (".", ".."):
+        raise SecurityViolation(
+            f"refusing repository {field} {part!r}: only letters, digits, '.', '_' and '-' "
+            f"are accepted, so the path checked against the allowlist is the path requested "
+            f"(section 9)"
+        )
+
+
+def assert_token_env_name_allowed(name: str) -> None:
+    """Refuse a token environment variable name that is not a bare shell identifier.
+
+    The name is written into the GIT_ASKPASS helper as ``"$NAME"``. Anything that can close
+    that quote runs as a command when git prompts, which is why the one operator-supplied
+    string that reaches a shell is allowlisted like every other surface here (section 9).
+    """
+    if not _ENV_NAME_RE.match(name):
+        raise SecurityViolation(
+            f"refusing token environment variable name {name!r}: it must match "
+            f"[A-Za-z_][A-Za-z0-9_]* so it cannot carry shell syntax into the credential "
+            f"helper (section 9)"
+        )
+
+
+def normalize_branch(name: str) -> str:
+    """Strip a ``refs/heads/`` namespace so two spellings of one branch compare equal.
+
+    ``refs/heads/main`` and ``main`` are the same branch to git. Comparing the raw strings
+    would let the namespaced spelling walk past the default-branch refusal, so the refusal
+    compares normalized names (section 9 hardening).
+    """
+    stripped = name.strip()
+    while stripped.startswith("refs/heads/"):
+        stripped = stripped[len("refs/heads/") :]
+    return stripped
 
 
 def assert_git_subcommand_allowed(argv: list[str]) -> None:
@@ -91,12 +146,12 @@ def assert_push_target_allowed(branch: str, default_branch: str) -> None:
     target is decided and it is this one (section 9: never a direct push to a default
     branch).
     """
-    name = branch.strip()
+    name = normalize_branch(branch)
     if not name:
         raise SecurityViolation("refusing a push with an empty branch name")
     if name.startswith("-"):
         raise SecurityViolation(f"refusing a push to option-shaped branch name {branch!r}")
-    if name == default_branch.strip():
+    if name == normalize_branch(default_branch):
         raise SecurityViolation(
             f"refusing to push to the default branch {default_branch!r}: the onboarding bot "
             f"opens a reviewed PR from a new branch and never writes to a default branch "

--- a/sdk/python/onboarding_bot/patch.py
+++ b/sdk/python/onboarding_bot/patch.py
@@ -4,12 +4,24 @@
 The only module that writes anything, and it writes only inside the clone that the run
 deletes afterwards. Nothing here composes code: every block comes from the catalog through
 :mod:`onboarding_bot.propose`, so this is placement and indentation, not generation.
+
+Placement is a real question, not a line-number increment. A matched line is often the
+first line of a longer statement (``app = FastAPI(\\n    title="demo",\\n)``), and inserting
+after it would land the block between a call's open paren and its arguments, producing a
+branch that does not compile. Every insertion point here is a statement boundary resolved
+with :mod:`ast`, every edit's ``placement`` is honoured, and nothing is written until the
+patched file has been through :func:`compile`. A file that would not compile is reported as
+a gap and left untouched, because pushing broken code into a customer repo is the one
+failure this component must not have (CLAUDE.md: honest under uncertainty).
 """
 
 from __future__ import annotations
 
+import ast
 from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from .guards import SecurityViolation
 from .propose import Proposal, ProposedEdit
@@ -27,91 +39,351 @@ HOLE_NOTICE = (
     "blank rather than guessing."
 )
 
+# Placements the catalog emits. An unrecognised placement is refused rather than guessed at:
+# a block put somewhere its recipe did not intend is a block that meters nothing.
+_KNOWN_PLACEMENTS = frozenset({"startup", "wrap_handler", "after_call", "config"})
 
-def apply_proposal(repo_dir: Path, proposal: Proposal) -> list[str]:
-    """Write every edit into the clone. Returns the repo-relative paths touched."""
+# Statement nodes that own an indented suite. A match on one of these headers belongs
+# inside the suite (``if __name__ == "__main__":`` wants tally.init() as its first
+# statement), never after the whole block.
+_SUITE_FIELDS = ("body", "orelse", "finalbody")
+
+
+@dataclass
+class PatchResult:
+    """What was written and what could not be.
+
+    ``gaps`` carries the same reported-gap shape the rest of the run uses, so a file the
+    patcher refuses to touch reaches the PR body as a gap instead of vanishing.
+    """
+
+    files_changed: list[str] = field(default_factory=list)
+    applied: list[ProposedEdit] = field(default_factory=list)
+    gaps: list[dict[str, Any]] = field(default_factory=list)
+
+
+def apply_proposal(repo_dir: Path, proposal: Proposal) -> PatchResult:
+    """Write every edit into the clone. Returns what landed and what was refused.
+
+    Nothing is written until every target file has been patched in memory and compiled, so
+    a file the bot cannot patch safely leaves the clone exactly as it found it.
+    """
     by_path: dict[str, list[ProposedEdit]] = defaultdict(list)
     for edit in proposal.edits:
         by_path[edit.path].append(edit)
 
-    touched: list[str] = []
+    result = PatchResult()
+    pending: list[tuple[Path, str]] = []
     for rel_path, edits in sorted(by_path.items()):
         target = _resolve_inside(repo_dir, rel_path)
-        lines = target.read_text(encoding="utf-8").splitlines()
-        # Descending so an insertion never shifts a later edit's line number. Two edits on
-        # the same line insert in reverse proposal order, which leaves them in proposal
-        # order in the file: tally.init() must land above the middleware that assumes it.
-        ordered = sorted(
-            enumerate(edits), key=lambda pair: (pair[1].line_no, pair[0]), reverse=True
-        )
-        for _, edit in ordered:
-            if edit.line_no < 0 or edit.line_no > len(lines):
-                raise SecurityViolation(
-                    f"edit for {rel_path} targets line {edit.line_no}, outside the file"
+        source = _read_source(target)
+        if source is None:
+            result.gaps.append(
+                _gap(
+                    f"{rel_path} is not decodable as UTF-8, so the bot did not rewrite it; "
+                    f"the edits for this file were dropped rather than written blind"
                 )
-            lines[edit.line_no : edit.line_no] = _block(edit)
-        # Only active blocks pull in imports: an import added for a commented-out block
-        # would be an unused import the developer's own linter then flags.
-        active_imports = {i for e in edits if not e.holes_to_fill for i in e.imports_to_add}
-        lines = _ensure_imports(lines, sorted(active_imports))
-        target.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        touched.append(rel_path)
-    return touched
+            )
+            continue
+        patched, applied, gaps = _patch_file(rel_path, source, edits)
+        result.gaps.extend(gaps)
+        if not applied:
+            continue
+        pending.append((target, patched))
+        result.files_changed.append(rel_path)
+        result.applied.extend(applied)
+
+    for target, text in pending:
+        # newline="" so the line endings assembled above survive the write verbatim: a
+        # whole-file CRLF rewrite would be a diff on every line of the developer's file.
+        with target.open("w", encoding="utf-8", newline="") as handle:
+            handle.write(text)
+    return result
 
 
-def _block(edit: ProposedEdit) -> list[str]:
-    """Indent a generated block to its call site and mark it for review."""
+def _gap(reason: str, **extra: Any) -> dict[str, Any]:
+    """The one reported-gap shape, matching onboarding_mcp.generate._gap."""
+    return {"gap": True, "reason": reason, **extra}
+
+
+def _read_source(path: Path) -> str | None:
+    """Read a file the bot is about to rewrite, strictly.
+
+    Strict on purpose, unlike the tolerant scan read: a lossy decode here would be written
+    back and would silently corrupt the developer's file. Undecodable means not patched.
+    """
+    try:
+        return path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _patch_file(
+    rel_path: str, source: str, edits: list[ProposedEdit]
+) -> tuple[str, list[ProposedEdit], list[dict[str, Any]]]:
+    """Patch one file in memory. Returns the new text, the edits that landed, and gaps."""
+    newline = "\r\n" if "\r\n" in source else "\n"
+    ends_with_newline = source.endswith(("\n", "\r"))
+    lines = source.splitlines()
+    spans = _statement_spans(source)
+
+    gaps: list[dict[str, Any]] = []
+    applied: list[ProposedEdit] = []
+    # (index, order) descending so an insertion never shifts a later one's index. Two edits
+    # at the same index insert in reverse proposal order, which leaves them in proposal
+    # order in the file: tally.init() must land above the middleware that assumes it.
+    plan: list[tuple[int, int, list[str]]] = []
+    for order, edit in enumerate(edits):
+        if edit.line_no < 1 or edit.line_no > len(lines):
+            raise SecurityViolation(
+                f"edit for {rel_path} targets line {edit.line_no}, outside the file"
+            )
+        if edit.placement not in _KNOWN_PLACEMENTS:
+            gaps.append(
+                _gap(
+                    f"{rel_path}:{edit.line_no} recipe {edit.recipe_id} asks for placement "
+                    f"{edit.placement!r}, which this bot does not know how to place safely",
+                    recipe_id=edit.recipe_id,
+                    code=edit.code,
+                )
+            )
+            continue
+        resolved = _resolve_insertion(lines, spans, edit)
+        if resolved is None:
+            gaps.append(
+                _gap(
+                    f"{rel_path}:{edit.line_no} has no safe statement boundary for a "
+                    f"{edit.placement!r} block, so it was not inserted; place the code below "
+                    f"by hand",
+                    recipe_id=edit.recipe_id,
+                    code=edit.code,
+                )
+            )
+            continue
+        index, indent = resolved
+        plan.append((index, order, _block(edit, indent)))
+        applied.append(edit)
+
+    if not applied:
+        return source, [], gaps
+
+    # Only active blocks pull in imports: an import added for a commented-out block would be
+    # an unused import the developer's own linter then flags.
+    active_imports = sorted({i for e in applied if not e.holes_to_fill for i in e.imports_to_add})
+    import_index = _import_insertion_point(lines, spans)
+    for offset, statement in enumerate(active_imports):
+        if any(line.strip() == statement for line in lines):
+            continue
+        plan.append((import_index, -1_000_000 + offset, [statement]))
+
+    patched_lines = list(lines)
+    for index, _order, block in sorted(plan, key=lambda item: (item[0], item[1]), reverse=True):
+        patched_lines[index:index] = block
+    text = newline.join(patched_lines) + (newline if ends_with_newline else "")
+
+    if rel_path.endswith(".py"):
+        try:
+            compile(text, rel_path, "exec")
+        except SyntaxError as exc:
+            # The safety net. A block that would not compile is never committed, and the
+            # reason travels to the PR body instead of to the customer's CI.
+            gaps.append(
+                _gap(
+                    f"{rel_path} would not compile after the generated blocks were inserted "
+                    f"({exc.msg} at line {exc.lineno}), so the file was left unchanged and "
+                    f"nothing was committed for it",
+                    recipe_ids=[e.recipe_id for e in applied],
+                )
+            )
+            return source, [], gaps
+    return text, applied, gaps
+
+
+# -- insertion points ------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _Span:
+    """One statement's extent, plus where its suite starts and whether it is module level."""
+
+    start: int
+    end: int
+    body_start: int | None
+    module_level: bool
+
+
+def _statement_spans(source: str) -> list[_Span] | None:
+    """Every statement in the file as a 1-based line span. ``None`` if it does not parse."""
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+    spans: list[_Span] = []
+    _collect_spans(tree.body, spans, module_level=True)
+    return spans
+
+
+def _collect_spans(body: list[ast.stmt], spans: list[_Span], *, module_level: bool) -> None:
+    for node in body:
+        start = node.lineno
+        # Decorators sit above the `def` line but belong to the same statement: a match on
+        # `@app.post("/ask")` must resolve to the function, not to module scope.
+        for decorator in getattr(node, "decorator_list", []) or []:
+            start = min(start, decorator.lineno)
+        end = getattr(node, "end_lineno", None) or node.lineno
+        suites = [
+            getattr(node, name, None) for name in _SUITE_FIELDS
+        ] + [h.body for h in getattr(node, "handlers", [])] + [
+            c.body for c in getattr(node, "cases", [])
+        ]
+        suites = [s for s in suites if s]
+        body_start = min(s[0].lineno for s in suites) if suites else None
+        spans.append(_Span(start=start, end=end, body_start=body_start, module_level=module_level))
+        for suite in suites:
+            _collect_spans(suite, spans, module_level=False)
+
+
+def _resolve_insertion(
+    lines: list[str], spans: list[_Span] | None, edit: ProposedEdit
+) -> tuple[int, str] | None:
+    """Where a block goes: a 0-based insertion index plus the indent to write it at."""
+    if spans is None:
+        return _fallback_insertion(lines, edit)
+
+    containing = [s for s in spans if s.start <= edit.line_no <= s.end]
+    if not containing:
+        # A match outside every statement is a comment or a blank line. There is no
+        # statement to attach to, so nothing is inserted.
+        return None
+    span = max(containing, key=lambda s: (s.start, -s.end))
+
+    if edit.placement == "wrap_handler" and not span.module_level:
+        # Middleware recipes are module-scope definitions. Inserted inside a function they
+        # would be a local def that never attaches to the app.
+        return None
+
+    if span.body_start is not None and edit.line_no < span.body_start:
+        # The match is in a compound statement's header, so the block belongs as the first
+        # statement of its suite: `if __name__ == "__main__":` wants init inside the block.
+        if edit.placement == "wrap_handler":
+            return None
+        index = span.body_start - 1
+        return index, _indent_of(lines[index])
+    return span.end, _indent_of(lines[span.start - 1])
+
+
+def _fallback_insertion(lines: list[str], edit: ProposedEdit) -> tuple[int, str] | None:
+    """Bracket balancing for a file that does not parse (already broken, or not Python).
+
+    Weaker than the ast path and used only where the ast path cannot run. It still refuses
+    to insert mid-statement: it walks forward until brackets balance and no continuation is
+    open, and gives up rather than guessing if the statement never closes.
+    """
+    depth = 0
+    index = edit.line_no - 1
+    while index < len(lines):
+        line = lines[index]
+        depth += _bracket_delta(line)
+        stripped = line.rstrip()
+        if depth <= 0 and not stripped.endswith("\\"):
+            if stripped.endswith(":"):
+                # A suite header: the block goes inside, at the suite's own indent.
+                nxt = index + 1
+                while nxt < len(lines) and not lines[nxt].strip():
+                    nxt += 1
+                if nxt >= len(lines):
+                    return None
+                return nxt, _indent_of(lines[nxt])
+            return index + 1, _indent_of(lines[edit.line_no - 1])
+        index += 1
+    return None
+
+
+def _bracket_delta(line: str) -> int:
+    """Net bracket depth of a line, ignoring brackets inside strings and comments."""
+    depth = 0
+    quote: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote:
+            if ch == "\\":
+                i += 2
+                continue
+            if line.startswith(quote, i):
+                i += len(quote)
+                quote = None
+                continue
+        elif ch in "\"'":
+            quote = line[i : i + 3] if line.startswith(line[i] * 3, i) else ch
+            i += len(quote)
+            continue
+        elif ch == "#":
+            break
+        elif ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        i += 1
+    return depth
+
+
+def _indent_of(line: str) -> str:
+    return line[: len(line) - len(line.lstrip())]
+
+
+def _block(edit: ProposedEdit, indent: str) -> list[str]:
+    """Indent a generated block to its insertion point and mark it for review."""
     commented = bool(edit.holes_to_fill)
-    out = ["", f"{edit.indent}{MARKER}"]
+    out = ["", f"{indent}{MARKER}"]
     if commented:
-        out.append(f"{edit.indent}{HOLE_NOTICE}")
+        out.append(f"{indent}{HOLE_NOTICE}")
     for line in edit.code.rstrip("\n").splitlines():
         if not line.strip():
             out.append("")
         elif commented and not line.lstrip().startswith("#"):
-            out.append(f"{edit.indent}# {line}")
+            out.append(f"{indent}# {line}")
         else:
-            out.append(f"{edit.indent}{line}")
+            out.append(f"{indent}{line}")
     return out
 
 
-def _ensure_imports(lines: list[str], imports: list[str]) -> list[str]:
-    """Add each import once, after the file's existing imports.
+def _import_insertion_point(lines: list[str], spans: list[_Span] | None) -> int:
+    """After the file's last top-level import, else after the module docstring and shebang.
 
-    An import already present is left alone: re-adding it would be a diff line that says
-    nothing, and this diff is read by a human.
+    Resolved from the parsed module when possible so an unindented ``import`` inside a
+    docstring or a string literal cannot be mistaken for the file's imports.
     """
-    result = list(lines)
-    for statement in imports:
-        if any(line.strip() == statement for line in result):
-            continue
-        result.insert(_import_insertion_point(result), statement)
-    return result
+    try:
+        tree = ast.parse("\n".join(lines))
+    except (SyntaxError, ValueError):
+        tree = None
+    if tree is not None:
+        last_import = 0
+        for node in tree.body:
+            if isinstance(node, ast.Import | ast.ImportFrom):
+                last_import = max(last_import, getattr(node, "end_lineno", node.lineno))
+        if last_import:
+            return last_import
+        first = tree.body[0] if tree.body else None
+        if (
+            first is not None
+            and isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            return getattr(first, "end_lineno", first.lineno)
+        return _prelude_end(lines)
+    return _prelude_end(lines)
 
 
-def _import_insertion_point(lines: list[str]) -> int:
-    """After the last top-level import, else after the module docstring and shebang."""
-    last_import = -1
-    for i, line in enumerate(lines):
-        if line.startswith(("import ", "from ")):
-            last_import = i
-    if last_import >= 0:
-        return last_import + 1
-
+def _prelude_end(lines: list[str]) -> int:
+    """First line after a shebang and any leading comments. Used when the file does not parse."""
     i = 0
     if i < len(lines) and lines[i].startswith("#!"):
         i += 1
     while i < len(lines) and (not lines[i].strip() or lines[i].lstrip().startswith("#")):
         i += 1
-    if i < len(lines) and lines[i].lstrip().startswith(('"""', "'''")):
-        quote = lines[i].lstrip()[:3]
-        # A single-line docstring opens and closes on the same line.
-        if lines[i].strip().endswith(quote) and len(lines[i].strip()) > 3:
-            return i + 1
-        i += 1
-        while i < len(lines) and quote not in lines[i]:
-            i += 1
-        return min(i + 1, len(lines))
     return i
 
 

--- a/sdk/python/onboarding_bot/propose.py
+++ b/sdk/python/onboarding_bot/propose.py
@@ -85,7 +85,19 @@ class Proposal:
 
     @property
     def layers_wired(self) -> list[str]:
-        return sorted({e.kind for e in self.edits})
+        """Layers that actually meter after this diff lands.
+
+        A block with an unfilled hole is inserted commented out, so it meters nothing. It
+        must never be counted here: a summary that lists ``vector`` because a commented-out
+        record_vector_call was inserted is a summary claiming work the diff did not do
+        (CLAUDE.md: honest under uncertainty).
+        """
+        return sorted({e.kind for e in self.edits if not e.holes_to_fill})
+
+    @property
+    def layers_inserted_inactive(self) -> list[str]:
+        """Layers whose block was inserted but commented out pending a hole being filled."""
+        return sorted({e.kind for e in self.edits if e.holes_to_fill})
 
     @property
     def holes(self) -> list[str]:
@@ -103,10 +115,12 @@ def account_candidates(repo_dir: Path) -> list[dict[str, str]]:
     """
     seen: set[tuple[str, str]] = set()
     out: list[dict[str, str]] = []
-    from .repo_scan import python_files  # local import keeps the scan surface in one module
+    # Local import keeps the scan surface in one module. _read is the tolerant reader: one
+    # unreadable file in the repo must not abort the whole run.
+    from .repo_scan import _read, python_files
 
     for path in python_files(repo_dir):
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = _read(path)
         for kind, pattern in _CANDIDATE_PATTERNS:
             for match in pattern.finditer(text):
                 key = (kind, match.group(1))
@@ -254,7 +268,12 @@ def _propose_call_sites(
 ) -> None:
     """The layer-specific record_* edits, each adapted to its real call site."""
     matched = list(proposal.detection.get("matched_recipes", []))
-    sites: list[CallSite] = find_call_sites(repo_dir, matched, catalog=cat, limit=max_call_sites)
+    sites: list[CallSite]
+    sites, weak = find_call_sites(repo_dir, matched, catalog=cat, limit=max_call_sites)
+    for match in weak:
+        # A pattern hit the scan could not bind to the recipe's library. Reported, never
+        # turned into a record_* call that would attribute the wrong provider.
+        proposal.gaps.append(gap(match.reason, recipe_id=match.recipe_id))
     for site in sites:
         recipe = cat.get(site.recipe_id)
         if site.source_line.startswith(("return ", "yield ")):

--- a/sdk/python/onboarding_bot/repo_scan.py
+++ b/sdk/python/onboarding_bot/repo_scan.py
@@ -14,11 +14,12 @@ MCP server's answers.
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+from onboarding_mcp.catalog import Recipe, RecipeCatalog, get_catalog
 from onboarding_mcp.detect import detect_stack
 
 MANIFEST_FILES = (
@@ -47,6 +48,14 @@ _MAX_EXCERPT_CHARS = 200_000
 # is actually constructed.
 _STARTUP_PATTERNS = ("FastAPI(", "Flask(", "def create_app(", "if __name__ ==")
 
+# Directories and file names that are never the process the developer deploys. tally.init()
+# landing in a test fixture would instrument the test run and leave the real entrypoint
+# unmetered, silently, which is worse than reporting that no entrypoint was found (CTO-261).
+_NON_ENTRYPOINT_DIRS = frozenset(
+    {"tests", "test", "testing", "examples", "example", "samples", "docs", "doc",
+     "scripts", "benchmarks", "bench", "fixtures", "migrations"}
+)
+
 
 @dataclass(frozen=True)
 class CallSite:
@@ -57,6 +66,21 @@ class CallSite:
     indent: str
     source_line: str
     recipe_id: str
+
+
+@dataclass(frozen=True)
+class WeakMatch:
+    """A pattern hit the bot refuses to turn into an edit, with the reason it refused.
+
+    A substring hit is not evidence a line belongs to the detected library: ``.query(`` is
+    SQLAlchemy's as often as Pinecone's. These reach the PR as gaps so the developer can
+    place the block, rather than as an edit that meters the wrong thing (CTO-261).
+    """
+
+    path: str
+    line_no: int
+    recipe_id: str
+    reason: str
 
 
 def python_files(repo_dir: Path) -> list[Path]:
@@ -121,14 +145,22 @@ def find_call_sites(
     *,
     catalog: RecipeCatalog | None = None,
     limit: int = 25,
-) -> list[CallSite]:
+) -> tuple[list[CallSite], list[WeakMatch]]:
     """Locate the real call sites the matched record_* recipes apply to (section 3 step 4).
 
     Only recipes that emit an SDK call are placed. A middleware or startup recipe has its
     own placement and is handled by the proposal step, not here.
+
+    Matching is done on the parsed call expression, not on raw text, so a hit inside a
+    comment or a string literal is not a call site. On top of that a match counts only when
+    the file imports the library the recipe is for: without that check a repo with both
+    pinecone and sqlalchemy gets ``record_vector_call(provider="pinecone")`` after
+    ``session.query(...)``. Everything that fails either test is returned as a
+    :class:`WeakMatch` for the PR to report.
     """
     cat = catalog or get_catalog()
     sites: list[CallSite] = []
+    weak: list[WeakMatch] = []
     placeable = []
     for recipe_id in recipe_ids:
         recipe = cat.get(recipe_id)
@@ -140,32 +172,115 @@ def find_call_sites(
 
     for path in python_files(repo_dir):
         text = _read(path)
-        for line_no, line in enumerate(text.splitlines(), start=1):
-            for recipe in placeable:
-                if any(pattern in line for pattern in recipe.call_patterns):
-                    sites.append(
-                        CallSite(
-                            path=str(path.relative_to(repo_dir)),
+        try:
+            tree = ast.parse(text)
+        except (SyntaxError, ValueError):
+            # A file the bot cannot parse is a file it cannot place an edit in safely.
+            continue
+        lines = text.splitlines()
+        rel = str(path.relative_to(repo_dir))
+        imported = _imported_roots(tree)
+        reported: set[str] = set()
+        for line_no, recipe in sorted(_call_matches(tree, placeable), key=lambda m: m[0]):
+            if not (set(recipe.imports) & imported):
+                if recipe.id not in reported:
+                    reported.add(recipe.id)
+                    weak.append(
+                        WeakMatch(
+                            path=rel,
                             line_no=line_no,
-                            indent=line[: len(line) - len(line.lstrip())],
-                            source_line=line.strip(),
                             recipe_id=recipe.id,
+                            reason=(
+                                f"{rel}:{line_no} looks like a {recipe.id} call site, but this "
+                                f"file imports none of {', '.join(recipe.imports)}. The bot "
+                                f"does not attribute a call to a library the file never "
+                                f"imported; place the block by hand if it belongs here"
+                            ),
                         )
                     )
-                    break
+                continue
+            line = lines[line_no - 1] if line_no <= len(lines) else ""
+            sites.append(
+                CallSite(
+                    path=rel,
+                    line_no=line_no,
+                    indent=line[: len(line) - len(line.lstrip())],
+                    source_line=line.strip(),
+                    recipe_id=recipe.id,
+                )
+            )
             if len(sites) >= limit:
-                return sites
-    return sites
+                return sites, weak
+    return sites, weak
+
+
+def _imported_roots(tree: ast.Module) -> set[str]:
+    """Root module names this file imports, which is what binds a match to a library."""
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+def _call_matches(tree: ast.Module, recipes: list[Recipe]) -> list[tuple[int, Recipe]]:
+    """Line numbers where a parsed call or decorator matches a recipe's patterns.
+
+    Only patterns that describe a call (``.query(``, ``Tool(``) or a decorator (``@tool``)
+    are matched. A pattern that is neither, such as pgvector's ``<->`` SQL operator, cannot
+    be recognised in the syntax tree and is left to the developer rather than matched as
+    text inside a string.
+    """
+    out: list[tuple[int, Recipe]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            try:
+                expr = ast.unparse(node.func) + "("
+            except Exception:  # pragma: no cover - unparse is total for parsed trees
+                continue
+            for recipe in recipes:
+                if any(_expression_matches(expr, p) for p in recipe.call_patterns):
+                    out.append((node.lineno, recipe))
+                    break
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            names = {f"@{ast.unparse(d)}" for d in node.decorator_list}
+            for recipe in recipes:
+                if any(p.startswith("@") and p in names for p in recipe.call_patterns):
+                    out.append((node.lineno, recipe))
+                    break
+    return out
+
+
+def _expression_matches(expr: str, pattern: str) -> bool:
+    """Match a call pattern against an unparsed call expression, on a name boundary.
+
+    ``.query(`` matches ``index.query(`` and not ``index.subquery(``; ``Tool(`` matches
+    ``Tool(`` and ``mod.Tool(`` and not ``MyTool(``.
+    """
+    if not pattern.endswith("("):
+        return False
+    if not expr.endswith(pattern):
+        return False
+    prefix = expr[: -len(pattern)]
+    if pattern.startswith("."):
+        # The pattern carries its own attribute boundary; it just needs something to be an
+        # attribute of.
+        return bool(prefix)
+    return not prefix or prefix.endswith(".")
 
 
 def find_startup_site(repo_dir: Path) -> CallSite | None:
     """Find where the process starts, so tally.init() lands before the first LLM call.
 
     Returns ``None`` when no startup line is recognisable. That is a gap the PR reports,
-    not a file the bot picks arbitrarily (section 2 decision 2).
+    not a file the bot picks arbitrarily (section 2 decision 2). Tests, examples and scripts
+    are excluded: they are not the process the developer runs in production.
     """
+    candidates = [p for p in python_files(repo_dir) if _is_entrypoint_candidate(p, repo_dir)]
     for pattern in _STARTUP_PATTERNS:
-        for path in python_files(repo_dir):
+        for path in candidates:
             for line_no, line in enumerate(_read(path).splitlines(), start=1):
                 if pattern in line:
                     indent = line[: len(line) - len(line.lstrip())]
@@ -205,6 +320,15 @@ def find_app_object_site(repo_dir: Path, framework: str) -> CallSite | None:
                     recipe_id=f"middleware.{framework.lower()}.account",
                 )
     return None
+
+
+def _is_entrypoint_candidate(path: Path, repo_dir: Path) -> bool:
+    """True when a file could plausibly be the deployed process, not a test or a sample."""
+    parts = path.relative_to(repo_dir).parts
+    if any(part.lower() in _NON_ENTRYPOINT_DIRS for part in parts[:-1]):
+        return False
+    name = parts[-1].lower()
+    return not (name.startswith("test_") or name.endswith(("_test.py", "_tests.py")))
 
 
 def _read(path: Path) -> str:

--- a/sdk/python/onboarding_bot/run.py
+++ b/sdk/python/onboarding_bot/run.py
@@ -5,9 +5,13 @@ This is the hosted PR bot's entrypoint. It runs the section 3 loop server-side w
 interactive session: detect the stack, retrieve recipes from the shared catalog, ask the
 account question (in the PR body, where the developer answers it), and propose a diff.
 
-Retention is a ``finally``, not a convention. The clone lives in a temporary directory the
-run deletes on every exit path including a raised refusal, and :class:`RunResult` carries
-paths, counts and generated code only, never the developer's source (section 9).
+Retention is a ``finally`` plus a signal handler. The clone lives in a temporary directory
+the run deletes on every exit path including a raised refusal, and SIGTERM and SIGINT are
+handled so a hosted runner that stops the job does not leave the clone behind: a ``finally``
+alone does not run when the process is killed. A ``SIGKILL`` still cannot be caught, so the
+guarantee is "every exit path this process controls", not "every possible end of the
+process". :class:`RunResult` carries paths, counts and generated code only, never the
+developer's source (section 9).
 
 A GitHub App remains the future hardening path (section 11 Q5): it would replace the
 operator-supplied token with a short-lived installation token and per-repo grants managed
@@ -18,10 +22,14 @@ guards, the reviewed-PR shape) is unchanged by that swap.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import shutil
+import signal
 import sys
 import tempfile
+import threading
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -30,10 +38,15 @@ from .config import DEFAULT_TOKEN_ENV, BotConfig
 from .git_ops import GitRunner
 from .github_pr import Transport, open_pull_request
 from .guards import assert_push_target_allowed
-from .patch import apply_proposal
+from .patch import PatchResult, apply_proposal
 from .propose import Proposal, build_proposal
 
 PR_TITLE = "Wire ai-tally: init, account attribution and per-layer cost records"
+
+# Working directories a running bot owns. The signal handler deletes these and nothing else,
+# so a stopped job leaves no clone behind (section 9) and touches no path it did not create.
+_LIVE_WORKDIRS: set[Path] = set()
+_LIVE_LOCK = threading.Lock()
 
 
 @dataclass
@@ -46,15 +59,97 @@ class RunResult:
     pr_url: str | None = None
     files_changed: list[str] = field(default_factory=list)
     layers_wired: list[str] = field(default_factory=list)
+    """Layers that meter after this diff. A commented-out block is not one of them."""
+
+    layers_inserted_inactive: list[str] = field(default_factory=list)
+    """Layers whose block was inserted commented out, pending a hole the reviewer fills."""
+
     gaps: list[dict[str, Any]] = field(default_factory=list)
     questions: list[dict[str, Any]] = field(default_factory=list)
     holes_to_fill: list[str] = field(default_factory=list)
     detection: dict[str, Any] = field(default_factory=dict)
     clone_removed: bool = False
+    cleanup_error: str | None = None
+    """Why the clone could not be removed, when it could not. Never silently swallowed."""
+
+    orphan_branch: str | None = None
+    """A branch pushed to the customer's remote with no PR on it, so it can be found."""
+
     note: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+class RunFailed(RuntimeError):
+    """A run that failed after it had already changed something on the remote.
+
+    Carries the :class:`RunResult` so the caller still learns the branch name. Raising a
+    bare error would discard it and leave a branch on the customer's remote that nothing
+    recorded (section 9).
+    """
+
+    def __init__(self, message: str, result: RunResult):
+        super().__init__(message)
+        self.result = result
+
+
+def _remove_workdir(workdir: Path) -> str | None:
+    """Delete a run's working directory. Returns why it could not, when it could not."""
+    reason: str | None = None
+    try:
+        shutil.rmtree(workdir)
+    except OSError as exc:
+        reason = str(exc)
+    with _LIVE_LOCK:
+        _LIVE_WORKDIRS.discard(workdir)
+    if workdir.exists():
+        # Reported, not swallowed: a clone that survived the run is the one retention
+        # promise this component makes, so a failure to delete has to be visible.
+        return reason or f"{workdir} still exists after removal"
+    return None
+
+
+def cleanup_live_workdirs() -> list[Path]:
+    """Delete every working directory a run currently owns. Returns what it removed."""
+    with _LIVE_LOCK:
+        live = list(_LIVE_WORKDIRS)
+    for workdir in live:
+        shutil.rmtree(workdir, ignore_errors=True)
+        with _LIVE_LOCK:
+            _LIVE_WORKDIRS.discard(workdir)
+    return live
+
+
+def _cleanup_on_signal(signum: int, _frame: Any) -> None:
+    """Delete every live clone, then let the default disposition end the process.
+
+    A ``finally`` does not run when a hosted runner sends SIGTERM, which is exactly when a
+    full clone of a customer repo would be left in /tmp (section 9).
+    """
+    cleanup_live_workdirs()
+    signal.signal(signum, signal.SIG_DFL)
+    signal.raise_signal(signum)
+
+
+@contextlib.contextmanager
+def _workdir() -> Iterator[Path]:
+    """A run's temporary directory, registered for signal cleanup while it exists."""
+    workdir = Path(tempfile.mkdtemp(prefix="tally-onboarding-"))
+    with _LIVE_LOCK:
+        _LIVE_WORKDIRS.add(workdir)
+    previous: list[tuple[int, Any]] = []
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        try:
+            previous.append((signum, signal.signal(signum, _cleanup_on_signal)))
+        except (ValueError, OSError):  # pragma: no cover - not the main thread
+            pass
+    try:
+        yield workdir
+    finally:
+        for signum, handler in previous:
+            with contextlib.suppress(ValueError, OSError):
+                signal.signal(signum, handler)
 
 
 def run_bot(
@@ -70,79 +165,148 @@ def run_bot(
     which is how the tests exercise the whole loop without a network. ``dry_run`` proposes
     and stops: no branch, no push, no PR.
     """
-    workdir = Path(tempfile.mkdtemp(prefix="tally-onboarding-"))
     result = RunResult(repo=config.repo, base_branch="")
-    try:
-        runner = GitRunner(config, workdir)
-        if clone_override is not None:
-            clone_dir = clone_override
-        else:
-            clone_dir = runner.clone(workdir / "repo")
+    with _workdir() as workdir:
+        try:
+            runner = GitRunner(config, workdir)
+            if clone_override is not None:
+                clone_dir = clone_override
+            else:
+                clone_dir = runner.clone(workdir / "repo")
 
-        base_branch = runner.default_branch(clone_dir)
-        result.base_branch = base_branch
-        branch = config.branch_name()
-        # Checked before any work: a run that could only end in a refused push should refuse
-        # up front rather than after cloning and editing.
-        assert_push_target_allowed(branch, base_branch)
+            base_branch = runner.default_branch(clone_dir)
+            result.base_branch = base_branch
+            branch = config.branch_name()
+            # Checked before any work: a run that could only end in a refused push should
+            # refuse up front rather than after cloning and editing.
+            assert_push_target_allowed(branch, base_branch)
 
-        proposal = build_proposal(
-            clone_dir,
-            account_source=config.account_source,
-            feature_tag=config.feature_tag,
-            max_call_sites=config.max_call_sites,
-        )
-        result.detection = proposal.detection
-        result.gaps = list(proposal.gaps)
-        result.questions = list(proposal.questions)
-        result.holes_to_fill = proposal.holes
-
-        if not proposal.edits:
-            # Nothing the catalog covers. An empty PR would claim work that did not happen.
-            result.note = (
-                "no recipe-backed edit applied to this repo; opened no PR. The gaps below say "
-                "why, rather than a diff that guesses."
+            proposal = build_proposal(
+                clone_dir,
+                account_source=config.account_source,
+                feature_tag=config.feature_tag,
+                max_call_sites=config.max_call_sites,
             )
+            result.detection = proposal.detection
+            result.gaps = list(proposal.gaps)
+            result.questions = list(proposal.questions)
+            result.holes_to_fill = proposal.holes
+
+            if not proposal.edits:
+                # Nothing the catalog covers. An empty PR would claim work that did not
+                # happen.
+                result.note = (
+                    "no recipe-backed edit applied to this repo; opened no PR. The gaps below "
+                    "say why, rather than a diff that guesses."
+                )
+                return result
+
+            if dry_run:
+                result.layers_wired = proposal.layers_wired
+                result.layers_inserted_inactive = proposal.layers_inserted_inactive
+                result.note = "dry run: proposed the diff, created no branch and opened no PR."
+                return result
+
+            if runner.remote_branch_exists(clone_dir, branch):
+                # An earlier run got this far. Saying so beats git's bare non-fast-forward
+                # error at push time, which reads like a bug rather than a repeat run.
+                result.note = (
+                    f"branch {branch!r} already exists on the remote, so this run stopped "
+                    f"before creating it. Review or delete that branch, or re-run with a "
+                    f"different --branch-suffix."
+                )
+                return result
+
+            runner.create_branch(clone_dir, branch, base_branch)
+            patched = apply_proposal(clone_dir, proposal)
+            result.gaps.extend(patched.gaps)
+            if not patched.applied:
+                # Every edit was refused (a file that would not compile, an unplaceable
+                # block). Nothing is committed and nothing is pushed: the branch stays local
+                # and dies with the clone, and the gaps say why.
+                result.note = (
+                    "no edit could be applied safely, so nothing was committed and no PR was "
+                    "opened. The gaps say which file the bot refused to rewrite."
+                )
+                return result
+
+            result.branch = branch
+            result.files_changed = list(patched.files_changed)
+            result.layers_wired = _layers(patched, active=True)
+            result.layers_inserted_inactive = _layers(patched, active=False)
+            result.holes_to_fill = [
+                f"{e.path}:{e.line_no} {hole}" for e in patched.applied for hole in e.holes_to_fill
+            ]
+
+            runner.commit_all(clone_dir, commit_message(result))
+            runner.push_branch(clone_dir, branch, base_branch)
+
+            try:
+                pr = open_pull_request(
+                    config,
+                    head=branch,
+                    base=base_branch,
+                    title=PR_TITLE,
+                    body=pr_body(proposal, config, result, patched),
+                    transport=transport,
+                )
+            except Exception as exc:
+                # The branch is already on the customer's remote. Naming it in the result
+                # (and in the raised error) is what makes it recoverable rather than an
+                # orphan nobody knows about.
+                result.orphan_branch = branch
+                result.note = (
+                    f"the branch was pushed but the pull request could not be opened, so "
+                    f"{branch!r} is on the remote with no PR on it. Open the PR by hand or "
+                    f"delete the branch."
+                )
+                raise RunFailed(f"{result.note} Cause: {exc}", result) from exc
+            result.pr_url = pr.get("html_url")
             return result
-
-        result.layers_wired = proposal.layers_wired
-        if dry_run:
-            result.note = "dry run: proposed the diff, created no branch and opened no PR."
-            return result
-
-        runner.create_branch(clone_dir, branch, base_branch)
-        result.branch = branch
-        result.files_changed = apply_proposal(clone_dir, proposal)
-        runner.commit_all(clone_dir, commit_message(proposal))
-        runner.push_branch(clone_dir, branch, base_branch)
-
-        pr = open_pull_request(
-            config,
-            head=branch,
-            base=base_branch,
-            title=PR_TITLE,
-            body=pr_body(proposal, config),
-            transport=transport,
-        )
-        result.pr_url = pr.get("html_url")
-        return result
-    finally:
-        # The clone is the only copy of the developer's source this component ever holds, and
-        # it goes on every exit path, including a refusal raised mid-run (section 9).
-        shutil.rmtree(workdir, ignore_errors=True)
-        result.clone_removed = not workdir.exists()
+        finally:
+            # The clone is the only copy of the developer's source this component ever holds,
+            # and it goes on every exit path, including a refusal raised mid-run (section 9).
+            result.cleanup_error = _remove_workdir(workdir)
+            result.clone_removed = result.cleanup_error is None
 
 
-def commit_message(proposal: Proposal) -> str:
-    layers = ", ".join(proposal.layers_wired) or "none"
-    return (
-        f"chore: wire ai-tally instrumentation ({layers})\n\n"
-        "Generated from the ai-tally recipe catalog by the onboarding bot (CTO-261).\n"
-        "Every block is marked for review. Nothing here was merged automatically."
-    )
+def _layers(patched: PatchResult, *, active: bool) -> list[str]:
+    """Layers among the edits that actually landed, split by whether they meter.
+
+    Read off the applied edits rather than the proposal: a block that was refused, or one
+    inserted commented out, must not appear as a wired layer anywhere (CLAUDE.md).
+    """
+    return sorted({e.kind for e in patched.applied if bool(e.holes_to_fill) is not active})
 
 
-def pr_body(proposal: Proposal, config: BotConfig) -> str:
+def commit_message(result: RunResult) -> str:
+    """The commit subject names the layers that meter, and only those.
+
+    An inserted-but-commented-out block is listed separately as inactive: naming it as
+    wired would be the commit claiming work the diff did not do (CLAUDE.md).
+    """
+    layers = ", ".join(result.layers_wired) or "none active"
+    body = [
+        f"chore: wire ai-tally instrumentation ({layers})",
+        "",
+        "Generated from the ai-tally recipe catalog by the onboarding bot (CTO-261).",
+        "Every block is marked for review. Nothing here was merged automatically.",
+    ]
+    if result.layers_inserted_inactive:
+        body += [
+            "",
+            "Inserted but INACTIVE (commented out until a <FILL:...> value is supplied, so "
+            "these layers meter nothing yet): " + ", ".join(result.layers_inserted_inactive),
+        ]
+    return "\n".join(body)
+
+
+def pr_body(
+    proposal: Proposal,
+    config: BotConfig,
+    result: RunResult | None = None,
+    patched: PatchResult | None = None,
+) -> str:
     """The PR description: what was wired, what is a gap, and the question still open.
 
     Deliberately made of generated code and detection results only. The developer's own
@@ -168,14 +332,37 @@ def pr_body(proposal: Proposal, config: BotConfig) -> str:
         "### What this PR wires",
         "",
     ]
-    if proposal.edits:
+    # The edits that actually landed, when the patch step has run. A table built from the
+    # proposal would list blocks the patcher refused, which is work the diff does not do.
+    edits = list(patched.applied) if patched is not None else list(proposal.edits)
+    active = [e for e in edits if not e.holes_to_fill]
+    inactive = [e for e in edits if e.holes_to_fill]
+    if active:
+        lines.append("Active: these layers meter as soon as this PR merges.")
+        lines.append("")
         lines.append("| Layer | File | Recipe |")
         lines.append("| --- | --- | --- |")
-        for edit in proposal.edits:
+        for edit in active:
             lines.append(f"| {edit.kind} | `{edit.path}:{edit.line_no}` | `{edit.recipe_id}` |")
+        lines.append("")
     else:
-        lines.append("Nothing: no recipe matched this repo.")
-    lines.append("")
+        lines.append("Nothing is active: no block in this PR meters anything as it stands.")
+        lines.append("")
+    if inactive:
+        lines += [
+            "Inserted but INACTIVE: these blocks are commented out until you fill their "
+            "`<FILL:...>` values, so they meter nothing yet and this PR does not count them "
+            "as wired.",
+            "",
+            "| Layer | File | Recipe |",
+            "| --- | --- | --- |",
+        ]
+        for edit in inactive:
+            lines.append(f"| {edit.kind} | `{edit.path}:{edit.line_no}` | `{edit.recipe_id}` |")
+        lines.append("")
+
+    if result is not None and result.orphan_branch:  # pragma: no cover - body reused on retry
+        lines += [f"Branch pushed without a PR on an earlier attempt: `{result.orphan_branch}`", ""]
 
     if proposal.holes:
         lines += [
@@ -208,12 +395,13 @@ def pr_body(proposal: Proposal, config: BotConfig) -> str:
             lines.append("No candidate resolver surfaced, so there is nothing to confirm yet.")
         lines += ["", question["how_to_answer"], ""]
 
-    if proposal.gaps:
+    gaps = list(result.gaps) if result is not None else list(proposal.gaps)
+    if gaps:
         lines += [
             "### Gaps (reported, not guessed)",
             "",
         ]
-        for entry in proposal.gaps:
+        for entry in gaps:
             lines.append(f"- {entry.get('reason', 'unknown gap')}")
             if entry.get("code"):
                 lines += ["", "```python", entry["code"].rstrip(), "```", ""]
@@ -251,8 +439,19 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - CLI wrappe
         ),
     )
     parser.add_argument("--feature-tag", default=None)
-    parser.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
-    parser.add_argument("--branch-suffix", default="")
+    parser.add_argument(
+        "--token-env",
+        default=DEFAULT_TOKEN_ENV,
+        help=(
+            "name of the environment variable holding the scoped token. A shell identifier: "
+            "it is interpolated into the credential helper and is refused otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--branch-suffix",
+        default="",
+        help="branch name suffix. Omitted, a per-run id is generated so two runs never collide.",
+    )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
 
@@ -263,7 +462,15 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - CLI wrappe
         feature_tag=args.feature_tag,
         branch_suffix=args.branch_suffix,
     )
-    result = run_bot(config, dry_run=args.dry_run)
+    try:
+        result = run_bot(config, dry_run=args.dry_run)
+    except RunFailed as exc:
+        # The run changed the remote before it failed. The result still prints, so the
+        # branch it left behind is recoverable rather than lost with the exception.
+        json.dump(exc.result.to_dict(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.stderr.write(f"{exc}\n")
+        return 1
     json.dump(result.to_dict(), sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0

--- a/sdk/python/tests/test_onboarding_bot_guards.py
+++ b/sdk/python/tests/test_onboarding_bot_guards.py
@@ -160,6 +160,92 @@ def test_redact_strips_the_secret_from_anything_surfaced():
     assert guards.redact("clean", None) == "clean"
 
 
+# --- the operator's own flags are allowlisted too --------------------------- #
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        'X"; touch /tmp/PWNED; :"',
+        "TOKEN; rm -rf /",
+        "TOKEN$(id)",
+        "TOKEN`id`",
+        "2TOKEN",
+        "",
+        "TOKEN NAME",
+    ],
+)
+def test_a_token_env_name_that_could_carry_shell_syntax_is_refused(name):
+    # --token-env is interpolated into the GIT_ASKPASS helper. Unvalidated it is a shell
+    # expression in the one module whose whole thesis is allowlisting.
+    with pytest.raises(SecurityViolation):
+        guards.assert_token_env_name_allowed(name)
+    with pytest.raises(SecurityViolation):
+        BotConfig(repo="acme/widgets", token_env=name)
+
+
+def test_the_askpass_helper_cannot_be_written_with_an_injected_name(tmp_path: Path):
+    runner = GitRunner(_config(), tmp_path)
+    # A config that got past construction (a mutated field, a subclass) is still refused at
+    # the point the helper is written.
+    object.__setattr__(runner.config, "token_env", 'X"; touch pwned; :"')
+    with pytest.raises(SecurityViolation):
+        runner._askpass_path()
+    assert not (tmp_path / "askpass.sh").exists()
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "acme/widgets?ref=x",
+        "acme/widgets#frag",
+        "acme/wid gets",
+        "acme/..",
+        "acme/widgets/pulls",
+    ],
+)
+def test_a_repo_that_would_make_the_checked_path_differ_from_the_sent_one_is_refused(repo):
+    # The endpoint allowlist matches the path the bot builds. "acme/widgets?ref=x" matches
+    # ^/repos/[^/]+/[^/]+/pulls$ while urllib sends POST /repos/acme/widgets with a query.
+    with pytest.raises(SecurityViolation):
+        BotConfig(repo=repo, token_env=TOKEN_ENV)
+
+
+def test_a_refs_heads_namespaced_default_branch_is_still_refused():
+    # refs/heads/main and main are the same branch to git, so the refusal compares
+    # normalized names rather than raw strings.
+    with pytest.raises(SecurityViolation):
+        guards.assert_push_target_allowed("refs/heads/main", "main")
+    with pytest.raises(SecurityViolation):
+        guards.assert_push_target_allowed("main", "refs/heads/main")
+    with pytest.raises(SecurityViolation):
+        guards.assert_push_target_allowed("refs/heads/refs/heads/main", "main")
+
+
+def test_the_push_path_inspects_the_flags_it_actually_passes(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv(TOKEN_ENV, "ghp_secret_value")
+    repo = _init_repo(tmp_path / "repo")
+    runner = GitRunner(_config(), tmp_path)
+    with pytest.raises(SecurityViolation) as exc:
+        runner.push_branch(repo, "tally/onboarding/x", "main", flags=("--force",))
+    assert "force" in str(exc.value)
+    assert runner.commands == [], "the refused push never reached git"
+
+
+def test_two_runs_get_two_branch_names():
+    # A fixed fallback suffix made the second run against a repo die at push with a bare
+    # non-fast-forward error and no PR.
+    first = BotConfig(repo="acme/widgets", token_env=TOKEN_ENV)
+    second = BotConfig(repo="acme/widgets", token_env=TOKEN_ENV)
+    assert first.branch_name() != second.branch_name()
+    assert first.branch_name().startswith("tally/onboarding/")
+    # An explicit suffix is still honoured verbatim.
+    assert (
+        BotConfig(repo="acme/widgets", token_env=TOKEN_ENV, branch_suffix="run-1").branch_name()
+        == "tally/onboarding/run-1"
+    )
+
+
 def _init_repo(path: Path) -> Path:
     path.mkdir(parents=True)
     subprocess.run(["git", "init", "-q", str(path)], check=True, capture_output=True)

--- a/sdk/python/tests/test_onboarding_bot_patch.py
+++ b/sdk/python/tests/test_onboarding_bot_patch.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Placement: a generated block lands on a statement boundary or not at all (CTO-261).
+
+The bot commits and pushes what it writes into a customer's repository, so "the branch
+still compiles" is not a nicety here. These tests cover the shapes that broke the
+line-number insertion: multi-line calls, decorators, nested brackets and suite headers,
+plus the compile() safety net that refuses to commit a file it could not patch cleanly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from onboarding_bot.patch import MARKER, apply_proposal
+from onboarding_bot.propose import Proposal, ProposedEdit, build_proposal
+
+MULTILINE_APP = '''\
+"""Demo service."""
+import os
+
+from fastapi import FastAPI
+from pinecone import Pinecone
+
+app = FastAPI(
+    title="demo",
+)
+index = Pinecone(api_key=os.environ["PINECONE_KEY"]).Index("docs")
+
+
+@app.post("/ask")
+def ask(question: str):
+    hits = index.query(
+        vector=[0.1],
+        top_k=3,
+    )
+    return hits
+'''
+
+
+def _repo(tmp_path: Path, source: str, name: str = "app/main.py") -> Path:
+    repo = tmp_path / "repo"
+    target = repo / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    (repo / "requirements.txt").write_text("fastapi\nopenai\npinecone\n")
+    target.write_text(source)
+    return repo
+
+
+def _edit(**kwargs) -> ProposedEdit:
+    base = {
+        "path": "app/main.py",
+        "line_no": 1,
+        "kind": "startup",
+        "recipe_id": "startup.tally.init",
+        "code": "tally.init(feature_tag=None)\n",
+        "imports_to_add": ["import tally"],
+        "placement": "startup",
+        "indent": "",
+    }
+    base.update(kwargs)
+    return ProposedEdit(**base)
+
+
+def test_blocks_never_land_inside_a_multi_line_call(tmp_path: Path):
+    # The exact shape that produced a branch that did not compile: both blocks were
+    # inserted between `FastAPI(` and `title="demo",`.
+    repo = _repo(tmp_path, MULTILINE_APP)
+    proposal = build_proposal(
+        repo, account_source='request.headers.get("X-Customer-Id")', feature_tag="ask"
+    )
+    result = apply_proposal(repo, proposal)
+    assert result.files_changed == ["app/main.py"]
+
+    patched = (repo / "app" / "main.py").read_text()
+    compile(patched, "main.py", "exec")
+    lines = patched.splitlines()
+    # Nothing was inserted between the open paren and the argument it belongs to.
+    open_paren = lines.index("app = FastAPI(")
+    assert lines[open_paren + 1].strip() == 'title="demo",'
+    assert lines[open_paren + 2].strip() == ")"
+    assert MARKER in patched
+    assert "tally.init(" in patched
+
+
+def test_a_block_after_a_multi_line_call_site_lands_after_the_closing_paren(tmp_path: Path):
+    repo = _repo(tmp_path, MULTILINE_APP)
+    proposal = build_proposal(repo, account_source="x")
+    apply_proposal(repo, proposal)
+    patched = (repo / "app" / "main.py").read_text()
+    compile(patched, "main.py", "exec")
+    lines = patched.splitlines()
+    # The record_* block sits after the call's closing paren, inside the function, at the
+    # call's own indentation.
+    marker = next(i for i, line in enumerate(lines) if MARKER in line and line.startswith("    "))
+    # A blank line, then the marked block: the call's closing paren is immediately above.
+    assert [line.strip() for line in lines[marker - 2 : marker]] == [")", ""]
+    assert lines[marker].startswith("    #")
+
+
+def test_a_suite_header_match_puts_the_block_inside_the_suite(tmp_path: Path):
+    source = 'import openai\n\n\nif __name__ == "__main__":\n    print("go")\n'
+    repo = _repo(tmp_path, source, name="main.py")
+    proposal = build_proposal(repo, account_source=None)
+    apply_proposal(repo, proposal)
+    patched = (repo / "main.py").read_text()
+    compile(patched, "main.py", "exec")
+    # Inside the guard, not after it: init has to run in the process that starts here.
+    body = patched.split('if __name__ == "__main__":\n', 1)[1]
+    assert "    tally.init(" in body
+
+
+def test_a_decorated_call_site_keeps_the_decorator_attached_to_its_function(tmp_path: Path):
+    source = (
+        "import functools\n"
+        "from pinecone import Pinecone\n\n"
+        "index = Pinecone().Index('docs')\n\n\n"
+        "@functools.cache\n"
+        "def ask(q):\n"
+        "    hits = index.query(vector=[0.1], top_k=2)\n"
+        "    return hits\n"
+    )
+    repo = _repo(tmp_path, source, name="svc.py")
+    proposal = build_proposal(repo, account_source=None)
+    apply_proposal(repo, proposal)
+    patched = (repo / "svc.py").read_text()
+    compile(patched, "svc.py", "exec")
+    assert "@functools.cache\ndef ask(q):" in patched, "nothing was inserted between the two"
+
+
+def test_nested_brackets_do_not_confuse_the_boundary(tmp_path: Path):
+    source = (
+        "from pinecone import Pinecone\n\n"
+        "index = Pinecone().Index('docs')\n\n\n"
+        "def ask(q):\n"
+        "    hits = index.query(\n"
+        "        vector=[[0.1, 0.2], [0.3]],\n"
+        "        filter={'a': ('b', 'c')},\n"
+        "        top_k=2,\n"
+        "    )\n"
+        "    return hits\n"
+    )
+    repo = _repo(tmp_path, source, name="svc.py")
+    proposal = build_proposal(repo, account_source=None)
+    apply_proposal(repo, proposal)
+    patched = (repo / "svc.py").read_text()
+    compile(patched, "svc.py", "exec")
+    assert "        top_k=2,\n    )\n" in patched
+
+
+def test_a_file_that_would_not_compile_is_left_alone_and_reported_as_a_gap(tmp_path: Path):
+    repo = _repo(tmp_path, "import os\n\nx = 1\n", name="svc.py")
+    original = (repo / "svc.py").read_text()
+    # A block the catalog would never emit, standing in for any future recipe or placement
+    # bug: the safety net is that broken output is never committed.
+    proposal = Proposal(
+        detection={},
+        edits=[_edit(path="svc.py", line_no=3, code="def (\n")],
+    )
+    result = apply_proposal(repo, proposal)
+
+    assert result.files_changed == []
+    assert result.applied == []
+    assert (repo / "svc.py").read_text() == original
+    assert any("would not compile" in g["reason"] for g in result.gaps)
+
+
+def test_a_non_utf8_file_is_a_gap_and_does_not_stop_the_other_files(tmp_path: Path):
+    repo = _repo(tmp_path, "import os\n\nx = 1\n", name="ok.py")
+    (repo / "bad.py").write_bytes(b"# \xff\xfe not utf-8\nx = 1\n")
+    proposal = Proposal(
+        detection={},
+        edits=[
+            _edit(path="bad.py", line_no=2),
+            _edit(path="ok.py", line_no=3),
+        ],
+    )
+    result = apply_proposal(repo, proposal)
+
+    assert result.files_changed == ["ok.py"]
+    assert any("not decodable as UTF-8" in g["reason"] for g in result.gaps)
+    assert (repo / "bad.py").read_bytes().startswith(b"# \xff\xfe")
+
+
+def test_line_endings_and_a_missing_trailing_newline_survive_the_patch(tmp_path: Path):
+    repo = _repo(tmp_path, "x = 1\r\ny = 2", name="crlf.py")
+    proposal = Proposal(detection={}, edits=[_edit(path="crlf.py", line_no=1)])
+    apply_proposal(repo, proposal)
+
+    raw = (repo / "crlf.py").read_bytes()
+    assert b"\n" not in raw.replace(b"\r\n", b""), "CRLF was not rewritten to LF"
+    assert not raw.endswith(b"\r\n"), "a trailing newline was not invented"
+
+
+def test_an_import_inside_a_docstring_is_not_mistaken_for_the_files_imports(tmp_path: Path):
+    source = '"""Usage:\n\nimport somelib\n"""\nimport os\n\nx = os.getpid()\n'
+    repo = _repo(tmp_path, source, name="doc.py")
+    proposal = Proposal(detection={}, edits=[_edit(path="doc.py", line_no=7)])
+    apply_proposal(repo, proposal)
+
+    patched = (repo / "doc.py").read_text()
+    compile(patched, "doc.py", "exec")
+    lines = patched.splitlines()
+    # After the real import, not after the one quoted in the docstring.
+    assert lines.index("import tally") == lines.index("import os") + 1
+
+
+def test_an_unknown_placement_is_reported_rather_than_placed(tmp_path: Path):
+    repo = _repo(tmp_path, "x = 1\n", name="svc.py")
+    proposal = Proposal(
+        detection={},
+        edits=[_edit(path="svc.py", line_no=1, placement="somewhere_new")],
+    )
+    result = apply_proposal(repo, proposal)
+    assert result.applied == []
+    assert any("does not know how to place" in g["reason"] for g in result.gaps)
+
+
+def test_module_scope_middleware_is_not_inserted_inside_a_function(tmp_path: Path):
+    source = "def build():\n    app = object()\n    return app\n"
+    repo = _repo(tmp_path, source, name="svc.py")
+    proposal = Proposal(
+        detection={},
+        edits=[
+            _edit(
+                path="svc.py",
+                line_no=2,
+                kind="account",
+                recipe_id="middleware.fastapi.account",
+                placement="wrap_handler",
+                code="@app.middleware('http')\nasync def mw(request, call_next):\n    pass\n",
+            )
+        ],
+    )
+    result = apply_proposal(repo, proposal)
+    assert result.applied == []
+    assert any("no safe statement boundary" in g["reason"] for g in result.gaps)

--- a/sdk/python/tests/test_onboarding_bot_propose.py
+++ b/sdk/python/tests/test_onboarding_bot_propose.py
@@ -136,8 +136,9 @@ def test_applying_the_proposal_writes_valid_marked_python(tmp_path: Path):
     proposal = build_proposal(
         repo, account_source='request.headers.get("X-Customer-Id")', feature_tag="ask"
     )
-    touched = apply_proposal(repo, proposal)
-    assert touched == ["app/main.py"]
+    patched_result = apply_proposal(repo, proposal)
+    assert patched_result.files_changed == ["app/main.py"]
+    assert patched_result.gaps == []
 
     patched = (repo / "app" / "main.py").read_text()
     compile(patched, "main.py", "exec")  # the diff must be syntactically valid Python
@@ -146,6 +147,68 @@ def test_applying_the_proposal_writes_valid_marked_python(tmp_path: Path):
     assert "tally.with_account(" in patched
     # import tally is added once, not per edit.
     assert patched.count("import tally\n") == 1
+
+
+def test_a_commented_out_block_is_never_reported_as_a_wired_layer(tmp_path: Path):
+    proposal = build_proposal(
+        sample_repo(tmp_path),
+        account_source='request.headers.get("X-Customer-Id")',
+        feature_tag="ask",
+    )
+    vector = next(e for e in proposal.edits if e.kind == "vector")
+    assert vector.holes_to_fill, "this block is inserted commented out"
+    # It meters nothing, so it is not a wired layer anywhere the run reports one.
+    assert "vector" not in proposal.layers_wired
+    assert "vector" in proposal.layers_inserted_inactive
+    assert set(proposal.layers_wired) == {"startup", "account"}
+
+
+def test_a_call_matched_from_another_library_is_a_gap_not_a_mislabelled_edit(tmp_path: Path):
+    # A repo with both pinecone and sqlalchemy: session.query(...) is not a Pinecone call,
+    # and a record_vector_call(provider="pinecone") after it would meter the wrong thing.
+    repo = tmp_path / "mixed"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("pinecone\nsqlalchemy\n")
+    (repo / "db.py").write_text(
+        "from sqlalchemy.orm import Session\n\n\n"
+        "def rows(session: Session, q):\n"
+        "    result = session.query(q).all()\n"
+        "    return result\n"
+    )
+    proposal = build_proposal(repo, account_source=None)
+
+    assert not any(e.path == "db.py" for e in proposal.edits)
+    assert any(
+        "imports none of" in g["reason"] and g.get("recipe_id") == "vector.pinecone.query"
+        for g in proposal.gaps
+    )
+
+
+def test_a_pattern_inside_a_comment_or_a_string_is_not_a_call_site(tmp_path: Path):
+    repo = tmp_path / "prose"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("pinecone\n")
+    (repo / "notes.py").write_text(
+        "from pinecone import Pinecone\n\n"
+        "# call index.query(vector=[0.1], top_k=3) to search\n"
+        'DOC = """index.query(vector=[0.1], top_k=3)"""\n'
+    )
+    proposal = build_proposal(repo, account_source=None)
+    assert not any(e.kind == "vector" for e in proposal.edits)
+
+
+def test_tally_init_is_not_dropped_into_a_test_fixture(tmp_path: Path):
+    # A startup site found only under tests/ is not the process the developer deploys.
+    # Reporting that is honest; instrumenting the test run and leaving the real entrypoint
+    # unmetered is not.
+    repo = tmp_path / "tested"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "requirements.txt").write_text("fastapi\nopenai\n")
+    (repo / "tests" / "test_app.py").write_text("from fastapi import FastAPI\n\napp = FastAPI()\n")
+    proposal = build_proposal(repo, account_source=None)
+
+    assert not any(e.kind == "startup" for e in proposal.edits)
+    assert any("no recognisable startup site" in g["reason"] for g in proposal.gaps)
 
 
 def test_a_block_with_an_unfilled_hole_is_inserted_inactive_not_invented(tmp_path: Path):

--- a/sdk/python/tests/test_onboarding_bot_run.py
+++ b/sdk/python/tests/test_onboarding_bot_run.py
@@ -10,6 +10,7 @@ asserted on the resulting remote and on the recorded command trail.
 from __future__ import annotations
 
 import json
+import signal
 import subprocess
 import tempfile
 from pathlib import Path
@@ -17,7 +18,7 @@ from pathlib import Path
 import pytest
 from onboarding_bot.config import BotConfig
 from onboarding_bot.guards import SecurityViolation
-from onboarding_bot.run import RunResult, pr_body, run_bot
+from onboarding_bot.run import RunFailed, RunResult, pr_body, run_bot
 
 TOKEN_ENV = "TALLY_TEST_GITHUB_TOKEN"
 DEFAULT_BRANCH = "main"
@@ -122,7 +123,10 @@ def test_a_run_opens_a_pr_from_a_new_branch(repo_with_remote, monkeypatch):
     assert result.branch == "tally/onboarding/run-1"
     assert result.pr_url == "https://github.com/acme/widgets/pull/1"
     assert result.files_changed == ["app/main.py"]
-    assert {"startup", "account", "vector"} <= set(result.layers_wired)
+    # Only the layers that actually meter. The pinecone block could not derive its index
+    # name, so it is inserted commented out and reported as inactive, never as wired.
+    assert set(result.layers_wired) == {"startup", "account"}
+    assert result.layers_inserted_inactive == ["vector"]
 
     # Exactly one GitHub write, and it is "open a pull request".
     assert len(github.calls) == 1
@@ -271,3 +275,81 @@ def test_the_pr_body_states_how_the_run_was_authorised(repo_with_remote, monkeyp
     body = pr_body(build_proposal(work, account_source=config.account_source), config)
     assert f"${TOKEN_ENV}" in body
     assert "Revoke it" in body
+
+
+# --- nothing claims work the diff did not do -------------------------------- #
+
+
+def test_the_commit_message_and_pr_body_separate_active_from_inactive(
+    repo_with_remote, monkeypatch
+):
+    work, _ = repo_with_remote
+    monkeypatch.setenv(TOKEN_ENV, "ghp_secret_value")
+    github = _StubGitHub()
+
+    run_bot(_config(), transport=github, clone_override=work)
+
+    subject = _git("log", "-1", "--pretty=%s", cwd=work).strip()
+    message = _git("log", "-1", "--pretty=%B", cwd=work)
+    # The pinecone block is commented out, so the subject must not list vector as wired.
+    assert "vector" not in subject
+    assert "startup" in subject and "account" in subject
+    assert "INACTIVE" in message and "vector" in message
+
+    body = github.calls[0][2]["body"]
+    active, inactive = body.split("Inserted but INACTIVE", 1)
+    assert "vector.pinecone.query" in inactive
+    assert "vector.pinecone.query" not in active.split("### What this PR wires", 1)[1]
+
+
+def test_a_pr_that_could_not_be_opened_still_reports_the_branch_it_pushed(
+    repo_with_remote, monkeypatch
+):
+    work, remote = repo_with_remote
+    monkeypatch.setenv(TOKEN_ENV, "ghp_secret_value")
+
+    def _failing(method, url, payload, headers):
+        raise RuntimeError("502 from GitHub")
+
+    with pytest.raises(RunFailed) as exc:
+        run_bot(_config(), transport=_failing, clone_override=work)
+
+    # The branch is on the remote. The result carries its name, so it is recoverable
+    # rather than an orphan nobody recorded.
+    result = exc.value.result
+    assert result.orphan_branch == "tally/onboarding/run-1"
+    assert "tally/onboarding/run-1" in json.dumps(result.to_dict())
+    refs = _git("for-each-ref", "--format=%(refname)", cwd=remote).splitlines()
+    assert "refs/heads/tally/onboarding/run-1" in refs
+    assert result.clone_removed is True
+
+
+def test_a_second_run_against_the_same_branch_reports_it_instead_of_failing(
+    repo_with_remote, monkeypatch
+):
+    work, _ = repo_with_remote
+    monkeypatch.setenv(TOKEN_ENV, "ghp_secret_value")
+    run_bot(_config(), transport=_StubGitHub(), clone_override=work)
+    _git("checkout", "-q", DEFAULT_BRANCH, cwd=work)
+
+    github = _StubGitHub()
+    second = run_bot(_config(), transport=github, clone_override=work)
+
+    assert second.pr_url is None
+    assert "already exists on the remote" in second.note
+    assert github.calls == [], "no PR was opened for a branch this run did not create"
+
+
+def test_a_stopped_run_leaves_no_clone_behind(monkeypatch):
+    # A finally does not run when a hosted runner sends SIGTERM, so the same cleanup is
+    # reachable from the signal handler.
+    from onboarding_bot.run import _LIVE_WORKDIRS, _workdir, cleanup_live_workdirs
+
+    with _workdir() as workdir:
+        assert workdir.exists() and workdir in _LIVE_WORKDIRS
+        assert signal.getsignal(signal.SIGTERM) is not signal.SIG_DFL
+        removed = cleanup_live_workdirs()
+        assert workdir in removed
+        assert not workdir.exists()
+    # The run's own handlers are restored when it finishes.
+    assert workdir not in _LIVE_WORKDIRS


### PR DESCRIPTION
Review fixes on #287. Each change maps to a numbered finding.

## 1. MUST FIX: blocks inserted mid-statement produced a branch that did not compile

`patch.py` inserted at `lines[line_no:line_no]`, immediately after the matched line, and never read `edit.placement`. Against the common shape

```python
app = FastAPI(
    title="demo",
)
```

both the startup and account blocks landed between `FastAPI(` and `title="demo",`. Because `generate_startup` returns no `holes_to_fill`, the block went in uncommented, and the bot then committed and pushed a file that does not parse.

- Insertion points are resolved from the parsed module: the innermost statement containing the matched line, inserted after its `end_lineno`, or as the first statement of its suite when the match is in a compound statement's header (`if __name__ == "__main__":` now gets `tally.init()` inside the block). Decorators count as part of the statement they decorate.
- `edit.placement` is honoured: an unknown placement is a reported gap, and `wrap_handler` refuses anything that is not module scope, since a middleware definition inside a function never attaches to the app.
- A file that does not parse falls back to bracket balancing plus continuation lines, and gives up rather than guessing.
- Safety net: nothing is written until every target file has been patched in memory and run through `compile()`. A file that would not compile is left untouched, no commit happens for it, and the reason travels to the PR body as a gap.

`apply_proposal` now returns a `PatchResult` (files changed, edits applied, gaps) instead of a list of paths, so a refusal is visible to the run rather than silent.

## 2. MUST FIX: shell injection into the GIT_ASKPASS helper

`--token-env` reached `_ASKPASS_TEMPLATE.replace(...)` unvalidated, so `--token-env 'X"; touch /tmp/PWNED; :"'` wrote a helper that ran the injected command when git prompted. `token_env` is now restricted to `[A-Za-z_][A-Za-z0-9_]*`, refused at `BotConfig` construction and again at the point the helper is written.

## 3. MUST FIX: `layers_wired` claimed layers that are not wired

It was built from every edit's `kind`, including the always-commented-out `record_*` blocks, so a real run reported `vector` as wired in the JSON result, the commit subject and the PR table while the block metered nothing.

`layers_wired` now counts only edits with no unfilled holes, and only edits that actually landed. Inactive blocks are reported separately as `layers_inserted_inactive`, in a labelled "Inserted but INACTIVE" table in the PR body and a separate paragraph in the commit message.

## 4. SHOULD FIX: endpoint allowlist was unsound

`repo="acme/widgets?ref=x"` produced a path matching `^/repos/[^/]+/[^/]+/pulls$` while urllib sent `POST /repos/acme/widgets` with query `ref=x/pulls`. Owner and name are now validated against `[A-Za-z0-9._-]+` (and `.` / `..` refused) at construction, so the path checked is the path requested.

## 5. SHOULD FIX: call-site matching was a raw substring test

Matching now runs over the syntax tree: the unparsed call expression is matched on a name boundary, so hits inside comments and string literals are gone, and a match counts only when the file imports one of the recipe's libraries. A repo with both pinecone and sqlalchemy no longer gets `record_vector_call(provider="pinecone")` after `session.query(...)`; that becomes a reported gap naming the file and the missing import. Patterns that are not call or decorator expressions (pgvector's `<->` SQL operators) are no longer matched as text, so those become gaps rather than edits.

## 6. SHOULD FIX: fixed branch name collided across runs

The `wire-tally` fallback is gone. An empty `--branch-suffix` gets a per-run id (`YYYYMMDD-<hex>`) at construction. The run also asks the remote (`ls-remote`) before creating the branch and stops with a clear note if it is already there, instead of dying at push with a bare non-fast-forward error and no PR.

## 7. SHOULD FIX: `assert_push_flags_allowed([])` inspected nothing

`push_branch` now builds its argv, passes the option-shaped arguments in it to the refusal, and takes a `flags` parameter so the refusal is reachable and tested. The refspec construction is unchanged.

## 8. SHOULD FIX: retention and orphan-branch reporting

- SIGTERM and SIGINT handlers delete every live working directory, so a stopped hosted run leaves no clone in `/tmp`. The handlers are installed for the run and restored afterwards.
- Cleanup failure is no longer swallowed by `ignore_errors=True`: `RunResult.cleanup_error` carries the reason and `clone_removed` reflects reality.
- A push that succeeds followed by a failed `open_pull_request` now raises `RunFailed`, which carries the `RunResult` with `orphan_branch` set. The CLI prints that result and exits non-zero, so the branch left on the customer's remote is recoverable.
- The module and package docstrings and the README now say what actually holds: every exit path the process controls, `SIGKILL` excepted.

## 9. MINOR

- Import insertion point comes from the parsed module, so an unindented `import` inside a docstring is no longer mistaken for the file's imports.
- Files to be rewritten are read strictly and all patching happens in memory before any write, so a non-UTF-8 file is a reported gap instead of a run that aborts after other files were already written.
- Line endings are preserved (no whole-file CRLF to LF rewrite) and a trailing newline is no longer invented.
- The startup site search skips tests, examples, scripts, docs and fixtures, so `tally.init()` cannot land in a test fixture while the real entrypoint goes uninstrumented.
- `propose.account_candidates` uses the tolerant `repo_scan._read`, so one unreadable file does not abort the run.

## 10. HARDENING

`assert_push_target_allowed` normalizes `refs/heads/` before comparing, so a namespaced spelling of the default branch is refused too.

## Preserved

The no-merge and no-default-branch-push allowlists, the refspec construction and `_resolve_inside`'s symlink defense are untouched, and their tests still pass.

## Tests

New `tests/test_onboarding_bot_patch.py` (12 cases): multi-line calls, nested brackets, decorators, suite headers, the compile() safety net, non-UTF-8 files, CRLF and trailing-newline preservation, the docstring import, unknown placement, and module-scope middleware refused inside a function. Every case compiles the patched file.

Added to the existing suites: token-env injection refused (7 shapes, plus at the helper), malformed repo refused (5 shapes), `refs/heads/` normalization, force-push refused through the real push path, per-run branch names, commented-out blocks never reported as wired, cross-library matches reported as gaps, patterns in comments and strings not matched, startup site not taken from `tests/`, active vs inactive split in the commit message and PR body, the orphan branch reported on PR failure, a second run reported cleanly, and signal-handler cleanup.

Two existing assertions were updated deliberately: `layers_wired` for the sample repo is now `{startup, account}` with `vector` inactive (finding 3), and `apply_proposal` returns a `PatchResult` (finding 1).

## Verification

```
cd sdk/python && uv run --extra dev pytest -q   # 1217 passed
cd sdk/python && uv run ruff check .            # All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
