### PR TITLE
fix(db,infra): mount the four unmounted migrations, document the 0005/0017 sequence (CTO-317)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -697,6 +697,8 @@ Knobs:
 |---|---|
 | `Database tally does not exist` | Gateway pointed at the wrong DB. Use `TALLY_CLICKHOUSE_DB=default` (the compose gateway already does). |
 | Dashboard shows the **"mock data"** badge | A page's ClickHouse query failed and fell back to mock. Check `make logs` and that step 3's count is non-zero. |
+| `relation "tenant_bq_export_config" does not exist` (or `bq_export_watermarks`, `tenant_athena_export_config`, `athena_export_watermarks`) | Those four migrations were never mounted into initdb, so on a stack first booted before CTO-317 the tables are absent and the BigQuery / Athena export sinks fail on their first query. The mounts are fixed, but `docker-entrypoint-initdb.d` only fires on a first boot against an empty volume, so an existing stack needs them applied by hand. See the replay recipe in `db/postgres/README.md`; every migration is `IF NOT EXISTS`, so it is safe over a populated database. |
+| A control-plane table is missing after `git pull` | Same cause as the row above, and the same fix. New migrations reach a running stack only by hand, never by restarting it. `db/postgres/README.md` has the loop that replays the whole directory. |
 | Dashboard empty despite ingested rows | Tenant mismatch. The UI reads the tenant **UUID**, not the name, so spans must be tagged with the UUID: re-send with `tenant_id` set to the UUID from step 3. With no Clerk account, point the web app at that same UUID via `TALLY_DEV_TENANT` (the dev escape hatch); `TALLY_TENANT_ID` is no longer read by anything. |
 
 ## Make targets (run from `infra/`)

--- a/db/postgres/README.md
+++ b/db/postgres/README.md
@@ -21,35 +21,37 @@ by-hand path below safe to run over a populated database.
 
 ### Applying migrations to a running stack
 
-From `infra/`, replay the whole directory. Order matters, and `LC_ALL=C` keeps the shell's sort
-identical to the one initdb uses:
+From `infra/`:
 
 ```sh
-for f in $(LC_ALL=C ls ../db/postgres/*.sql); do
-  echo "-- $f"
-  docker compose exec -T postgres psql -v ON_ERROR_STOP=1 -U tally -d tally < "$f"
-done
+make pg-migrate
 ```
 
-This is non-destructive: it creates what is missing and leaves what exists alone. To apply a
-single file instead:
+That replays the whole directory in `LC_ALL=C` order, under the same `POSTGRES_USER` /
+`POSTGRES_DB` the stack was started with, and **stops on the first failure** with the failing
+filename. It is non-destructive: it creates what is missing and leaves what exists alone.
+
+A stop leaves the schema partially applied. Fix the file it named and re-run `make pg-migrate`;
+replaying from the top is a no-op for everything that already landed.
+
+To apply a single file instead (`make psql` uses the same user and database):
 
 ```sh
-docker compose exec -T postgres psql -v ON_ERROR_STOP=1 -U tally -d tally \
+docker compose exec -T postgres psql -v ON_ERROR_STOP=1 \
+  -U "${POSTGRES_USER:-tally}" -d "${POSTGRES_DB:-tally}" \
   < ../db/postgres/0009_tenant_bq_export_config.sql
 ```
 
 Then confirm what landed:
 
 ```sh
-docker compose exec -T postgres psql -U tally -d tally \
-  -c "\dt"
+make psql   # then \dt
 ```
 
 ## Known sequence irregularities
 
-Two irregularities are permanent facts about this repo's history. Neither is a bug to be fixed by
-renumbering, and both are recorded here so nobody "corrects" them later.
+Two irregularities are permanent facts about this repo's history, recorded here so nobody
+"corrects" them later.
 
 ### `0005` is used twice
 
@@ -57,14 +59,42 @@ renumbering, and both are recorded here so nobody "corrects" them later.
 number 0005. They are unrelated and neither depends on the other; both only need `tenants` from
 `0001`.
 
