### PR TITLE
fix(clickhouse): repair historical spans stored as a priced $0

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -173,8 +173,9 @@ stack, `make nuke && make up && make seed` and re-backfill.
 That limitation is narrower than it was. CTO-313 repairs the pre-cutover zeros that can be decided
 on structural evidence: it reprices the ones whose true cost still sits on the row, and marks the
 ones that were never priced at all as unknown rather than as `$0.00`. What it still cannot separate
-is a genuine provider-reported `0` from an unknown that ingest flattened **on a row that carries a
-real model, real tokens and a real catalog version**. Those stay `0`. See "Historical rows stored as
+is a genuine provider-reported `0` from an unknown that ingest flattened **on any row that carries a
+real catalog version**. Those stay `0`, and the check names the ambiguous ones among them
+(`measured_zero_no_model`, `measured_zero_flat_usage`) rather than implying they are all decided. See "Historical rows stored as
 a priced $0" below.
 
 ### Batch idempotency (CTO-245)
@@ -446,19 +447,42 @@ days, so a date comparison would mark freshly-written rows as historical and mis
 
 | Class | What it means | What the repair does |
 |---|---|---|
-| `recoverable` | cost is 0 but the original client-reported cost still sits in `SpanAttributes['gen_ai.tool.cost_micro_usd']`, from before the gateway promoted that attribute into the column | reprices from the attribute |
-| `unknown_no_price_input` | cost is 0 and nothing priceable was ever recorded: no model either side, no tokens, no client cost. The stored 0 is a column default, not a result, even where a `PriceCatalogVersion` is stamped | marks `NULL` / `unpriced` |
+| `recoverable` | cost is 0, `PriceCatalogVersion` is `''`, and the original client-reported cost still sits in `SpanAttributes['gen_ai.tool.cost_micro_usd']`, from before the gateway promoted that attribute into the column | reprices from the attribute |
+| `unknown_no_price_input` | cost is 0 and nothing priceable was ever recorded: no model either side, no tokens, no usable client cost. The stored 0 is a column default, not a result, even where a `PriceCatalogVersion` is stamped | marks `NULL` / `unpriced` |
 | `unknown_catalog_miss` | cost is 0 and `PriceCatalogVersion` is `''`, the empty-version signal `tally.pricing` returns on a catalog miss. These usually carry a real model and real tokens, so the money is real and unknown | marks `NULL` / `unpriced` |
-| `measured_zero` | cost is 0 with a real catalog version and a model to have priced. This was priced and the answer was zero | left as `0`, deliberately |
+| `measured_zero` | cost is 0 with a real catalog version, a model to have priced and tokens to have priced it on. This was priced and the answer was zero | left as `0`, deliberately |
+| `measured_zero_no_model` | cost is 0 with a real catalog version and tokens, but no model on either side, which `enrich_cost` can never price | left as `0`, deliberately |
+| `measured_zero_flat_usage` | cost is 0 with a real catalog version and a model, but tokens coerced to `0`, which is CTO-244's own motivating case | left as `0`, deliberately |
 
-That last row is not an oversight. CTO-244 was explicit that a real `0` stays `0` and stays
+The last three rows are not an oversight. CTO-244 was explicit that a real `0` stays `0` and stays
 distinguishable from `NULL`; turning genuine zeros into unknowns destroys information, which is the
-same sin in the other direction.
+same sin in the other direction. A real `PriceCatalogVersion` means a catalog did produce that
+number, so all three are left alone. The last two are named rather than folded into `measured_zero`
+because that name claims more certainty than they have: they are the residue neither the check nor
+the repair can decide, and they should be visible.
+
+The `recoverable` requirement that `PriceCatalogVersion` be `''` is load-bearing.
+`gen_ai.tool.cost_micro_usd` is not promoted out of `SpanAttributes`, so it survives on a row next to
+a cost the catalog computed. Without that requirement a tool span the catalog legitimately priced at
+zero would be classed `recoverable` and the repair would overwrite a catalog-authoritative zero with
+a client hint, while leaving the catalog version in place so the substituted number inherited
+provenance it never earned.
+
+**One thing the repair can get wrong, stated rather than glossed.** A non-tool span that carried
+`gen_ai.cost.estimated_micro_usd = 0` with no model and no tokens is stored as a genuine priced zero,
+because `enrich_cost` returns early without popping that key when provider or model are not strings.
+That key **is** promoted, so nothing survives in `SpanAttributes` to tell such a row apart from the
+column default the repair is aimed at, and it is marked unknown. That is information loss in the
+opposite direction. The shape is rare, and the alternative is leaving every column-default zero
+asserting a measurement nobody took, so it is accepted. Exclude such spans by hand if you have them.
 
 The check also replays the repricing arithmetic against every span the gateway itself already
 promoted, where the source attribute and the promoted column both survive and must agree exactly.
 `conversion_mismatches` must be `0`. That is what makes the reprice a repricing rather than an
-estimate: it is provably the same operation the gateway performs.
+estimate: it is provably the same operation the gateway performs. The replay is scoped to
+`PriceCatalogVersion = ''`, which is what "the gateway promoted this" means; a catalog-priced tool
+span keeps the attribute too, as a client hint that may legitimately differ, and sweeping those in
+would report a mismatch and block the repair on a deployment where nothing is wrong.
 
 **Repair it.**
 
@@ -516,6 +540,16 @@ After `make ch-rollup-rebuild`, all three rollups reconciled exactly against a `
 spans at `$139,664.4182253` with `drift_micro_usd = 0`, and `live-cto219`'s rollup rows went from
 claiming `$0.00` spend over 600,000 calls with `UnpricedSpanCount = 0` to `UnpricedSpanCount =
 600,000`, which is the signal the dashboard needs to blank the figure rather than render a zero.
+
+The guards added in review were exercised on the same stack with two synthetic spans, removed
+afterwards from raw spans and from all three rollups. A tool span at `$0.00` with a real
+`PriceCatalogVersion` and a `gen_ai.tool.cost_micro_usd` hint of `5000` was claimed by the old step 1
+(which would have overwritten a catalog-authoritative zero) and classed `recoverable`; under the
+empty-version guard it is claimed by neither step and classes as `measured_zero`. A span with
+`gen_ai.tool.cost_micro_usd = 'n/a'`, a real model, real tokens and an empty catalog version was
+skipped by the old step 2 and would have stayed a fabricated `$0` through any number of re-runs;
+under `toInt64OrNull(...) IS NULL` it is marked `NULL` / `unpriced`, which is what makes the claim
+above that the `unknown_*` classes are gone after a repair actually true.
 
 Two notes on what this changed that were not bugs being fixed. The issue quoted the affected
 population as "28,586 tool/vector spans holding $93.11". On this stack it is exactly 28,586 spans

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -170,6 +170,13 @@ measure, and the pre-cutover `UnpricedSpanCount` of `0` means "nobody counted", 
 unknowns". Post-cutover data is honest. If a clean baseline matters more than history on a local
 stack, `make nuke && make up && make seed` and re-backfill.
 
+That limitation is narrower than it was. CTO-313 repairs the pre-cutover zeros that can be decided
+on structural evidence: it reprices the ones whose true cost still sits on the row, and marks the
+ones that were never priced at all as unknown rather than as `$0.00`. What it still cannot separate
+is a genuine provider-reported `0` from an unknown that ingest flattened **on a row that carries a
+real model, real tokens and a real catalog version**. Those stay `0`. See "Historical rows stored as
+a priced $0" below.
+
 ### Batch idempotency (CTO-245)
 
 Re-posting a batch with a `batch_id` the gateway has already accepted returns the original response
@@ -365,6 +372,106 @@ The not-derivable figure is the honest residue: 519 of those grains are `local-d
 2025-09-09 to 2026-08-03 whose raw spans aged out, plus three retired test tenants
 (`cto210-shorthistory`, `mv-test`, `cto199-verify`). Whether they contain duplicated money is
 unknowable, and this repair does not pretend otherwise.
