### PR TITLE
fix(sdk): require package-shaped context for ambiguous tokens in explain_layer (CTO-261)

### DIFF
--- a/sdk/python/onboarding_mcp/detect.py
+++ b/sdk/python/onboarding_mcp/detect.py
@@ -31,6 +31,57 @@ def tokenize(text: str) -> set[str]:
     return {t.lower() for t in _TOKEN_RE.findall(text)}
 
 
+# Catalog import tokens that are also ordinary English words a developer can write in a
+# question without meaning the package (CTO-261 review finding 2). The ambiguity only bites
+# in explain_layer, whose input is free-text prose: detect_stack reads a manifest or an
+# import excerpt, where the token appearing genuinely means the dependency is present, so
+# these stay fully live there and together.ai detection is untouched.
+#
+# The bar for entry is "the non-package sense plausibly occurs in a question about metering
+# an AI app", not merely "the string is in a dictionary":
+#   together - an everyday adverb ("let us work through this together"), the case that
+#              motivated this change.
+#   agents   - in this exact domain the general noun ("how are my agents metered?") is far
+#              more common than the openai-agents package.
+#   cohere   - an ordinary verb, and the useful package-sense questions ("this cohere.embed()
+#              call") still carry the dotted shape below, so nothing real is lost.
+# Deliberately NOT listed: flask and pinecone. They are concrete-object nouns whose non-package
+# sense does not occur in an instrumentation question, so requiring a stronger signal there
+# would only throw away correct answers ("what layer covers my flask app?").
+AMBIGUOUS_IMPORT_TOKENS = frozenset({"together", "agents", "cohere"})
+
+
+def _ambiguous_context_re(token: str) -> re.Pattern[str]:
+    """Import-shaped or package-shaped uses of ``token``: the stronger signal prose must carry."""
+    t = re.escape(token)
+    return re.compile(
+        # import together / from together import ...
+        rf"\b(?:import|from)\s+{t}\b"
+        # together==1.2.3, together>=, together~=, together[extra]
+        rf"|\b{t}\s*(?:==|>=|<=|~=|!=|\[)"
+        # together.ai, together.Complete(...): a dotted use is package-shaped, not prose.
+        rf"|\b{t}\.[a-zA-Z_]",
+        re.IGNORECASE,
+    )
+
+
+_AMBIGUOUS_CONTEXT_RES = {tok: _ambiguous_context_re(tok) for tok in AMBIGUOUS_IMPORT_TOKENS}
+
+
+def import_token_matches_prose(token: str, prose: str, prose_tokens: set[str]) -> bool:
+    """True when ``token`` is a trustworthy signal inside a human's free-text ``prose``.
+
+    An unambiguous package name matches on an identifier-token boundary as before. An
+    ambiguous common-word name additionally has to appear in an import-shaped or
+    package-shaped context, because a confidently wrong grounded answer is worse than a
+    gap (CTO-261 review finding 2, CLAUDE.md "honest under uncertainty").
+    """
+    token = token.lower()
+    if token not in AMBIGUOUS_IMPORT_TOKENS:
+        return token in prose_tokens
+    return bool(_AMBIGUOUS_CONTEXT_RES[token].search(prose))
+
+
 def _classify(tokens: set[str], vocabulary: set[str]) -> list[str]:
     return sorted(tokens & vocabulary)
 

--- a/sdk/python/onboarding_mcp/generate.py
+++ b/sdk/python/onboarding_mcp/generate.py
@@ -14,7 +14,7 @@ import re
 from typing import Any
 
 from onboarding_mcp.catalog import RecipeCatalog, get_catalog
-from onboarding_mcp.detect import tokenize
+from onboarding_mcp.detect import import_token_matches_prose, tokenize
 from onboarding_mcp.sdk_surface import emitted_tally_calls, layer_grounding
 
 _HOLE_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
