### PR TITLE
fix: make unknown token counts and cost representable (CTO-244)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -97,6 +97,46 @@ curl -s 'http://localhost:8123/?user=tally&password=tally&database=default' \
 or open a SQL shell with `make ch` and run
 `SELECT FeatureTag, count(), sum(EstimatedCost) FROM otel_spans WHERE TenantId='local-dev' GROUP BY FeatureTag`.
 
+### Nullable usage and cost (CTO-244)
+
+`InputTokens`, `OutputTokens`, `CachedInputTokens` and `EstimatedCost` are **nullable**. "We do not
+know" is a real state and it is not zero. The common case is a streamed response through the edge
+proxy: usage cannot be scanned off the stream, so the provider never tells us what the call
+consumed. Those spans store `NULL`, and `CostSource = 'unpriced'` records why the cost is missing
+(the same empty `PriceCatalogVersion` that `tally.pricing` already returns on a catalog miss). A
+cost or token count that the provider really did report as `0` still stores as `0` and stays
+distinguishable from `NULL`.
+
+This matters when you read the data yourself. `sum()` skips NULLs, so a plain
+`sum(EstimatedCost)` is a **lower bound**, not a total. Ask for the coverage alongside it:
+
+```sql
+SELECT sum(EstimatedCost)                AS known_spend,
+       countIf(EstimatedCost IS NULL)    AS unpriced_spans,
+       count()                           AS spans
+FROM otel_spans WHERE TenantId = 'local-dev';
+```
+
+The rollups carry the same disclosure as `UnpricedSpanCount` and `UnknownUsageSpanCount` columns.
+Anything that divides cost by a count (per call, per user, per conversion, per token) is a ratio
+between a partial numerator and a complete denominator whenever `unpriced_spans > 0`; the dashboard
+renders those as a blank with a reason rather than a smaller number.
+
+**Applying it to a stack that is already up.** Run `make ch-migrate` from `infra/`. Unlike the
+earlier additive column migrations, this one issues `MODIFY COLUMN`, which is a real ClickHouse
+mutation: it rewrites the affected parts in the background (watch `system.mutations`) instead of
+being metadata-only. Ingest keeps working while it runs. Replaying is safe, because modifying a
+column to the type it already has is a no-op.
+
+**Known limitation: figures from before this cutover may understate spend.** Rows written earlier
+hold `0` where the truth was either a genuine provider-reported zero **or** an unknown that ingest
+flattened to zero. Nothing recorded which, so nothing can separate them now. There is deliberately
+no backfill: guessing which zeros "should" be NULL would fabricate exactly the kind of number this
+change removes. So pre-cutover totals may be lower than the real spend, by an amount no query can
+measure, and the pre-cutover `UnpricedSpanCount` of `0` means "nobody counted", not "there were no
+unknowns". Post-cutover data is honest. If a clean baseline matters more than history on a local
+stack, `make nuke && make up && make seed` and re-backfill.
+
 ## 4. Run the web dashboard
 
 In a separate terminal:

--- a/db/clickhouse/account_rollups.sql
+++ b/db/clickhouse/account_rollups.sql
@@ -48,6 +48,11 @@ CREATE TABLE IF NOT EXISTS daily_account_rollup
     EstimatedCost       Decimal64(8),
     ReconciledCost      Decimal64(8),
     SpanCount           UInt64,
+    -- CTO-244. otel_spans.EstimatedCost is Nullable: a call we could not price is unpriced, not
+    -- free. sum() skips those rows, so EstimatedCost above is a LOWER BOUND on what this account
+    -- really cost. This counter is what keeps that from being silent. A caller that finds it
+    -- non-zero must label the figure partial rather than rank an under-count as a total.
+    UnpricedSpanCount   UInt64,
     UserCountState      AggregateFunction(uniq, FixedString(64))
 )
 ENGINE = SummingMergeTree
@@ -66,7 +71,21 @@ PARTITION BY toYYYYMM(Day)
 -- while making the grain of a row honest: one row per account per day per feature per operation.
 ORDER BY (TenantId, AccountIdHash, Day, FeatureTag, GenAiOperation);
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS daily_account_rollup_mv
+-- CTO-244 migration for an EXISTING deployment. The CREATE TABLE above is IF NOT EXISTS and so is
+-- a no-op on a live stack; add the coverage counter explicitly. `AFTER SpanCount` keeps the
+-- physical column order identical to the CREATE TABLE. DEFAULT 0 makes it metadata-only, and on
+-- pre-cutover rows that 0 means "nobody counted", NOT "there were no unknowns": before the cutover
+-- an unpriced call was indistinguishable from a free one. Those figures may understate spend and
+-- cannot be corrected after the fact. See the CTO-244 note in otel_spans.sql and RUNNING.md.
+--
+-- The MV is DROPped and recreated rather than CREATE ... IF NOT EXISTS, because a materialized
+-- view's SELECT cannot be ALTERed and IF NOT EXISTS would silently leave the old definition in
+-- place. Dropping a `TO`-table MV leaves the target table and all its history untouched.
+ALTER TABLE daily_account_rollup
+    ADD COLUMN IF NOT EXISTS UnpricedSpanCount UInt64 DEFAULT 0 AFTER SpanCount;
+
+DROP VIEW IF EXISTS daily_account_rollup_mv;
+CREATE MATERIALIZED VIEW daily_account_rollup_mv
 TO daily_account_rollup
 AS SELECT
     TenantId,
@@ -74,13 +93,17 @@ AS SELECT
     AccountIdHash,
     FeatureTag,
     GenAiOperation,
-    sum(EstimatedCost)                     AS EstimatedCost,
+    -- CTO-244: ifNull sits OUTSIDE the aggregate (an all-NULL group sums to NULL) so the result
+    -- stays non-Nullable for the SummingMergeTree column. The honesty lives in UnpricedSpanCount
+    -- below, not in this sum.
+    ifNull(sum(otel_spans.EstimatedCost), toDecimal64(0, 8)) AS EstimatedCost,
     -- ReconciledCost is Nullable on otel_spans and NOT NULL here. ifNull(..., 0) is what makes the
     -- SummingMergeTree column safe to sum: a NULL would poison the total. A day that has not been
     -- reconciled therefore reads as 0 reconciled, and callers compare against EstimatedCost rather
     -- than treating 0 as "this cost nothing".
-    sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+    ifNull(sum(otel_spans.ReconciledCost), toDecimal64(0, 8)) AS ReconciledCost,
     count()                                AS SpanCount,
+    countIf(otel_spans.EstimatedCost IS NULL) AS UnpricedSpanCount,
     uniqState(UserIdHash)                  AS UserCountState
 FROM otel_spans
 GROUP BY TenantId, Day, AccountIdHash, FeatureTag, GenAiOperation;
@@ -109,9 +132,10 @@ GROUP BY TenantId, Day, AccountIdHash, FeatureTag, GenAiOperation;
 --          AccountIdHash,
 --          FeatureTag,
 --          GenAiOperation,
---          sum(EstimatedCost)                             AS EstimatedCost,
---          sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+--          ifNull(sum(otel_spans.EstimatedCost), toDecimal64(0, 8))  AS EstimatedCost,
+--          ifNull(sum(otel_spans.ReconciledCost), toDecimal64(0, 8)) AS ReconciledCost,
 --          count()                                        AS SpanCount,
+--          countIf(EstimatedCost IS NULL)                 AS UnpricedSpanCount,
 --          uniqState(UserIdHash)                          AS UserCountState
 --      FROM otel_spans
 --      WHERE Timestamp < '<cutoff>'          -- see the double-count warning below

--- a/db/clickhouse/last_touch_index.sql
+++ b/db/clickhouse/last_touch_index.sql
@@ -13,13 +13,25 @@ CREATE TABLE IF NOT EXISTS last_touch_index
     UserIdHashKeyVersion LowCardinality(String),
     LastTraceId          String,
     LastTraceTs          DateTime64(9),
-    LastTraceCost        Decimal64(8),
+    -- CTO-244: Nullable because otel_spans.EstimatedCost is. This column is a single span's cost,
+    -- not a sum, so there is nothing to fall back to: if that call could not be priced, the honest
+    -- value is NULL and the reader renders a blank with a reason. A 0 here would assert the user's
+    -- last touch was free.
+    LastTraceCost        Nullable(Decimal64(8)),
     UpdatedAt            DateTime64(9) DEFAULT now64()
 )
 ENGINE = ReplacingMergeTree(UpdatedAt)
 ORDER BY (TenantId, UserIdHash, FeatureTag);
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS last_touch_index_mv
+-- CTO-244 migration for an EXISTING deployment: widen the column in place (a no-op when it is
+-- already Nullable, so replaying stays idempotent) and recreate the MV, whose SELECT cannot be
+-- ALTERed and which CREATE ... IF NOT EXISTS would silently leave on the old definition. Dropping
+-- a `TO`-table MV does not touch last_touch_index itself.
+ALTER TABLE last_touch_index
+    MODIFY COLUMN LastTraceCost Nullable(Decimal64(8));
+
+DROP VIEW IF EXISTS last_touch_index_mv;
+CREATE MATERIALIZED VIEW last_touch_index_mv
 TO last_touch_index
 AS SELECT
     TenantId,

--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -57,15 +57,27 @@ CREATE TABLE IF NOT EXISTS otel_spans
     GenAiResponseModel     LowCardinality(String),
     GenAiOperation         LowCardinality(String),
     GenAiToolName          LowCardinality(String),
-    InputTokens            UInt32                   CODEC(T64, ZSTD(1)),
-    OutputTokens           UInt32                   CODEC(T64, ZSTD(1)),
-    CachedInputTokens      UInt32                   CODEC(T64, ZSTD(1)),
+    -- CTO-244: usage is NULLABLE because "we do not know" is a real, common state and it is not 0.
+    -- The motivating case is a streamed response through the edge proxy: usage cannot be scanned
+    -- off the stream, so the provider never tells us how many tokens the call consumed. Storing 0
+    -- there made the dashboard read a real, billed call as one that consumed nothing, silently
+    -- understating spend. A provider-reported 0 still stores as 0 and stays distinguishable from
+    -- NULL. T64 is retained: it composes with Nullable on integer types.
+    InputTokens            Nullable(UInt32)         CODEC(T64, ZSTD(1)),
+    OutputTokens           Nullable(UInt32)         CODEC(T64, ZSTD(1)),
+    CachedInputTokens      Nullable(UInt32)         CODEC(T64, ZSTD(1)),
 
     -- Cost (dual-track; Decimal64(8), NOT Float64)
-    EstimatedCost          Decimal64(8)             CODEC(ZSTD(1)),
+    --
+    -- CTO-244: EstimatedCost is NULLABLE for the same reason. A price-catalog miss, or usage we
+    -- never learned, cannot be priced, and $0.00 is a lie about a call that really did cost money.
+    -- CostSource carries the WHY: 'unpriced' means we could not put a number on this span, so a
+    -- reader can say so instead of summing a fabricated zero. PriceCatalogVersion is '' on those
+    -- rows, which is the same empty-version signal tally.pricing already uses for a catalog miss.
+    EstimatedCost          Nullable(Decimal64(8))   CODEC(ZSTD(1)),
     ReconciledCost         Nullable(Decimal64(8))   CODEC(ZSTD(1)),
     CostCurrency           LowCardinality(String),
-    CostSource             Enum8('estimated' = 1, 'reconciled' = 2),
+    CostSource             Enum8('estimated' = 1, 'reconciled' = 2, 'unpriced' = 3),
     PriceCatalogVersion    LowCardinality(String),
 
     -- Agent context
@@ -151,3 +163,33 @@ ALTER TABLE otel_spans
 ALTER TABLE otel_spans
     ADD COLUMN IF NOT EXISTS AccountIdHash           FixedString(64) DEFAULT '' CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS AccountIdHashKeyVersion LowCardinality(String);