-They are **not** renumbered. Nothing tracks applied migrations by filename, so a rename would not
-be reconciled by any tooling. It would only mean that an operator who applied
-`0005_tenant_eval_config.sql` now sees, in the repo, a filename they have never run and no
-filename matching what they did run, with nothing to tell them the two are the same migration.
-The filename is the only identity a migration has here, so it is the one thing worth keeping
-stable. The ambiguity that actually mattered, initdb's ordering, is resolved in
-`infra/docker-compose.yml`: the eval-config file is mounted as `0005a_tenant_eval_config.sql`, so
-the two always run in a fixed order.
+These two are **not** renumbered, and the reason is when they were caught, not a rule against
+renumbering. This repo does renumber: `e0cc998` moved the idempotency migration to `0032` to clear
+a collision, `0023_tenant_revenue_uploads` became `0025_`, and `0013/0014_athena` became
+`0020/0021_`. Every one of those was renamed **before it merged**, while the file had never been
+applied to any database. Renaming an unapplied file costs nothing.
+
+Both 0005 files are long deployed to real installs under these names. Nothing here tracks applied
+migrations, so renaming one now would not be reconciled by any tooling: an operator who ran
+`0005_tenant_eval_config.sql` would see a filename in the repo they have never run, no filename
+matching what they did run, and nothing to tell them the two are the same migration. That is the
+distinguishing fact. A duplicate number caught before merge should still be renumbered.
+
+Ordering is handled by giving each file a distinct `/docker-entrypoint-initdb.d` target in
+`infra/docker-compose.yml`, which is what makes initdb deterministic. The eval-config file is
+mounted as `0005a_tenant_eval_config.sql`, and that suffix does **not** order it after
+`0005_cac_periods.sql`. See below.
+
+#### The `0005a_` suffix does not mean what it looks like
+
+`postgres:16` runs with `LANG=en_US.utf8`, and its entrypoint iterates a bash glob over
+`/docker-entrypoint-initdb.d/*`. Under glibc collation the underscore is ignored, so the actual
+initdb order is:
+
+```
+0005a_tenant_eval_config.sql     <- first
+0005_cac_periods.sql             <- second
+```
+
+A `LC_ALL=C` sort (what `make pg-migrate` uses) orders them the other way around. The two orders
+are exactly opposite, so the by-hand replay does not reproduce initdb's order.
+
+Nothing is broken by this: the two 0005 tables are independent, so either order works. But do
+**not** rely on an `a` suffix to sequence a **dependent** pair. Such a pair would run backwards on
+a fresh boot while passing an `LC_ALL=C` by-hand replay, which means it would look green in
+testing and fail on a customer's first install. If one migration depends on another, give it a
+higher number.
 
 ### `0017` does not exist
 
@@ -83,5 +113,5 @@ failure mode the numbering exists to prevent.
    second file at an existing number.
 2. Make it idempotent, so the by-hand path above stays replayable.
 3. Add the `infra/docker-compose.yml` mount in the same commit.
-4. If a running stack needs it, apply it by hand as above. A fresh `make up` on an existing volume
-   will not do it.
+4. If a running stack needs it, `make pg-migrate` from `infra/`. A fresh `make up` on an existing
+   volume will not do it.