@@ -235,15 +235,28 @@ def explain_layer(query: str, *, catalog: RecipeCatalog | None = None) -> dict[s
     if facts is None:
         # Not a bare layer name: try to match the excerpt to a recipe by its detect block.
         # Imports match on identifier-token boundaries, not bare substrings: a plain
-        # substring test lets an ordinary English word inside a question ("together")
-        # or an unrelated dependency name pass as a confident LLM answer, and a
-        # confidently wrong grounded answer is worse than a gap (CTO-261 review
+        # substring test lets an unrelated dependency name pass as a confident LLM answer,
+        # and a confidently wrong grounded answer is worse than a gap (CTO-261 review
         # finding 2, CLAUDE.md "honest under uncertainty").
+        #
+        # A token boundary is not enough for a package whose name is also an ordinary
+        # English word, because the token genuinely IS a word: "let us work through this
+        # together" would otherwise ground on the together.ai import and answer with the
+        # LLM layer. Those names need an import-shaped or package-shaped context here.
+        # This is explain_layer only: detect_stack reads manifests and import excerpts,
+        # where the same token really does mean the dependency is installed, so together.ai
+        # detection keeps working there (CTO-261 review finding 2).
         query_tokens = tokenize(query)
+
+        def _import_hit(imp: str) -> bool:
+            return any(
+                import_token_matches_prose(tok, query, query_tokens) for tok in tokenize(imp)
+            )
+
         for recipe in cat.recipes:
             if not (
                 any(pat in query for pat in recipe.call_patterns)
-                or any(tokenize(imp) & query_tokens for imp in recipe.imports)
+                or any(_import_hit(imp) for imp in recipe.imports)
             ):
                 continue
             grounding = layer_grounding(recipe.verify.get("layer", ""))

--- a/sdk/python/tests/test_onboarding_mcp.py
+++ b/sdk/python/tests/test_onboarding_mcp.py
@@ -155,6 +155,42 @@ def test_explain_layer_on_boto3_is_a_gap_not_a_confident_llm_answer():
     assert result["gap"] is True
 
 
+def test_explain_layer_on_ambiguous_common_word_prose_is_a_gap():
+    # "together" is a real package (together.ai) AND an everyday adverb, so free-text prose
+    # containing it must not ground on the LLM layer. A gap beats a confident wrong answer
+    # (CTO-261 review finding 2, CLAUDE.md "honest under uncertainty").
+    for prose in (
+        "let us work through this together",
+        "do these two calls get metered together?",
+        "how are my agents metered?",
+        "do the numbers cohere across layers?",
+    ):
+        result = explain_layer(prose)
+        assert result["gap"] is True, prose
+
+
+def test_explain_layer_still_answers_an_ambiguous_token_in_package_shaped_context():
+    # The stronger signal is import-shaped or package-shaped context, so a genuine
+    # together.ai question still gets the grounded LLM answer.
+    for excerpt in (
+        "import together",
+        "what records this together.ai call?",
+        "from together import Together",
+    ):
+        result = explain_layer(excerpt)
+        assert result.get("gap") is not True, excerpt
+        assert result["call"] == "tally.record_llm_call", excerpt
+
+
+def test_detect_stack_still_detects_together_from_a_manifest_and_from_imports():
+    # The explain_layer guard must not cost together.ai manifest / import detection: in
+    # detect_stack the token appearing really does mean the dependency is present.
+    manifest = detect_stack("together==1.2.3\n")
+    assert "llm.generic.call" in manifest["matched_recipes"]
+    excerpt = detect_stack("", "import together\nclient = together.Together()")
+    assert "llm.generic.call" in excerpt["matched_recipes"]
+
+
 def test_explain_layer_does_not_match_an_import_name_buried_in_a_longer_identifier():
     # Imports match on identifier-token boundaries rather than bare substrings, so an
     # unrelated name that merely contains a provider name is a gap, not a confident


### PR DESCRIPTION
Closes the last honesty gap from the PR #282 review, the one #295 deliberately left open for a decision. The decision: keep together.ai detection AND stop the false confident answer.

## The problem

`together` stays in `llm.generic.call`'s `detect.imports` because removing it would lose manifest detection of together.ai. But it is also an ordinary English word, so `explain_layer("let us work through this together")` returned a confident `record_llm_call` / LLM-layer answer where an honest gap is correct. Token-boundary matching does not help: the token genuinely is a word. Same class as the boto3 finding, where a confidently wrong grounded answer is worse than a gap.

## The fix

The ambiguity only bites in `explain_layer`'s free-text prose matching, not in manifest or import detection, so the two are separated rather than traded off:

- `detect_stack` is unchanged. Its input is a manifest or an import excerpt, where the token appearing really does mean the dependency is present. together.ai detection keeps working.
- `explain_layer` requires a stronger signal for an ambiguous common-word package name: an import-shaped or package-shaped context (`import together`, `from together`, `together.ai`, `together==`, `together[extra]`). Anything else is a gap.

The stronger-context approach was chosen over a blanket removal or a per-recipe flag because it keeps every genuinely useful question answerable (`what records this together.ai call?` still grounds on the LLM layer) while prose falls through to the honest gap.

## Catalog audit

Every import token in the catalog was checked for the same problem. Bar for entry: the non-package sense plausibly occurs in a question about metering an AI app, not merely that the string is in a dictionary.

- `together` (llm.generic.call): ambiguous, guarded. Everyday adverb.
- `agents` (tool.generic.call): ambiguous, guarded. In this domain the general noun ("how are my agents metered?") is more common than the openai-agents package.
- `cohere` (embedding.generic.call): ambiguous, guarded. An ordinary verb; the useful package-sense questions carry a dotted shape (`cohere.embed(`) and still answer.
- `flask` (middleware.flask.account) and `pinecone` (vector.pinecone.query): concrete-object nouns whose non-package sense does not occur in an instrumentation question. Deliberately left unguarded, since requiring stronger context would only discard correct answers such as "what layer covers my flask app?". Documented in the code.
- Everything else (ollama, vllm, groq, openai, anthropic, langchain, llama_index, pgvector, psycopg, sqlalchemy, qdrant_client, weaviate, django, fastapi, opentelemetry, sentence_transformers, voyageai) is not an English word.

Call patterns were also reviewed and need no change: they are code-shaped (`@tool`, `Tool(`, `<->`, `/v1/chat/completions`) or uppercase (`MIDDLEWARE`).

## Tests added

- `test_explain_layer_on_ambiguous_common_word_prose_is_a_gap`: four prose queries covering together, agents and cohere all return the gap shape.
- `test_explain_layer_still_answers_an_ambiguous_token_in_package_shaped_context`: `import together`, `together.ai`, `from together import Together` still ground on `tally.record_llm_call`.
- `test_detect_stack_still_detects_together_from_a_manifest_and_from_imports`: `together==1.2.3` in a manifest and `import together` in an excerpt both still match `llm.generic.call`, so the fix cannot silently regress together.ai detection.

The existing boto3 regression test passes unchanged, and the `sdk_surface.py` anti-hallucination guard is untouched.

## Verification

`cd sdk/python && uv run --extra dev pytest -q && uv run ruff check .` gives 1153 passed, ruff "All checks passed!". No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
