### PR TITLE
fix(web): stop attribution revenue fanning out across the span join, and typecheck examples/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
         run: npm ci
       - name: Typecheck
         run: npm run typecheck
+      # #341: examples/ is outside web/tsconfig.json's include, so nothing compiled the example
+      # scripts. They run under `tsx`, not a bundler, and examples/tsconfig.json is written to match
+      # that; it borrows this job's TypeScript rather than adding a second lockfile for two files.
+      - name: Typecheck examples
+        run: npx tsc -p ../examples/tsconfig.json
       - name: Lint
         run: npm run lint
       - name: Test

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Typecheck scope for the standalone example scripts (#341).
+//
+// These files sat outside every CI check: web/tsconfig.json includes only paths under web/, and
+// `npm run typecheck` there is the repo's only TypeScript check, so nothing compiled
+// examples/vercel-chatbot/scripts/*.ts. That is not hypothetical. backfill-spans.ts has carried two
+// real bugs that review caught and CI could not (#315: a 503 {"status":"retry"} treated as fatal,
+// losing a run at 450,000 of 512,056 spans; #324: a bounded per-batch retry budget that turned a
+// gateway-down run into roughly four days while the progress lines counted undelivered spans as
+// posted).
+//
+// The options below describe how these files actually EXECUTE, which is `pnpm exec tsx <file>`
+// (infra/Makefile chatbot-demo-backfill, examples/vercel-chatbot/run.sh), not a bundle:
+//
+//   * `module`/`moduleResolution: bundler` matches tsx's esbuild-based resolution, which is what
+//     lets `import { postEmbeddingSpan } from "../app/lib/tally"` resolve without a file extension.
+//     Node's own ESM resolver would reject that, and "node16" here would report an error the
+//     runtime does not have.
+//   * `isolatedModules` is the truth about tsx: it transpiles file by file and erases types without
+//     a type checker, so anything that needs cross-file type information at emit time is a bug.
+//   * `lib` is ES only and `types` is node only. Inheriting web's DOM lib would let a browser-only
+//     API typecheck happily in a script that runs under node and would crash there.
+//
+// `typeRoots` points into web/node_modules because that is where the repo's single TypeScript
+// toolchain lives; the CI job runs this config from web/ after its `npm ci`. Giving examples/ its
+// own package.json and lockfile would add a second dependency surface to keep current for two
+// scripts, which buys nothing that this line does not.
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "typeRoots": ["../web/node_modules/@types"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  // The vendored Next.js app under vercel-chatbot/app is upstream's, with its own toolchain and its
+  // own dependencies, and is deliberately not checked here. Only the scripts we wrote are.
+  "include": ["vercel-chatbot/scripts/**/*.ts"]
+}

--- a/web/lib/clickhouse.test.ts
+++ b/web/lib/clickhouse.test.ts
@@ -1327,3 +1327,142 @@ describe("otel_spans read paths dedupe (#314)", () => {
     }
   });
 });
