### PR TITLE
fix(ingest): retry a retryable ingest failure instead of treating it as fatal

### DIFF
--- a/examples/vercel-chatbot/scripts/backfill-spans.ts
+++ b/examples/vercel-chatbot/scripts/backfill-spans.ts
@@ -947,13 +947,32 @@ const EVENTS_PER_BATCH = 500;
 const RETRY_MAX_ATTEMPTS = 60;
 const DEFAULT_RETRY_AFTER_MS = 250;
 const MAX_RETRY_WAIT_MS = 5_000;
+const RETRY_JITTER = 0.25; // +/- fraction, matching the SDK's BackoffPolicy
+
+/**
+ * Consecutive shed batches that end the run.
+ *
+ * A bounded PER-BATCH budget is not a bound on the run. Every batch spends its own 61 attempts
+ * independently, and with the waits capped at 5s that is ~4.7 minutes each, so against a gateway
+ * that is simply gone a 30-day corpus (~1024 span batches) would grind for roughly three days
+ * before printing INCOMPLETE. Bounded budget, unbounded run (#324 review).
+ *
+ * 2, deliberately. Spending even ONE full budget already means ~4.7 minutes of unbroken failure,
+ * which is far longer than the load spike that shed-and-count exists to ride out, so the marginal
+ * news in a second exhausted budget is small: one shed batch is tolerated and the run continues
+ * (that is the case #315 added, an 88%-loaded run should not die for 500 spans), two in a row is a
+ * gateway that is not coming back inside this run. Any delivered batch resets the count. This
+ * bounds the worst case at ~9.5 minutes whatever the corpus size, and being wrong is cheap: a
+ * re-run at the same --seed is idempotent and refills the gap.
+ */
+const MAX_CONSECUTIVE_SHED_BATCHES = 2;
 
 /**
  * Rows this run metered and could not ship. Shed-and-COUNT is the terminal case of the retry loop
  * (#315): a bounded budget can be spent, and when it is, the run says so in numbers rather than
- * reporting a clean finish over a hole in the data.
+ * reporting a clean finish over a hole in the data. `consecutive` drives the circuit breaker above.
  */
-const shed = { spans: 0, events: 0, batches: 0 };
+const shed = { spans: 0, events: 0, batches: 0, consecutive: 0 };
 
 /**
  * What the gateway asked us to wait, in ms, or null when it named nothing.
@@ -984,18 +1003,33 @@ function hintedWaitMs(res: Response | null, text: string): number | null {
   return null;
 }
 
-/** The gateway's own wait when it named a positive one, clamped, else capped exponential backoff. */
+/**
+ * The gateway's own wait when it named a positive one, clamped, else capped exponential backoff.
+ *
+ * The fallback jitters +/- 25%, which is what the SDK's `BackoffPolicy` does and what "the backoff
+ * is mirrored" has to mean to be true (#324 review). A hinted wait is used as stated, unjittered:
+ * the gateway named that number, and both the SDK and the proxy honour it as named.
+ */
 function retryWaitMs(attempt: number, hinted: number | null): number {
   if (hinted !== null && hinted > 0) return Math.min(hinted, MAX_RETRY_WAIT_MS);
-  return Math.min(DEFAULT_RETRY_AFTER_MS * 2 ** Math.min(attempt, 5), MAX_RETRY_WAIT_MS);
+  const raw = Math.min(DEFAULT_RETRY_AFTER_MS * 2 ** Math.min(attempt, 5), MAX_RETRY_WAIT_MS);
+  return Math.max(0, raw + raw * RETRY_JITTER * (Math.random() * 2 - 1));
 }
 
