### PR TITLE
fix(web): dedupe every otel_spans read with FINAL (#314)

### DIFF
--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -1139,3 +1139,61 @@ describe("CTO-244 - reading a mix of known and unknown", () => {
     expect(out.monthlyCostMicroUsd).toBe(Math.round((1_400_000 * 30) / 7));
   });
 });
+
+// #314 (CTO-245): every otel_spans read dedupes.
+//
+// otel_spans is a ReplacingMergeTree, so a duplicate span that got past the durable idempotency
+// store stays readable until a background merge collapses it, and a plain sum() over-counts by the
+// replayed spend in the meantime. FINAL makes the read exact at query time.
+//
+// The value of the fix is that it is applied to ALL of the reads rather than to the ones that
+// looked risky: a surface where some panels dedupe and some do not is worse than one where none do,
+// because two panels then disagree and neither is obviously wrong. That property spans ~40 query
+// sites across five files, which is more than review can hold, so it is asserted against the source
+// text. A query added later that forgets FINAL fails here.
+describe("otel_spans read paths dedupe (#314)", () => {
+  // Files that build SQL against otel_spans. Listed explicitly rather than globbed so that adding a
+  // new reader is a deliberate act which shows up in this list.
+  const SOURCES = [
+    "clickhouse.ts",
+    "waste/duplicated-work.ts",
+    "waste/no-measured-return.ts",
+    "waste/paid-for-nothing.ts",
+    "waste/wrong-sized-model.ts",
+  ];
+
+  // The single deliberate exemption, matched as a whole line so it cannot drift. queryFirstEventSeen
+  // selects the literal 1 and asks only whether a row exists; a duplicate cannot change a boolean,
+  // so FINAL would buy nothing there and it is not free on an endpoint the onboarding panel polls.
+  const EXEMPT = "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1";
+
+  // FROM/JOIN otel_spans, plus an optional alias, plus FINAL if it is there.
+  const READ =
+    /\b(?:FROM|(?:INNER |LEFT |RIGHT |CROSS )?JOIN)\s+otel_spans\b(?:\s+(?!FINAL\b)[A-Za-z_]\w*)?(?:\s+FINAL\b)?/g;
+
+  async function source(rel: string): Promise<string> {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    // Vitest's root is `web/`, so these resolve against the checkout rather than the bundle.
+    return readFile(resolve(process.cwd(), "lib", rel), "utf8");
+  }
+
+  it.each(SOURCES)("%s reads otel_spans only with FINAL", async (rel) => {
+    // Drop the one exempt query before matching, so the exemption is scoped to that exact text and
+    // not to the file it lives in.
+    const src = (await source(rel)).split(EXEMPT).join("");
+    const missing = (src.match(READ) ?? []).filter((m) => !/\bFINAL\b/.test(m));
+    expect(missing, `${rel}: otel_spans read without FINAL`).toEqual([]);
+  });
+
+  it("matches the reads it is meant to be guarding", async () => {
+    // Guards the guard: if the pattern ever stops matching, the assertion above passes vacuously.
+    const src = await source("clickhouse.ts");
+    expect((src.match(READ) ?? []).length).toBeGreaterThan(30);
+  });
+
+  it("keeps the exemption to exactly one query", async () => {
+    const src = await source("clickhouse.ts");
+    expect(src.split(EXEMPT).length - 1).toBe(1);
+  });
+});

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -1149,51 +1149,181 @@ describe("CTO-244 - reading a mix of known and unknown", () => {
 // The value of the fix is that it is applied to ALL of the reads rather than to the ones that
 // looked risky: a surface where some panels dedupe and some do not is worse than one where none do,
 // because two panels then disagree and neither is obviously wrong. That property spans ~40 query
-// sites across five files, which is more than review can hold, so it is asserted against the source
-// text. A query added later that forgets FINAL fails here.
+// sites, which is more than review can hold, so it is asserted against the source text.
+//
+// The guard DISCOVERS its own inputs: it walks web/ and checks every file that mentions otel_spans.
+// A hardcoded file list would only guard the readers that existed when the list was written, and the
+// failure this exists to prevent is a NEW reader (a detector, an /api route) shipping without FINAL.
 describe("otel_spans read paths dedupe (#314)", () => {
-  // Files that build SQL against otel_spans. Listed explicitly rather than globbed so that adding a
-  // new reader is a deliberate act which shows up in this list.
-  const SOURCES = [
-    "clickhouse.ts",
-    "waste/duplicated-work.ts",
-    "waste/no-measured-return.ts",
-    "waste/paid-for-nothing.ts",
-    "waste/wrong-sized-model.ts",
+  // Vitest's root is `web/`, so the walk covers the checkout rather than a bundle.
+  const WEB_ROOT = process.cwd();
+
+  // Build output and dependencies are not source we own, and scanning node_modules is minutes, not
+  // milliseconds.
+  const SKIP_DIRS = new Set([
+    ".git",
+    ".next",
+    ".turbo",
+    ".vercel",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+  ]);
+  const CODE = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
+
+  // This file is the one exclusion: it carries the guard's own fixtures, including deliberately
+  // un-FINAL'd SQL that the pattern below is supposed to flag.
+  const SELF = "lib/clickhouse.test.ts";
+
+  // Deliberate exemptions, matched as whole query strings so an exemption cannot drift onto a
+  // neighbouring read. queryFirstEventSeen selects the literal 1 and asks only whether a row exists;
+  // a duplicate cannot change a boolean, so FINAL would buy nothing there and it is not free on an
+  // endpoint the onboarding panel polls. Blanked rather than deleted so reported line numbers stay
+  // true to the file on disk.
+  const EXEMPT_READS = [
+    "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1",
   ];
 
-  // The single deliberate exemption, matched as a whole line so it cannot drift. queryFirstEventSeen
-  // selects the literal 1 and asks only whether a row exists; a duplicate cannot change a boolean,
-  // so FINAL would buy nothing there and it is not free on an endpoint the onboarding panel polls.
-  const EXEMPT = "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1";
-
-  // FROM/JOIN otel_spans, plus an optional alias, plus FINAL if it is there.
+  // FROM/JOIN otel_spans, plus an optional database qualifier, an optional `AS`, an optional alias,
+  // and FINAL if it is there. The alias is matched so that a read WITHOUT FINAL still produces a
+  // match to flag: dropping it would turn a missing FINAL into zero matches, which is the silent
+  // pass this guard exists to rule out. Case-insensitive and qualifier-aware for the same reason.
   const READ =
-    /\b(?:FROM|(?:INNER |LEFT |RIGHT |CROSS )?JOIN)\s+otel_spans\b(?:\s+(?!FINAL\b)[A-Za-z_]\w*)?(?:\s+FINAL\b)?/g;
+    /\b(?:FROM|(?:(?:INNER|LEFT|RIGHT|FULL|OUTER|CROSS|ANY|ALL|ASOF|SEMI|ANTI)\s+)*JOIN)\s+(?:[A-Za-z_]\w*\s*\.\s*)?otel_spans\b(?:\s+AS\b)?(?:\s+(?!FINAL\b)[A-Za-z_]\w*)?(?:\s+FINAL\b)?/gi;
 
-  async function source(rel: string): Promise<string> {
-    const { readFile } = await import("node:fs/promises");
-    const { resolve } = await import("node:path");
-    // Vitest's root is `web/`, so these resolve against the checkout rather than the bundle.
-    return readFile(resolve(process.cwd(), "lib", rel), "utf8");
+  const HAS_FINAL = /\bFINAL\b/i;
+
+  // Comments are prose, not reads: several files (and one /api route owned by another PR) describe
+  // the query in a sentence that contains "FROM otel_spans", and failing the build on those would
+  // train contributors to silence the guard. String literals are not parsed, so a `//` inside one
+  // would over-strip; the ">30 reads" check below fails loudly if that ever eats the real SQL.
+  // Blanked in place, newlines kept, so match offsets still map to real line numbers.
+  function stripComments(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+      .replace(/(^|[^:])\/\/[^\n]*/gm, (m, lead: string) => lead + " ".repeat(m.length - lead.length));
   }
 
-  it.each(SOURCES)("%s reads otel_spans only with FINAL", async (rel) => {
-    // Drop the one exempt query before matching, so the exemption is scoped to that exact text and
-    // not to the file it lives in.
-    const src = (await source(rel)).split(EXEMPT).join("");
-    const missing = (src.match(READ) ?? []).filter((m) => !/\bFINAL\b/.test(m));
-    expect(missing, `${rel}: otel_spans read without FINAL`).toEqual([]);
+  function blank(src: string, literal: string): string {
+    return src.split(literal).join(" ".repeat(literal.length));
+  }
+
+  function lineOf(src: string, index: number): number {
+    return src.slice(0, index).split("\n").length;
+  }
+
+  async function walk(): Promise<string[]> {
+    const { readdir } = await import("node:fs/promises");
+    const { join, relative, sep } = await import("node:path");
+    const found: string[] = [];
+    async function visit(dir: string): Promise<void> {
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (!SKIP_DIRS.has(entry.name)) await visit(full);
+        } else if (entry.isFile() && CODE.test(entry.name)) {
+          found.push(relative(WEB_ROOT, full).split(sep).join("/"));
+        }
+      }
+    }
+    await visit(WEB_ROOT);
+    return found.sort();
+  }
+
+  /** Every file under web/ whose text mentions otel_spans, with its comment-stripped source. */
+  async function mentions(): Promise<Array<{ rel: string; src: string }>> {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const out: Array<{ rel: string; src: string }> = [];
+    for (const rel of await walk()) {
+      if (rel === SELF) continue;
+      const raw = await readFile(resolve(WEB_ROOT, rel), "utf8");
+      if (!raw.includes("otel_spans")) continue;
+      out.push({ rel, src: stripComments(raw) });
+    }
+    return out;
+  }
+
+  function offenders(rel: string, src: string): string[] {
+    let scanned = src;
+    for (const exempt of EXEMPT_READS) scanned = blank(scanned, exempt);
+    const found: string[] = [];
+    for (const m of scanned.matchAll(READ)) {
+      if (HAS_FINAL.test(m[0])) continue;
+      found.push(`${rel}:${lineOf(scanned, m.index)}: ${m[0].replace(/\s+/g, " ").trim()}`);
+    }
+    return found;
+  }
+
+  it("every otel_spans read under web/ says FINAL", async () => {
+    const bad = (await mentions()).flatMap(({ rel, src }) => offenders(rel, src));
+    expect(
+      bad,
+      "otel_spans is a ReplacingMergeTree: read it with FINAL or the panel over-counts replayed " +
+        "spend until a background merge runs. Add FINAL to the read below, or, if the query " +
+        "provably cannot see a duplicate, add its exact SQL to EXEMPT_READS in this file with the " +
+        "reason.",
+    ).toEqual([]);
   });
 
   it("matches the reads it is meant to be guarding", async () => {
-    // Guards the guard: if the pattern ever stops matching, the assertion above passes vacuously.
-    const src = await source("clickhouse.ts");
-    expect((src.match(READ) ?? []).length).toBeGreaterThan(30);
+    // Guards the guard: if the pattern, the walk or the comment stripper ever stops seeing the SQL,
+    // the assertion above passes vacuously.
+    const files = await mentions();
+    const total = files.reduce((n, f) => n + (f.src.match(READ) ?? []).length, 0);
+    expect(total).toBeGreaterThan(30);
+    for (const rel of [
+      "lib/clickhouse.ts",
+      "lib/waste/duplicated-work.ts",
+      "lib/waste/no-measured-return.ts",
+      "lib/waste/paid-for-nothing.ts",
+      "lib/waste/wrong-sized-model.ts",
+    ]) {
+      expect(files.map((f) => f.rel)).toContain(rel);
+    }
   });
 
-  it("keeps the exemption to exactly one query", async () => {
-    const src = await source("clickhouse.ts");
-    expect(src.split(EXEMPT).length - 1).toBe(1);
+  it("keeps the exemption to exactly one query, everywhere it is honored", async () => {
+    // The exemption is stripped from every scanned file, so copying the marker into a detector would
+    // silently exempt it there too. Counting across the same set the exemption applies to is what
+    // makes "exactly one" mean anything.
+    const files = await mentions();
+    for (const exempt of EXEMPT_READS) {
+      const uses = files.reduce((n, f) => n + (f.src.split(exempt).length - 1), 0);
+      expect(uses, `EXEMPT_READS entry is honored in more than one place: ${exempt}`).toBe(1);
+    }
+  });
+
+  it("reads the SQL forms a contributor might actually write", () => {
+    // The pattern is the whole guard, so its two failure modes are pinned here: a FALSE FAILURE on
+    // correct SQL trains people to work around it, and a SILENT PASS on a lowercase or
+    // database-qualified read makes it worthless.
+    const flag = (sql: string) =>
+      [...sql.matchAll(READ)].filter((m) => !HAS_FINAL.test(m[0])).map((m) => m[0]);
+
+    for (const ok of [
+      "FROM otel_spans FINAL",
+      "FROM otel_spans s FINAL",
+      "FROM otel_spans AS s FINAL", // the `AS` form used at clickhouse.ts (attribution_records AS ar FINAL)
+      "from otel_spans as s final",
+      "FROM tally.otel_spans AS s FINAL",
+      "INNER JOIN otel_spans AS s FINAL ON s.UserIdHash = b.UserIdHash",
+      "LEFT JOIN otel_spans FINAL ON 1",
+    ]) {
+      expect(flag(ok), `false failure on correct SQL: ${ok}`).toEqual([]);
+    }
+
+    for (const bad of [
+      "FROM otel_spans WHERE TenantId = {tenant:String}",
+      "FROM otel_spans AS s WHERE 1",
+      "from otel_spans where 1",
+      "FROM tally.otel_spans AS s WHERE 1",
+      "INNER JOIN otel_spans AS s ON s.UserIdHash = b.UserIdHash",
+      "SELECT sum(EstimatedCost) FROM otel_spans GROUP BY Model",
+    ]) {
+      expect(flag(bad), `silent pass on a read without FINAL: ${bad}`).toHaveLength(1);
+    }
   });
 });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -10,6 +10,27 @@
 // layers; vector/compute/egress are zero until those sources are instrumented. That's honest: the
 // dashboard shows exactly the telemetry that exists.
 //
+// EVERY otel_spans READ SAYS `FINAL` (CTO-245 / #314). otel_spans is a ReplacingMergeTree keyed on
+// (TenantId, FeatureTag, ServiceName, SpanName, Timestamp, TraceId, SpanId), so a duplicate span
+// that got past the durable idempotency store collapses only when a background merge runs. Between
+// the duplicate insert and that merge a plain `sum(EstimatedCost)` reads both rows and over-states
+// spend by exactly the replayed amount. FINAL makes the read exact at query time instead of
+// eventually.
+//
+// It is applied to ALL of them in one pass, not to the ones that looked risky. A read surface where
+// some panels dedupe and some do not is worse than one where none do: two panels disagree and
+// neither is obviously wrong. The single documented exception is queryFirstEventSeen, which selects
+// a literal rather than a value (see the comment there); `clickhouse.test.ts` fails the build if any
+// other otel_spans read drops FINAL.
+//
+// The cost is real but small, and it is bounded by how un-merged the table is rather than by how
+// much data the query reads. Measured on the local corpus (1.54M spans, three tenants): with the
+// table fully merged (one part per partition) FINAL is inside the noise; forced to 372 parts over 31
+// partitions, roughly twelve times un-merged, the heaviest dashboard query goes from 148ms to 200ms
+// of ClickHouse time and the rest move by 25-50ms each. End to end that leaves /waste at ~620ms and
+// Home at ~470ms against a production build, both inside the one-second bar CTO-227 bought back and
+// both inside run-to-run noise. Numbers and method are in the PR for #314.
+//
 // Server-only: imported solely by Route Handlers pinned to the nodejs runtime (never a client
 // component), so it never reaches the browser bundle.
 
@@ -141,6 +162,12 @@ export async function queryFirstEventSeen(): Promise<FirstEventStatus> {
   const seen = await tryLive(async (db, tenant) => {
     const r = await rows<{ one: number }>(
       db,
+      // CTO-245 / #314: the ONE otel_spans read that deliberately omits FINAL. Every other read in
+      // this module takes a value off the table and so can be inflated by an un-merged duplicate.
+      // This one takes no value: it selects the literal 1 and asks only "does a row exist". A
+      // duplicate cannot change a boolean, so FINAL would buy nothing here and it is not free on a
+      // polled endpoint (measured on 372 un-merged parts: 7ms -> 43ms of ClickHouse time). The
+      // guard in clickhouse.test.ts allowlists this line by name so the exemption stays this one.
       "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1",
       tenant,
     );
@@ -289,14 +316,14 @@ export async function querySpendSummary(windowDays = 30): Promise<SpendSummary |
          sumIf(EstimatedCost, CostSource = 'estimated') AS estimated,
          sumIf(EstimatedCost, CostSource = 'reconciled') AS reconciled,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY`,
       tenant,
     );
     const byLayerRows = await rows<{ layer: Layer; cost: string }>(
       db,
       `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY
        GROUP BY layer`,
       tenant,
@@ -333,7 +360,7 @@ export async function queryPriorMonthSpend(): Promise<MicroUSD | null> {
     const r = await rows<{ total: string }>(
       db,
       `SELECT sum(EstimatedCost) AS total
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= toStartOfMonth(now()) - INTERVAL 1 MONTH
          AND Timestamp < toStartOfMonth(now())`,
@@ -362,7 +389,7 @@ export async function queryOutliers(windowDays = 30): Promise<CostOutlier[] | nu
       `WITH runs AS (
          SELECT TraceId AS runId, any(ServiceName) AS agent,
                 if(countIf(EstimatedCost IS NULL) > 0, NULL, sum(EstimatedCost)) AS cost
-         FROM otel_spans
+         FROM otel_spans FINAL
          WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY
            AND ServiceName != '' AND ServiceName != 'unknown'
            AND GenAiOperation NOT IN ('compute', 'egress')
@@ -445,7 +472,7 @@ export async function queryCostSeries(
     const out = await rowsP<{ day: string; layer: Layer; cost: string }>(
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY ${tagClause}
        GROUP BY day, layer
        ORDER BY day`,
@@ -498,7 +525,7 @@ export async function queryFeatureCostRows(
     const out = await rowsP<{ feature: string; layer: Layer; cost: string }>(
       db,
       `SELECT FeatureTag AS feature, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY AND FeatureTag != '' ${tagClause}
        GROUP BY feature, layer`,
       { tenant, tag },
@@ -656,7 +683,7 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
               sum(EstimatedCost) AS cost,
               count() AS spans,
               countIf(EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${scope} ${filterClause}
        GROUP BY grp
        ORDER BY cost DESC`,
@@ -680,7 +707,7 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
         ? await rowsP<{ day: string; grp: string; cost: string }>(
             db,
             `SELECT toString(toDate(Timestamp)) AS day, ${groupExpr} AS grp, sum(EstimatedCost) AS cost
-             FROM otel_spans
+             FROM otel_spans FINAL
              WHERE ${scope} ${filterClause} AND ${groupExpr} IN {kept:Array(String)}
              GROUP BY day, grp`,
             { ...common, kept },
@@ -690,7 +717,7 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
       ? await rowsP<{ day: string; cost: string }>(
           db,
           `SELECT toString(toDate(Timestamp)) AS day, sum(EstimatedCost) AS cost
-           FROM otel_spans
+           FROM otel_spans FINAL
            WHERE ${scope} ${filterClause} AND ${groupExpr} NOT IN {kept:Array(String)}
            GROUP BY day`,
           { ...common, kept },
@@ -795,7 +822,7 @@ export async function queryCostBreakdownPrior(
     const rows = await rowsP<{ grp: string; cost: string }>(
       db,
       `SELECT ${groupExpr} AS grp, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${scope} ${filterClause}
        GROUP BY grp`,
       { tenant, windowStart: b.windowStart, windowDays, ...filterParams },
@@ -847,7 +874,7 @@ export async function queryCostSliceTotals(
          countIf(EstimatedCost IS NULL) AS unpriced,
          count() AS spans,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY ${clause}`,
       { tenant, ...params },
     );
@@ -1079,7 +1106,7 @@ export async function querySettledCostSeries(
     const costRows = await rowsP<{ day: string; layer: Layer; cost: string }>(
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${inWindow} ${clause}
        GROUP BY day, layer`,
       params,
@@ -1099,7 +1126,7 @@ export async function querySettledCostSeries(
               countIf(${LAYER_CASE} = 'compute') AS compute,
               countIf(${LAYER_CASE} = 'egress') AS egress,
               countIf(CostSource = 'reconciled') AS reconciled
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${inWindow}
        GROUP BY day`,
       params,
@@ -1582,7 +1609,7 @@ async function accountDetail(
               countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps,
               max(StatusCode) AS maxStatus
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND AccountIdHash = {account:String}
          AND ${ACCOUNT_SPAN_WINDOW} AND ${DIRECT_ONLY}
        GROUP BY TraceId
@@ -1664,7 +1691,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
     const totalRows = await rowsP<{ total: string }>(
       db,
       `SELECT sum(EstimatedCost) AS total
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}`,
       { tenant, tag },
     );
@@ -1684,7 +1711,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
          if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
          countIf(GenAiOperation = 'tool' AND (EstimatedCost IS NULL OR EstimatedCost = 0)) AS uncosted,
          sum(EstimatedCost) AS featureCost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}
        GROUP BY feature
        HAVING uncosted > {threshold:UInt32}
@@ -1699,7 +1726,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
          if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
          countIf(${LAYER_CASE} = 'llm') / nullIf(uniqExact(SessionId), 0) AS callsPerSession,
          sum(EstimatedCost) AS featureCost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
          AND SessionId != '' ${tagClause}
        GROUP BY feature
@@ -1784,7 +1811,7 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
       // CTO-244: `unpriced` gates the cost-per-user ratio below. See FeatureEconomics.
       `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users,
               countIf(EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY AND FeatureTag != ''
        GROUP BY FeatureTag
        ORDER BY cost DESC`,
@@ -2067,7 +2094,7 @@ export async function queryAccountStitching(): Promise<AccountStitching | null> 
     const direct = await rows<{ direct_accounts: string }>(
       db,
       `SELECT uniqExact(AccountIdHash) AS direct_accounts
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
          AND AccountIdHash != ''`,
@@ -2093,7 +2120,7 @@ export async function queryAccountStitching(): Promise<AccountStitching | null> 
       const costs = await rowsP<{ user_hash: string; cost: string; spans: string }>(
         db,
         `SELECT UserIdHash AS user_hash, sum(EstimatedCost) AS cost, count() AS spans
-         FROM otel_spans
+         FROM otel_spans FINAL
          WHERE TenantId = {tenant:String}
            AND Timestamp >= now() - INTERVAL 30 DAY
            AND AccountIdHash = ''
@@ -2142,7 +2169,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
 
     const sample = await rows<{ rate: string }>(
       db,
-      `SELECT avg(SampleRate) AS rate FROM otel_spans
+      `SELECT avg(SampleRate) AS rate FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY`,
       tenant,
     );
@@ -2150,7 +2177,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
 
     const perFeature = await rows<{ feature: string; events: string }>(
       db,
-      `SELECT FeatureTag AS feature, count() AS events FROM otel_spans
+      `SELECT FeatureTag AS feature, count() AS events FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 7 DAY AND FeatureTag != ''
        GROUP BY feature ORDER BY events DESC`,
       tenant,
@@ -2171,7 +2198,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
               any(SpanAttributes['telemetry.sdk.version']) AS sdk,
               countIf(ContextDroppedMessages > 0) AS drops,
               count() AS spans
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 24 HOUR
        GROUP BY service`,
       tenant,
@@ -2189,7 +2216,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
       `SELECT toString(toDate(Timestamp)) AS date,
               sum(EstimatedCost) AS est,
               sumIf(EstimatedCost, CostSource = 'reconciled') AS recon
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY
        GROUP BY date ORDER BY date`,
       tenant,
@@ -2219,7 +2246,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
               count() AS spans,
               avg(EstimatedCost) AS mean,
               stddevPop(EstimatedCost) AS std
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
          AND SamplingStratum IN ('body', 'mid', 'tail')
@@ -2340,7 +2367,7 @@ async function fetchSpansFor(
   const inList = safeIds.map((id) => `'${id}'`).join(",");
   const sql = `SELECT TraceId AS runId, SpanId AS spanId, ParentSpanId AS parentSpanId,
             SpanName AS name, EstimatedCost AS cost, DurationNs AS durNs, StatusCode AS status
-     FROM otel_spans
+     FROM otel_spans FINAL
      WHERE TenantId = {tenant:String} AND TraceId IN (${inList})
      ORDER BY AgentStepIndex, Timestamp`;
   const spanRows = await rows<SpanRowRaw>(db, sql, tenant);
@@ -2415,7 +2442,7 @@ export async function queryAgents(
               count() AS steps,
               max(StatusCode) AS maxStatus,
               toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL ${w} DAY
          AND ServiceName != ''
@@ -2496,7 +2523,7 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
       `SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost,
               countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps, max(StatusCode) AS maxStatus, toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND TraceId = {runId:String}
        GROUP BY TraceId`,
       { tenant, runId },
@@ -2509,7 +2536,7 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
     const peers = await rowsP<{ cost: string; unpriced: string }>(
       db,
       `SELECT sum(EstimatedCost) AS cost, countIf(EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND FeatureTag = {agent:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
        GROUP BY TraceId`,
@@ -2646,7 +2673,7 @@ export async function queryGuardrailActivity(): Promise<Map<string, GuardrailAct
          extract(key, '^gen_ai\\\\.guardrail\\\\.(.+)\\\\.verdict$') AS ruleId,
          count() AS runs,
          countIf(val IN ('enforced', 'shadow_observed')) AS wouldFire
-       FROM otel_spans
+       FROM otel_spans FINAL
        ARRAY JOIN mapKeys(SpanAttributes) AS key, mapValues(SpanAttributes) AS val
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 7 DAY
@@ -2774,7 +2801,7 @@ export async function queryConnectorActivity(): Promise<ConnectorActivity | null
       db,
       `SELECT ${LAYER_CASE} AS layer, GenAiSystem AS system, count() AS n,
               toString(max(Timestamp)) AS last
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
        GROUP BY layer, system`,
       tenant,
@@ -2854,7 +2881,7 @@ export async function querySpanFeatureTags(days?: number): Promise<string[] | nu
     const out = await rows<{ feature: string }>(
       db,
       `SELECT DISTINCT FeatureTag AS feature
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${windowDays} DAY
          AND FeatureTag != ''
        ORDER BY feature`,
@@ -2904,7 +2931,7 @@ export async function queryAttribution(
          uniqExact(s.SessionId) AS sessions,
          sum(s.EstimatedCost) AS cost,
          countIf(s.EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans s
+       FROM otel_spans s FINAL
        WHERE s.TenantId = {tenant:String}
          AND s.Timestamp >= ${windowSql}
          AND s.GenAiOperation NOT IN ('compute', 'egress')
@@ -2923,7 +2950,7 @@ export async function queryAttribution(
          ${providerExpr} AS provider,
          uniqExact(b.BusinessEventId) AS conversions
        FROM business_events b
-       INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
+       INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
          AND b.EventName = {outcome:String}
          AND b.OccurredAt >= ${windowSql}
@@ -2980,7 +3007,7 @@ export async function queryAttribution(
            b.ValueType IN {positiveTypes:Array(String)} OR b.ValueType = {refundType:String}
          ) AS users
        FROM business_events b
-       INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
+       INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
          AND b.OccurredAt >= ${windowSql}
          AND b.UserIdHash != ''
@@ -3031,7 +3058,7 @@ export async function queryAttribution(
     const dailyRows = await rowsP<{ day: string; provider: string; cost: string }>(
       db,
       `SELECT toString(toDate(s.Timestamp)) AS day, ${providerExpr} AS provider, sum(s.EstimatedCost) AS cost
-       FROM otel_spans s
+       FROM otel_spans s FINAL
        WHERE s.TenantId = {tenant:String}
          AND s.Timestamp >= ${windowSql}
          AND s.GenAiOperation NOT IN ('compute', 'egress')
@@ -3177,7 +3204,7 @@ export async function queryCurrentModel(): Promise<{
          quantileExact(0.95)(if(DurationNs > 0, DurationNs, NULL)) / 1e6 AS p95Ms,
          countIf(StatusCode = 2) / count() AS errRate,
          count() AS sampleCount
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 7 DAY
          AND (GenAiResponseModel != '' OR GenAiRequestModel != '')

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -23,13 +23,17 @@
 // a literal rather than a value (see the comment there); `clickhouse.test.ts` fails the build if any
 // other otel_spans read drops FINAL.
 //
-// The cost is real but small, and it is bounded by how un-merged the table is rather than by how
-// much data the query reads. Measured on the local corpus (1.54M spans, three tenants): with the
-// table fully merged (one part per partition) FINAL is inside the noise; forced to 372 parts over 31
-// partitions, roughly twelve times un-merged, the heaviest dashboard query goes from 148ms to 200ms
-// of ClickHouse time and the rest move by 25-50ms each. End to end that leaves /waste at ~620ms and
-// Home at ~470ms against a production build, both inside the one-second bar CTO-227 bought back and
-// both inside run-to-run noise. Numbers and method are in the PR for #314.
+// The cost is real. FINAL merges the scanned rows across the parts that hold them, so it scales
+// with BOTH how much data the query reads and how un-merged the table is; only the RATIO between a
+// merged and an un-merged table is bounded by un-mergedness. Measured on the local corpus (1.54M
+// spans, three tenants): with the table fully merged (one part per partition) FINAL is inside the
+// noise; forced to 372 parts over 31 partitions, roughly twelve times un-merged, the heaviest
+// dashboard query goes from 148ms to 200ms of ClickHouse time and the rest move by 25-50ms each.
+// End to end /waste measured 644ms before and 617ms after against a production build, which is a
+// speedup after adding work and therefore noise: the page-level delta is UNMEASURED, not shown to
+// be small, because the run-to-run spread (617-728ms) is wider than any effect this could have. All
+// that is established at page level is that both pages stay inside the one-second bar CTO-227
+// bought back. Numbers and method are in the PR for #314.
 //
 // Server-only: imported solely by Route Handlers pinned to the nodejs runtime (never a client
 // component), so it never reaches the browser bundle.
@@ -2989,6 +2993,20 @@ export async function queryAttribution(
     // ValueAmountMicro is Nullable(Int64), so `sumIf` over a group with no matching row yields NULL
     // rather than 0 and the NULL then swallows the whole subtraction. The `ifNull(..., 0)` inside
     // each sumIf is what keeps a tenant with zero refunds from reporting NULL revenue.
+    //
+    // KNOWN WRONG, SEPARATELY (both predate #314 / CTO-245, do not read the FINAL below as a fix):
+    //
+    // 1. Join fan-out. This sums b.ValueAmountMicro across an INNER JOIN on otel_spans, so a
+    //    business event is counted once per matching span for that user: a user with 30 spans
+    //    contributes their revenue 30 times. FINAL removes the DUPLICATE-SPAN multiplier and nothing
+    //    else, so the figure stays inflated by the real span count. The sibling conversions query
+    //    above survives the same join only because uniqExact collapses the fan-out; a sum cannot.
+    //    The fix is to aggregate business_events before joining (or drop the join and filter users
+    //    by a subquery), which changes the number this panel shows and needs its own change.
+    // 2. Float dollars in SQL. The `/ 1000000` divides integer micro-USD inside ClickHouse, so the
+    //    value arrives already converted and already floating, against the money invariant (integer
+    //    micro-USD end to end, converted at the boundary only). It should return micro-USD and let
+    //    micro() do the conversion.
     const positiveTypes = positiveValueTypes(policy);
     const sourceFilter = revenueSourceFilter(policy, "b");
     const revenueRows = await rowsP<{

--- a/web/lib/waste/duplicated-work.ts
+++ b/web/lib/waste/duplicated-work.ts
@@ -284,6 +284,9 @@ export async function collectDuplicatedWork(
     // clusters inside ClickHouse (an IN over the cluster tuple) instead of shipping one row per trace
     // to Node and clustering the whole tenant in JS. On the demo corpus that is 740 rows instead of
     // ~420k. This is lossless: a failure-free cluster is dropped precisely because it can never match.
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const rows = await rowsPCached<RunRow>(
       db,
       `WITH runs AS (
@@ -295,7 +298,7 @@ export async function collectDuplicatedWork(
                 toString(toUnixTimestamp(max(Timestamp))) AS tsSec,
                 sum(EstimatedCost) AS cost,
                 max(StatusCode) AS maxStatusNum
-         FROM otel_spans
+         FROM otel_spans FINAL
          WHERE TenantId = {tenant:String}
            AND Timestamp >= now() - INTERVAL ${w} DAY
            AND GenAiOperation NOT IN ('compute', 'egress')

--- a/web/lib/waste/no-measured-return.ts
+++ b/web/lib/waste/no-measured-return.ts
@@ -164,10 +164,13 @@ export async function collectNoMeasuredReturn(
   const live = await tryLive(async (db, tenant) => {
     // Per-feature windowed spend. `w` is a clamped int, so interpolating it is injection-safe (same
     // pattern as the sibling queries in lib/clickhouse.ts). `filters.feature` binds as an array param.
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const spendRows = await rowsPCached<FeatureSpendRow>(
       db,
       `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL ${w} DAY
          AND FeatureTag != ''

--- a/web/lib/waste/paid-for-nothing.ts
+++ b/web/lib/waste/paid-for-nothing.ts
@@ -170,6 +170,9 @@ export async function collectPaidForNothing(
     // Stage 1 (runs subquery): one row per TraceId with its cost, terminal-error flag, feature and
     // agent. `isFailed` reuses queryAgents' derivation: max(StatusCode)=2 (OTel Error) => failed.
     // `GenAiOperation NOT IN ('compute','egress')` keeps this to run-shaped, billable spend.
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const runsCte = `
       SELECT
         TraceId AS runId,
@@ -177,7 +180,7 @@ export async function collectPaidForNothing(
         any(ServiceName) AS agent,
         sum(EstimatedCost) AS runCost,
         max(StatusCode) = 2 AS isFailed
-      FROM otel_spans
+      FROM otel_spans FINAL
       WHERE TenantId = {tenant:String}
         AND Timestamp >= now() - INTERVAL ${w} DAY
         AND GenAiOperation NOT IN ('compute', 'egress')

--- a/web/lib/waste/structural-inefficiency.ts
+++ b/web/lib/waste/structural-inefficiency.ts
@@ -170,7 +170,7 @@ function med0(n: number): number {
 function detectContextBloat(rows: StructuralRunRow[]): WasteFinding[] {
   const outliersByFeature = new Map<string, Outlier[]>();
 
-  for (const cohort of groupBy(rows, (r) => `${r.feature} ${r.model}`).values()) {
+  for (const cohort of groupBy(rows, (r) => `${r.feature}\u0000${r.model}`).values()) {
     if (cohort.length < MIN_COHORT_RUNS) continue;
     const { median: med, cutoff } = outlierGate(cohort.map((r) => r.inputTokens));
     for (const run of cohort) {
@@ -349,6 +349,11 @@ export async function collectStructuralInefficiency(
     // is judged in the cohort of the model that actually did the work. steps = span count, exactly
     // what queryAgents reports. Compute/egress spans are excluded: they are tenant infrastructure, not
     // agent steps, and would inflate both signals. `w` is a clamped int (injection-safe).
+    //
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums EstimatedCost per run and counts spans as steps, so an un-merged duplicate would
+    // both inflate the run's cost and add a phantom step, which is enough to push a run over the
+    // outlier gate and invent a finding.
     const raw = await rowsPCached<StructuralRunRaw>(
       db,
       `SELECT TraceId AS runId,
@@ -359,7 +364,7 @@ export async function collectStructuralInefficiency(
               sum(OutputTokens) AS outputTokens,
               count() AS steps,
               sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL ${w} DAY
          AND ServiceName != '' AND ServiceName != 'unknown'

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -301,6 +301,9 @@ interface FeatureIncumbent {
 async function queryFeatureIncumbents(windowDays: number): Promise<FeatureIncumbent[] | null> {
   const w = clampWindowDays(windowDays);
   return tryLive(async (db, tenant) => {
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const out = await rowsPCached<{ feature: string; model: string; spend: string; calls: string | number }>(
       db,
       `SELECT FeatureTag AS feature,
@@ -308,7 +311,7 @@ async function queryFeatureIncumbents(windowDays: number): Promise<FeatureIncumb
                  if(GenAiRequestModel != '', GenAiRequestModel, 'unknown')) AS model,
               sum(EstimatedCost) AS spend,
               count() AS calls
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY
          AND GenAiOperation NOT IN ('compute', 'egress')


### PR DESCRIPTION
Closes #314.

## What was wrong, precisely

CTO-245 made `otel_spans` a `ReplacingMergeTree` keyed on `(TenantId, FeatureTag, ServiceName, SpanName, Timestamp, TraceId, SpanId)`. Collapsing happens at merge time, and no read path was converted, so between a duplicate insert and the background merge a plain `sum(EstimatedCost)` reads both rows and over-states spend by exactly the replayed amount.

Severity, stated the same way the DDL states it: **reads are never worse than they were before the engine change**. Previously the duplicate was permanent. Now it converges. This closes the window between "converges" and "exact".

## The decision

Three options were on the table. `FINAL` won.

**`FINAL` on every read.** Chosen. It is exact at query time, it is one word per query, and it is the same construct `business_events` and `attribution_records` have used since CTO-176, so a reader already knows what it means. It merges the scanned rows across the parts holding them, so its cost scales with both how much data the query reads and how un-merged the table is, which is the thing that had to be measured rather than guessed. It was measured (below) and it is affordable.

**`argMax` / `GROUP BY` dedupe.** Rejected. Collapsing by hand means grouping by the full seven-column sorting key inside every one of ~40 queries, several of which already carry a `GROUP BY TraceId` run-grain CTE, a `WITH` chain, or a join. It buys nothing over `FINAL` here because there is no version column to arbitrate: the duplicate rows are byte-identical, so there is no winner to pick, only a row to drop. It would trade one word per query for a nested subquery per query and a much larger surface for a subtle mistake.

**A targeted subset.** Rejected as a rule, but the reasoning was done per query rather than waved off, and it produced exactly one exemption (below). Everything else that reads `otel_spans` reads a *value* off it: money, a span count, a token count, a distinct list, a quantile, a max timestamp. All of those move when a row is duplicated. Picking a subset of those would produce the failure mode this change exists to avoid: two panels disagreeing, neither obviously wrong.

### The one exemption

`queryFirstEventSeen` runs `SELECT 1 AS one FROM otel_spans WHERE TenantId = ... LIMIT 1`. It selects a literal and asks only whether a row exists. A duplicate cannot change a boolean, so `FINAL` buys nothing there, and it is not free: the onboarding panel polls this endpoint, and on an un-merged table `FINAL` takes it from 7ms to 43ms of ClickHouse time. It is commented in place and allowlisted by its exact text in the guard test.

### Keeping it coherent

The value of this change is that it is applied to *all* of the reads, and that property spans ~40 query sites, which is more than review can hold. `clickhouse.test.ts` asserts against the source text that every `FROM`/`JOIN otel_spans` carries `FINAL`, with the one exemption matched by its full query string rather than by filename. A query added later that forgets `FINAL` fails the build.

The guard **discovers its own inputs**: it walks `web/` (skipping `node_modules` and build output), takes every file whose text mentions `otel_spans`, and reports offenders as `file:line` alongside what to do about them. An earlier revision scanned a hardcoded five-file list, which could only ever guard the readers that existed when the list was written; the failure this exists to prevent is a *new* reader shipping without `FINAL`. Discovery is not theoretical here: turning it on immediately found `web/lib/waste/structural-inefficiency.ts`, a sixth reader that had been missed (see the scope note).

The pattern is case-insensitive, understands a database qualifier (`db.otel_spans`) and both alias forms (`otel_spans s`, `otel_spans AS s`), and a dedicated test pins the read forms a contributor might write, in both directions: correct SQL must not fail the build, and a lowercase or qualified read without `FINAL` must not slip through. Comments are stripped before matching, because several files describe the query in prose and failing the build on a sentence would only train people to silence the guard. The guard is itself guarded: one case asserts the walk still finds the known readers and still matches >30 reads, so it cannot pass vacuously.

## Scope note

The five waste detectors (`web/lib/waste/{duplicated-work,no-measured-return,paid-for-nothing,structural-inefficiency,wrong-sized-model}.ts`) read `otel_spans` directly and sum money off it. They are included.

`structural-inefficiency.ts` was missed on the first pass and found by the rediscovering guard. It was invisible to review because it was invisible to `grep`: CTO-233 wrote the cohort key's separator as a literal NUL byte, which makes the file `data` rather than text, so every `grep -r` over `web/` silently skipped it. The separator is fine and is unchanged in behaviour; it is now written as the `\u0000` escape so the file is text again. The detector sums `EstimatedCost` per run *and* counts spans as steps, so an un-merged duplicate both inflated a run's cost and added a phantom step, which is enough to push a run past the outlier gate and invent a finding. Converting `clickhouse.ts` alone would have left the Recoverable Cost page over-counting while the Cost page did not, which is precisely the two-panels-disagree failure this pass exists to prevent. Rollup tables are untouched: they are `SummingMergeTree` and are polluted permanently rather than eventually, which is #311's problem, not this one.

## Measured cost

Live local stack, 1,542,971 spans across three tenants, ClickHouse 24.8.14. Timings are best-of-5 wall clock; the ~59ms `docker exec` round trip is subtracted where noted.

### Steady state (table merged, 35 parts / 35 partitions)

`FINAL` is inside the noise. Every query landed within a few ms of its plain counterpart, several of them faster. ClickHouse skips the merging transform when a partition holds one part, which is the normal condition for anything but the newest partition.

| query | plain | FINAL |
|---|---|---|
| spend summary totals, 30d | 73.5ms | 68.9ms |
| spend by layer, 30d | 69.9ms | 62.3ms |
| agents run-grain `GROUP BY TraceId`, 30d | 93.3ms | 83.4ms |
| waste duplicated-work, 30d | 139.6ms | 135.9ms |
| daily cost series, 30d | 70.9ms | 67.0ms |

### Adverse case (forced to 372 parts over 31 partitions)

The real question is what `FINAL` costs when the table is *not* merged, so the same corpus was copied into a scratch table with merges stopped and inserted in 12 passes, leaving ~12 un-merged parts in **every** partition. That is deliberately worse than a live install, where only the newest partition is typically un-merged.

| query | plain | FINAL | delta | net of exec overhead |
|---|---|---|---|---|
| spend summary totals | 87.1ms | 121.0ms | +33.9ms | 28ms -> 62ms |
| spend by layer | 85.1ms | 121.1ms | +36.0ms | 26ms -> 62ms |
| agents run-grain | 124.1ms | 150.6ms | +26.5ms | 65ms -> 92ms |
| waste duplicated-work (heaviest) | 206.9ms | 258.6ms | +51.7ms | 148ms -> 200ms |
| per-user cost, 30d | 113.6ms | 150.3ms | +36.7ms | 55ms -> 91ms |
| explore breakdown | 78.7ms | 125.4ms | +46.7ms | 20ms -> 66ms |
| feature-tag options | 109.4ms | 114.3ms | +4.9ms | 50ms -> 55ms |
| first-event probe (**exempted**) | 66.4ms | 101.7ms | +35.3ms | 7ms -> 43ms |

Read this as a *ratio*: on this 1.54M-span corpus, twelve-deep un-mergedness costs tens of milliseconds per query. It is not a claim that `FINAL` is independent of how much data a query reads. `FINAL` merges the rows a query scans across the K parts holding them, so its absolute cost scales with both the scan size and the part count; what is bounded by un-mergedness is the merged-to-un-merged ratio, at a fixed scan. A query scanning far more than these do would pay proportionally more.

### End to end: does anything cross one second?

No. Production build (`npm run build && npm run start`), `curl` against the running server, best-of-5 after a warm request.

| route | before | after |
|---|---|---|
| `/waste` (Recoverable Cost) | 644.3ms | 616.8ms |
| `/` (Home) | 532.7ms | 463.7ms |
| `/cost` | 86.6ms | 76.9ms |
| `/api/waste` | 627.2ms | 620.0ms |
| `/api/home` | 469.9ms | 509.7ms |
| `/api/agents` | 761.8ms | 775.9ms |
| `/api/features` | 332.2ms | 318.6ms |
| `/api/cost` | 63.3ms | 59.6ms |
| `/api/explore` | 42.5ms | 40.1ms |
| `/api/data-quality` | 69.7ms | 63.1ms |

Read these as **unmeasured**, not as "faster" and not as "a small change". `/waste` at 644ms before and 617ms after is a speedup after adding work, which is the signature of noise, and two runs of the *same* binary spread `/waste` across 617ms and 728ms. The noise floor is wider than any effect `FINAL` could have at this page's query mix, so this table does not bound the page-level delta in either direction; it only shows both pages staying inside the one-second bar CTO-227 bought back. The claim that is actually supported is the per-query one above.

## Proof of the dedupe property

Against the live stack: merges stopped on `otel_spans`, one real priced span replayed byte for byte (exactly what a retried batch writes past the idempotency store), then the shipped `querySpendSummary` called before and after.

```
span replayed: TraceId e696ca364ee42c73eb76251966a9a131 / SpanId 17ffb4e22b2b6b2f, $48.642273

plain SELECT, before insert  53903.057843   497316 spans
plain SELECT, after insert   53951.700116   497317 spans   <- over-counts by $48.64
FINAL SELECT, after insert   53903.057843   497316 spans   <- exact

querySpendSummary() before    53903057843 micro-USD, 497316 spans
querySpendSummary() after     53903057843 micro-USD, 497316 spans   <- unmoved
```

The span count is asserted alongside the money, so the test would catch a `FINAL` that collapsed the total by accident rather than by identity.

Cleanup: merges restarted, the partition optimised, the plain read confirmed back at `53903.057843 / 497316`, and `SELECT count() FROM (SELECT TraceId, SpanId, count() c FROM otel_spans GROUP BY TenantId, TraceId, SpanId HAVING c>1)` returns `0`. The scratch bench table was dropped. No test rows remain.

## Verification

```
cd web && npm run typecheck   # clean
              npm run lint    # clean (one pre-existing warning in lib/useLivePoll.ts, untouched)
              npm run test    # 63 files, 766 tests passing
              npm run build   # clean, and every route smoke-tested 200 against the live stack
```

The guard was checked by breaking it, in every form that previously slipped past it. Dropping a new un-`FINAL`ed reader into `web/lib/` and into `web/app/api/` fails the build and names the offender:

```
"app/api/zz-probe/route.ts:2: from otel_spans where",
"app/api/zz-probe/route.ts:3: FROM tally.otel_spans AS s",
"lib/zz-probe-bypass.ts:2: FROM otel_spans WHERE",
```

That covers all three of the old bypasses at once: a file outside the hardcoded list, a lowercase read, and a database-qualified read. Separately, `FROM otel_spans AS s FINAL` (correct SQL, and the style already used at `attribution_records AS ar FINAL`) now passes, where the earlier pattern failed the build on it.

## Not done here

Two pre-existing bugs in the per-provider revenue query (`queryUnitEconomics`, `web/lib/clickhouse.ts`) were found while reviewing the `FINAL` conversion. Both are on `origin/main` and neither is caused or fixed by this PR, so both are marked in a comment and left for their own ticket rather than folded into a correctness diff:

1. **Join fan-out.** The query sums `b.ValueAmountMicro` across an `INNER JOIN otel_spans`, so a business event is counted once per matching span for that user: a user with 30 spans contributes their revenue 30 times. `FINAL` removes the duplicate-span multiplier and nothing else, so revenue per provider stays inflated by the real span count. The sibling conversions query survives the same join only because `uniqExact` collapses the fan-out; a `sum` cannot.
2. **Float dollars in SQL.** The same expression divides by `1000000` inside ClickHouse, so the value arrives already converted and already floating, against the money invariant (integer micro-USD end to end, converted at the boundary only).

`web/lib/clickhouse.ts` and the waste detectors carry 53 em dashes in existing comments, which the parallel prose sweep excluded. Removing them means rewording 53 lines of prose, which does not belong in a correctness diff. Left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

