### PR TITLE
fix(gateway): promote tool and vector cost into the span cost (CTO-243)

### DIFF
--- a/infra/gateway/tests/test_tool_vector_cost.py
+++ b/infra/gateway/tests/test_tool_vector_cost.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-243 — tool and vector spend must reach the EstimatedCost column, not read as $0.
+
+The SDK writes per-call spend to ``gen_ai.tool.cost_micro_usd``. Nothing promoted that carrier into
+the canonical cost attribute, so every tool and vector span was written with EstimatedCost 0 and a
+whole cost layer looked free. These tests drive the real ingest path (POST /v1/batches into a fake
+ClickHouse) and assert the row that actually gets written.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from tally.schema import GenAI, SpanFields, build_span_attributes
+
+from gateway import app as app_module
+from gateway.app import app
+from gateway.config import get_settings
+from gateway.mapping import COLUMNS
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.spans: list[tuple] = []
+        self._lock = threading.Lock()
+
+    def insert_spans(self, rows: list[tuple]) -> int:
+        with self._lock:
+            self.spans.extend(rows)
+        return len(rows)
+
+    def insert_business_events(self, tenant_id: str, events: list) -> int:
+        return 0
+
+    def insert_identity_links(self, tenant_id: str, links: list) -> int:
+        return 0
+
+    def ping(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+@contextmanager
+def _client(store: FakeStore) -> Iterator[TestClient]:
+    """A TestClient writing synchronously into ``store`` (buffering off, so rows land on POST)."""
+    settings = get_settings()
+    prev_buffered = settings.ingest_buffered
+    settings.ingest_buffered = False
+    orig_factory = app_module.ClickHouseStore
+    app_module.ClickHouseStore = lambda _settings: store  # type: ignore[assignment]
+    try:
+        with TestClient(app) as c:
+            app.state.settings.require_api_key = False
+            yield c
+    finally:
+        app_module.ClickHouseStore = orig_factory  # type: ignore[assignment]
+        settings.ingest_buffered = prev_buffered
+
+
+def _post(c: TestClient, spans: list[dict]) -> dict:
+    r = c.post(
+        "/v1/batches",
+        json={"tenant_id": "t-local", "sdk_version": "test", "resource_spans": spans},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _row(store: FakeStore, index: int = 0) -> dict[str, object]:
+    return dict(zip(COLUMNS, store.spans[index], strict=True))
+
+
+def _tool_span(**over: object) -> dict:
+    attrs = build_span_attributes(
+        SpanFields(
+            system="tavily",
+            operation="tool",
+            tool_name="search",
+            tool_call_id="call-1",
+            tool_cost_micro_usd=10_000,  # 0.01 USD, what record_tool_call resolves
+            feature_tag="assistant",
+        )
+    )
+    attrs.update({"trace_id": "trace-tool", "span_id": "span-tool"})
+    attrs.update(over)
+    return attrs
+
+
+def _vector_span(**over: object) -> dict:
+    attrs = build_span_attributes(
+        SpanFields(
+            system="pinecone",
+            operation="vector",
+            tool_name="pinecone.docs.query",
+            tool_cost_micro_usd=400,  # 0.0004 USD
+            feature_tag="assistant",
+        )
+    )
+    attrs.update({"trace_id": "trace-vec", "span_id": "span-vec"})
+    attrs.update(over)
+    return attrs
+
+
+def test_recorded_tool_call_no_longer_reads_zero() -> None:
+    """Regression for the reported symptom: a recorded tool call showing $0 in the product."""
+    store = FakeStore()
+    with _client(store) as c:
+        _post(c, [_tool_span()])
+
+    row = _row(store)
+    assert row["GenAiOperation"] == "tool"
+    assert row["EstimatedCost"] != Decimal(0)
+    assert row["EstimatedCost"] == Decimal("0.01")
+
+
+def test_vector_call_cost_lands_on_the_row() -> None:
+    store = FakeStore()
+    with _client(store) as c:
+        _post(c, [_vector_span()])
+
+    row = _row(store)
+    assert row["GenAiOperation"] == "vector"
+    # Priced off the last segment of "pinecone.docs.query", the operation the catalog keys on.
+    assert row["EstimatedCost"] == Decimal("0.0004")
+    assert row["PriceCatalogVersion"] != ""
+
+
+def test_client_reported_cost_survives_a_catalog_miss() -> None:
+    """A negotiated per-call rate the catalog cannot know must not be discarded as $0."""
+    store = FakeStore()
+    with _client(store) as c:
+        _post(c, [_tool_span(**{GenAI.SYSTEM: "acme-internal", GenAI.TOOL_NAME: "lookup"})])
+
+    row = _row(store)
+    assert row["EstimatedCost"] == Decimal("0.01")  # the client figure, kept
+    assert row["PriceCatalogVersion"] == ""  # no catalog priced it, so no version is claimed
+
+
+def test_unpriced_tool_span_is_not_given_a_fabricated_cost() -> None:
+    """No catalog entry and no client figure: nothing is asserted beyond the base column default."""
+    store = FakeStore()
+    span = _tool_span(**{GenAI.SYSTEM: "acme-internal", GenAI.TOOL_NAME: "lookup"})
+    span.pop(GenAI.TOOL_COST_MICRO_USD)
+    with _client(store) as c:
+        _post(c, [span])
+
+    row = _row(store)
+    assert row["PriceCatalogVersion"] == ""
+    # The base branch's row mapper still coerces an absent cost to Decimal(0); the point here is
+    # that enrichment asserts nothing of its own. Nullable cost lands separately (CTO-243 note).
+    assert row["EstimatedCost"] == Decimal(0)
+
+
+def test_llm_span_cost_is_unchanged() -> None:
+    """The token-priced path must be untouched by the per-call branch."""
+    store = FakeStore()
+    attrs = build_span_attributes(
+        SpanFields(
+            system="openai",
+            request_model="gpt-5-mini",
+            response_model="gpt-5-mini",
+            operation="chat",
+            input_tokens=1_000_000,
+            output_tokens=0,
+        )
+    )
+    attrs.update({"trace_id": "trace-llm", "span_id": "span-llm"})
+    with _client(store) as c:
+        _post(c, [attrs])
+
+    assert _row(store)["EstimatedCost"] > Decimal(0)

--- a/sdk/python/src/tally/client.py
+++ b/sdk/python/src/tally/client.py
@@ -269,7 +269,10 @@ class TallyClient:
         """Record a tool call so the span lands in the gateway's ``tools`` cost-layer bucket.
 
         Bucketing is keyed off ``gen_ai.operation.name == 'tool'``. The tool's cost rides on
-        ``gen_ai.tool.cost_micro_usd``. When ``cost_micro_usd`` is omitted we resolve the rate from
+        ``gen_ai.tool.cost_micro_usd``; the gateway promotes it into the span's canonical cost
+        (``gen_ai.cost.estimated_micro_usd``, the ``EstimatedCost`` column) during enrichment,
+        preferring its own catalog price where it has one (CTO-243).
+        When ``cost_micro_usd`` is omitted we resolve the rate from
         the versioned price catalog (CTO-141) under ``PriceType.TOOL_CALL`` and stamp
         ``price_catalog_version`` on the span; an unknown ``(provider, tool)`` pair (or no catalog)
         defaults to 0 with a one-time WARN. A caller-supplied ``cost_micro_usd`` always overrides.
@@ -436,8 +439,9 @@ class TallyClient:
         """Record a vector-DB call so the span lands in the gateway's ``vector`` cost-layer bucket.
 
         Bucketing is keyed off ``gen_ai.operation.name == 'vector'``. The call's cost rides on
-        ``gen_ai.tool.cost_micro_usd`` (same carrier as ``record_tool_call`` — the gateway promotes
-        it into the layer's spend). The tool-name slot encodes ``{provider}.{index}.{operation}``.
+        ``gen_ai.tool.cost_micro_usd`` (same carrier as ``record_tool_call``, and the gateway
+        promotes it into the span's canonical cost during enrichment, CTO-243). The tool-name slot
+        encodes ``{provider}.{index}.{operation}``, and the gateway prices off the last segment.
         When ``cost_micro_usd`` is omitted we resolve the rate from the versioned price catalog
         (CTO-141) under ``PriceType.VECTOR_CALL`` keyed by ``(provider, operation)`` and stamp
         ``price_catalog_version`` on the span; an unknown pair (or no catalog) defaults to 0 with a

--- a/sdk/python/src/tally/enrichment.py
+++ b/sdk/python/src/tally/enrichment.py
@@ -9,7 +9,11 @@ from the server value by more than a threshold (default 5%), that's logged as ca
 client's price table is stale, or ours is). The authoritative server value is written onto the
 span along with the catalog version (so it can be recomputed later).
 
-Pure function over a span attribute dict — no infra.
+Pure function over a span attribute dict, no infra.
+
+Non-LLM layers (tools, CTO-135; vector, CTO-142) are priced per *call*, not per token, and the SDK
+carries their cost on ``gen_ai.tool.cost_micro_usd``. They go through the same funnel here so that
+``gen_ai.cost.estimated_micro_usd`` stays the one canonical cost attribute every consumer reads.
 """
 
 from __future__ import annotations
@@ -17,10 +21,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from tally.pricing import PriceCatalog, Usage, compute_cost_micro_usd
+from tally.pricing import (
+    PriceCatalog,
+    PriceType,
+    Usage,
+    compute_call_cost_micro_usd,
+    compute_cost_micro_usd,
+)
 from tally.schema import GenAI
 
 DEFAULT_DRIFT_THRESHOLD = 0.05  # 5%
+
+# Operations whose spend is a flat per-call price instead of token math. Keyed on
+# ``gen_ai.operation.name``, the same discriminator the cost-layer buckets use.
+_CALL_PRICED_OPERATIONS: dict[str, PriceType] = {
+    "tool": PriceType.TOOL_CALL,
+    "vector": PriceType.VECTOR_CALL,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,8 +68,19 @@ def enrich_cost(
     - ``gen_ai.cost.price_catalog_version`` is set;
     - the client-emitted value is treated as a hint and compared for drift;
     - on a catalog miss the cost key is removed and ``catalog_miss`` is True (span still returned).
+
+    Tool and vector spans (``gen_ai.operation.name`` of ``tool``/``vector``) are priced per call
+    and take the branch in :func:`_enrich_call_cost`; everything else is priced from token usage.
     """
     out = dict(attributes)
+
+    operation = out.get(GenAI.OPERATION_NAME)
+    price_type = _CALL_PRICED_OPERATIONS.get(operation) if isinstance(operation, str) else None
+    if price_type is not None:
+        return _enrich_call_cost(
+            out, catalog, price_type, at=at, tenant_id=tenant_id, drift_threshold=drift_threshold
+        )
+
     client_cost = _int_or_none(out.get(GenAI.COST_ESTIMATED_MICRO_USD))
 
     provider = out.get(GenAI.SYSTEM)
@@ -78,6 +106,92 @@ def enrich_cost(
         return EnrichmentResult(out, None, client_cost, None, False, catalog_miss=True)
 
     # authoritative server value wins
+    out[GenAI.COST_ESTIMATED_MICRO_USD] = server_cost
+    out[GenAI.COST_CURRENCY] = out.get(GenAI.COST_CURRENCY, "USD")
+    out[GenAI.COST_PRICE_CATALOG_VERSION] = version
+
+    drift: float | None = None
+    drift_exceeded = False
+    if client_cost is not None and server_cost > 0:
+        drift = abs(client_cost - server_cost) / server_cost
+        drift_exceeded = drift > drift_threshold
+
+    return EnrichmentResult(
+        attributes=out,
+        server_cost_micro_usd=server_cost,
+        client_cost_micro_usd=client_cost,
+        drift=drift,
+        drift_exceeded=drift_exceeded,
+        catalog_miss=False,
+    )
+
+
+def _catalog_name(operation: str, tool_name: str) -> str:
+    """Return the catalog ``model`` slot for a per-call priced span.
+
+    Tool spans put the tool name straight in ``gen_ai.tool.name`` and the catalog is keyed on it.
+    Vector spans encode ``{provider}.{index}.{operation}`` in the same slot (CTO-142) because the
+    index is worth keeping on the span, while the catalog prices ``(provider, operation)``; the
+    operation is the last dot-segment, so an index name containing dots still resolves.
+    """
+    if operation == "vector":
+        return tool_name.rsplit(".", 1)[-1]
+    return tool_name
+
+
+def _enrich_call_cost(
+    out: dict[str, object],
+    catalog: PriceCatalog,
+    price_type: PriceType,
+    *,
+    at: date | None,
+    tenant_id: str | None,
+    drift_threshold: float,
+) -> EnrichmentResult:
+    """Resolve the cost of a per-call priced span (tool, vector) onto the canonical cost key.
+
+    The SDK writes these costs to ``gen_ai.tool.cost_micro_usd``, which is a carrier attribute and
+    not a cost column: until CTO-243 nothing promoted it, so every tool and vector span landed in
+    ClickHouse with EstimatedCost 0 and a whole layer of real spend read as free. The promotion
+    happens here, on the one path that already owns cost, rather than by teaching the row mapper a
+    second cost field.
+
+    Precedence matches the LLM path: the server catalog is authoritative and the client value is a
+    drift hint. The one deliberate difference is the miss case. A per-call price is frequently a
+    negotiated rate the catalog cannot know, so when the catalog has no entry we keep the
+    client-reported figure instead of discarding it; discarding it is what made the spend
+    invisible. With no entry and no client figure there is nothing honest to assert, so the cost
+    key is dropped exactly as on the LLM path.
+    """
+    client_cost = _int_or_none(out.get(GenAI.TOOL_COST_MICRO_USD))
+
+    provider = out.get(GenAI.SYSTEM)
+    tool_name = out.get(GenAI.TOOL_NAME)
+    operation = out.get(GenAI.OPERATION_NAME)
+    server_cost = 0
+    version = ""
+    if isinstance(provider, str) and isinstance(tool_name, str) and isinstance(operation, str):
+        server_cost, version = compute_call_cost_micro_usd(
+            catalog,
+            provider,
+            _catalog_name(operation, tool_name),
+            price_type,
+            at=at,
+            tenant_id=tenant_id,
+        )
+
+    if not version:
+        if client_cost is None:
+            # Nothing priced it and the client asserted nothing: do not invent a number.
+            out.pop(GenAI.COST_ESTIMATED_MICRO_USD, None)
+            out.pop(GenAI.COST_PRICE_CATALOG_VERSION, None)
+            return EnrichmentResult(out, None, None, None, False, catalog_miss=True)
+        # Client-reported spend survives. The catalog version the SDK stamped (if any) rides along
+        # untouched so the number keeps its provenance.
+        out[GenAI.COST_ESTIMATED_MICRO_USD] = client_cost
+        out[GenAI.COST_CURRENCY] = out.get(GenAI.COST_CURRENCY, "USD")
+        return EnrichmentResult(out, None, client_cost, None, False, catalog_miss=True)
+
     out[GenAI.COST_ESTIMATED_MICRO_USD] = server_cost
     out[GenAI.COST_CURRENCY] = out.get(GenAI.COST_CURRENCY, "USD")
     out[GenAI.COST_PRICE_CATALOG_VERSION] = version

--- a/sdk/python/tests/test_enrichment.py
+++ b/sdk/python/tests/test_enrichment.py
@@ -83,3 +83,81 @@ def test_original_not_mutated():
     before = dict(span)
     enrich_cost(span, seed_catalog(), at=AT)
     assert span == before  # enrich returns a copy
+
+
+# --- per-call layers: tools and vector (CTO-243) ------------------------------------------------
+#
+# The SDK carries these costs on gen_ai.tool.cost_micro_usd. Nothing promoted that into the
+# canonical cost attribute, so the tools and vector layers reported zero spend.
+
+
+def _tool_span(client_cost=10_000, provider="tavily", tool="search"):
+    return build_span_attributes(
+        SpanFields(
+            system=provider,
+            operation="tool",
+            tool_name=tool,
+            tool_call_id="call-1",
+            tool_cost_micro_usd=client_cost,
+        )
+    )
+
+
+def _vector_span(client_cost=400, provider="pinecone", index="docs", operation="query"):
+    return build_span_attributes(
+        SpanFields(
+            system=provider,
+            operation="vector",
+            tool_name=f"{provider}.{index}.{operation}",
+            tool_cost_micro_usd=client_cost,
+        )
+    )
+
+
+def test_tool_cost_is_promoted_to_the_canonical_cost_key():
+    res = enrich_cost(_tool_span(), seed_catalog(), at=AT)
+    assert res.attributes[GenAI.COST_ESTIMATED_MICRO_USD] == 10_000  # tavily search, 0.01 USD
+    assert res.attributes[GenAI.COST_PRICE_CATALOG_VERSION] == "seed-2026-06-15"
+    assert res.catalog_miss is False
+
+
+def test_vector_cost_is_priced_off_the_operation_segment():
+    res = enrich_cost(_vector_span(), seed_catalog(), at=AT)
+    assert res.attributes[GenAI.COST_ESTIMATED_MICRO_USD] == 400  # pinecone query, 0.0004 USD
+    assert res.attributes[GenAI.COST_PRICE_CATALOG_VERSION] == "seed-2026-06-15"
+
+
+def test_vector_index_name_containing_dots_still_prices():
+    res = enrich_cost(_vector_span(index="docs.v2"), seed_catalog(), at=AT)
+    assert res.attributes[GenAI.COST_ESTIMATED_MICRO_USD] == 400
+
+
+def test_call_cost_server_catalog_wins_and_drift_is_flagged():
+    res = enrich_cost(_tool_span(client_cost=1), seed_catalog(), at=AT)
+    assert res.server_cost_micro_usd == 10_000
+    assert res.client_cost_micro_usd == 1
+    assert res.drift_exceeded is True
+
+
+def test_call_cost_survives_a_catalog_miss():
+    # A negotiated per-call rate the catalog has no entry for is kept, not discarded as zero.
+    res = enrich_cost(_tool_span(provider="acme-internal", tool="lookup"), seed_catalog(), at=AT)
+    assert res.catalog_miss is True
+    assert res.attributes[GenAI.COST_ESTIMATED_MICRO_USD] == 10_000
+    assert res.server_cost_micro_usd is None
+    assert GenAI.COST_PRICE_CATALOG_VERSION not in res.attributes
+
+
+def test_unpriced_call_asserts_no_cost():
+    span = _tool_span(client_cost=None, provider="acme-internal", tool="lookup")
+    res = enrich_cost(span, seed_catalog(), at=AT)
+    assert res.catalog_miss is True
+    assert GenAI.COST_ESTIMATED_MICRO_USD not in res.attributes
+    assert res.client_cost_micro_usd is None
+
+
+def test_call_cost_original_not_mutated():
+    span = _tool_span()
+    before = dict(span)
+    enrich_cost(span, seed_catalog(), at=AT)
+    assert span == before


### PR DESCRIPTION
## The bug: an entire cost layer reads $0

The SDK's `record_tool_call` and `record_vector_call` put per-call spend on the carrier attribute
`gen_ai.tool.cost_micro_usd`. `record_vector_call`'s docstring stated that "the gateway promotes it
into the layer's spend". Nothing did.

`tally.enrichment.enrich_cost` is the only place the ingest path resolves cost, and it priced token
usage only. Tool and vector spans carry no model, so they hit the `nothing to price against` early
return, `gen_ai.cost.estimated_micro_usd` was never set, and `gateway.mapping.span_to_row` wrote
`EstimatedCost` as `Decimal(0)`. The carrier value survived only as a stringified entry in the
`SpanAttributes` map, which nothing reads.

Measured on the local stack:

| operation | rows with EstimatedCost = 0 | spend carried on `gen_ai.tool.cost_micro_usd` |
| --- | --- | --- |
| tool | 28,586 | $93.11 |

Top invisible pairs: `openai/updateDocument` $21.88, `openai/createDocument` $21.23,
`anthropic/createDocument` $14.62, `anthropic/updateDocument` $13.99, `openai/requestSuggestions`
$8.48, `anthropic/requestSuggestions` $5.82, `openai/getWeather` $4.24, `anthropic/getWeather` $2.85.

For real customers this means tool and vector spend is silently reported as zero.

## The fix, and why this side

Fixed in the gateway's enrichment, not by changing what the SDK emits.

`enrich_cost` now branches on `gen_ai.operation.name`: `tool` and `vector` are priced per call from
the same versioned catalog (`PriceType.TOOL_CALL` / `PriceType.VECTOR_CALL`) and the result is
written to `gen_ai.cost.estimated_micro_usd`, the same canonical attribute LLM spans use. No second
cost field, and the row mapper is untouched.

Why not have the SDK write `gen_ai.cost.estimated_micro_usd` directly:

- The gateway, not the client, is the authority on cost. That is the whole premise of the
  enrichment module, and the LLM path already works this way (client value is a drift hint,
  server catalog wins). Promoting in the SDK would make the client the source of truth for two of
  the layers and the gateway for the rest.
- `gen_ai.tool.cost_micro_usd` is a carrier for a client-side hint, exactly like the LLM client
  cost. Keeping it as a carrier and promoting in one place preserves a single source of truth.
- `gen_ai.tool.name` and `gen_ai.tool.cost_micro_usd` are already on the wire from shipped SDKs and
  the TypeScript example emitter; fixing the gateway repairs spans from every existing client with
  no SDK upgrade.

Vector spans encode `{provider}.{index}.{operation}` in the tool-name slot while the catalog prices
`(provider, operation)`, so the gateway prices off the last dot-segment. An index name containing
dots still resolves.

One deliberate divergence from the LLM path, at the catalog miss. Per-call rates are frequently
negotiated prices the catalog cannot know (every pair in the table above is a catalog miss), so a
client-reported figure is kept rather than discarded, with no catalog version claimed for it since
none priced it. Discarding it is precisely what made the spend invisible. With neither a catalog
entry nor a client figure there is nothing honest to assert, so the cost key is dropped exactly as
on the LLM path.

Docstrings on `record_tool_call` and `record_vector_call` now describe what the code actually does.

## Honest-under-uncertainty and the interaction with #297

This branch does not depend on nullable cost. On this base, an absent cost key still becomes
`Decimal(0)` in `span_to_row`, and that is unchanged here: enrichment simply asserts nothing when
nothing priced the call. Two notes for whoever lands both:

- `#297` makes `EstimatedCost` nullable and adds `CostSource='unpriced'`. The unpriced tool/vector
  case here (no catalog entry, no client figure) is exactly a case that should become NULL/`unpriced`
  once that lands, and it will do so with no change to this branch: it already leaves the cost key
  absent, which is the signal `#297` keys on.
- The SDK still coerces an unresolved tool/vector cost to `0` before emitting (a pre-existing
  behaviour with a one-time WARN, asserted by existing tests). That is out of scope here and is not
  made worse, but it does mean the gateway can receive a client-reported `0` that is really an
  unknown. It should become `None` when nullable cost lands, so the distinction reaches the row.
- `CostSource` is left as `estimated`. Recording provenance for a client-reported figure would need
  a new value in the ClickHouse `Enum8`, which belongs with `#297`'s `unpriced` migration, not here.

## Tests

`infra/gateway/tests/test_tool_vector_cost.py` drives the real ingest path (`POST /v1/batches` into
a fake ClickHouse store) and asserts the row that is actually written:

- regression for the reported symptom: a recorded tool call no longer reads $0
- a vector span lands with its cost, priced off the operation segment
- a client-reported cost survives a catalog miss
- an unpriced span gets no fabricated cost beyond the base branch's column default
- LLM span costing is unchanged

`sdk/python/tests/test_enrichment.py` adds unit coverage for promotion, the operation-segment
lookup (including an index name with dots), server-wins drift, the catalog-miss fallback, the
no-cost case, and non-mutation of the input.

## Verification

- `cd infra/gateway && uv run --extra dev pytest -q` — 904 passed; `ruff check .` clean
- `cd sdk/python && uv run --extra dev pytest -q` — all passed; `ruff check .` clean
- Confirmed the new gateway tests fail on the unfixed enrichment module (3 of 5 fail), so they
  reproduce the bug rather than merely describing it.
- Before/after on real data: a real zero-cost row (`openai`/`updateDocument`, carrier `5000`) was
  replayed through the fixed `enrich_cost` + `span_to_row` and lands `EstimatedCost 0.00500000`
  instead of `0`. A `pinecone.docs.query` span lands `0.00040000` with `PriceCatalogVersion
  seed-2026-06-15`.

Not verified: no rows were rewritten and the shared composed gateway was not rebuilt or restarted,
so the 28,586 existing rows still read $0 in the dashboard until they are re-ingested or backfilled.
The demonstration above is the real row's attributes replayed through the fixed code path, not a
live write. A backfill for historical rows is not included here.

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