--- a/db/postgres/README.md
+++ b/db/postgres/README.md
@@ -1,0 +1,87 @@
+# Control-plane migrations
+
+Numbered SQL files, `0001_` upward, applied to the control-plane Postgres.
+
+## How they are applied
+
+There is no migration runner and **no table that records which migrations have run**.
+A migration reaches a database exactly two ways:
+
+1. **On a first boot against an empty volume.** Each file is mounted into the Postgres
+   container's `/docker-entrypoint-initdb.d/` by `infra/docker-compose.yml`, and the official
+   image runs `*.sql` there in alphabetical order of the *mounted* filename. A file with no
+   mount never runs, so **adding a migration is not done until its compose mount is added too**.
+2. **By hand, against a stack that is already running.** `docker-entrypoint-initdb.d` only fires
+   when the data directory is empty, so an existing stack never picks up a new migration on its
+   own, no matter how many times it is restarted.
+
+Every file in this directory is idempotent (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT
+EXISTS`, `CREATE INDEX IF NOT EXISTS`), so re-running one is a no-op. That is what makes the
+by-hand path below safe to run over a populated database.
+
+### Applying migrations to a running stack
+
+From `infra/`, replay the whole directory. Order matters, and `LC_ALL=C` keeps the shell's sort
+identical to the one initdb uses:
+
+```sh
+for f in $(LC_ALL=C ls ../db/postgres/*.sql); do
+  echo "-- $f"
+  docker compose exec -T postgres psql -v ON_ERROR_STOP=1 -U tally -d tally < "$f"
+done
+```
+
+This is non-destructive: it creates what is missing and leaves what exists alone. To apply a
+single file instead:
+
+```sh
+docker compose exec -T postgres psql -v ON_ERROR_STOP=1 -U tally -d tally \
+  < ../db/postgres/0009_tenant_bq_export_config.sql
+```
+
+Then confirm what landed:
+
+```sh
+docker compose exec -T postgres psql -U tally -d tally \
+  -c "\dt"
+```
+
+## Known sequence irregularities
+
+Two irregularities are permanent facts about this repo's history. Neither is a bug to be fixed by
+renumbering, and both are recorded here so nobody "corrects" them later.
+
+### `0005` is used twice
+
+`0005_cac_periods.sql` (CTO-107) and `0005_tenant_eval_config.sql` (CTO-114) both carry the
+number 0005. They are unrelated and neither depends on the other; both only need `tenants` from
+`0001`.
+
+They are **not** renumbered. Nothing tracks applied migrations by filename, so a rename would not
+be reconciled by any tooling. It would only mean that an operator who applied
+`0005_tenant_eval_config.sql` now sees, in the repo, a filename they have never run and no
+filename matching what they did run, with nothing to tell them the two are the same migration.
+The filename is the only identity a migration has here, so it is the one thing worth keeping
+stable. The ambiguity that actually mattered, initdb's ordering, is resolved in
+`infra/docker-compose.yml`: the eval-config file is mounted as `0005a_tenant_eval_config.sql`, so
+the two always run in a fixed order.
+
+### `0017` does not exist
+
+There is no `0017_*.sql` and there never was one on any branch. It is a skipped number, not a
+withdrawn migration: no table, column or index was ever assigned to it, so no database anywhere
+is missing anything on account of the gap. `docs/specs/initiative-1-orgs-and-access.md` records
+the same observation from when 0029 was allocated.
+
+`0017` is **not** to be backfilled with an unrelated migration. Reusing it would make the number
+mean two different things depending on when a deployment was provisioned, which is the one
+failure mode the numbering exists to prevent.
+
+## Adding a migration
+
+1. Take the next free number after the highest file present. Do not reuse `0017` and do not add a
+   second file at an existing number.
+2. Make it idempotent, so the by-hand path above stays replayable.
+3. Add the `infra/docker-compose.yml` mount in the same commit.
+4. If a running stack needs it, apply it by hand as above. A fresh `make up` on an existing volume
+   will not do it.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,7 +2,7 @@
 COMPOSE := docker compose
 GATEWAY := ai-tally-gateway
 
-.PHONY: help up down nuke logs ps seed demo ch-migrate ch-migrate-otel-engine aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
+.PHONY: help up down nuke logs ps seed demo pg-migrate ch-migrate ch-migrate-otel-engine aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
@@ -33,6 +33,36 @@ down: ## Stop the stack (keep data volumes)
 
 nuke: ## Stop and wipe all data volumes (DDL re-applies on next up)
 	$(COMPOSE) down -v
+
+# Directory replayed by pg-migrate. Overridable so the failure stop below can be exercised
+# against a scratch directory without pointing psql at the real migration set.
+PG_MIGRATIONS_DIR := ../db/postgres
+
+pg-migrate: ## Apply db/postgres migrations to a RUNNING stack (initdb only fires on a fresh volume)
+	@# Same gap as ch-migrate below: the /docker-entrypoint-initdb.d mounts in docker-compose.yml
+	@# run ONLY on a first boot against an empty volume, so an already-running stack never picks up
+	@# a new migration. That is how 0009/0010/0011/0012/0015/0016 stayed unapplied for months
+	@# (CTO-317). Every file in db/postgres is idempotent (CREATE ... IF NOT EXISTS, ADD COLUMN IF
+	@# NOT EXISTS), so replaying the whole directory is a no-op over a populated database.
+	@#
+	@# PG_USER / PG_DB rather than a hardcoded `tally`: a dev running POSTGRES_USER=ai_tally would
+	@# otherwise get `FATAL: role "tally" does not exist` on every file in the set.
+	@#
+	@# ON_ERROR_STOP=1 stops psql inside one file; the `|| { ...; exit 1; }` is what stops the LOOP.
+	@# Without it a failure scrolls past the remaining files and the operator walks away from a
+	@# partially applied schema believing the replay succeeded.
+	@#
+	@# Replay order is LC_ALL=C, which is NOT initdb's order: postgres:16 runs its entrypoint glob
+	@# under LANG=en_US.utf8, where glibc collation ignores the underscore and sorts
+	@# 0005a_tenant_eval_config.sql BEFORE 0005_cac_periods.sql. The two 0005 tables are
+	@# independent, so both orders work; see db/postgres/README.md before adding a dependent pair.
+	@for f in $$(LC_ALL=C ls $(PG_MIGRATIONS_DIR)/*.sql); do \
+	  echo "  applying $$f"; \
+	  $(COMPOSE) exec -T postgres psql -v ON_ERROR_STOP=1 -U $(PG_USER) -d $(PG_DB) -q < $$f \
+	    || { echo ""; echo "FAILED on $$f - stopping. The schema is PARTIALLY applied: fix that"; \
+	         echo "file and re-run 'make pg-migrate' (replaying is idempotent)."; exit 1; }; \
+	done
+	@echo "Postgres migrations applied."
 
 # Canonical ClickHouse DDL, in the same dependency order compose mounts it into initdb.
 CH_DDL := ../db/clickhouse/otel_spans.sql ../db/clickhouse/rollups.sql \
@@ -165,7 +195,7 @@ ch: ## Open a ClickHouse SQL shell
 	$(COMPOSE) exec clickhouse clickhouse-client -u tally --password tally -d default
 
 psql: ## Open a Postgres shell
-	$(COMPOSE) exec postgres psql -U tally -d tally
+	$(COMPOSE) exec postgres psql -U $(PG_USER) -d $(PG_DB)
 
 gateway-shell: ## Shell into the gateway container
 	$(COMPOSE) exec gateway bash

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: clickhouse/clickhouse-server:24.8
     environment:
       # NOTE: the official image runs /docker-entrypoint-initdb.d/*.sql against the `default`
-      # database, and our DDL is unqualified — so all tables live in `default`. We use `default`
+      # database, and our DDL is unqualified, so all tables live in `default`. We use `default`
       # throughout rather than create a confusing empty `tally` db.
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-tally}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
@@ -50,7 +50,7 @@ services:
       - clickhouse-data:/var/lib/clickhouse
       # Tiered storage policy: defines the `warm` volume that otel_spans' TTL moves parts to.
       - ./clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml:ro
-      # DDL is applied alphabetically on first boot — numbered prefixes pin dependency order:
+      # DDL is applied alphabetically on first boot; numbered prefixes pin dependency order:
       # spans table must exist before the rollup MVs that target it.
       - ../db/clickhouse/otel_spans.sql:/docker-entrypoint-initdb.d/01_otel_spans.sql:ro
       - ../db/clickhouse/rollups.sql:/docker-entrypoint-initdb.d/02_rollups.sql:ro
@@ -82,11 +82,20 @@ services:
       - ../db/postgres/0002_tenant_connectors.sql:/docker-entrypoint-initdb.d/0002_tenant_connectors.sql:ro
       - ../db/postgres/0003_tenant_stripe_config.sql:/docker-entrypoint-initdb.d/0003_tenant_stripe_config.sql:ro
       - ../db/postgres/0004_tenant_replay_config.sql:/docker-entrypoint-initdb.d/0004_tenant_replay_config.sql:ro
+      # Two migrations share the number 0005. Deliberately NOT renumbered: nothing tracks applied
+      # migrations by filename here, so a rename would silently desync every operator's by-hand
+      # record from the repo for no functional gain. The `0005a_` target below is what keeps
+      # initdb's alphabetical order deterministic. See db/postgres/README.md (CTO-317).
       - ../db/postgres/0005_cac_periods.sql:/docker-entrypoint-initdb.d/0005_cac_periods.sql:ro
       - ../db/postgres/0005_tenant_eval_config.sql:/docker-entrypoint-initdb.d/0005a_tenant_eval_config.sql:ro
       - ../db/postgres/0006_tenant_guardrails.sql:/docker-entrypoint-initdb.d/0006_tenant_guardrails.sql:ro
       - ../db/postgres/0007_tenant_integration_runs.sql:/docker-entrypoint-initdb.d/0007_tenant_integration_runs.sql:ro
       - ../db/postgres/0008_reconciliation_runs.sql:/docker-entrypoint-initdb.d/0008_reconciliation_runs.sql:ro
+      # BigQuery export config + watermarks (CTO-154). These went unmounted from the day they
+      # landed, so on every fresh initdb both tables were simply absent and the export sink failed
+      # on its first query (CTO-317). Mounted now; an already-running stack needs them by hand.
+      - ../db/postgres/0009_tenant_bq_export_config.sql:/docker-entrypoint-initdb.d/0009_tenant_bq_export_config.sql:ro
+      - ../db/postgres/0010_bq_export_watermarks.sql:/docker-entrypoint-initdb.d/0010_bq_export_watermarks.sql:ro
       - ../db/postgres/0011_tenant_compute_config.sql:/docker-entrypoint-initdb.d/0011_tenant_compute_config.sql:ro
       - ../db/postgres/0012_tenant_egress_config.sql:/docker-entrypoint-initdb.d/0012_tenant_egress_config.sql:ro
       - ../db/postgres/0013_cac_revenue_fields.sql:/docker-entrypoint-initdb.d/0013_cac_revenue_fields.sql:ro
@@ -98,6 +107,10 @@ services:
       - ../db/postgres/0014_tenant_feature_value_events.sql:/docker-entrypoint-initdb.d/0014_tenant_feature_value_events.sql:ro
       - ../db/postgres/0015_tenant_compute_config_gcp.sql:/docker-entrypoint-initdb.d/0015_tenant_compute_config_gcp.sql:ro
       - ../db/postgres/0016_tenant_vercel_config.sql:/docker-entrypoint-initdb.d/0016_tenant_vercel_config.sql:ro
+      # S3 / Athena export config + watermarks (CTO-160), the AWS analog of 0009 / 0010 above and
+      # unmounted for the same reason (CTO-317).
+      - ../db/postgres/0020_tenant_athena_export.sql:/docker-entrypoint-initdb.d/0020_tenant_athena_export.sql:ro
+      - ../db/postgres/0021_athena_export_watermarks.sql:/docker-entrypoint-initdb.d/0021_athena_export_watermarks.sql:ro
       # Revenue: which sources count (CTO-194) and the uploaded-snapshot manifest (CTO-198), plus
       # the account labels table (CTO-186). initdb only runs when the data directory is empty, so
       # on an already-running local stack these have to be applied by hand (`make psql`).

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -82,10 +82,16 @@ services:
       - ../db/postgres/0002_tenant_connectors.sql:/docker-entrypoint-initdb.d/0002_tenant_connectors.sql:ro
       - ../db/postgres/0003_tenant_stripe_config.sql:/docker-entrypoint-initdb.d/0003_tenant_stripe_config.sql:ro
       - ../db/postgres/0004_tenant_replay_config.sql:/docker-entrypoint-initdb.d/0004_tenant_replay_config.sql:ro
-      # Two migrations share the number 0005. Deliberately NOT renumbered: nothing tracks applied
-      # migrations by filename here, so a rename would silently desync every operator's by-hand
-      # record from the repo for no functional gain. The `0005a_` target below is what keeps
-      # initdb's alphabetical order deterministic. See db/postgres/README.md (CTO-317).
+      # Two migrations share the number 0005. Deliberately NOT renumbered: both files have been
+      # applied to real installs under these names, and nothing here tracks applied migrations, so
+      # a rename would leave every operator with a by-hand record that matches no filename in the
+      # repo. Distinct mount targets are what make initdb's order deterministic; the `0005a_`
+      # target does NOT sequence these two the way its name suggests. postgres:16 runs with
+      # LANG=en_US.utf8 and its entrypoint iterates a bash glob, and glibc collation ignores the
+      # underscore, so initdb applies `0005a_tenant_eval_config.sql` BEFORE `0005_cac_periods.sql`
+      # (a LC_ALL=C sort orders them the other way). Harmless here because the two tables are
+      # independent, but do not use an `a` suffix to order a DEPENDENT pair: it would sequence them
+      # backwards on a fresh boot. See db/postgres/README.md (CTO-317).
       - ../db/postgres/0005_cac_periods.sql:/docker-entrypoint-initdb.d/0005_cac_periods.sql:ro
       - ../db/postgres/0005_tenant_eval_config.sql:/docker-entrypoint-initdb.d/0005a_tenant_eval_config.sql:ro
       - ../db/postgres/0006_tenant_guardrails.sql:/docker-entrypoint-initdb.d/0006_tenant_guardrails.sql:ro


### PR DESCRIPTION
Closes #317

## What was actually broken

`0009_tenant_bq_export_config.sql`, `0010_bq_export_watermarks.sql`, `0020_tenant_athena_export.sql` and `0021_athena_export_watermarks.sql` had no `infra/docker-compose.yml` mount. Since a migration reaches a database only via an initdb mount or a by-hand `psql`, those four tables were absent on every fresh install, and the gateway reads all four (`gateway/tenant_bq_export.py`, `gateway/tenant_athena_export.py`), so the BigQuery and Athena export sinks failed on their first query.

This is the whole of the functional bug. The numbering irregularities are cosmetic by comparison, and one of them turned out not to be a defect at all.

## Verification: fresh stack, before and after

Throwaway compose project (`-p tallymigtest`, `POSTGRES_PORT=55432`) against a genuinely empty volume, so the running stack and its 1.5M spans were never touched.

**Before (main): 37 tables.** **After: 41 tables.** The diff is exactly the four:

```
> athena_export_watermarks
> bq_export_watermarks
> tenant_athena_export_config
> tenant_bq_export_config
```

No errors in the initdb log either way.

## The by-hand path for existing installs

`docker-entrypoint-initdb.d` only runs on a first boot against an empty volume, so the mounts do nothing for a stack that is already up. `db/postgres/README.md` documents the replay loop, and `RUNNING.md`'s troubleshooting table now routes there from the symptom an operator actually sees (`relation "tenant_bq_export_config" does not exist`).

Verified two ways:

1. Replayed all 32 migrations over the fully populated throwaway database. Every file re-applied with no error, which confirms the whole directory is idempotent (`CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` throughout).
2. Applied the four migrations by hand to the **real running local stack**, which was missing all four. They created cleanly, a second pass emitted only `NOTICE: relation ... already exists, skipping`, and row counts were unchanged across the operation (`tenants=1, api_keys=5, cac_periods=0, tenant_connectors=3` before and after).

## Renumbering decision: leave both numbers alone

Deliberate, and recorded in `db/postgres/README.md` so it does not get "fixed" later.

**There is no migration tracker.** No `schema_migrations` table, no runner, nothing anywhere in the repo records what has been applied. A migration arrives by initdb mount or by hand, and that is it. So renumbering would not be reconciled by any tooling, and equally would not re-run or orphan anything mechanically.

**That absence is the argument against renumbering, not for it.** Because nothing tracks migrations, the filename is the only identity a migration has. An operator who applied `0005_tenant_eval_config.sql` in June would, after a rename, find a file in the repo they have never run and no file matching what they did run, with nothing to tell them the two are the same migration. The rename buys tidiness and costs the one thing that makes the by-hand path auditable.

**The ordering ambiguity, the part that could actually bite, was already handled.** The compose mount renames the eval-config file to `0005a_tenant_eval_config.sql` in the container, so initdb's alphabetical order between the two 0005s is pinned. I added a comment there explaining why it is written that way.

## `0017` was never withdrawn, it never existed

Checked every ref: no `0017_*.sql` has ever been committed on any branch. It is a skipped number, not a withdrawn migration, so no database anywhere is missing anything on account of it. `docs/specs/initiative-1-orgs-and-access.md` records the same observation from when 0029 was allocated.

So it is **not** backfilled. Dropping an unrelated 2026-06 migration into 0017 would make that number mean different things depending on when a deployment was provisioned, which is precisely the failure mode the numbering exists to prevent.

## Also

Removed the two em dashes in `infra/docker-compose.yml` per CLAUDE.md. The em dashes in `db/postgres/*.sql` comment prose are left alone to keep this diff reviewable.

## Checks

- `infra/gateway`: 940 passed, 8 skipped; `ruff check` clean.
- `docker compose config -q` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
