### PR TITLE
fix(sdk): stop coverage_report reusing the retired tenant env var (CTO-261)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -208,8 +208,16 @@ things from the environment:
 | Variable | What it is |
 |---|---|
 | `TALLY_GATEWAY_URL` | base URL of the gateway that holds your telemetry. Must be `https://`, because the request carries the service token; plain `http://` is accepted only for `localhost`, `127.0.0.1` or `::1` so local dev still works |
-| `TALLY_TENANT_ID` | your tenant UUID, sent as `x-tenant-id` |
+| `TALLY_MCP_TENANT_ID` | your tenant UUID, sent as `x-tenant-id`. Must be a canonical UUID, not a tenant name like `local-dev` |
 | `GATEWAY_SERVICE_TOKEN` | the control-plane service token. Set `TALLY_GATEWAY_SERVICE_TOKEN_ENV` to read it from a differently named variable instead |
+
+`TALLY_MCP_TENANT_ID` is deliberately not the retired `TALLY_TENANT_ID`, which used to scope the
+dashboard and which some older deploy manifests still set, inertly, to `local-dev`. The tool never
+reads the retired name, not even as a fallback: a stale value would silently scope your coverage
+report to the wrong tenant. If it finds `TALLY_TENANT_ID` set while `TALLY_MCP_TENANT_ID` is not,
+it answers `probe_available: false` and tells you to rename the variable, rather than guessing with
+it. A value that is not a canonical UUID is refused the same way, because the probe binds it into a
+UUID read filter where a tenant name matches nothing and would look like an honest empty answer.
 
 The token is held by reference: the tool reads the variable at the moment it calls the probe and
 never stores, echoes or logs the value. The `tenant_key` argument is likewise reported only as