+
+### Historical rows stored as a priced $0 (CTO-313)
+
+CTO-244 made `EstimatedCost` nullable so a span we cannot price stores `NULL` with
+`CostSource = 'unpriced'` and renders as a blank with a reason. That stopped **new** spans asserting
+a fabricated `$0`. It did not rewrite the rows already written that way, and those rows are what a
+dashboard over historical data reads: a confident, measured-looking `$0.00` on calls that either
+cost real money or cost an amount nobody ever established.
+
+**See what you have.**
+
+```bash
+make ch-priced-zero-check   # from infra/, read-only
+```
+
+It splits every `EstimatedCost = 0` span into four mutually exclusive classes, and the split is
+structural: it reads what each row carries rather than comparing against a cutover date. A cutover
+date does not work here, and the reason is worth knowing. Nothing in `otel_spans` records when a row
+was **written**; `Timestamp` is the span's own time and the demo backfill posts spans backdated 30
+days, so a date comparison would mark freshly-written rows as historical and miss backdated ones.
+
+| Class | What it means | What the repair does |
+|---|---|---|
+| `recoverable` | cost is 0 but the original client-reported cost still sits in `SpanAttributes['gen_ai.tool.cost_micro_usd']`, from before the gateway promoted that attribute into the column | reprices from the attribute |
+| `unknown_no_price_input` | cost is 0 and nothing priceable was ever recorded: no model either side, no tokens, no client cost. The stored 0 is a column default, not a result, even where a `PriceCatalogVersion` is stamped | marks `NULL` / `unpriced` |
+| `unknown_catalog_miss` | cost is 0 and `PriceCatalogVersion` is `''`, the empty-version signal `tally.pricing` returns on a catalog miss. These usually carry a real model and real tokens, so the money is real and unknown | marks `NULL` / `unpriced` |
+| `measured_zero` | cost is 0 with a real catalog version and a model to have priced. This was priced and the answer was zero | left as `0`, deliberately |
+
+That last row is not an oversight. CTO-244 was explicit that a real `0` stays `0` and stays
+distinguishable from `NULL`; turning genuine zeros into unknowns destroys information, which is the
+same sin in the other direction.
+
+The check also replays the repricing arithmetic against every span the gateway itself already
+promoted, where the source attribute and the promoted column both survive and must agree exactly.
+`conversion_mismatches` must be `0`. That is what makes the reprice a repricing rather than an
+estimate: it is provably the same operation the gateway performs.
+
+**Repair it.**
+
+```bash
+make ch-repair-priced-zero   # from infra/
+make ch-rollup-rebuild       # REQUIRED follow-up, see below
+```
+
+Nothing is invented. Where the true cost survives on the row it is promoted; where it does not, the
+row is marked `EstimatedCost = NULL`, `CostSource = 'unpriced'`, which is exactly what a
+post-CTO-244 gateway writes in the same situation, so the dashboard blanks it with a reason instead
+of showing a confident zero. What those calls really cost is not recorded anywhere and is not
+recoverable, so no number is put there.
+
+The script prints a before-and-after ledger, and the ledger carries its own proof. Known spend must
+move **up** by exactly the recoverable micro-USD and by nothing else, because marking a row unknown
+removes a zero from a sum and a zero changes no total. If known spend moves by any other amount, the
+mark step touched money it should not have.
+
+#### Order of operations
+
+`ALTER ... UPDATE` is a ClickHouse mutation, and **materialized views fire on INSERT, never on a
+mutation**. So every dollar the repair changes leaves `daily_feature_rollup`,
+`hourly_feature_rollup` and `daily_account_rollup` holding the old money, and the dashboard reads
+rollups. Run the two repairs in this order:
+
+1. `make ch-migrate-otel-engine`, if `otel_spans` is not yet a `ReplacingMergeTree` (CTO-245). Both
+   checks below define truth as a `FINAL` read, which is a no-op on a plain `MergeTree`.
+2. `make ch-priced-zero-check`, then `make ch-repair-priced-zero`. Ingest does not need quiescing:
+   every predicate is structural, and a span written while it runs is already honest.
+3. `make ch-rollup-rebuild` (CTO-311), with ingest quiesced. This is where the repriced money
+   reaches the dashboard.
+4. `make ch-rollup-check` and `make ch-priced-zero-check` again to confirm.
+
+Doing 3 before 2 leaves the rollups derived from the pre-repair costs, which looks like a successful
+rebuild and is wrong by exactly the recovered spend.
+
+#### Verified on the live local stack
+
+1,542,996 spans across three tenants. Every priced-`$0` population on the stack, before and after:
+
+| Population | Spans | Before | After |
+|---|---|---|---|
+| `local-dev` tool spans carrying `gen_ai.tool.cost_micro_usd` | 28,586 | `$0.00`, `CostSource = 'estimated'` | **`$93.106`** (93,106,000 micro-USD), still `estimated` |
+| `live-cto219` load-test spans, no model, no tokens, no cost attribute | 600,000 | `$0.00`, `CostSource = 'estimated'`, `PriceCatalogVersion = 'v1'` | `NULL`, `CostSource = 'unpriced'` |
+| `local-dev` embedding spans, real model and real tokens, empty catalog version | 3,989 | `$0.00`, `CostSource = 'estimated'` | `NULL`, `CostSource = 'unpriced'` |
+
+Stack-wide: priced-`$0` spans 632,575 to **0**; spans honestly marked unknown 0 to **603,989**; known
+spend `$139,571.3122253` to `$139,664.4182253`, a move of exactly `$93.106`, which is the recovered
+tool spend and nothing else. The repricing arithmetic replayed against the 183,169 spans the gateway
+had already promoted with **0** mismatches, and after the repair that replay covers all 211,755
+spans carrying the attribute, still with 0 mismatches (`$535.96335` = `$442.85735` + `$93.106`).
+
+After `make ch-rollup-rebuild`, all three rollups reconciled exactly against a `FINAL` sum over raw
+spans at `$139,664.4182253` with `drift_micro_usd = 0`, and `live-cto219`'s rollup rows went from
+claiming `$0.00` spend over 600,000 calls with `UnpricedSpanCount = 0` to `UnpricedSpanCount =
+600,000`, which is the signal the dashboard needs to blank the figure rather than render a zero.
+
+Two notes on what this changed that were not bugs being fixed. The issue quoted the affected
+population as "28,586 tool/vector spans holding $93.11". On this stack it is exactly 28,586 spans
+holding `$93.106`, and every one of them is a `tool` span: `local-dev`'s 40,000 `vector` spans were
+already correctly priced at `$8,262.74` and were not touched. And `live-cto219`'s reported spend does
+not fall to a smaller number, it stops being a number at all: 600,000 synthetic load-test calls that
+were reading as `$0.00` of confirmed spend now read as unknown, because that is what they are.
 
 ## 4. Run the web dashboard
 
@@ -807,6 +914,8 @@ Knobs:
 | `make chatbot-demo-stop` | Kill the background chatbot dev server started by `chatbot-demo` |
 | `make ch-rollup-check` | Report rollup spend inflated by duplicated spans, per rollup and tenant (read-only, CTO-311) |
 | `make ch-rollup-rebuild` | Rebuild the rollup targets from the deduplicated raw spans (one-shot, quiesce ingest, CTO-311) |