+
+// #340: the attribution revenue query must not fan revenue out across the span join, and must not
+// convert micro-USD to dollars inside SQL.
+//
+// The fan-out property (a user with N spans contributes their revenue ONCE, not N times) is a
+// property of how the SQL joins, so it is asserted against the SQL the builder emits rather than
+// against mocked rows: a mock can only hand back whatever numbers the test author invented, and
+// would have passed just as happily on the broken query. The check below is run against the
+// PRE-FIX query text too, so a change that reintroduces the old shape fails here.
+describe("attributionRevenueSql: no fan-out, no float dollars (#340)", () => {
+  const OPTS = {
+    policy: { sources: null, includeMrr: true },
+    windowSql: "now() - INTERVAL 30 DAY",
+    providerExpr: "coalesce(nullIf(s.GenAiSystem, ''), 'unknown')",
+    spanFilterSql: "",
+  };
+
+  // The query as it stood before this fix, kept verbatim as the negative fixture. It sums
+  // ValueAmountMicro straight across the one-to-many join and divides by 1e6 in SQL.
+  const PRE_FIX_SQL = `SELECT
+     coalesce(nullIf(s.GenAiSystem, ''), 'unknown') AS provider,
+     (sumIf(ifNull(b.ValueAmountMicro, 0), b.ValueType IN {positiveTypes:Array(String)})
+        - sumIf(abs(ifNull(b.ValueAmountMicro, 0)), b.ValueType = {refundType:String}))
+       / 1000000 AS revenue,
+     uniqExactIf(b.UserIdHash, b.ValueType IN {positiveTypes:Array(String)}) AS users
+   FROM business_events b
+   INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
+   WHERE b.TenantId = {tenant:String}
+   GROUP BY provider`;
+
+  /** The subquery text that reads business_events, or null when it is read at the top level. */
+  function businessEventsScope(sql: string): string | null {
+    const at = sql.indexOf("business_events");
+    if (at < 0) return null;
+    // Walk back to the innermost unclosed "(" before the read, then forward to its match.
+    let depth = 0;
+    let open = -1;
+    for (let i = at; i >= 0; i--) {
+      if (sql[i] === ")") depth++;
+      else if (sql[i] === "(") {
+        if (depth === 0) {
+          open = i;
+          break;
+        }
+        depth--;
+      }
+    }
+    if (open < 0) return null;
+    let close = -1;
+    depth = 0;
+    for (let i = open; i < sql.length; i++) {
+      if (sql[i] === "(") depth++;
+      else if (sql[i] === ")" && --depth === 0) {
+        close = i;
+        break;
+      }
+    }
+    return close < 0 ? null : sql.slice(open, close + 1);
+  }
+
+  /**
+   * Revenue is summed over a per-user pre-aggregate, so it cannot be multiplied by a span count.
+   * Two things make that true: business_events is read inside its own subquery that never mentions
+   * otel_spans, and that subquery collapses to one row per user with GROUP BY.
+   */
+  function fanoutSafe(sql: string): boolean {
+    const scope = businessEventsScope(sql);
+    if (scope === null) return false;
+    if (/otel_spans/i.test(scope)) return false;
+    return /GROUP\s+BY\s+user_hash\b/i.test(scope);
+  }
+
+  it("flags the pre-fix query, which summed revenue across the span join", () => {
+    expect(fanoutSafe(PRE_FIX_SQL)).toBe(false);
+  });
+
+  it("aggregates business_events per user before joining spans", async () => {
+    const { attributionRevenueSql } = await freshSut();
+    expect(fanoutSafe(attributionRevenueSql(OPTS).sql)).toBe(true);
+  });
+
+  it("joins the DISTINCT (user, provider) pairs, so the provider dimension survives", async () => {
+    const { attributionRevenueSql } = await freshSut();
+    const { sql } = attributionRevenueSql(OPTS);
+    // The span side is still there (it is what attributes revenue to a provider) but reduced to
+    // one row per user per provider, and still deduped with FINAL.
+    expect(sql).toMatch(/SELECT\s+DISTINCT\s+s\.UserIdHash\s+AS\s+user_hash/);
+    expect(sql).toMatch(/FROM\s+otel_spans\s+s\s+FINAL/);
+    expect(sql).toMatch(/GROUP\s+BY\s+provider/);
+  });
+
+  it("returns integer micro-USD, never dollars", async () => {
+    const { attributionRevenueSql } = await freshSut();
+    const { sql } = attributionRevenueSql(OPTS);
+    expect(sql).not.toMatch(/\/\s*1000000/);
+    expect(sql).not.toMatch(/\/\s*1e6/i);
+    expect(PRE_FIX_SQL).toMatch(/\/\s*1000000/); // the fixture really does carry the defect
+  });
+
+  it("keeps the refund subtraction and the money-typed user count", async () => {
+    const { attributionRevenueSql } = await freshSut();
+    const { sql, params } = attributionRevenueSql(OPTS);
+    expect(sql).toContain("{refundType:String}");
+    expect(sql).toMatch(/uniqExactIf\(r\.user_hash, r\.revenue_events > 0\)/);
+    expect(params.positiveTypes).toEqual(["monetary", "mrr"]);
+    expect(params.refundType).toBe("refund");
+  });
+
+  it("drops mrr from the positive types when the tenant excludes it", async () => {
+    const { attributionRevenueSql } = await freshSut();
+    const { params } = attributionRevenueSql({
+      ...OPTS,
+      policy: { sources: null, includeMrr: false },
+    });
+    expect(params.positiveTypes).toEqual(["monetary"]);
+  });
+});
+
+// #340: the caller must read that column as micro-USD. Feeding an already-micro value to micro()
+// would multiply it by 1e6 a second time, the mirror image of the SQL-side divide.
+describe("queryAttribution reads revenue as micro-USD (#340)", () => {
+  it("passes ClickHouse's integer micro-USD through unscaled", async () => {
+    const { queryAttribution } = await freshSut();
+    // sessions, conversions, revenue, daily, bounds: the five reads queryAttribution issues.
+    respondRows([{ provider: "openai", sessions: "10", cost: "1.5", unpriced: "0" }]);
+    respondRows([{ provider: "openai", conversions: "4" }]);
+    respondRows([{ provider: "openai", revenue: "3596171155434", users: "10053" }]);
+    respondRows([]);
+    respondRows([{ start: "2026-08-10" }]);
+
+    const out = await queryAttribution({ tag: null, provider: null, outcome: null });
+    expect(out).not.toBeNull();
+    const openai = out!.perProvider.find((p) => p.provider === "openai");
+    // Value/user is revenue/users straight out of micro-USD. Had the row been fed through micro(),
+    // this would read 1e6 times larger: $357.72 per user, not $357,721,193.
+    expect(openai?.valuePerUserMicroUsd).toBe(Math.round(3_596_171_155_434 / 10053));
+    expect(openai?.valuePerUserMicroUsd).toBeLessThan(1_000_000_000);
+  });
+});

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -105,6 +105,7 @@ import {
 import type { GuardrailMode, GuardrailRule, GuardrailScopeKind } from "./guardrails";
 import {
   REFUND_VALUE_TYPE,
+  type RevenuePolicy,
   positiveValueTypes,
   queryRevenuePolicy,
   revenueSourceFilter,
@@ -201,6 +202,20 @@ export function microOrNull(decimalUsd: string | number | null | undefined): num
   if (decimalUsd === null || decimalUsd === undefined || decimalUsd === "\\N") return null;
   const n = typeof decimalUsd === "number" ? decimalUsd : parseFloat(decimalUsd);
   return Number.isFinite(n) ? Math.round(n * 1_000_000) : null;
+}
+
+/**
+ * A ClickHouse integer column -> JS number, with no unit conversion.
+ *
+ * #340. The counterpart to `micro()` for columns that are ALREADY integer micro-USD: the money
+ * invariant is integer micro-USD end to end, converted at the boundary only, so a query that sums
+ * `ValueAmountMicro` must not divide by 1e6 in SQL and must not be re-multiplied here. ClickHouse
+ * serialises Int64 as a JSON string (output_format_json_quote_64bit_integers), so the string form
+ * is the normal one, not an edge case.
+ */
+function int(v: string | number | null | undefined): number {
+  const n = typeof v === "number" ? v : parseInt(v ?? "0", 10);
+  return Number.isFinite(n) ? n : 0;
 }
 
 function zeroLayers(): SpendByLayer {
@@ -2895,6 +2910,90 @@ export async function querySpanFeatureTags(days?: number): Promise<string[] | nu
   });
 }
 