+/**
+ * POSTs one batch. Returns whether it was actually DELIVERED, so the caller counts only what
+ * shipped: a shed batch used to be counted into the running `posted` total, which printed a tick
+ * over a hole and left the honest number to the final summary (#324 review, CLAUDE.md).
+ *
+ * Throws when the circuit breaker trips (MAX_CONSECUTIVE_SHED_BATCHES) or on a non-retryable
+ * status; both end the run.
+ */
 async function postBatch(
   args: Args,
   n: number,
   spans: Span[],
   events: Record<string, unknown>[],
-): Promise<void> {
+): Promise<boolean> {
   const batch = {
     tenant_id: args.tenant,
     sdk_version: "vercel-chatbot-backfill/0.2",
@@ -1003,7 +1037,7 @@ async function postBatch(
     resource_spans: spans,
     business_events: events,
   };
-  if (args.dryRun) return;
+  if (args.dryRun) return true;
   const body = JSON.stringify(batch);
   // A 30-day corpus is ~500k spans, which is far more than a flat-out loop can push past the
   // gateway's two load guards: the per-tenant rate limit (429, CTO-33) and backpressure shedding
@@ -1021,7 +1055,8 @@ async function postBatch(
   // transport error, a 429 or any 5xx; honour the gateway's stated wait, clamped; bound the
   // attempts; then shed and COUNT. The budget is far longer than the proxy's four attempts because
   // this is a one-shot corpus load with no hot path behind it, and riding out a minute of shedding
-  // is worth more here than failing fast.
+  // is worth more here than failing fast. Where the two policies deliberately differ is tabulated
+  // in the sdk/python/src/tally/transport.py module docstring, which is the authoritative list.
   for (let attempt = 0; ; attempt++) {
     let res: Response | null = null;
     let text = "";
@@ -1032,7 +1067,10 @@ async function postBatch(
         headers: { "Content-Type": "application/json" },
         body,
       });
-      if (res.ok) return;
+      if (res.ok) {
+        shed.consecutive = 0; // a delivery means the gateway is answering; re-arm the breaker
+        return true;
+      }
       text = await res.text();
       why = `${res.status}: ${text}`;
     } catch (err) {
@@ -1052,11 +1090,24 @@ async function postBatch(
       shed.spans += spans.length;
       shed.events += events.length;
       shed.batches++;
+      shed.consecutive++;
       console.warn(
         `  ! batch ${n} shed after ${attempt + 1} attempts (${spans.length} spans, ` +
           `${events.length} events lost) - last failure ${why}`,
       );
-      return;
+      if (shed.consecutive >= MAX_CONSECUTIVE_SHED_BATCHES) {
+        // The circuit breaker. Each batch gets its own budget, so without this the run keeps
+        // paying ~4.7 minutes per batch against a gateway that is gone (#324 review). Name the
+        // cause: an operator staring at this needs to know it is the gateway, not the corpus.
+        throw new Error(
+          `aborting after ${shed.consecutive} consecutive shed batches: the ingest endpoint ` +
+            `${args.gatewayUrl} is not accepting batches (last failure ${why}). ` +
+            `Shed ${shed.spans} spans and ${shed.events} events in ${shed.batches} batch(es) so ` +
+            `far. Bring the stack up (cd infra && make up) and re-run at --seed ${args.seed}: it ` +
+            "is idempotent, so nothing already loaded is duplicated.",
+        );
+      }
+      return false;
     }
     await new Promise((r) => setTimeout(r, retryWaitMs(attempt, hintedWaitMs(res, text)) + 25));
   }
@@ -1104,8 +1155,10 @@ async function main(): Promise<void> {
   let posted = 0;
   for (let i = 0; i < gen.spans.length; i += SPANS_PER_BATCH) {
     const chunk = gen.spans.slice(i, i + SPANS_PER_BATCH);
-    await postBatch(args, batchN++, chunk, []);
-    posted += chunk.length;
+    // Only what actually shipped. Counting a shed batch here reported undelivered spans as posted
+    // and left the truth to the final summary, which is the tick over a hole this whole path
+    // exists to remove (#324 review, CLAUDE.md honest under uncertainty).
+    if (await postBatch(args, batchN++, chunk, [])) posted += chunk.length;
     if (batchN % 25 === 0) {
       console.log(`  · posted ${posted}/${gen.spans.length} spans`);
     }
@@ -1122,7 +1175,9 @@ async function main(): Promise<void> {
     console.error(
       `! Backfill INCOMPLETE: ${shed.spans} spans and ${shed.events} events in ${shed.batches} ` +
         `batch(es) were shed after ${RETRY_MAX_ATTEMPTS + 1} failed attempts each. ` +
-        `Delivered ${gen.spans.length - shed.spans}/${gen.spans.length} spans and ` +
+        // `posted` is the same running total the progress lines printed, not a second computation
+        // of it, so the two cannot disagree (#324 review).
+        `Delivered ${posted}/${gen.spans.length} spans and ` +
         `${gen.events.length - shed.events}/${gen.events.length} events in ${batchN} batches. ` +
         `Re-run at --seed ${args.seed} to fill the gap: it is idempotent.`,
     );
@@ -1131,7 +1186,7 @@ async function main(): Promise<void> {
   }
   console.log(
     `✓ Backfill ${args.dryRun ? "(dry-run) " : ""}done. ` +
-      `${gen.spans.length} spans + ${gen.events.length} events in ${batchN} batches. ` +
+      `${posted} spans + ${gen.events.length} events in ${batchN} batches. ` +
       `Re-run at --seed ${args.seed} is idempotent.`,
   );
 }

--- a/examples/vercel-chatbot/scripts/backfill-spans.ts
+++ b/examples/vercel-chatbot/scripts/backfill-spans.ts
@@ -172,7 +172,7 @@ function parseArgs(argv: string[]): Args {
   return out;
 }
 
-// Mulberry32 — same deterministic PRNG the live driver uses.
+// Mulberry32: the same deterministic PRNG the live driver uses.
 function makeRng(seed: number): () => number {
   let state = seed >>> 0;
   return () => {
@@ -267,7 +267,7 @@ function fmtUsd(micro: bigint): string {
 // report an expectation the ClickHouse total can be checked against.
 // ---------------------------------------------------------------------------
 
-// Feature mix — share of the LLM-layer spend — plus the agent (ServiceName) that runs it. Distinct
+// Feature mix (share of the LLM-layer spend) plus the agent (ServiceName) that runs it. Distinct
 // agents matter: /agents groups by ServiceName, and the waste detectors scope a finding to a
 // feature when tagged and to its agent otherwise, so a single ServiceName would collapse the whole
 // corpus into one row and prove nothing.
@@ -324,7 +324,7 @@ const EMBED_MODELS: { model: string; microPerMtok: bigint }[] = [
   { model: "text-embedding-3-large", microPerMtok: 130_000n }, // $0.13 / Mtok
 ];
 
-// Per-call tool rates — _TOOL_SEEDS in the seed catalog, in micro-USD per call.
+// Per-call tool rates, _TOOL_SEEDS in the seed catalog, in micro-USD per call.
 const TOOLS: { provider: string; name: string; microPerCall: bigint }[] = [
   { provider: "tavily", name: "search", microPerCall: 10_000n },
   { provider: "serpapi", name: "search", microPerCall: 15_000n },
@@ -334,7 +334,7 @@ const TOOLS: { provider: string; name: string; microPerCall: bigint }[] = [
   { provider: "openai", name: "code_interpreter", microPerCall: 30_000n },
 ];
 
-// Per-query vector rates — _VECTOR_SEEDS, in micro-USD per call. This is the SERVING portion only:
+// Per-query vector rates, _VECTOR_SEEDS, in micro-USD per call. This is the SERVING portion only:
 // the deployed-index node-hours that dominate a real vector bill are a COMPUTE cost by design (see
 // the cost-split note on _VECTOR_SEEDS in pricing.py), and are carried by the compute rows below.
 // So the Vector layer here is honestly small; it is not padded to look like the mock's 13%.
@@ -948,6 +948,48 @@ const RETRY_MAX_ATTEMPTS = 60;
 const DEFAULT_RETRY_AFTER_MS = 250;
 const MAX_RETRY_WAIT_MS = 5_000;
 
+/**
+ * Rows this run metered and could not ship. Shed-and-COUNT is the terminal case of the retry loop
+ * (#315): a bounded budget can be spent, and when it is, the run says so in numbers rather than
+ * reporting a clean finish over a hole in the data.
+ */
+const shed = { spans: 0, events: 0, batches: 0 };
+
+/**
+ * What the gateway asked us to wait, in ms, or null when it named nothing.
+ *
+ * `Retry-After` (delay-seconds) is the header form the rate limiter and the overload shed both send
+ * (gateway/app.py). The body states it at the top level on a 429 and under `server_hints` on a 503.
+ * A hinted 0 is a REAL value: the overload shed sends `retry_after_ms: 0` meaning "retry, we have
+ * no specific delay for you", which is not licence to hammer a gateway that is already shedding, so
+ * the caller answers a 0 with its own backoff. A malformed header or body yields null the same way.
+ */
+function hintedWaitMs(res: Response | null, text: string): number | null {
+  const header = res?.headers.get("retry-after");
+  if (header) {
+    const secs = Number.parseInt(header.trim(), 10);
+    if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  }
+  try {
+    const parsed = JSON.parse(text) as {
+      retry_after_ms?: number;
+      server_hints?: { retry_after_ms?: number };
+    };
+    for (const v of [parsed.retry_after_ms, parsed.server_hints?.retry_after_ms]) {
+      if (typeof v === "number" && Number.isFinite(v) && v >= 0) return v;
+    }
+  } catch {
+    // body was not the shape we expected; it carries no hint
+  }
+  return null;
+}
+
+/** The gateway's own wait when it named a positive one, clamped, else capped exponential backoff. */
+function retryWaitMs(attempt: number, hinted: number | null): number {
+  if (hinted !== null && hinted > 0) return Math.min(hinted, MAX_RETRY_WAIT_MS);
+  return Math.min(DEFAULT_RETRY_AFTER_MS * 2 ** Math.min(attempt, 5), MAX_RETRY_WAIT_MS);
+}
+
 async function postBatch(
   args: Args,
   n: number,
@@ -966,38 +1008,57 @@ async function postBatch(
   // A 30-day corpus is ~500k spans, which is far more than a flat-out loop can push past the
   // gateway's two load guards: the per-tenant rate limit (429, CTO-33) and backpressure shedding
   // (503 `status: retry`, CTO-36). Both are the gateway working as designed and both say "come
-  // back shortly", so honour them rather than failing a half-loaded backfill. Re-posting the same
-  // batch_id is safe by construction: the (tenant_id, batch_id) dedup means a retry, or a whole
-  // re-run after an abort, can never double-count.
+  // back shortly", so honour them rather than failing a half-loaded backfill: this run died at
+  // 450,000 of 512,056 spans on a 503 it treated as fatal (#315).
+  //
+  // `body` is serialized ONCE, above, and every attempt resends those same bytes. That is what
+  // makes a resend a replay rather than a duplicate: batch_id is stable, so the gateway's
+  // (tenant_id, batch_id) dedup absorbs it. A retry that rebuilt the payload would instead write
+  // duplicate spans, which permanently pollute the SummingMergeTree rollups (#311). The same
+  // property is why a whole re-run at the same --seed is idempotent.
+  //
+  // The policy mirrors the edge proxy (infra/edge-proxy/internal/telemetry/telemetry.go): retry a
+  // transport error, a 429 or any 5xx; honour the gateway's stated wait, clamped; bound the
+  // attempts; then shed and COUNT. The budget is far longer than the proxy's four attempts because
+  // this is a one-shot corpus load with no hot path behind it, and riding out a minute of shedding
+  // is worth more here than failing fast.
   for (let attempt = 0; ; attempt++) {
-    const res = await fetch(args.gatewayUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body,
-    });
-    if (res.ok) return;
-    const text = await res.text();
-    const retryable = res.status === 429 || res.status === 503;
-    if (retryable && attempt < RETRY_MAX_ATTEMPTS) {
-      // The gateway states its own wait, at the top level (429) or under server_hints (503). A
-      // hinted 0 means "no specific delay", so fall back to a small backoff rather than spinning.
-      let waitMs = 0;
-      try {
-        const parsed = JSON.parse(text) as {
-          retry_after_ms?: number;
-          server_hints?: { retry_after_ms?: number };
-        };
-        waitMs = parsed.retry_after_ms ?? parsed.server_hints?.retry_after_ms ?? 0;
-      } catch {
-        // body was not the shape we expected; fall through to the backoff below
-      }
-      if (!(waitMs > 0)) {
-        waitMs = Math.min(DEFAULT_RETRY_AFTER_MS * 2 ** Math.min(attempt, 5), MAX_RETRY_WAIT_MS);
-      }
-      await new Promise((r) => setTimeout(r, waitMs + 25));
-      continue;
+    let res: Response | null = null;
+    let text = "";
+    let why = "";
+    try {
+      res = await fetch(args.gatewayUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      if (res.ok) return;
+      text = await res.text();
+      why = `${res.status}: ${text}`;
+    } catch (err) {
+      // A transport failure is the most retryable failure there is: nothing says the gateway even
+      // saw the batch, and the stable batch_id makes a blind resend safe.
+      why = `transport error: ${err instanceof Error ? err.message : String(err)}`;
     }
-    throw new Error(`POST ${args.gatewayUrl} ${res.status}: ${text}`);
+    // Backpressure and server faults are transient by definition. Every other status is the gateway
+    // saying this batch (or this configuration) is wrong, and resending identical bytes would only
+    // buy a second refusal, so it aborts the run: unlike the proxy, a CLI has an operator who can
+    // fix the credential or the tenant and re-run, and every later batch would fail identically.
+    const retryable = res === null || res.status === 429 || res.status >= 500;
+    if (!retryable) {
+      throw new Error(`POST ${args.gatewayUrl} ${why}`);
+    }
+    if (attempt >= RETRY_MAX_ATTEMPTS) {
+      shed.spans += spans.length;
+      shed.events += events.length;
+      shed.batches++;
+      console.warn(
+        `  ! batch ${n} shed after ${attempt + 1} attempts (${spans.length} spans, ` +
+          `${events.length} events lost) - last failure ${why}`,
+      );
+      return;
+    }
+    await new Promise((r) => setTimeout(r, retryWaitMs(attempt, hintedWaitMs(res, text)) + 25));
   }
 }
 
@@ -1008,7 +1069,7 @@ async function main(): Promise<void> {
       `(LLM target $${args.targetUsd.toLocaleString("en-US")}, seed=${args.seed}, tenant=${args.tenant})…`,
   );
   console.log(
-    "  NOTE: synthetic-seed data — backdated spans, no LLM calls, $0 API spend.",
+    "  NOTE: synthetic-seed data: backdated spans, no LLM calls, $0 API spend.",
   );
 
   const accounts = await resolveAccounts(args);
@@ -1055,6 +1116,19 @@ async function main(): Promise<void> {
   }
 
   console.log("");
+  if (shed.batches > 0) {
+    // Honest under uncertainty (CLAUDE.md): a run that lost rows says how many and exits non-zero,
+    // rather than printing a tick over a hole. Re-running at the same --seed is safe and refills it.
+    console.error(
+      `! Backfill INCOMPLETE: ${shed.spans} spans and ${shed.events} events in ${shed.batches} ` +
+        `batch(es) were shed after ${RETRY_MAX_ATTEMPTS + 1} failed attempts each. ` +
+        `Delivered ${gen.spans.length - shed.spans}/${gen.spans.length} spans and ` +
+        `${gen.events.length - shed.events}/${gen.events.length} events in ${batchN} batches. ` +
+        `Re-run at --seed ${args.seed} to fill the gap: it is idempotent.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   console.log(
     `✓ Backfill ${args.dryRun ? "(dry-run) " : ""}done. ` +
       `${gen.spans.length} spans + ${gen.events.length} events in ${batchN} batches. ` +

--- a/sdk/python/src/tally/transport.py
+++ b/sdk/python/src/tally/transport.py
@@ -10,9 +10,17 @@ the ingest key as bearer. The design guarantees, all non-negotiable (CLAUDE.md, 
   thread. A full buffer drops the oldest span and counts it (backpressure, drop-oldest).
 - **Never raises.** Every path runs inside the safety boundary; a transport error is recorded to
   self-observability, never propagated.
-- **Buffering + retry.** A failed flush retries the whole batch (idempotent by ``batch_id``) with
-  capped exponential backoff + jitter, bounded by ``retry_max``; an exhausted batch is dropped with
-  a counter, never retried forever.
+- **Buffering + bounded retry, then shed and count.** A *retryable* failure (transport error, 429,
+  any 5xx) resends the exact same bytes, so ``batch_id`` is stable and the gateway's
+  ``(tenant_id, batch_id)`` idempotency key turns the resend into a replay rather than a duplicate.
+  The wait honors the gateway's own hint (``Retry-After``, or ``server_hints.retry_after_ms``, which
+  is what a 503 ``status: retry`` carries) clamped to the backoff ceiling, else capped exponential
+  backoff + jitter. The attempt count is bounded by ``retry_max``; an exhausted batch is shed and
+  COUNTED (``undelivered_span_count``), never retried forever and never silently forgotten. A
+  *non-retryable* refusal (400, 401, 403, 422) is terminal on the first answer: resending identical
+  bytes would only buy a second refusal, so the batch is shed and counted as
+  ``rejected_span_count``. This mirrors ``infra/edge-proxy/internal/telemetry/telemetry.go``, which
+  is the reference implementation of the pattern (CTO-36, #315).
 - **Drains on shutdown.** :meth:`flush` and an ``atexit`` hook drain with a bounded timeout so a
   short-lived script still ships its spans.
 
@@ -33,6 +41,7 @@ import urllib.error
 import urllib.request
 from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from tally.egress import BackoffPolicy
 from tally.hmac_keys import HmacKeyBootstrap
@@ -43,15 +52,87 @@ _log = logging.getLogger("tally")
 
 DEFAULT_ENDPOINT = "https://ingest.ai-tally.com"
 
-#: Sends one POST. Returns the HTTP status code; raises on a network-level failure. Injectable.
-Sender = Callable[[str, dict[str, str], bytes], int]
+@dataclass(frozen=True, slots=True)
+class SendResult:
+    """One POST's answer: the status, plus how long the gateway asked us to wait before a resend.
+
+    ``retry_after_ms`` is ``None`` when the gateway named no delay and the client falls back to its
+    own backoff. ``0`` is a real, distinct value: the gateway's overload shed sends
+    ``server_hints.retry_after_ms = 0`` (gateway/backpressure.py) meaning "retry, we have no
+    specific delay for you", not "hammer us". The client answers a 0 with its own bounded backoff,
+    which is the same treatment the edge proxy gives an absent Retry-After.
+    """
+
+    status: int
+    retry_after_ms: int | None = None
 
 
-def _urllib_sender(url: str, headers: dict[str, str], body: bytes, *, timeout: float = 5.0) -> int:
-    """Default POST sender over ``urllib`` (stdlib). Raises ``urllib.error.URLError`` on failure."""
+#: Sends one POST. Returns a :class:`SendResult`, or a bare status code (the older shape, still
+#: accepted so an injected test sender or a caller's own sender keeps working); raises on a
+#: network-level failure. Injectable.
+Sender = Callable[[str, dict[str, str], bytes], "int | SendResult"]
+
+#: Bounds how much of an ingest error body is read to find a retry hint. The ack is a small JSON
+#: object; the cap only stops a misconfigured endpoint that streams from making us buffer without
+#: limit. Nothing from the body is logged or stored: only the integer hint is used.
+_MAX_ACK_BYTES = 64 * 1024
+
+
+def _retry_hint_ms(headers: object, body: bytes) -> int | None:
+    """Extract the gateway's requested wait, preferring the header, then the body hint.
+
+    ``Retry-After`` is read in its delay-seconds form, which is what the gateway's rate limiter and
+    its overload shed both send (gateway/app.py). An HTTP-date form or garbage yields ``None`` and
+    the caller falls back to its own backoff, so a malformed header can never stall the worker.
+    """
+    get = getattr(headers, "get", None)
+    if callable(get):
+        raw = get("Retry-After")
+        if raw:
+            try:
+                secs = int(str(raw).strip())
+            except ValueError:
+                secs = -1
+            if secs >= 0:
+                return secs * 1000
+    if not body:
+        return None
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except Exception:  # noqa: BLE001 - a body we cannot parse simply carries no hint
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    hints = parsed.get("server_hints")
+    nested = hints.get("retry_after_ms") if isinstance(hints, dict) else None
+    # A 429 states it at the top level, a 503 shed under server_hints (gateway/app.py).
+    for candidate in (parsed.get("retry_after_ms"), nested):
+        if isinstance(candidate, int) and not isinstance(candidate, bool) and candidate >= 0:
+            return candidate
+    return None
+
+
+def _urllib_sender(
+    url: str, headers: dict[str, str], body: bytes, *, timeout: float = 5.0
+) -> SendResult:
+    """Default POST sender over ``urllib`` (stdlib). Raises ``urllib.error.URLError`` on failure.
+
+    urllib raises ``HTTPError`` for every non-2xx, but an HTTPError *is* the response, so the 429 /
+    503 answers that carry a retry hint are read here rather than collapsing into a bare exception
+    that loses the gateway's own instruction (#315).
+    """
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed https endpoint
-        return int(resp.status)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed endpoint
+            return SendResult(int(resp.status))
+    except urllib.error.HTTPError as err:
+        try:
+            ack = err.read(_MAX_ACK_BYTES)
+        except Exception:  # noqa: BLE001 - a body we cannot read simply carries no hint
+            ack = b""
+        finally:
+            err.close()
+        return SendResult(int(err.code), _retry_hint_ms(err.headers, ack))
 
 
 def fetch_hmac_key(
@@ -135,8 +216,19 @@ class BatchingTransport:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._consecutive_failures = 0
-        # A batch pinned in flight across retries, so its batch_id is stable (idempotent resend).
-        self._pending: tuple[BatchRequest, int] | None = None
+        # A batch pinned in flight across retries together with the EXACT bytes that were sent, so
+        # every resend is byte-identical and batch_id is stable. Re-encoding per attempt would be
+        # the bug that matters now that a duplicate span permanently pollutes the SummingMergeTree
+        # rollups (#311): the gateway's (tenant_id, batch_id) idempotency store only recognizes a
+        # replay if the replay is actually the same batch (#315).
+        self._pending: tuple[BatchRequest, bytes, int] | None = None
+        # The gateway's own requested wait from the last retryable answer, or None for "it named
+        # none, use our backoff". 0 is a real value and means "retry, no specific delay".
+        self._retry_after_ms: int | None = None
+        # Spans metered and then lost, kept apart because the two losses have different fixes: a
+        # spent retry budget is an ingest availability problem, a refusal is a client-side one.
+        self.undelivered_span_count = 0
+        self.rejected_span_count = 0
         self._atexit_registered = False
 
     # --- Exporter protocol (hot path) ---
@@ -162,6 +254,14 @@ class BatchingTransport:
         # tenant_id="" - the bearer key decides the tenant at the gateway (CTO-260 §3.1).
         return BatchRequest(tenant_id="", sdk_version=self._sdk_version, resource_spans=spans)
 
+    @staticmethod
+    def _is_retryable(status: int) -> bool:
+        """Backpressure and server faults are transient by definition; the same bytes are accepted
+        once ingest recovers. Every other non-2xx is the gateway saying this batch is wrong (bad
+        credential, wrong tenant, failed validation), and a resend only buys a second refusal. This
+        is exactly the edge proxy's split (telemetry.go ``attempt``)."""
+        return status == 429 or status >= 500
+
     def flush_once(self) -> bool:
         """Flush a single batch. Returns True on delivery, False on empty/failure. Never raises.
 
@@ -171,55 +271,105 @@ class BatchingTransport:
         """
         with self._flush_lock:
             # Assemble or reclaim the in-flight batch, then pin it before the send so a mid-send
-            # failure (even a thread death) can never lose the already-dequeued spans.
+            # failure (even a thread death) can never lose the already-dequeued spans. The body is
+            # encoded once, with the batch, and every attempt resends those same bytes.
             with self._lock:
                 if self._pending is not None:
-                    batch, attempts = self._pending
+                    batch, body, attempts = self._pending
                 else:
                     if not self._buf:
                         return False
                     n = min(self.max_batch_size, len(self._buf))
                     spans = [self._buf.popleft() for _ in range(n)]
                     batch = self._build_batch(spans)
+                    body = encode_request(batch).encode("utf-8")
                     attempts = 0
-                    self._pending = (batch, attempts)
+                    self._pending = (batch, body, attempts)
 
             headers = {
                 "Authorization": f"Bearer {self._key}",
                 "Content-Type": "application/json",
             }
-            body = encode_request(batch).encode("utf-8")
+            ok = False
+            retryable = True  # a transport error is the most retryable failure there is
+            status: int | None = None
+            hint: int | None = None
             try:
-                status = self._sender(self._url, headers, body)
+                result = self._sender(self._url, headers, body)
+                if isinstance(result, SendResult):
+                    status, hint = result.status, result.retry_after_ms
+                else:
+                    status = int(result)
                 ok = 200 <= status < 300
+                retryable = ok or self._is_retryable(status)
             except Exception as exc:  # noqa: BLE001 - transport errors must never escape
                 self.obs.record_error(exc, "BatchingTransport.flush")
-                ok = False
 
             with self._lock:
                 if ok:
                     self._pending = None
                     self._consecutive_failures = 0
+                    self._retry_after_ms = None
                     return True
 
-                # Failure: keep the batch pinned for retry, bounded by retry_max (idempotent resend
-                # by batch_id).
                 attempts += 1
                 self._consecutive_failures += 1
-                if attempts >= self.retry_max:
-                    self.obs.dropped_span_count += len(batch.resource_spans)
-                    self.obs.record_error(
-                        RuntimeError(f"batch dropped after {attempts} attempts"),
-                        "BatchingTransport.flush",
-                    )
-                    self._pending = None
+                self._retry_after_ms = hint
+                if not retryable:
+                    # Terminal on the first answer: shed and count, no resend. Counted apart from a
+                    # spent budget because a 401 is fixed by the operator, not by waiting.
+                    self.rejected_span_count += len(batch.resource_spans)
+                    self._shed_locked(batch, f"refused with status {status}")
+                elif attempts >= self.retry_max:
+                    self.undelivered_span_count += len(batch.resource_spans)
+                    self._shed_locked(batch, f"undelivered after {attempts} attempts")
                 else:
-                    self._pending = (batch, attempts)
+                    # Keep the batch, and its bytes, pinned for an identical resend.
+                    self._pending = (batch, body, attempts)
             return False
 
+    def _shed_locked(self, batch: BatchRequest, why: str) -> None:
+        """Terminal loss of one batch. Counted and logged, never quietly forgotten and never
+        reported as a success: an unshipped span is a real, visible number (CLAUDE.md, honest under
+        uncertainty). Caller holds _lock."""
+        lost = len(batch.resource_spans)
+        self.obs.dropped_span_count += lost
+        self.obs.record_error(
+            RuntimeError(f"batch dropped: {why}"), "BatchingTransport.flush"
+        )
+        self._pending = None
+        self._retry_after_ms = None
+        # Warn, not debug: dropped spend is the one transport event an operator has to see.
+        _log.warning("tally: shed %d span(s), batch %s", lost, why)
+
+    def shed_counts(self) -> dict[str, int]:
+        """Spans this transport metered and could not ship, by cause. The honest total the caller
+        needs to know a run lost data (#315)."""
+        with self._lock:
+            return {
+                "undelivered_span_count": self.undelivered_span_count,
+                "rejected_span_count": self.rejected_span_count,
+                "buffer_overflow_span_count": (
+                    self.obs.dropped_span_count
+                    - self.undelivered_span_count
+                    - self.rejected_span_count
+                ),
+            }
+
+    def _has_pending(self) -> bool:
+        with self._lock:
+            return self._pending is not None
+
     def current_backoff_ms(self) -> float:
+        """Wait before the next attempt. The gateway's own hint wins when it named one, clamped to
+        the backoff ceiling so a server asking for a five minute pause cannot stall the worker; a
+        hinted 0 falls back to our jittered backoff, because "no specific delay" is not licence to
+        hammer a gateway that is already shedding."""
         with self._lock:
             failures = self._consecutive_failures
+            hint = self._retry_after_ms
+        if hint is not None and hint > 0:
+            return float(min(hint, self.backoff.max_ms))
         return self.backoff.delay_ms(failures)
 
     # --- background loop ---

--- a/sdk/python/src/tally/transport.py
+++ b/sdk/python/src/tally/transport.py
@@ -24,6 +24,34 @@ the ingest key as bearer. The design guarantees, all non-negotiable (CLAUDE.md, 
 - **Drains on shutdown.** :meth:`flush` and an ``atexit`` hook drain with a bounded timeout so a
   short-lived script still ships its spans.
 
+Where these clients deliberately differ from the proxy (the authoritative list, kept here rather
+than only in a PR description so it stays true as the code moves, #315 review):
+
+===========================  ==============================  ====================================
+divergence                   edge proxy                      SDK / backfill
+===========================  ==============================  ====================================
+retry budget                 4 attempts                      SDK ``retry_max`` (5); the backfill
+                                                             61, a one-shot corpus load with no
+                                                             hot path behind it
+non-retryable refusal        shed, worker continues          SDK sheds and continues; the backfill
+                                                             aborts, since a CLI has an operator
+                                                             who can fix the credential, and a
+                                                             re-run at the same seed is idempotent
+hint clamp                   ``Max: 2 * time.Second``        SDK clamps to ``BackoffPolicy.max_ms``
+                                                             (30s by default) so one policy object
+                                                             governs every wait; the wait sits on
+                                                             ``_stop.wait``, so stop()/atexit still
+                                                             interrupt it and ``export()`` is never
+                                                             blocked by it
+backoff jitter               none                            SDK jitters +/- 25% via
+                                                             ``BackoffPolicy``; the backfill now
+                                                             jitters to match
+body retry hint              header only                     both clients also read
+                                                             ``server_hints.retry_after_ms``,
+                                                             which is the only place the gateway's
+                                                             503 shed states its wait
+===========================  ==============================  ====================================
+
 The tenant is omitted from the envelope: the bearer key is authoritative and the gateway maps it to
 the tenant (CTO-260 §3.1). The batch carries ``tenant_id=""`` so it claims no tenant.
 
@@ -76,6 +104,13 @@ Sender = Callable[[str, dict[str, str], bytes], "int | SendResult"]
 #: object; the cap only stops a misconfigured endpoint that streams from making us buffer without
 #: limit. Nothing from the body is logged or stored: only the integer hint is used.
 _MAX_ACK_BYTES = 64 * 1024
+
+#: How many further sheds of one cause pass before the log speaks about it again. A standing cause
+#: (a rotated ingest key answering 401) sheds a batch per flush for as long as the app runs, so the
+#: first one warns in full and the rest are rolled into one line per this many. Counted by sheds
+#: rather than by elapsed time so the damping is deterministic and testable, and because a busy app
+#: and an idle one should both get the same number of lines per unit of loss (#315 review).
+_SHED_LOG_EVERY = 100
 
 
 def _retry_hint_ms(headers: object, body: bytes) -> int | None:
@@ -220,8 +255,9 @@ class BatchingTransport:
         # every resend is byte-identical and batch_id is stable. Re-encoding per attempt would be
         # the bug that matters now that a duplicate span permanently pollutes the SummingMergeTree
         # rollups (#311): the gateway's (tenant_id, batch_id) idempotency store only recognizes a
-        # replay if the replay is actually the same batch (#315).
-        self._pending: tuple[BatchRequest, bytes, int] | None = None
+        # replay if the replay is actually the same batch (#315). The bytes are None only in the
+        # window between taking the batch off the buffer and encoding it outside the lock.
+        self._pending: tuple[BatchRequest, bytes | None, int] | None = None
         # The gateway's own requested wait from the last retryable answer, or None for "it named
         # none, use our backoff". 0 is a real value and means "retry, no specific delay".
         self._retry_after_ms: int | None = None
@@ -229,6 +265,12 @@ class BatchingTransport:
         # spent retry budget is an ingest availability problem, a refusal is a client-side one.
         self.undelivered_span_count = 0
         self.rejected_span_count = 0
+        # Counted where it happens, in export(), not derived by subtracting the other two from
+        # obs.dropped_span_count: obs can be shared with a BatchProcessor, which drops spans of its
+        # own, and a subtracted figure would report those as this buffer overflowing (#315 review).
+        self.buffer_overflow_span_count = 0
+        # cause -> [sheds, spans] accumulated since that cause last spoke in the log.
+        self._shed_log_state: dict[str, list[int]] = {}
         self._atexit_registered = False
 
     # --- Exporter protocol (hot path) ---
@@ -239,6 +281,7 @@ class BatchingTransport:
                 if len(self._buf) >= self.max_buffer:
                     self._buf.popleft()
                     self.obs.dropped_span_count += 1
+                    self.buffer_overflow_span_count += 1
                 self._buf.append(attributes)
 
     def pending(self) -> int:
@@ -271,8 +314,7 @@ class BatchingTransport:
         """
         with self._flush_lock:
             # Assemble or reclaim the in-flight batch, then pin it before the send so a mid-send
-            # failure (even a thread death) can never lose the already-dequeued spans. The body is
-            # encoded once, with the batch, and every attempt resends those same bytes.
+            # failure (even a thread death) can never lose the already-dequeued spans.
             with self._lock:
                 if self._pending is not None:
                     batch, body, attempts = self._pending
@@ -282,9 +324,24 @@ class BatchingTransport:
                     n = min(self.max_batch_size, len(self._buf))
                     spans = [self._buf.popleft() for _ in range(n)]
                     batch = self._build_batch(spans)
-                    body = encode_request(batch).encode("utf-8")
-                    attempts = 0
+                    body, attempts = None, 0
+                    # Pinned with body=None, i.e. "taken, not yet encoded": pending() still counts
+                    # these spans and a death before the encode cannot lose them.
                     self._pending = (batch, body, attempts)
+
+            if body is None:
+                # Encoded OUTSIDE _lock, deliberately. Serializing up to max_batch_size (512) spans
+                # is not the "brief state transition" _lock exists for, and doing it under the lock
+                # stalls every export() on the hot path once per flush, which the invariant above
+                # forbids (CTO-260 §5, #315 review). Encoding stays exactly once per batch: the
+                # bytes are pinned here and every attempt resends these same bytes, which is what
+                # makes a resend a replay rather than a rollup-polluting duplicate (#311).
+                body = encode_request(batch).encode("utf-8")
+                with self._lock:
+                    # Only re-pin our own batch. _flush_lock serializes flushes, so nothing can
+                    # have replaced it, but a shed batch must never be resurrected by this write.
+                    if self._pending is not None and self._pending[0] is batch:
+                        self._pending = (batch, body, self._pending[2])
 
             headers = {
                 "Authorization": f"Bearer {self._key}",
@@ -319,19 +376,22 @@ class BatchingTransport:
                     # Terminal on the first answer: shed and count, no resend. Counted apart from a
                     # spent budget because a 401 is fixed by the operator, not by waiting.
                     self.rejected_span_count += len(batch.resource_spans)
-                    self._shed_locked(batch, f"refused with status {status}")
+                    self._shed_locked(batch, f"refused with status {status}", f"status {status}")
                 elif attempts >= self.retry_max:
                     self.undelivered_span_count += len(batch.resource_spans)
-                    self._shed_locked(batch, f"undelivered after {attempts} attempts")
+                    self._shed_locked(
+                        batch, f"undelivered after {attempts} attempts", "spent retry budget"
+                    )
                 else:
                     # Keep the batch, and its bytes, pinned for an identical resend.
                     self._pending = (batch, body, attempts)
             return False
 
-    def _shed_locked(self, batch: BatchRequest, why: str) -> None:
+    def _shed_locked(self, batch: BatchRequest, why: str, cause: str) -> None:
         """Terminal loss of one batch. Counted and logged, never quietly forgotten and never
         reported as a success: an unshipped span is a real, visible number (CLAUDE.md, honest under
-        uncertainty). Caller holds _lock."""
+        uncertainty). ``cause`` is the stable key the log damping groups by, ``why`` the detail.
+        Caller holds _lock."""
         lost = len(batch.resource_spans)
         self.obs.dropped_span_count += lost
         self.obs.record_error(
@@ -339,26 +399,45 @@ class BatchingTransport:
         )
         self._pending = None
         self._retry_after_ms = None
-        # Warn, not debug: dropped spend is the one transport event an operator has to see.
-        _log.warning("tally: shed %d span(s), batch %s", lost, why)
+        # Warn, not debug: dropped spend is the one transport event an operator has to see. But a
+        # standing cause (a rotated key answering 401) sheds one batch per flush indefinitely, so
+        # an undamped warning here floods a busy app's log with the same line. First of each cause
+        # speaks, then one rolled-up line per _SHED_LOG_EVERY further sheds of that cause;
+        # shed_counts() remains the exact record (#315 review).
+        seen = self._shed_log_state.get(cause)
+        if seen is None:
+            self._shed_log_state[cause] = [0, 0]
+            _log.warning(
+                "tally: shed %d span(s), batch %s (further sheds from this cause are summarized "
+                "every %d; see shed_counts())",
+                lost,
+                why,
+                _SHED_LOG_EVERY,
+            )
+            return
+        seen[0] += 1
+        seen[1] += lost
+        if seen[0] >= _SHED_LOG_EVERY:
+            _log.warning(
+                "tally: shed %d more batch(es), %d span(s), still %s", seen[0], seen[1], cause
+            )
+            seen[0] = 0
+            seen[1] = 0
 
     def shed_counts(self) -> dict[str, int]:
         """Spans this transport metered and could not ship, by cause. The honest total the caller
-        needs to know a run lost data (#315)."""
+        needs to know a run lost data (#315).
+
+        Every figure is tracked at its own site rather than derived by subtraction: ``obs`` is
+        shared, and :class:`~tally.egress.BatchProcessor` also writes ``dropped_span_count``, so a
+        subtracted overflow figure would silently absorb another component's drops (#315 review).
+        """
         with self._lock:
             return {
                 "undelivered_span_count": self.undelivered_span_count,
                 "rejected_span_count": self.rejected_span_count,
-                "buffer_overflow_span_count": (
-                    self.obs.dropped_span_count
-                    - self.undelivered_span_count
-                    - self.rejected_span_count
-                ),
+                "buffer_overflow_span_count": self.buffer_overflow_span_count,
             }
-
-    def _has_pending(self) -> bool:
-        with self._lock:
-            return self._pending is not None
 
     def current_backoff_ms(self) -> float:
         """Wait before the next attempt. The gateway's own hint wins when it named one, clamped to

--- a/sdk/python/tests/test_transport.py
+++ b/sdk/python/tests/test_transport.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import threading
 
 from tally.egress import BackoffPolicy
-from tally.transport import BatchingTransport
+from tally.transport import BatchingTransport, SendResult, _retry_hint_ms
 from tally.wire import decode_request
 
 
@@ -200,3 +200,143 @@ def test_sender_error_never_raises():
     # Must not raise; failure recorded to self-observability.
     assert t.flush_once() is False
     assert t.obs.internal_error_count >= 1
+
+
+# --- #315: bounded retry that honors the gateway's own instruction ---
+
+
+class _ScriptedSender:
+    """Replays a scripted list of answers, then 200s. Records every (headers, body) POSTed.
+
+    An entry is a ``SendResult``, a bare status int (the older sender shape), or an exception
+    instance to raise (a transport-level failure).
+    """
+
+    def __init__(self, script: list[object]) -> None:
+        self._script = list(script)
+        self.calls: list[tuple[str, dict, bytes]] = []
+
+    def __call__(self, url: str, headers: dict, body: bytes):
+        self.calls.append((url, headers, body))
+        if not self._script:
+            return SendResult(200)
+        nxt = self._script.pop(0)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return nxt
+
+
+def test_503_retry_hint_zero_succeeds_on_attempt_two():
+    # The exact shape that killed a backfill at 450k of 512,056 spans: the gateway shed under load
+    # and said "retry", with server_hints.retry_after_ms = 0.
+    sender = _ScriptedSender([SendResult(503, 0)])
+    t = _transport(sender)
+    t.export({"gen_ai.system": "openai"})
+    assert t.flush_once() is False  # shed answer, batch held, not thrown away
+    assert t.pending() == 1
+    assert t.flush_once() is True
+    assert len(sender.calls) == 2
+    assert t.shed_counts() == {
+        "undelivered_span_count": 0,
+        "rejected_span_count": 0,
+        "buffer_overflow_span_count": 0,
+    }
+
+
+def test_resend_is_byte_identical():
+    # The property that keeps a retry a replay rather than a duplicate: identical bytes means a
+    # stable batch_id, which the gateway's (tenant_id, batch_id) idempotency store recognizes.
+    # Duplicate spans permanently pollute the SummingMergeTree rollups (#311).
+    sender = _ScriptedSender([SendResult(503, 0), ConnectionError("blip"), SendResult(500)])
+    t = _transport(sender)
+    t.export({"gen_ai.system": "openai", "n": 1})
+    t.export({"gen_ai.system": "anthropic", "n": 2})
+    for _ in range(4):
+        t.flush_once()
+    assert len(sender.calls) == 4
+    bodies = {body for (_, _, body) in sender.calls}
+    assert len(bodies) == 1  # byte-for-byte identical, not merely the same batch_id
+    assert len({decode_request(b.decode()).batch_id for b in bodies}) == 1
+
+
+def test_retry_after_hint_is_honored_and_clamped():
+    sender = _ScriptedSender([SendResult(429, 3_000)])
+    t = _transport(sender, backoff=BackoffPolicy(base_ms=10, max_ms=30_000))
+    t.export({"n": 1})
+    t.flush_once()
+    # The gateway's wait wins over our own (which would be ~10ms here).
+    assert t.current_backoff_ms() == 3_000
+    # ...but is clamped to the ceiling, so a server asking for a five minute pause cannot stall us.
+    t2 = _transport(
+        _ScriptedSender([SendResult(429, 300_000)]), backoff=BackoffPolicy(max_ms=2_000)
+    )
+    t2.export({"n": 1})
+    t2.flush_once()
+    assert t2.current_backoff_ms() == 2_000
+
+
+def test_retry_after_zero_falls_back_to_our_backoff():
+    # "No specific delay" is not licence to hammer a gateway that is already shedding.
+    sender = _ScriptedSender([SendResult(503, 0)])
+    t = _transport(sender, backoff=BackoffPolicy(base_ms=100, max_ms=1_000, jitter=0.0))
+    t.export({"n": 1})
+    t.flush_once()
+    assert t.current_backoff_ms() == 100
+
+
+def test_retry_bound_exhausted_sheds_and_counts():
+    sender = _ScriptedSender([SendResult(503, 0)] * 10)
+    t = _transport(sender, retry_max=3)
+    for i in range(4):
+        t.export({"n": i})
+    assert t.flush_once() is False
+    assert t.flush_once() is False
+    assert t.flush_once() is False
+    assert len(sender.calls) == 3  # bounded: a down gateway fails fast, it does not hang forever
+    assert t.pending() == 0
+    # Shed, and COUNTED. The count is what makes the loss honest rather than silent.
+    assert t.shed_counts()["undelivered_span_count"] == 4
+    assert t.obs.dropped_span_count == 4
+
+
+def test_non_retryable_status_is_not_retried():
+    sender = _ScriptedSender([SendResult(400)])
+    t = _transport(sender, retry_max=5)
+    t.export({"n": 1})
+    assert t.flush_once() is False
+    assert t.pending() == 0  # terminal on the first answer, no resend
+    assert len(sender.calls) == 1
+    assert t.shed_counts()["rejected_span_count"] == 1
+    assert t.shed_counts()["undelivered_span_count"] == 0
+
+
+def test_unauthorized_is_not_retried():
+    sender = _ScriptedSender([SendResult(401)])
+    t = _transport(sender, retry_max=5)
+    t.export({"n": 1})
+    t.flush_once()
+    t.flush_once()  # buffer empty now; must not have re-sent the refused batch
+    assert len(sender.calls) == 1
+    assert t.shed_counts()["rejected_span_count"] == 1
+
+
+def test_bare_status_sender_still_works():
+    # The older Sender shape (an int) stays supported for callers with their own sender.
+    sender = _ScriptedSender([503, 200])
+    t = _transport(sender)
+    t.export({"n": 1})
+    assert t.flush_once() is False
+    assert t.flush_once() is True
+
+
+def test_retry_hint_parsing():
+    # Header form (delay-seconds) wins over the body.
+    assert _retry_hint_ms({"Retry-After": "2"}, b'{"server_hints":{"retry_after_ms":9000}}') == 2000
+    # The 503 shed body: a real 0, distinct from "no hint at all".
+    assert _retry_hint_ms({}, b'{"status":"retry","server_hints":{"retry_after_ms":0}}') == 0
+    # The 429 body puts it at the top level (gateway/app.py).
+    assert _retry_hint_ms({}, b'{"retry_after_ms":1500}') == 1500
+    # Garbage never stalls the worker: no hint, fall back to our own backoff.
+    assert _retry_hint_ms({"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}, b"") is None
+    assert _retry_hint_ms({}, b"not json") is None
+    assert _retry_hint_ms({}, b'{"retry_after_ms":"soon"}') is None

--- a/sdk/python/tests/test_transport.py
+++ b/sdk/python/tests/test_transport.py
@@ -340,3 +340,99 @@ def test_retry_hint_parsing():
     assert _retry_hint_ms({"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}, b"") is None
     assert _retry_hint_ms({}, b"not json") is None
     assert _retry_hint_ms({}, b'{"retry_after_ms":"soon"}') is None
+
+
+# --- #315 review: the hot-path invariant, damped shed logging, directly tracked counters ---
+
+
+def test_encode_happens_outside_the_lock(monkeypatch):
+    # The lock is held only for brief state transitions, never for work: serializing a full batch
+    # under it stalls every export() on the hot path once per flush, which the module docstring and
+    # CTO-260 §5 forbid. Probe it from inside the encode: _lock is not reentrant, so a successful
+    # non-blocking acquire on the flushing thread proves the encode is not holding it.
+    import tally.transport as transport_mod
+
+    real_encode = transport_mod.encode_request
+    seen: list[bool] = []
+    t = _transport(_RecordingSender())
+
+    def probing_encode(batch):
+        free = t._lock.acquire(blocking=False)
+        seen.append(free)
+        if free:
+            t._lock.release()
+        return real_encode(batch)
+
+    monkeypatch.setattr(transport_mod, "encode_request", probing_encode)
+    for i in range(3):
+        t.export({"n": i})
+    assert t.flush_once() is True
+    assert seen == [True]  # encoded exactly once, and with the lock free
+
+
+def test_export_is_not_blocked_by_an_in_flight_encode(monkeypatch):
+    # The same invariant from the producer's side: a slow encode must not hold up export().
+    import tally.transport as transport_mod
+
+    real_encode = transport_mod.encode_request
+    in_encode = threading.Event()
+    release_encode = threading.Event()
+    t = _transport(_RecordingSender())
+
+    def slow_encode(batch):
+        in_encode.set()
+        release_encode.wait(timeout=5.0)
+        return real_encode(batch)
+
+    monkeypatch.setattr(transport_mod, "encode_request", slow_encode)
+    t.export({"n": 0})
+    flusher = threading.Thread(target=t.flush_once)
+    flusher.start()
+    assert in_encode.wait(timeout=5.0)
+    exported = threading.Thread(target=t.export, args=({"n": 1},))
+    exported.start()
+    exported.join(timeout=2.0)
+    assert not exported.is_alive()  # would hang if the encode ran under _lock
+    release_encode.set()
+    flusher.join(timeout=5.0)
+    assert t.pending() == 1  # the span exported mid-flush is still queued, not lost
+
+
+def test_shed_warning_is_damped_per_cause(caplog):
+    # A rotated key answers 401 on every flush forever. The counters stay exact; the log must not
+    # emit one WARNING per flush for the life of the process.
+    import logging
+
+    from tally.transport import _SHED_LOG_EVERY
+
+    t = _transport(_ScriptedSender([SendResult(401)] * 400))
+    with caplog.at_level(logging.WARNING, logger="tally"):
+        for i in range(_SHED_LOG_EVERY + 1):
+            t.export({"n": i})
+            t.flush_once()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    # One line for the first shed, one rolled-up summary at the interval. Not 101 lines.
+    assert len(warnings) == 2
+    assert "shed 1 span(s)" in warnings[0].getMessage()
+    assert "status 401" in warnings[1].getMessage()
+    # The record is the counters, and it is complete.
+    assert t.shed_counts()["rejected_span_count"] == _SHED_LOG_EVERY + 1
+
+
+def test_buffer_overflow_count_is_not_polluted_by_another_component(caplog):
+    # obs is shareable, and BatchProcessor increments dropped_span_count too (egress.py). Deriving
+    # the overflow figure by subtraction reported those foreign drops as this buffer overflowing.
+    from tally.safety import SelfObservability
+
+    obs = SelfObservability()
+    t = _transport(_ScriptedSender([SendResult(400)]), observability=obs, max_buffer=2)
+    t.export({"n": 1})
+    t.export({"n": 2})
+    t.export({"n": 3})  # one real overflow
+    obs.dropped_span_count += 7  # a co-tenant of this obs drops spans of its own
+    t.flush_once()  # refused: 2 spans rejected
+    assert t.shed_counts() == {
+        "undelivered_span_count": 0,
+        "rejected_span_count": 2,
+        "buffer_overflow_span_count": 1,
+    }


### PR DESCRIPTION
Closes #315.

The edge proxy already rides out a retryable ingest failure: 429, any 5xx or a transport error is resent with capped backoff, the gateway's `Retry-After` is honored, and the SAME BYTES go back out so `batch_id` is stable and the resend is a replay rather than a duplicate. The Python SDK transport and the chatbot backfill did not, and a backfill died at 450,000 of 512,056 spans on

```
POST /v1/batches 503 {"status":"retry", "server_hints":{"retry_after_ms":0}}
```

which is the gateway shedding under load and explicitly saying come back shortly.

This ports the proxy's bounded-retry-then-shed-and-count pattern to both clients, matching `infra/edge-proxy/internal/telemetry/telemetry.go` rather than inventing a second retry policy.

## sdk/python/src/tally/transport.py

- `Sender` now returns a `SendResult` (status plus the gateway's requested wait); a bare status int stays accepted, so an injected or caller-supplied sender keeps working. The urllib sender reads the 429/503 answer out of urllib's `HTTPError` (which *is* the response) instead of collapsing it into a bare exception that loses the gateway's instruction.
- `Retry-After` (delay-seconds) and `retry_after_ms` (top level on a 429, under `server_hints` on a 503) set the wait, clamped to the backoff ceiling so a server asking for a five minute pause cannot stall the worker. A hinted `0` falls back to our own jittered backoff: "no specific delay" is not licence to hammer a gateway that is already shedding. This is exactly `RetryPolicy.delay`.
- A non-retryable refusal (400, 401, 403, 422) is now terminal on the first answer. It previously burned the whole budget on a guaranteed second refusal.
- The body is encoded once, with the batch, and pinned across attempts, so a resend is byte-identical rather than merely carrying the same `batch_id`. That property is what keeps a retry a replay, and it matters more now that a duplicate span permanently pollutes the `SummingMergeTree` rollups (#311).
- A shed batch is counted by cause (`undelivered_span_count` for a spent budget, `rejected_span_count` for a refusal), warned once at WARNING, and surfaced to the caller through `shed_counts()`. Nothing is silently dropped: the count is what makes the loss honest.

## examples/vercel-chatbot/scripts/backfill-spans.ts

- Retries a thrown `fetch` (a transport error was fatal, and it is the most retryable failure there is) and any 5xx, not only 429/503.
- Honors the `Retry-After` header alongside the body hint, with the same clamp and the same treatment of a hinted `0`.
- When the bound is spent it sheds and COUNTS the batch, then reports the exact spans and events lost and exits non-zero, rather than aborting a run that is 88% loaded or printing a tick over a hole.
- `body` is still serialized once outside the loop, so every attempt is byte-identical.

### Divergence from the proxy

Five, not two. The full table also lives in the `transport.py` module docstring so it stays true as
the code moves, and the backfill's retry comment points at it.

| | edge proxy | these clients | aligned? |
|---|---|---|---|
| Budget | 4 attempts | SDK `retry_max` 5 (unchanged); backfill 61, because a one-shot corpus load has no hot path behind it | declared |
| Non-retryable status | shed the batch, worker continues | SDK the same; the backfill aborts, because a CLI has an operator who can fix the credential and every later batch would fail identically, and a re-run at the same `--seed` is idempotent | declared |
| Hint clamp | `Max: 2s` | `BackoffPolicy.max_ms` (30s default), so one policy object governs every wait. The wait sits on `_stop.wait`, which `stop()` and atexit interrupt and which never blocks `export()` | declared |
| Backoff jitter | plus or minus 25% | now matched in the TS fallback. A hinted wait stays unjittered, because the gateway named that number | **aligned** |
| Hint source | `Retry-After` header only | both clients also read `retry_after_ms` from the body (top level on a 429, under `server_hints` on a 503) | declared, a superset |

### Run-level circuit breaker

A bounded per-batch budget is not a bounded run: 1229 batches each burning 61 attempts is roughly
four days against a gateway that answers the control plane but not ingest. The run now aborts after
2 consecutive shed batches, and any delivery re-arms it. One shed batch is tolerated so an
88%-loaded run does not die for 500 spans; a second straight after is a gateway that is gone.
Measured on the 30-day corpus against a refused ingest port: 96 hours extrapolated before, 9 minutes
23 seconds after.

## Verification

- `cd sdk/python && uv run --extra dev pytest -q` -> 1328 passed. `uv run ruff check .` clean.
- New tests cover the 503 with `retry_after_ms: 0` succeeding on attempt two, `Retry-After` honored and clamped, a hinted 0 falling back to backoff, the bound being exhausted and the shed count reported, a 400 and a 401 not being retried, byte-identical resends asserted on the payload itself, and hint parsing including garbage.
- `examples/` is outside the `web` typecheck scope (`web/tsconfig.json` includes only paths under `web/`, and CI's only TS check is `npm run typecheck` there), so the script was typechecked standalone under the same `--strict` settings: clean.
- The backfill was driven end to end against a mock gateway that sheds with `retry_after_ms: 0`, 500s, and destroys sockets: 158 POSTs for 72 batches, 71 shed answers, run completed, and **0 batch_ids whose resend bytes differed**. Against an always-503 mock it shed both batches after 61 attempts, reported "86 spans and 11 events in 2 batch(es) were shed", and exited 1. Against an always-400 mock it made exactly 1 POST and aborted.

### Against the real gateway (local stack up)

The dangerous case is an ambiguous failure: the gateway received and processed the batch but the client sees a retryable answer and resends. A sender that really POSTs but reports attempt 1 as the 503 shed reproduces it exactly.

```
exported 25 spans under ServiceName=replay-check-1788901007
  attempt 1: gateway really answered 200
  attempt 2: gateway really answered 200
POSTs made: 2
identical bytes on the resend: True
batch_id: 01a082cf-218a-7ba6-98ab-cfa692792ba0
rows in ClickHouse for replay-check-1788901007: 25 (exported 25, POSTed 2 times)
daily_feature_rollup for today: SpanCount 25, InputTokens 2500
```

25 rows and a rollup of 25 spans / 2500 input tokens from two identical POSTs of 25 spans: the replay did not duplicate, in the raw table or in the `SummingMergeTree` rollup. One caveat worth recording: this stack logs `durable batch idempotency UNAVAILABLE (relation "ingest_batch_idempotency" does not exist)`, so it was the gateway's in-process cache that absorbed the replay, not the durable store from `db/postgres/0032_ingest_batch_idempotency.sql`. The client-side property under test (identical bytes, stable `batch_id`) is what this proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