+| `make ch-priced-zero-check` | Report historical spans stored as a priced `$0` that was never measured (read-only, CTO-313) |
+| `make ch-repair-priced-zero` | Reprice what is derivable, mark the rest unknown; follow with `ch-rollup-rebuild` (CTO-313) |
 | `make ps` / `make logs` | Status / tail gateway logs |
 | `make ch` / `make psql` | ClickHouse / Postgres SQL shell |
 | `make down` | Stop the stack (keep data volumes) |

--- a/db/clickhouse/checks/priced_zero.sql
+++ b/db/clickhouse/checks/priced_zero.sql
@@ -16,14 +16,24 @@
 -- backdated ones. So this classifies on what the row itself carries, which is exact and needs no
 -- date at all:
 --
---   recoverable        cost is 0 but the span still carries the ORIGINAL client-reported cost in
---                      SpanAttributes['gen_ai.tool.cost_micro_usd']. The gateway now promotes that
---                      attribute into EstimatedCost; these rows predate the promotion. The money is
---                      right there, so this is a repricing, not a guess. The test is
---                      toInt64OrNull(...) IS NOT NULL rather than "the key is present", on purpose:
---                      toInt64OrZero on a malformed value would manufacture the very zero this is
---                      trying to remove, so an unparseable attribute falls through to a class below
---                      and is treated as unknown.
+--   recoverable        cost is 0, PriceCatalogVersion is '', and the span still carries the ORIGINAL
+--                      client-reported cost in SpanAttributes['gen_ai.tool.cost_micro_usd']. The
+--                      gateway now promotes that attribute into EstimatedCost; these rows predate
+--                      the promotion. The money is right there, so this is a repricing, not a guess.
+--                      The test is toInt64OrNull(...) IS NOT NULL rather than "the key is present",
+--                      on purpose: toInt64OrZero on a malformed value would manufacture the very
+--                      zero this is trying to remove, so an unparseable attribute falls through to a
+--                      class below and is treated as unknown.
+--                      THE EMPTY-VERSION REQUIREMENT IS LOAD-BEARING, and it used to be missing.
+--                      gen_ai.tool.cost_micro_usd is not promoted out of SpanAttributes (it is
+--                      absent from mapping.py's _PROMOTED_GENAI), so it survives on the row next to
+--                      a cost the price catalog computed. A tool or vector span the catalog
+--                      legitimately prices at zero therefore carries a REAL version and the client
+--                      hint at once. Because this branch is evaluated first, such a row was never
+--                      even reported as measured_zero, and the repair would have overwritten a
+--                      catalog-authoritative zero with a client hint. An empty version is the only
+--                      state in which no catalog ever spoke and the hint is the best evidence there
+--                      is.
 --
 --   unknown_no_price_input
 --                      cost is 0 and the span records NOTHING that could ever have been priced: no
@@ -39,12 +49,27 @@
 --                      Rows here usually DO carry a model and real token counts, so the money is
 --                      real and unknown, which is the worst of the three to report as $0.00.
 --
---   measured_zero      cost is 0, a real price catalog version is stamped, and there is a model to
---                      have priced. This is a provider-reported or catalog-computed zero and it is
---                      a fact. It is listed so it is visibly EXCLUDED from any repair. CTO-244 was
---                      explicit that a real 0 stays 0 and stays distinguishable from NULL; turning
---                      these into unknowns would destroy information, which is the same sin in the
---                      opposite direction.
+--   measured_zero      cost is 0, a real price catalog version is stamped, there is a model to have
+--                      priced AND there are tokens to have priced it on. This is a provider-reported
+--                      or catalog-computed zero and it is a fact. It is listed so it is visibly
+--                      EXCLUDED from any repair. CTO-244 was explicit that a real 0 stays 0 and
+--                      stays distinguishable from NULL; turning these into unknowns would destroy
+--                      information, which is the same sin in the opposite direction.
+--
+--   measured_zero_no_model
+--   measured_zero_flat_usage
+--                      the residue, split out rather than folded into measured_zero, because the
+--                      class doc used to promise "a real model, real tokens and a real catalog
+--                      version" while the SQL asked only for a version plus (a model OR non-zero
+--                      tokens). Two populations slipped through that gap and sat inside a class name
+--                      claiming more certainty than it had: rows with tokens but no model on either
+--                      side, which enrich_cost can never price, and pre-CTO-244 flattened-usage rows
+--                      with a model, a real version and tokens coerced to 0, which is CTO-244's own
+--                      motivating case. Both keep a real PriceCatalogVersion, so a catalog did
+--                      produce that number and the repair leaves them alone exactly as it leaves
+--                      measured_zero alone. Naming them is the point: this is the residue that
+--                      neither the repair nor this check can decide, and it should be visible rather
+--                      than laundered into a confident label.
 --
 -- The classes are evaluated in that order and are mutually exclusive, so the counts partition the
 -- priced-zero population exactly.
@@ -56,10 +81,13 @@ SELECT
     TenantId,
     GenAiOperation,
     multiIf(
-        toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL, 'recoverable',
+        PriceCatalogVersion = ''
+            AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL, 'recoverable',
         GenAiRequestModel = '' AND GenAiResponseModel = ''
             AND ifNull(InputTokens, 0) = 0 AND ifNull(OutputTokens, 0) = 0, 'unknown_no_price_input',
         PriceCatalogVersion = '', 'unknown_catalog_miss',
+        GenAiRequestModel = '' AND GenAiResponseModel = '', 'measured_zero_no_model',
+        ifNull(InputTokens, 0) = 0 AND ifNull(OutputTokens, 0) = 0, 'measured_zero_flat_usage',
         'measured_zero'
     ) AS class,
     count() AS spans,
