### PR TITLE
fix(deploy,docs): close the review findings on the tenant-UUID kit (CTO-243)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -84,6 +84,12 @@ when auth is on and no service token is set, rather than coming up with an open 
 
 Ingest (`/v1/batches`) is unchanged: it still authenticates with the ingest API key above.
 
+Note that the synthetic demo seeders do **not** support auth on.
+`examples/vercel-chatbot/scripts/backfill-spans.ts` (used by `make chatbot-demo-backfill` and by the
+`deploy/demo` kit) posts to `/v1/batches` with no `Authorization` header and has no api-key option,
+so with `TALLY_REQUIRE_API_KEY=true` every batch takes a `401`. Seed the demo data with auth off,
+then turn auth on.
+
 ## 3. Push telemetry through the gateway
 
 Easiest: the built-in demo batch (resolves the seeded tenant's UUID and writes under it, then
@@ -99,7 +105,9 @@ first (this is the same lookup `make demo` and the demo-deploy kit do):
 ```bash
 TENANT=$(docker compose exec -T postgres \
   psql -U tally -d tally -tAc "SELECT id FROM tenants WHERE name='local-dev' LIMIT 1" | tr -d '[:space:]')
-test -n "$TENANT" || echo "not seeded, run 'make seed' first"
+# Abort rather than fall through: an empty $TENANT would POST 40 batches under tenant_id ""
+# that the dashboard will never render, with no error anywhere.
+test -n "$TENANT" || { echo "not seeded, run 'make seed' first" >&2; exit 1; }
 
 for i in $(seq 1 40); do
   curl -s -X POST localhost:8080/v1/batches \
@@ -477,7 +485,7 @@ Knobs:
 |---|---|
 | `Database tally does not exist` | Gateway pointed at the wrong DB. Use `TALLY_CLICKHOUSE_DB=default` (the compose gateway already does). |
 | Dashboard shows the **"mock data"** badge | A page's ClickHouse query failed and fell back to mock. Check `make logs` and that step 3's count is non-zero. |
-| Dashboard empty despite ingested rows | Tenant mismatch — the UI reads `local-dev`. Post with `tenant_id: local-dev` (or set `TALLY_TENANT_ID` for the web app). |
+| Dashboard empty despite ingested rows | Tenant mismatch. The UI reads the tenant **UUID**, not the name, so spans must be tagged with the UUID: re-send with `tenant_id` set to the UUID from step 3. With no Clerk account, point the web app at that same UUID via `TALLY_DEV_TENANT` (the dev escape hatch); `TALLY_TENANT_ID` is no longer read by anything. |
 
 ## Make targets (run from `infra/`)
 

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -83,6 +83,13 @@ Edit `deploy/demo/.env`:
   the token empty the gateway refuses to boot rather than serve an open control plane, so
   `deploy.sh` and `reseed.sh` stop up front and say so.
 
+  **This kit's seeding path does not support auth on.** The synthetic backfill
+  (`examples/vercel-chatbot/scripts/backfill-spans.ts`) posts to `/v1/batches` with no
+  `Authorization` header and has no api-key option, and with `TALLY_REQUIRE_API_KEY=true` the
+  gateway answers `401`. The stack and dashboard still come up, but the backfill step fails and you
+  get no demo data. Seed with auth off, then turn auth on afterwards if you need it. Both scripts
+  warn about this before they do any work rather than letting you discover it minutes in.
+
 - Do **not** set the tenant by hand. The dashboard reads `TALLY_DEV_TENANT`, and it must hold the
   tenant **UUID**, not the name `local-dev`: the web binds that value straight into the ClickHouse
   read filter (`TenantId = ...`) and the backfill tags spans with the UUID, so a name matches no
@@ -185,6 +192,10 @@ docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.ym
   exec -T clickhouse clickhouse-client -u tally --password tally -d default \
   --query "SELECT TenantId, count() FROM otel_spans GROUP BY TenantId"
 ```
+
+(Those commands assume the `.env.example` defaults `POSTGRES_USER=tally` / `POSTGRES_DB=tally` and
+`CLICKHOUSE_USER=tally`. If you changed them in `deploy/demo/.env`, substitute your own values; the
+scripts themselves read the env vars, only these copy-paste one-liners are literal.)
 
 All three must show the same **UUID**. A `local-dev` (the name) in either of the last two means
 something bypassed `deploy.sh`; re-running `./deploy/demo/reseed.sh` re-resolves and repairs it.

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -47,6 +47,7 @@ source "${SCRIPT_DIR}/lib-tenant.sh"
 
 # Cheap check first: a missing service token with auth on means the gateway never boots.
 require_service_token_if_auth_on
+warn_backfill_unsupported_if_auth_on
 
 echo "==> Building images and starting the stack"
 "${COMPOSE[@]}" up -d --build

--- a/deploy/demo/lib-tenant.sh
+++ b/deploy/demo/lib-tenant.sh
@@ -92,3 +92,31 @@ ERR
     return 1
   fi
 }
