### PR TITLE
style(web): drop em dashes from clickhouse and waste comments

### DIFF
--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -1139,3 +1139,61 @@ describe("CTO-244 - reading a mix of known and unknown", () => {
     expect(out.monthlyCostMicroUsd).toBe(Math.round((1_400_000 * 30) / 7));
   });
 });
+
+// #314 (CTO-245): every otel_spans read dedupes.
+//
+// otel_spans is a ReplacingMergeTree, so a duplicate span that got past the durable idempotency
+// store stays readable until a background merge collapses it, and a plain sum() over-counts by the
+// replayed spend in the meantime. FINAL makes the read exact at query time.
+//
+// The value of the fix is that it is applied to ALL of the reads rather than to the ones that
+// looked risky: a surface where some panels dedupe and some do not is worse than one where none do,
+// because two panels then disagree and neither is obviously wrong. That property spans ~40 query
+// sites across five files, which is more than review can hold, so it is asserted against the source
+// text. A query added later that forgets FINAL fails here.
+describe("otel_spans read paths dedupe (#314)", () => {
+  // Files that build SQL against otel_spans. Listed explicitly rather than globbed so that adding a
+  // new reader is a deliberate act which shows up in this list.
+  const SOURCES = [
+    "clickhouse.ts",
+    "waste/duplicated-work.ts",
+    "waste/no-measured-return.ts",
+    "waste/paid-for-nothing.ts",
+    "waste/wrong-sized-model.ts",
+  ];
+
+  // The single deliberate exemption, matched as a whole line so it cannot drift. queryFirstEventSeen
+  // selects the literal 1 and asks only whether a row exists; a duplicate cannot change a boolean,
+  // so FINAL would buy nothing there and it is not free on an endpoint the onboarding panel polls.
+  const EXEMPT = "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1";
+
+  // FROM/JOIN otel_spans, plus an optional alias, plus FINAL if it is there.
+  const READ =
+    /\b(?:FROM|(?:INNER |LEFT |RIGHT |CROSS )?JOIN)\s+otel_spans\b(?:\s+(?!FINAL\b)[A-Za-z_]\w*)?(?:\s+FINAL\b)?/g;
+
+  async function source(rel: string): Promise<string> {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    // Vitest's root is `web/`, so these resolve against the checkout rather than the bundle.
+    return readFile(resolve(process.cwd(), "lib", rel), "utf8");
+  }
+
+  it.each(SOURCES)("%s reads otel_spans only with FINAL", async (rel) => {
+    // Drop the one exempt query before matching, so the exemption is scoped to that exact text and
+    // not to the file it lives in.
+    const src = (await source(rel)).split(EXEMPT).join("");
+    const missing = (src.match(READ) ?? []).filter((m) => !/\bFINAL\b/.test(m));
+    expect(missing, `${rel}: otel_spans read without FINAL`).toEqual([]);
+  });
+
+  it("matches the reads it is meant to be guarding", async () => {
+    // Guards the guard: if the pattern ever stops matching, the assertion above passes vacuously.
+    const src = await source("clickhouse.ts");
+    expect((src.match(READ) ?? []).length).toBeGreaterThan(30);
+  });
+
+  it("keeps the exemption to exactly one query", async () => {
+    const src = await source("clickhouse.ts");
+    expect(src.split(EXEMPT).length - 1).toBe(1);
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -2,7 +2,7 @@
 // Live ClickHouse reads for the dashboard (server-only).
 //
 // The Route Handlers call these and fall back to mock data when ClickHouse is unreachable (no
-// stack running, CI, fresh clone) — so `npm run dev/build/test` never depend on infra. Money comes
+// stack running, CI, fresh clone), so `npm run dev/build/test` never depend on infra. Money comes
 // back from ClickHouse as Decimal strings; we convert to integer micro-USD at the boundary to match
 // the wire/UI contract.
 //
@@ -943,7 +943,7 @@ export async function queryCostSliceTotals(
 // 31st a plain 30-day window would clip the 1st). A rolling `now() - INTERVAL 30 DAY` drifts by the
 // second and clips a partial day, which is why nothing here uses one.
 //
-// Clocks: every date in the result — window start, today, the day list, the day count — comes from
+// Clocks: every date in the result (window start, today, the day list, the day count) comes from
 // ClickHouse. None of it is generated from the Node process clock. Those are two clocks in two
 // timezones, and when they straddle midnight the JS-built list is shifted a day against the SQL
 // window, so the oldest day silently has no slot to land in while still counting toward the totals.
@@ -1009,7 +1009,7 @@ export interface SettledSpendSeries {
    * number (honest-under-uncertainty, and the minimum-history guard in the scope doc).
    */
   baselineDays: string[];
-  /** Newest settled day, or null when none is — never a fabricated date. */
+  /** Newest settled day, or null when none is. Never a fabricated date. */
   settledThrough: string | null;
   /** Which connector layers this tenant actually uses, i.e. what settlement waits on. */
   connectorLayers: ConnectorLayer[];
@@ -1469,7 +1469,7 @@ export async function queryExcludedInfraCost(query?: AccountCostQuery): Promise<
  * One account: layer split, top features, and a day-by-day trend across the window.
  *
  * Pass `''` for the unattributed bucket. Returns `null` when the tenant has no rollup rows at all
- * for this account in the window, i.e. we know nothing about it — that is a genuinely unknown
+ * for this account in the window, i.e. we know nothing about it: that is a genuinely unknown
  * account, not one that cost zero, and the caller should render it as not found rather than as a
  * free customer. An account we HAVE seen but whose spend is entirely compute and egress comes back
  * as a real row with zeroes, which is a different and true statement.
@@ -1646,18 +1646,18 @@ async function accountDetail(
 //
 // Real detection over the telemetry we actually have (otel_spans), replacing the canned
 // lib/cost.ts `hiddenCostAlerts` on the live path. Two rules fire today; both run per-tenant over
-// the last 30 days and only emit above a sane threshold (no fabricated alerts — returns [] when
+// the last 30 days and only emit above a sane threshold (no fabricated alerts; returns [] when
 // nothing qualifies).
 //
 //   1. Uncosted tool/agent activity: `GenAiOperation = 'tool'` spans with no cost attached, i.e.
 //      `EstimatedCost IS NULL` (the post-CTO-244 representation of "we could not price this") or
 //      `= 0` (how the same condition was flattened before that cutover). Emitted only above
 //      UNCOSTED_TOOL_THRESHOLD.
-//   2. High LLM-calls-per-session ratio — features whose avg LLM spans per SessionId exceeds
+//   2. High LLM-calls-per-session ratio: features whose avg LLM spans per SessionId exceeds
 //      LLM_PER_SESSION_THRESHOLD, a classic retry-loop / fan-out cost smell.
 //
 // DEFERRED: the "vendor-billed vs estimated" reconciliation rule (alert when a connector's billed
-// spend diverges from our estimate) has NO source today — the billing connectors aren't built yet
+// spend diverges from our estimate) has NO source today; the billing connectors aren't built yet
 // (CTO-143/144). It is intentionally omitted rather than faked.
 //
 // Alerts are ranked by impact = (share of total spend attributable to the offending feature) ×
@@ -1679,7 +1679,7 @@ interface RankedAlert {
  * Detect hidden-cost alerts from `otel_spans` for the current tenant over the last 30 days.
  *
  * Returns the top {@link MAX_HIDDEN_COST_ALERTS} alerts ranked by impact, or `[]` when nothing
- * qualifies (honest-empty — we never fabricate). Returns `null` (via tryLive) when ClickHouse is
+ * qualifies (honest-empty; we never fabricate). Returns `null` (via tryLive) when ClickHouse is
  * unreachable so the route can fall back to the canned mock for CI / fresh-clone rendering.
  */
 export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<HiddenCostAlert[] | null> {
@@ -1687,7 +1687,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
     const tag = filter?.tag ?? "";
     const tagClause = tag ? "AND FeatureTag = {tag:String}" : "";
 
-    // Total tenant spend over the window — the denominator for the impact ranking.
+    // Total tenant spend over the window: the denominator for the impact ranking.
     const totalRows = await rowsP<{ total: string }>(
       db,
       `SELECT sum(EstimatedCost) AS total
@@ -1742,7 +1742,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
       const uncosted = parseInt(r.uncosted, 10) || 0;
       if (uncosted <= UNCOSTED_TOOL_THRESHOLD) continue;
       const share = totalSpend > 0 ? micro(r.featureCost) / totalSpend : 0;
-      // Confidence is high — a zero-cost tool span is an unambiguous instrumentation gap.
+      // Confidence is high: a zero-cost tool span is an unambiguous instrumentation gap.
       const confidence = 0.9;
       ranked.push({
         impact: share * confidence,
@@ -1779,7 +1779,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
 
 // --- Features (ROI + attribution diagnostics) ---------------------------------------------------
 
-// Below this many attributed conversions we refuse to print value/payback/attributionRate — the
+// Below this many attributed conversions we refuse to print value/payback/attributionRate; the
 // numbers would be too noisy to trust. The UI renders these honest nulls as `—`.
 const MIN_CONVERSIONS_FOR_ECONOMICS = 5;
 
@@ -1788,7 +1788,7 @@ const MIN_CONVERSIONS_FOR_ECONOMICS = 5;
 // Cost side: sum(EstimatedCost)/uniq(UserIdHash) from `otel_spans` over 30d (unchanged).
 //
 // Value side: each row in `attribution_records` ties one converting `business_events` row
-// (BusinessEventId) to the `FeatureTag` of the agent run that last touched it — the per-feature
+// (BusinessEventId) to the `FeatureTag` of the agent run that last touched it, the per-feature
 // normalization that was missing. We join attribution_records (FINAL, to collapse the
 // ReplacingMergeTree) → business_events (FINAL) ON (TenantId, BusinessEventId) to pull EventName and
 // the converting user, then per feature compute:
@@ -1948,7 +1948,7 @@ export interface ObservedBusinessEvent {
 
 /**
  * Distinct `business_events.EventName` for the current tenant over the last 30 days, most-frequent
- * first — the live source for the /features "configure value event" modal (CTO-140). Returns null
+ * first: the live source for the /features "configure value event" modal (CTO-140). Returns null
  * when ClickHouse is unreachable so the route can distinguish "infra down" from "no events yet"
  * (an empty array), which drives the honest-empty state in the modal.
  */
@@ -1977,11 +1977,11 @@ interface ReconciliationRun {
  * The single real source for the reconciler's "last run" freshness (CTO-80): the latest
  * reconciliation_runs row (CTO-139) for this tenant, read from the gateway's reconciler run log via
  * GET /v1/tenant/reconciliation/status. Every surface that carries "reconciler last trued-up N min
- * ago" — Features diagnostics, Agents, Compare, Estimate — derives it from THIS function so they all
+ * ago" (Features diagnostics, Agents, Compare, Estimate) derives it from THIS function so they all
  * reflect one truth instead of independent hardcoded constants.
  *
- * Returns null when no reconciler run exists yet (`run` is null) — or the gateway is unreachable /
- * non-2xx — so callers can apply honest-null (`—`) rather than fabricate a value.
+ * Returns null when no reconciler run exists yet (`run` is null), or the gateway is unreachable /
+ * non-2xx, so callers can apply honest-null (`—`) rather than fabricate a value.
  */
 async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null> {
   try {
@@ -2010,7 +2010,7 @@ function minutesSince(finishedAt: string): number {
 /**
  * Minutes since the reconciler last finished a pass for the current tenant, from the real
  * reconciliation_runs source (see {@link fetchLatestReconciliationRun}). Returns null when the
- * reconciler has never run or the gateway is unavailable — the caller renders `—` (honest-null),
+ * reconciler has never run or the gateway is unavailable; the caller renders `—` (honest-null),
  * NEVER a fabricated constant (CTO-169 / the CTO-80 staleness guard).
  */
 export async function queryReconcilerLastRun(): Promise<number | null> {
@@ -2024,7 +2024,7 @@ export async function queryReconcilerLastRun(): Promise<number | null> {
  * convert to the page's units (hours / minutes-ago). Reads the same real source as
  * {@link queryReconcilerLastRun} so the freshness signal agrees across surfaces.
  *
- * Honest-null: when no reconciler run exists yet — or the gateway is unreachable / non-2xx — we
+ * Honest-null: when no reconciler run exists yet, or the gateway is unreachable / non-2xx, we
  * return null so the /api/features route falls back to its mock via `?? diagnostics`.
  */
 export async function queryAttributionDiagnostics(): Promise<AttributionDiagnostics | null> {
@@ -2230,7 +2230,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
     // CTO-119: per-stratum stats from typed columns. The "ci_half" formula is the standard
     // coefficient-of-variation half-width: zCrit × stddev(cost) / mean(cost) / sqrt(n), which
     // assumes cost is approximately log-normal within the stratum. Fine for body (high-volume,
-    // similar costs); heroic for tail (rare, expensive) — flagged in CTO-119 as a follow-up
+    // similar costs); heroic for tail (rare, expensive), flagged in CTO-119 as a follow-up
     // where a bootstrap estimator may be warranted. n<30 → null (page renders "—") rather than
     // a meaninglessly wide band.
     const strata = await rows<{ stratum: string; rate: string; n: string; spans: string; mean: string; std: string }>(
@@ -2352,7 +2352,7 @@ function toRunSpan(s: SpanRowRaw): RunSpan {
   };
 }
 
-// Fetch ordered spans for the given trace ids, grouped by trace id (a plain Record — avoids Map +
+// Fetch ordered spans for the given trace ids, grouped by trace id (a plain Record; avoids Map +
 // for-of, which behaved unreliably under Next's bundling for this query path).
 async function fetchSpansFor(
   db: ClickHouseClient,
@@ -2431,7 +2431,7 @@ export async function queryAgents(
     const runClause = run ? "AND TraceId = {run:String}" : "";
     const agentClause = agent ? "AND ServiceName = {agent:String}" : "";
     // Agent identity comes from ServiceName (e.g. "aider", "vercel-chatbot-demo"),
-    // not FeatureTag (which is the workflow-3 dimension — that's the /features view).
+    // not FeatureTag (which is the workflow-3 dimension; that's the /features view).
     // ?tag= still narrows agents to runs that produced a given feature.
     const aggs = await rowsP<RunAgg>(
       db,
@@ -2611,7 +2611,7 @@ export async function queryIntegrationStatus(): Promise<IntegrationStatusRow[] |
 //   params.max_cost_micro_usd     -> maxCostMicroUsd
 //   params.max_steps              -> maxSteps
 // The control plane does not carry fire counts, so wouldHaveFiredThisWeek / runsThisWeek default to
-// 0 (those are observability tallies the SDK emits, not config) — honest rather than fabricated.
+// 0 (those are observability tallies the SDK emits, not config), which is honest rather than fabricated.
 
 interface GatewayGuardrailRule {
   rule_id: string;
@@ -2645,13 +2645,13 @@ function mapGuardrailRule(r: GatewayGuardrailRule): GuardrailRule {
     mode,
     maxCostMicroUsd: guardrailIntOrNull(params["max_cost_micro_usd"]),
     maxSteps: guardrailIntOrNull(params["max_steps"]),
-    // Control plane carries config, not telemetry — fire counts come from the SDK, default 0.
+    // Control plane carries config, not telemetry; fire counts come from the SDK, default 0.
     wouldHaveFiredThisWeek: guardrailIntOrNull(params["would_have_fired_this_week"]) ?? 0,
     runsThisWeek: guardrailIntOrNull(params["runs_this_week"]) ?? 0,
   };
 }
 
-// Per-rule trip telemetry (CTO-146). The control plane stores config, not counts — the real
+// Per-rule trip telemetry (CTO-146). The control plane stores config, not counts; the real
 // runsThisWeek / wouldHaveFiredThisWeek come from guardrail-verdict spans the SDK emits. When a
 // rule is evaluated on a trace the SDK sets one map attribute per rule:
 //   SpanAttributes['gen_ai.guardrail.{rule_id}.verdict'] ∈ {enforced, shadow_observed, passed}
@@ -2659,7 +2659,7 @@ function mapGuardrailRule(r: GatewayGuardrailRule): GuardrailRule {
 //   runsThisWeek           = every verdict present (the rule was evaluated)
 //   wouldHaveFiredThisWeek = verdict ∈ {enforced, shadow_observed} (it fired / would have)
 // The key is dynamic per rule_id, so we ARRAY JOIN the attribute map and extract the rule_id from
-// keys matching `gen_ai.guardrail.%.verdict` — no need to enumerate rule ids in SQL.
+// keys matching `gen_ai.guardrail.%.verdict`, with no need to enumerate rule ids in SQL.
 export interface GuardrailActivity {
   runsThisWeek: number;
   wouldHaveFiredThisWeek: number;
@@ -2716,7 +2716,7 @@ export async function queryGuardrailRules(): Promise<GuardrailRule[] | null> {
     const body = (await res.json()) as { rules?: GatewayGuardrailRule[] };
     const rules = Array.isArray(body.rules) ? body.rules.map(mapGuardrailRule) : [];
     // Overlay live trip counts from verdict spans. If telemetry is unavailable (null), leave the
-    // config-default 0s — never fabricate a count.
+    // config-default 0s; never fabricate a count.
     const activity = await queryGuardrailActivity();
     if (activity) {
       for (const rule of rules) {
@@ -2847,10 +2847,10 @@ export async function queryConnectorActivity(): Promise<ConnectorActivity | null
 /**
  * $/conversion per provider, joined from otel_spans (cost) ⋈ business_events
  * (outcomes) on UserIdHash. The chatbot demo's lib/tally.ts derives one stable
- * UserIdHash per session — when a session converts, its events share that
+ * UserIdHash per session; when a session converts, its events share that
  * hash, so the join is direct.
  *
- * Filters are URL-driven (?tag=, ?provider=, ?outcome=) — see lib/attribution.ts.
+ * Filters are URL-driven (?tag=, ?provider=, ?outcome=); see lib/attribution.ts.
  * Returns null on any ClickHouse error so the API can fall back to the mock
  * report (CI / fresh-clone friendliness).
  */
@@ -2898,7 +2898,7 @@ export async function queryAttribution(
   return tryLive(async (db, tenant) => {
     // CTO-194: which sources/value types count as revenue for this tenant. Resolved from the
     // control plane, and falls back to the defaults (all sources, monetary + mrr, refunds net off)
-    // when the tenant has no row or the gateway is unreachable — it never throws, so a gateway
+    // when the tenant has no row or the gateway is unreachable. It never throws, so a gateway
     // outage degrades to the default policy rather than blanking the whole attribution report.
     const policy = await queryRevenuePolicy();
     const outcomeName = filters.outcome ?? "conversion";
@@ -2978,8 +2978,8 @@ export async function queryAttribution(
     // This used to require `b.Source = 'stripe'` and key off EventName. Both were wrong: `Source`
     // is an unconstrained LowCardinality(String) chosen by whichever connector ingested the row, so
     // any tenant on a non-Stripe biller had 100% of its revenue silently dropped, and EventName is
-    // equally freeform. `ValueType` is the real discriminator — a ClickHouse enum of
-    // ('monetary'=1,'count'=2,'mrr'=3,'refund'=4) — so we sum the money-typed events and subtract
+    // equally freeform. `ValueType` is the real discriminator, a ClickHouse enum of
+    // ('monetary'=1,'count'=2,'mrr'=3,'refund'=4), so we sum the money-typed events and subtract
     // refunds, which net off rather than being ignored. Source is now only ever a per-tenant
     // NARROWING, and absent config means every source counts (see lib/revenueSources.ts).
     //
@@ -3134,7 +3134,7 @@ export async function queryAccountRevenue(days?: number): Promise<AccountRevenue
   });
 }
 
-// --- Compare (Workflow 2) — current model from real traffic --------------------------------------
+// --- Compare (Workflow 2): current model from real traffic --------------------------------------
 //
 // Replaces the "current" half of the hardcoded mock in lib/compare.ts with a live read. Candidates,
 // quality scores, and latencies still mock today (those need workflow-5 replay infra). At least the
@@ -3162,7 +3162,7 @@ export async function queryCurrentModel(): Promise<{
   // (candidate per-call cost × this figure). Without it the route could only weigh a ~150-trace
   // replay corpus against a full month of incumbent spend, which reported a bogus ~100% reduction.
   monthlyCalls: number;
-  // null when sampleCount < MIN_SPANS_FOR_LATENCY_ERROR — the route surfaces these as "—" on the
+  // null when sampleCount < MIN_SPANS_FOR_LATENCY_ERROR; the route surfaces these as "—" on the
   // page rather than fabricating numbers off a too-small window.
   latencyP95Ms: number | null;
   errorRate: number | null;
@@ -3181,7 +3181,7 @@ export async function queryCurrentModel(): Promise<{
       sampleCount: string | number;
     }>(
       db,
-      // StatusCode is OTel semconv (UInt8): 0=Unset, 1=Ok, 2=Error — so an error span is
+      // StatusCode is OTel semconv (UInt8): 0=Unset, 1=Ok, 2=Error, so an error span is
       // `StatusCode = 2`. (The ticket suggested HTTP-style `>= 400`; the codebase already
       // uses `=== 2` for OTel error semantics, e.g. agents.ts toRunSpan().)
       // DurationNs is wrapped in `if(... > 0, ..., NULL)` because some insertion paths land
@@ -3191,8 +3191,8 @@ export async function queryCurrentModel(): Promise<{
       // (response model first, request model otherwise). Resolving the model any other way (e.g. the
       // old SpanAttributes['chatbot.real_model'] coalesce, whose historical-fallback rows have long
       // rolled out of the 30-day window per CTO-106) produced an id that never matched a breakdown row
-      // on the chatbot demo, so the wrong-sized-model detector always returned []. Resolve — and GROUP
-      // BY — on the SAME expression the cost breakdown uses so the join key matches by construction.
+      // on the chatbot demo, so the wrong-sized-model detector always returned []. Resolve (and GROUP
+      // BY) on the SAME expression the cost breakdown uses so the join key matches by construction.
       `SELECT
          ${EXPLORE_GROUP_EXPR.model} AS model,
          coalesce(
@@ -3272,7 +3272,7 @@ export async function queryCurrentModel(): Promise<{
 //
 // The gateway runs cross-provider replay against captured samples and returns per-candidate
 // cost / latency / error rate from real call outcomes. Cached for 5 minutes per (tenant, tag)
-// because each projection burns real provider spend — we don't want the dashboard re-replaying
+// because each projection burns real provider spend; we don't want the dashboard re-replaying
 // on every page refresh.
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
@@ -3303,20 +3303,20 @@ const REPLAY_CACHE_TTL_MS = isDemoMode() ? 4 * 60 * 60 * 1000 : 5 * 60 * 1000;
 const _replayCache = new Map<string, { at: number; data: ReplayProjection | null }>();
 
 // Default candidate list when the caller doesn't override. Models come from the SDK's expanded
-// catalog (CTO-106) — picked to mirror the existing mock so the dashboard's switcher looks the
+// catalog (CTO-106), picked to mirror the existing mock so the dashboard's switcher looks the
 // same when replay is active.
 //
 // CTO-166: Google/Gemini is a first-class priced provider (CTO-149), so the gemini candidate now
-// goes through the SAME /v1/replay + /v1/eval path as anthropic/openai — no provider allowlist.
+// goes through the SAME /v1/replay + /v1/eval path as anthropic/openai, with no provider allowlist.
 // It was previously absent here, which meant the gemini-3-flash row never got real replay/eval
 // data and stayed stuck on the compare.ts mock fallback. Adding it is the whole fix: the route
 // and the gateway clients are already provider-generic.
 //
-// CTO-171: dropped the retired `openai/gpt-4o-mini` — it is no longer a model we want the Compare
+// CTO-171: dropped the retired `openai/gpt-4o-mini`; it is no longer a model we want the Compare
 // switcher to surface. Every id below MUST be a current, catalog-priced model (see the SDK's
 // `seed_catalog()` in sdk/python/src/tally/pricing.py). This list is hardcoded rather than derived
 // from live provider discovery: the gateway discovers its lineup at boot (`app.state.models` via
-// `discover_models()`), but it does NOT yet expose that over HTTP — there is no `/v1/models` route.
+// `discover_models()`), but it does NOT yet expose that over HTTP; there is no `/v1/models` route.
 // Building one is the follow-up; until then, the guard test in clickhouse.test.ts asserts every id
 // here is present in a current known-good catalog set, so a retired id can't silently return.
 export const DEFAULT_CANDIDATES = [
@@ -3352,7 +3352,7 @@ export async function queryReplayCandidates(
         sample_size: 50,
       }),
       cache: "no-store",
-      // Replay is synchronous — 30s is plenty for 50 samples × 3 candidates on the mock client.
+      // Replay is synchronous; 30s is plenty for 50 samples × 3 candidates on the mock client.
       signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) {
@@ -3375,7 +3375,7 @@ export async function queryReplayCandidates(
 //
 // /estimate's POST surface lets an operator swap a candidate model AND tighten the system prompt,
 // then re-project cost off the captured corpus. Unlike queryReplayCandidates (which is cached and
-// multi-candidate), this is a single-candidate, override-bearing, uncached call — each what-if is
+// multi-candidate), this is a single-candidate, override-bearing, uncached call: each what-if is
 // a distinct intent and burns a fresh (cheap, mock-by-default) replay.
 
 export interface ReplayEstimateRequest {
@@ -3425,7 +3425,7 @@ export async function queryReplayEstimate(
 //
 // The gateway's /v1/eval runs a frontier judge over the replay outputs and returns per-candidate
 // win-rate with a Wilson 95% CI. We cache aggressively (10 minutes) because each pass burns real
-// judge spend — the dashboard must not re-judge on every refresh.
+// judge spend; the dashboard must not re-judge on every refresh.
 
 export interface EvalCandidateRow {
   provider: string;
@@ -3484,7 +3484,7 @@ export async function queryEvalCandidates(
         sample_size: 50,
       }),
       cache: "no-store",
-      // Eval is synchronous — judge calls are slower than replay calls. 10-minute timeout
+      // Eval is synchronous; judge calls are slower than replay calls. 10-minute timeout
       // matches the gateway-side allowance.
       signal: AbortSignal.timeout(600_000),
     });

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -10,6 +10,27 @@
 // layers; vector/compute/egress are zero until those sources are instrumented. That's honest: the
 // dashboard shows exactly the telemetry that exists.
 //
+// EVERY otel_spans READ SAYS `FINAL` (CTO-245 / #314). otel_spans is a ReplacingMergeTree keyed on
+// (TenantId, FeatureTag, ServiceName, SpanName, Timestamp, TraceId, SpanId), so a duplicate span
+// that got past the durable idempotency store collapses only when a background merge runs. Between
+// the duplicate insert and that merge a plain `sum(EstimatedCost)` reads both rows and over-states
+// spend by exactly the replayed amount. FINAL makes the read exact at query time instead of
+// eventually.
+//
+// It is applied to ALL of them in one pass, not to the ones that looked risky. A read surface where
+// some panels dedupe and some do not is worse than one where none do: two panels disagree and
+// neither is obviously wrong. The single documented exception is queryFirstEventSeen, which selects
+// a literal rather than a value (see the comment there); `clickhouse.test.ts` fails the build if any
+// other otel_spans read drops FINAL.
+//
+// The cost is real but small, and it is bounded by how un-merged the table is rather than by how
+// much data the query reads. Measured on the local corpus (1.54M spans, three tenants): with the
+// table fully merged (one part per partition) FINAL is inside the noise; forced to 372 parts over 31
+// partitions, roughly twelve times un-merged, the heaviest dashboard query goes from 148ms to 200ms
+// of ClickHouse time and the rest move by 25-50ms each. End to end that leaves /waste at ~620ms and
+// Home at ~470ms against a production build, both inside the one-second bar CTO-227 bought back and
+// both inside run-to-run noise. Numbers and method are in the PR for #314.
+//
 // Server-only: imported solely by Route Handlers pinned to the nodejs runtime (never a client
 // component), so it never reaches the browser bundle.
 
@@ -141,6 +162,12 @@ export async function queryFirstEventSeen(): Promise<FirstEventStatus> {
   const seen = await tryLive(async (db, tenant) => {
     const r = await rows<{ one: number }>(
       db,
+      // CTO-245 / #314: the ONE otel_spans read that deliberately omits FINAL. Every other read in
+      // this module takes a value off the table and so can be inflated by an un-merged duplicate.
+      // This one takes no value: it selects the literal 1 and asks only "does a row exist". A
+      // duplicate cannot change a boolean, so FINAL would buy nothing here and it is not free on a
+      // polled endpoint (measured on 372 un-merged parts: 7ms -> 43ms of ClickHouse time). The
+      // guard in clickhouse.test.ts allowlists this line by name so the exemption stays this one.
       "SELECT 1 AS one FROM otel_spans WHERE TenantId = {tenant:String} LIMIT 1",
       tenant,
     );
@@ -289,14 +316,14 @@ export async function querySpendSummary(windowDays = 30): Promise<SpendSummary |
          sumIf(EstimatedCost, CostSource = 'estimated') AS estimated,
          sumIf(EstimatedCost, CostSource = 'reconciled') AS reconciled,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY`,
       tenant,
     );
     const byLayerRows = await rows<{ layer: Layer; cost: string }>(
       db,
       `SELECT ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY
        GROUP BY layer`,
       tenant,
@@ -333,7 +360,7 @@ export async function queryPriorMonthSpend(): Promise<MicroUSD | null> {
     const r = await rows<{ total: string }>(
       db,
       `SELECT sum(EstimatedCost) AS total
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= toStartOfMonth(now()) - INTERVAL 1 MONTH
          AND Timestamp < toStartOfMonth(now())`,
@@ -362,7 +389,7 @@ export async function queryOutliers(windowDays = 30): Promise<CostOutlier[] | nu
       `WITH runs AS (
          SELECT TraceId AS runId, any(ServiceName) AS agent,
                 if(countIf(EstimatedCost IS NULL) > 0, NULL, sum(EstimatedCost)) AS cost
-         FROM otel_spans
+         FROM otel_spans FINAL
          WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY
            AND ServiceName != '' AND ServiceName != 'unknown'
            AND GenAiOperation NOT IN ('compute', 'egress')
@@ -445,7 +472,7 @@ export async function queryCostSeries(
     const out = await rowsP<{ day: string; layer: Layer; cost: string }>(
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY ${tagClause}
        GROUP BY day, layer
        ORDER BY day`,
@@ -498,7 +525,7 @@ export async function queryFeatureCostRows(
     const out = await rowsP<{ feature: string; layer: Layer; cost: string }>(
       db,
       `SELECT FeatureTag AS feature, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY AND FeatureTag != '' ${tagClause}
        GROUP BY feature, layer`,
       { tenant, tag },
@@ -656,7 +683,7 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
               sum(EstimatedCost) AS cost,
               count() AS spans,
               countIf(EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${scope} ${filterClause}
        GROUP BY grp
        ORDER BY cost DESC`,
@@ -680,7 +707,7 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
         ? await rowsP<{ day: string; grp: string; cost: string }>(
             db,
             `SELECT toString(toDate(Timestamp)) AS day, ${groupExpr} AS grp, sum(EstimatedCost) AS cost
-             FROM otel_spans
+             FROM otel_spans FINAL
              WHERE ${scope} ${filterClause} AND ${groupExpr} IN {kept:Array(String)}
              GROUP BY day, grp`,
             { ...common, kept },
@@ -690,7 +717,7 @@ export async function queryCostExplore(params: ExploreParams): Promise<ExploreSe
       ? await rowsP<{ day: string; cost: string }>(
           db,
           `SELECT toString(toDate(Timestamp)) AS day, sum(EstimatedCost) AS cost
-           FROM otel_spans
+           FROM otel_spans FINAL
            WHERE ${scope} ${filterClause} AND ${groupExpr} NOT IN {kept:Array(String)}
            GROUP BY day`,
           { ...common, kept },
@@ -795,7 +822,7 @@ export async function queryCostBreakdownPrior(
     const rows = await rowsP<{ grp: string; cost: string }>(
       db,
       `SELECT ${groupExpr} AS grp, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${scope} ${filterClause}
        GROUP BY grp`,
       { tenant, windowStart: b.windowStart, windowDays, ...filterParams },
@@ -847,7 +874,7 @@ export async function queryCostSliceTotals(
          countIf(EstimatedCost IS NULL) AS unpriced,
          count() AS spans,
          toString(maxOrNull(if(CostSource = 'reconciled', toDate(Timestamp), NULL))) AS recThrough
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY ${clause}`,
       { tenant, ...params },
     );
@@ -1079,7 +1106,7 @@ export async function querySettledCostSeries(
     const costRows = await rowsP<{ day: string; layer: Layer; cost: string }>(
       db,
       `SELECT toString(toDate(Timestamp)) AS day, ${LAYER_CASE} AS layer, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${inWindow} ${clause}
        GROUP BY day, layer`,
       params,
@@ -1099,7 +1126,7 @@ export async function querySettledCostSeries(
               countIf(${LAYER_CASE} = 'compute') AS compute,
               countIf(${LAYER_CASE} = 'egress') AS egress,
               countIf(CostSource = 'reconciled') AS reconciled
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE ${inWindow}
        GROUP BY day`,
       params,
@@ -1582,7 +1609,7 @@ async function accountDetail(
               countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps,
               max(StatusCode) AS maxStatus
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND AccountIdHash = {account:String}
          AND ${ACCOUNT_SPAN_WINDOW} AND ${DIRECT_ONLY}
        GROUP BY TraceId
@@ -1664,7 +1691,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
     const totalRows = await rowsP<{ total: string }>(
       db,
       `SELECT sum(EstimatedCost) AS total
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}`,
       { tenant, tag },
     );
@@ -1684,7 +1711,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
          if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
          countIf(GenAiOperation = 'tool' AND (EstimatedCost IS NULL OR EstimatedCost = 0)) AS uncosted,
          sum(EstimatedCost) AS featureCost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY ${tagClause}
        GROUP BY feature
        HAVING uncosted > {threshold:UInt32}
@@ -1699,7 +1726,7 @@ export async function queryHiddenCostAlerts(filter?: { tag?: string }): Promise<
          if(FeatureTag != '', FeatureTag, ServiceName) AS feature,
          countIf(${LAYER_CASE} = 'llm') / nullIf(uniqExact(SessionId), 0) AS callsPerSession,
          sum(EstimatedCost) AS featureCost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
          AND SessionId != '' ${tagClause}
        GROUP BY feature
@@ -1784,7 +1811,7 @@ export async function queryFeatureEconomics(windowDays = 30): Promise<FeatureEco
       // CTO-244: `unpriced` gates the cost-per-user ratio below. See FeatureEconomics.
       `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost, uniqExact(UserIdHash) AS users,
               countIf(EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${w} DAY AND FeatureTag != ''
        GROUP BY FeatureTag
        ORDER BY cost DESC`,
@@ -2067,7 +2094,7 @@ export async function queryAccountStitching(): Promise<AccountStitching | null> 
     const direct = await rows<{ direct_accounts: string }>(
       db,
       `SELECT uniqExact(AccountIdHash) AS direct_accounts
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
          AND AccountIdHash != ''`,
@@ -2093,7 +2120,7 @@ export async function queryAccountStitching(): Promise<AccountStitching | null> 
       const costs = await rowsP<{ user_hash: string; cost: string; spans: string }>(
         db,
         `SELECT UserIdHash AS user_hash, sum(EstimatedCost) AS cost, count() AS spans
-         FROM otel_spans
+         FROM otel_spans FINAL
          WHERE TenantId = {tenant:String}
            AND Timestamp >= now() - INTERVAL 30 DAY
            AND AccountIdHash = ''
@@ -2142,7 +2169,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
 
     const sample = await rows<{ rate: string }>(
       db,
-      `SELECT avg(SampleRate) AS rate FROM otel_spans
+      `SELECT avg(SampleRate) AS rate FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY`,
       tenant,
     );
@@ -2150,7 +2177,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
 
     const perFeature = await rows<{ feature: string; events: string }>(
       db,
-      `SELECT FeatureTag AS feature, count() AS events FROM otel_spans
+      `SELECT FeatureTag AS feature, count() AS events FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 7 DAY AND FeatureTag != ''
        GROUP BY feature ORDER BY events DESC`,
       tenant,
@@ -2171,7 +2198,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
               any(SpanAttributes['telemetry.sdk.version']) AS sdk,
               countIf(ContextDroppedMessages > 0) AS drops,
               count() AS spans
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 24 HOUR
        GROUP BY service`,
       tenant,
@@ -2189,7 +2216,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
       `SELECT toString(toDate(Timestamp)) AS date,
               sum(EstimatedCost) AS est,
               sumIf(EstimatedCost, CostSource = 'reconciled') AS recon
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 14 DAY
        GROUP BY date ORDER BY date`,
       tenant,
@@ -2219,7 +2246,7 @@ export async function queryDataQualityReport(): Promise<DataQualityReport | null
               count() AS spans,
               avg(EstimatedCost) AS mean,
               stddevPop(EstimatedCost) AS std
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
          AND SamplingStratum IN ('body', 'mid', 'tail')
@@ -2340,7 +2367,7 @@ async function fetchSpansFor(
   const inList = safeIds.map((id) => `'${id}'`).join(",");
   const sql = `SELECT TraceId AS runId, SpanId AS spanId, ParentSpanId AS parentSpanId,
             SpanName AS name, EstimatedCost AS cost, DurationNs AS durNs, StatusCode AS status
-     FROM otel_spans
+     FROM otel_spans FINAL
      WHERE TenantId = {tenant:String} AND TraceId IN (${inList})
      ORDER BY AgentStepIndex, Timestamp`;
   const spanRows = await rows<SpanRowRaw>(db, sql, tenant);
@@ -2415,7 +2442,7 @@ export async function queryAgents(
               count() AS steps,
               max(StatusCode) AS maxStatus,
               toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL ${w} DAY
          AND ServiceName != ''
@@ -2496,7 +2523,7 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
       `SELECT TraceId AS runId, any(FeatureTag) AS agent, sum(EstimatedCost) AS cost,
               countIf(EstimatedCost IS NULL) AS unpriced,
               count() AS steps, max(StatusCode) AS maxStatus, toString(toUnixTimestamp(max(Timestamp))) AS tsEpoch
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND TraceId = {runId:String}
        GROUP BY TraceId`,
       { tenant, runId },
@@ -2509,7 +2536,7 @@ export async function queryAgentRun(runId: string): Promise<AgentRun | null> {
     const peers = await rowsP<{ cost: string; unpriced: string }>(
       db,
       `SELECT sum(EstimatedCost) AS cost, countIf(EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND FeatureTag = {agent:String}
          AND Timestamp >= now() - INTERVAL 30 DAY
        GROUP BY TraceId`,
@@ -2646,7 +2673,7 @@ export async function queryGuardrailActivity(): Promise<Map<string, GuardrailAct
          extract(key, '^gen_ai\\\\.guardrail\\\\.(.+)\\\\.verdict$') AS ruleId,
          count() AS runs,
          countIf(val IN ('enforced', 'shadow_observed')) AS wouldFire
-       FROM otel_spans
+       FROM otel_spans FINAL
        ARRAY JOIN mapKeys(SpanAttributes) AS key, mapValues(SpanAttributes) AS val
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 7 DAY
@@ -2774,7 +2801,7 @@ export async function queryConnectorActivity(): Promise<ConnectorActivity | null
       db,
       `SELECT ${LAYER_CASE} AS layer, GenAiSystem AS system, count() AS n,
               toString(max(Timestamp)) AS last
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL 30 DAY
        GROUP BY layer, system`,
       tenant,
@@ -2854,7 +2881,7 @@ export async function querySpanFeatureTags(days?: number): Promise<string[] | nu
     const out = await rows<{ feature: string }>(
       db,
       `SELECT DISTINCT FeatureTag AS feature
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String} AND Timestamp >= now() - INTERVAL ${windowDays} DAY
          AND FeatureTag != ''
        ORDER BY feature`,
@@ -2904,7 +2931,7 @@ export async function queryAttribution(
          uniqExact(s.SessionId) AS sessions,
          sum(s.EstimatedCost) AS cost,
          countIf(s.EstimatedCost IS NULL) AS unpriced
-       FROM otel_spans s
+       FROM otel_spans s FINAL
        WHERE s.TenantId = {tenant:String}
          AND s.Timestamp >= ${windowSql}
          AND s.GenAiOperation NOT IN ('compute', 'egress')
@@ -2923,7 +2950,7 @@ export async function queryAttribution(
          ${providerExpr} AS provider,
          uniqExact(b.BusinessEventId) AS conversions
        FROM business_events b
-       INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
+       INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
          AND b.EventName = {outcome:String}
          AND b.OccurredAt >= ${windowSql}
@@ -2980,7 +3007,7 @@ export async function queryAttribution(
            b.ValueType IN {positiveTypes:Array(String)} OR b.ValueType = {refundType:String}
          ) AS users
        FROM business_events b
-       INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
+       INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
        WHERE b.TenantId = {tenant:String}
          AND b.OccurredAt >= ${windowSql}
          AND b.UserIdHash != ''
@@ -3031,7 +3058,7 @@ export async function queryAttribution(
     const dailyRows = await rowsP<{ day: string; provider: string; cost: string }>(
       db,
       `SELECT toString(toDate(s.Timestamp)) AS day, ${providerExpr} AS provider, sum(s.EstimatedCost) AS cost
-       FROM otel_spans s
+       FROM otel_spans s FINAL
        WHERE s.TenantId = {tenant:String}
          AND s.Timestamp >= ${windowSql}
          AND s.GenAiOperation NOT IN ('compute', 'egress')
@@ -3177,7 +3204,7 @@ export async function queryCurrentModel(): Promise<{
          quantileExact(0.95)(if(DurationNs > 0, DurationNs, NULL)) / 1e6 AS p95Ms,
          countIf(StatusCode = 2) / count() AS errRate,
          count() AS sampleCount
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL 7 DAY
          AND (GenAiResponseModel != '' OR GenAiRequestModel != '')

--- a/web/lib/waste/duplicated-work.ts
+++ b/web/lib/waste/duplicated-work.ts
@@ -284,6 +284,9 @@ export async function collectDuplicatedWork(
     // clusters inside ClickHouse (an IN over the cluster tuple) instead of shipping one row per trace
     // to Node and clustering the whole tenant in JS. On the demo corpus that is 740 rows instead of
     // ~420k. This is lossless: a failure-free cluster is dropped precisely because it can never match.
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const rows = await rowsPCached<RunRow>(
       db,
       `WITH runs AS (
@@ -295,7 +298,7 @@ export async function collectDuplicatedWork(
                 toString(toUnixTimestamp(max(Timestamp))) AS tsSec,
                 sum(EstimatedCost) AS cost,
                 max(StatusCode) AS maxStatusNum
-         FROM otel_spans
+         FROM otel_spans FINAL
          WHERE TenantId = {tenant:String}
            AND Timestamp >= now() - INTERVAL ${w} DAY
            AND GenAiOperation NOT IN ('compute', 'egress')

--- a/web/lib/waste/no-measured-return.ts
+++ b/web/lib/waste/no-measured-return.ts
@@ -164,10 +164,13 @@ export async function collectNoMeasuredReturn(
   const live = await tryLive(async (db, tenant) => {
     // Per-feature windowed spend. `w` is a clamped int, so interpolating it is injection-safe (same
     // pattern as the sibling queries in lib/clickhouse.ts). `filters.feature` binds as an array param.
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const spendRows = await rowsPCached<FeatureSpendRow>(
       db,
       `SELECT FeatureTag AS feature, sum(EstimatedCost) AS cost
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= now() - INTERVAL ${w} DAY
          AND FeatureTag != ''

--- a/web/lib/waste/no-measured-return.ts
+++ b/web/lib/waste/no-measured-return.ts
@@ -51,7 +51,7 @@ export interface NoReturnEconRow {
   attributionRate: number | null;
   /**
    * Raw attributed-conversion count for the scope over the window, from `queryFeatureEconomics`.
-   * CTO-227 review finding (Bug 3): `attributionRate` is `null` in TWO different states — a feature
+   * CTO-227 review finding (Bug 3): `attributionRate` is `null` in TWO different states: a feature
    * with genuinely zero attribution AND a feature with some conversions but below the trust floor
    * (MIN_CONVERSIONS_FOR_ECONOMICS). Only the count tells them apart, so the detector gates on this,
    * not on the null rate, to avoid false-flagging a sparse-but-converting feature as pure waste.

--- a/web/lib/waste/paid-for-nothing.ts
+++ b/web/lib/waste/paid-for-nothing.ts
@@ -170,6 +170,9 @@ export async function collectPaidForNothing(
     // Stage 1 (runs subquery): one row per TraceId with its cost, terminal-error flag, feature and
     // agent. `isFailed` reuses queryAgents' derivation: max(StatusCode)=2 (OTel Error) => failed.
     // `GenAiOperation NOT IN ('compute','egress')` keeps this to run-shaped, billable spend.
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const runsCte = `
       SELECT
         TraceId AS runId,
@@ -177,7 +180,7 @@ export async function collectPaidForNothing(
         any(ServiceName) AS agent,
         sum(EstimatedCost) AS runCost,
         max(StatusCode) = 2 AS isFailed
-      FROM otel_spans
+      FROM otel_spans FINAL
       WHERE TenantId = {tenant:String}
         AND Timestamp >= now() - INTERVAL ${w} DAY
         AND GenAiOperation NOT IN ('compute', 'egress')

--- a/web/lib/waste/wrong-sized-model.ts
+++ b/web/lib/waste/wrong-sized-model.ts
@@ -301,6 +301,9 @@ interface FeatureIncumbent {
 async function queryFeatureIncumbents(windowDays: number): Promise<FeatureIncumbent[] | null> {
   const w = clampWindowDays(windowDays);
   return tryLive(async (db, tenant) => {
+    // #314: FINAL, like every other otel_spans read (the rationale is in lib/clickhouse.ts). This
+    // detector sums money off the raw span table, so an un-merged duplicate would inflate the
+    // recoverable figure it puts in front of a user until a background merge collapsed it.
     const out = await rowsPCached<{ feature: string; model: string; spend: string; calls: string | number }>(
       db,
       `SELECT FeatureTag AS feature,
@@ -308,7 +311,7 @@ async function queryFeatureIncumbents(windowDays: number): Promise<FeatureIncumb
                  if(GenAiRequestModel != '', GenAiRequestModel, 'unknown')) AS model,
               sum(EstimatedCost) AS spend,
               count() AS calls
-       FROM otel_spans
+       FROM otel_spans FINAL
        WHERE TenantId = {tenant:String}
          AND Timestamp >= toDate(now()) - INTERVAL ${w - 1} DAY
          AND GenAiOperation NOT IN ('compute', 'egress')


### PR DESCRIPTION
## What

CLAUDE.md requires prose, comments and docs to carry no em dashes. A parallel prose sweep deliberately excluded `web/lib/clickhouse.ts` and `web/lib/waste/*.ts`, leaving 53 occurrences behind. This finishes the sweep.

- **43 punctuation em dashes reworded** with a colon, semicolon, comma, parenthetical or full stop, whichever fit the sentence.
- **10 occurrences kept.** Each is the literal glyph inside backticks or quotes (`` `—` ``, `"—"`), naming the character the honest-blank UI actually renders. The convention exempts those, and rewriting them would make the comments wrong.

No code, no SQL and no user-visible string changed. Every line in the diff is a comment line:

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(//|\*|/\*)'
```

returns nothing.

## Stacked on #326

#326 (`fix/read-path-final`) touches these same files and has not landed yet, so this branch is based on its head rather than on `main`. Until #326 merges, this PR's commit list also shows `fix(web): dedupe every otel_spans read with FINAL (#314)`. **Merge #326 first**, and this PR reduces to its single commit.

## Verification

`cd web && npm run typecheck && npm run lint && npm run test`

- typecheck: clean
- lint: clean apart from one pre-existing warning in `lib/useLivePoll.ts`, a file this PR does not touch
- test: 63 files, 769 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)