### PR TITLE
fix(edge-proxy): meter under the default self-host config, retry ingest backpressure

### DIFF
--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -59,6 +59,7 @@ These are enforced by tests, not just documented:
 | `EDGE_PROXY_SELF_HOSTED` | `false` | label emitted telemetry as `self-host` vs `cloud` |
 | `EDGE_PROXY_TELEMETRY_URL` | — | gateway ingest endpoint (`https://gateway/v1/batches`) the proxy POSTs metadata-only spans to; empty disables shipping |
 | `EDGE_PROXY_INGEST_TOKEN` | — | **fallback** bearer for those POSTs, used for every record whose `X-Tenant-Key` the edge-key cache did not resolve; normally a resolved `X-Tenant-Key` authenticates. Set it on any self-host without `EDGE_PROXY_KEYS_URL`, or telemetry is shed |
+| `EDGE_PROXY_TENANT_ID` | — | your tenant **UUID**, claimed in the batch envelope for every record the edge-key cache did not resolve. **Required when the gateway runs with auth disabled** (`TALLY_REQUIRE_API_KEY=false`), which cannot derive a tenant from the credential and refuses a batch claiming none with `422`. A tenant name is rejected at startup |
 | `EDGE_PROXY_ROUTES` | — | hosted multi-provider route table (see below); empty keeps single-origin `EDGE_PROXY_UPSTREAM` |
 | `EDGE_PROXY_ROUTE_MODE` | `host` | `host` (match on hostname, hosted default) or `path` (match+strip a leading prefix) |
 | `EDGE_PROXY_KEYS_URL` | — | gateway delta feed `GET /v1/edge/keys?since={cursor}` for key-to-tenant resolution; empty disables it |
@@ -232,6 +233,28 @@ credential, so it never becomes an outgoing bearer: `EDGE_PROXY_INGEST_TOKEN` is
 neither available the record is shed and counted (`HTTPSink.Unauthenticated()`) rather than posted
 unattributable. The key travels on the header only; it is never a field in the body and never
 logged.
+
+**Who the batch says it belongs to.** The envelope's `tenant_id` is the UUID the edge-key cache
+resolved. A gateway running with auth **on** ignores an empty claim, because the authenticating key
+decides the tenant. A gateway running with auth **off** (`TALLY_REQUIRE_API_KEY=false`, the
+`make up` default) has nothing to derive a tenant from and answers `422 tenant_id required when
+auth is disabled`, so a self-host with no key feed used to meter absolutely nothing while looking
+healthy. Set `EDGE_PROXY_TENANT_ID` to your tenant UUID and it is claimed for every unresolved
+record, the same records `EDGE_PROXY_INGEST_TOKEN` authenticates: the credential and the tenant are
+one operator-scoped pair. A record the cache *did* resolve always keeps its own tenant. Nothing is
+ever invented: unset means the envelope honestly claims no tenant, and a value that is not a UUID
+fails at startup rather than writing a claim that joins to nothing. If ingest answers `422` to a
+batch that claimed no tenant, the sink says so once, in full, naming the variable to set.
+
+**Backpressure does not cost you spend.** A retryable ingest failure (a network error, `429`, or a
+`5xx`) is resent, byte for byte so the stable `batch_id` makes the resend idempotent, with capped
+exponential backoff and jitter up to a small attempt cap (`RetryPolicy`, mirroring the SDK's
+`BatchingTransport`). A non-retryable `4xx` (validation, credential, scope, protocol) is never
+resent: identical bytes cannot change a deterministic answer. Past the cap the record is shed and
+counted (`HTTPSink.Undelivered()`), which keeps the terminal behavior bounded in both time and
+memory: the buffer is fixed-size, the retry budget is fixed, `Record` never blocks the proxied
+request, and shutdown abandons what it cannot ship inside a short drain grace rather than holding
+the process open on a dead gateway.
 
 **Failure is never silent.** A config that can authenticate nothing (`EDGE_PROXY_TELEMETRY_URL` set,
 no `EDGE_PROXY_INGEST_TOKEN`, no `EDGE_PROXY_KEYS_URL`) is warned about at startup rather than

--- a/infra/edge-proxy/cmd/edge-proxy/main.go
+++ b/infra/edge-proxy/cmd/edge-proxy/main.go
@@ -66,13 +66,24 @@ func main() {
 			URL:         cfg.TelemetryURL,
 			Deployment:  dep,
 			IngestToken: cfg.IngestToken,
+			// The envelope tenant for records the edge-key cache did not resolve. Without it a
+			// gateway running with auth disabled has no tenant to attribute the batch to and refuses
+			// every one of them.
+			TenantId: cfg.TenantId,
 			// Shed records are the only evidence of a telemetry pipeline that is failing without
 			// erroring (no credential, every span rejected per item). Report them on a cadence so the
 			// operator finds out from the proxy's own log instead of from a missing dashboard.
 			ReportInterval: telemetryReportInterval,
 		})
 		opts = append(opts, proxy.WithSink(sink))
-		log.Printf("edge-proxy: telemetry -> %s (deployment=%s)", cfg.TelemetryURL, dep)
+		// The tenant claim is logged because it decides where proxied spend lands and it is a UUID,
+		// not a secret. "unresolved-only" is not a fallback: it means the envelope claims no tenant.
+		tenantClaim := cfg.TenantId
+		if tenantClaim == "" {
+			tenantClaim = "none (the ingest credential's tenant decides)"
+		}
+		log.Printf("edge-proxy: telemetry -> %s (deployment=%s, fallback tenant=%s)",
+			cfg.TelemetryURL, dep, tenantClaim)
 	}
 
 	// Provider-protocol mode (CTO-167): the proxy reads scalar model/usage metadata off responses.

--- a/infra/edge-proxy/deploy/helm/edge-proxy/templates/configmap.yaml
+++ b/infra/edge-proxy/deploy/helm/edge-proxy/templates/configmap.yaml
@@ -15,6 +15,9 @@ data:
   EDGE_PROXY_BROKER_TTL: {{ .Values.proxy.brokerTTL | quote }}
   EDGE_PROXY_SELF_HOSTED: {{ .Values.proxy.selfHosted | quote }}
   EDGE_PROXY_TELEMETRY_URL: {{ .Values.proxy.telemetryURL | quote }}
+  {{- if .Values.proxy.tenantId }}
+  EDGE_PROXY_TENANT_ID: {{ .Values.proxy.tenantId | quote }}
+  {{- end }}
   {{- if eq .Values.proxy.mode "broker" }}
   EDGE_PROXY_BROKER_FILE: "{{ .Values.broker.mountPath }}/{{ .Values.broker.secretKey }}"
   {{- end }}

--- a/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
+++ b/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
@@ -52,6 +52,14 @@ proxy:
   # secret, so set it on the Deployment from your own Secret rather than through this ConfigMap.
   telemetryURL: ""
 
