### PR TITLE
fix(sdk): stop the onboarding LLM recipe double-metering, honest mcp errors (CTO-261)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -191,10 +191,10 @@ has it installed instead: `"command": "/path/to/.venv/bin/tally-onboarding-mcp"`
 
 | Tool | What it returns |
 |---|---|
-| `detect_stack` | providers, agent frameworks, vector DBs and web frameworks found in a manifest, plus the recipe ids that match and the gaps that matched nothing |
+| `detect_stack` | providers, agent frameworks, vector DBs and web frameworks found in a manifest, plus the recipe ids that match, the `already_covered` notes for layers you must not meter twice, and the gaps that matched nothing |
 | `get_recipe` | one machine-readable recipe, by id or by a friendly name (`pinecone`, `fastapi`) |
 | `generate_startup` | the `tally.init()` line for application startup |
-| `generate_middleware` | account / feature middleware bound to the resolver you confirm, bundled with the startup line |
+| `generate_middleware` | account / feature middleware bound to the resolver you confirm, bundled with the startup line under `startup` (a generated snippet, or a gap with `code: None` if the catalog has no startup recipe, so `startup["code"]` is always safe to read) |
 | `instrument_call_site` | the adapted `record_*` edit for one concrete call site |
 | `explain_layer` | which `record_*` method covers a layer and why, grounded on the live SDK surface |
 | `coverage_report` | per-layer coverage; reports `not_probed` until the probe ships, never a guessed verdict |
@@ -205,5 +205,16 @@ reported gap and the account layer stays unattributed. And it never invents an S
 stack with no recipe comes back as a gap, and every hole it cannot fill from the call site you
 passed is left as a visible `<FILL:...>` marker for you to complete.
 
-Both mcp 1.x (`FastMCP`) and mcp 2.x (`MCPServer`) are supported. Without the extra installed,
-launching the server fails with a clear error rather than starting a server that does nothing.
+One thing the server will not let you do twice. `tally.init()` already patches the `openai` and
+`anthropic` clients in your process, so those call sites need no edit. `detect_stack` reports
+any such provider under `already_covered`, and the manual `llm.generic.call` recipe deliberately
+does not match a patched call shape: adding `record_llm_call` beside one would meter the same
+call twice and double your reported cost. Use that recipe only where the patch does not reach,
+such as a raw `/v1/chat/completions` POST, `bedrock-runtime`, `ollama`, or a self-hosted or
+gateway-fronted model.
+
+Both mcp 1.x (`FastMCP`, 1.2.0 and up) and mcp 2.x (`MCPServer`) are supported. Without the
+extra installed, launching the server fails with a clear error rather than starting a server
+that does nothing. The extra is also what makes the tools usable at all: `onboarding_mcp` ships
+in the base wheel so the console script resolves, but the recipe catalog is YAML and `pyyaml`
+comes with the extra, since the SDK runtime itself stays dependency-free.

--- a/sdk/python/onboarding_mcp/catalog.py
+++ b/sdk/python/onboarding_mcp/catalog.py
@@ -15,7 +15,19 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - depends on which extras are installed
+    # onboarding_mcp ships in the base wheel (the console entrypoint has to resolve for an
+    # installed SDK, and a wheel cannot vary its contents by extra), but the recipe catalog
+    # is YAML and pyyaml lives in the mcp extra. Without it the honest answer is which
+    # install is missing, not a bare "No module named 'yaml'" (CTO-261 review finding 4).
+    raise ModuleNotFoundError(
+        "the onboarding recipe catalog is YAML and needs pyyaml, which ships with the "
+        "'mcp' extra: pip install 'tally-sdk[mcp]'. onboarding_mcp is present in the base "
+        "tally-sdk wheel so the tally-onboarding-mcp entrypoint resolves, but it is not "
+        "usable without that extra; the SDK runtime itself stays dependency-free."
+    ) from exc
 
 # In-tree, recipes/ sits next to onboarding_mcp/ under sdk/python/. In an installed
 # wheel the catalog is force-included at onboarding_mcp/recipes/ so the console

--- a/sdk/python/onboarding_mcp/detect.py
+++ b/sdk/python/onboarding_mcp/detect.py
@@ -26,12 +26,18 @@ _VECTOR_DBS = {"pinecone", "weaviate", "qdrant_client", "chromadb", "pgvector"}
 _TOKEN_RE = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
 
 
-def _tokens(text: str) -> set[str]:
+def tokenize(text: str) -> set[str]:
+    """Lowercased identifier tokens in ``text``. Shared with ``explain_layer``."""
     return {t.lower() for t in _TOKEN_RE.findall(text)}
 
 
 def _classify(tokens: set[str], vocabulary: set[str]) -> list[str]:
     return sorted(tokens & vocabulary)
