### PR TITLE
docs(running): record that the otel_spans engine migration is exercised

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -252,6 +252,27 @@ copy of the raw span table: it needs disk for a second copy, it takes as long as
 large, and rows written into the old table while the copy runs are not carried over, so quiesce
 ingest for the duration. It keeps the pre-migration table as `otel_spans_cto245` for rollback.
 
+Exercised against a populated pre-CTO-245 install (1,542,971 spans across three tenants, engine
+`MergeTree`, sorting key without span identity). What was checked afterwards, rather than assumed:
+
+| Check | Result |
+|---|---|
+| Engine and sorting key | `ReplacingMergeTree`, old key intact as a prefix with `TraceId, SpanId` appended |
+| Row counts and cost totals, per tenant | identical before and after |
+| TTL | restored (warm 7d, cold 30d, delete 90d) |
+| Nullable token and cost columns, `unpriced` | intact through the copy and swap |
+| Materialized views | all four still attached, and a test insert reached the daily and hourly rollups |
+| Dedupe | two identical `(TenantId, TraceId, SpanId)` spans collapse to one row at the real cost, not double |
+
+The TTL line is the one worth knowing about: `CREATE TABLE ... AS` copies skipping indexes but not
+TTL, so the script restores it explicitly. Had that been missed the table would have migrated
+cleanly and silently stopped tiering to warm and cold storage.
+
+Two things this run did not prove. The install had no duplicates going in, so the collapse of an
+already-duplicated table is still unexercised. And rollups that already absorbed duplicates are not
+repaired by this: the materialized views sum into `SummingMergeTree` targets at insert time, so a
+duplicate counted there stays counted even after the raw rows collapse.
+
 ## 4. Run the web dashboard
 
 In a separate terminal:


### PR DESCRIPTION
Closes #312.

The create-copy-swap was documented but had never been run against a real populated install. It has now been run against one: **1,542,971 spans across three tenants**, on a `MergeTree` table whose sorting key carried no span identity, i.e. a genuine pre-CTO-245 database.

| Check | Result |
|---|---|
| Engine and sorting key | `ReplacingMergeTree`, old key intact as a prefix with `TraceId, SpanId` appended |
| Row counts and cost totals, per tenant | identical before and after |
| TTL | restored (warm 7d, cold 30d, delete 90d) |
| Nullable token/cost columns, `unpriced` | intact through the copy and swap |
| Materialized views | all four still attached, and a test insert reached the daily and hourly rollups |
| Dedupe | two identical `(TenantId, TraceId, SpanId)` spans collapse to one row at the real cost |

The TTL restore is the detail worth naming: `CREATE TABLE ... AS` copies skipping indexes but **not** TTL. A migration that missed it would look completely clean and silently stop tiering to warm and cold storage.

Two things this run did **not** prove, now written down rather than left implied:

- The install had **no duplicates going in**, so collapsing an already-duplicated table is still unexercised. It proves the mechanism and the data preservation, not the repair.
- Rollups that already absorbed duplicates are **not** repaired by this, because the MVs sum into `SummingMergeTree` targets at insert time. That remains #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)