+/**
+ * Per-provider revenue for the attribution report: SQL plus the parameters it binds (#340).
+ *
+ * Extracted from queryAttribution so the shape can be asserted in a unit test. It fixes two defects
+ * that shipped together and had to be fixed together, because the first one is what made the second
+ * one look harmless.
+ *
+ * 1. JOIN FAN-OUT. The previous query summed `b.ValueAmountMicro` straight across
+ *    `business_events b INNER JOIN otel_spans s ON s.UserIdHash = b.UserIdHash`. The join is
+ *    one-to-many by construction (a user has many spans), so every business event was summed once
+ *    per matching span: a user with 30 spans contributed their revenue 30 times. FINAL removed the
+ *    DUPLICATE-span multiplier only, and the real span count stayed. The sibling conversions query
+ *    survives the identical join because `uniqExact(b.BusinessEventId)` collapses the fan-out; a
+ *    `sum` cannot. On the local demo corpus this inflated per-provider revenue by up to 2.5x.
+ *
+ *    The fix keeps BOTH sides of the join, because the join is what does the attribution: it is the
+ *    only thing that says which provider served the user who paid. Instead of de-duplicating the
+ *    result it de-duplicates the INPUTS. Revenue is aggregated per user before anything is joined,
+ *    and the span side is reduced to the DISTINCT (user, provider) pairs it was really contributing.
+ *    Each (user, provider) pair therefore contributes that user's revenue exactly once, whether the
+ *    user has one span or thirty thousand. The per-provider dimension is untouched, and a user
+ *    served by two providers still counts under both, which is the same attribution rule the
+ *    conversions query has always applied (the panel compares providers, it does not sum them).
+ *
+ * 2. FLOAT DOLLARS IN SQL. The old expression ended `/ 1000000 AS revenue`, doing the micro-USD
+ *    conversion inside ClickHouse and handing JS a float. Money is integer micro-USD end to end and
+ *    is converted at the boundary only, so this returns micro-USD and the caller parses it as an
+ *    integer. There is deliberately no micro() on the result.
+ *
+ * `users` still counts only users carrying a revenue-typed event, so a user whose only event is a
+ * 'count' engagement signal cannot dilute value/user into a fabricated number. `ValueAmountMicro`
+ * is Nullable(Int64), so each sumIf zero-fills with `ifNull(..., 0)`: without it a tenant with no
+ * refunds gets NULL from the refund term and the NULL swallows the whole subtraction.
+ */
+export function attributionRevenueSql(opts: {
+  policy: RevenuePolicy;
+  /** SQL expression for the window start, e.g. `now() - INTERVAL 30 DAY`. */
+  windowSql: string;
+  /** Provider expression over the `s` alias, shared with the sessions/conversions queries. */
+  providerExpr: string;
+  /** Tag / feature / provider narrowing fragments, all written against the `s` alias. */
+  spanFilterSql: string;
+}): { sql: string; params: Record<string, unknown> } {
+  const { policy, windowSql, providerExpr, spanFilterSql } = opts;
+  const positiveTypes = positiveValueTypes(policy);
+  const sourceFilter = revenueSourceFilter(policy, "b");
+  const moneyTyped =
+    "(b.ValueType IN {positiveTypes:Array(String)} OR b.ValueType = {refundType:String})";
+
+  return {
+    sql: `SELECT
+         u.provider                                      AS provider,
+         sum(r.revenue_micro)                            AS revenue,
+         uniqExactIf(r.user_hash, r.revenue_events > 0)  AS users
+       FROM (
+         SELECT
+           b.UserIdHash AS user_hash,
+           sumIf(ifNull(b.ValueAmountMicro, 0), b.ValueType IN {positiveTypes:Array(String)})
+             - sumIf(abs(ifNull(b.ValueAmountMicro, 0)), b.ValueType = {refundType:String})
+             AS revenue_micro,
+           countIf(${moneyTyped}) AS revenue_events
+         FROM business_events b
+         WHERE b.TenantId = {tenant:String}
+           AND b.OccurredAt >= ${windowSql}
+           AND b.UserIdHash != ''
+           ${sourceFilter.sql}
+         GROUP BY user_hash
+       ) AS r
+       INNER JOIN (
+         SELECT DISTINCT s.UserIdHash AS user_hash, ${providerExpr} AS provider
+         FROM otel_spans s FINAL
+         WHERE s.TenantId = {tenant:String}
+           AND s.UserIdHash != ''
+           ${spanFilterSql}
+       ) AS u ON u.user_hash = r.user_hash
+       GROUP BY provider`,
+    params: {
+      positiveTypes,
+      refundType: REFUND_VALUE_TYPE,
+      ...sourceFilter.params,
+    },
+  };
+}
+
 export async function queryAttribution(
   filters: AttributionFilters,
   query?: AttributionQuery,
@@ -2987,70 +3086,37 @@ export async function queryAttribution(
     // refunds, which net off rather than being ignored. Source is now only ever a per-tenant
     // NARROWING, and absent config means every source counts (see lib/revenueSources.ts).
     //
-    // `users` counts only users who actually carry a revenue-typed event; a user whose only event
-    // is a 'count' engagement signal must not dilute value/user into a fabricated number.
-    //
-    // ValueAmountMicro is Nullable(Int64), so `sumIf` over a group with no matching row yields NULL
-    // rather than 0 and the NULL then swallows the whole subtraction. The `ifNull(..., 0)` inside
-    // each sumIf is what keeps a tenant with zero refunds from reporting NULL revenue.
-    //
-    // KNOWN WRONG, SEPARATELY (both predate #314 / CTO-245, do not read the FINAL below as a fix):
-    //
-    // 1. Join fan-out. This sums b.ValueAmountMicro across an INNER JOIN on otel_spans, so a
-    //    business event is counted once per matching span for that user: a user with 30 spans
-    //    contributes their revenue 30 times. FINAL removes the DUPLICATE-SPAN multiplier and nothing
-    //    else, so the figure stays inflated by the real span count. The sibling conversions query
-    //    above survives the same join only because uniqExact collapses the fan-out; a sum cannot.
-    //    The fix is to aggregate business_events before joining (or drop the join and filter users
-    //    by a subquery), which changes the number this panel shows and needs its own change.
-    // 2. Float dollars in SQL. The `/ 1000000` divides integer micro-USD inside ClickHouse, so the
-    //    value arrives already converted and already floating, against the money invariant (integer
-    //    micro-USD end to end, converted at the boundary only). It should return micro-USD and let
-    //    micro() do the conversion.
-    const positiveTypes = positiveValueTypes(policy);
-    const sourceFilter = revenueSourceFilter(policy, "b");
+    // #340 fixed two defects that predate #314 / CTO-245 (the FINAL there was never a fix for
+    // either): the join fanned revenue out by span count, and the query divided micro-USD by 1e6
+    // inside SQL. Both live in attributionRevenueSql() now; see the note there.
+    const revenue = attributionRevenueSql({
+      policy,
+      windowSql,
+      providerExpr,
+      spanFilterSql: `${tagSql}
+           ${featureSql}
+           ${providerSql}`,
+    });
     const revenueRows = await rowsP<{
       provider: string;
-      revenue: string;
-      users: string;
-    }>(
-      db,
-      `SELECT
-         ${providerExpr} AS provider,
-         (sumIf(ifNull(b.ValueAmountMicro, 0), b.ValueType IN {positiveTypes:Array(String)})
-            - sumIf(abs(ifNull(b.ValueAmountMicro, 0)), b.ValueType = {refundType:String}))
-           / 1000000 AS revenue,
-         uniqExactIf(
-           b.UserIdHash,
-           b.ValueType IN {positiveTypes:Array(String)} OR b.ValueType = {refundType:String}
-         ) AS users
-       FROM business_events b
-       INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
-       WHERE b.TenantId = {tenant:String}
-         AND b.OccurredAt >= ${windowSql}
-         AND b.UserIdHash != ''
-         ${sourceFilter.sql}
-         ${tagSql}
-         ${featureSql}
-         ${providerSql}
-       GROUP BY provider`,
-      {
-        tenant,
-        tag: filters.tag ?? "",
-        provider: filters.provider ?? "",
-        features: featureValues,
-        positiveTypes,
-        refundType: REFUND_VALUE_TYPE,
-        ...sourceFilter.params,
-      },
-    );
+      revenue: string | number | null;
+      users: string | number | null;
+    }>(db, revenue.sql, {
+      tenant,
+      tag: filters.tag ?? "",
+      provider: filters.provider ?? "",
+      features: featureValues,
+      ...revenue.params,
+    });
     const revenueByProvider = new Map<
       string,
       { revenueMicroUsd: number; distinctUsers: number }
     >();
     for (const r of revenueRows) {
-      const users = parseInt(r.users, 10) || 0;
-      const revenueMicroUsd = micro(r.revenue);
+      const users = int(r.users);
+      // #340: `revenue` is integer micro-USD off the wire. No micro() here: converting a value that
+      // is already in micro-USD would multiply it by 1e6 a second time.
+      const revenueMicroUsd = int(r.revenue);
       if (users > 0) {
         revenueByProvider.set(r.provider, { revenueMicroUsd, distinctUsers: users });
       }


### PR DESCRIPTION
Stacked on #345 (`fix/dev-tenant-production-guard`) and targets that branch, not `main`. Do not merge before it.

Two independent tickets: #340 (attribution revenue is inflated and float) and #341 (examples/ has no CI coverage).

## The revenue number on /attribution drops, a lot

**This changes what the panel shows, downward, and that is the point.** Measured on the live local stack over the same rolling 30-day window, before and after, per provider:

### `local-dev`

| provider | before | after | change |
|---|---:|---:|---:|
| anthropic | $6,718,708.46 | $2,682,801.48 | -60.1% |
| openai | $8,931,546.36 | $3,595,945.96 | -59.7% |
| **total** | **$15,650,254.82** | **$6,278,747.45** | **-59.9%** |

### `38a6c264-9ca4-411c-92bb-b75433fe509c`

| provider | before | after | change |
|---|---:|---:|---:|
| anthropic | $1,816,695.44 | $716,429.10 | -60.6% |
| brave | $69,370.45 | $69,370.45 | 0.0% |
| exa | $63,611.38 | $63,611.38 | 0.0% |
| firecrawl | $62,698.80 | $62,657.98 | -0.1% |
| google | $555,522.61 | $226,411.13 | -59.2% |
| openai | $2,802,410.15 | $1,172,681.63 | -58.2% |
| pinecone | $1,189,736.52 | $831,484.56 | -30.1% |
| qdrant | $610,224.39 | $504,178.34 | -17.4% |
| serpapi | $73,679.46 | $73,583.56 | -0.1% |
| tavily | $67,757.14 | $67,711.61 | -0.1% |
| weaviate | $602,436.01 | $508,515.46 | -15.6% |
| **total** | **$7,914,142.34** | **$4,296,635.21** | **-45.7%** |

### `live-cto219`

Nothing to report, and reporting zero would be dishonest: the tenant has 60,000 `business_events` and **none of them are money-typed** (every `ValueAmountMicro` is NULL, they are `count` engagement signals). Both the old and the new query return no money-typed users for it, so the panel's Value/user and Margin/user cells were blank before and are blank now. That is the correct state, not a regression and not a zero.

The size of the drop is the size of the bug: revenue was being multiplied by each user's span count. The rows that barely move (brave, exa, serpapi, tavily) are the providers whose users have roughly one span each, which is exactly what the fan-out model predicts.

One user, concretely, on `local-dev`: user `1528b746...` has 4 openai spans and $501.53 of revenue. Before, they contributed $2,006.10 to openai. After, $501.53.

**No figure in `RUNNING.md` or `docs/` needed correcting.** I checked: the $52,400 target quoted in the backfill section is the LLM cost layer, not revenue, and the `/attribution` walkthrough describes the Value/user and Margin/user columns without quoting a number.

## #340, defect 1: join fan-out

The query was:

```sql
FROM business_events b
INNER JOIN otel_spans s FINAL ON s.UserIdHash = b.UserIdHash AND s.TenantId = b.TenantId
```

aggregating with `sumIf(ifNull(b.ValueAmountMicro, 0), ...)`. That join is one-to-many by construction, so each business event was summed once per matching span: a user with 30 spans contributed their revenue 30 times. The `FINAL` from #314 removed the *duplicate*-span multiplier only; the real span count stayed. The sibling conversions query survives the identical join because `uniqExact(b.BusinessEventId)` collapses the fan-out. A `sum` cannot.

**The approach, and why per-provider attribution survives.** The join stays, because the join *is* the attribution: it is the only thing that says which provider served the user who paid. Dropping it would give one global revenue number and no provider column. Instead of de-duplicating the *result*, this de-duplicates the *inputs*:

- `business_events` is aggregated to one row per user (revenue, refunds netted off, and a money-typed event count) before anything is joined.
- The span side becomes the `SELECT DISTINCT (UserIdHash, provider)` pairs it was really contributing, still read with `FINAL`.

Each (user, provider) pair therefore carries that user's revenue exactly once, whether the user has one span or thirty thousand. A user served by two providers still counts under both, which is the same rule the conversions query has always applied and the right one for a panel that compares providers rather than summing them.

## #340, defect 2: float dollars in SQL

The same expression ended `/ 1000000 AS revenue`, doing the micro-USD conversion inside ClickHouse and handing JS a float, against the money invariant. It now returns integer micro-USD.

**Every consumer updated coherently.** That column has exactly one consumer, the fold in `queryAttribution` that built `revenueByProvider`; it used `micro(r.revenue)` and now parses the integer directly. Nothing downstream of `revenueMicroUsd` changed: `buildProviderRow` already worked in micro-USD, and the `<Money>` boundary is where dollars appear. Feeding an already-micro value to `micro()` would have multiplied it by 1e6 a second time, so there is a test pinning value/user to a sane magnitude.

## Sibling queries: checked

- **`queryAttribution` conversions query** (same join, immediately above): correct as-is. `uniqExact(b.BusinessEventId)` is fan-out proof, and it returns a count, not money. Unchanged.
- **`accountRevenueSql` (`web/lib/accountRevenue.ts`)**: has neither defect. No join at all, and it already keeps micro-USD end to end with no divide by 1e6.
- **The `attribution_records` reads (~line 1840)**: no fan-out. They join `business_events` on `BusinessEventId`, which is 1:1, both sides `FINAL`, and sum `ValueAmountMicro` in micro-USD.
- Those are the only `JOIN otel_spans` / `JOIN business_events` sites in `web/`, and line 3022 was the only `/ 1000000` on money in a query (the other in-SQL divide, `DurationNs / 1e6`, is nanoseconds to milliseconds).

Noted but deliberately **not** fixed here: the revenue read does not say `FINAL` on `business_events`, which is also a `ReplacingMergeTree`. Neither does `accountRevenueSql`. That is a third, separate defect with its own blast radius on the numbers, and folding it in would make this PR's before/after measurement unreadable.

## The `FINAL` guard

`web/lib/clickhouse.test.ts` still passes with no new exemptions. The rewritten span side is `FROM otel_spans s FINAL`, which the guard already recognises.

## Tests

822 passed / 66 files, up from the 815 / 66 baseline on #345. One pre-existing lint warning at `lib/useLivePoll.ts:94`, left alone.

The fan-out property (a user with N spans contributes their revenue once, not N times) is a property of how the SQL joins, so it is asserted against the SQL the builder emits, not against mocked rows: a mock only ever returns numbers the test author invented, and would have passed just as happily on the broken query. The revenue SQL is extracted into an exported `attributionRevenueSql()` and the test checks that `business_events` is read inside a subquery that never mentions `otel_spans` and collapses to one row per user with `GROUP BY`. **The same check is run against the pre-fix query text**, kept verbatim as a fixture, and must flag it, so a regression to the old shape fails the build. The numeric proof of the property is the live-stack measurement above.

## #341: examples/ has no CI coverage

`web/tsconfig.json` includes only paths under `web/`, and `npm run typecheck` there is the repo's only TypeScript check, so `examples/vercel-chatbot/scripts/*.ts` compiled in no job. Not hypothetical: that file lost a run at 450,000 of 512,056 spans by treating a `503 {"status":"retry"}` as fatal (#315), and made a gateway-down run take roughly four days while its progress lines counted undelivered spans as posted (#324). Review caught both.

**Decision: its own tsconfig, as a step in the existing web job.**

Its own tsconfig, because the scripts run under `tsx`, not a bundler, and web's config describes a Next app. Extending web's would inherit `jsx`, the DOM lib and the `@/*` paths, and a browser-only API would then typecheck happily in a script that runs under node and would crash there. `examples/tsconfig.json` instead sets bundler resolution (which is what lets `../app/lib/tally` resolve without a file extension, and what Node's own ESM resolver would reject), `isolatedModules` (tsx transpiles file by file with no type checker), and an ES-only lib with node types.

A step in the web job rather than a job of its own, because that borrows the repo's single TypeScript toolchain. A standalone job would need `examples/` to carry a package.json and lockfile, a second dependency surface to keep current for two files. The cost is that an examples-only break reddens the `web` check; the `typeRoots` line pointing into `web/node_modules` is the one wire that arrangement needs, and it is commented.

`examples/vercel-chatbot/app` is upstream's vendored Next app with its own toolchain, and stays out of scope.

**Confirmed the check bites.** With `const __ci_probe: number = "not a number";` appended to `backfill-spans.ts`:

```
../examples/vercel-chatbot/scripts/backfill-spans.ts(1200,7): error TS2322: Type 'string' is not assignable to type 'number'.
exit=2
```

On the same tree, `npm run typecheck` in `web/` was green, which is precisely the gap. The probe has been removed.

## Merge note

This touches `.github/workflows/ci.yml`, and so does the image-build PR in a separate stack. The change here is four added lines inside the existing `web` job's step list and nothing else in that file, so the two should merge cleanly, but they do touch the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