+
+# Say up front that this kit's SEEDING path does not work with gateway auth on.
+#
+# WHY (CTO-243): with TALLY_REQUIRE_API_KEY on, /v1/batches demands a bearer ingest API key, but
+# examples/vercel-chatbot/scripts/backfill-spans.ts sends no Authorization header and has no
+# api-key option, so it takes a 401 on the first batch. Without this warning the operator finds out
+# minutes into a run that has already built images and seeded, which is exactly the late failure
+# the preflight exists to eliminate. This warns rather than aborts because bringing the stack up
+# with auth on is still a valid thing to do; only the synthetic backfill cannot run that way.
+warn_backfill_unsupported_if_auth_on() {
+  local auth_on="${TALLY_REQUIRE_API_KEY:-false}"
+  case "${auth_on}" in
+    true|TRUE|True|1|yes|on) ;;
+    *) return 0 ;;
+  esac
+
+  cat >&2 <<'WARN'
+WARNING: TALLY_REQUIRE_API_KEY is on, and the demo kit's SEEDING path does not support that.
+
+         The synthetic backfill (examples/vercel-chatbot/scripts/backfill-spans.ts) posts to
+         /v1/batches with no Authorization header, and with auth on the gateway answers 401. The
+         stack and the dashboard will come up fine; the backfill step near the end of this run WILL
+         fail and the dashboard will have no demo data.
+
+         To seed the demo, run with auth off (leave TALLY_REQUIRE_API_KEY unset or false), then
+         turn auth on afterwards if you need it. Continuing anyway.
+WARN
+}

--- a/deploy/demo/reseed.sh
+++ b/deploy/demo/reseed.sh
@@ -4,9 +4,14 @@
 # ai-tally demo-deploy-kit - reset + re-seed the SYNTHETIC demo data (CTO-243).
 #
 # Run nightly so the demo always shows a fresh, backdated "last 30 days". It:
-#   1. TRUNCATEs the ClickHouse telemetry tables (spans, events, rollups, replay corpus).
-#   2. Re-runs `make seed` (idempotent: tenant + API key + price catalog).
-#   3. Re-POSTs 30 days of backdated synthetic spans via the backfill script.
+#   1. Re-runs `make seed` (idempotent: tenant + API key + price catalog), so a stack whose control
+#      plane was wiped bootstraps itself instead of failing every night at the resolve below.
+#   2. Resolves the demo tenant's UUID, aborting if it cannot.
+#   3. TRUNCATEs the ClickHouse telemetry tables (spans, events, rollups, replay corpus).
+#   4. Re-POSTs 30 days of backdated synthetic spans via the backfill script.
+#
+# Steps 2 and 3 are in that order on purpose: never truncate without a resolved tenant to repost
+# under (a failed resolve then leaves the previous night's data on screen).
 #
 # The stack keeps running throughout (no container restart); only the data is reset. The Postgres
 # control plane (tenant row, API key, connector config) is left intact.
@@ -53,6 +58,7 @@ COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD
 source "${SCRIPT_DIR}/lib-tenant.sh"
 
 require_service_token_if_auth_on
+warn_backfill_unsupported_if_auth_on
 
 CH_USER="${CLICKHOUSE_USER:-tally}"
 CH_PASSWORD="${CLICKHOUSE_PASSWORD:-tally}"
@@ -74,9 +80,19 @@ TABLES=(
   replay_samples
 )
 
-# Resolve the tenant BEFORE truncating. If the control plane cannot answer, a nightly run must abort
-# with the old data still on screen rather than empty the tables and then discover it has no tenant
-# to repost under (CTO-243).
+# Seed FIRST so a wiped control plane can bootstrap itself. `make seed` is idempotent, so on a
+# normal nightly run this is a no-op, but on a stack whose Postgres volume was recreated (fresh VM,
+# `make nuke`, a restore from an empty volume) it is the only thing that recreates the tenant row.
+# Resolving before this point meant every cron run on such a host aborted at "could not resolve the
+# tenant UUID" and could never reach the step that would have fixed it (CTO-243).
+echo "==> Re-seeding the demo tenant (make seed)"
+make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" seed
+
+# Then resolve, still BEFORE the TRUNCATE. That ordering is the safety property: if the control
+# plane cannot answer even after seeding, a nightly run aborts with the old data still on screen
+# rather than emptying the tables and only then discovering it has no tenant to repost under. Under
+# `set -euo pipefail` a failed resolve_tenant_uuid aborts the script here, so no path reaches the
+# TRUNCATE loop without a validated UUID (CTO-243).
 echo "==> Resolving the demo tenant UUID"
 TENANT_UUID="$(resolve_tenant_uuid)"
 echo "    ${DEMO_TENANT_NAME} = ${TENANT_UUID}"