+  # Your tenant UUID, claimed in the batch envelope for every record the edge-key cache did not
+  # resolve. Required when the gateway you ship to runs with auth disabled (TALLY_REQUIRE_API_KEY
+  # false, the self-hosted default): it cannot derive a tenant from the credential, so it refuses a
+  # batch that claims none with 422 and nothing is recorded. Leave empty against a gateway with auth
+  # on, where the ingest credential's own tenant decides. It must be the UUID, not the tenant name;
+  # a name is rejected at startup. Not a secret, so the ConfigMap is the right place for it.
+  tenantId: ""
+
 # --- key broker (broker mode only) -------------------------------------------------------------
 broker:
   # The KMS-export mapping tenant key -> provider Authorization header. Two ways to supply it:

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -140,6 +140,18 @@ type Config struct {
 	// instead and Warnings() says so at startup when it is missing. It is a reference
 	// to a deployment secret (env var rendered from Secret Manager / KMS), never a key we mint.
 	IngestToken string
+	// TenantId is the operator's own tenant UUID, claimed in the batch envelope for every record the
+	// edge-key cache did not resolve (the records IngestToken authenticates). It exists because the
+	// gateway derives the tenant from the bearer key only when it runs with auth ON; with
+	// TALLY_REQUIRE_API_KEY=false (the `make up` default) it has no way to derive one and rejects a
+	// batch carrying an empty tenant_id with 422, so a default self-host meters nothing.
+	//
+	// It is operator-supplied, never inferred or invented: unset stays empty and the envelope claims
+	// no tenant, which is the honest state. It is validated as a UUID at boot because the canonical
+	// TenantId is the tenant UUID, so feeding in a tenant NAME (`local-dev`) would write a value that
+	// joins to nothing. A wrong UUID is not a cross-tenant write either: with auth on the gateway
+	// enforces TENANT_MISMATCH against the authenticating key's tenant and refuses the batch.
+	TenantId string
 
 	// --- Hosted multi-provider routing (Initiative 2 sec 6.1) ---
 
@@ -232,6 +244,18 @@ func FromEnv(lookup Env) (Config, error) {
 	// Forwarding joins onto the upstream path, so a trailing slash would double up ("//v1").
 	u.Path = strings.TrimRight(u.Path, "/")
 	cfg.Upstream = u
+
+	// The envelope tenant claim is refused rather than coerced when it is not a UUID: a name here
+	// would be silently useless downstream, and telemetry that looks configured but joins to nothing
+	// is worse than telemetry that refuses to start.
+	if v := strings.TrimSpace(lookup("EDGE_PROXY_TENANT_ID")); v != "" {
+		if !isUUID(v) {
+			return Config{}, fmt.Errorf(
+				"EDGE_PROXY_TENANT_ID %q is not a tenant UUID (the canonical TenantId is the UUID, "+
+					"not the tenant name)", v)
+		}
+		cfg.TenantId = strings.ToLower(v)
+	}
 
 	if v := lookup("EDGE_PROXY_REQUIRE_TENANT"); v != "" {
 		b, err := strconv.ParseBool(v)
@@ -335,21 +359,38 @@ func FromEnv(lookup Env) (Config, error) {
 // EDGE_PROXY_INGEST_TOKEN, RequireTenant off, no edge-key feed) ships exactly zero telemetry, since
 // no record can produce a credential, while startup still logs a cheerful "telemetry -> <url>". A
 // total, permanent failure must not be silent.
+//
+// The sibling hole (an empty envelope tenant_id, which a gateway running with auth disabled refuses
+// with 422) is deliberately NOT warned about from here for the configs where it is ambiguous: an
+// empty claim is correct against a gateway with auth on, so warning about it unconditionally would
+// fire on a healthy hosted deployment and teach operators to ignore these lines. What config CAN
+// say for certain is warned below; the case only the gateway's answer settles is escalated at
+// runtime by the telemetry sink, which sees the actual 422 and names EDGE_PROXY_TENANT_ID.
 func (c Config) Warnings() []string {
 	var out []string
-	if c.TelemetryURL == "" || c.IngestToken != "" {
+	if c.TelemetryURL == "" {
 		return out
 	}
-	// Only a key the edge-key cache resolved is used as a bearer, so with no feed configured no
-	// record can ever authenticate itself and the ingest token is the only possible credential.
-	if c.KeysURL == "" {
-		out = append(out, "EDGE_PROXY_TELEMETRY_URL is set but EDGE_PROXY_INGEST_TOKEN is empty and "+
-			"EDGE_PROXY_KEYS_URL is unset: no record can be authenticated, so every span will be shed "+
-			"and NO telemetry will reach ingest")
-	} else if !c.RequireTenant {
-		out = append(out, "EDGE_PROXY_TELEMETRY_URL is set but EDGE_PROXY_INGEST_TOKEN is empty and "+
-			"EDGE_PROXY_REQUIRE_TENANT is off: telemetry for any request that arrives without a "+
-			"resolvable tenant key will be shed unauthenticated")
+	if c.IngestToken == "" {
+		// Only a key the edge-key cache resolved is used as a bearer, so with no feed configured no
+		// record can ever authenticate itself and the ingest token is the only possible credential.
+		if c.KeysURL == "" {
+			out = append(out, "EDGE_PROXY_TELEMETRY_URL is set but EDGE_PROXY_INGEST_TOKEN is empty and "+
+				"EDGE_PROXY_KEYS_URL is unset: no record can be authenticated, so every span will be shed "+
+				"and NO telemetry will reach ingest")
+		} else if !c.RequireTenant {
+			out = append(out, "EDGE_PROXY_TELEMETRY_URL is set but EDGE_PROXY_INGEST_TOKEN is empty and "+
+				"EDGE_PROXY_REQUIRE_TENANT is off: telemetry for any request that arrives without a "+
+				"resolvable tenant key will be shed unauthenticated")
+		}
+		// The configured tenant is claimed only on batches the ingest token authenticates (an
+		// unresolved record has no other credential), so without that token it is dead configuration
+		// and the operator is not getting the attribution they think they set up.
+		if c.TenantId != "" {
+			out = append(out, "EDGE_PROXY_TENANT_ID is set but EDGE_PROXY_INGEST_TOKEN is empty: the "+
+				"configured tenant is only claimed on batches the ingest token authenticates, so it "+
+				"will never be sent")
+		}
 	}
 	return out
 }
@@ -458,6 +499,29 @@ func buildRoute(match, rawUpstream string, prov Provider, mode RouteMode) (Route
 	}
 	u.Path = strings.TrimRight(u.Path, "/")
 	return Route{Match: match, Upstream: u, Provider: prov}, nil
+}
+
+// isUUID reports whether s is the canonical 8-4-4-4-12 hex form. Written out rather than pulled in
+// as a dependency: the proxy has no third-party modules and this is the whole of the check we need
+// (we validate the shape so a tenant NAME cannot slip through, not the version or variant bits).
+func isUUID(s string) bool {
+	groups := strings.Split(s, "-")
+	want := []int{8, 4, 4, 4, 12}
+	if len(groups) != len(want) {
+		return false
+	}
+	for i, g := range groups {
+		if len(g) != want[i] {
+			return false
+		}
+		for _, c := range g {
+			isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+			if !isHex {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/infra/edge-proxy/internal/config/tenant_id_test.go
+++ b/infra/edge-proxy/internal/config/tenant_id_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for EDGE_PROXY_TENANT_ID, the envelope tenant claim that lets the default self-hosted
+// config (a gateway running with auth disabled) actually record spend instead of having every
+// batch refused with 422.
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTenantIdDefaultsToEmpty(t *testing.T) {
+	cfg, err := FromEnv(envMap(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TenantId != "" {
+		t.Fatalf("TenantId = %q, want empty: an unconfigured tenant is unknown, never invented", cfg.TenantId)
+	}
+}
+
+func TestTenantIdAcceptsUUID(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_TELEMETRY_URL": "http://gateway:8080/v1/batches",
+		"EDGE_PROXY_INGEST_TOKEN":  "svc_token",
+		"EDGE_PROXY_TENANT_ID":     " 7F1C3A2E-0000-4000-8000-000000000001 ",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Lowercased and trimmed so the claim matches the gateway's own rendering of the UUID.
+	if cfg.TenantId != "7f1c3a2e-0000-4000-8000-000000000001" {
+		t.Fatalf("TenantId = %q, want the trimmed lowercase UUID", cfg.TenantId)
+	}
+	if got := cfg.Warnings(); len(got) != 0 {
+		t.Fatalf("unexpected warnings on a fully configured self-host: %v", got)
+	}
+}
+
+// TestTenantIdRejectsNonUUID: the canonical TenantId is the tenant UUID. A tenant NAME here would
+// parse fine and then join to nothing downstream, so it fails loudly at boot rather than quietly
+// metering into a bucket nobody reads.
+func TestTenantIdRejectsNonUUID(t *testing.T) {
+	for _, bad := range []string{
+		"local-dev",
+		"7f1c3a2e00004000800000000000001",
+		"7f1c3a2e-0000-4000-8000-00000000000g",
+		"7f1c3a2e-0000-4000-8000",
+	} {
+		_, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_TENANT_ID": bad}))
+		if err == nil {
+			t.Fatalf("EDGE_PROXY_TENANT_ID %q was accepted, want a boot failure", bad)
+		}
+		if !strings.Contains(err.Error(), "EDGE_PROXY_TENANT_ID") {
+			t.Fatalf("error for %q does not name the offending var: %v", bad, err)
+		}
+	}
+}
+
+// TestWarnsWhenTenantIdCannotBeUsed: the configured tenant only ever rides on a batch the ingest
+// token authenticates. Without that token it is dead configuration, and an operator who set it
+// believes their telemetry is attributed when none of it is even sent.
+func TestWarnsWhenTenantIdCannotBeUsed(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_TELEMETRY_URL": "http://gateway:8080/v1/batches",
+		"EDGE_PROXY_KEYS_URL":      "https://gw.example.com/v1/edge/keys",
+		"EDGE_PROXY_SERVICE_TOKEN": "svc",
+		"EDGE_PROXY_TENANT_ID":     "7f1c3a2e-0000-4000-8000-000000000001",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var found bool
+	for _, w := range cfg.Warnings() {
+		if strings.Contains(w, "EDGE_PROXY_TENANT_ID") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want a warning that the configured tenant can never be sent, got %v", cfg.Warnings())
+	}
+}
+
+// TestDefaultSelfHostShapeStillWarnsLoudly: the shape the integration run used (telemetry on, no
+// credential, no key feed) must keep failing loudly rather than being masked by the new knob.
+func TestDefaultSelfHostShapeStillWarnsLoudly(t *testing.T) {
+	cfg, err := FromEnv(envMap(map[string]string{
+		"EDGE_PROXY_TELEMETRY_URL": "http://gateway:8080/v1/batches",
+		"EDGE_PROXY_TENANT_ID":     "7f1c3a2e-0000-4000-8000-000000000001",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	warnings := strings.Join(cfg.Warnings(), " | ")
+	if !strings.Contains(warnings, "NO telemetry") {
+		t.Fatalf("want the loud no-credential warning, got %q", warnings)
+	}
+}

--- a/infra/edge-proxy/internal/telemetry/resilience_test.go
+++ b/infra/edge-proxy/internal/telemetry/resilience_test.go
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for the two telemetry holes an end-to-end integration run surfaced: an envelope that
+// claimed no tenant (so a gateway with auth disabled refused every batch), and a sink that threw a
+// record away on the first sign of gateway backpressure.
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- Bug 1: the default self-hosted config shipped an empty tenant_id ---------------------------
+
+// tenantOf pulls the envelope's tenant claim out of an encoded batch.
+func tenantOf(t *testing.T, body []byte) string {
+	t.Helper()
+	var batch map[string]any
+	if err := json.Unmarshal(body, &batch); err != nil {
+		t.Fatalf("bad batch json: %v", err)
+	}
+	v, ok := batch["tenant_id"].(string)
+	if !ok {
+		t.Fatalf("tenant_id missing or not a string: %v", batch["tenant_id"])
+	}
+	return v
+}
+
+// captureCollector records the last body it received and answers 200.
+func captureCollector(body *[]byte, mu *sync.Mutex) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		*body = b
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// TestEnvelopeClaimsConfiguredTenantWhenUnresolved is the fix for the default self-host path: with
+// no edge-key feed the record resolves no tenant, and a gateway running with auth disabled needs an
+// explicit one in the envelope or it refuses the batch with 422.
+func TestEnvelopeClaimsConfiguredTenantWhenUnresolved(t *testing.T) {
+	const operatorTenant = "9d4b2c11-0000-4000-8000-0000000000aa"
+	var (
+		mu   sync.Mutex
+		body []byte
+	)
+	srv := captureCollector(&body, &mu)
+	defer srv.Close()
+
+	rec := sampleRecord()
+	rec.TenantKey = "" // no edge-key feed: nothing resolved
+	rec.TenantId = ""
+	sink := NewHTTPSink(Options{
+		URL:         srv.URL,
+		Deployment:  DeploymentSelfHost,
+		IngestToken: "svc_token",
+		TenantId:    operatorTenant,
+	})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := tenantOf(t, body); got != operatorTenant {
+		t.Fatalf("tenant_id = %q, want the configured tenant %q", got, operatorTenant)
+	}
+}
+
+// TestResolvedTenantWinsOverConfiguredOne: the configured tenant is a fallback for unresolved
+// records only. A record the edge-key cache resolved keeps its own tenant, or a hosted
+// multi-tenant proxy would file one org's spend under the operator's.
+func TestResolvedTenantWinsOverConfiguredOne(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		body []byte
+	)
+	srv := captureCollector(&body, &mu)
+	defer srv.Close()
+
+	rec := sampleRecord() // carries a resolved TenantId
+	sink := NewHTTPSink(Options{
+		URL:        srv.URL,
+		Deployment: DeploymentCloud,
+		TenantId:   "9d4b2c11-0000-4000-8000-0000000000aa",
+	})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := tenantOf(t, body); got != rec.TenantId {
+		t.Fatalf("tenant_id = %q, want the record's resolved tenant %q", got, rec.TenantId)
+	}
+}
+
+// TestNoTenantIsNeverFabricated: with nothing configured and nothing resolved the envelope claims
+// no tenant. A placeholder would be worse than none, since a wrong tenant silently files spend into
+// the wrong account instead of failing visibly.
+func TestNoTenantIsNeverFabricated(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		body []byte
+	)
+	srv := captureCollector(&body, &mu)
+	defer srv.Close()
+
+	rec := sampleRecord()
+	rec.TenantKey = ""
+	rec.TenantId = ""
+	sink := NewHTTPSink(Options{URL: srv.URL, Deployment: DeploymentSelfHost, IngestToken: "svc_token"})
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := tenantOf(t, body); got != "" {
+		t.Fatalf("tenant_id = %q, want an empty claim rather than an invented one", got)
+	}
+}
+
+// TestEmptyTenant422IsEscalatedLoudly is the failure the integration run actually hit. The
+// gateway's 422 is the only place this misconfiguration is knowable, so the sink names the fix
+// rather than logging a bare status code, says it once, and counts the loss.
+func TestEmptyTenant422IsEscalatedLoudly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"tenant_id required when auth is disabled"}`))
+	}))
+	defer srv.Close()
+
+	var (
+		mu    sync.Mutex
+		lines []string
+	)
+	rec := sampleRecord()
+	rec.TenantKey = ""
+	rec.TenantId = ""
+	sink := NewHTTPSink(Options{
+		URL:         srv.URL,
+		Deployment:  DeploymentSelfHost,
+		IngestToken: "svc_token",
+		Logf: func(format string, args ...any) {
+			mu.Lock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		},
+	})
+	sink.Record(rec)
+	sink.Record(rec)
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	hints := 0
+	for _, l := range lines {
+		if strings.Contains(l, "EDGE_PROXY_TENANT_ID") {
+			hints++
+		}
+	}
+	if hints != 1 {
+		t.Fatalf("want exactly one actionable EDGE_PROXY_TENANT_ID hint, got %d in %v", hints, lines)
+	}
+	if got := sink.Rejected(); got != 2 {
+		t.Fatalf("Rejected() = %d, want 2 (the refusal must be counted, not swallowed)", got)
+	}
+}
+
+// TestNoTenantHintWhenTenantWasClaimed: a 422 on a batch that DID claim a tenant is a different
+// problem, and pointing at EDGE_PROXY_TENANT_ID would send the operator down a dead end.
+func TestNoTenantHintWhenTenantWasClaimed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	defer srv.Close()
+
+	var (
+		mu    sync.Mutex
+		lines []string
+	)
+	sink := NewHTTPSink(Options{
+		URL:        srv.URL,
+		Deployment: DeploymentCloud,
+		Logf: func(format string, args ...any) {
+			mu.Lock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		},
+	})
+	sink.Record(sampleRecord()) // resolved tenant, so the claim is non-empty
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, l := range lines {
+		if strings.Contains(l, "EDGE_PROXY_TENANT_ID") {
+			t.Fatalf("hinted at an empty tenant on a batch that claimed one: %v", lines)
+		}
+	}
+}
+
+// --- Bug 2: telemetry was dropped on the first sign of gateway backpressure ---------------------
+
+// fastRetry keeps the bounded-retry shape (attempt cap, growth, jitter) while making tests cheap.
+func fastRetry() *RetryPolicy {
+	return &RetryPolicy{
+		MaxAttempts: 3,
+		Base:        5 * time.Millisecond,
+		Max:         20 * time.Millisecond,
+		Jitter:      0.25,
+	}
+}
+
+// TestRetriesRetryableStatusesThenShedsAndCounts: a 429 and a 5xx are transient, so the same bytes
+// are resent up to the cap. Past the cap the record is shed and counted, never held forever and
+// never silently forgotten.
+func TestRetriesRetryableStatusesThenShedsAndCounts(t *testing.T) {
+	for name, status := range map[string]int{
+		"429 backpressure": http.StatusTooManyRequests,
+		"503 server fault": http.StatusServiceUnavailable,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var (
+				mu     sync.Mutex
+				bodies [][]byte
+			)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				mu.Lock()
+				bodies = append(bodies, b)
+				mu.Unlock()
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			policy := fastRetry()
+			sink := NewHTTPSink(Options{
+				URL:         srv.URL,
+				Deployment:  DeploymentCloud,
+				IngestToken: "svc_token",
+				Retry:       policy,
+				Logf:        func(string, ...any) {},
+			})
+			start := time.Now()
+			sink.Record(sampleRecord())
+			sink.Close()
+			elapsed := time.Since(start)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(bodies) != policy.MaxAttempts {
+				t.Fatalf("collector saw %d attempts, want the %d-attempt cap",
+					len(bodies), policy.MaxAttempts)
+			}
+			// Resent byte for byte: batch_id stays stable, so the gateway's (tenant_id, batch_id)
+			// idempotency key turns a retry into a replay rather than a duplicate span.
+			for i, b := range bodies[1:] {
+				if string(b) != string(bodies[0]) {
+					t.Fatalf("attempt %d resent a different body, breaking batch_id idempotency", i+2)
+				}
+			}
+			// Backoff, not a hot loop: two waits of at least Base each separate three attempts,
+			// discounted by the jitter floor.
+			minWait := time.Duration(float64(policy.Base)*(1-policy.Jitter)) * 2
+			if elapsed < minWait {
+				t.Fatalf("retried in %s, want at least %s of backoff", elapsed, minWait)
+			}
+			if got := sink.Undelivered(); got != 1 {
+				t.Fatalf("Undelivered() = %d, want 1 shed record after the budget was spent", got)
+			}
+			if got := sink.Dropped(); got != 0 {
+				t.Fatalf("Dropped() = %d, want 0 (the buffer was never full)", got)
+			}
+		})
+	}
+}
+
+// TestRetryStopsOnFirstSuccess: the budget exists for transient failures only, so a batch the
+// gateway accepts on the second attempt is not sent a third time and is not counted as loss.
+func TestRetryStopsOnFirstSuccess(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		hits int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		hits++
+		n := hits
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"accepted","accepted_spans":1}`))
+	}))
+	defer srv.Close()
+
+	sink := NewHTTPSink(Options{
+		URL:         srv.URL,
+		Deployment:  DeploymentCloud,
+		IngestToken: "svc_token",
+		Retry:       fastRetry(),
+		Logf:        func(string, ...any) {},
+	})
+	sink.Record(sampleRecord())
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 2 {
+		t.Fatalf("collector saw %d attempts, want 2 (retry once, then stop on success)", hits)
+	}
+	if got := sink.Undelivered(); got != 0 {
+		t.Fatalf("Undelivered() = %d, want 0 after a delivered batch", got)
+	}
+	if got := sink.Rejected(); got != 0 {
+		t.Fatalf("Rejected() = %d, want 0 after a fully accepted batch", got)
+	}
+}
+
+// TestNonRetryable4xxIsNotRetried: a validation refusal, a bad credential or a wrong scope is
+// deterministic. Resending identical bytes cannot change the answer, so it stays a single attempt.
+func TestNonRetryable4xxIsNotRetried(t *testing.T) {
+	for name, status := range map[string]int{
+		"422 validation":     http.StatusUnprocessableEntity,
+		"401 bad credential": http.StatusUnauthorized,
+		"403 wrong scope":    http.StatusForbidden,
+		"400 bad protocol":   http.StatusBadRequest,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var (
+				mu   sync.Mutex
+				hits int
+			)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				hits++
+				mu.Unlock()
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			sink := NewHTTPSink(Options{
+				URL:         srv.URL,
+				Deployment:  DeploymentCloud,
+				IngestToken: "svc_token",
+				Retry:       fastRetry(),
+				Logf:        func(string, ...any) {},
+			})
+			sink.Record(sampleRecord())
+			sink.Close()
+
+			mu.Lock()
+			defer mu.Unlock()
+			if hits != 1 {
+				t.Fatalf("collector saw %d attempts for %d, want exactly 1", hits, status)
+			}
+			if got := sink.Undelivered(); got != 0 {
+				t.Fatalf("Undelivered() = %d, want 0: a refused batch is rejected, not undelivered", got)
+			}
+		})
+	}
+}
+
+// TestRetriesTransportFailure: a connection that never reached the gateway is the most retryable
+// failure there is, and before this change it was logged and forgotten without even a counter.
+func TestRetriesTransportFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
+	sink := NewHTTPSink(Options{
+		URL:         url,
+		Deployment:  DeploymentCloud,
+		IngestToken: "svc_token",
+		Retry:       fastRetry(),
+		Logf:        func(string, ...any) {},
+	})
+	sink.Record(sampleRecord())
+	sink.Close()
+
+	if got := sink.Undelivered(); got != 1 {
+		t.Fatalf("Undelivered() = %d, want 1 after an unreachable collector", got)
+	}
+}
+
+// TestRetryAfterIsHonoredButCapped: the gateway asks for a pause on a 429. We honor it, but a
+// server asking for minutes must not stall the worker, so it is clamped to the policy's Max.
+func TestRetryAfterIsHonoredButCapped(t *testing.T) {
+	p := RetryPolicy{MaxAttempts: 2, Base: time.Millisecond, Max: 50 * time.Millisecond, Jitter: 0}
+	if got := p.delay(1, 300*time.Second); got != p.Max {
+		t.Fatalf("delay with a 5 minute Retry-After = %s, want the %s cap", got, p.Max)
+	}
+	if got := p.delay(1, 20*time.Millisecond); got != 20*time.Millisecond {
+		t.Fatalf("delay = %s, want the server's 20ms", got)
+	}
+	if got := parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT"); got != 0 {
+		t.Fatalf("parseRetryAfter(http-date) = %s, want 0 so our own backoff applies", got)
+	}
+	if got := parseRetryAfter("2"); got != 2*time.Second {
+		t.Fatalf("parseRetryAfter(%q) = %s, want 2s", "2", got)
+	}
+}
+
+// TestBackoffGrowsAndIsCapped: exponential growth bounded by Max, which is what keeps a persistent
+// outage from turning the worker into an unbounded sleep.
+func TestBackoffGrowsAndIsCapped(t *testing.T) {
+	p := RetryPolicy{MaxAttempts: 10, Base: 10 * time.Millisecond, Max: 40 * time.Millisecond, Jitter: 0}
+	want := []time.Duration{10, 20, 40, 40, 40}
+	for i, w := range want {
+		if got := p.delay(i+1, 0); got != w*time.Millisecond {
+			t.Fatalf("delay(%d) = %s, want %s", i+1, got, w*time.Millisecond)
+		}
+	}
+}
+
+// TestCloseIsNotHeldOpenByRetries: shutdown must not wait out the retry budget of a buffer full of
+// records aimed at a dead gateway. The remaining attempts are abandoned, and the records are shed
+// and counted rather than reported as shipped.
+func TestCloseIsNotHeldOpenByRetries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	slow := &RetryPolicy{MaxAttempts: 5, Base: 5 * time.Second, Max: 10 * time.Second, Jitter: 0}
+	sink := NewHTTPSink(Options{
+		URL:         srv.URL,
+		Deployment:  DeploymentCloud,
+		IngestToken: "svc_token",
+		Retry:       slow,
+		Logf:        func(string, ...any) {},
+	})
+	sink.Record(sampleRecord())
+	start := time.Now()
+	sink.Close()
+	if elapsed := time.Since(start); elapsed > 4*time.Second {
+		t.Fatalf("Close took %s, want it to abandon the backoff rather than sleep it out", elapsed)
+	}
+	if got := sink.Undelivered(); got != 1 {
+		t.Fatalf("Undelivered() = %d, want the abandoned record counted as loss", got)
+	}
+}