--- a/sdk/python/onboarding_mcp/coverage_client.py
+++ b/sdk/python/onboarding_mcp/coverage_client.py
@@ -15,9 +15,9 @@ client on the dashboard side applies the same defense (``web/lib/firstEvent.ts``
 for the agent-facing path.
 
 WHY EVERY FAILURE IS ``unknown``, NEVER "not covered". An unreachable gateway, a 5xx, a timeout, a
-malformed body or absent configuration all mean we do not know. Collapsing any of them into
-``not_wired`` would tell a developer their instrumentation is missing when the truth is that ours
-could not answer (CLAUDE.md, honest under uncertainty).
+malformed body, a tenant id that is not a UUID or absent configuration all mean we do not know.
+Collapsing any of them into ``not_wired`` would tell a developer their instrumentation is missing
+when the truth is that ours could not answer (CLAUDE.md, honest under uncertainty).
 
 Stdlib ``urllib`` only, so the SDK runtime stays dependency-free, and the transport is injectable
 so the test suite never touches the network (the pattern ``onboarding_bot/github_pr.py`` uses).
@@ -30,6 +30,7 @@ import os
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -40,9 +41,19 @@ COVERAGE_PATH = "/v1/tenant/onboarding/coverage"
 # NAME of the environment variable, never its value, so a serialized config or a logged repr
 # cannot leak it (CLAUDE.md, credentials by reference).
 GATEWAY_URL_ENV = "TALLY_GATEWAY_URL"
-TENANT_ID_ENV = "TALLY_TENANT_ID"
+TENANT_ID_ENV = "TALLY_MCP_TENANT_ID"
 DEFAULT_TOKEN_ENV = "GATEWAY_SERVICE_TOKEN"
 TOKEN_ENV_REF = "TALLY_GATEWAY_SERVICE_TOKEN_ENV"
+
+# WHY THIS TOOL DOES NOT READ ``TALLY_TENANT_ID`` (CTO-261). That name is retired: it used to scope
+# the dashboard, no product code reads it any more, and several deploy manifests still SET it,
+# inertly, to the old value ``local-dev``. Reading it here (even as a fallback) would let a stale
+# taskdef, Helm value or ``.env`` silently scope the coverage probe to a tenant the operator did not
+# choose. Worse, ``local-dev`` is a tenant NAME while this value is bound into a UUID read filter,
+# so it would match nothing and the tool would report a confident, entirely wrong "nothing is
+# wired". So the retired name is never a value source: it is only DETECTED, to tell the operator to
+# rename it, and the answer stays an honest gap (CLAUDE.md, honest under uncertainty).
+RETIRED_TENANT_ID_ENV = "TALLY_TENANT_ID"
 
 # The probe does two ClickHouse reads, one of them a grouped pass over ``otel_spans`` that gets no
 # key-prefix benefit, so a large or cold tenant can sit well past a few seconds. A short timeout
@@ -122,6 +133,17 @@ def config_from_env(env: Mapping[str, str] | None = None) -> tuple[CoverageConfi
 
     required = ((GATEWAY_URL_ENV, gateway_url), (TENANT_ID_ENV, tenant_id))
     missing = [name for name, value in required if not value]
+
+    # The retired name set while the current one is absent is the stale-manifest case, and it gets
+    # its own reason: "not configured" would send an operator hunting for a variable they believe
+    # they already set. We still do not READ it (CTO-261).
+    if not tenant_id and (source.get(RETIRED_TENANT_ID_ENV) or "").strip():
+        return None, (
+            f"${RETIRED_TENANT_ID_ENV} is set but that name is retired and is not read: rename it "
+            f"to ${TENANT_ID_ENV}, whose value must be your tenant UUID. Its value was not used "
+            f"and nothing is being claimed about your instrumentation."
+        )
+
     if missing:
         return None, (
             f"the coverage probe is not configured: set {' and '.join(missing)}, plus "
@@ -132,7 +154,29 @@ def config_from_env(env: Mapping[str, str] | None = None) -> tuple[CoverageConfi
     if scheme_reason:
         return None, scheme_reason
 
+    if not _is_tenant_uuid(tenant_id):
+        return None, (
+            f"${TENANT_ID_ENV} must be your tenant UUID, not a tenant name. The coverage probe "
+            f"binds this value into a UUID read filter, so a name matches nothing and would be "
+            f"reported as an empty but confident-looking answer. The probe was not called and "
+            f"nothing is being claimed about your instrumentation."
+        )
+
     return CoverageConfig(gateway_url=gateway_url, tenant_id=tenant_id, token_env=token_env), ""
+
+
+def _is_tenant_uuid(value: str) -> bool:
+    """True only for a canonical 36-character UUID (CTO-261).
+
+    Deliberately stricter than ``uuid.UUID`` alone, which also accepts braced, URN and undashed
+    forms: the gateway compares this against a canonical UUID column, so accepting a shape it will
+    not match would just move the silent-empty-answer failure one step later. The value is never
+    echoed into the reason, since a mis-set variable can hold anything (CLAUDE.md, no bodies).
+    """
+    try:
+        return str(uuid.UUID(value)) == value.lower()
+    except (ValueError, AttributeError, TypeError):
+        return False
 
 
 def _reject_unsafe_base(gateway_url: str) -> str:

--- a/sdk/python/tests/test_onboarding_mcp_coverage.py
+++ b/sdk/python/tests/test_onboarding_mcp_coverage.py
@@ -28,9 +28,8 @@ from onboarding_mcp.coverage_client import (
     fetch_coverage,
 )
 
-CONFIG = CoverageConfig(
-    gateway_url="https://gateway.example/", tenant_id="11111111-2222-3333-4444-555555555555"
-)
+TENANT_UUID = "11111111-2222-3333-4444-555555555555"
+CONFIG = CoverageConfig(gateway_url="https://gateway.example/", tenant_id=TENANT_UUID)
 ENV = {"GATEWAY_SERVICE_TOKEN": "svc-token-value"}
 
 
@@ -224,12 +223,105 @@ def test_missing_configuration_is_unknown_and_names_what_to_set():
     result = coverage_report("k", env={})
     _assert_all_unknown_with_reason(result, "not configured")
     assert "TALLY_GATEWAY_URL" in result["reason"]
-    assert "TALLY_TENANT_ID" in result["reason"]
+    assert "TALLY_MCP_TENANT_ID" in result["reason"]
 
 
 def test_missing_service_token_is_unknown_and_never_an_anonymous_call():
     result = coverage_report("k", transport=_transport(_payload()), config=CONFIG, env={})
     _assert_all_unknown_with_reason(result, "GATEWAY_SERVICE_TOKEN")
+
+
+# ---------------------------------------------------------------------------------------------
+# The tenant variable: the current name, the retired one, and the UUID shape (CTO-261).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_current_tenant_variable_configures_the_probe():
+    sink: list[tuple[str, dict[str, str]]] = []
+    env = {
+        "TALLY_GATEWAY_URL": "https://gw.example",
+        "TALLY_MCP_TENANT_ID": TENANT_UUID,
+        "GATEWAY_SERVICE_TOKEN": "svc-token-value",
+    }
+    result = coverage_report("k", config=None, env=env, transport=_transport(_payload(), sink))
+    assert result["probe_available"] is True
+    assert sink[0][1]["x-tenant-id"] == TENANT_UUID
+
+
+def test_the_retired_tenant_variable_alone_does_not_configure_the_probe():
+    # The whole point of the rename: a stale TALLY_TENANT_ID left in an old taskdef or .env must
+    # never silently scope the report to that tenant.
+    env = {
+        "TALLY_GATEWAY_URL": "https://gw.example",
+        "TALLY_TENANT_ID": TENANT_UUID,
+        "GATEWAY_SERVICE_TOKEN": "svc-token-value",
+    }
+    result = coverage_report("k", config=None, env=env, transport=_transport(_payload()))
+    _assert_all_unknown_with_reason(result, "retired")
+    assert "TALLY_MCP_TENANT_ID" in result["reason"]
+
+
+def test_the_retired_variable_is_not_used_as_a_fallback_value():
+    # Even a perfectly valid UUID under the retired name is refused rather than borrowed.
+    config, reason = config_from_env(
+        {"TALLY_GATEWAY_URL": "https://gw.example", "TALLY_TENANT_ID": TENANT_UUID}
+    )
+    assert config is None
+    assert "rename" in reason
+
+
+def test_the_retired_variable_is_ignored_when_the_current_one_is_set():
+    config, reason = config_from_env(
+        {
+            "TALLY_GATEWAY_URL": "https://gw.example",
+            "TALLY_MCP_TENANT_ID": TENANT_UUID,
+            "TALLY_TENANT_ID": "local-dev",
+        }
+    )
+    assert reason == ""
+    assert config is not None and config.tenant_id == TENANT_UUID
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "local-dev",
+        "abc",
+        "11111111-2222-3333-4444-55555555555",
+        "111111112222333344445555555555555",
+        "{11111111-2222-3333-4444-555555555555}",
+        "urn:uuid:11111111-2222-3333-4444-555555555555",
+    ],
+)
+def test_a_tenant_name_or_malformed_uuid_is_a_reasoned_gap_not_a_query(value):
+    # A name bound into a UUID read filter matches nothing, which would surface as a confident
+    # "nothing is wired". It must never reach the transport at all.
+    calls: list[str] = []
+
+    def send(url, headers, timeout):
+        calls.append(url)
+        return _payload()
+
+    env = {
+        "TALLY_GATEWAY_URL": "https://gw.example",
+        "TALLY_MCP_TENANT_ID": value,
+        "GATEWAY_SERVICE_TOKEN": "svc-token-value",
+    }
+    result = coverage_report("k", config=None, env=env, transport=send)
+    _assert_all_unknown_with_reason(result, "must be your tenant UUID")
+    assert calls == []
+    # A mis-set variable can hold anything, so its value never rides out in the reason.
+    assert value not in json.dumps(result)
+
+
+def test_the_tenant_uuid_check_is_refused_before_the_token_is_read():
+    env = {
+        "TALLY_GATEWAY_URL": "https://gw.example",
+        "TALLY_MCP_TENANT_ID": "local-dev",
+        "GATEWAY_SERVICE_TOKEN": "svc-token-value",
+    }
+    result = coverage_report("k", config=None, env=env, transport=_transport(_payload()))
+    assert "svc-token-value" not in json.dumps(result)
 
 
 # ---------------------------------------------------------------------------------------------
@@ -241,7 +333,7 @@ def test_config_from_env_holds_a_token_reference_not_a_token():
     config, reason = config_from_env(
         {
             "TALLY_GATEWAY_URL": "https://gw.example",
-            "TALLY_TENANT_ID": "abc",
+            "TALLY_MCP_TENANT_ID": TENANT_UUID,
             "TALLY_GATEWAY_SERVICE_TOKEN_ENV": "MY_TOKEN_VAR",
             "MY_TOKEN_VAR": "s3cret",
         }
@@ -328,7 +420,9 @@ def test_a_non_utf8_body_decodes_instead_of_raising():
     ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080", "https://gw.example"],
 )
 def test_a_safe_base_url_is_accepted(base):
-    config, reason = config_from_env({"TALLY_GATEWAY_URL": base, "TALLY_TENANT_ID": "abc"})
+    config, reason = config_from_env(
+        {"TALLY_GATEWAY_URL": base, "TALLY_MCP_TENANT_ID": TENANT_UUID}
+    )
     assert reason == ""
     assert config is not None and config.gateway_url == base
 
@@ -344,7 +438,9 @@ def test_a_safe_base_url_is_accepted(base):
     ],
 )
 def test_an_unsafe_base_url_is_a_reasoned_gap_not_an_exception(base):