@@ -88,9 +104,6 @@ for t in "${TABLES[@]}"; do
     clickhouse-client -u "${CH_USER}" --password "${CH_PASSWORD}" -d default \
     --query "TRUNCATE TABLE IF EXISTS ${t}"
 done
-
-echo "==> Re-seeding the demo tenant (make seed)"
-make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${REPO_ROOT}/${BASE_COMPOSE} -f ${REPO_ROOT}/${PROD_COMPOSE}" seed
 
 echo "==> Re-backfilling 30 days of SYNTHETIC demo spans"
 # Same throwaway-container approach as deploy.sh: no host Node, reaches the gateway internally.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -6,11 +6,18 @@ GATEWAY := ai-tally-gateway
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
+# Honor the same POSTGRES_USER / POSTGRES_DB that .env.example exposes, so a dev running a
+# non-default user does not get told to `make up && make seed` after both already succeeded.
+PG_USER := $(or $(POSTGRES_USER),tally)
+PG_DB := $(or $(POSTGRES_DB),tally)
+
 # Canonical TenantId is the tenant UUID (Initiative 1, §8). Resolve the seeded local-dev tenant's
 # UUID from Postgres so the demo backfill tags spans with the UUID the dashboard reads, not the
 # name `local-dev`. Lazily expanded (`=`, not `:=`) so it runs when a target uses it, after the
-# stack is up and `make seed` has created the row; empty before then.
-TENANT_UUID = $(shell $(COMPOSE) exec -T postgres psql -U tally -d tally -tAc "SELECT id FROM tenants WHERE name='local-dev' LIMIT 1" 2>/dev/null | tr -d '[:space:]')
+# stack is up and `make seed` has created the row; empty before then. `:=` would shell out on every
+# single make invocation, `make help` included. Recipes that need it more than once capture it into
+# a shell variable so the lookup still runs exactly once per target.
+TENANT_UUID = $(shell $(COMPOSE) exec -T postgres psql -U $(PG_USER) -d $(PG_DB) -tAc "SELECT id FROM tenants WHERE name='local-dev' LIMIT 1" 2>/dev/null | tr -d '[:space:]')
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -65,10 +72,13 @@ demo: ## Send a sample batch through the gateway into ClickHouse
 	@# send_batch.py defaults to the tenant NAME, but ingest writes TenantId verbatim while the
 	@# dashboard reads by UUID (Initiative 1, §8), so the default would land rows the UI never shows.
 	@# Fail loudly rather than write invisible rows: an empty UUID means the tenant is not seeded.