+
+-- CTO-244 migration: make usage and estimated cost NULLABLE, and teach CostSource to say why.
+--
+-- WHY. UInt32 and Decimal64(8) have no way to spell "unknown", so ingest was coercing an absent
+-- token count or an unpriceable call to 0. The dashboard then read a real, billed call as one that
+-- consumed nothing and cost nothing. That breaks the repo's first invariant (an unknown value is
+-- null, never 0) and it understates spend in the single most common case there is: a streamed
+-- response through the edge proxy, where usage cannot be scanned off the stream.
+--
+-- This is NOT the additive `ADD COLUMN IF NOT EXISTS` pattern used above. `MODIFY COLUMN` widening
+-- a type to its Nullable form is a real mutation: ClickHouse rewrites the affected parts in the
+-- background (watch system.mutations). It is safe to replay because modifying a column to the type
+-- it already has is a no-op, so `make ch-migrate` stays idempotent. Ingest is not blocked while it
+-- runs. Widening UInt32 -> Nullable(UInt32) and Decimal64(8) -> Nullable(Decimal64(8)) loses no
+-- value. Extending the CostSource enum keeps 1 and 2 on their existing labels, so already-written
+-- rows keep their meaning.
+--
+-- THE CUTOVER IS AMBIGUOUS AND WE DO NOT PAPER OVER IT. Rows written before this migration hold 0
+-- where the truth was EITHER a genuine provider-reported zero OR an unknown that ingest flattened.
+-- Nothing recorded which, so nothing can tell them apart now. There is deliberately no backfill:
+-- guessing which zeros "should" be NULL would fabricate exactly the kind of number this change
+-- exists to remove. Consequence, stated plainly: token and cost figures covering any period before
+-- the cutover may UNDERSTATE real spend, and no query can quantify by how much. Post-cutover rows
+-- are honest. See RUNNING.md ("Nullable usage and cost").
+ALTER TABLE otel_spans
+    MODIFY COLUMN InputTokens       Nullable(UInt32)       CODEC(T64, ZSTD(1)),
+    MODIFY COLUMN OutputTokens      Nullable(UInt32)       CODEC(T64, ZSTD(1)),
+    MODIFY COLUMN CachedInputTokens Nullable(UInt32)       CODEC(T64, ZSTD(1)),
+    MODIFY COLUMN EstimatedCost     Nullable(Decimal64(8)) CODEC(ZSTD(1)),
+    MODIFY COLUMN CostSource        Enum8('estimated' = 1, 'reconciled' = 2, 'unpriced' = 3);

--- a/db/clickhouse/rollups.sql
+++ b/db/clickhouse/rollups.sql
@@ -19,6 +19,15 @@ CREATE TABLE IF NOT EXISTS daily_feature_rollup
     EstimatedCost       Decimal64(8),
     ReconciledCost      Decimal64(8),
     SpanCount           UInt64,
+    -- CTO-244 coverage counters. otel_spans.InputTokens/OutputTokens/EstimatedCost are Nullable:
+    -- "the provider never told us" is a real state and it is not 0. The sums above therefore cover
+    -- only the spans we actually know, which makes them a LOWER BOUND, not a total. These two
+    -- counters are what stops that from being silent: a reader that finds them non-zero must say
+    -- the figure is partial (and blank any per-call or per-token derivation from it) rather than
+    -- present an under-count as complete. They are plain UInt64 so SummingMergeTree adds them the
+    -- same way it adds SpanCount.
+    UnknownUsageSpanCount UInt64,
+    UnpricedSpanCount     UInt64,
     TraceCountState     AggregateFunction(uniq, String),
     UserCountState      AggregateFunction(uniq, FixedString(64))
 )
@@ -26,19 +35,51 @@ ENGINE = SummingMergeTree
 PARTITION BY toYYYYMM(Day)
 ORDER BY (TenantId, FeatureTag, GenAiResponseModel, Day);
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS daily_feature_rollup_mv
+
+-- CTO-244 migration for an EXISTING deployment. Two steps, and both are needed.
+--
+-- 1. The CREATE TABLE above is IF NOT EXISTS, so it is a no-op on a stack that already has these
+--    tables. Add the coverage counters explicitly. `AFTER SpanCount` keeps the physical column
+--    order identical to the CREATE TABLE, and DEFAULT 0 makes it metadata-only: rows rolled up
+--    before this change read 0 unknown, which is not a claim that they had no unknowns. It is a
+--    claim that nobody counted, because before the cutover an unknown was indistinguishable from a
+--    real zero. Pre-cutover rollup figures may understate spend and cannot be corrected. See the
+--    CTO-244 note in otel_spans.sql and RUNNING.md.
+-- 2. A materialized view's SELECT cannot be ALTERed, and `CREATE ... IF NOT EXISTS` will not
+--    replace one that already exists, so a replay would leave the old definition writing the old
+--    columns forever. The MVs below are therefore DROPped and recreated on every replay. Dropping
+--    a `TO`-table MV does not touch the target table, so no history is lost; the only cost is that
+--    spans inserted during the drop/create window are not rolled up, which is why ch-migrate is an
+--    operator action rather than something on the ingest path.
+ALTER TABLE daily_feature_rollup
+    ADD COLUMN IF NOT EXISTS UnknownUsageSpanCount UInt64 DEFAULT 0 AFTER SpanCount,
+    ADD COLUMN IF NOT EXISTS UnpricedSpanCount     UInt64 DEFAULT 0 AFTER UnknownUsageSpanCount;
+
+ALTER TABLE hourly_feature_rollup
+    ADD COLUMN IF NOT EXISTS UnknownUsageSpanCount UInt64 DEFAULT 0 AFTER SpanCount,
+    ADD COLUMN IF NOT EXISTS UnpricedSpanCount     UInt64 DEFAULT 0 AFTER UnknownUsageSpanCount;
+
+DROP VIEW IF EXISTS daily_feature_rollup_mv;
+CREATE MATERIALIZED VIEW daily_feature_rollup_mv
 TO daily_feature_rollup
 AS SELECT
     TenantId,
     toDate(Timestamp)                      AS Day,
     FeatureTag,
     GenAiResponseModel,
-    sum(InputTokens)                       AS InputTokens,
-    sum(OutputTokens)                      AS OutputTokens,
-    sum(CachedInputTokens)                 AS CachedInputTokens,
-    sum(EstimatedCost)                     AS EstimatedCost,
-    sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+    -- CTO-244: sum() already skips NULLs. ifNull sits OUTSIDE the aggregate (an all-NULL group sums
+    -- to NULL) so the result stays non-Nullable for the SummingMergeTree target column; wrapping the
+    -- column instead trips ClickHouse's nested-aggregate check. The `otel_spans.` qualifier is
+    -- required for the same reason: the output alias shadows the column name, so an unqualified
+    -- reference inside the aggregate resolves to the alias and ClickHouse sees sum() inside sum(). The honesty lives in the two counters below, not in the sum.
+    ifNull(sum(otel_spans.InputTokens), 0)            AS InputTokens,
+    ifNull(sum(otel_spans.OutputTokens), 0)           AS OutputTokens,
+    ifNull(sum(otel_spans.CachedInputTokens), 0)      AS CachedInputTokens,
+    ifNull(sum(otel_spans.EstimatedCost), toDecimal64(0, 8))  AS EstimatedCost,
+    ifNull(sum(otel_spans.ReconciledCost), toDecimal64(0, 8)) AS ReconciledCost,
     count()                                AS SpanCount,
+    countIf(otel_spans.InputTokens IS NULL OR otel_spans.OutputTokens IS NULL) AS UnknownUsageSpanCount,
+    countIf(otel_spans.EstimatedCost IS NULL) AS UnpricedSpanCount,
     uniqState(TraceId)                     AS TraceCountState,
     uniqState(UserIdHash)                  AS UserCountState
 FROM otel_spans
@@ -57,6 +98,15 @@ CREATE TABLE IF NOT EXISTS hourly_feature_rollup
     EstimatedCost       Decimal64(8),
     ReconciledCost      Decimal64(8),
     SpanCount           UInt64,
+    -- CTO-244 coverage counters. otel_spans.InputTokens/OutputTokens/EstimatedCost are Nullable:
+    -- "the provider never told us" is a real state and it is not 0. The sums above therefore cover
+    -- only the spans we actually know, which makes them a LOWER BOUND, not a total. These two
+    -- counters are what stops that from being silent: a reader that finds them non-zero must say
+    -- the figure is partial (and blank any per-call or per-token derivation from it) rather than
+    -- present an under-count as complete. They are plain UInt64 so SummingMergeTree adds them the
+    -- same way it adds SpanCount.
+    UnknownUsageSpanCount UInt64,
+    UnpricedSpanCount     UInt64,
     TraceCountState     AggregateFunction(uniq, String),
     UserCountState      AggregateFunction(uniq, FixedString(64))
 )
@@ -64,19 +114,27 @@ ENGINE = SummingMergeTree
 PARTITION BY toYYYYMM(Hour)
 ORDER BY (TenantId, FeatureTag, GenAiResponseModel, Hour);
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS hourly_feature_rollup_mv
+DROP VIEW IF EXISTS hourly_feature_rollup_mv;
+CREATE MATERIALIZED VIEW hourly_feature_rollup_mv
 TO hourly_feature_rollup
 AS SELECT
     TenantId,
     toStartOfHour(Timestamp)               AS Hour,
     FeatureTag,
     GenAiResponseModel,
-    sum(InputTokens)                       AS InputTokens,
-    sum(OutputTokens)                      AS OutputTokens,
-    sum(CachedInputTokens)                 AS CachedInputTokens,
-    sum(EstimatedCost)                     AS EstimatedCost,
-    sum(ifNull(ReconciledCost, toDecimal64(0, 8))) AS ReconciledCost,
+    -- CTO-244: sum() already skips NULLs. ifNull sits OUTSIDE the aggregate (an all-NULL group sums
+    -- to NULL) so the result stays non-Nullable for the SummingMergeTree target column; wrapping the
+    -- column instead trips ClickHouse's nested-aggregate check. The `otel_spans.` qualifier is
+    -- required for the same reason: the output alias shadows the column name, so an unqualified
+    -- reference inside the aggregate resolves to the alias and ClickHouse sees sum() inside sum(). The honesty lives in the two counters below, not in the sum.
+    ifNull(sum(otel_spans.InputTokens), 0)            AS InputTokens,
+    ifNull(sum(otel_spans.OutputTokens), 0)           AS OutputTokens,
+    ifNull(sum(otel_spans.CachedInputTokens), 0)      AS CachedInputTokens,
+    ifNull(sum(otel_spans.EstimatedCost), toDecimal64(0, 8))  AS EstimatedCost,
+    ifNull(sum(otel_spans.ReconciledCost), toDecimal64(0, 8)) AS ReconciledCost,
     count()                                AS SpanCount,
+    countIf(otel_spans.InputTokens IS NULL OR otel_spans.OutputTokens IS NULL) AS UnknownUsageSpanCount,
+    countIf(otel_spans.EstimatedCost IS NULL) AS UnpricedSpanCount,
     uniqState(TraceId)                     AS TraceCountState,
     uniqState(UserIdHash)                  AS UserCountState
 FROM otel_spans

--- a/infra/gateway/src/gateway/connectors/base.py
+++ b/infra/gateway/src/gateway/connectors/base.py
@@ -16,9 +16,10 @@ the same emitter / run contract / recorder are reused verbatim.
 Synthetic-span approach (matches the gateway ingest path in :mod:`gateway.mapping`): the cost is
 already authoritative from the billing API, so we set ``gen_ai.cost.estimated_micro_usd`` directly
 and reuse :func:`gateway.mapping.span_to_row` — we do NOT route through catalog cost enrichment