-    config, reason = config_from_env({"TALLY_GATEWAY_URL": base, "TALLY_TENANT_ID": "abc"})
+    config, reason = config_from_env(
+        {"TALLY_GATEWAY_URL": base, "TALLY_MCP_TENANT_ID": TENANT_UUID}
+    )
     assert config is None
     assert "TALLY_GATEWAY_URL" in reason
     assert "othing is being claimed" in reason
@@ -353,7 +449,7 @@ def test_an_unsafe_base_url_is_a_reasoned_gap_not_an_exception(base):
 def test_a_cleartext_base_is_refused_before_the_token_is_read():
     env = {
         "TALLY_GATEWAY_URL": "http://gw.example",
-        "TALLY_TENANT_ID": "abc",
+        "TALLY_MCP_TENANT_ID": TENANT_UUID,
         "GATEWAY_SERVICE_TOKEN": "svc-token-value",
     }
     result = coverage_report("k", config=None, env=env, transport=_transport(_payload()))

--- a/sdk/python/tests/test_onboarding_mcp_server.py
+++ b/sdk/python/tests/test_onboarding_mcp_server.py
@@ -80,6 +80,9 @@ def test_registered_tools_delegate_to_the_plain_functions(built: RecordingServer
     # Unconfigured, so the probe cannot run: unknown with a reason through the binding too,
     # never a fabricated verdict (CTO-261 section 7).
     monkeypatch.delenv("TALLY_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("TALLY_MCP_TENANT_ID", raising=False)
+    # The retired name too: it is not read, but clearing it keeps this test honest about which
+    # variable the tool actually consults (CTO-261).
     monkeypatch.delenv("TALLY_TENANT_ID", raising=False)
     coverage = built.tools["coverage_report"]("tally_sk_live_x")
     assert coverage["probe_available"] is False


### PR DESCRIPTION
## Note on the base branch

This was originally scoped to stack on `fix/explain-layer-ambiguous-tokens` (#298). That branch does not contain `sdk/python/onboarding_mcp/coverage_client.py`: it sits in the `feat/i3-p1-mcp-connectable` -> `fix/mcp-connectable-review` lane, while `coverage_client.py` is introduced by #288 in the sibling `feat/i3-p2-pr-bot` -> `feat/i3-p3-coverage-report-mcp` lane. So this PR targets `fix/coverage-report-mcp-review` (#289), the tip of the lane that actually owns the file. Retarget if that is not the intent.

## The problem

`coverage_report` scoped its probe with `TALLY_TENANT_ID`. That name is retired: it used to be the dashboard's tenant variable, no product code reads it any more, and several deploy manifests still set it, inertly, to `local-dev`.

The failure was silent. An operator with a stale `TALLY_TENANT_ID=local-dev` in an old ECS taskdef, Helm values or a `.env` would have had the coverage tool pick that value up and scope to a tenant they did not choose. Worse, `local-dev` is a tenant NAME while the probe binds a tenant UUID into a read filter, so it would have matched nothing and the tool would have reported a confident, entirely wrong "nothing is wired" for the wrong tenant. That is exactly the fabricated-negative failure CTO-261 exists to prevent.

## The fix

Renamed to `TALLY_MCP_TENANT_ID`. It names the consumer (this MCP tool) rather than the destination, so it cannot collide with a dashboard-era variable again, and it reads consistently beside the tool's other config (`TALLY_GATEWAY_URL`, `TALLY_GATEWAY_SERVICE_TOKEN_ENV`).

Two guards, both landing in the tool's existing honest gap shape (`probe_available: false`, every layer `unknown`, reason attached):

- **The retired name is never a value source, not even as a fallback**, because a fallback recreates the bug verbatim. It is only *detected*: set while `TALLY_MCP_TENANT_ID` is absent, it returns a gap whose reason tells the operator to rename the variable and states that its value was not used. A plain "not configured" reason would have sent them hunting for a variable they believe they already set.
- **The value must be a canonical UUID.** A tenant name is refused with a reason before the probe is called and before the service token is read out of the environment. The check is deliberately stricter than `uuid.UUID` alone, which also accepts braced, URN and undashed forms the gateway's UUID column will not match; accepting those would just move the silent-empty-answer one step later.

The mis-set value is never echoed into the reason, since a wrong variable can hold anything.

Nothing else moved: the same-origin redirect refusal, the scheme validation, the token-by-reference handling and the `sdk_surface.py` anti-hallucination guard are untouched, and SDK runtime dependencies stay empty (`uuid` is stdlib).

## Tests

Added to `test_onboarding_mcp_coverage.py`:

- the new variable configures the probe and sends the UUID as `x-tenant-id`
- the retired name alone does not configure the probe, and the reason names the rename
- the retired name is not borrowed as a fallback even when it holds a valid UUID
- the retired name is ignored entirely when the new one is set
- six non-UUID values (`local-dev`, `abc`, a short UUID, an undashed one, a braced one, a URN one) each produce a gap, assert the transport was never called, and assert the value does not appear in the result
- the UUID refusal happens before the service token is read

Existing tests were updated to the new variable name and to UUID-shaped tenant values; every prior failure mode still asserts `probe_available: false` with a reason.

## Verification

```
cd sdk/python && uv run --extra dev pytest -q   ->  1242 passed
                 uv run ruff check .            ->  All checks passed!
```

Grep confirms no code path reads the retired name as a tenant source: `tenant_id` is assigned only from `TENANT_ID_ENV` (`TALLY_MCP_TENANT_ID`); the single reference to `RETIRED_TENANT_ID_ENV` in `config_from_env` is a presence test whose result is used only to build the rename reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
