### PR TITLE
fix(demo): drop the dual-carrier workaround from the backfill generator

### DIFF
--- a/examples/vercel-chatbot/scripts/backfill-spans.ts
+++ b/examples/vercel-chatbot/scripts/backfill-spans.ts
@@ -576,13 +576,13 @@ function toolSpan(
     "gen_ai.system": tool.provider,
     "gen_ai.operation.name": "tool",
     "gen_ai.tool.name": tool.name,
-    // Two carriers on purpose. `gen_ai.tool.cost_micro_usd` is what the SDK's record_tool_call
-    // emits, so keeping it makes this corpus wire-identical to a real tool span; but only
-    // `gen_ai.cost.estimated_micro_usd` reaches the EstimatedCost column (gateway.mapping), and a
-    // tool span carries no model, so cost enrichment leaves the client value in place rather than
-    // overwriting it. Without the second key the Tools layer bar is a fabricated $0.
+    // One carrier, the same one the SDK's record_tool_call emits, so this corpus is wire-identical
+    // to a real tool span and exercises the gateway's promotion rather than bypassing it (CTO-243).
+    // This previously also set `gen_ai.cost.estimated_micro_usd` directly, because nothing promoted
+    // the tool carrier and the Tools layer bar read a fabricated $0. Now that enrich_cost prices
+    // tool and vector calls, writing the cost column here would mask a regression in that promotion:
+    // the corpus would look correct even if the gateway stopped resolving these costs.
     "gen_ai.tool.cost_micro_usd": micro,
-    "gen_ai.cost.estimated_micro_usd": micro,
     "gen_ai.cost.currency": "USD",
   };
 }
@@ -599,10 +599,11 @@ function vectorSpan(
     SpanName: "vector.query",
     "gen_ai.system": v.provider,
     "gen_ai.operation.name": "vector",
-    // Same {provider}.{index}.{operation} slot the SDK's record_vector_call uses.
+    // Same {provider}.{index}.{operation} slot the SDK's record_vector_call uses. The gateway
+    // prices off the last dot-segment, so an index name containing dots still resolves.
     "gen_ai.tool.name": `${v.provider}.${v.index}.${v.op}`,
+    // Single carrier, for the reason spelled out in toolSpan above (CTO-243).
     "gen_ai.tool.cost_micro_usd": micro,
-    "gen_ai.cost.estimated_micro_usd": micro,
     "gen_ai.cost.currency": "USD",
   };
 }


### PR DESCRIPTION
## Why

`toolSpan` / `vectorSpan` wrote the per-call cost to **two** keys: `gen_ai.tool.cost_micro_usd` (what the SDK's `record_tool_call` / `record_vector_call` actually emit) and `gen_ai.cost.estimated_micro_usd` (the key `mapping.span_to_row` reads for `EstimatedCost`).

The second write was a workaround for the wire-contract gap: nothing promoted the tool carrier, so a real tool span landed `EstimatedCost = 0` and the Tools layer bar read a fabricated `$0`.

That gap is fixed by the gateway-side promotion (`enrich_cost` now prices `tool` / `vector` per call and resolves onto the canonical cost key). So the workaround is no longer redundant, it is **actively harmful**: with both carriers set, this corpus looks correct even if the gateway stops promoting the tool cost. Silently masking that regression is the opposite of what a test corpus is for, and this generator is the thing best placed to catch it.

## What changed

Both builders now emit only `gen_ai.tool.cost_micro_usd`, making the corpus wire-identical to a real SDK-instrumented span and exercising the promotion path rather than bypassing it. Comments updated to record why the second carrier is deliberately absent, so it does not get "helpfully" restored later.

## Merge order matters

⚠️ This depends on the gateway-side promotion. **Land that first.** If this merges without it, the Tools and Vector layer bars go back to reading `$0`.

The two are siblings off the same base rather than stacked, which is why this is a separate PR rather than part of either.

## Verification

Type-strips and parses clean. Not exercised against a live stack here: proving it end to end needs the gateway-side promotion present, which is a different branch. That check belongs in the integration pass, where the corpus should show non-zero Tools and Vector layer totals with only the single carrier set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)