-(there is no model to price). ``CostSource`` lands as ``'estimated'`` (mapping's default), which is
-correct: it's an estimate from the provider's *un-invoiced* Cost Explorer / Billing numbers, not a
-reconciled invoice.
+(there is no model to price). ``CostSource`` lands as ``'estimated'`` because a cost is present,
+which is correct: it's an estimate from the provider's *un-invoiced* Cost Explorer / Billing
+numbers, not a reconciled invoice. (Since CTO-244 a span with no cost attribute would instead land
+as ``'unpriced'`` with a NULL ``EstimatedCost``; connectors always supply one, so they never do.)
 
 Idempotency: ``otel_spans`` is a plain ``MergeTree`` (no dedup), so re-running a day would
 double-count. Each synthetic span gets a DETERMINISTIC id derived from

--- a/infra/gateway/src/gateway/mapping.py
+++ b/infra/gateway/src/gateway/mapping.py
@@ -166,6 +166,20 @@ def _i(v: object | None) -> int:
     return int(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else 0
 
 
+def _i_or_none(v: object | None) -> int | None:
+    """Like :func:`_i` but returns None (-> ClickHouse NULL) when the value is not a number.
+
+    CTO-244. The columns this feeds (InputTokens/OutputTokens/CachedInputTokens) are Nullable
+    precisely so that "the provider never told us" is representable. Coercing an absent or
+    unparseable count to 0 asserted that a real, billed call consumed nothing, which is a
+    fabricated number, not a conservative one. A provider-reported 0 is a number and still
+    stores as 0, distinct from NULL.
+    """
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return None
+    return int(v)
+
+
 def _fixed64(v: object | None) -> str:
     """FixedString(64) wants exactly 64 bytes; ClickHouse pads, but truncate over-long input."""
     s = _s(v)
@@ -198,11 +212,17 @@ def span_to_row(
     """
     ts = datetime.fromtimestamp(effective_ts_ns / 1e9, tz=timezone.utc)
 
+    # CTO-244. A span that carries no priced cost is UNPRICED, not free. Writing Decimal(0) here
+    # told every downstream sum that a real call cost nothing; the honest write is NULL plus the
+    # reason. The reason reuses the existing cost-source notion rather than a parallel one:
+    # CostSource = 'unpriced', alongside the empty PriceCatalogVersion that tally.pricing already
+    # returns on a catalog miss (see compute_cost_micro_usd, which yields version "" when a rate is
+    # missing). A provider/SDK-reported cost of exactly 0 micro-USD is a real priced zero and is
+    # still stored as 0 with CostSource = 'estimated'.
     cost_micro = span.get(GenAI.COST_ESTIMATED_MICRO_USD)
-    estimated_cost: Decimal = (
-        micro_to_usd(cost_micro) if isinstance(cost_micro, int) and not isinstance(cost_micro, bool)
-        else Decimal(0)
-    )
+    priced = isinstance(cost_micro, int) and not isinstance(cost_micro, bool)
+    estimated_cost: Decimal | None = micro_to_usd(cost_micro) if priced else None
+    cost_source = "estimated" if priced else "unpriced"
 
     # Long-tail attributes: anything not promoted and not structural, stringified for Map(String,String).
     # PII guard (CTO-118): refuse to persist any key that looks like it could carry a message body.
@@ -241,12 +261,13 @@ def span_to_row(
         _s(span.get(GenAI.RESPONSE_MODEL)),
         _s(span.get(GenAI.OPERATION_NAME)),
         _s(span.get(GenAI.TOOL_NAME)),
-        _i(span.get(GenAI.USAGE_INPUT_TOKENS)),
-        _i(span.get(GenAI.USAGE_OUTPUT_TOKENS)),
-        _i(span.get(GenAI.USAGE_CACHED_INPUT_TOKENS)),
+        # CTO-244: absent usage writes NULL, never 0. See _i_or_none.
+        _i_or_none(span.get(GenAI.USAGE_INPUT_TOKENS)),
+        _i_or_none(span.get(GenAI.USAGE_OUTPUT_TOKENS)),
+        _i_or_none(span.get(GenAI.USAGE_CACHED_INPUT_TOKENS)),
         estimated_cost,
         _s(span.get(GenAI.COST_CURRENCY) or "USD"),
-        "estimated",
+        cost_source,
         _s(span.get(GenAI.COST_PRICE_CATALOG_VERSION)),
         _s(span.get(GenAI.AGENT_RUN_ID)),
         _i(span.get(GenAI.AGENT_STEP_INDEX)),

--- a/infra/gateway/tests/test_mapping.py
+++ b/infra/gateway/tests/test_mapping.py
@@ -60,11 +60,77 @@ def test_defaults_for_missing_fields() -> None:
     assert row["FeatureTag"] == "untagged"
     assert row["ServiceName"] == "unknown"
     assert row["SpanName"] == "llm.call"
-    assert row["EstimatedCost"] == Decimal(0)
-    assert row["InputTokens"] == 0
+    # CTO-244: absent usage and an unpriceable call are NULL, not 0. See the tests below.
+    assert row["EstimatedCost"] is None
+    assert row["InputTokens"] is None
     # trace/span ids are generated when absent
     assert row["TraceId"] and isinstance(row["TraceId"], str)
     assert row["SpanId"] and isinstance(row["SpanId"], str)
+
+
+# --- CTO-244: unknown must be representable, and distinguishable from a real zero --------------
+
+
+def test_absent_usage_maps_to_null_not_zero() -> None:
+    """The streamed-response case: the provider never reported usage, so we do not know it.
+
+    Writing 0 here told the dashboard a real, billed call consumed nothing.
+    """
+    row = _row_dict(span_to_row({GenAI.SYSTEM: "openai"}, tenant_id="t1", effective_ts_ns=0))
+    assert row["InputTokens"] is None
+    assert row["OutputTokens"] is None
+    assert row["CachedInputTokens"] is None
+
+
+def test_provider_reported_zero_stays_zero_and_is_distinct_from_unknown() -> None:
+    attrs = {
+        GenAI.USAGE_INPUT_TOKENS: 0,
+        GenAI.USAGE_OUTPUT_TOKENS: 0,
+        GenAI.USAGE_CACHED_INPUT_TOKENS: 0,
+    }
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=0))
+    assert row["InputTokens"] == 0
+    assert row["OutputTokens"] == 0
+    assert row["CachedInputTokens"] == 0
+    # The distinction that did not exist before: a real 0 is not None.
+    assert row["InputTokens"] is not None
+
+
+def test_unparseable_usage_maps_to_null_not_zero() -> None:
+    attrs = {GenAI.USAGE_INPUT_TOKENS: "lots", GenAI.USAGE_OUTPUT_TOKENS: True}
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=0))
+    # A bool is not a token count; neither is a string. Guessing 0 would be a fabricated number.
+    assert row["InputTokens"] is None
+    assert row["OutputTokens"] is None
+
+
+def test_catalog_miss_yields_null_cost_with_a_recorded_reason() -> None:
+    """No priced cost on the span (a catalog miss) must not become $0.00.
+
+    The reason reuses the existing cost-source notion: CostSource = 'unpriced', with the empty
+    PriceCatalogVersion that tally.pricing already returns when a rate is missing.
+    """
+    attrs = {
+        GenAI.SYSTEM: "openai",
+        GenAI.REQUEST_MODEL: "some-model-the-catalog-has-never-heard-of",
+        GenAI.USAGE_INPUT_TOKENS: 1000,
+        GenAI.USAGE_OUTPUT_TOKENS: 250,
+    }
+    row = _row_dict(span_to_row(attrs, tenant_id="t1", effective_ts_ns=0))
+    assert row["EstimatedCost"] is None
+    assert row["CostSource"] == "unpriced"
+    assert row["PriceCatalogVersion"] == ""
+    # Usage was reported even though the cost could not be derived: the two are independent.
+    assert row["InputTokens"] == 1000
+
+
+def test_priced_zero_cost_is_estimated_not_unpriced() -> None:
+    """A genuine 0 micro-USD (e.g. a free-tier rate) is a real price, not an unknown."""
+    row = _row_dict(
+        span_to_row({GenAI.COST_ESTIMATED_MICRO_USD: 0}, tenant_id="t1", effective_ts_ns=0)
+    )
+    assert row["EstimatedCost"] == Decimal(0)
+    assert row["CostSource"] == "estimated"
 
 
 def test_unpromoted_attrs_land_in_span_attributes_map() -> None:

--- a/sdk/python/tests/test_otel_spans_ddl.py
+++ b/sdk/python/tests/test_otel_spans_ddl.py
@@ -40,9 +40,22 @@ def test_tenant_id_first_in_order_by(ddl):
 
 
 def test_cost_is_decimal_not_float(ddl):
-    assert "EstimatedCost          Decimal64(8)" in ddl
+    assert "EstimatedCost          Nullable(Decimal64(8))" in ddl
     assert "ReconciledCost         Nullable(Decimal64(8))" in ddl
     assert "EstimatedCost          Float" not in ddl
+
+
+def test_unknown_is_representable(ddl_code):
+    """CTO-244: usage and estimated cost must be able to say "we do not know".
+
+    Non-nullable columns forced ingest to write 0 for an unknown, which reported a real billed
+    call as free. This guards the fix against being quietly reverted to UInt32/Decimal64.
+    """
+    for col in ("InputTokens", "OutputTokens", "CachedInputTokens"):
+        assert re.search(rf"\b{col}\s+Nullable\(UInt32\)", ddl_code), \
+            f"{col} must be Nullable(UInt32) so an absent count is not stored as 0"
+    # CostSource carries WHY a cost is NULL, reusing the existing cost-source enum.
+    assert "'unpriced' = 3" in ddl_code
 
 
 def test_dual_track_and_key_version_columns(ddl):

--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -121,12 +121,23 @@ export function HomeLive({
   // identical number (CTO-228). "Estimated" is always Spend minus Reconciled, so no figure is lost.
   const reconciledPct =
     s.totalMicroUsd === 0 ? 0 : Math.round((s.reconciledMicroUsd / s.totalMicroUsd) * 100);
+
+  // CTO-244. ClickHouse sum() skips NULLs, so when some spans could not be priced the Spend
+  // headline is a LOWER BOUND, not the total. Say so on the tile. We deliberately do NOT blank the
+  // headline: what we know is real money already spent, and hiding it would be its own dishonesty.
+  // What we must never do is present it as complete, which is what the old zero-filled column did.
+  const unpricedSpans = s.unpricedSpanCount ?? 0;
+  const totalSpans = s.spanCount ?? 0;
+  const spendHint =
+    unpricedSpans > 0
+      ? `at least: ${unpricedSpans.toLocaleString()} of ${totalSpans.toLocaleString()} spans in the last ${windowDays} days could not be priced`
+      : `last ${windowDays} days`;
   const tiles = (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
       <SummaryTile
         label="Spend"
         micro={s.totalMicroUsd}
-        hint={`last ${windowDays} days`}
+        hint={spendHint}
         higherIsBetter={false}
       />
       <SummaryTile
@@ -164,7 +175,9 @@ export function HomeLive({
             {visibleRoi.map((r) => (
               <tr key={r.feature} className="border-t border-edge">
                 <td className="py-1.5">{r.feature}</td>
-                <td className="py-1.5 text-right">{formatUSD(r.costPerUserMicroUsd)}</td>
+                <td className="py-1.5 text-right">
+  <Money micro={r.costPerUserMicroUsd} reason="some spans for this feature could not be priced, so cost per user is unknown" />
+</td>
                 <td className="py-1.5 text-right">
                   {r.valuePerUserMicroUsd === null ? (
                     <span className="text-muted">—</span>

--- a/web/app/agents/Live.tsx
+++ b/web/app/agents/Live.tsx
@@ -30,6 +30,7 @@ import {
 import { ExploreChartCard } from "@/components/ExploreChartCard";
 import { FilterBar } from "@/components/FilterBar";
 import { Histogram } from "@/components/Histogram";
+import { Blank, Money } from "@/components/HonestValue";
 import { LiveIndicator } from "@/components/LiveIndicator";
 import { PageHeader } from "@/components/PageHeader";
 import { SummaryTile, TileGrid } from "@/components/SummaryTile";
@@ -43,6 +44,31 @@ import {
 import { formatUSD, type MicroUSD } from "@/lib/types";
 import { useFilters } from "@/lib/useFilters";
 import { useLivePoll } from "@/lib/useLivePoll";
+
+const UNPRICED_RUN =
+  "at least one step in this run could not be priced, so the run total is unknown";
+
+/**
+ * Coverage marker for a per-agent figure computed over the priced runs only (CTO-244).
+ *
+ * The alternative was to blank cost/day, p50 and p99 outright whenever a single run was unpriced,
+ * which would empty the table for one bad span. These are statistics over a population, so naming
+ * the excluded runs is the honest disclosure; a per-RUN figure still blanks, because there is no
+ * population to be a statistic over.
+ */
+function PartialRuns({ n }: { n: number }) {
+  return (
+    <span
+      title={`Excludes ${n} run${n === 1 ? "" : "s"} that could not be priced, so this is a lower bound.`}
+      className="ml-1 cursor-help text-muted underline decoration-dotted decoration-muted/60 underline-offset-4"
+    >
+      <span aria-hidden>*</span>
+      <span className="sr-only">
+        Excludes {n} run{n === 1 ? "" : "s"} that could not be priced, so this is a lower bound.
+      </span>
+    </span>
+  );
+}
 
 export interface AgentsPayload {
   agents: AgentSummary[];
@@ -93,9 +119,23 @@ export function AgentsLive({
   // introduced. A null when there is nothing to reduce keeps the honest-blank posture over a fake 0.
   const totalCostPerDay = agents.reduce((s, a) => s + a.costPerDayMicroUsd, 0);
   const priciestAgent = maxBy(agents, (a) => a.costPerDayMicroUsd);
-  const sortedRuns = runs.slice().sort((a, b) => b.totalCostMicroUsd - a.totalCostMicroUsd);
-  const topOutlier = maxBy(runs, (r) => r.totalCostMicroUsd);
-  const outlierTotal = runs.reduce((s, r) => s + r.totalCostMicroUsd, 0);
+  // CTO-244: a run with an unpriced step has an unknown total. It sorts to the TOP of the outlier
+  // list (unknown is the strongest reason to look, and as $0 it used to sink to the bottom), it is
+  // excluded from maxBy so it cannot win "top outlier" with a fabricated figure, and it makes the
+  // flagged-outlier total unknown rather than a silently smaller sum.
+  const sortedRuns = runs.slice().sort((a, b) => {
+    if (a.totalCostMicroUsd === null && b.totalCostMicroUsd === null) return 0;
+    if (a.totalCostMicroUsd === null) return -1;
+    if (b.totalCostMicroUsd === null) return 1;
+    return b.totalCostMicroUsd - a.totalCostMicroUsd;
+  });
+  const topOutlier = maxBy(
+    runs.filter((r) => r.totalCostMicroUsd !== null),
+    (r) => r.totalCostMicroUsd ?? 0,
+  );
+  const unpricedRuns = runs.filter((r) => r.totalCostMicroUsd === null).length;
+  const outlierTotal =
+    unpricedRuns > 0 ? null : runs.reduce((s, r) => s + (r.totalCostMicroUsd ?? 0), 0);
 
   // The FilterBar's feature filter lists the agents themselves (agents are features in the cost
   // model): filtering to one narrows the live chart to that agent's spend.
@@ -120,12 +160,16 @@ export function AgentsLive({
           label="Top outlier run"
           micro={topOutlier?.value ?? null}
           reason="no outlier runs captured"
-          hint={topOutlier ? `${topOutlier.row.multipleOfMedian}× median` : undefined}
+          hint={topOutlier?.row.multipleOfMedian != null ? `${topOutlier.row.multipleOfMedian}× median` : undefined}
         />
         <SummaryTile
           label="Flagged outlier spend"
           micro={runs.length > 0 ? outlierTotal : null}
-          reason="no outlier runs captured"
+          reason={
+            unpricedRuns > 0
+              ? `${unpricedRuns} of ${runs.length} flagged runs could not be priced, so the total is unknown`
+              : "no outlier runs captured"
+          }
           hint={`${runs.length} run${runs.length === 1 ? "" : "s"}`}
         />
       </TileGrid>
@@ -157,7 +201,12 @@ export function AgentsLive({
                 <tr key={a.name} className="border-t border-edge">
                   <td className="py-2 font-medium">{a.name}</td>
                   <td className="py-2 text-right tabular-nums">{a.runsPerDay.toLocaleString()}</td>
-                  <td className="py-2 text-right tabular-nums">{formatUSD(a.costPerDayMicroUsd)}</td>
+                  {/* CTO-244: these three describe the PRICED runs only. When some runs could not
+                      be priced, say so on the figure rather than let it read as the whole agent. */}
+                  <td className="py-2 text-right tabular-nums">
+                    {formatUSD(a.costPerDayMicroUsd)}
+                    {(a.unpricedRuns ?? 0) > 0 && <PartialRuns n={a.unpricedRuns ?? 0} />}
+                  </td>
                   <td className="py-2 text-right tabular-nums">{formatUSD(a.p50MicroUsd)}</td>
                   <td className="py-2 text-right tabular-nums">{formatUSD(a.p99MicroUsd)}</td>
                   <td className="py-2 text-right tabular-nums">
@@ -187,8 +236,14 @@ export function AgentsLive({
               </Link>
               <span className="flex items-center gap-3">
                 <OutcomeBadge outcome={r.outcome} />
-                <span className="tabular-nums">{formatUSD(r.totalCostMicroUsd)}</span>
-                <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+                <span className="tabular-nums">
+                  <Money micro={r.totalCostMicroUsd} reason={UNPRICED_RUN} />
+                </span>
+                {r.multipleOfMedian === null ? (
+                  <Blank reason={UNPRICED_RUN} />
+                ) : (
+                  <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+                )}
               </span>
             </li>
           ))}

--- a/web/app/agents/runs/[runId]/page.tsx
+++ b/web/app/agents/runs/[runId]/page.tsx
@@ -2,10 +2,10 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Card } from "@/components/Card";
+import { Blank, Money } from "@/components/HonestValue";
 // runs imported for generateStaticParams (build-time only); page reads via API at runtime.
 import { type AgentRun, runs as runsBuildtime } from "@/lib/agents";
 import { apiGet } from "@/lib/api";
-import { formatUSD } from "@/lib/types";
 
 export function generateStaticParams() {
   return runsBuildtime.map((r) => ({ runId: r.runId }));
@@ -21,7 +21,12 @@ export default async function RunPage({ params }: { params: Promise<{ runId: str
   }
   if (!run) notFound();
 
-  const max = Math.max(...run.spans.map((s) => s.costMicroUsd));
+  // CTO-244: an unpriced span has no bar to scale. Only priced spans set the waterfall's scale;
+  // an unpriced one renders an honest blank instead of a full-width or zero-width bar.
+  const pricedCosts = run.spans.map((s) => s.costMicroUsd).filter((c): c is number => c !== null);
+  const max = pricedCosts.length > 0 ? Math.max(...pricedCosts) : 0;
+  const UNPRICED_SPAN = "this step could not be priced (no usage reported, or no matching price-catalog entry)";
+  const UNPRICED_RUN = "at least one step in this run could not be priced, so the run total is unknown";
 
   return (
     <div className="space-y-6">
@@ -35,8 +40,14 @@ export default async function RunPage({ params }: { params: Promise<{ runId: str
 
       <div className="flex items-baseline gap-4">
         <h1 className="text-xl font-semibold">{run.agent}</h1>
-        <span className="text-2xl font-semibold tabular-nums">{formatUSD(run.totalCostMicroUsd)}</span>
-        <span className="text-bad">{run.multipleOfMedian}× median</span>
+        <span className="text-2xl font-semibold tabular-nums">
+          <Money micro={run.totalCostMicroUsd} reason={UNPRICED_RUN} />
+        </span>
+        {run.multipleOfMedian === null ? (
+          <Blank reason={UNPRICED_RUN} />
+        ) : (
+          <span className="text-bad">{run.multipleOfMedian}× median</span>
+        )}
         <span className="text-muted">· {run.steps} steps · {run.outcome}</span>
       </div>
 
@@ -48,7 +59,7 @@ export default async function RunPage({ params }: { params: Promise<{ runId: str
         <div className="space-y-1.5">
           {run.spans.map((s) => {
             const depth = s.parentSpanId ? 1 : 0;
-            const pct = max === 0 ? 0 : (s.costMicroUsd / max) * 100;
+            const pct = max === 0 || s.costMicroUsd === null ? 0 : (s.costMicroUsd / max) * 100;
             return (
               <div key={s.spanId} className="flex items-center gap-3 text-sm">
                 <div className="w-64 shrink-0 truncate" style={{ paddingLeft: depth * 16 }}>
@@ -57,12 +68,16 @@ export default async function RunPage({ params }: { params: Promise<{ runId: str
                   </span>
                 </div>
                 <div className="relative h-4 flex-1 rounded bg-ink">
-                  <div
-                    className="absolute inset-y-0 left-0 rounded bg-accent/70"
-                    style={{ width: `${Math.max(1, pct)}%` }}
-                  />
+                  {s.costMicroUsd !== null && (
+                    <div
+                      className="absolute inset-y-0 left-0 rounded bg-accent/70"
+                      style={{ width: `${Math.max(1, pct)}%` }}
+                    />
+                  )}
                 </div>
-                <div className="w-20 shrink-0 text-right tabular-nums">{formatUSD(s.costMicroUsd)}</div>
+                <div className="w-20 shrink-0 text-right tabular-nums">
+                  <Money micro={s.costMicroUsd} reason={UNPRICED_SPAN} />
+                </div>
               </div>
             );
           })}

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -156,7 +156,12 @@ export async function GET(req: Request) {
         ...comparison.current,
         model: live.model,
         provider: live.provider,
-        monthlyCostMicroUsd: live.monthlyCostMicroUsd,
+        // CTO-244: an unknown incumbent cost maps to 0 here deliberately, because 0 is this
+        // payload's existing "no baseline" sentinel: web/app/compare/page.tsx gates on
+        // `current.monthlyCostMicroUsd === 0` and renders the empty-state banner instead of a
+        // dollar figure. So the page shows "no baseline", not a fabricated $0.00/mo, and the
+        // recommendation built above states the actual reason.
+        monthlyCostMicroUsd: live.monthlyCostMicroUsd ?? 0,
         // CTO-115: live p95 / error from otel_spans over the same 7-day window. `null` when
         // fewer than 50 spans landed — page renders "—" so we never fabricate.
         latencyP95Ms: live.latencyP95Ms,
@@ -193,7 +198,13 @@ export async function GET(req: Request) {
   //      to the user's actual workload size. Still an approximation — real ratios depend on token
   //      mix, which is what workflow-5 replay actually solves — but it's no longer absurd.
   const mockCurrentCost = comparison.current.monthlyCostMicroUsd;
-  const scale = mockCurrentCost > 0 ? live.monthlyCostMicroUsd / mockCurrentCost : 0;
+  // CTO-244: with an unknown live cost there is nothing to anchor the rescale to. Scale 0 collapses
+  // every candidate to $0, which would read as a free alternative, so the branch below hands
+  // deriveRecommendation the null and it refuses to project at all.
+  const scale =
+    mockCurrentCost > 0 && live.monthlyCostMicroUsd !== null
+      ? live.monthlyCostMicroUsd / mockCurrentCost
+      : 0;
   const candidates = comparison.candidates
     .filter((c) => c.model !== live.model)
     .map((c) => {

--- a/web/app/cost/AgentDetail.tsx
+++ b/web/app/cost/AgentDetail.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from "react";
 
 import { Card } from "@/components/Card";
 import { StaleBadge } from "@/components/DataStateBanner";
+import { Blank, Money } from "@/components/HonestValue";
 import { Histogram } from "@/components/Histogram";
 import { type AgentRun, type AgentSummary, p99Ratio } from "@/lib/agents";
 import {
@@ -90,7 +91,15 @@ export function AgentDetail({ agent, queryString }: { agent: string; queryString
   const summary = data.agents.find((a) => a.name === agent) ?? null;
   const agentRuns = data.runs
     .filter((r) => r.agent === agent)
-    .sort((a, b) => b.totalCostMicroUsd - a.totalCostMicroUsd);
+    // CTO-244: a run whose total is unknown sorts to the TOP of the outlier list. It used to sort
+    // as $0 and vanish to the bottom, hiding the runs we understand least on the page whose whole
+    // job is to surface the runs worth looking at.
+    .sort((a, b) => {
+      if (a.totalCostMicroUsd === null && b.totalCostMicroUsd === null) return 0;
+      if (a.totalCostMicroUsd === null) return -1;
+      if (b.totalCostMicroUsd === null) return 1;
+      return b.totalCostMicroUsd - a.totalCostMicroUsd;
+    });
 
   // No summary for the selected agent means it had no runs in this window. State it; never fabricate.
   if (summary === null) {
@@ -165,8 +174,14 @@ export function AgentDetail({ agent, queryString }: { agent: string; queryString
                   </Link>
                   <span className="flex items-center gap-3">
                     <OutcomeBadge outcome={r.outcome} />
-                    <span className="tabular-nums">{formatUSD(r.totalCostMicroUsd)}</span>
-                    <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+                    <span className="tabular-nums">
+                      <Money micro={r.totalCostMicroUsd} reason={UNPRICED_RUN} />
+                    </span>
+                    {r.multipleOfMedian === null ? (
+                      <Blank reason={UNPRICED_RUN} />
+                    ) : (
+                      <span className="text-bad tabular-nums">{r.multipleOfMedian}× median</span>
+                    )}
                   </span>
                 </li>
               ))}
@@ -177,6 +192,9 @@ export function AgentDetail({ agent, queryString }: { agent: string; queryString
     </Card>
   );
 }
+
+const UNPRICED_RUN =
+  "at least one step in this run could not be priced, so the run total is unknown";
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (

--- a/web/app/features/FeatureValueEvents.tsx
+++ b/web/app/features/FeatureValueEvents.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { Card } from "@/components/Card";
+import { Money } from "@/components/HonestValue";
 import { type FeatureEconomics, margin } from "@/lib/features";
 import { formatUSD } from "@/lib/types";
 
@@ -122,7 +123,9 @@ export function FeatureValueEvents({ initialFeatures }: { initialFeatures: Featu
                 return (
                   <tr key={f.feature} className="border-t border-edge">
                     <td className="py-2 font-medium">{f.feature}</td>
-                    <td className="py-2 text-right tabular-nums">{formatUSD(f.costPerUserMicroUsd)}</td>
+                    <td className="py-2 text-right tabular-nums">
+  <Money micro={f.costPerUserMicroUsd} reason="some spans for this feature could not be priced, so cost per user is unknown" />
+</td>
                     <td className="py-2 text-right tabular-nums">
                       {f.valuePerUserMicroUsd === null ? <Dash /> : formatUSD(f.valuePerUserMicroUsd)}
                     </td>

--- a/web/lib/agents.ts
+++ b/web/lib/agents.ts
@@ -11,6 +11,15 @@ export interface AgentSummary {
   p99MicroUsd: MicroUSD;
   /** log-scale distribution buckets (counts), cheap → expensive */
   distribution: number[];
+  /**
+   * Runs in the window whose cost could not be priced at all (CTO-244).
+   *
+   * They are EXCLUDED from costPerDay/p50/p99/distribution rather than counted as $0. A run we
+   * could not price is not a cheap run, and letting it into the quantile array dragged p50 down
+   * with a number nobody measured. The three figures above are therefore statistics over the
+   * priced runs only; a non-zero value here means they describe a subset and the UI must say so.
+   */
+  unpricedRuns?: number;
 }
 
 export function p99Ratio(a: AgentSummary): number {
@@ -27,7 +36,12 @@ export interface RunSpan {
   spanId: string;
   parentSpanId: string | null;
   name: string;
-  costMicroUsd: MicroUSD;
+  /**
+   * CTO-244: nullable because otel_spans.EstimatedCost is. This is ONE span's cost, so there is no
+   * aggregate to hide an unknown inside: if the call could not be priced, the honest value is null
+   * and the UI renders a blank with a reason. It used to render "$0.00" for a real, billed step.
+   */
+  costMicroUsd: MicroUSD | null;
   durationMs: number;
   status: "ok" | "retry" | "error";
 }
@@ -35,8 +49,14 @@ export interface RunSpan {
 export interface AgentRun {
   runId: string;
   agent: string;
-  totalCostMicroUsd: MicroUSD;
-  multipleOfMedian: number;
+  /**
+   * CTO-244: null when any span in the run is unpriced. A run total is a sum over a handful of
+   * steps, so one missing step materially changes it; reporting the partial sum as "the run cost"
+   * understates the very runs this page exists to flag as expensive.
+   */
+  totalCostMicroUsd: MicroUSD | null;
+  /** Null whenever the run total is unknown, or there is no priced peer median to compare against. */
+  multipleOfMedian: number | null;
   steps: number;
   outcome: "success" | "failed" | "abandoned";
   /** one-sentence auto-generated root cause (CTO-57) */

--- a/web/lib/attribution.ts
+++ b/web/lib/attribution.ts
@@ -104,16 +104,25 @@ export function buildProviderRow(
   costMicroUsd: MicroUSD,
   // Optional revenue side — provider rows are unchanged when no Stripe data exists.
   revenue?: { revenueMicroUsd: MicroUSD; distinctUsers: number } | null,
+  /**
+   * Spans for this provider that could not be priced (CTO-244). Non-zero means `costMicroUsd` is a
+   * lower bound, so every per-unit figure derived from it is understated by an unknowable amount:
+   * the cost numerator skips those spans while the conversion and user denominators still count
+   * them. Those ratios are nulled rather than published; the sum itself is kept because it is real
+   * money already spent, and the caller reports the coverage alongside it.
+   */
+  unpricedSpans = 0,
 ): ProviderAttribution {
   const { p, lo, hi } = wilsonInterval(conversions, sessions);
+  const costKnown = unpricedSpans === 0;
   const costPerConversion =
-    conversions > 0 ? Math.round(costMicroUsd / conversions) : null;
+    costKnown && conversions > 0 ? Math.round(costMicroUsd / conversions) : null;
   // Revenue lights up only when Stripe events exist for *this* provider. Without users we have
   // no denominator, so the row stays honest with nulls.
   let valuePerUser: MicroUSD | null = null;
   let marginPerUser: MicroUSD | null = null;
   let marginPct: number | null = null;
-  if (revenue && revenue.distinctUsers > 0 && revenue.revenueMicroUsd !== 0) {
+  if (costKnown && revenue && revenue.distinctUsers > 0 && revenue.revenueMicroUsd !== 0) {
     valuePerUser = Math.round(revenue.revenueMicroUsd / revenue.distinctUsers);
     const costPerUser = Math.round(costMicroUsd / revenue.distinctUsers);
     marginPerUser = valuePerUser - costPerUser;

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -991,3 +991,97 @@ describe("querySettledCostSeries — settled-day rule (CTO-207)", () => {
     expect(await querySettledCostSeries()).toBeNull();
   });
 });
+
+// --- CTO-244: unknown usage / cost must survive into the readers as unknown ---------------------
+//
+// The write side is covered in infra/gateway (an absent token count stores NULL, a real 0 stores 0,
+// a catalog miss stores a NULL cost with CostSource = 'unpriced'). These cases cover the READ side:
+// what the dashboard does when a slice is part known and part unknown. The rule under test is that
+// a partly-unknown figure is never presented as though it were complete, and a per-unit figure
+// derived from a partial numerator blanks rather than silently shrinking.
+
+describe("CTO-244 - reading a mix of known and unknown", () => {
+  it("microOrNull keeps NULL as null while micro() would flatten it to 0", async () => {
+    const { micro, microOrNull } = await freshSut();
+    // ClickHouse serialises a Nullable column as JSON null in JSONEachRow.
+    expect(micro(null)).toBe(0);
+    expect(microOrNull(null)).toBeNull();
+    // A real zero is still a number on both paths, and stays distinct from the unknown.
+    expect(microOrNull("0")).toBe(0);
+    expect(microOrNull("0.75")).toBe(750_000);
+  });
+
+  it("querySpendSummary reports how much of the window it could not price", async () => {
+    const { querySpendSummary } = await freshSut();
+    // Two of five spans in the window were unpriced: the $12.50 total is a LOWER BOUND.
+    respondRows([
+      { total: "12.50", estimated: "12.50", reconciled: "0", recThrough: null, unpriced: "2", spans: "5" },
+    ]);
+    respondRows([{ layer: "llm", cost: "12.50" }]);
+    const out = (await querySpendSummary())!;
+    expect(out.totalMicroUsd).toBe(12_500_000);
+    // The disclosure that stops the headline reading as complete.
+    expect(out.unpricedSpanCount).toBe(2);
+    expect(out.spanCount).toBe(5);
+  });
+
+  it("querySpendSummary reports zero unpriced spans when everything is priced", async () => {
+    const { querySpendSummary } = await freshSut();
+    respondRows([
+      { total: "12.50", estimated: "12.50", reconciled: "0", recThrough: null, unpriced: "0", spans: "5" },
+    ]);
+    respondRows([{ layer: "llm", cost: "12.50" }]);
+    const out = (await querySpendSummary())!;
+    expect(out.unpricedSpanCount).toBe(0);
+  });
+
+  it("queryOutliers blanks the multiple rather than fabricating 1x median", async () => {
+    const { queryOutliers } = await freshSut();
+    respondRows([
+      // An unpriced run: ClickHouse returns NULL for both the sum and the derived multiple.
+      { runId: "r_unknown", agent: "a", cost: null, mult: null },
+      { runId: "r_known", agent: "a", cost: "2.00", mult: "4" },
+    ]);
+    const out = (await queryOutliers())!;
+    expect(out[0].costMicroUsd).toBeNull();
+    // Was `: 1` - a reassuring, invented figure for the run we understand least.
+    expect(out[0].multipleOfMedian).toBeNull();
+    expect(out[1].costMicroUsd).toBe(2_000_000);
+    expect(out[1].multipleOfMedian).toBe(4);
+  });
+
+  it("queryCurrentModel refuses to project a month from a partly-unpriced week", async () => {
+    const { queryCurrentModel } = await freshSut();
+    respond({
+      model: "claude-sonnet-4.5",
+      provider: "anthropic",
+      cost7d: "1.40",
+      unpriced7d: "3",
+      p95Ms: 2400,
+      errRate: 0.004,
+      sampleCount: 500,
+    });
+    const out = (await queryCurrentModel())!;
+    // monthlyCalls projects ALL calls; the cost sum covers only the priced ones. Publishing both
+    // would put a savings percentage on a coverage gap.
+    expect(out.monthlyCostMicroUsd).toBeNull();
+    expect(out.monthlyCalls).toBe(Math.round((500 * 30) / 7));
+    // Latency and error rate are unaffected: they do not depend on pricing.
+    expect(out.latencyP95Ms).not.toBeNull();
+  });
+
+  it("queryCurrentModel still projects when the whole week is priced", async () => {
+    const { queryCurrentModel } = await freshSut();
+    respond({
+      model: "claude-sonnet-4.5",
+      provider: "anthropic",
+      cost7d: "1.40",
+      unpriced7d: "0",
+      p95Ms: 2400,
+      errRate: 0.004,
+      sampleCount: 500,
+    });
+    const out = (await queryCurrentModel())!;
+    expect(out.monthlyCostMicroUsd).toBe(Math.round((1_400_000 * 30) / 7));
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -156,6 +156,22 @@ export function micro(decimalUsd: string | number | null | undefined): number {
   return Math.round((Number.isFinite(n) ? n : 0) * 1_000_000);
 }
 
+/**
+ * Decimal string (USD) -> integer micro-USD, preserving "we do not know" as `null`.
+ *
+ * CTO-244. `micro()` above maps a JSON `null` to 0, which is the right default for a `sum()` (an
+ * empty set really did cost nothing measurable) but a lie for anything that can be genuinely
+ * unknown: a single span's cost, or an aggregate over a slice where every row was unpriced.
+ * ClickHouse serialises a Nullable column as JSON `null` in JSONEachRow, and `Nullable(Decimal)`
+ * arrives as `null` rather than `"0"`, so this is the only place that distinction survives into JS.
+ * Feed the result to `<Money micro={...} reason={...} />`, which renders the honest blank.
+ */
+export function microOrNull(decimalUsd: string | number | null | undefined): number | null {
+  if (decimalUsd === null || decimalUsd === undefined || decimalUsd === "\\N") return null;
+  const n = typeof decimalUsd === "number" ? decimalUsd : parseFloat(decimalUsd);
+  return Number.isFinite(n) ? Math.round(n * 1_000_000) : null;
+}
+
 function zeroLayers(): SpendByLayer {
   return { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 };
 }
@@ -253,10 +269,23 @@ export async function querySpendSummary(windowDays = 30): Promise<SpendSummary |
     // window stays ClickHouse-clock derived (CTO-203), never the Node clock. `w - 1` keeps the
     // historical 29-day-for-30 form so the default view is byte-for-byte unchanged.
     const w = clampWindowDays(windowDays);
-    const totals = await rows<{ total: string; estimated: string; reconciled: string; recThrough: string | null }>(
+    // CTO-244: `unpriced` / `spans` travel with the totals. sum() skips NULLs, so without them the
+    // headline would silently be a lower bound whenever anything in the window could not be priced.
+    // Note the estimated/reconciled split no longer adds up to the total: an 'unpriced' span is in
+    // neither bucket, which is exactly why the count has to be reported alongside.
+    const totals = await rows<{
+      total: string;
+      estimated: string;
+      reconciled: string;
+      recThrough: string | null;
+      unpriced: string;
+      spans: string;
+    }>(
       db,
       `SELECT
          sum(EstimatedCost) AS total,
+         countIf(EstimatedCost IS NULL) AS unpriced,
+         count() AS spans,
          sumIf(EstimatedCost, CostSource = 'estimated') AS estimated,
          sumIf(EstimatedCost, CostSource = 'reconciled') AS reconciled,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
@@ -276,11 +305,15 @@ export async function querySpendSummary(windowDays = 30): Promise<SpendSummary |
     for (const r of byLayerRows) {
       if ((LAYERS as readonly string[]).includes(r.layer)) byLayer[r.layer] = micro(r.cost);
     }
-    const t = totals[0] ?? { total: "0", estimated: "0", reconciled: "0", recThrough: null };
+    const t = totals[0] ?? {
+      total: "0", estimated: "0", reconciled: "0", recThrough: null, unpriced: "0", spans: "0",
+    };
     return {
       totalMicroUsd: micro(t.total),
       estimatedMicroUsd: micro(t.estimated),
       reconciledMicroUsd: micro(t.reconciled),
+      unpricedSpanCount: parseInt(t.unpriced, 10) || 0,
+      spanCount: parseInt(t.spans, 10) || 0,
       // No reconciled data yet → boundary in the far past so everything reads as estimated.
       reconciledThrough: t.recThrough && t.recThrough !== "\\N" ? t.recThrough : "1970-01-01",
       byLayer,
@@ -316,10 +349,19 @@ export async function queryOutliers(windowDays = 30): Promise<CostOutlier[] | nu
     // User-selectable window (CTO-226): rolling `now() - INTERVAL w DAY`, w a bound-checked int
     // (injection-safe), anchored on the ClickHouse clock (CTO-203), never the Node clock.
     const w = clampWindowDays(windowDays);
-    const out = await rows<{ runId: string; agent: string; cost: string; mult: string | null }>(
+    // CTO-244. Three things change once EstimatedCost is Nullable:
+    //   - `unpriced` marks a run whose sum covers only part of its spans, so `cost` is NULL for it
+    //     rather than a partial total that would rank it as cheaper than it is.
+    //   - the median divides only FULLY-PRICED runs. Mixing partial sums into the denominator would
+    //     depress it and inflate every multiple measured against it.
+    //   - unknown-cost runs sort FIRST. `ORDER BY cost DESC` puts NULLs last in ClickHouse, so an
+    //     expensive run we could not price could never surface as an outlier, which is precisely
+    //     backwards for a detector whose job is to find the runs worth looking at.
+    const out = await rows<{ runId: string; agent: string; cost: string | null; mult: string | null }>(
       db,
       `WITH runs AS (
-         SELECT TraceId AS runId, any(ServiceName) AS agent, sum(EstimatedCost) AS cost
+         SELECT TraceId AS runId, any(ServiceName) AS agent,
+                if(countIf(EstimatedCost IS NULL) > 0, NULL, sum(EstimatedCost)) AS cost
          FROM otel_spans
          WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY
            AND ServiceName != '' AND ServiceName != 'unknown'
@@ -327,17 +369,18 @@ export async function queryOutliers(windowDays = 30): Promise<CostOutlier[] | nu
          GROUP BY TraceId
        )
        SELECT runId, agent, cost,
-              cost / nullIf((SELECT quantileExact(0.5)(cost) FROM runs), 0) AS mult
+              cost / nullIf((SELECT quantileExact(0.5)(cost) FROM runs WHERE cost IS NOT NULL), 0) AS mult
        FROM runs
-       ORDER BY cost DESC
+       ORDER BY cost IS NULL DESC, cost DESC
        LIMIT 5`,
       tenant,
     );
     return out.map((r) => ({
       runId: r.runId,
       agent: r.agent || "untagged",
-      costMicroUsd: micro(r.cost),
-      multipleOfMedian: r.mult ? Math.round(parseFloat(r.mult) * 10) / 10 : 1,
+      costMicroUsd: microOrNull(r.cost),
+      // Was `: 1` - a fabricated, reassuring "1x median" for the run we understand least.
+      multipleOfMedian: r.mult ? Math.round(parseFloat(r.mult) * 10) / 10 : null,
     }));
   });
 }
@@ -1505,6 +1548,7 @@ async function accountDetail(
       `SELECT TraceId AS runId,
               any(ServiceName) AS agent,
               sum(EstimatedCost) AS cost,
+              countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps,
               max(StatusCode) AS maxStatus
        FROM otel_spans
@@ -1547,8 +1591,10 @@ async function accountDetail(
 // the last 30 days and only emit above a sane threshold (no fabricated alerts — returns [] when
 // nothing qualifies).
 //
-//   1. Uncosted tool/agent activity — `GenAiOperation = 'tool'` spans with `EstimatedCost = 0`,
-//      i.e. tools running without a cost attached. Emitted only above UNCOSTED_TOOL_THRESHOLD.
+//   1. Uncosted tool/agent activity: `GenAiOperation = 'tool'` spans with no cost attached, i.e.
+//      `EstimatedCost IS NULL` (the post-CTO-244 representation of "we could not price this") or
+//      `= 0` (how the same condition was flattened before that cutover). Emitted only above
+//      UNCOSTED_TOOL_THRESHOLD.
 //   2. High LLM-calls-per-session ratio — features whose avg LLM spans per SessionId exceeds
 //      LLM_PER_SESSION_THRESHOLD, a classic retry-loop / fan-out cost smell.
 //
@@ -1593,13 +1639,19 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
     );
     const totalSpend = micro(totalRows[0]?.total ?? "0");
 
-    // Rule 1: uncosted tool/agent activity. Count tool spans with EstimatedCost = 0 per feature,
+    // Rule 1: uncosted tool/agent activity. Count tool spans with no cost attached per feature,
     // alongside that feature's total spend (for the impact ranking).
+    //
+    // CTO-244: `EstimatedCost = 0` alone would silently stop firing. Since EstimatedCost became
+    // Nullable, an unpriceable tool span writes NULL, and `NULL = 0` is NULL, not true, so countIf
+    // would skip exactly the spans this rule exists to find. `IS NULL` catches post-cutover rows;
+    // `= 0` still catches pre-cutover rows, where an unknown was flattened to zero. Both are
+    // "uncosted tool activity" as far as this alert is concerned.
     const uncostedRows = await rowsP<{ feature: string; uncosted: string; featureCost: string }>(
       db,
       `SELECT
          if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
-         countIf(GenAiOperation = 'tool' AND EstimatedCost = 0) AS uncosted,
+         countIf(GenAiOperation = 'tool' AND (EstimatedCost IS NULL OR EstimatedCost = 0)) AS uncosted,
          sum(EstimatedCost) AS featureCost
        FROM otel_spans
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}
@@ -1696,9 +1748,11 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
     // User-selectable window (CTO-226): bound-checked int (injection-safe), rolling and anchored on
     // the ClickHouse clock (CTO-203). Default 30 keeps every existing caller byte-for-byte unchanged.
     const w = clampWindowDays(windowDays);
-    const cost = await rows<{ feature: string; cost: string; users: string }>(
+    const cost = await rows<{ feature: string; cost: string; users: string; unpriced: string }>(
       db,
-      `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users
+      // CTO-244: `unpriced` gates the cost-per-user ratio below. See FeatureEconomics.
+      `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users,
+              countIf(EstimatedCost IS NULL) AS unpriced
        FROM otel_spans
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY AND FeatureTag != ''
        GROUP BY FeatureTag
@@ -1762,7 +1816,11 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
 
     return cost.map((r) => {
       const users = Math.max(1, parseInt(r.users, 10) || 1);
-      const costPerUserMicroUsd = Math.round(micro(r.cost) / users);
+      // CTO-244: a feature with ANY unpriced span has an unknown cost per user. sum() skips those
+      // spans but uniqExact(UserIdHash) counts their users, so the ratio would divide a partial
+      // numerator by a complete denominator and understate spend per user by an unknowable amount.
+      const costPerUserMicroUsd =
+        (parseInt(r.unpriced, 10) || 0) > 0 ? null : Math.round(micro(r.cost) / users);
       const a = attrByFeature.get(r.feature);
 
       const conversions = a ? parseInt(a.conversions, 10) || 0 : 0;
@@ -1803,7 +1861,11 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
       const valuePerUserMicroUsd = Math.round((parseInt(a!.value_micro, 10) || 0) / matchedUsers);
       // payback = cost / (value per day). Guard div-by-zero: no value ⇒ payback unknowable.
       const valuePerDay = valuePerUserMicroUsd / 30;
-      const paybackDays = valuePerDay > 0 ? Math.round(costPerUserMicroUsd / valuePerDay) : null;
+      // Payback inherits the unknown: an unknown cost per user cannot yield a known payback.
+      const paybackDays =
+        costPerUserMicroUsd !== null && valuePerDay > 0
+          ? Math.round(costPerUserMicroUsd / valuePerDay)
+          : null;
       const attributionRate = totalUsers > 0 ? matchedUsers / totalUsers : null;
 
       return {
@@ -2113,11 +2175,17 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
     // similar costs); heroic for tail (rare, expensive) — flagged in CTO-119 as a follow-up
     // where a bootstrap estimator may be warranted. n<30 → null (page renders "—") rather than
     // a meaninglessly wide band.
-    const strata = await rows<{ stratum: string; rate: string; n: string; mean: string; std: string }>(
+    const strata = await rows<{ stratum: string; rate: string; n: string; spans: string; mean: string; std: string }>(
       db,
+      // CTO-244: `n` counts PRICED spans, not all spans. avg/stddevPop skip NULLs, so pairing them
+      // with a total count would divide a priced-only spread by an all-spans sample size and report
+      // a confidence interval NARROWER than the data supports, on the one page whose job is to
+      // state uncertainty honestly. `spans` keeps the true total so the caller can say what share
+      // of the stratum the band actually covers.
       `SELECT SamplingStratum AS stratum,
               avg(SamplingRate) AS rate,
-              count() AS n,
+              countIf(EstimatedCost IS NOT NULL) AS n,
+              count() AS spans,
               avg(EstimatedCost) AS mean,
               stddevPop(EstimatedCost) AS std
        FROM otel_spans
@@ -2129,11 +2197,17 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
     );
     const Z95 = 1.96;
     const byStratum = new Map(strata.map((r) => {
-      const n = parseInt(r.n, 10) || 0;
+      // CTO-244: `priced` is the sample the band is actually computed from; `spans` is the stratum.
+      // The n>=30 gate now applies to the priced count, and the band is suppressed entirely when
+      // any span in the stratum is unpriced: a coefficient-of-variation half-width derived from a
+      // biased subset of the costs is worse than no band, and the page renders "—" for a null.
+      const priced = parseInt(r.n, 10) || 0;
+      const spans = parseInt(r.spans, 10) || 0;
       const mean = parseFloat(r.mean) || 0;
       const std = parseFloat(r.std) || 0;
-      const ci = n >= 30 && mean > 0 ? (Z95 * std) / mean / Math.sqrt(n) : null;
-      return [r.stratum, { rate: parseFloat(r.rate) || 0, ci, spans: n }];
+      const complete = priced === spans;
+      const ci = complete && priced >= 30 && mean > 0 ? (Z95 * std) / mean / Math.sqrt(priced) : null;
+      return [r.stratum, { rate: parseFloat(r.rate) || 0, ci, spans }];
     }));
     const sampling: SampleByStratum[] = (["tail", "mid", "body"] as const).map((s) => {
       const row = byStratum.get(s);
@@ -2176,6 +2250,20 @@ interface RunAgg {
   steps: string;
   maxStatus: string;
   tsEpoch: string;
+  /** CTO-244: spans in this run that could not be priced. Non-zero => `cost` is a partial sum. */
+  unpriced?: string;
+}
+
+/**
+ * A run's total cost, or null when any of its spans is unpriced (CTO-244).
+ *
+ * A trace is a handful of steps, not a large sample, so a single unpriced step can dominate the
+ * total. Returning the partial sum would systematically understate exactly the runs this view
+ * exists to surface as unusually expensive.
+ */
+function runCost(a: RunAgg): number | null {
+  if ((parseInt(a.unpriced ?? "0", 10) || 0) > 0) return null;
+  return microOrNull(a.cost);
 }
 
 // Order-of-magnitude histogram bucket (micro-USD) → 10 buckets, cheap → expensive.
@@ -2199,7 +2287,8 @@ function toRunSpan(s: SpanRowRaw): RunSpan {
     spanId: s.spanId,
     parentSpanId: s.parentSpanId || null,
     name: s.name,
-    costMicroUsd: micro(s.cost),
+    // CTO-244: microOrNull, not micro. A per-span cost has nothing to average away an unknown.
+    costMicroUsd: microOrNull(s.cost),
     durationMs: Math.round((parseInt(s.durNs, 10) || 0) / 1e6),
     status: parseInt(s.status, 10) === 2 ? "error" : "ok",
   };
@@ -2230,20 +2319,33 @@ async function fetchSpansFor(
   return grouped;
 }
 
-function whyExpensive(spans: RunSpan[], total: number): string {
-  if (spans.length === 0 || total <= 0) return "No cost breakdown available for this run.";
-  const top = [...spans].sort((a, b) => b.costMicroUsd - a.costMicroUsd)[0];
-  const pct = Math.round((top.costMicroUsd / total) * 100);
+function whyExpensive(spans: RunSpan[], total: number | null): string {
+  // CTO-244: an unpriced step must not be silently treated as the cheapest one. Concentration is a
+  // share of the run total, and neither the share nor the total means anything while a step in the
+  // run has no price, so say that instead of naming a runner-up as the culprit.
+  const unpriced = spans.filter((s) => s.costMicroUsd === null).length;
+  if (unpriced > 0) {
+    return `Cost breakdown unavailable: ${unpriced} of ${spans.length} steps could not be priced.`;
+  }
+  if (spans.length === 0 || total === null || total <= 0) {
+    return "No cost breakdown available for this run.";
+  }
+  const top = [...spans].sort((a, b) => (b.costMicroUsd ?? 0) - (a.costMicroUsd ?? 0))[0];
+  const pct = Math.round(((top.costMicroUsd ?? 0) / total) * 100);
   return `${pct}% of run cost concentrated in ${top.name} across ${spans.length} steps.`;
 }
 
 function buildRun(agg: RunAgg, spans: RunSpan[], agentMedian: number): AgentRun {
-  const total = micro(agg.cost);
+  // CTO-244: a run with any unpriced step has an unknown total, and `multipleOfMedian` must then be
+  // null rather than the old fallback of 1. "1x median" is a fabricated, reassuring number for
+  // precisely the run we know least about.
+  const total = spans.some((s) => s.costMicroUsd === null) ? null : runCost(agg);
   return {
     runId: agg.runId,
     agent: agg.agent || "untagged",
     totalCostMicroUsd: total,
-    multipleOfMedian: agentMedian > 0 ? Math.round((total / agentMedian) * 10) / 10 : 1,
+    multipleOfMedian:
+      total !== null && agentMedian > 0 ? Math.round((total / agentMedian) * 10) / 10 : null,
     steps: parseInt(agg.steps, 10) || spans.length,
     // Only success/failed are inferable from OTel StatusCode (2 = error); abandoned isn't tracked.
     outcome: parseInt(agg.maxStatus, 10) === 2 ? "failed" : "success",
@@ -2278,6 +2380,7 @@ export async function queryAgents(
       `SELECT TraceId AS runId,
               any(ServiceName) AS agent,
               sum(EstimatedCost) AS cost,
+              countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps,
               max(StatusCode) AS maxStatus,
               toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
@@ -2305,7 +2408,12 @@ export async function queryAgents(
     const agentMedian = new Map<string, number>();
 
     const agents: AgentSummary[] = [...byAgent.entries()].map(([name, list]) => {
-      const costs = list.map((r) => micro(r.cost));
+      // CTO-244: unpriced runs are EXCLUDED, not zeroed. micro() maps a NULL sum to 0, and a 0 in
+      // this array is not inert: costBucket() files it in the cheapest histogram bucket and
+      // quantile() drags p50/p99 down with a number nobody measured. Dropping them makes every
+      // figure below a statistic over the priced runs, which `unpricedRuns` then discloses.
+      const costs = list.map(runCost).filter((c): c is number => c !== null);
+      const unpricedRuns = list.length - costs.length;
       agentMedian.set(name, median(costs));
       const distribution = new Array(10).fill(0);
       for (const c of costs) distribution[costBucket(c)]++;
@@ -2322,12 +2430,25 @@ export async function queryAgents(
         p50MicroUsd: quantile(costs, 0.5),
         p99MicroUsd: quantile(costs, 0.99),
         distribution,
+        unpricedRuns,
       };
     });
     agents.sort((a, b) => b.costPerDayMicroUsd - a.costPerDayMicroUsd);
 
     // Top expensive runs across all agents (with span trees) for the run list / drill-down.
-    const topAggs = [...aggs].sort((a, b) => micro(b.cost) - micro(a.cost)).slice(0, 12);
+    // CTO-244: an unpriced run sorts FIRST, not last. Its cost is unknown, and the whole purpose of
+    // this list is "which runs should you look at?" - "we cannot price this one" is the strongest
+    // possible reason to look. Ranking it as $0 buried it at the bottom.
+    const topAggs = [...aggs]
+      .sort((a, b) => {
+        const ca = runCost(a);
+        const cb = runCost(b);
+        if (ca === null && cb === null) return 0;
+        if (ca === null) return -1;
+        if (cb === null) return 1;
+        return cb - ca;
+      })
+      .slice(0, 12);
     const spansByRun = await fetchSpansFor(db, tenant, topAggs.map((a) => a.runId));
     const runs = topAggs.map((a) =>
       buildRun(a, spansByRun[a.runId] ?? [], agentMedian.get(a.agent) ?? 0),
@@ -2342,6 +2463,7 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
     const aggs = await rowsP<RunAgg>(
       db,
       `SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost,
+              countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps, max(StatusCode) AS maxStatus, toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
        FROM otel_spans
        WHERE TenantId = {tenant:String} AND TraceId = {runId:String}
@@ -2351,15 +2473,22 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
     const agg = aggs[0];
     if (!agg) return null;
 
-    const peers = await rowsP<{ cost: string }>(
+    // CTO-244: only fully-priced peers form the median. A partial peer sum would pull the median
+    // down and inflate every run's "Nx median" against it.
+    const peers = await rowsP<{ cost: string; unpriced: string }>(
       db,
-      `SELECT sum(EstimatedCost) AS cost FROM otel_spans
+      `SELECT sum(EstimatedCost) AS cost, countIf(EstimatedCost IS NULL) AS unpriced
+       FROM otel_spans
        WHERE TenantId = {tenant:String} AND FeatureTag = {agent:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
        GROUP BY TraceId`,
       { tenant, agent: agg.agent },
     );
-    const agentMedian = median(peers.map((p) => micro(p.cost)));
+    const agentMedian = median(
+      peers
+        .filter((p) => (parseInt(p.unpriced, 10) || 0) === 0)
+        .map((p) => micro(p.cost)),
+    );
     const spans = (await fetchSpansFor(db, tenant, [runId]))[runId] ?? [];
     return buildRun(agg, spans, agentMedian);
   });
@@ -2737,12 +2866,13 @@ export async function queryAttribution(
       : "";
 
     // sessions per provider (distinct session ids per real provider).
-    const sessionsRows = await rowsP<{ provider: string; sessions: string; cost: string }>(
+    const sessionsRows = await rowsP<{ provider: string; sessions: string; cost: string; unpriced: string }>(
       db,
       `SELECT
          ${providerExpr} AS provider,
          uniqExact(s.SessionId) AS sessions,
-         sum(s.EstimatedCost) AS cost
+         sum(s.EstimatedCost) AS cost,
+         countIf(s.EstimatedCost IS NULL) AS unpriced
        FROM otel_spans s
        WHERE s.TenantId = {tenant:String}
          AND s.Timestamp >= ${windowSql}
@@ -2855,7 +2985,11 @@ export async function queryAttribution(
       const conversions = convByProvider.get(r.provider) ?? 0;
       const costMicro = micro(r.cost);
       const revenue = revenueByProvider.get(r.provider) ?? null;
-      return buildProviderRow(r.provider, sessions, conversions, costMicro, revenue);
+      // CTO-244: pass the unpriced count so the per-conversion and per-user ratios blank instead
+      // of dividing a partial cost by a complete denominator.
+      return buildProviderRow(
+        r.provider, sessions, conversions, costMicro, revenue, parseInt(r.unpriced, 10) || 0,
+      );
     });
     perProvider.sort((a, b) => b.sessions - a.sessions);
 
@@ -2896,8 +3030,16 @@ export async function queryAttribution(
       costMicroUsd: perProvider.reduce((s, p) => s + p.costMicroUsd, 0),
       costPerConversionMicroUsd: null as number | null,
     };
+    // CTO-244: if ANY provider row has an unknown cost per conversion, the roll-up of all of them
+    // is unknown too. A total built from a partial numerator and a complete denominator is wrong,
+    // not merely small.
+    const anyUnpriced = perProvider.some(
+      (p) => p.conversions > 0 && p.costPerConversionMicroUsd === null,
+    );
     totals.costPerConversionMicroUsd =
-      totals.conversions > 0 ? Math.round(totals.costMicroUsd / totals.conversions) : null;
+      !anyUnpriced && totals.conversions > 0
+        ? Math.round(totals.costMicroUsd / totals.conversions)
+        : null;
 
     if (perProvider.length === 0) return emptyReport(filters);
     return { filters, perProvider, totals, dailyByProvider, isMock: false };
@@ -2952,7 +3094,10 @@ export const MIN_SPANS_FOR_LATENCY_ERROR = 50;
 export async function queryCurrentModel(): Promise<{
   model: string;
   provider: string;
-  monthlyCostMicroUsd: number;
+  // CTO-244: null when the 7-day window contains a span we could not price. See the note at the
+  // projection below: a partial cost projected against a full call count is a wrong ratio, not a
+  // smaller one, and the /api/compare route must render "—" rather than a savings figure.
+  monthlyCostMicroUsd: number | null;
   // CTO-231: the current model's full-traffic call count over the same window, projected to a
   // 30-day month exactly like monthlyCostMicroUsd. The /api/compare route needs a full-traffic
   // call volume to rescale each candidate's replayed-corpus cost onto the incumbent's basis
@@ -2970,6 +3115,7 @@ export async function queryCurrentModel(): Promise<{
       model: string;
       provider: string;
       cost7d: string;
+      unpriced7d: string | number;
       // ClickHouse can serialize numeric aggregates as either JSON numbers or strings
       // (count() over UInt64 frequently lands as a string). Accept both at the boundary.
       p95Ms: string | number | null;
@@ -2996,6 +3142,7 @@ export async function queryCurrentModel(): Promise<{
            any(GenAiSystem)
          ) AS provider,
          sum(EstimatedCost) AS cost7d,
+         countIf(EstimatedCost IS NULL) AS unpriced7d,
          quantileExact(0.95)(if(DurationNs > 0, DurationNs, NULL)) / 1e6 AS p95Ms,
          countIf(StatusCode = 2) / count() AS errRate,
          count() AS sampleCount
@@ -3010,7 +3157,18 @@ export async function queryCurrentModel(): Promise<{
     );
     if (out.length === 0 || !out[0].model) return null;
     // Cost over 7 days → linearly projected to a 30-day month. Honest about what this is.
-    const monthlyCostMicroUsd = Math.round((micro(out[0].cost7d) * 30) / 7);
+    //
+    // CTO-244: null when any span in the window was unpriced. This figure is weighed against a
+    // candidate's (per-call cost × monthlyCalls), and monthlyCalls projects ALL calls while the
+    // cost sum covers only priced ones. Mismatched denominators here fabricate a savings
+    // percentage out of a coverage gap, which is the same class of bug the comment above records
+    // this code having already shipped once (the bogus ~100% reduction).
+    const unpriced7d =
+      typeof out[0].unpriced7d === "number"
+        ? out[0].unpriced7d
+        : parseInt(out[0].unpriced7d, 10) || 0;
+    const monthlyCostMicroUsd =
+      unpriced7d > 0 ? null : Math.round((micro(out[0].cost7d) * 30) / 7);
     const sampleCount =
       typeof out[0].sampleCount === "number"
         ? out[0].sampleCount

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -250,7 +250,15 @@ const MIN_MEANINGFUL_SAVINGS_PCT = 0.05;
  */
 export function deriveRecommendation(input: {
   currentModel: string;
-  currentCostMicroUsd: MicroUSD;
+  /**
+   * CTO-244: null when the incumbent's spend could not be fully priced over the window.
+   *
+   * A savings projection is `current - candidate`, so an under-counted `current` understates the
+   * saving; worse, the candidate side is derived from a FULL call count, so the two sides describe
+   * different populations and the percentage is wrong rather than merely small. We refuse to
+   * project rather than publish a confident number built on a coverage gap.
+   */
+  currentCostMicroUsd: MicroUSD | null;
   candidates: RecommendationCandidate[];
   /** total replayed responses across candidates — the gate for whether we recommend at all. */
   samplesReplayed: number;
@@ -261,6 +269,17 @@ export function deriveRecommendation(input: {
     (best, c) => (best === null || c.monthlyCostMicroUsd < best.monthlyCostMicroUsd ? c : best),
     null,
   );
+
+  // CTO-244: an unpriced incumbent cannot anchor a savings projection. Report zero savings with a
+  // verdict that says WHY, instead of a percentage measured against a number we do not have.
+  if (currentCostMicroUsd === null) {
+    return {
+      verdict: "mixed",
+      summary: `— cannot project savings for ${currentModel}: some of its spend over the window could not be priced, so its monthly cost is unknown. Fix the pricing gap before comparing candidates.`,
+      projectedSavingsMicroUsd: 0,
+      projectedSavingsPct: 0,
+    };
+  }
 
   const projectedSavingsMicroUsd = cheapest
     ? Math.max(0, currentCostMicroUsd - cheapest.monthlyCostMicroUsd)

--- a/web/lib/features.ts
+++ b/web/lib/features.ts
@@ -7,7 +7,8 @@ export interface FeatureEconomics {
   feature: string;
   /** value event the ROI is attributed against; null = unattributed */
   valueEvent: string | null;
-  costPerUserMicroUsd: MicroUSD;
+  /** CTO-244: null when any span for this feature could not be priced. See types.ts FeatureRoi. */
+  costPerUserMicroUsd: MicroUSD | null;
   valuePerUserMicroUsd: MicroUSD | null;
   paybackDays: number | null;
   attributionRate: number | null; // 0..1
@@ -29,7 +30,10 @@ export interface FeatureEconomics {
 }
 
 export function margin(e: FeatureEconomics): number | null {
-  if (e.valuePerUserMicroUsd === null) return null;
+  // CTO-244: an unknown cost per user makes the margin unknown too. Substituting 0 for the cost
+  // would report a 100% margin on a feature we cannot price, which is the most flattering possible
+  // fabrication and exactly the failure the honest-blank posture exists to prevent.
+  if (e.valuePerUserMicroUsd === null || e.costPerUserMicroUsd === null) return null;
   if (e.valuePerUserMicroUsd === 0) return 0;
   return (e.valuePerUserMicroUsd - e.costPerUserMicroUsd) / e.valuePerUserMicroUsd;
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -38,18 +38,42 @@ export interface SpendSummary {
   reconciledMicroUsd: MicroUSD;
   reconciledThrough: string; // ISO date — boundary between reconciled and estimated
   byLayer: SpendByLayer;
+  /**
+   * Spans in the window we could not put a price on (CTO-244).
+   *
+   * `totalMicroUsd` is a sum, and ClickHouse `sum()` skips NULLs, so when this is non-zero the
+   * headline is a LOWER BOUND on real spend, not the total. It is deliberately a count and not a
+   * cost: the whole point is that those spans have no cost to add. The UI must disclose it rather
+   * than present an under-count as complete; it must not guess what the missing spend was.
+   *
+   * Optional so a mock or an older payload that predates the field still typechecks and reads as
+   * "nobody counted", which is what it honestly is.
+   */
+  unpricedSpanCount?: number;
+  /** Total spans in the same window, so `unpricedSpanCount` can be stated as a share. */
+  spanCount?: number;
 }
 
 export interface CostOutlier {
   runId: string;
   agent: string;
-  costMicroUsd: MicroUSD;
-  multipleOfMedian: number;
+  /** CTO-244: null when any span in the run could not be priced, so the run total is unknown. */
+  costMicroUsd: MicroUSD | null;
+  /** CTO-244: null when the run total is unknown, or there is no priced peer median to divide by. */
+  multipleOfMedian: number | null;
 }
 
 export interface FeatureRoi {
   feature: string;
-  costPerUserMicroUsd: MicroUSD;
+  /**
+   * CTO-244: null when any span for this feature could not be priced.
+   *
+   * This is cost divided by a user count. The numerator skips unpriced spans while the denominator
+   * counts every user, so a partly-unpriced feature produced a cost-per-user that was understated
+   * by an unknowable amount, and paybackDays (derived from it) then looked BETTER than reality.
+   * A ratio built from mismatched populations is not a smaller number, it is a wrong one.
+   */
+  costPerUserMicroUsd: MicroUSD | null;
   valuePerUserMicroUsd: MicroUSD | null; // null = no value event configured
   paybackDays: number | null;
   attributionRate: number | null; // 0..1


### PR DESCRIPTION
## The invariant violation

CLAUDE.md is explicit: *"A value that is unknown is `null`/`—`, never `0`."* Storage made that impossible for usage and cost, so ingest wrote `0`.

- `db/clickhouse/otel_spans.sql`: `InputTokens`, `OutputTokens`, `CachedInputTokens` were `UInt32`; `EstimatedCost` was `Decimal64(8)`. None nullable.
- `mapping._i()` returned `0` for anything non-numeric, including absent.
- A price-catalog miss hard-coded `EstimatedCost = Decimal(0)`.

So a call we could not measure was stored as one that consumed nothing and cost nothing. The dashboard summed it as real. The most common trigger is the ordinary one: a streamed response through the edge proxy, where usage cannot be scanned off the stream. Every total on the product silently understated spend, and nothing on the surface said so.

## What changed

**Schema.** The three token columns and `EstimatedCost` become `Nullable`. `T64` and `ZSTD` compose with `Nullable` on these types, so the codecs are unchanged (verified against ClickHouse 24.8). `CostSource` gains `'unpriced' = 3`: this reuses the existing cost-source enum to carry *why* a cost is missing, rather than inventing a parallel signal, and sits beside the empty `PriceCatalogVersion` that `tally.pricing` already returns on a catalog miss.

**Ingest.** `span_to_row` writes `NULL` for an absent or unparseable token count (new `_i_or_none`), and `NULL` + `CostSource='unpriced'` when no priced cost is present. A provider-reported `0` still stores as `0` with `CostSource='estimated'`, distinguishable from `NULL`.

**Rollups.** The materialized views keep non-nullable SummingMergeTree targets and gain `UnknownUsageSpanCount` / `UnpricedSpanCount`, so a partial sum is never silent. `last_touch_index.LastTraceCost` is a per-span scalar with nothing to average an unknown into, so it becomes `Nullable`.

## The cutover is ambiguous, and this PR does not pretend otherwise

Rows written before this change hold `0` where the truth was **either** a genuine provider-reported zero **or** an unknown that ingest flattened. Nothing recorded which, and nothing can separate them now.

There is deliberately **no backfill**. Guessing which zeros "should" be NULL would fabricate exactly the class of number this change exists to remove.

Stated consequences, documented in the DDL comment and in `RUNNING.md`:
- Figures covering any period before the cutover may **understate real spend**, by an amount no query can measure.
- A pre-cutover `UnpricedSpanCount` of `0` means "nobody counted", not "there were no unknowns".
- Post-cutover data is honest.

## Blast radius of the reader changes

`sum()` skips NULLs, so every `sum(EstimatedCost)` quietly became a lower bound. Every read site was audited. Three treatments:

**1. Sums stay sums, but disclose coverage.** A sum of what we know is real money already spent; hiding it would be its own dishonesty. What it must never do is read as complete.
- `querySpendSummary` returns `unpricedSpanCount` / `spanCount`; the Home Spend tile's hint becomes *"at least: N of M spans could not be priced"*.
- Note the estimated/reconciled split no longer adds to the total, because an `'unpriced'` span is in neither bucket.

**2. Ratios and quantiles blank with a reason.** A partial numerator over a complete denominator is a *wrong* figure, not a smaller one.
- `queryFeatureEconomics`: `costPerUserMicroUsd` -> `MicroUSD | null`, cascading to `paybackDays`, `margin()` and `queryRoi`. Substituting 0 would have reported a 100% margin on a feature we cannot price.
- `buildProviderRow` (attribution): `costPerConversionMicroUsd` and the per-user margin null out; the roll-up total inherits it.
- `queryCurrentModel`: `monthlyCostMicroUsd` -> `number | null`. `monthlyCalls` projects *all* calls while the cost covers only priced ones; `deriveRecommendation` now refuses to project savings and says why. The compare page routes through its existing `=== 0` no-baseline state rather than showing `$0.00/mo`.
- `queryDataQualityReport`: `n` becomes `countIf(EstimatedCost IS NOT NULL)`. Pairing an all-spans count with a priced-only `stddev` reported a confidence band **narrower than the data supports**, on the page whose job is to state uncertainty. The band is suppressed entirely when coverage is partial.

**3. Fabricated zeros removed from distributions and per-span reads.**
- `queryHiddenCostAlerts` rule 1: `EstimatedCost = 0` -> `(EstimatedCost IS NULL OR EstimatedCost = 0)`. `NULL = 0` is `NULL`, so the "uncosted tool activity" detector would have gone **silent on exactly the population it exists to find**. Verified live: old predicate matched 1 row, new one matched 2.
- `queryAgents`: unpriced runs are excluded from `costs` rather than zeroed. A `0` there is not inert; `costBucket()` filed it in the cheapest histogram bucket and `quantile()` dragged p50/p99 down. New `AgentSummary.unpricedRuns` discloses the exclusion with a `*` marker.
- `queryOutliers` / `buildRun`: `multipleOfMedian` was `: 1` on failure, a reassuring invented figure for the run we understand least. Now `null`. The peer median is computed over fully-priced runs only.
- Unknown-cost runs now sort **first**, not last. `ORDER BY cost DESC` puts NULLs last, so an expensive run we could not price could never surface as an outlier, which is backwards for a detector meant to find runs worth looking at.
- `RunSpan.costMicroUsd` -> `MicroUSD | null`. The run waterfall was the one cost render in the app calling `formatUSD` directly with no blank path; it printed `$0.00` for a real billed step. Now `<Money>` with a reason, and no bar is drawn.
- `whyExpensive` says how many steps could not be priced instead of naming a runner-up as the culprit.

New `microOrNull()` sits beside `micro()`, which maps a JSON `null` to `0`; that is right for a sum and a lie for a scalar. Widening the types made the compiler enumerate the UI sites, and `HonestValue`'s `NullableProps` forced a reason on every one.

## Verification

- ClickHouse migration applied to the running local stack via `make ch-migrate`; re-ran it to confirm idempotency. NULLs round-trip, and a real 0 stays distinguishable (`unpriced=1`, `real_zero_cost=1`, `spans=3` over the same slice).
- End-to-end through the real `span_to_row` + `clickhouse-connect` insert path: unknown row lands `(NULL, NULL, NULL, 'unpriced', '')`, provider-zero row lands `(0, 0, 0E-8, 'estimated')`, and the rollup MV recorded `SpanCount=3, UnknownUsageSpanCount=1, UnpricedSpanCount=1`.
- gateway: 900 passed, ruff clean. sdk: 1118 passed, ruff clean. web: 710/710 passed, typecheck and lint clean. edge-proxy: builds, tests pass, gofmt clean.
- New tests cover: absent usage stores NULL not 0; a provider-reported 0 stores as 0 and is distinguishable; unparseable input is NULL; a catalog miss yields NULL cost with `CostSource='unpriced'` and an empty catalog version; a priced 0 is `'estimated'` not `'unpriced'`; and the read side over a mixed known/unknown slice.

## Known gaps

- `bq_export.py` does not export the two new rollup coverage counters. NULLs themselves round-trip (BigQuery columns are NULLABLE by default), so nothing is fabricated; the coverage signal just is not in the warehouse yet.
- `querySettledCostSeries` (the forecast baseline) still treats a partly-unpriced day as settled. There is a good argument it should not be, and the `awaitingLayers` machinery is already there for it. Left out to keep this diff reviewable.
- `sdk/tally.pricing.Usage` still defaults token counts to `int = 0`, so the SDK cannot itself distinguish "0 tokens" from "unknown". The gateway boundary handles it correctly today; pushing nullability into the SDK is a separate change.
- `reconciler.CostSource` (the Python mirror of the enum) has not gained `UNPRICED`. It is fed from day-level aggregates rather than raw spans, so nothing is wrong today, but the two definitions are now out of sync.
- One operational note: the local ClickHouse container exited with SIGSEGV partway through the first `MODIFY COLUMN` mutation. It restarted cleanly, `system.mutations` showed all four `is_done: 1`, and a subsequent full replay was clean. I could not reproduce it and cannot say whether it was related or an unrelated resource issue on this Docker host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