@@ -71,8 +99,13 @@ SELECT
     if(class = 'recoverable',
        toString(sum(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']))),
        '') AS recoverable_micro_usd,
+    -- Divided BEFORE widening. `toDecimal64(micro, 8)` widens the micro-USD integer to a scale-8
+    -- Decimal64, which leaves ten integer digits and throws above about 92,233,720,368 micro-USD,
+    -- roughly $92,233 on one span. One client sending nanos would hard-fail a READ-ONLY check,
+    -- which is the last thing a check should do. divideDecimal converts at scale 0 instead.
     if(class = 'recoverable',
-       toString(sum(toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8)) / 1000000),
+       toString(divideDecimal(sum(toDecimal64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd'], 0)),
+                              toDecimal64(1000000, 0), 8)),
        '') AS recoverable_usd
 FROM otel_spans FINAL
 WHERE EstimatedCost = 0
@@ -85,17 +118,29 @@ FORMAT PrettyCompact;
 -- conversion can be replayed against them and checked. `conversion_mismatches` must be 0; if it is
 -- not, the attribute and the column disagree about what the gateway does and the reprice in
 -- db/clickhouse/migrations/priced_zero_repair.sql must not be run until that is understood.
+--
+-- SCOPED TO PriceCatalogVersion = '', which is what "the gateway promoted this" actually means. The
+-- attribute is not promoted out of SpanAttributes, so it also survives on tool and vector spans the
+-- price CATALOG costed, where EstimatedCost is the server's price and the attribute is only a client
+-- hint that may legitimately differ. Without this scope every such row with any drift at all counts
+-- as a mismatch, and the lines above then tell an operator the repair must not be run, on a
+-- deployment where nothing is wrong. That is a false block on the only remedy, so it is fixed rather
+-- than explained.
 SELECT
     count() AS gateway_promoted_spans,
-    countIf(EstimatedCost != toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8) / 1000000)
+    countIf(EstimatedCost != divideDecimal(toDecimal64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd'], 0),
+                                           toDecimal64(1000000, 0), 8))
         AS conversion_mismatches,
     -- Reported separately because a NULL comparison is neither true nor false, so an unparseable
     -- attribute would sit silently outside conversion_mismatches rather than being flagged by it.
     countIf(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NULL) AS unparseable_attrs,
     sum(EstimatedCost) AS stored_usd,
-    sum(toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8)) / 1000000 AS replayed_usd
+    divideDecimal(sum(toDecimal64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd'], 0)),
+                  toDecimal64(1000000, 0), 8) AS replayed_usd
 FROM otel_spans FINAL
-WHERE SpanAttributes['gen_ai.tool.cost_micro_usd'] != '' AND EstimatedCost != 0
+WHERE SpanAttributes['gen_ai.tool.cost_micro_usd'] != ''
+  AND EstimatedCost != 0
+  AND PriceCatalogVersion = ''
 FORMAT Vertical;
 
 -- Already-honest rows, for contrast: spans that correctly say "unknown" rather than "$0.00". A

--- a/db/clickhouse/checks/priced_zero.sql
+++ b/db/clickhouse/checks/priced_zero.sql
@@ -1,0 +1,113 @@
+-- CTO-313: which historical spans assert a priced $0 that is not a measurement?
+-- READ-ONLY. Run it with `make ch-priced-zero-check` from infra/. It writes nothing.
+--
+-- WHY THIS EXISTS. CTO-244 made EstimatedCost nullable so a span we cannot price stores NULL with
+-- CostSource = 'unpriced' and renders as a blank with a reason. That stopped NEW spans asserting a
+-- fabricated $0. It did not rewrite the rows already written that way, and those rows are still
+-- what a dashboard over historical data reads: a confident, measured-looking $0.00 on calls that
+-- either cost real money or cost an amount nobody ever established.
+--
+-- HOW A FABRICATED ZERO IS TOLD APART FROM A REAL ONE, without a cutover date.
+--
+-- The tempting rule is "everything before the CTO-244 cutover". It does not work here, and saying
+-- why matters more than the rule. Nothing in otel_spans records when a row was WRITTEN: Timestamp
+-- is the span's own time, and the demo backfill posts spans backdated 30 days. A cutover date
+-- compared against Timestamp would therefore mark freshly-written rows as historical and miss
+-- backdated ones. So this classifies on what the row itself carries, which is exact and needs no
+-- date at all:
+--
+--   recoverable        cost is 0 but the span still carries the ORIGINAL client-reported cost in
+--                      SpanAttributes['gen_ai.tool.cost_micro_usd']. The gateway now promotes that
+--                      attribute into EstimatedCost; these rows predate the promotion. The money is
+--                      right there, so this is a repricing, not a guess. The test is
+--                      toInt64OrNull(...) IS NOT NULL rather than "the key is present", on purpose:
+--                      toInt64OrZero on a malformed value would manufacture the very zero this is
+--                      trying to remove, so an unparseable attribute falls through to a class below
+--                      and is treated as unknown.
+--
+--   unknown_no_price_input
+--                      cost is 0 and the span records NOTHING that could ever have been priced: no
+--                      request model, no response model, no tokens, no client-reported cost. A
+--                      price catalog cannot produce a number from that, so the stored 0 is a column
+--                      default, not a result. (These rows can still carry a PriceCatalogVersion,
+--                      which is what makes them look measured and is exactly the trap.)
+--
+--   unknown_catalog_miss
+--                      cost is 0 and PriceCatalogVersion is '', which is the empty-version signal
+--                      tally.pricing already returns on a catalog miss (see the CTO-244 note in
+--                      otel_spans.sql). The catalog never produced a price; ingest wrote 0 anyway.
+--                      Rows here usually DO carry a model and real token counts, so the money is
+--                      real and unknown, which is the worst of the three to report as $0.00.
+--
+--   measured_zero      cost is 0, a real price catalog version is stamped, and there is a model to
+--                      have priced. This is a provider-reported or catalog-computed zero and it is
+--                      a fact. It is listed so it is visibly EXCLUDED from any repair. CTO-244 was
+--                      explicit that a real 0 stays 0 and stays distinguishable from NULL; turning
+--                      these into unknowns would destroy information, which is the same sin in the
+--                      opposite direction.
+--
+-- The classes are evaluated in that order and are mutually exclusive, so the counts partition the
+-- priced-zero population exactly.
+--
+-- Money is integer micro-USD. `recoverable_micro_usd` is summed straight off the attribute with no
+-- conversion at all; the Decimal64(8) USD column is only computed for display.
+
+SELECT
+    TenantId,
+    GenAiOperation,
+    multiIf(
+        toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL, 'recoverable',
+        GenAiRequestModel = '' AND GenAiResponseModel = ''
+            AND ifNull(InputTokens, 0) = 0 AND ifNull(OutputTokens, 0) = 0, 'unknown_no_price_input',
+        PriceCatalogVersion = '', 'unknown_catalog_miss',
+        'measured_zero'
+    ) AS class,
+    count() AS spans,
+    min(toDate(Timestamp)) AS first_day,
+    max(toDate(Timestamp)) AS last_day,
+    -- Only the recoverable class has a number to report. The other classes are unknown, and an
+    -- unknown does not get a total: summing them would produce the same confident 0.00 this check
+    -- exists to expose. They read as a blank here for the same reason the dashboard blanks them.
+    if(class = 'recoverable',
+       toString(sum(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']))),
+       '') AS recoverable_micro_usd,
+    if(class = 'recoverable',
+       toString(sum(toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8)) / 1000000),
+       '') AS recoverable_usd
+FROM otel_spans FINAL
+WHERE EstimatedCost = 0
+GROUP BY TenantId, GenAiOperation, class
+ORDER BY spans DESC
+FORMAT PrettyCompact;
+
+-- Confidence that the repricing formula is the gateway's own, not one invented here. Every span the
+-- gateway ALREADY promoted still carries the source attribute alongside the promoted cost, so the
+-- conversion can be replayed against them and checked. `conversion_mismatches` must be 0; if it is
+-- not, the attribute and the column disagree about what the gateway does and the reprice in
+-- db/clickhouse/migrations/priced_zero_repair.sql must not be run until that is understood.
+SELECT
+    count() AS gateway_promoted_spans,
+    countIf(EstimatedCost != toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8) / 1000000)
+        AS conversion_mismatches,
+    -- Reported separately because a NULL comparison is neither true nor false, so an unparseable
+    -- attribute would sit silently outside conversion_mismatches rather than being flagged by it.
+    countIf(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NULL) AS unparseable_attrs,
+    sum(EstimatedCost) AS stored_usd,
+    sum(toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8)) / 1000000 AS replayed_usd
+FROM otel_spans FINAL
+WHERE SpanAttributes['gen_ai.tool.cost_micro_usd'] != '' AND EstimatedCost != 0
+FORMAT Vertical;
+
+-- Already-honest rows, for contrast: spans that correctly say "unknown" rather than "$0.00". A
+-- deployment that has been repaired should see the unknown_* classes above collapse into this.
+SELECT
+    TenantId,
+    CostSource,
+    count() AS spans,
+    min(toDate(Timestamp)) AS first_day,
+    max(toDate(Timestamp)) AS last_day
+FROM otel_spans FINAL
+WHERE EstimatedCost IS NULL
+GROUP BY TenantId, CostSource
+ORDER BY spans DESC
+FORMAT PrettyCompact;