-	@test -n "$(strip $(TENANT_UUID))" || { \
-	  echo "cannot resolve the local-dev tenant UUID from Postgres; run 'make up && make seed' first"; \
-	  exit 1; }
-	$(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py --tenant $(TENANT_UUID)
+	@# One expansion of TENANT_UUID, captured in a shell variable: the guard and the send must agree,
+	@# and a second expansion would be a second round trip into psql.
+	@t="$(strip $(TENANT_UUID))"; \
+	 test -n "$$t" || { \
+	   echo "cannot resolve the local-dev tenant UUID from Postgres; run 'make up && make seed' first"; \
+	   exit 1; }; \
+	 set -x; $(COMPOSE) exec gateway python /app/infra/gateway/examples/send_batch.py --tenant "$$t"
 
 aider-demo: ## Run Aider against a fixture repo through the edge proxy (needs OPENAI_API_KEY)
 	@curl -sf http://localhost:8080/healthz >/dev/null || { \


### PR DESCRIPTION
Review follow-up to #285. Docs and script ordering only. **Nothing here weakens the tenant resolution**: `resolve_tenant_uuid` still regex-validates its output, still refuses a non-identifier tenant name before it reaches psql, still has no fallback to the name or to empty, and the preflight still cannot print the service token.

## Findings addressed

**1 (must fix) - `RUNNING.md` reintroduced the bug this branch fixes.** The burst snippet added by #285 was `test -n "$TENANT" || echo "not seeded..."`, which only printed and then fell through into the `for` loop, POSTing 40 batches with `"tenant_id":""` that the dashboard silently never renders. Exactly the empty-tenant failure the branch exists to prevent, and a violation of honest-under-uncertainty. It now aborts. Everything downstream of the guard (the verify query) is on the abort's far side, so nothing else can run with an empty tenant.

**2 (must fix) - `RUNNING.md` troubleshooting row instructed reintroducing it.** The row an operator lands on for "dashboard empty despite ingested rows" said the UI reads `local-dev`, told them to post under the NAME, and pointed at `TALLY_TENANT_ID`. Both halves are wrong now. Rewritten for the UUID and `TALLY_DEV_TENANT`. Its em dash is gone (CLAUDE.md forbids them in prose/docs).

**3 (should fix) - `deploy/demo/reseed.sh` could not self-heal a wiped control plane.** The tenant was resolved before `make seed`, so a stack whose Postgres volume had been recreated (fresh VM, `make nuke`, restore from an empty volume) aborted every nightly cron run at "could not resolve the tenant UUID" and never reached the seed step that would have created the row, despite the header advertising the idempotent seed. Seeding now runs first.

**The critical ordering is preserved exactly.** The new order is seed -> resolve -> TRUNCATE -> backfill. The resolve is still strictly before the TRUNCATE loop, and under `set -euo pipefail` a failed `resolve_tenant_uuid` aborts the script at the assignment, so no path reaches a TRUNCATE without a validated UUID. A resolve failure still leaves the previous night's data on screen rather than emptying the tables with nowhere to repost.

**4 (fix) - auth-on was presented as supported for seeding, and it is not.** `examples/vercel-chatbot/scripts/backfill-spans.ts` sends no `Authorization` header and has no api-key option, while `/v1/batches` raises 401 when `require_api_key` is on (`infra/gateway/src/gateway/app.py`). An operator following the README with `TALLY_REQUIRE_API_KEY=true` got a run that built images, seeded, and then died at the backfill minutes later, the late-failure class the preflight was added to eliminate. Adding auth to the backfill is out of scope, so instead: the demo README and `RUNNING.md` state plainly that the seeding path does not support auth on, and a new `warn_backfill_unsupported_if_auth_on` preflight says so before any work happens. It **warns rather than aborts** because bringing the stack up with auth on is still a valid thing to do; only the synthetic backfill cannot run that way.

**5 (minor) - `infra/Makefile` hardcoded `-U tally -d tally`.** Now honors `POSTGRES_USER` / `POSTGRES_DB` (already exposed by `infra/.env.example`) with `tally` defaults, so a dev on a non-default user stops being told to run `make up && make seed` after both already succeeded. `make demo` captures `TENANT_UUID` once into a shell variable instead of expanding it twice, so the guard and the send agree and there is one psql round trip.

## Deliberately not done

- **`TENANT_UUID` stays lazily expanded (`=`, not `:=`).** `:=` would shell out to psql on *every* make invocation, `make help` and `make up` included, and would be empty before the stack is up. The double-expansion the review flagged is fixed at the one call site that had it instead. Comment updated to record why.
- **`-U tally` in `deploy/demo/README.md` troubleshooting commands left literal.** Those are copy-paste one-liners run from a shell that has not sourced `deploy/demo/.env`, so `${POSTGRES_USER:-tally}` would expand to the wrong thing rather than the right one. Added a note that they assume the `.env.example` defaults and to substitute if changed. The scripts themselves already read the env vars.
- **No auth support added to the backfill** (out of scope per review); the limitation is documented instead.
- **Pre-existing em dashes elsewhere in `RUNNING.md`** are untouched; only the one in the rewritten row was in scope.

## Verification

- `bash -n` on all three touched scripts: `reseed.sh` rc=0, `lib-tenant.sh` rc=0, `deploy.sh` rc=0.
- `docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml config` renders **rc=0**, `TALLY_TENANT_ID` occurrences: **0**, `TALLY_DEV_TENANT: ""` present.
- Against the running local stack, `resolve_tenant_uuid` still returns the real UUID (`38a6c264-...`), still exits 1 with the full diagnostic for a missing tenant, and still refuses `local-dev' OR '1'='1` before touching psql.
- `make -n demo` shows a single `TENANT_UUID` expansion; `POSTGRES_USER=custompg POSTGRES_DB=customdb make -n seed` confirms the override reaches psql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