--- a/infra/edge-proxy/internal/telemetry/telemetry.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry.go
@@ -27,8 +27,12 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	mrand "math/rand"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
@@ -122,10 +126,12 @@ type wireSpan struct {
 // per batch: records arrive one at a time off the async channel, and a per-record batch keeps the
 // tenant boundary trivially correct, since a batch belongs to exactly one tenant.
 type wireBatch struct {
-	// TenantId is the UUID the edge key cache resolved (sec 6.3). The gateway treats the
-	// authenticating key's tenant as authoritative and refuses a batch claiming a different one, so
-	// this is a claim it verifies, never a way to write into another tenant. Empty (no resolver
-	// configured) is accepted: the key still decides.
+	// TenantId is the UUID the edge key cache resolved (sec 6.3), or the operator's configured
+	// EDGE_PROXY_TENANT_ID for records it did not resolve. The gateway treats the authenticating
+	// key's tenant as authoritative and refuses a batch claiming a different one, so this is a claim
+	// it verifies, never a way to write into another tenant. Empty is accepted only by a gateway
+	// running with auth ON, which derives the tenant from the key; with auth off it has nothing to
+	// derive from and answers 422, which is why the configured fallback exists.
 	TenantId       string     `json:"tenant_id"`
 	SdkVersion     string     `json:"sdk_version"`
 	ResourceSpans  []wireSpan `json:"resource_spans"`
@@ -226,11 +232,18 @@ func encode(dep Deployment, rec proxy.TraceRecord, id ids) ([]byte, error) {
 // HTTPSink is a proxy.Sink that batches records and POSTs them to a collector URL out of band of
 // the request hot path. Record never blocks the proxy: it drops onto a buffered channel and a
 // background worker flushes. If the buffer is full (collector down / slow), records are dropped
-// rather than back-pressuring customer traffic — telemetry must never degrade the proxied call.
+// rather than back-pressuring customer traffic; telemetry must never degrade the proxied call.
+//
+// A retryable failure (network error, 429, 5xx) is resent under RetryPolicy before the record is
+// shed and counted, so a gateway restart or a burst of backpressure costs latency in the worker
+// rather than lost spend. The shed-and-count path stays the terminal case: the buffer is bounded,
+// the retry budget is bounded, and neither the hot path nor memory grows because ingest is down.
 type HTTPSink struct {
 	url         string
 	deployment  Deployment
 	ingestToken string
+	tenantId    string
+	retry       RetryPolicy
 	client      *http.Client
 	ch          chan proxy.TraceRecord
 	logf        func(format string, args ...any)
@@ -238,15 +251,24 @@ type HTTPSink struct {
 	wg       sync.WaitGroup
 	closeOne sync.Once
 	done     chan struct{}
+	// drainGrace bounds how long the whole shutdown drain may keep retrying; drainDeadline is the
+	// wall-clock instant it expires (unix nanos, 0 while the sink is running).
+	drainGrace    time.Duration
+	drainDeadline atomic.Int64
+	// tenantHint fires the empty-tenant advice at most once: the gateway answers every batch the
+	// same way, so repeating it per record would bury the advice in its own noise.
+	tenantHint sync.Once
 
 	// dropped counts records shed because the buffer was full, unauthenticated counts records shed
-	// because no ingest credential was available for them, and rejected counts spans the gateway
-	// declined per item (observability for the operator: all three are real telemetry loss and none
-	// is silently papered over).
+	// because no ingest credential was available for them, rejected counts spans the gateway
+	// declined per item, and undelivered counts records shed after the retry budget was spent
+	// (observability for the operator: all four are real telemetry loss and none is silently papered
+	// over).
 	mu              sync.Mutex
 	dropped         int64
 	unauthenticated int64
 	rejected        int64
+	undelivered     int64
 	// reported is the last snapshot logged, so a periodic report says what changed rather than
 	// re-reporting a total that has stopped moving.
 	reported Stats
@@ -263,11 +285,82 @@ type Stats struct {
 	// deployment whose every span is refused (PII_DETECTED, PAYLOAD_TOO_LARGE, load shedding) looks
 	// perfectly healthy from here.
 	Rejected int64
+	// Undelivered is records shed after the bounded retry budget was spent on a retryable failure
+	// (network error, 429, 5xx). It is the honest name for spend the proxy metered and then lost
+	// because ingest stayed unavailable longer than the proxy is willing to hold the record.
+	Undelivered int64
 }
 
 // Any reports whether anything at all has been shed. An operator only needs to hear from the sink
 // when the answer is yes.
-func (s Stats) Any() bool { return s.Dropped > 0 || s.Unauthenticated > 0 || s.Rejected > 0 }
+func (s Stats) Any() bool {
+	return s.Dropped > 0 || s.Unauthenticated > 0 || s.Rejected > 0 || s.Undelivered > 0
+}
+
+// RetryPolicy bounds how hard the sink tries to deliver one batch before shedding it. It mirrors
+// the SDK transport's bounded-retry-then-drop-with-a-counter contract (sdk/python/src/tally/
+// transport.py): a retryable failure is resent with capped exponential backoff and jitter, and an
+// exhausted batch is dropped and counted, never retried forever.
+//
+// The budget is deliberately small. Retries run on the sink's single worker goroutine, so time
+// spent here is time not spent draining the buffer, and a long budget would convert a slow gateway
+// into buffer-full drops instead. Record still never blocks the request hot path either way: the
+// channel is bounded and a full one sheds immediately.
+type RetryPolicy struct {
+	// MaxAttempts is the total number of sends for one batch, including the first.
+	MaxAttempts int
+	// Base is the first backoff; each further attempt doubles it up to Max.
+	Base time.Duration
+	// Max caps a single backoff, including one taken from a Retry-After header.
+	Max time.Duration
+	// Jitter spreads each backoff by +/- this fraction so a fleet of proxies does not resend in
+	// lockstep after a gateway blip.
+	Jitter float64
+}
+
+// DefaultRetryPolicy is 4 attempts over roughly 0.1s + 0.2s + 0.4s of backoff: enough to ride out a
+// gateway restart or a burst of 429s, short enough that a persistently failing ingest costs the
+// worker under a second per record on top of the HTTP timeout.
+var DefaultRetryPolicy = RetryPolicy{
+	MaxAttempts: 4,
+	Base:        100 * time.Millisecond,
+	Max:         2 * time.Second,
+	Jitter:      0.25,
+}
+
+// DefaultDrainGrace is how long Close lets retries continue while draining. It is short on purpose:
+// shutdown is not the time to wait out a broken gateway, and what cannot be shipped inside it is
+// shed and counted rather than reported as delivered.
+const DefaultDrainGrace = 2 * time.Second
+
+// delay returns the backoff before the given attempt number (1 = after the first send). retryAfter,
+// when the gateway supplied one, wins over the computed value but is still clamped to Max: a server
+// asking for a five minute pause must not stall the worker.
+func (p RetryPolicy) delay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > p.Max {
+			return p.Max
+		}
+		return retryAfter
+	}
+	d := p.Base
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= p.Max {
+			d = p.Max
+			break
+		}
+	}
+	if p.Jitter > 0 {
+		// math/rand is fine here: this only spreads resend times, it is not security material.
+		spread := float64(d) * p.Jitter
+		d = time.Duration(float64(d) + (mrand.Float64()*2-1)*spread)
+	}
+	if d < 0 {
+		return 0
+	}
+	return d
+}
 
 // Options configures an HTTPSink.
 type Options struct {
@@ -279,6 +372,15 @@ type Options struct {
 	// single-tenant self-host running with EDGE_PROXY_REQUIRE_TENANT unset). In the hosted
 	// multi-tenant deployment the per-request tenant key is what authenticates, so this stays empty.
 	IngestToken string
+	// TenantId is the operator's tenant UUID, claimed in the envelope of every batch IngestToken
+	// authenticates (config.Config.TenantId). Empty means the envelope claims no tenant, which is
+	// correct against a gateway with auth on and is refused with 422 by one with auth off.
+	TenantId string
+	// Retry bounds redelivery of a retryable failure; nil uses DefaultRetryPolicy.
+	Retry *RetryPolicy
+	// DrainGrace bounds how long Close keeps retrying before shedding what is left; <= 0 uses
+	// DefaultDrainGrace.
+	DrainGrace time.Duration
 	// Buffer is the channel depth; defaults to 1024.
 	Buffer int
 	// Client overrides the HTTP client (mainly for tests); defaults to a short-timeout client.
@@ -309,10 +411,24 @@ func NewHTTPSink(o Options) *HTTPSink {
 	if logf == nil {
 		logf = log.Printf
 	}
+	retry := DefaultRetryPolicy
+	if o.Retry != nil {
+		retry = *o.Retry
+	}
+	if retry.MaxAttempts < 1 {
+		retry.MaxAttempts = 1
+	}
+	grace := o.DrainGrace
+	if grace <= 0 {
+		grace = DefaultDrainGrace
+	}
 	s := &HTTPSink{
+		drainGrace:  grace,
 		url:         o.URL,
 		deployment:  dep,
 		ingestToken: o.IngestToken,
+		tenantId:    o.TenantId,
+		retry:       retry,
 		client:      client,
 		ch:          make(chan proxy.TraceRecord, buf),
 		logf:        logf,
@@ -360,12 +476,28 @@ func (s *HTTPSink) Rejected() int64 {
 	return s.rejected
 }
 
-// Stats snapshots all three loss counters at once, so an operator report cannot mix reads from
+// Undelivered returns the number of records shed after the retry budget was spent.
+func (s *HTTPSink) Undelivered() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.undelivered
+}
+
+// Stats snapshots every loss counter at once, so an operator report cannot mix reads from
 // different instants.
 func (s *HTTPSink) Stats() Stats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return Stats{Dropped: s.dropped, Unauthenticated: s.unauthenticated, Rejected: s.rejected}
+	return s.statsLocked()
+}
+
+func (s *HTTPSink) statsLocked() Stats {
+	return Stats{
+		Dropped:         s.dropped,
+		Unauthenticated: s.unauthenticated,
+		Rejected:        s.rejected,
+		Undelivered:     s.undelivered,
+	}
 }
 
 // ReportLoss logs what has been shed since the previous report and stays silent when nothing has.
@@ -373,12 +505,13 @@ func (s *HTTPSink) Stats() Stats {
 // short-lived process gets to say that it shipped nothing.
 func (s *HTTPSink) ReportLoss() {
 	s.mu.Lock()
+	total := s.statsLocked()
 	delta := Stats{
-		Dropped:         s.dropped - s.reported.Dropped,
-		Unauthenticated: s.unauthenticated - s.reported.Unauthenticated,
-		Rejected:        s.rejected - s.reported.Rejected,
+		Dropped:         total.Dropped - s.reported.Dropped,
+		Unauthenticated: total.Unauthenticated - s.reported.Unauthenticated,
+		Rejected:        total.Rejected - s.reported.Rejected,
+		Undelivered:     total.Undelivered - s.reported.Undelivered,
 	}
-	total := Stats{Dropped: s.dropped, Unauthenticated: s.unauthenticated, Rejected: s.rejected}
 	s.reported = total
 	s.mu.Unlock()
 
@@ -387,9 +520,9 @@ func (s *HTTPSink) ReportLoss() {
 	}
 	s.logf(
 		"edge-proxy telemetry: shed since last report: %d buffer-full, %d unauthenticated, "+
-			"%d rejected by ingest (totals: %d / %d / %d)",
-		delta.Dropped, delta.Unauthenticated, delta.Rejected,
-		total.Dropped, total.Unauthenticated, total.Rejected,
+			"%d rejected by ingest, %d undelivered after retries (totals: %d / %d / %d / %d)",
+		delta.Dropped, delta.Unauthenticated, delta.Rejected, delta.Undelivered,
+		total.Dropped, total.Unauthenticated, total.Rejected, total.Undelivered,
 	)
 }
 
@@ -434,6 +567,36 @@ func (s *HTTPSink) credentialFor(rec proxy.TraceRecord) string {
 	return s.ingestToken
 }
 
+// tenantFor picks the tenant_id claim for this record's envelope.
+//
+// A record the edge-key cache resolved carries its own tenant and is authenticated by its own key.
+// Everything else is authenticated by the configured ingest token (credentialFor), so the
+// operator's configured tenant is the right claim for exactly those records: the credential and the
+// tenant are one operator-scoped pair. That closes the hole where a self-host running against a
+// gateway with auth disabled (TALLY_REQUIRE_API_KEY=false) sent tenant_id "" and had every batch
+// refused with 422.
+//
+// Nothing is invented here. With no configured tenant this returns "" and the batch honestly claims
+// none, exactly as before. It is also not a way to write into someone else's tenant: with auth on
+// the gateway compares the claim against the authenticating key's tenant and refuses a mismatch.
+func (s *HTTPSink) tenantFor(rec proxy.TraceRecord) string {
+	if rec.TenantId != "" {
+		return rec.TenantId
+	}
+	return s.tenantId
+}
+
+// outcome classifies one delivery attempt.
+type outcome int
+
+const (
+	// outcomeDone means the batch reached ingest, or was refused for a reason resending cannot fix.
+	outcomeDone outcome = iota
+	// outcomeRetry means the failure is transient (network error, 429, 5xx) and the same bytes are
+	// worth resending.
+	outcomeRetry
+)
+
 func (s *HTTPSink) post(rec proxy.TraceRecord) {
 	token := s.credentialFor(rec)
 	if token == "" {
@@ -444,15 +607,72 @@ func (s *HTTPSink) post(rec proxy.TraceRecord) {
 		s.mu.Unlock()
 		return
 	}
+	rec.TenantId = s.tenantFor(rec)
+	// Encoded once and resent byte for byte, so batch_id is stable across attempts and the gateway's
+	// (tenant_id, batch_id) idempotency key turns a retry after an ambiguous failure into a replay
+	// rather than a duplicate span.
 	body, err := Encode(s.deployment, rec)
 	if err != nil {
 		return
 	}
+	for attempt := 1; ; attempt++ {
+		res, retryAfter := s.attempt(body, token, rec.TenantId)
+		if res == outcomeDone {
+			return
+		}
+		if attempt >= s.retry.MaxAttempts {
+			s.shedUndelivered(attempt)
+			return
+		}
+		if !s.wait(s.retry.delay(attempt, retryAfter)) {
+			// Shutting down. The remaining budget is not worth holding Close open on a gateway that
+			// is already failing, so shed and count instead of sleeping through the drain.
+			s.shedUndelivered(attempt)
+			return
+		}
+	}
+}
+
+// shedUndelivered records the terminal case of the retry loop: one span the proxy metered and could
+// not ship. Counted and logged, never quietly forgotten and never re-reported as a success.
+func (s *HTTPSink) shedUndelivered(attempts int) {
+	s.mu.Lock()
+	s.undelivered += spansPerBatch
+	s.mu.Unlock()
+	s.logf("edge-proxy telemetry: shed %d span after %d failed attempts", spansPerBatch, attempts)
+}
+
+// wait sleeps for d before the next attempt. It returns false once the shutdown drain grace is
+// spent, which is what stops a buffer full of records aimed at a dead gateway from holding Close
+// open for the sum of every remaining retry budget. Shutdown still gets a real grace window rather
+// than zero, so a short-lived process does not lose its last spans to the first blip.
+func (s *HTTPSink) wait(d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	if dl := s.drainDeadline.Load(); dl != 0 {
+		remaining := time.Until(time.Unix(0, dl))
+		if remaining <= 0 {
+			return false
+		}
+		if d > remaining {
+			d = remaining
+		}
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	<-t.C
+	return true
+}
+
+// attempt makes one POST. It returns whether the batch is worth resending and, for a 429, how long
+// the gateway asked us to wait.
+func (s *HTTPSink) attempt(body []byte, token, envelopeTenant string) (outcome, time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
 	if err != nil {
-		return
+		return outcomeDone, 0
 	}
 	req.Header.Set("Content-Type", "application/json")
 	// The ingest protocol the gateway negotiates against (gateway/protocol.py). Sending it
@@ -463,22 +683,68 @@ func (s *HTTPSink) post(rec proxy.TraceRecord) {
 	resp, err := s.client.Do(req)
 	if err != nil {
 		// The error can name the collector host but never the credential (it is only ever a header
-		// value, which net/http does not include in its error strings).
+		// value, which net/http does not include in its error strings). A transport failure is the
+		// most retryable failure there is: nothing says the gateway even saw the batch.
 		log.Printf("edge-proxy telemetry: post failed: %v", err)
-		return
+		return outcomeRetry, 0
 	}
 	// Read a bounded prefix of the body, then drain the remainder and close, so the connection goes
 	// back to the pool for reuse (net/http only reuses a connection whose body was read to EOF).
 	ackBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxAckBytes))
 	_, _ = io.Copy(io.Discard, resp.Body)
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
 	_ = resp.Body.Close()
 
+	// Backpressure and server faults are transient by definition: the same bytes will be accepted
+	// once ingest recovers. Every other 4xx is the gateway saying this batch is wrong (bad
+	// credential, wrong tenant, failed validation, unsupported protocol), and resending identical
+	// bytes would only burn the budget on a guaranteed second refusal.
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		log.Printf("edge-proxy telemetry: ingest returned %d, retrying", resp.StatusCode)
+		return outcomeRetry, retryAfter
+	}
 	if resp.StatusCode >= 400 {
 		// A 401/403 here is the operator's signal that the ingest credential or the key's scope is
 		// wrong.
 		log.Printf("edge-proxy telemetry: ingest rejected batch with status %d", resp.StatusCode)
+		s.hintEmptyTenant(resp.StatusCode, envelopeTenant)
 	}
 	s.recordAck(resp.StatusCode, ackBody)
+	return outcomeDone, 0
+}
+
+// hintEmptyTenant escalates the one misconfiguration startup cannot diagnose on its own: a gateway
+// running with auth disabled cannot derive a tenant from the bearer key, so it refuses a batch
+// whose envelope claims none with 422. Config cannot know which mode the gateway runs in, but this
+// answer settles it, so say plainly what to set rather than leaving the operator with a bare status
+// code and a dashboard that never fills in.
+//
+// Nothing from the response body is used or echoed: the trigger is the status plus what we know we
+// sent, so a rejection can never become its own leak.
+func (s *HTTPSink) hintEmptyTenant(status int, envelopeTenant string) {
+	if status != http.StatusUnprocessableEntity || envelopeTenant != "" {
+		return
+	}
+	s.tenantHint.Do(func() {
+		s.logf("edge-proxy telemetry: WARNING: ingest refused a batch carrying no tenant_id (422). " +
+			"A gateway running with auth disabled (TALLY_REQUIRE_API_KEY=false) cannot derive the " +
+			"tenant from the ingest credential and needs it in the batch: set EDGE_PROXY_TENANT_ID to " +
+			"your tenant UUID, or run the gateway with auth on. Until then NO telemetry is recorded.")
+	})
+}
+
+// parseRetryAfter reads the delay-seconds form of the Retry-After header, which is what the
+// gateway's rate limiter sends. An HTTP-date form or garbage yields 0, and the caller falls back to
+// its own backoff, so a malformed header can never stall the worker.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
 }
 
 // maxAckBytes bounds how much of the ingest response is read. The ack is a small JSON object; the
@@ -536,6 +802,9 @@ const spansPerBatch = 1
 // a proxy that shipped nothing at all for its whole life would exit without ever saying so.
 func (s *HTTPSink) Close() {
 	s.closeOne.Do(func() {
+		// Start the drain clock before the worker can see the close, so retries in flight are bounded
+		// by the same grace window as the ones that follow.
+		s.drainDeadline.Store(time.Now().Add(s.drainGrace).UnixNano())
 		close(s.ch)
 		close(s.done)
 	})


### PR DESCRIPTION
Follow-ups to PR #290 for two telemetry bugs an end-to-end integration run found.

## Bug 1 (MEDIUM): the proxy shipped nothing in the default self-hosted config

`TraceRecord.TenantId` was only ever populated by the edge-key cache (`EDGE_PROXY_KEYS_URL`), which a standard self-host does not configure, so the batch envelope claimed no tenant. A gateway running with auth disabled (`TALLY_REQUIRE_API_KEY=false`, the `make up` default) cannot derive the tenant from the credential and refuses such a batch with `422 tenant_id required when auth is disabled`. The proxy looked healthy, every batch was refused, and no spend was recorded.

**Fix.** New `EDGE_PROXY_TENANT_ID`: the operator's own tenant UUID, claimed in the envelope for every record the cache did not resolve, which is exactly the set of records `EDGE_PROXY_INGEST_TOKEN` authenticates. The credential and the tenant are one operator-scoped pair, so this cannot leak into someone else's tenant: a resolved record always keeps its own tenant, and with auth on the gateway still enforces `TENANT_MISMATCH` against the authenticating key.

Nothing is fabricated. Unset means the envelope honestly claims no tenant, exactly as before. A value that is not a UUID (a tenant NAME such as `local-dev`, the classic name-into-a-UUID-column mistake) fails at boot rather than writing a claim that joins to nothing.

**Telling the operator.** `Config.Warnings()` is extended rather than duplicated: it warns about what startup can know for certain (a configured tenant with no ingest token to carry it). It deliberately does not warn about an empty claim in general, since that is correct against a gateway with auth on and a false alarm there would train operators to ignore these lines. The case only the gateway's answer settles is escalated at runtime: a `422` on a batch that claimed no tenant logs the fix once, by name, derived from the status plus what we know we sent, never from the response body.

## Bug 2 (LOW): telemetry dropped under gateway backpressure

Any `4xx`/`5xx` logged and discarded the record, and a transport error was not even counted, so the backfill's 429s lost those spans outright.

**Fix.** A retryable failure (network error, `429`, `5xx`) is resent byte for byte, so the stable `batch_id` makes the resend idempotent at the gateway, with capped exponential backoff plus jitter and an attempt cap (`RetryPolicy`, 4 attempts over ~0.7s by default), honoring a `Retry-After` clamped to the cap. A non-retryable `4xx` (validation, credential, scope, protocol) is never resent. Past the cap the record is shed and counted as `HTTPSink.Undelivered()`, reported alongside the existing loss counters. This stays consistent with the SDK's `BatchingTransport`: bounded retry, then drop with a counter.

Bounded on every axis: the buffer is still fixed-size and `Record` still never blocks the proxied request; retries run on the sink's single worker, so a slow gateway costs worker time rather than memory; and `Close` abandons remaining backoff after a short drain grace instead of holding the process open on a dead gateway.

## Real before/after

Ran against a throwaway ClickHouse plus a gateway with `TALLY_REQUIRE_API_KEY=false` on spare ports (the shared `ai-tally-*` and `ai-tally-e2e-*` stacks were not touched, and the throwaway stack was removed afterwards). One proxied `POST /v1/chat/completions` in each configuration.

Before (no `EDGE_PROXY_TENANT_ID`), `SELECT count() FROM otel_spans` = `0`:

```
edge-proxy telemetry: ingest rejected batch with status 422
edge-proxy telemetry: WARNING: ingest refused a batch carrying no tenant_id (422). A gateway
running with auth disabled (TALLY_REQUIRE_API_KEY=false) cannot derive the tenant from the ingest
credential and needs it in the batch: set EDGE_PROXY_TENANT_ID to your tenant UUID, or run the
gateway with auth on. Until then NO telemetry is recorded.
edge-proxy telemetry: ingest accepted 0/1 spans (http 422, status "", codes [])
```

After (`EDGE_PROXY_TENANT_ID=7f1c3a2e-...-000000000001`), no rejection, and the span is in storage:

```
TenantId                              ServiceName  GenAiSystem  GenAiResponseModel  In  Out
7f1c3a2e-0000-4000-8000-000000000001  edge-proxy   openai       gpt-4o-2024-08-06   11  7
```

## Tests

`internal/config/tenant_id_test.go`: the tenant defaults to empty and is never invented, a UUID is accepted (trimmed and lowercased) with no warnings, a tenant name or malformed UUID fails at boot naming the variable, a configured tenant with no credential warns, and the original no-credential shape still warns loudly.

`internal/telemetry/resilience_test.go`: the unresolved-record envelope carries the configured tenant, a resolved record keeps its own, an unconfigured one claims none rather than a placeholder, the `422` hint fires exactly once and only when the claim was empty, and the refusal is still counted. For the retry path: a `429` and a `503` are each retried to the cap with real backoff and identical bytes before being shed and counted, success on the second attempt stops the loop and counts no loss, `401`/`403`/`400`/`422` get exactly one attempt, an unreachable collector is retried and counted, `Retry-After` is honored but clamped, backoff growth is capped, and `Close` is not held open by a pending retry.

## Verification

`go build ./... && go vet ./... && go test ./... && gofmt -l .` (gofmt lists nothing) and `go test -race ./...` all pass, `TestOverheadBudget` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)