--- a/db/clickhouse/migrations/priced_zero_repair.sql
+++ b/db/clickhouse/migrations/priced_zero_repair.sql
@@ -37,6 +37,18 @@
 --      0 and stays distinguishable from NULL. Turning those into unknowns would destroy information,
 --      which is the same sin in the other direction, so this script does not touch them.
 --
+-- WHAT THIS COSTS, STATED RATHER THAN GLOSSED. Limb (a) of step 2 can turn a genuine client-reported
+-- zero into an unknown, and there is no predicate that can stop it. tally.enrichment.enrich_cost
+-- returns early WITHOUT popping gen_ai.cost.estimated_micro_usd when provider or model are not
+-- strings, so a non-tool span carrying that key with a value of 0, no model and no tokens is stored
+-- as a REAL priced zero with CostSource = 'estimated' (mapping.py is explicit that this is a real
+-- priced zero). That key IS promoted, so nothing survives in SpanAttributes to tell such a row apart
+-- from the column default limb (a) is aimed at, and it is marked NULL. That is information loss in
+-- the opposite direction from the bug being repaired. It is accepted rather than hidden: the shape
+-- requires a client to report a cost of exactly zero on a span with no model and no usage at all,
+-- which is rare, and the alternative is to leave every column-default zero asserting a measurement
+-- that was never taken. If a deployment has such spans, exclude them by hand before running step 2.
+--
 -- WHY NOT A CUTOVER DATE, which the issue offered as an option. Nothing in otel_spans records when a
 -- row was WRITTEN. Timestamp is the span's own time and the demo backfill posts spans backdated 30
 -- days, so a date comparison would mark freshly-written rows as historical and miss backdated ones.
@@ -72,10 +84,12 @@ SELECT
     'before' AS phase,
     countIf(EstimatedCost = 0) AS priced_zero_spans,
     countIf(EstimatedCost IS NULL) AS unknown_spans,