+
+
+# The manual LLM recipe. Named here because detect_stack has to say out loud when it
+# would double-meter an already-patched call (CTO-261 review finding 1).
+_MANUAL_LLM_RECIPE = "llm.generic.call"
 
 
 def detect_stack(
@@ -48,17 +54,18 @@ def detect_stack(
             ``call_patterns`` (section 4.2: manifests are the cheap default, excerpts opt-in).
         catalog: override for tests; defaults to the in-tree catalog.
 
-    Returns a dict of detected components plus ``matched_recipes`` (recipe ids that apply)
-    and ``gaps`` (detected components with no recipe).
+    Returns a dict of detected components plus ``matched_recipes`` (recipe ids that apply),
+    ``already_covered`` (coverage the agent must not add a second meter to), and ``gaps``
+    (detected components with no recipe).
     """
     cat = catalog or get_catalog()
-    manifest_tokens = _tokens(manifest)
-    excerpt_tokens = _tokens(import_excerpts)
+    manifest_tokens = tokenize(manifest)
+    excerpt_tokens = tokenize(import_excerpts)
     all_tokens = manifest_tokens | excerpt_tokens
 
     matched: list[str] = []
     for recipe in cat.recipes:
-        import_hit = any(_tokens(imp) & all_tokens for imp in recipe.imports)
+        import_hit = any(tokenize(imp) & all_tokens for imp in recipe.imports)
         pattern_hit = any(pat in import_excerpts for pat in recipe.call_patterns)
         if import_hit or pattern_hit:
             matched.append(recipe.id)
@@ -90,6 +97,26 @@ def detect_stack(
             f"{', '.join(unhandled_web)} but no middleware recipe matched"
         )
 
+    # An auto-instrumented provider is coverage the agent must not add to. tally.init
+    # patches the openai / anthropic clients (CTO-260), so a manual record_llm_call beside
+    # one of those call sites meters the SAME call twice and doubles reported cost, which
+    # corrupts the product's core number. The recipe template carries the warning, but a
+    # template comment is not in the tool OUTPUT: without this marker an agent reading
+    # matched_recipes has nothing telling it the call is already covered (CTO-261 review
+    # finding 1). The recipe still matches when a genuinely unpatched path is present too
+    # (openai alongside ollama is a real stack), so this flags rather than silently drops.
+    already_covered: list[str] = []
+    if llm:
+        already_covered.append(
+            f"llm: {', '.join(llm)} detected. tally.init() auto-instruments these clients "
+            "(CTO-260), so those call sites need no edit. Do NOT add "
+            "tally.record_llm_call beside a patched "
+            "client call: the same call would be metered twice and reported cost would "
+            f"double. Apply {_MANUAL_LLM_RECIPE} only to a call site the patch does not "
+            "reach (a raw /v1/chat/completions POST, bedrock-runtime, ollama, a "
+            "self-hosted or gateway-fronted model)."
+        )
+
     return {
         # All detected web frameworks, so a second framework is never dropped. web_framework keeps
         # the single-framework field prior callers read (the first, alphabetically).
@@ -99,5 +126,6 @@ def detect_stack(
         "agent_frameworks": agents,
         "vector_dbs": vector,
         "matched_recipes": sorted(matched),
+        "already_covered": already_covered,
         "gaps": gaps,
     }

--- a/sdk/python/onboarding_mcp/generate.py
+++ b/sdk/python/onboarding_mcp/generate.py
@@ -14,6 +14,7 @@ import re
 from typing import Any
 
 from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+from onboarding_mcp.detect import tokenize
 from onboarding_mcp.sdk_surface import emitted_tally_calls, layer_grounding
 
 _HOLE_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
@@ -70,6 +71,11 @@ def generate_middleware(
     ``account_source`` is the confirmed resolver expression (an ``X-Customer-Id`` header, an
     auth dependency); it is injected verbatim, never inferred. Without an answer the account
     layer stays unattributed, so an empty ``account_source`` is a reported gap, not a guess.
+
+    The ``startup`` value is a union: normally the ``generate_startup`` result, but a gap
+    dict (``gap``, ``reason``) when the catalog has no startup recipe. Both shapes carry
+    ``code`` / ``placement`` / ``imports_to_add``, with ``code`` set to None in the gap case,
+    so ``result["startup"]["code"]`` is always safe to read.
     """
     cat = catalog or get_catalog()
     if not account_source.strip():
@@ -101,6 +107,15 @@ def generate_middleware(
     # middleware + record_*". Returning the startup snippet alongside the middleware is
     # what makes the bundle complete: the developer's agent would otherwise wire
     # with_account into a process that never called init.
+    startup = generate_startup(feature_tag, catalog=cat)
+    if startup.get("gap"):
+        # generate_startup returns a union: a generated snippet, or a _gap dict that
+        # carries none of the code / placement / imports_to_add keys. A caller reading
+        # result["startup"]["code"] would then raise KeyError instead of seeing the gap
+        # it was told about (CTO-261 review finding 6). Normalize to one shape: the
+        # gap and its reason survive, and code is None, which reads as "nothing to
+        # apply" rather than blowing up.
+        startup = {"code": None, "placement": None, "imports_to_add": [], **startup}
     return {
         "recipe_id": recipe.id,
         "web_framework": web_framework,
@@ -109,7 +124,7 @@ def generate_middleware(
         "placement": recipe.edit["placement"],
         "bound_account_source": account_source,
         "feature_tag": feature_tag,
-        "startup": generate_startup(feature_tag, catalog=cat),
+        "startup": startup,
     }
 
 
@@ -219,13 +234,27 @@ def explain_layer(query: str, *, catalog: RecipeCatalog | None = None) -> dict[s
     matched_recipe = None
     if facts is None:
         # Not a bare layer name: try to match the excerpt to a recipe by its detect block.
+        # Imports match on identifier-token boundaries, not bare substrings: a plain
+        # substring test lets an ordinary English word inside a question ("together")
+        # or an unrelated dependency name pass as a confident LLM answer, and a
+        # confidently wrong grounded answer is worse than a gap (CTO-261 review
+        # finding 2, CLAUDE.md "honest under uncertainty").
+        query_tokens = tokenize(query)
         for recipe in cat.recipes:
-            if any(pat in query for pat in recipe.call_patterns) or any(
-                imp in query for imp in recipe.imports
+            if not (
+                any(pat in query for pat in recipe.call_patterns)
+                or any(tokenize(imp) & query_tokens for imp in recipe.imports)
             ):
-                facts = layer_grounding(recipe.verify.get("layer", ""))
-                matched_recipe = recipe.id
-                break
+                continue
+            grounding = layer_grounding(recipe.verify.get("layer", ""))
+            if grounding is None:
+                # A recipe whose layer carries no record_* grounding (the startup line
+                # is the one such recipe) answers nothing here. Keep looking rather than
+                # reporting a gap a later recipe could have answered honestly.
+                continue
+            facts = grounding
+            matched_recipe = recipe.id
+            break
     if facts is None:
         return _gap(
             f"no known layer or recipe matches {query!r}",

--- a/sdk/python/onboarding_mcp/server.py
+++ b/sdk/python/onboarding_mcp/server.py
@@ -9,6 +9,7 @@ an optional runtime dependency, imported lazily so the SDK test suite needs no M
 
 from __future__ import annotations
 
+import importlib.util
 from typing import Any
 
 from onboarding_mcp import (
@@ -38,8 +39,19 @@ TOOL_NAMES = (
 
 _MISSING_MCP = (
     "the 'mcp' package is required to run the onboarding MCP server; install it with "
-    "`pip install 'tally-sdk[mcp]'`. The tools themselves are importable without it."
+    "`pip install 'tally-sdk[mcp]'`. That extra also brings pyyaml, which the recipe "
+    "catalog needs, so the onboarding tools are importable and usable only with it "
+    "(onboarding_mcp is in the base wheel purely so this entrypoint resolves)."
 )
+
+
+def _mcp_installed() -> bool:
+    """True when a top-level ``mcp`` package is importable in this environment."""
+    try:
+        return importlib.util.find_spec("mcp") is not None
+    except (ImportError, ValueError):
+        # ValueError: sys.modules holds a None entry for mcp (how tests simulate absence).
+        return False
 
 
 def load_server_class() -> Any:
@@ -55,12 +67,21 @@ def load_server_class() -> Any:
 
         return MCPServer
     except ImportError:
-        pass
+        # The mcp 2.x module imports siblings of its own, so a partial or broken mcp-2
+        # install raises ImportError for a reason that is NOT "mcp is not installed".
+        # Swallowing it fell through to the 1.x path and reported "install the mcp
+        # package" for an environment where mcp IS installed, the exact misleading error
+        # this work set out to remove. Only a genuinely absent mcp falls through
+        # (CTO-261 review finding 5).
+        if _mcp_installed():
+            raise
     try:
         from mcp.server.fastmcp import FastMCP  # mcp 1.x
 
         return FastMCP
     except ImportError as exc:
+        if _mcp_installed():
+            raise
         raise RuntimeError(_MISSING_MCP) from exc
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -22,7 +22,11 @@ dev = [
 # pyyaml is a real runtime need here (the recipe catalog is YAML), which is why it is
 # listed again rather than borrowed from dev.
 mcp = [
-    "mcp>=1.0",
+    # >=1.2, not >=1.0: FastMCP was only merged into the official mcp SDK in 1.2.0, so a
+    # resolver landing on 1.0.x / 1.1.x gives a wheel with no fastmcp module and the server
+    # dies with "the 'mcp' package is required" while mcp IS installed, which is exactly the
+    # misleading error this work removes (CTO-261 review finding 3).
+    "mcp>=1.2",
     "pyyaml>=6.0",
 ]
 
@@ -38,6 +42,12 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 # onboarding_mcp ships in the wheel so the console entrypoint above resolves for an
 # installed SDK; recipes/ is the data the server reads and is forced in below.
+# A wheel's contents cannot vary by extra, so onboarding_mcp is present in the base wheel
+# but is NOT usable from it: the recipe catalog is YAML and pyyaml lives in the mcp extra,
+# which the SDK runtime deliberately does not carry (dependencies = [] above). Importing it
+# without the extra raises a clear, actionable error from catalog.py rather than a bare
+# "No module named 'yaml'", and server.py's message says the same thing (CTO-261 review
+# finding 4). Do not "fix" this by moving pyyaml into dependencies.
 packages = ["src/tally", "onboarding_mcp"]
 force-include = { "recipes" = "onboarding_mcp/recipes" }
 

--- a/sdk/python/recipes/index.yaml
+++ b/sdk/python/recipes/index.yaml
@@ -39,7 +39,7 @@ recipes:
   # and these two are the broadest detect blocks in the catalog.
   - id: startup.tally.init
     file: startup.tally.init.yaml
-    kind: llm
+    kind: startup
   - id: llm.generic.call
     file: llm.generic.call.yaml
     kind: llm

--- a/sdk/python/recipes/llm.generic.call.yaml
+++ b/sdk/python/recipes/llm.generic.call.yaml
@@ -6,8 +6,17 @@ id: llm.generic.call
 kind: llm
 title: "Unpatched LLM call site -> tally.record_llm_call"
 detect:
-  imports: ["httpx", "requests", "boto3", "ollama", "vllm", "together", "groq"]
-  call_patterns: [".chat.completions.create(", "messages.create(", "/v1/chat/completions"]
+  # Deliberately narrow (CTO-261 review findings 1 and 2). Two things must never appear
+  # here. httpx / requests / boto3 sit in nearly every Python app, so listing them made
+  # this recipe match an app with no LLM at all. And .chat.completions.create( /
+  # messages.create( are the shapes tally.init already monkeypatches (CTO-260), so
+  # matching them told an agent to add a second meter beside a call that is already
+  # metered, doubling reported cost. Only genuinely unpatched paths belong here.
+  # boto3 Bedrock is reached through the bedrock-runtime call pattern rather than the
+  # boto3 import, because boto3 on its own is overwhelmingly S3 / DynamoDB.
+  imports: ["ollama", "vllm", "together", "groq"]
+  call_patterns:
+    ["/v1/chat/completions", "bedrock-runtime", "ollama.chat(", "ollama.generate("]
 sdk_surface:
   call: "tally.record_llm_call"
   delegates_to: "tally.client.TallyClient.record_llm_call"
@@ -32,4 +41,4 @@ edit:
 verify:
   layer: llm
   operation_name: "chat"
-notes: "Cost resolves from the versioned catalog keyed by (provider, model); an unpriced pair keeps cost unknown with a one-time WARN rather than reporting a fabricated zero. Pass cached_input_tokens on Usage where the provider reports it."
+notes: "Applies only where tally.init's CTO-260 patch does not reach: a self-hosted or gateway-fronted model, a raw /v1/chat/completions POST, boto3 bedrock-runtime, ollama. Never apply it beside a patched openai / anthropic client call; detect_stack flags that case in already_covered. Cost resolves from the versioned catalog keyed by (provider, model); an unpriced pair keeps cost unknown with a one-time WARN rather than reporting a fabricated zero. Pass cached_input_tokens on Usage where the provider reports it."

--- a/sdk/python/recipes/schema.json
+++ b/sdk/python/recipes/schema.json
@@ -14,7 +14,8 @@
     },
     "kind": {
       "type": "string",
-      "enum": ["vector", "tool", "embedding", "llm", "middleware", "otel"]
+      "description": "Component this recipe instruments. 'startup' is the tally.init() line, which is not an LLM-call recipe: keeping it under 'llm' made by_kind('llm') and detect_stack's matched_kinds count the init line as LLM-layer coverage (CTO-261 review finding 7).",
+      "enum": ["vector", "tool", "embedding", "llm", "middleware", "otel", "startup"]
     },
     "title": {
       "type": "string",
@@ -62,8 +63,8 @@
         },
         "layer": {
           "type": "string",
-          "enum": ["vector", "tool", "embedding", "llm", "account", "otel"],
-          "description": "Gateway cost-layer / coverage bucket this recipe lands in."
+          "enum": ["vector", "tool", "embedding", "llm", "account", "otel", "startup"],
+          "description": "Gateway cost-layer / coverage bucket this recipe lands in. 'startup' is not a cost layer: it marks a recipe that connects the process rather than metering one call, so no coverage bucket may count it (CTO-261 review finding 7)."
         }
       }
     },
@@ -95,7 +96,7 @@
       "properties": {
         "layer": {
           "type": "string",
-          "enum": ["vector", "tool", "embeddings", "llm", "account", "otel"]
+          "enum": ["vector", "tool", "embeddings", "llm", "account", "otel", "startup"]
         },
         "operation_name": {
           "type": "string",

--- a/sdk/python/recipes/startup.tally.init.yaml
+++ b/sdk/python/recipes/startup.tally.init.yaml
@@ -3,7 +3,11 @@
 # Without this recipe the agent wires middleware and record_* calls into a process that
 # was never connected, so nothing ships.
 id: startup.tally.init
-kind: llm
+# Not kind/layer llm. This is the line that connects the process, not a metered LLM call:
+# under llm it made by_kind("llm") and detect_stack's matched_kinds count the init line as
+# LLM-layer coverage, which would mislead the first consumer that branches on it (the P3
+# coverage probe). CTO-261 review finding 7.
+kind: startup
 title: "Application startup -> tally.init()"
 detect:
   # init applies to any metered app; the LLM clients are the strongest manifest signal
@@ -14,7 +18,7 @@ sdk_surface:
   call: "tally.init"
   delegates_to: "tally.init.init"
   required_args: [feature_tag]
-  layer: llm
+  layer: startup
 edit:
   imports_to_add: ["import tally"]
   template: |
@@ -26,6 +30,8 @@ edit:
     tally.init(feature_tag={feature_tag})
   placement: startup
 verify:
-  layer: llm
-  operation_name: "chat"
+  # No operation_name: init emits no span of its own. What it lights up is whatever the
+  # patched clients then record, so pinning it to GenAiOperation='chat' here would claim
+  # coverage this recipe does not itself prove.
+  layer: startup
 notes: "feature_tag sets the process-wide default feature dimension; the middleware recipe overrides it per request via start_trace. Passing no key degrades to a disabled client with one warning rather than raising, so a missing TALLY_KEY is visible in logs and never silently fabricates telemetry."

--- a/sdk/python/tests/test_onboarding_mcp.py
+++ b/sdk/python/tests/test_onboarding_mcp.py
@@ -89,6 +89,80 @@ def test_detect_stack_gap_names_the_unhandled_web_framework():
     assert "fastapi" not in account_gaps[0]
 
 
+# --------------------------------------------------------------------------- #
+# The manual LLM recipe must not fire on an already-patched call, and must not fire
+# on an app with no LLM at all (CTO-261 review findings 1 and 2).
+# --------------------------------------------------------------------------- #
+def test_patched_openai_call_does_not_match_the_manual_llm_recipe():
+    # tally.init monkeypatches client.chat.completions.create (CTO-260). Matching the
+    # manual recipe here made an agent add a second record_llm_call beside a metered
+    # call, doubling reported cost: the product's core number.
+    result = detect_stack(
+        "openai==1.0\nfastapi==0.115",
+        "r = client.chat.completions.create(model=m, messages=msgs)",
+    )
+    assert "llm.generic.call" not in result["matched_recipes"]
+
+
+def test_detected_auto_instrumented_provider_is_flagged_as_already_covered():
+    # A marker in the tool OUTPUT is not optional: the recipe template's comment never
+    # reaches the agent reading detect_stack's result.
+    result = detect_stack("openai==1.0\nanthropic==0.34\n")
+    assert result["already_covered"], "an auto-instrumented provider must be flagged"
+    marker = result["already_covered"][0]
+    assert "openai" in marker
+    assert "twice" in marker
+    assert "tally.init()" in marker
+
+
+def test_no_llm_provider_means_no_already_covered_marker():
+    result = detect_stack("requests==2.32.0\nflask==3.0\n")
+    assert result["already_covered"] == []
+
+
+def test_plain_requests_and_flask_app_does_not_match_the_llm_recipe():
+    # httpx / requests / boto3 are in nearly every Python app. Matching on them told an
+    # app with no LLM to add record_llm_call while llm_providers was empty.
+    result = detect_stack("requests==2.32.0\nflask==3.0\n")
+    assert result["llm_providers"] == []
+    assert "llm.generic.call" not in result["matched_recipes"]
+
+
+def test_boto3_alone_does_not_match_but_bedrock_runtime_does():
+    # boto3 is overwhelmingly S3 / DynamoDB, so it only signals an LLM call site with a
+    # bedrock-runtime call pattern alongside it.
+    plain = detect_stack("boto3==1.34.0\n", "s3 = boto3.client('s3')")
+    assert "llm.generic.call" not in plain["matched_recipes"]
+    bedrock = detect_stack("boto3==1.34.0\n", "brt = boto3.client('bedrock-runtime')")
+    assert "llm.generic.call" in bedrock["matched_recipes"]
+
+
+def test_genuinely_unpatched_providers_still_match():
+    # Narrowing must not blind the recipe to the call sites it exists for.
+    assert "llm.generic.call" in detect_stack("ollama==0.3.0\n")["matched_recipes"]
+    assert (
+        "llm.generic.call"
+        in detect_stack("", 'httpx.post("https://x/v1/chat/completions")')["matched_recipes"]
+    )
+
+
+def test_explain_layer_on_boto3_is_a_gap_not_a_confident_llm_answer():
+    # A confidently wrong grounded answer is worse than a gap (CLAUDE.md). boto3 must not
+    # resolve to record_llm_call / GenAiOperation='chat'.
+    result = explain_layer("what records this boto3 call?")
+    assert result["gap"] is True
+    result = explain_layer("boto3")
+    assert result["gap"] is True
+
+
+def test_explain_layer_does_not_match_an_import_name_buried_in_a_longer_identifier():
+    # Imports match on identifier-token boundaries rather than bare substrings, so an
+    # unrelated name that merely contains a provider name is a gap, not a confident
+    # LLM answer. (Guards the same class of bug as the boto3 case above.)
+    result = explain_layer("what records this vllmlike_helper call?")
+    assert result["gap"] is True
+
+
 def test_get_recipe_by_id_and_by_alias():
     by_id = get_recipe("vector.pinecone.query")
     assert by_id["id"] == "vector.pinecone.query"
@@ -160,6 +234,41 @@ def test_generate_startup_without_the_recipe_is_a_gap():
     result = generate_startup("chatbot", catalog=without)
     assert result["gap"] is True
     assert "code" not in result
+
+
+def test_middleware_startup_gap_is_readable_without_a_key_error():
+    # Finding 6: generate_startup returns a union, and the gap arm carries no code /
+    # placement / imports_to_add. A caller reading result["startup"]["code"] must see the
+    # gap, not a KeyError.
+    from onboarding_mcp.catalog import RecipeCatalog, get_catalog
+
+    full = get_catalog()
+    without = RecipeCatalog(
+        [r for r in full.recipes if r.id != "startup.tally.init"], full.schema
+    )
+    result = generate_middleware(
+        "fastapi", 'request.headers["X-Customer-Id"]', "chatbot", catalog=without
+    )
+    startup = result["startup"]
+    assert startup["gap"] is True
+    assert startup["code"] is None
+    assert startup["placement"] is None
+    assert startup["imports_to_add"] == []
+    assert startup["reason"]
+
+
+def test_startup_recipe_is_not_counted_as_llm_layer_coverage():
+    # Finding 7: the init line is a startup recipe, not an LLM-call recipe. Counting it
+    # under llm would mislead the first consumer that branches on the kind (the P3
+    # coverage probe).
+    from onboarding_mcp.catalog import get_catalog
+
+    cat = get_catalog()
+    startup = cat.get("startup.tally.init")
+    assert startup.kind == "startup"
+    assert startup.sdk_surface["layer"] == "startup"
+    assert startup.verify["layer"] == "startup"
+    assert startup.id not in {r.id for r in cat.by_kind("llm")}
 
 
 def test_instrument_call_site_adapts_the_llm_recipe():

--- a/sdk/python/tests/test_onboarding_mcp_server.py
+++ b/sdk/python/tests/test_onboarding_mcp_server.py
@@ -85,11 +85,20 @@ def test_unknown_input_stays_a_gap_through_the_tool_layer(built: RecordingServer
     assert built.tools["generate_middleware"]("fastapi", "  ")["gap"] is True
 
 
-def test_missing_mcp_dependency_raises_a_clear_runtime_error(monkeypatch):
-    # Blocking both module paths in sys.modules makes the import fail the same way an
-    # uninstalled extra does, whether or not mcp happens to be present in this env.
+def _simulate_mcp_absent(monkeypatch) -> None:
+    """Make mcp look uninstalled regardless of what this environment actually has.
+
+    The None entries make the submodule imports fail the way an uninstalled extra does;
+    the top-level None entry is what ``_mcp_installed`` reads, so the "is it really
+    missing?" check agrees instead of re-raising (CTO-261 review finding 5).
+    """
+    monkeypatch.setitem(sys.modules, "mcp", None)
     monkeypatch.setitem(sys.modules, "mcp.server.mcpserver", None)
     monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", None)
+
+
+def test_missing_mcp_dependency_raises_a_clear_runtime_error(monkeypatch):
+    _simulate_mcp_absent(monkeypatch)
     with pytest.raises(RuntimeError) as excinfo:
         server_mod.load_server_class()
     message = str(excinfo.value)
@@ -98,10 +107,39 @@ def test_missing_mcp_dependency_raises_a_clear_runtime_error(monkeypatch):
 
 
 def test_build_server_propagates_the_missing_dependency_error(monkeypatch):
-    monkeypatch.setitem(sys.modules, "mcp.server.mcpserver", None)
-    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", None)
+    _simulate_mcp_absent(monkeypatch)
     with pytest.raises(RuntimeError):
         server_mod.build_server()
+
+
+def test_broken_mcp_install_reraises_instead_of_claiming_mcp_is_missing(monkeypatch):
+    # Finding 5: the mcp 2.x module imports siblings of its own, so a partial or broken
+    # mcp-2 install raises ImportError for a reason other than "not installed". The old
+    # bare `except ImportError: pass` fell through and told the developer to install a
+    # package they already had. With mcp importable, the real ImportError must surface.
+    monkeypatch.setitem(sys.modules, "mcp.server.mcpserver", None)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", None)
+    monkeypatch.setattr(server_mod, "_mcp_installed", lambda: True)
+    with pytest.raises(ImportError):
+        server_mod.load_server_class()
+
+
+def test_mcp_extra_requires_a_version_that_actually_ships_fastmcp():
+    # FastMCP was merged into the official mcp SDK in 1.2.0; the 1.0.0 wheel has no
+    # fastmcp module, so a resolver picking 1.0.x / 1.1.x would produce the misleading
+    # "install the mcp package" error for an installed mcp (finding 3).
+    pyproject = tomllib.loads(PYPROJECT.read_text())
+    mcp_extra = pyproject["project"]["optional-dependencies"]["mcp"]
+    pins = [p for p in mcp_extra if p.startswith("mcp")]
+    assert pins == ["mcp>=1.2"], f"unexpected mcp pin: {pins}"
+
+
+def test_missing_mcp_message_does_not_claim_the_tools_import_without_the_extra():
+    # Finding 4: onboarding_mcp is in the base wheel, but catalog.py needs pyyaml, which
+    # only the mcp extra brings. The message must not claim otherwise.
+    message = server_mod._MISSING_MCP
+    assert "importable without it" not in message
+    assert "pyyaml" in message
 
 
 def test_declared_console_entrypoint_resolves():


### PR DESCRIPTION
Review fixes for #282. Stacked on `feat/i3-p1-mcp-connectable`, which is the base. All changes are under `sdk/python/`.

## What each change addresses

**Finding 1 (MUST FIX, double-metering).** `recipes/llm.generic.call.yaml` matched `.chat.completions.create(` and `messages.create(`, the call shapes `tally.init()` already monkeypatches (CTO-260). A coding agent added a manual `record_llm_call` beside a patched call and the same LLM call was metered twice, doubling reported cost.

- `call_patterns` narrowed to genuinely unpatched paths: `/v1/chat/completions`, `bedrock-runtime`, `ollama.chat(`, `ollama.generate(`.
- `detect_stack` now returns an `already_covered` list naming any auto-instrumented provider it found, with the do-not-double-meter instruction. The template's warning was only a comment inside the recipe, so it never reached the tool output the agent reads.
- The recipe still matches when a genuinely unpatched path is present alongside a patched one (openai plus ollama is a real stack), so this flags rather than silently drops.

**Finding 2 (MUST FIX, honesty regression).** `detect.imports` was `["httpx", "requests", "boto3", ...]`, which matches essentially any Python app.

- Narrowed to `["ollama", "vllm", "together", "groq"]`. boto3 Bedrock is reached through the `bedrock-runtime` call pattern instead of the `boto3` import, since boto3 alone is overwhelmingly S3/DynamoDB.
- `explain_layer` now matches recipe imports on identifier-token boundaries rather than bare substrings, and skips a recipe whose layer carries no `record_*` grounding instead of turning that into a gap a later recipe could have answered.

**Finding 3 (MUST FIX).** `mcp>=1.0` could resolve to a wheel with no `fastmcp` module. Changed to `mcp>=1.2`. Verified below.

**Finding 4 (FIX, packaging).** A wheel's contents cannot vary by extra, so `onboarding_mcp` cannot be shipped "only with the extra" while keeping the console entrypoint resolvable. Took the other option in the finding: corrected the claim, and made the failure honest. SDK runtime `dependencies` stay empty.

- `server.py`'s message no longer claims "The tools themselves are importable without it"; it says the extra is what makes them importable and usable, and why.
- `catalog.py` raises an actionable `ModuleNotFoundError` naming the extra, rather than a bare `No module named 'yaml'`.
- The reasoning is recorded in `pyproject.toml` next to `packages`, with a do-not-move-pyyaml-into-dependencies note.

**Finding 5 (FIX, honest errors).** `except ImportError: pass` on the mcp 2.x path meant a partial or broken mcp-2 install fell through and surfaced as "install the mcp package" for an environment where mcp is installed. `load_server_class` now re-raises unless `importlib.util.find_spec("mcp")` says mcp is genuinely absent.

**Finding 6 (MINOR).** `generate_middleware` embedded `generate_startup(...)` under `"startup"`, and that value could be a `_gap()` dict with no `code` key, so `result["startup"]["code"]` raised `KeyError`. The gap arm is now normalized to carry `code: None`, `placement: None`, `imports_to_add: []` with the gap and reason preserved. Documented in the docstring and the README table.

**Finding 7 (MINOR, taxonomy).** `startup.tally.init` was registered `kind: llm` with `sdk_surface.layer: llm` / `verify.layer: llm`, so `by_kind("llm")` and `detect_stack`'s `matched_kinds` counted the init line as LLM-layer coverage. Introduced a `startup` kind and layer, extended the three schema enums (`additionalProperties: false` kept), and updated `index.yaml` and the recipe. Dropped `verify.operation_name` from that recipe: init emits no span of its own, so claiming `GenAiOperation='chat'` was coverage it does not prove.

## Tests added

`tests/test_onboarding_mcp.py`
- `test_patched_openai_call_does_not_match_the_manual_llm_recipe` (the verified failure from the review, finding 1)
- `test_detected_auto_instrumented_provider_is_flagged_as_already_covered`
- `test_no_llm_provider_means_no_already_covered_marker`
- `test_plain_requests_and_flask_app_does_not_match_the_llm_recipe` (finding 2, requested regression test)
- `test_boto3_alone_does_not_match_but_bedrock_runtime_does`
- `test_genuinely_unpatched_providers_still_match` (narrowing must not blind the recipe)
- `test_explain_layer_on_boto3_is_a_gap_not_a_confident_llm_answer` (finding 2, requested regression test)
- `test_explain_layer_does_not_match_an_import_name_buried_in_a_longer_identifier`
- `test_middleware_startup_gap_is_readable_without_a_key_error` (finding 6)
- `test_startup_recipe_is_not_counted_as_llm_layer_coverage` (finding 7)

`tests/test_onboarding_mcp_server.py`
- `test_broken_mcp_install_reraises_instead_of_claiming_mcp_is_missing` (finding 5)
- `test_mcp_extra_requires_a_version_that_actually_ships_fastmcp` (finding 3)
- `test_missing_mcp_message_does_not_claim_the_tools_import_without_the_extra` (finding 4)
- The two existing missing-mcp tests now also block the top-level `mcp` entry so they are deterministic whether or not mcp is installed in the environment.

The existing no-bodies-in-telemetry test across all templates still passes, and `sdk_surface.py`'s anti-hallucination guard is untouched.

## Verification

`cd sdk/python && uv run --extra dev pytest -q` -> all 1150 tests pass, no new failures.
`uv run ruff check .` -> All checks passed.

Wheel actually built and installed into clean venvs.

Base wheel, no extra (finding 4 behaves as claimed):

```
=== base install: pyyaml present? ===
pyyaml NOT installed (runtime deps empty, as required)
=== base install: import tally ===
tally imports OK
=== base install: import onboarding_mcp ===
ModuleNotFoundError: the onboarding recipe catalog is YAML and needs pyyaml, which ships
with the 'mcp' extra: pip install 'tally-sdk[mcp]'. onboarding_mcp is present in the base
tally-sdk wheel so the tally-onboarding-mcp entrypoint resolves, but it is not usable
without that extra; the SDK runtime itself stays dependency-free.
```

With the extra, recipes resolve from the installed location:

```
mcp 2.1.1, PyYAML 6.0.3, tally-sdk 0.0.1
load_server_class() -> <class 'mcp.server.mcpserver.server.MCPServer'>
RECIPES_DIR = /tmp/venvmcp/lib/python3.13/site-packages/onboarding_mcp/recipes
recipes loaded: 12
startup kind: startup
```

Finding 3 premise confirmed against the real wheels: `mcp==1.0.0` contains 0 `fastmcp` files, `mcp==1.2.0` contains `mcp/server/fastmcp/{__init__,exceptions,server}.py`. `mcp>=1.2,<2` resolves to 1.29.1.

Behaviour from the installed wheel:

```
detect_stack('openai==1.0\nfastapi==0.115', 'r = client.chat.completions.create(...)')
  matched_recipes: ['embedding.generic.call', 'middleware.fastapi.account', 'startup.tally.init']
  already_covered: ["llm: openai detected. tally.init() auto-instruments these clients
    (CTO-260), so those call sites need no edit. Do NOT add tally.record_llm_call beside a
    patched client call: the same call would be metered twice and reported cost would
    double. ..."]
detect_stack('requests==2.32.0\nflask==3.0\n') -> ['middleware.flask.account']
explain_layer('what records this boto3 call?') -> {'gap': True, ...}
```

## Deliberately not changed

- `together` is kept in `detect.imports` as the finding specified. It is an ordinary English word, so `explain_layer` on prose containing "together" can still return an LLM answer. Token-boundary matching does not help for a real word. Removing it would lose manifest detection of together.ai, so it is left as specified and noted here rather than silently changed.
- `onboarding_mcp` still ships in the base wheel. A wheel cannot vary its contents by extra, and removing it would break the `tally-onboarding-mcp` console entrypoint the parent PR added, so the finding's second option (correct the claim) was taken.
- `sdk_surface.py`'s anti-hallucination guard, `dependencies = []`, the env-reference key in the startup recipe, and the no-bodies template test are all untouched.

DO NOT MERGE yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)