### PR TITLE
fix(web): refuse to boot a production build with authentication disabled

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -584,6 +584,16 @@ npm run dev
 Use the UUID, not `local-dev`: the value is bound into the ClickHouse read filter and a name matches
 no rows. Leave it unset and the dashboard errors rather than guessing a tenant.
 
+`TALLY_DEV_TENANT` is a **development** escape hatch in the literal sense: setting it turns the
+dashboard's authentication off completely (no Clerk middleware, no `ClerkProvider`, every visitor an
+org admin). `npm run dev` is unaffected, and so is the vitest suite, which pins the same variable.
+But a **production** build (`npm run build && npm start`, or either Dockerfile's standalone server)
+refuses to boot with it set: it prints what is wrong and exits non-zero before serving a request,
+rather than publish every number in the system to anyone with the URL. Serving with no
+authentication deliberately (the public demo kit does, behind Caddy basic auth, with synthetic data)
+takes a second variable as well, `TALLY_ALLOW_INSECURE_NO_AUTH=1`, and then every boot logs a
+standing warning. The guard is `web/lib/authGuard.ts`, run from `web/instrumentation.ts` (CTO-268).
+
 Each Route Handler queries ClickHouse live and falls back to mock data **only** if ClickHouse is
 unreachable. With the stack up and a batch sent, the **Cost**, **Features**, **Agents**, and **Data
 Quality** pages render your ingested spans.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -361,7 +361,8 @@ organization to a tenant UUID through the gateway control plane. So leave `web.c
 `gateway.config.requireApiKey=true` (the cloud default) so ingest requires
 `Authorization: Bearer <key>`. Seed keys with the gateway's `seed.py` against RDS.
 
-Two things follow from that, and both bite silently if you get them wrong:
+Three things follow from that. The first two bite silently if you get them wrong; the third
+stops the deployment dead, on purpose:
 
 - **Control-plane calls need the service token.** Every `/v1/tenant/*` request carries
   `Authorization: Bearer $TALLY_GATEWAY_SERVICE_TOKEN`, and with `requireApiKey` on the gateway
@@ -371,6 +372,17 @@ Two things follow from that, and both bite silently if you get them wrong:
   `ai-tally-gateway-service-token` Secrets Manager entry, so put a real value in it
   (`openssl rand -hex 32`) and never a committed literal. A mismatch surfaces as a `401` on every
   dashboard control-plane write.
+
+- **The dashboard refuses to boot with the escape hatch on.** `TALLY_DEV_TENANT` does not only pin a
+  tenant, it turns the dashboard's authentication OFF completely: the Clerk middleware becomes a
+  pass-through, no `ClerkProvider` is mounted, and `canManage()` returns true for every visitor, so
+  API key mint / rotate / revoke is ungated too. Anyone with the URL sees every number in the system.
+  A production build started with it set therefore prints an explanation and exits non-zero before
+  it serves a single request, so the task crash-loops with the reason in its logs rather than coming
+  up wide open. Serving with no authentication on purpose (a public demo of synthetic data behind
+  access control you supply yourself) takes a second, deliberate variable as well,
+  `TALLY_ALLOW_INSECURE_NO_AUTH=1` / `web.config.allowInsecureNoAuth: "1"`, and then every boot logs
+  a standing warning. The check is `web/lib/authGuard.ts`, run from `web/instrumentation.ts`.
 
 - **If you do pin a tenant, pin the UUID.** `TALLY_DEV_TENANT` / `web.config.devTenant` is a
   single-tenant demo escape hatch, and its value is bound straight into the ClickHouse read filter

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -22,6 +22,7 @@
         { "name": "PORT", "value": "3000" },
         { "name": "TALLY_GATEWAY_URL", "value": "REPLACE_GATEWAY_URL" },
         { "name": "TALLY_DEV_TENANT", "value": "" },
+        { "name": "TALLY_ALLOW_INSECURE_NO_AUTH", "value": "" },
         { "name": "TALLY_CLICKHOUSE_URL", "value": "REPLACE_CLICKHOUSE_URL" },
         { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
         { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },

--- a/deploy/aws/helm/ai-tally-eks/templates/web-configmap.yaml
+++ b/deploy/aws/helm/ai-tally-eks/templates/web-configmap.yaml
@@ -15,6 +15,11 @@ data:
   # caller's Clerk org). When pinned it must be the tenant UUID, not a name: the value is
   # bound into the ClickHouse read filter (TenantId = ...), so a name matches no rows.
   TALLY_DEV_TENANT: {{ .Values.web.config.devTenant | quote }}
+  # CTO-268: devTenant does not only pin a tenant, it disables the dashboard's authentication
+  # entirely. The web image therefore REFUSES TO BOOT when devTenant is set in a production build
+  # unless this second value explicitly says so. Leave it empty. Set it to "1" only for a public
+  # demo serving synthetic data behind your own access control.
+  TALLY_ALLOW_INSECURE_NO_AUTH: {{ .Values.web.config.allowInsecureNoAuth | default "" | quote }}
   TALLY_CLICKHOUSE_URL: {{ printf "%s://%s:%d" .Values.clickhouse.scheme (include "ai-tally.clickhouseHost" .) (int .Values.clickhouse.httpPort) | quote }}
   TALLY_CLICKHOUSE_DB: {{ .Values.web.config.clickhouseDb | quote }}
   TALLY_CLICKHOUSE_USER: {{ .Values.web.config.clickhouseUser | quote }}

--- a/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values-eks.example.yaml
@@ -57,3 +57,6 @@ web:
     # Empty: the tenant comes from the caller's Clerk org. To pin one for a demo, use its
     # UUID (`make seed` prints it), never the name `local-dev`.
     devTenant: ""
+    # CTO-268: leave empty. Setting devTenant without this turns auth off, and the web container
+    # refuses to boot rather than serve every number in the system to anyone with the URL.
+    allowInsecureNoAuth: ""

--- a/deploy/aws/helm/ai-tally-eks/values.yaml
+++ b/deploy/aws/helm/ai-tally-eks/values.yaml
@@ -139,6 +139,11 @@ web:
     # single-tenant demo set the tenant UUID (`make seed` prints it), never the name
     # `local-dev`: this is bound into the ClickHouse read filter and a name matches no rows.
     devTenant: ""
+    # CTO-268: the explicit "yes, serve this with NO AUTHENTICATION" opt-in. devTenant alone in a
+    # production build makes the web container refuse to boot, because setting it turns auth off
+    # completely (no Clerk middleware, no ClerkProvider, every visitor an org admin). Leave EMPTY.
+    # "1" only for a public demo: synthetic data, behind access control you supply yourself.
+    allowInsecureNoAuth: ""
     clickhouseDb: default
     clickhouseUser: tally
     dashboardRefreshMs: "5000"   # NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -97,6 +97,18 @@ Edit `deploy/demo/.env`:
   `deploy.sh` resolves it from Postgres, hands it to the backfill, and recreates the web service
   with it. If resolution ever fails, both scripts abort with the reason instead of falling back.
 
+- **This kit runs with the dashboard's authentication switched OFF, on purpose.** `TALLY_DEV_TENANT`
+  does not only pin a tenant: with it set there is no Clerk middleware, no `ClerkProvider`, and
+  every visitor is treated as an org admin who can mint, rotate and revoke API keys. That is fine
+  *here*: the data is synthetic, the host is separate, and Caddy basic auth is the access control.
+  It is a disaster on an instance holding real tenant data, and this kit is the most copyable thing
+  in the repo, so the web image now **refuses to boot** on `TALLY_DEV_TENANT` alone in a production
+  build. Turning auth off takes a second, deliberate variable, `TALLY_ALLOW_INSECURE_NO_AUTH=1`,
+  which `deploy.sh` and `reseed.sh` set for you (`pin_dashboard_tenant` in `lib-tenant.sh`) and
+  which every boot then warns about in the web container's logs. **If you are adapting this kit to
+  stand up a real instance, delete both variables and configure Clerk** (see `deploy/aws/README.md`
+  or `deploy/vercel/README.md`); do not carry them across.
+
 ### 4. Deploy
 
 ```
@@ -199,6 +211,14 @@ scripts themselves read the env vars, only these copy-paste one-liners are liter
 
 All three must show the same **UUID**. A `local-dev` (the name) in either of the last two means
 something bypassed `deploy.sh`; re-running `./deploy/demo/reseed.sh` re-resolves and repairs it.
+
+**The `web` container restarts in a loop and its logs say "REFUSES TO START".** The image was
+started with `TALLY_DEV_TENANT` set but without `TALLY_ALLOW_INSECURE_NO_AUTH`, so it stopped rather
+than serve with authentication disabled. That happens when something bypassed the scripts, typically
+a bare `docker compose up` with a stale `TALLY_DEV_TENANT` still exported in the shell. Re-run
+`./deploy/demo/deploy.sh` (or `./deploy/demo/reseed.sh`), which set both variables together. If you
+are adapting this kit to serve REAL data, that message is telling you the truth: unset both and
+configure Clerk instead.
 
 **A control-plane write from the dashboard returns 401.** Gateway auth is on and the two tiers hold
 different tokens. They come from the single `TALLY_GATEWAY_SERVICE_TOKEN` key in `.env`, so confirm

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -81,13 +81,13 @@ make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${R
 
 # --- Point the dashboard at the tenant that was just seeded -------------------------------------
 # The UUID only exists after `make seed`, so the web container above started without it. Resolve it
-# now and recreate just the web service with TALLY_DEV_TENANT set. Exported so Compose interpolation
-# picks it up: a host env var wins over the same key in --env-file.
+# now and recreate just the web service with TALLY_DEV_TENANT set (plus the explicit no-auth opt-in
+# this kit deliberately takes; see pin_dashboard_tenant in lib-tenant.sh, CTO-268).
 echo "==> Resolving the demo tenant UUID"
 TENANT_UUID="$(resolve_tenant_uuid)"
 echo "    ${DEMO_TENANT_NAME} = ${TENANT_UUID}"
-export TALLY_DEV_TENANT="${TENANT_UUID}"
-"${COMPOSE[@]}" up -d web
+echo "==> Pointing the dashboard at it (auth OFF: synthetic demo data behind Caddy basic auth)"
+pin_dashboard_tenant "${TENANT_UUID}"
 
 echo "==> Backfilling 30 days of SYNTHETIC demo spans"
 # The `make chatbot-demo-backfill` target runs on the HOST and POSTs to localhost:8080 - neither

--- a/deploy/demo/docker-compose.prod.yml
+++ b/deploy/demo/docker-compose.prod.yml
@@ -61,6 +61,14 @@ services:
       # empty on the very first `up` (before seeding), where the dashboard errors loudly rather
       # than rendering a blank page for an unknown tenant.
       TALLY_DEV_TENANT: ${TALLY_DEV_TENANT:-}
+      # CTO-268: the explicit "yes, serve this with no authentication" opt-in. TALLY_DEV_TENANT does
+      # not only pin the tenant, it turns the dashboard's auth off completely, and this kit is the
+      # thing operators copy when standing up a REAL instance. So the web image refuses to boot on
+      # TALLY_DEV_TENANT alone in a production build; disabling auth for real takes this second
+      # variable too. The demo sets it deliberately (deploy.sh / reseed.sh, via pin_dashboard_tenant)
+      # because the data here is synthetic and Caddy basic auth is the access control. Do NOT carry
+      # this line into a deployment that serves real tenant data.
+      TALLY_ALLOW_INSECURE_NO_AUTH: ${TALLY_ALLOW_INSECURE_NO_AUTH:-}
       # Initiative 1 §6: the control-plane service token, the same secret the gateway reads as
       # TALLY_GATEWAY_SERVICE_TOKEN (the gateway picks it up from the base compose file and the
       # same .env, so the two cannot disagree). The gateway's gate is a no-op while the demo VM

--- a/deploy/demo/lib-tenant.sh
+++ b/deploy/demo/lib-tenant.sh
@@ -64,6 +64,25 @@ ERR
   printf '%s\n' "${uuid}"
 }
 
+# Export the two variables the demo's web tier needs, and recreate the web service with them.
+#
+# WHY TWO (CTO-268): TALLY_DEV_TENANT pins the tenant AND turns the dashboard's authentication off
+# entirely (no Clerk middleware, no ClerkProvider, every visitor an org admin). That is a deliberate
+# choice for this kit, which serves SYNTHETIC data behind Caddy basic auth on its own host. It is a
+# disaster on a real instance, and this kit is the thing people copy. So the web tier now REFUSES TO
+# BOOT on TALLY_DEV_TENANT alone in a production build, and serving with no auth takes a second,
+# unmistakable variable that nobody sets by accident. The demo says it out loud, here, once, so both
+# scripts agree and so an operator reading this file sees exactly what the demo is opting into.
+#
+# Takes the resolved tenant UUID. Exported (not passed in --env-file) so Compose interpolation picks
+# them up: a host env var wins over the same key in the env file.
+pin_dashboard_tenant() {
+  local tenant_uuid="$1"
+  export TALLY_DEV_TENANT="${tenant_uuid}"
+  export TALLY_ALLOW_INSECURE_NO_AUTH=1
+  "${COMPOSE[@]}" up -d web
+}
+
 # Fail before the stack is touched when gateway auth is on but no service token was supplied.
 #
 # WHY up front (Initiative 1, §6): with TALLY_REQUIRE_API_KEY on and TALLY_GATEWAY_SERVICE_TOKEN

--- a/deploy/demo/reseed.sh
+++ b/deploy/demo/reseed.sh
@@ -125,9 +125,9 @@ docker run --rm \
   npx --yes tsx /scripts/backfill-spans.ts --seed "${BACKFILL_SEED}" --tenant "${TENANT_UUID}"
 
 # Repair the web tier if it is running without TALLY_DEV_TENANT (for example after a bare
-# `docker compose up` that bypassed deploy.sh). Compose recreates only when the value actually
-# changes, so on a normal nightly run this is a no-op.
-export TALLY_DEV_TENANT="${TENANT_UUID}"
-"${COMPOSE[@]}" up -d web
+# `docker compose up` that bypassed deploy.sh, which now leaves the web container refusing to boot
+# rather than serving an unknown tenant). Compose recreates only when a value actually changes, so
+# on a normal nightly run this is a no-op.
+pin_dashboard_tenant "${TENANT_UUID}"
 
 echo "==> Demo data reset. The dashboard now shows a fresh synthetic 30-day window."

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -311,7 +311,8 @@ organization to a tenant UUID through the gateway control plane. So leave `web.c
 `gateway.config.requireApiKey=true` (the cloud default) so ingest requires
 `Authorization: Bearer <key>`. Seed keys with the gateway's `seed.py` against Cloud SQL.
 
-Two things follow from that, and both bite silently if you get them wrong:
+Three things follow from that. The first two bite silently if you get them wrong; the third
+stops the deployment dead, on purpose:
 
 - **Control-plane calls need the service token.** Every `/v1/tenant/*` request carries
   `Authorization: Bearer $TALLY_GATEWAY_SERVICE_TOKEN`, and with `requireApiKey` on the gateway
@@ -320,6 +321,17 @@ Two things follow from that, and both bite silently if you get them wrong:
   `GATEWAY_SERVICE_TOKEN`; both are wired here as Secret Manager references, so put a real value in
   the `ai-tally-gateway-service-token` secret (`openssl rand -hex 32`) and never a committed
   literal. A mismatch surfaces as a `401` on every dashboard control-plane write.
+
+- **The dashboard refuses to boot with the escape hatch on.** `TALLY_DEV_TENANT` does not only pin a
+  tenant, it turns the dashboard's authentication OFF completely: the Clerk middleware becomes a
+  pass-through, no `ClerkProvider` is mounted, and `canManage()` returns true for every visitor, so
+  API key mint / rotate / revoke is ungated too. Anyone with the URL sees every number in the system.
+  A production build started with it set therefore prints an explanation and exits non-zero before
+  it serves a single request, so the task crash-loops with the reason in its logs rather than coming
+  up wide open. Serving with no authentication on purpose (a public demo of synthetic data behind
+  access control you supply yourself) takes a second, deliberate variable as well,
+  `TALLY_ALLOW_INSECURE_NO_AUTH=1` / `web.config.allowInsecureNoAuth: "1"`, and then every boot logs
+  a standing warning. The check is `web/lib/authGuard.ts`, run from `web/instrumentation.ts`.
 
 - **If you do pin a tenant, pin the UUID.** `TALLY_DEV_TENANT` / `web.config.devTenant` is a
   single-tenant demo escape hatch, and its value is bound straight into the ClickHouse read filter

--- a/deploy/gcp/cloudrun/web.service.yaml
+++ b/deploy/gcp/cloudrun/web.service.yaml
@@ -41,6 +41,11 @@ spec:
             # never to a name: the value is bound into the ClickHouse read filter (TenantId = ...),
             # so a name matches no rows and renders an empty dashboard.
             - { name: TALLY_DEV_TENANT,     value: "" }
+            # CTO-268: setting TALLY_DEV_TENANT does not only pin a tenant, it disables the
+            # dashboard's authentication completely. The container REFUSES TO BOOT when it is set in
+            # a production build unless this second variable explicitly says that is intended. Leave
+            # it empty. "1" only for a public demo of synthetic data behind your own access control.
+            - { name: TALLY_ALLOW_INSECURE_NO_AUTH, value: "" }
             - { name: TALLY_CLICKHOUSE_URL, value: "REPLACE_CLICKHOUSE_URL" }
             - { name: TALLY_CLICKHOUSE_DB,  value: "default" }
             - { name: TALLY_CLICKHOUSE_USER, value: "tally" }

--- a/deploy/gcp/helm/ai-tally/templates/web-configmap.yaml
+++ b/deploy/gcp/helm/ai-tally/templates/web-configmap.yaml
@@ -15,6 +15,11 @@ data:
   # caller's Clerk org). When pinned it must be the tenant UUID, not a name: the value is
   # bound into the ClickHouse read filter (TenantId = ...), so a name matches no rows.
   TALLY_DEV_TENANT: {{ .Values.web.config.devTenant | quote }}
+  # CTO-268: devTenant does not only pin a tenant, it disables the dashboard's authentication
+  # entirely. The web image therefore REFUSES TO BOOT when devTenant is set in a production build
+  # unless this second value explicitly says so. Leave it empty. Set it to "1" only for a public
+  # demo serving synthetic data behind your own access control.
+  TALLY_ALLOW_INSECURE_NO_AUTH: {{ .Values.web.config.allowInsecureNoAuth | default "" | quote }}
   TALLY_CLICKHOUSE_URL: {{ printf "%s://%s:%d" .Values.clickhouse.scheme (include "ai-tally.clickhouseHost" .) (int .Values.clickhouse.httpPort) | quote }}
   TALLY_CLICKHOUSE_DB: {{ .Values.web.config.clickhouseDb | quote }}
   TALLY_CLICKHOUSE_USER: {{ .Values.web.config.clickhouseUser | quote }}

--- a/deploy/gcp/helm/ai-tally/values-gke.example.yaml
+++ b/deploy/gcp/helm/ai-tally/values-gke.example.yaml
@@ -49,3 +49,6 @@ web:
     # Empty: the tenant comes from the caller's Clerk org. To pin one for a demo, use its
     # UUID (`make seed` prints it), never the name `local-dev`.
     devTenant: ""
+    # CTO-268: leave empty. Setting devTenant without this turns auth off, and the web container
+    # refuses to boot rather than serve every number in the system to anyone with the URL.
+    allowInsecureNoAuth: ""

--- a/deploy/gcp/helm/ai-tally/values.yaml
+++ b/deploy/gcp/helm/ai-tally/values.yaml
@@ -128,6 +128,11 @@ web:
     # single-tenant demo set the tenant UUID (`make seed` prints it), never the name
     # `local-dev`: this is bound into the ClickHouse read filter and a name matches no rows.
     devTenant: ""
+    # CTO-268: the explicit "yes, serve this with NO AUTHENTICATION" opt-in. devTenant alone in a
+    # production build makes the web container refuse to boot, because setting it turns auth off
+    # completely (no Clerk middleware, no ClerkProvider, every visitor an org admin). Leave EMPTY.
+    # "1" only for a public demo: synthetic data, behind access control you supply yourself.
+    allowInsecureNoAuth: ""
     clickhouseDb: default
     clickhouseUser: tally
     dashboardRefreshMs: "5000"   # NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -71,6 +71,7 @@ fallback — the dashboard boots without any of them (it just renders the mock/`
 | `TALLY_GATEWAY_URL` | Ingest gateway base URL | `https://gateway.example.com` | Plain env |
 | `GATEWAY_SERVICE_TOKEN` | Bearer token on every gateway `/v1/tenant/*` call | `openssl rand -hex 32` output | **Encrypted / Sensitive** |
 | `TALLY_DEV_TENANT` | Dev escape hatch: pin a tenant, skip Clerk | unset in prod (demo: the tenant **UUID**) | Plain env |
+| `TALLY_ALLOW_INSECURE_NO_AUTH` | Explicit "serve with NO authentication" opt-in, required alongside `TALLY_DEV_TENANT` in production | unset (demo: `1`) | Plain env |
 
 `GATEWAY_SERVICE_TOKEN` must be the exact same string the gateway holds as
 `TALLY_GATEWAY_SERVICE_TOKEN`. The gateway rejects every control-plane call without it once
@@ -83,6 +84,19 @@ caller's Clerk organization. Set it only for a single-tenant demo, and set it to
 ClickHouse read filter (`TenantId = ...`) and spans are tagged with the UUID, so a name matches no
 rows and the dashboard renders empty with no error. The older `TALLY_TENANT_ID` variable is gone;
 delete it from any project that still has it.
+
+That is no longer only advice. `TALLY_DEV_TENANT` does not only pin a tenant: it disables the
+dashboard's authentication completely (the Clerk middleware becomes a pass-through, no
+`ClerkProvider` is mounted, and every visitor is treated as an org admin who can mint, rotate and
+revoke API keys). A Production deployment that boots with it set now **fails to start**: it prints
+what is wrong and exits non-zero before serving a request, so Vercel shows a failed deployment
+rather than a public URL exposing every number in the system. Serving with no authentication on
+purpose, the way the public demo does, takes a second variable that nobody sets by accident,
+`TALLY_ALLOW_INSECURE_NO_AUTH=1`, and then every boot logs a standing warning. The check is
+`web/lib/authGuard.ts`, run at startup from `web/instrumentation.ts`. The trigger is
+`NODE_ENV=production`, which on Vercel covers **Preview** deployments as well as Production; a
+preview URL is public too, so that is deliberate. `vercel dev` runs with `NODE_ENV=development` and
+is unaffected.
 
 **Optional UI/build knobs (`NEXT_PUBLIC_*` are inlined at build time — non-secret by definition):**
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,6 +12,13 @@
 # prints the exact line to copy (`export TALLY_DEV_TENANT=<uuid>`). The value is a UUID like the one
 # below; get yours from `make seed`.
 # TALLY_DEV_TENANT=00000000-0000-0000-0000-000000000000
+#
+# In a PRODUCTION build the line above alone is fatal (CTO-268): `npm start` and both Dockerfiles'
+# standalone server print what is wrong and exit non-zero rather than serve with authentication off.
+# `npm run dev`, `next build` and the vitest suite are unaffected. To serve with no authentication
+# on purpose (the deploy/demo/ kit does: synthetic data, behind Caddy basic auth) set the explicit
+# opt-in as well. Do not set this on anything holding real tenant data.
+# TALLY_ALLOW_INSECURE_NO_AUTH=1
 
 # --- Gateway ---
 # Where the control-plane gateway lives (server-side only).

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Next.js instrumentation hook (CTO-268).
+//
+// WHY HERE. `register()` is the only place Next.js guarantees to run ONCE, before the server
+// accepts its first request, in every way this app is started: `next start`, the standalone
+// `node server.js` both Dockerfiles ship, `next dev`, and once per runtime (Node and Edge). That is
+// exactly what a security assertion needs. The alternatives all fail the requirement:
+//
+//   * A check inside a route handler or a server component fires on the FIRST REQUEST to that one
+//     page, and any route that forgets to call it is unguarded.
+//   * `middleware.ts` module scope is evaluated lazily by the Edge runtime, so a misconfigured
+//     server still comes up and only fails once traffic arrives. Worse, `process.env` reads in the
+//     Edge bundle can be inlined at BUILD time, so a copy of this check there would be judging the
+//     build's environment rather than the container's.
+//   * `app/layout.tsx` module scope runs at render time, and it is prerendered at build time, so it
+//     says nothing about the environment the container is finally started with.
+//
+// The guard is deliberately fatal rather than throw-and-hope: Next logs an instrumentation error but
+// its behaviour on a throw is not a contract we want a security control to rest on, so we print the
+// message and exit non-zero ourselves. An orchestrator (ECS, Cloud Run, Kubernetes, Compose) then
+// shows a crash-looping task with the reason in the logs, which is what an operator mid-deploy
+// needs to see.
+
+import { assertAuthConfig } from "./lib/authGuard";
+
+export function register(): void {
+  try {
+    assertAuthConfig(process.env);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    // The Edge runtime has no process.exit; there a throw is all we have (and the Node runtime's
+    // register() has already exited the process by then anyway).
+    if (typeof process !== "undefined" && typeof process.exit === "function") {
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/web/lib/authGuard.test.ts
+++ b/web/lib/authGuard.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// The production guard on the dev escape hatch (CTO-268).
+//
+// The guard is pure over an env bag, so these assert the decision table directly instead of mutating
+// process.env. The BOOT behaviour it feeds (instrumentation.ts printing and exiting non-zero) is
+// exercised against a real production build, not here: see the PR body.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ALLOW_INSECURE_ENV,
+  DEV_TENANT_ENV,
+  InsecureAuthConfigError,
+  assertAuthConfig,
+  checkAuthConfig,
+} from "./authGuard";
+
+const TENANT = "11111111-2222-3333-4444-555555555555";
+
+describe("checkAuthConfig", () => {
+  it("refuses production + dev tenant with no opt-in", () => {
+    const v = checkAuthConfig({ NODE_ENV: "production", TALLY_DEV_TENANT: TENANT });
+    expect(v.kind).toBe("refuse");
+  });
+
+  it("allows production + dev tenant + explicit opt-in", () => {
+    const v = checkAuthConfig({
+      NODE_ENV: "production",
+      TALLY_DEV_TENANT: TENANT,
+      TALLY_ALLOW_INSECURE_NO_AUTH: "1",
+    });
+    expect(v.kind).toBe("insecure-allowed");
+  });
+
+  it("allows development + dev tenant (`make up`)", () => {
+    const v = checkAuthConfig({ NODE_ENV: "development", TALLY_DEV_TENANT: TENANT });
+    expect(v).toEqual({ kind: "ok" });
+  });
+
+  it("allows the test env + dev tenant (the vitest suite pins one)", () => {
+    const v = checkAuthConfig({ NODE_ENV: "test", TALLY_DEV_TENANT: TENANT });
+    expect(v).toEqual({ kind: "ok" });
+  });
+
+  it("allows production with neither variable (the product path)", () => {
+    expect(checkAuthConfig({ NODE_ENV: "production" })).toEqual({ kind: "ok" });
+  });
+
+  it("allows the production BUILD phase, which CI runs through the escape hatch", () => {
+    const v = checkAuthConfig({
+      NODE_ENV: "production",
+      NEXT_PHASE: "phase-production-build",
+      TALLY_DEV_TENANT: TENANT,
+    });
+    expect(v).toEqual({ kind: "ok" });
+  });
+
+  it("treats an empty or whitespace dev tenant as unset (the manifests set it to \"\")", () => {
+    expect(checkAuthConfig({ NODE_ENV: "production", TALLY_DEV_TENANT: "" })).toEqual({ kind: "ok" });
+    expect(checkAuthConfig({ NODE_ENV: "production", TALLY_DEV_TENANT: "   " })).toEqual({
+      kind: "ok",
+    });
+  });
+
+  it("accepts the same opt-in spellings the demo shell scripts accept", () => {
+    for (const value of ["1", "true", "TRUE", "yes", "on", " On "]) {
+      expect(
+        checkAuthConfig({
+          NODE_ENV: "production",
+          TALLY_DEV_TENANT: TENANT,
+          TALLY_ALLOW_INSECURE_NO_AUTH: value,
+        }).kind,
+      ).toBe("insecure-allowed");
+    }
+  });
+
+  it("does not accept a falsey opt-in as consent", () => {
+    for (const value of ["", "0", "false", "no", "off", "maybe"]) {
+      expect(
+        checkAuthConfig({
+          NODE_ENV: "production",
+          TALLY_DEV_TENANT: TENANT,
+          TALLY_ALLOW_INSECURE_NO_AUTH: value,
+        }).kind,
+      ).toBe("refuse");
+    }
+  });
+});
+
+describe("the refusal message", () => {
+  const message = (() => {
+    const v = checkAuthConfig({ NODE_ENV: "production", TALLY_DEV_TENANT: TENANT });
+    if (v.kind !== "refuse") throw new Error("expected a refusal");
+    return v.message;
+  })();
+
+  it("names both variables and the pinned tenant", () => {
+    expect(message).toContain(DEV_TENANT_ENV);
+    expect(message).toContain(ALLOW_INSECURE_ENV);
+    expect(message).toContain(TENANT);
+  });
+
+  it("states the consequence and gives a fix for each of the two situations", () => {
+    expect(message).toContain("disables authentication");
+    expect(message).toContain("CLERK_SECRET_KEY");
+    expect(message).toContain("deploy/demo/");
+  });
+});
+
+describe("assertAuthConfig", () => {
+  it("throws InsecureAuthConfigError on the one-variable production case", () => {
+    expect(() => assertAuthConfig({ NODE_ENV: "production", TALLY_DEV_TENANT: TENANT })).toThrow(
+      InsecureAuthConfigError,
+    );
+  });
+
+  it("warns but returns on the opted-in case, so the demo is loud rather than silent", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      assertAuthConfig({
+        NODE_ENV: "production",
+        TALLY_DEV_TENANT: TENANT,
+        TALLY_ALLOW_INSECURE_NO_AUTH: "1",
+      });
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toContain("NO AUTHENTICATION");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("stays silent on a healthy configuration", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      assertAuthConfig({ NODE_ENV: "production" });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/web/lib/authGuard.ts
+++ b/web/lib/authGuard.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Boot-time guard on the dev escape hatch (CTO-268).
+//
+// WHY this file exists. `TALLY_DEV_TENANT` is one environment variable that turns authentication
+// OFF everywhere at once: `middleware.ts` exports a pass-through instead of `clerkMiddleware()`,
+// `app/layout.tsx` mounts no `ClerkProvider`, `getTenant()` short-circuits to the pinned tenant
+// instead of resolving the signed-in Clerk org, and `canManage()` returns true for every visitor,
+// so key mint / rotate / revoke is ungated too. That is correct and wanted for `make up`, for CI,
+// for the vitest suite and for the public demo VM. It is a catastrophe on a real instance: anyone
+// with the URL reads every number in the system.
+//
+// The trap is concrete. `deploy/demo/` is the only genuine one-command deploy in the repo, so it is
+// the thing an operator copies when standing up a real instance, and it exports `TALLY_DEV_TENANT`
+// on purpose. The production manifests set it empty today, but nothing enforced that they stay that
+// way. This module is that enforcement.
+//
+// THE CONTRACT. Disabling auth in a production build now takes TWO variables, the second of which
+// nobody sets by accident:
+//
+//   TALLY_DEV_TENANT              pins the tenant (unchanged)
+//   TALLY_ALLOW_INSECURE_NO_AUTH  "yes, I mean it, serve this with no authentication"
+//
+// One variable alone in a production build is a hard boot failure. Two is allowed and prints a
+// standing warning on every boot, so the demo keeps working but stops being silent.
+//
+// Pure and dependency-free on purpose: it is imported from `instrumentation.ts` (Node runtime),
+// from `middleware.ts` (Edge runtime) and from the vitest suite, so it must not import
+// `server-only`, Clerk, or anything Node-specific.
+
+/** Env keys this guard reads. Named once so the message and the checks cannot drift. */
+export const DEV_TENANT_ENV = "TALLY_DEV_TENANT";
+export const ALLOW_INSECURE_ENV = "TALLY_ALLOW_INSECURE_NO_AUTH";
+
+/** The subset of `process.env` the guard needs. Passed explicitly so tests never mutate globals. */
+export interface AuthGuardEnv {
+  NODE_ENV?: string;
+  NEXT_PHASE?: string;
+  TALLY_DEV_TENANT?: string;
+  TALLY_ALLOW_INSECURE_NO_AUTH?: string;
+}
+
+/** Raised when the escape hatch is active in a production build with no explicit opt-in. */
+export class InsecureAuthConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InsecureAuthConfigError";
+  }
+}
+
+/** Same truthiness spelling `deploy/demo/lib-tenant.sh` accepts, so shell and app agree. */
+function isTruthy(v: string | undefined): boolean {
+  if (!v) return false;
+  return ["1", "true", "yes", "on"].includes(v.trim().toLowerCase());
+}
+
+function isSet(v: string | undefined): boolean {
+  return typeof v === "string" && v.trim() !== "";
+}
+
+/**
+ * What the guard decided, for callers that want to log rather than throw.
+ *
+ * - `ok`: authentication is on, or this is not a production build.
+ * - `insecure-allowed`: auth is off and the operator opted in explicitly. Warn, loudly, forever.
+ * - `refuse`: auth is off in production with no opt-in. `message` is the operator-facing text.
+ */
+export type AuthGuardVerdict =
+  | { kind: "ok" }
+  | { kind: "insecure-allowed"; message: string }
+  | { kind: "refuse"; message: string };
+
+function refusalMessage(devTenant: string): string {
+  return `
+================================================================================
+ai-tally REFUSES TO START: ${DEV_TENANT_ENV} is set in a production build.
+
+${DEV_TENANT_ENV} is the development escape hatch, and it disables authentication
+COMPLETELY. With it set, the Clerk middleware becomes a pass-through, no
+ClerkProvider is mounted, the tenant is pinned to
+
+    ${devTenant}
+
+instead of being resolved from a signed-in organization, and every visitor is
+treated as an org admin who can mint, rotate and revoke API keys. Anyone who has
+the URL sees every number in the system and can act on it.
+
+There is no safe fallback here, so this process stops instead of serving.
+
+You are in ONE OF TWO situations:
+
+  1. You want a REAL, authenticated deployment. This is the normal case.
+
+     Unset ${DEV_TENANT_ENV} (or set it to the empty string) and configure Clerk:
+
+         NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
+         CLERK_SECRET_KEY=sk_live_...
+
+     The tenant then resolves from the signed-in Clerk organization, per
+     web/lib/getTenant.ts.
+
+     If you copied deploy/demo/, that export is the line to delete. The demo kit
+     sets ${DEV_TENANT_ENV} deliberately and is NOT a template for a real
+     instance: it serves synthetic data behind Caddy basic auth.
+
+  2. You genuinely want an UNAUTHENTICATED instance, the way the public demo is.
+
+     Then say so, explicitly, alongside ${DEV_TENANT_ENV}:
+
+         ${ALLOW_INSECURE_ENV}=1
+
+     Only do this behind access control you supply yourself, and only with
+     synthetic data. deploy/demo/deploy.sh and deploy/demo/reseed.sh set it for
+     you; you do not need to add it by hand there.
+
+Checked: NODE_ENV=production, ${DEV_TENANT_ENV} set, ${ALLOW_INSECURE_ENV} not set.
+================================================================================
+`.trim();
+}
+
+function insecureWarning(devTenant: string): string {
+  return `
+================================================================================
+ai-tally WARNING: serving with NO AUTHENTICATION.
+
+${DEV_TENANT_ENV}=${devTenant} and ${ALLOW_INSECURE_ENV} is set, so this
+production build starts with the dev escape hatch on: no sign-in, no Clerk org,
+every visitor pinned to that tenant and treated as an org admin.
+
+This is a deliberate configuration (the public demo runs this way behind basic
+auth, with synthetic data). If you did not mean it, unset ${ALLOW_INSECURE_ENV}
+and ${DEV_TENANT_ENV} and configure Clerk.
+================================================================================
+`.trim();
+}
+
+/**
+ * Decide whether this process may serve, given its environment.
+ *
+ * Pure. `assertAuthConfig` is the one that actually stops the boot; this is separated out so tests
+ * (and callers that want to log the allowed-but-insecure case) can inspect the decision.
+ *
+ * The production-BUILD phase is exempt. `next build` runs with NODE_ENV=production and CI builds
+ * through the escape hatch on purpose (.github/workflows/ci.yml pins the same placeholder UUID the
+ * vitest suite uses, because CI holds no Clerk keys). A build serves no requests; the artifact it
+ * produces is checked when it boots, which is where the exposure would actually be.
+ */
+export function checkAuthConfig(env: AuthGuardEnv): AuthGuardVerdict {
+  if (env.NEXT_PHASE === "phase-production-build") {
+    return { kind: "ok" };
+  }
+  if (env.NODE_ENV !== "production") {
+    return { kind: "ok" };
+  }
+  const devTenant = env.TALLY_DEV_TENANT;
+  if (!isSet(devTenant)) {
+    return { kind: "ok" };
+  }
+  const pinned = (devTenant as string).trim();
+  if (isTruthy(env.TALLY_ALLOW_INSECURE_NO_AUTH)) {
+    return { kind: "insecure-allowed", message: insecureWarning(pinned) };
+  }
+  return { kind: "refuse", message: refusalMessage(pinned) };
+}
+
+/**
+ * Throw {@link InsecureAuthConfigError} when the escape hatch is active in a production build with
+ * no explicit opt-in, and warn on stderr when it is active WITH one.
+ *
+ * Call sites are boot-time on purpose (see `instrumentation.ts`). A per-request check would be
+ * skippable by any route that forgets to call it.
+ */
+export function assertAuthConfig(env: AuthGuardEnv = process.env as AuthGuardEnv): void {
+  const verdict = checkAuthConfig(env);
+  if (verdict.kind === "refuse") {
+    throw new InsecureAuthConfigError(verdict.message);
+  }
+  if (verdict.kind === "insecure-allowed") {
+    console.warn(verdict.message);
+  }
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -6,6 +6,14 @@
 // Dev escape hatch (§10): when TALLY_DEV_TENANT is set, this is a NO-OP so `make up` and CI reach
 // every route with no Clerk session and no Clerk keys. The product path (flag unset) requires a
 // session, exactly as intended.
+//
+// That hatch is guarded in a production build (CTO-268): TALLY_DEV_TENANT alone refuses to boot,
+// and turning auth off for real takes the explicit TALLY_ALLOW_INSECURE_NO_AUTH opt-in as well. The
+// assertion lives in instrumentation.ts, which runs once before the first request in every runtime,
+// so a bad configuration never reaches this file: the process is already gone. It is deliberately
+// NOT repeated here, because this module is compiled into the Edge bundle where `process.env` reads
+// can be inlined at BUILD time; a copy of the check here would be reasoning about the build's
+// environment rather than the container's, which is worse than no check at all.
 
 import {
   clerkMiddleware,


### PR DESCRIPTION
## The problem

`TALLY_DEV_TENANT` is a single environment variable that disables **all** authentication on the dashboard, and nothing prevented it in production:

- `web/middleware.ts` exports a no-op pass-through instead of `clerkMiddleware()`, so `auth.protect()` never runs on any route.
- `web/lib/getTenant.ts` short-circuits, pinning the tenant instead of resolving the signed-in Clerk org.
- `web/app/layout.tsx` mounts no `ClerkProvider` and needs no Clerk keys.
- `canManage()` returns `true` unconditionally, so API key mint / rotate / revoke is ungated too.

There was no boot-time assertion anywhere.

The trap is concrete rather than theoretical. `deploy/demo/deploy.sh` and `deploy/demo/reseed.sh` both `export TALLY_DEV_TENANT=...`, and `deploy/demo/` is the only path in the repo that works as a genuine one-command deploy, so it is the natural thing to copy when standing up a real instance. Copying it yields an unauthenticated dashboard where anyone with the URL sees every number in the system. The production manifests set the variable empty today, but nothing enforced that they stay correct.

This blocks the self-hosting work in `docs/self-hosted-scope.md` and the AWS bundle in `docs/aws-bundle-scope.md`, whose release gate says exactly this.

## Where the assertion lives, and why it genuinely runs at boot

`web/lib/authGuard.ts` holds a pure decision over the environment. `web/instrumentation.ts` runs it.

Next.js `register()` in `instrumentation.ts` is the only hook Next guarantees to run **once, before the server accepts its first request**, in every way this app is started: `next start`, the standalone `node server.js` that both Dockerfiles ship, `next dev`, and once per runtime (Node and Edge). That is what a security assertion needs. The alternatives all fail the requirement:

- A check inside a route handler or server component fires on the first request to that one page, and any route that forgets to call it is unguarded. That is exactly the "not what this is" case.
- `middleware.ts` module scope is evaluated lazily by the Edge runtime, so a misconfigured server still comes up and only fails once traffic arrives. Worse, `process.env` reads in the Edge bundle can be inlined at **build** time, so a copy of the check there would be judging the build's environment rather than the container's. I deliberately did **not** duplicate the guard there and said so in a comment, because a security control that might silently be a no-op is worse than none.
- `app/layout.tsx` module scope runs at render time and is prerendered at build time, so it says nothing about the environment the container is finally started with.

The guard prints the message and calls `process.exit(1)` rather than relying on a thrown instrumentation error: Next logs such an error, but its exact behaviour is not a contract I want a security control resting on. Exiting non-zero means ECS / Cloud Run / Kubernetes / Compose show a crash-looping task with the reason in its logs, which is what an operator mid-deploy needs.

`next build` is exempt (`NEXT_PHASE === "phase-production-build"`). A build serves no requests, and `.github/workflows/ci.yml` builds through the escape hatch on purpose because CI holds no Clerk keys. The artifact that build produces is checked when it boots, which is where the exposure actually is.

## The opt-in mechanism, and why this shape

Disabling authentication in a production build now takes **two** variables:

| Variable | Meaning |
|---|---|
| `TALLY_DEV_TENANT` | pins the tenant (unchanged) |
| `TALLY_ALLOW_INSECURE_NO_AUTH` | "yes, serve this with no authentication" |

`TALLY_DEV_TENANT` alone in a production build is a hard boot failure. Both together are allowed and print a standing warning on **every** boot.

Reasoning:

- The failure mode being fixed is an operator who copies a working configuration without understanding what one of its variables does. A second variable does not fix that on its own; a second variable whose name is a sentence about the consequence does. Nobody sets `TALLY_ALLOW_INSECURE_NO_AUTH=1` while believing they are configuring a tenant.
- It keeps `TALLY_DEV_TENANT`'s meaning unchanged, so the four legitimate users of the flag need no migration and no existing doc becomes wrong.
- The alternative I rejected was inverting the flag (make the demo pass a `TALLY_PUBLIC_DEMO=1` that also implies the tenant). That couples "which tenant" to "no auth", which is precisely the conflation that caused this bug: they are two decisions and should stay two variables.
- The demo keeps working **and** stops being a silent trap: `deploy/demo/deploy.sh` and `reseed.sh` set both variables through one shared `pin_dashboard_tenant` helper in `lib-tenant.sh` (the file that exists so those two scripts cannot drift), the compose overlay passes the opt-in through with a comment saying not to carry it into a real deployment, and the running container logs the warning banner forever.

The four legitimate users are untouched: `next dev` (`NODE_ENV=development`), CI, the vitest suite (`NODE_ENV=test`, and it pins `TALLY_DEV_TENANT` in `vitest.config.ts`), and the demo kit.

## The failure message

Verbatim, as printed by a real production build started with the bad configuration:

```
================================================================================
ai-tally REFUSES TO START: TALLY_DEV_TENANT is set in a production build.

TALLY_DEV_TENANT is the development escape hatch, and it disables authentication
COMPLETELY. With it set, the Clerk middleware becomes a pass-through, no
ClerkProvider is mounted, the tenant is pinned to

    00000000-0000-0000-0000-000000000000

instead of being resolved from a signed-in organization, and every visitor is
treated as an org admin who can mint, rotate and revoke API keys. Anyone who has
the URL sees every number in the system and can act on it.

There is no safe fallback here, so this process stops instead of serving.

You are in ONE OF TWO situations:

  1. You want a REAL, authenticated deployment. This is the normal case.

     Unset TALLY_DEV_TENANT (or set it to the empty string) and configure Clerk:

         NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
         CLERK_SECRET_KEY=sk_live_...

     The tenant then resolves from the signed-in Clerk organization, per
     web/lib/getTenant.ts.

     If you copied deploy/demo/, that export is the line to delete. The demo kit
     sets TALLY_DEV_TENANT deliberately and is NOT a template for a real
     instance: it serves synthetic data behind Caddy basic auth.

  2. You genuinely want an UNAUTHENTICATED instance, the way the public demo is.

     Then say so, explicitly, alongside TALLY_DEV_TENANT:

         TALLY_ALLOW_INSECURE_NO_AUTH=1

     Only do this behind access control you supply yourself, and only with
     synthetic data. deploy/demo/deploy.sh and deploy/demo/reseed.sh set it for
     you; you do not need to add it by hand there.

Checked: NODE_ENV=production, TALLY_DEV_TENANT set, TALLY_ALLOW_INSECURE_NO_AUTH not set.
================================================================================
```

The opted-in case prints a shorter banner headed `ai-tally WARNING: serving with NO AUTHENTICATION.` and then serves.

It follows `deploy/demo/lib-tenant.sh`: name the cause, say outright that there is no safe fallback, and give ordered, concrete fixes.

## The gateway: follow-up, not this PR

`TALLY_REQUIRE_API_KEY=false` is the same shape of hazard on the gateway (open ingest and an open control plane), and it has no production guard either. `infra/gateway/src/gateway/app.py:286` guards only the narrower "auth on but no service token" case, correctly, at boot.

I am leaving it to a follow-up, deliberately:

1. **There is nothing to test against.** `infra/gateway/src/gateway/config.py` has no environment notion at all: no `NODE_ENV` equivalent, no deploy-environment field. Guarding it means introducing a deployment-environment concept for the gateway (a `TALLY_ENV`, or deriving it from something else), which is a design decision with its own blast radius across every gateway setting, not a line of code.
2. **Auth-off is a supported gateway configuration somewhere.** `infra/edge-proxy/README.md` documents `EDGE_PROXY_TENANT_ID` as "Required when the gateway runs with auth disabled". I am not going to break that combination blind, and working out which deployments legitimately rely on it is the first task of that follow-up.
3. Keeping this PR to the web tier keeps it reviewable, and the web tier is where the reported exposure is: an unauthenticated *dashboard* URL.

## What I proved by running, and what is only unit tested

**Proved by running** (all against a real `next build`, on port 3047):

- Bad configuration refuses to boot. `NODE_ENV=production` + `TALLY_DEV_TENANT`, no opt-in: `npx next start` printed the message above and **exited 1**. It never bound the port, never served a request.
- Same against the real production artifact: a standalone build (`NEXT_PRIVATE_STANDALONE=true`, what both Dockerfiles run) started with `node server.js` and the same env also printed and exited 1. Confirmed `instrumentation.js` and `edge-instrumentation.js` are emitted into `.next/standalone/.next/server/`.
- Good configuration with the opt-in comes up. Both `next start` and the standalone `node server.js` with `TALLY_ALLOW_INSECURE_NO_AUTH=1` reached `Ready`, served `GET /` with **HTTP 200**, and logged the no-auth warning banner (twice: once per runtime, Node and Edge).
- Production with **neither** variable comes up: `Ready`, guard silent. `GET /` then 500s on Clerk's `Missing publishableKey`, which is the pre-existing and fail-closed behaviour of an instance with no Clerk keys, not the guard.
- `next dev` with `TALLY_DEV_TENANT` set: `Ready`, `GET /` 200, zero guard output. The `make up` path is unaffected.
- `npm run build` with `TALLY_DEV_TENANT` set (exactly CI's build step): succeeds. The build-phase exemption works.
- Demo path: `bash -n` clean on all three scripts; a harness sourced `lib-tenant.sh` with a stubbed `docker` and showed `pin_dashboard_tenant` exporting both variables and issuing `... up -d web`; and `docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml config` renders the `web` service with **both** `TALLY_DEV_TENANT` and `TALLY_ALLOW_INSECURE_NO_AUTH: "1"`. Combined with the standalone-server boot proof above (that container runs exactly that binary with exactly those variables), that is the demo path end to end.
- `deploy/aws/ecs/web.taskdef.json` still parses as JSON; the touched YAML files still parse.

**Not run, and why:** I did not stand up the full demo stack. `deploy.sh` builds every image, seeds Postgres and ClickHouse, and backfills 30 days of spans through a throwaway container, and it needs a `deploy/demo/.env` with a domain and a bcrypt basic-auth hash that does not exist here. I exercised the scripts' tenant and env handling instead, which is the part this PR changes. I also did not run `helm template` or `helm lint` (helm is not installed on this machine); the chart edits are a values key plus a ConfigMap line following the pattern immediately above them, and the values files parse.

**Unit tested only** (`web/lib/authGuard.test.ts`, 14 tests): the full decision table, including production + dev tenant + no opt-in fails; production + both succeeds; development + dev tenant succeeds; test env succeeds; production with neither succeeds; the build phase is exempt; empty and whitespace `TALLY_DEV_TENANT` counts as unset (the manifests set it to `""`); the opt-in accepts the same truthy spellings `deploy/demo/lib-tenant.sh` accepts and treats `0` / `false` / `off` as no consent; and the message names both variables, the pinned tenant, the consequence, and a fix for each situation.

## Verification

- `cd web && npm run typecheck && npm run lint && npm run test`: typecheck clean, lint shows only the pre-existing `lib/useLivePoll.ts:94` warning (left alone), **815 passed / 66 files** (baseline 801 / 65, plus this PR's 14 tests in 1 file).
- Gateway untouched, so its suite was not run.

## Docs and manifests updated

`RUNNING.md`, `deploy/aws/README.md`, `deploy/gcp/README.md`, `deploy/vercel/README.md`, `deploy/demo/README.md` (contract plus a troubleshooting entry for the crash-loop), `web/.env.example`, and the manifests themselves: `deploy/aws/ecs/web.taskdef.json`, `deploy/gcp/cloudrun/web.service.yaml`, both `web-configmap.yaml`, both `values.yaml`, both example values files, and `deploy/demo/docker-compose.prod.yml`.

One note for the Vercel doc: the trigger is `NODE_ENV=production`, which on Vercel covers **Preview** deployments as well as Production. A preview URL is public too, so that is deliberate and the README now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