-    countIf(EstimatedCost = 0 AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
+    countIf(EstimatedCost = 0 AND PriceCatalogVersion = '' AND CostSource != 'reconciled'
+            AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
         AS repriceable_spans,
     sumIf(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']),
-          EstimatedCost = 0 AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
+          EstimatedCost = 0 AND PriceCatalogVersion = '' AND CostSource != 'reconciled'
+          AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
         AS recoverable_micro_usd,
     sum(EstimatedCost) AS known_spend_usd
 FROM otel_spans FINAL
@@ -88,15 +102,41 @@ FORMAT Vertical;
 --    toInt64OrNull(...) IS NOT NULL so a malformed attribute is left for step 2 rather than being
 --    coerced to a zero by toInt64OrZero, which would manufacture the exact defect being repaired.
 --
+--    ALSO SCOPED TO PriceCatalogVersion = '', and that is the one guard the header's prose used to
+--    claim without the SQL containing it. gen_ai.tool.cost_micro_usd is NOT promoted out of
+--    SpanAttributes (it is absent from mapping.py's _PROMOTED_GENAI), so it SURVIVES on the row
+--    alongside a cost the price catalog computed. A tool or vector span whose catalog entry
+--    legitimately prices it at zero therefore lands as EstimatedCost = 0 with a REAL version and the
+--    client's hint still attached. Without this predicate step 1 would overwrite a catalog-
+--    authoritative zero with a client hint while deliberately leaving PriceCatalogVersion alone,
+--    so the substituted number would inherit provenance it did not earn. An empty version is the
+--    signal that no catalog ever priced the row, which is the only case where the hint is the best
+--    evidence available.
+--
+--    And scoped away from CostSource = 'reconciled'. That is a live enum value (otel_spans.sql) and
+--    the web read path splits spend on it, so a reconciled row that happens to hold 0 must not be
+--    silently downgraded to an estimate. No such row exists today; the guard costs nothing.
+--
 --    PriceCatalogVersion is deliberately NOT set. This cost came from the client, not from a price
 --    catalog, and the empty version is the honest record of that. It is the same version the
 --    gateway leaves on the spans it promotes today, so repaired rows and new rows agree.
 -- ============================================================================================
 ALTER TABLE otel_spans
 UPDATE
-    EstimatedCost = toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8) / 1000000,
+    -- Divided BEFORE widening. `toDecimal64(micro, 8)` widens the micro-USD INTEGER to a scale-8
+    -- Decimal64 first, which leaves ten integer digits and therefore overflows above about
+    -- 92,233,720,368 micro-USD, roughly $92,233 on a single span. One client sending nanos instead
+    -- of micros would abort the whole mutation. divideDecimal converts at scale 0 and produces the
+    -- scale-8 result directly, so the only ceiling left is what the Decimal64(8) column can actually
+    -- store, a million times higher. The OrNull keeps an unparseable attribute out of the arithmetic
+    -- entirely; the WHERE below has already excluded those rows.
+    EstimatedCost = divideDecimal(
+        toDecimal64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd'], 0),
+        toDecimal64(1000000, 0), 8),
     CostSource = 'estimated'
 WHERE EstimatedCost = 0
+  AND PriceCatalogVersion = ''
+  AND CostSource != 'reconciled'
   AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL
 SETTINGS mutations_sync = 2;
 
@@ -105,9 +145,20 @@ SETTINGS mutations_sync = 2;
 --    repriceable span is no longer 0 by the time this predicate is evaluated, so it cannot be
 --    caught here and have its recovered money thrown away again.
 --
---    The two limbs are the (a) and (b) shapes described at the top. The attribute exclusion is a
---    belt-and-braces guard for a client that genuinely reported a cost of zero: that is a
---    measurement and it stays 0, even though limb (b) would otherwise match it.
+--    The two limbs are the (a) and (b) shapes described at the top.
+--
+--    The attribute exclusion is `toInt64OrNull(...) IS NULL`, not `... = ''`. The equality was
+--    described as protecting a client-reported cost of zero, but it cannot have been doing that:
+--    '0' parses, so step 1 has already claimed such a row and it is no longer 0 here. What the
+--    equality actually excluded was rows whose attribute is UNPARSEABLE, which is the opposite of
+--    what checks/priced_zero.sql promises ("an unparseable attribute falls through to a class below
+--    and is treated as unknown"). A span with attr = 'n/a', a real model, real tokens and an empty
+--    catalog version was therefore classed unknown_catalog_miss, skipped here, and left as a
+--    fabricated $0, so a post-repair re-run still reported unknown_* rows. `IS NULL` keeps the row
+--    that carries a usable number out of this step, which is the only thing that needs keeping out,
+--    and lets the unparseable ones through to be marked unknown, which is what they are.
+--
+--    Reconciled rows are excluded here too, for the same reason as in step 1.
 -- ============================================================================================
 ALTER TABLE otel_spans
 UPDATE
@@ -115,7 +166,8 @@ UPDATE
     CostSource = 'unpriced',
     PriceCatalogVersion = ''
 WHERE EstimatedCost = 0
-  AND SpanAttributes['gen_ai.tool.cost_micro_usd'] = ''
+  AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NULL
+  AND CostSource != 'reconciled'
   AND (
         (GenAiRequestModel = '' AND GenAiResponseModel = ''
          AND ifNull(InputTokens, 0) = 0 AND ifNull(OutputTokens, 0) = 0)
@@ -129,14 +181,16 @@ SETTINGS mutations_sync = 2;
 --    from the sum and a zero changes no total. That is the arithmetic proof that the mark step
 --    subtracted no money: it only stopped claiming that money was known.
 --
---    priced_zero_spans should now be only the genuine measured zeros (usually none), and
---    unknown_spans should have grown by exactly the number of rows step 2 marked.
+--    priced_zero_spans should now be only the zeros a real price catalog produced, which
+--    checks/priced_zero.sql splits into measured_zero and the two ambiguous residue classes beside
+--    it, and unknown_spans should have grown by exactly the number of rows step 2 marked.
 -- ============================================================================================
 SELECT
     'after' AS phase,
     countIf(EstimatedCost = 0) AS priced_zero_spans,
     countIf(EstimatedCost IS NULL) AS unknown_spans,
-    countIf(EstimatedCost = 0 AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
+    countIf(EstimatedCost = 0 AND PriceCatalogVersion = '' AND CostSource != 'reconciled'
+            AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
         AS repriceable_spans,
     sum(EstimatedCost) AS known_spend_usd
 FROM otel_spans FINAL
@@ -163,6 +217,10 @@ FORMAT PrettyCompact;
 --
 --   make ch-rollup-rebuild   # from infra/, CTO-311, quiesce ingest for the duration
 --
---    Then `make ch-priced-zero-check` again. The unknown_* classes should be gone, and whatever
---    remains under `measured_zero` is a real zero that was correctly left alone.
+--    Then `make ch-priced-zero-check` again. The unknown_* classes should be gone. What remains is
+--    the catalog-priced residue: `measured_zero` proper, plus `measured_zero_no_model` and
+--    `measured_zero_flat_usage`, which this repair deliberately does not touch because a real
+--    PriceCatalogVersion says a catalog produced that number and turning it into NULL would destroy
+--    information. Those two are reported separately so the residue stays auditable rather than
+--    disappearing into a class whose name claims more certainty than it has.
 -- ============================================================================================

--- a/db/clickhouse/migrations/priced_zero_repair.sql
+++ b/db/clickhouse/migrations/priced_zero_repair.sql
@@ -1,0 +1,168 @@
+-- CTO-313: repair historical spans stored as a priced $0 that was never a measurement.
+-- EXPLICIT, one-shot, operator-run. Not part of `make ch-migrate`. Run `make ch-repair-priced-zero`.
+--
+-- RUN `make ch-priced-zero-check` FIRST and read db/clickhouse/checks/priced_zero.sql. That file
+-- carries the full definition of the four classes below and why each is decided the way it is; this
+-- one only acts on them. This script mutates the raw span table.
+--
+-- ############################################################################################
+-- # THE DECISION, PER POPULATION                                                              #
+-- ############################################################################################
+--
+-- CTO-244 stopped NEW spans asserting a fabricated $0 but did not rewrite the rows already written
+-- that way, so a dashboard over history still shows measured-looking zeros. The issue asked whether
+-- to backfill, mark, or document the cutover. The answer differs per population, and only one of
+-- the three options is available for any given row:
+--
+--   1. REPRICE where the true cost survives. Tool spans written before the gateway promoted
+--      `gen_ai.tool.cost_micro_usd` into EstimatedCost still carry that attribute. The money is in
+--      the row. Step 1 promotes it with the same arithmetic the gateway uses, and the check file
+--      verifies that arithmetic against the 183k+ spans the gateway itself already promoted, where
+--      attribute and column must agree exactly. This is a repricing, not an estimate.
+--
+--   2. MARK UNKNOWN where it does not. Two shapes, both structural:
+--        a. the span records nothing that could ever have been priced (no model either side, no
+--           tokens, no client-reported cost), so the stored 0 is a column default, not a result;
+--        b. PriceCatalogVersion is '', the empty-version signal tally.pricing returns on a catalog
+--           miss, so the catalog never produced a price and ingest wrote 0 anyway. These rows often
+--           carry a real model and real token counts, which makes their $0.00 the most misleading
+--           figure in the table.
+--      They become EstimatedCost = NULL, CostSource = 'unpriced', which is exactly what a
+--      post-CTO-244 gateway writes for the same situation, so the dashboard renders them as a blank
+--      with a reason instead of a confident zero. No value is invented for them, now or ever: what
+--      the call really cost is not recorded anywhere and cannot be recovered.
+--
+--   3. DOCUMENT, for the zeros that are real. A span with a genuine PriceCatalogVersion AND a model
+--      to have priced was priced, and the answer was zero. CTO-244 was explicit that a real 0 stays
+--      0 and stays distinguishable from NULL. Turning those into unknowns would destroy information,
+--      which is the same sin in the other direction, so this script does not touch them.
+--
+-- WHY NOT A CUTOVER DATE, which the issue offered as an option. Nothing in otel_spans records when a
+-- row was WRITTEN. Timestamp is the span's own time and the demo backfill posts spans backdated 30
+-- days, so a date comparison would mark freshly-written rows as historical and miss backdated ones.
+-- Every predicate below is therefore structural: it reads what the row itself carries. That is
+-- exact, needs no operator-supplied date, and is correct on a stack whose history was backfilled.
+--
+-- ############################################################################################
+-- # BEFORE YOU RUN IT                                                                         #
+-- ############################################################################################
+--
+--   * ALTER ... UPDATE is a ClickHouse mutation: it rewrites the affected parts in the background.
+--     `mutations_sync = 2` below makes each statement wait for completion so the verification at
+--     the end is meaningful. Watch system.mutations if one appears to hang.
+--   * THE ROLLUPS DO NOT FOLLOW. Materialized views fire on INSERT, never on a mutation, so every
+--     dollar this script changes leaves daily_feature_rollup, hourly_feature_rollup and
+--     daily_account_rollup holding the OLD money. The dashboard reads rollups. Run
+--     `make ch-rollup-rebuild` (CTO-311) AFTERWARDS, in that order, or the repair is invisible where
+--     it matters and the raw table and the rollups disagree. RUNNING.md sequences this.
+--   * There is no shadow-table rollback here, because a mutation is not a swap. Snapshot first if
+--     this is not a local stack. What the script does give you is a before-and-after ledger of every
+--     row it touched, so the change to any historical total is explicable rather than mysterious.
+--   * Quiescing ingest is not required. Every predicate is structural, and a span the gateway writes
+--     while this runs is already honest.
+--
+-- Money is integer micro-USD throughout. The conversion to the Decimal64(8) USD column happens once,
+-- at the single boundary where the attribute becomes the column, and nowhere else.
+
+-- ============================================================================================
+-- 0. BEFORE. Recorded first so the ledger in step 3 has something to be compared against, and so a
+--    run that is interrupted still leaves the operator with the starting numbers.
+-- ============================================================================================
+SELECT
+    'before' AS phase,
+    countIf(EstimatedCost = 0) AS priced_zero_spans,
+    countIf(EstimatedCost IS NULL) AS unknown_spans,
+    countIf(EstimatedCost = 0 AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
+        AS repriceable_spans,
+    sumIf(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']),
+          EstimatedCost = 0 AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
+        AS recoverable_micro_usd,
+    sum(EstimatedCost) AS known_spend_usd
+FROM otel_spans FINAL
+FORMAT Vertical;
+
+-- ============================================================================================
+-- 1. REPRICE the spans whose true cost survives on the row.
+--
+--    Scoped to EstimatedCost = 0 so a span the gateway already promoted is never rewritten, and to
+--    toInt64OrNull(...) IS NOT NULL so a malformed attribute is left for step 2 rather than being
+--    coerced to a zero by toInt64OrZero, which would manufacture the exact defect being repaired.
+--
+--    PriceCatalogVersion is deliberately NOT set. This cost came from the client, not from a price
+--    catalog, and the empty version is the honest record of that. It is the same version the
+--    gateway leaves on the spans it promotes today, so repaired rows and new rows agree.
+-- ============================================================================================
+ALTER TABLE otel_spans
+UPDATE
+    EstimatedCost = toDecimal64(toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']), 8) / 1000000,
+    CostSource = 'estimated'
+WHERE EstimatedCost = 0
+  AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL
+SETTINGS mutations_sync = 2;
+
+-- ============================================================================================
+-- 2. MARK THE REST UNKNOWN. Runs strictly after step 1, and the ordering is load-bearing: a
+--    repriceable span is no longer 0 by the time this predicate is evaluated, so it cannot be
+--    caught here and have its recovered money thrown away again.
+--
+--    The two limbs are the (a) and (b) shapes described at the top. The attribute exclusion is a
+--    belt-and-braces guard for a client that genuinely reported a cost of zero: that is a
+--    measurement and it stays 0, even though limb (b) would otherwise match it.
+-- ============================================================================================
+ALTER TABLE otel_spans
+UPDATE
+    EstimatedCost = NULL,
+    CostSource = 'unpriced',
+    PriceCatalogVersion = ''
+WHERE EstimatedCost = 0
+  AND SpanAttributes['gen_ai.tool.cost_micro_usd'] = ''
+  AND (
+        (GenAiRequestModel = '' AND GenAiResponseModel = ''
+         AND ifNull(InputTokens, 0) = 0 AND ifNull(OutputTokens, 0) = 0)
+        OR PriceCatalogVersion = ''
+      )
+SETTINGS mutations_sync = 2;
+
+-- ============================================================================================
+-- 3. AFTER, and the ledger. `known_spend_usd` moving UP is the recovered tool spend; it must move
+--    up by exactly recoverable_micro_usd from step 0, because marking a row unknown removes a zero
+--    from the sum and a zero changes no total. That is the arithmetic proof that the mark step
+--    subtracted no money: it only stopped claiming that money was known.
+--
+--    priced_zero_spans should now be only the genuine measured zeros (usually none), and
+--    unknown_spans should have grown by exactly the number of rows step 2 marked.
+-- ============================================================================================
+SELECT
+    'after' AS phase,
+    countIf(EstimatedCost = 0) AS priced_zero_spans,
+    countIf(EstimatedCost IS NULL) AS unknown_spans,
+    countIf(EstimatedCost = 0 AND toInt64OrNull(SpanAttributes['gen_ai.tool.cost_micro_usd']) IS NOT NULL)
+        AS repriceable_spans,
+    sum(EstimatedCost) AS known_spend_usd
+FROM otel_spans FINAL
+FORMAT Vertical;
+
+SELECT
+    TenantId,
+    GenAiOperation,
+    CostSource,
+    count() AS spans,
+    sum(EstimatedCost) AS known_spend_usd,
+    countIf(EstimatedCost IS NULL) AS unknown_spans,
+    min(toDate(Timestamp)) AS first_day,
+    max(toDate(Timestamp)) AS last_day
+FROM otel_spans FINAL
+GROUP BY TenantId, GenAiOperation, CostSource
+ORDER BY TenantId, spans DESC
+FORMAT PrettyCompact;
+
+-- ============================================================================================
+-- 4. NOW REBUILD THE ROLLUPS. Not optional, and not something this script can do for you: the
+--    materialized views did not see any of the mutations above, so every rollup still holds the
+--    pre-repair money and the dashboard, which reads rollups, still shows it.
+--
+--   make ch-rollup-rebuild   # from infra/, CTO-311, quiesce ingest for the duration
+--
+--    Then `make ch-priced-zero-check` again. The unknown_* classes should be gone, and whatever
+--    remains under `measured_zero` is a real zero that was correctly left alone.
+-- ============================================================================================

--- a/db/clickhouse/otel_spans.sql
+++ b/db/clickhouse/otel_spans.sql
@@ -236,6 +236,16 @@ ALTER TABLE otel_spans
 -- exists to remove. Consequence, stated plainly: token and cost figures covering any period before
 -- the cutover may UNDERSTATE real spend, and no query can quantify by how much. Post-cutover rows
 -- are honest. See RUNNING.md ("Nullable usage and cost").
+--
+-- CTO-313 narrows that, without weakening the rule above. It repairs only the pre-cutover zeros
+-- that can be decided on STRUCTURAL evidence carried by the row itself, never on a guess or a
+-- cutover date: it reprices spans whose original client-reported cost still sits in SpanAttributes,
+-- and marks spans that nothing could ever have priced (no model, no tokens, no cost attribute, or a
+-- catalog that missed) as NULL / 'unpriced'. A zero on a row with a real model, real tokens and a
+-- real PriceCatalogVersion is a genuine priced zero and is deliberately left alone. See
+-- db/clickhouse/checks/priced_zero.sql and db/clickhouse/migrations/priced_zero_repair.sql. That
+-- repair mutates rows, and mutations do not fire materialized views, so it must be followed by the
+-- CTO-311 rollup rebuild or the rollups keep the pre-repair money.
 ALTER TABLE otel_spans
     MODIFY COLUMN InputTokens       Nullable(UInt32)       CODEC(T64, ZSTD(1)),
     MODIFY COLUMN OutputTokens      Nullable(UInt32)       CODEC(T64, ZSTD(1)),

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,7 +2,7 @@
 COMPOSE := docker compose
 GATEWAY := ai-tally-gateway
 
-.PHONY: help up down nuke logs ps seed demo ch-migrate ch-migrate-otel-engine ch-rollup-check ch-rollup-rebuild aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
+.PHONY: help up down nuke logs ps seed demo ch-migrate ch-migrate-otel-engine ch-rollup-check ch-rollup-rebuild ch-priced-zero-check ch-repair-priced-zero aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
@@ -104,6 +104,33 @@ ch-rollup-rebuild: ## One-shot: rebuild the rollup targets from the deduplicated
 	  --multiquery < ../db/clickhouse/checks/rollup_drift.sql
 	@echo ""
 	@echo "The pre-rebuild tables are kept as <rollup>_cto311. Drop them once you are satisfied."
+
+ch-priced-zero-check: ## Report historical spans stored as a priced $$0 that was never measured (CTO-313)
+	@# READ-ONLY. Splits every EstimatedCost = 0 span into: recoverable (the original client-reported
+	@# cost still sits in SpanAttributes and can be promoted), unknown (nothing was ever priced, or
+	@# the price catalog missed) and measured_zero (a real, catalog-priced zero, which stays 0).
+	@# Safe to run any time against a live stack.
+	@$(COMPOSE) exec -T clickhouse clickhouse-client -u tally --password tally -d default \
+	  --multiquery < ../db/clickhouse/checks/priced_zero.sql
+	@echo ""
+	@echo "recoverable            = repriceable from the row itself by 'make ch-repair-priced-zero'."
+	@echo "unknown_no_price_input = nothing priceable was ever recorded; that repair marks them NULL / 'unpriced'."
+	@echo "unknown_catalog_miss   = the price catalog never priced them; same marking."
+	@echo "measured_zero          = a real zero from a real catalog version; deliberately left as 0."
+
+ch-repair-priced-zero: ## One-shot: reprice what is derivable, mark the rest unknown, never invent (CTO-313)
+	@# Deliberately NOT part of ch-migrate: it mutates the raw span table. Run ch-priced-zero-check
+	@# first and read the header of the script. Mutations do not fire materialized views, so the
+	@# rollups still hold the pre-repair money afterwards and ch-rollup-rebuild is a required
+	@# follow-up, not a suggestion.
+	@$(COMPOSE) exec -T clickhouse clickhouse-client -u tally --password tally -d default \
+	  --multiquery < ../db/clickhouse/migrations/priced_zero_repair.sql
+	@echo ""
+	@echo "RAW SPANS ARE REPAIRED, THE ROLLUPS ARE NOT. Materialized views do not fire on a mutation,"
+	@echo "so daily/hourly/account rollups still hold the pre-repair money and the dashboard reads"
+	@echo "those. Finish the job:"
+	@echo ""
+	@echo "  make ch-rollup-rebuild"
 
 logs: ## Tail the gateway logs
 	$(COMPOSE) logs -f gateway

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -123,7 +123,9 @@ ch-priced-zero-check: ## Report historical spans stored as a priced $$0 that was
 	@echo "recoverable            = repriceable from the row itself by 'make ch-repair-priced-zero'."
 	@echo "unknown_no_price_input = nothing priceable was ever recorded; that repair marks them NULL / 'unpriced'."
 	@echo "unknown_catalog_miss   = the price catalog never priced them; same marking."
-	@echo "measured_zero          = a real zero from a real catalog version; deliberately left as 0."
+	@echo "measured_zero*         = a real catalog version produced that zero; deliberately left as 0."
+	@echo "                         measured_zero_no_model and measured_zero_flat_usage are the"
+	@echo "                         ambiguous residue, named rather than folded into measured_zero."
 
 ch-repair-priced-zero: ## One-shot: reprice what is derivable, mark the rest unknown, never invent (CTO-313)
 	@# Deliberately NOT part of ch-migrate: it mutates the raw span table. Run ch-priced-zero-check


### PR DESCRIPTION
Closes #313

**Stacked on #325 (`fix/rollup-rebuild`). Review that one first; this PR targets it, not `main`.**

## The problem

CTO-244 made `EstimatedCost` nullable so a span we cannot price stores `NULL` with `CostSource = 'unpriced'` and renders as a blank with a reason. That stopped **new** spans asserting a fabricated `$0`. It did not rewrite the rows already written that way, and those rows are what a dashboard over historical data reads: a confident, measured-looking `$0.00` on calls that either cost real money or cost an amount nobody ever established.

## Why not a cutover date

The issue offered backfill, mark, or document the cutover. A cutover date does not work here, and the reason is the interesting part: **nothing in `otel_spans` records when a row was written**. `Timestamp` is the span's own time, and the demo backfill posts spans backdated 30 days, so a date comparison would mark freshly-written rows as historical and miss backdated ones.

So every predicate here is structural: it reads what the row itself carries. That is exact, needs no operator-supplied date, and is correct on a stack whose history was backfilled.

## The decision, per population

`make ch-priced-zero-check` (read-only) partitions every `EstimatedCost = 0` span into four mutually exclusive classes:

| Class | Evidence on the row | Decision |
|---|---|---|
| `recoverable` | the original client-reported cost still sits in `SpanAttributes['gen_ai.tool.cost_micro_usd']`, from before the gateway promoted it into the column | **reprice** from the attribute |
| `unknown_no_price_input` | no model either side, no tokens, no cost attribute. Nothing could ever have been priced, so the 0 is a column default, not a result, even where a `PriceCatalogVersion` is stamped | **mark** `NULL` / `unpriced` |
| `unknown_catalog_miss` | `PriceCatalogVersion` is `''`, the empty-version signal `tally.pricing` returns on a catalog miss. Usually carries a real model and real tokens, so the money is real and unknown | **mark** `NULL` / `unpriced` |
| `measured_zero` | a real catalog version and a model to have priced. This was priced and the answer was zero | **left as `0`** |

That last row is not an oversight. CTO-244 was explicit that a real `0` stays `0` and stays distinguishable from `NULL`; turning genuine zeros into unknowns destroys information, which is the same sin in the other direction.

**The reprice is provably the gateway's own arithmetic, not an estimate.** Every span the gateway already promoted still carries the source attribute alongside the promoted column, so the check replays the conversion against them and requires `conversion_mismatches = 0`. On this stack that is 183,169 spans agreeing exactly before the repair, and all 211,755 agreeing exactly after it.

`toInt64OrNull` rather than `toInt64OrZero` throughout: coercing a malformed attribute to zero would manufacture the exact defect being repaired, so an unparseable attribute falls through and is treated as unknown.

## Ordering, and the interaction with #325

`ALTER ... UPDATE` is a ClickHouse mutation, and **materialized views fire on INSERT, never on a mutation**. Every dollar this repair changes leaves the three rollups holding the old money, and the dashboard reads rollups. `RUNNING.md` gains an "Order of operations" section:

1. `make ch-migrate-otel-engine` if `otel_spans` is not yet `ReplacingMergeTree` (both checks define truth as a `FINAL` read).
2. `make ch-priced-zero-check`, then `make ch-repair-priced-zero`. No need to quiesce ingest: the predicates are structural and a span written mid-run is already honest.
3. `make ch-rollup-rebuild` (#325), with ingest quiesced. This is where the repriced money reaches the dashboard.
4. Both checks again to confirm.

Doing 3 before 2 leaves the rollups derived from pre-repair costs, which looks like a successful rebuild and is wrong by exactly the recovered spend.

## The change is explicable, not silent

The repair prints a before-and-after ledger, and the ledger carries its own proof: known spend must move **up by exactly the recoverable micro-USD and by nothing else**, because marking a row unknown removes a zero from a sum and a zero changes no total. Any other movement means the mark step touched money it should not have.

## Verified on the live local stack

1,542,996 spans across three tenants. Every priced-`$0` population, before and after:

| Population | Spans | Before | After |
|---|---|---|---|
| `local-dev` tool spans carrying `gen_ai.tool.cost_micro_usd` | 28,586 | `$0.00`, `estimated` | **`$93.106`** (93,106,000 micro-USD), `estimated` |
| `live-cto219` load-test spans: no model, no tokens, no cost attribute | 600,000 | `$0.00`, `estimated`, `PriceCatalogVersion = 'v1'` | `NULL`, `unpriced` |
| `local-dev` embedding spans: real model, real tokens, empty catalog version | 3,989 | `$0.00`, `estimated` | `NULL`, `unpriced` |

Stack-wide:

| Measure | Before | After |
|---|---|---|
| Spans asserting a priced `$0` | 632,575 | **0** |
| Spans honestly marked unknown | 0 | **603,989** |
| Known spend | `$139,571.3122253` | `$139,664.4182253` |
| Movement | | exactly `$93.106`, the recovered tool spend and nothing else |
| Reprice replay mismatches | 0 of 183,169 | 0 of 211,755 (`$535.96335` = `$442.85735` + `$93.106`) |

After `make ch-rollup-rebuild`, all three rollups reconciled exactly against a `FINAL` sum over raw spans at `$139,664.4182253` with `drift_micro_usd = 0`, and `live-cto219`'s rollup went from claiming `$0.00` of spend over 600,000 calls with `UnpricedSpanCount = 0` to `UnpricedSpanCount = 600,000`, which is the signal the dashboard needs to blank the figure rather than render a zero.

## Two findings worth flagging

The issue quoted "28,586 tool/vector spans holding $93.11". On this stack it is exactly 28,586 spans holding `$93.106`, and **every one is a `tool` span**: `local-dev`'s 40,000 `vector` spans were already correctly priced at `$8,262.74` and were not touched.

And `live-cto219`'s reported spend does not fall to a smaller number, it **stops being a number at all**. 600,000 synthetic load-test calls that were reading as `$0.00` of confirmed spend now read as unknown, because that is what they are. A reader comparing a dashboard before and after will see a total disappear rather than shrink, which is why it is documented in `RUNNING.md` with the exact counts.

## Checks

No source in `sdk/python/`, `infra/gateway/`, `web/` or `infra/edge-proxy/` is touched, so none of those four suites is affected. The change is ClickHouse DDL comments, two operator scripts, two Makefile targets and docs, exercised end to end against the running stack as recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
