### PR TITLE
test: close out the unverified paths from #318 (backfill corpus, Anthropic protocol, published-schema fixtures)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -711,6 +711,30 @@ cd infra && make chatbot-demo-backfill
 # tune it: make chatbot-demo-backfill BACKFILL_ARGS="--days 30 --target-usd 52400 --seed 138 --accounts 12"
 ```
 
+Those numbers were inherited and unverified until issue #318; they have now been
+measured. A default run at `--seed 138` against a local stack posted 512,056
+spans and 101,799 events in 1,229 batches with nothing shed, and ClickHouse then
+reported, from the cost the **gateway** recomputed rather than the figure the
+script printed:
+
+| Layer (`GenAiOperation`) | Spans | 30-day cost |
+| --- | ---: | ---: |
+| `chat` (LLM) | 293,352 | **$52,401.67** |
+| `compute` | 150 | $2,351.71 |
+| `tool` | 26,678 | $397.86 |
+| `egress` | 150 | $209.04 |
+| `embeddings` | 35,235 | $88.12 |
+| `vector` | 156,491 | $45.00 |
+| all-in | 512,056 | **$55,493.40** |
+
+So the `~$52,400/mo` claim holds, and the feature mix lands on the documented
+split exactly (54 / 17 / 12 / 10 / 7 percent of LLM spend). The script's own
+printed expectation was `$52,401.56`, 11 cents under what the gateway stored,
+which is per-span rounding rather than catalog drift: the script's rates and
+`seed_catalog` still agree. The run shapes in the table below check out too:
+of 121,660 runs, 4,162 failed without a retry (3.4%), 2,953 failed and were
+retried (2.4%), and 9,914 were deliberately unattributed (8.2%).
+
 The target refuses to run when the `local-dev` tenant UUID does not resolve, and
 prints what to check. It used to drop `--tenant` in that case, which quietly
 wrote 30 days of rows under the tenant NAME that the dashboard (which reads by

--- a/infra/edge-proxy/internal/proxy/provider_anthropic_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_anthropic_test.go
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// CTO-318: the Anthropic protocol through the proxy.
+//
+// The CTO-244/245 end-to-end verification drove only the openai and gemini protocols, so
+// EDGE_PROXY_PROVIDER=anthropic had never been exercised past the one unit assertion in
+// TestOpenAIAndAnthropicMeta. This file drives it end to end and covers the payload variations a
+// real Messages API deployment actually produces.
+//
+// PROVENANCE OF THE FIXTURES, WHICH IS THE POINT. Every file under testdata/anthropic/ is
+// transcribed from Anthropic's PUBLISHED Messages API documentation (the response shape on
+// /en/api/messages, the SSE event sequence on /en/build-with-claude/streaming, and the error
+// envelope on /en/api/errors), not derived from anthropicMeta below. A fixture written by reading
+// our own parser can only ever confirm that the parser agrees with itself; one written from the
+// provider's published schema can actually disagree with it. Ids, token counts and text are
+// illustrative, the field names and nesting are the documented ones.
+//
+// WHAT THIS STILL DOES NOT PROVE. No request in this file reaches api.anthropic.com. The fixtures
+// match the published schema; a real endpoint can still emit a field the docs do not describe, and
+// only real traffic with a real key settles that. See the issue for what remains open.
+
+// readFixture loads a recorded provider payload from testdata/.
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", filepath.FromSlash(name)))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}
+
+// newAnthropicProxy builds an anthropic-protocol proxy in front of the given upstream. Mirrors
+// newGeminiProxy, with EDGE_PROXY_PROVIDER=anthropic so ModifyResponse metadata capture is active.
+func newAnthropicProxy(t *testing.T, upstream http.Handler) (*httptest.Server, *recordingSink) {
+	t.Helper()
+	origin := httptest.NewServer(upstream)
+	t.Cleanup(origin.Close)
+
+	cfg, err := config.FromEnv(func(k string) string {
+		switch k {
+		case "EDGE_PROXY_UPSTREAM":
+			return origin.URL
+		case "EDGE_PROXY_PROVIDER":
+			return "anthropic"
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	sink := &recordingSink{}
+	front := httptest.NewServer(New(cfg, WithSink(sink)))
+	t.Cleanup(front.Close)
+	return front, sink
+}
+
+// TestAnthropicMetaFromPublishedResponses parses each documented non-streaming response shape.
+// The nil cases are the honesty invariant: a payload that carries no usage must leave the counts
+// unknown, never 0, because a 0 reads downstream as a real call that cost nothing.
+func TestAnthropicMetaFromPublishedResponses(t *testing.T) {
+	cases := []struct {
+		fixture    string
+		wantModel  string
+		wantPrompt *int64
+		wantComp   *int64
+	}{
+		// The ordinary completion: both counts present.
+		{"anthropic/message_end_turn.json", "claude-opus-5", ptr(10), ptr(15)},
+		// stop_reason "tool_use": usage is reported exactly as on a text turn, so a tool-calling
+		// turn must meter identically. Nothing about the tool_use content block is retained.
+		{"anthropic/message_tool_use.json", "claude-opus-5", ptr(472), ptr(89)},
+		// A truncated generation is still fully billed input plus what it managed to emit.
+		{"anthropic/message_max_tokens.json", "claude-sonnet-5", ptr(1204), ptr(8)},
+		// A refusal (stop_reason "refusal", empty content) bills the input and produces no output.
+		// The 0 here is the provider's own reported figure, not a proxy-invented one.
+		{"anthropic/message_refusal.json", "claude-opus-5", ptr(331), ptr(0)},
+		// Cache hit: see TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens below.
+		{"anthropic/message_cache_read.json", "claude-opus-5", ptr(21), ptr(44)},
+		// The error envelope carries neither model nor usage. Everything stays unknown.
+		{"anthropic/error_overloaded.json", "", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			meta := extractMeta(config.ProviderAnthropic, "/v1/messages", readFixture(t, tc.fixture))
+			if meta.Model != tc.wantModel {
+				t.Errorf("Model = %q, want %q", meta.Model, tc.wantModel)
+			}
+			assertTokens(t, "PromptTokens", meta.PromptTokens, tc.wantPrompt)
+			assertTokens(t, "CompletionTokens", meta.CompletionTokens, tc.wantComp)
+		})
+	}
+}
+
+// TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens pins a real fidelity limit rather than
+// asserting it away. Anthropic reports cache_read_input_tokens and cache_creation_input_tokens
+// alongside input_tokens, and input_tokens EXCLUDES them, so PromptTokens on a cache hit is the
+// uncached prompt only. That is honest (it is the field the provider labels input tokens) but it
+// is not the whole billable input, and pricing a cached call from this record alone under-reports
+// it. Recording the cache counts is a schema change beyond this proxy, so the test exists to make
+// the gap visible instead of letting a future reader assume the number is complete.
+func TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens(t *testing.T) {
+	meta := extractMeta(config.ProviderAnthropic, "/v1/messages",
+		readFixture(t, "anthropic/message_cache_read.json"))
+	if !tokensEq(meta.PromptTokens, 21) {
+		t.Fatalf("PromptTokens = %s, want 21 (input_tokens only)", tokensStr(meta.PromptTokens))
+	}
+	// If this ever starts reporting 18944 (21 + 18923), the proxy learned about cache tokens and
+	// this test should be replaced by one that asserts the new, richer record.
+	if tokensEq(meta.PromptTokens, 18944) {
+		t.Errorf("cache tokens are now folded into PromptTokens; update this test and the pricing path")
+	}
+}
+
+// TestAnthropicProxyRecordsMetadataAndHidesKey is the end-to-end acceptance: a POST /v1/messages
+// through an anthropic-protocol proxy relays the body byte-for-byte, records the model and token
+// counts, forwards the credential upstream, and keeps that credential out of the TraceRecord.
+func TestAnthropicProxyRecordsMetadataAndHidesKey(t *testing.T) {
+	const secretKey = "sk-ant-api03-super-secret-key"
+	body := readFixture(t, "anthropic/message_end_turn.json")
+
+	var gotAPIKey, gotVersion, gotPath string
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	front, sink := newAnthropicProxy(t, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages",
+		strings.NewReader(`{"model":"claude-opus-5","max_tokens":1024,"messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	// Anthropic authenticates on x-api-key, not Authorization: a different header from the openai
+	// and gemini paths, and the reason this needs its own end-to-end test.
+	req.Header.Set("x-api-key", secretKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if string(got) != string(body) {
+		t.Errorf("response body altered in transit")
+	}
+	if gotAPIKey != secretKey {
+		t.Errorf("upstream x-api-key = %q, want it forwarded untouched", gotAPIKey)
+	}
+	if gotVersion != "2023-06-01" {
+		t.Errorf("upstream anthropic-version = %q, want it forwarded", gotVersion)
+	}
+	if gotPath != "/v1/messages" {
+		t.Errorf("upstream path = %q", gotPath)
+	}
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if rec.Model != "claude-opus-5" {
+		t.Errorf("trace Model = %q, want claude-opus-5", rec.Model)
+	}
+	if !tokensEq(rec.PromptTokens, 10) || !tokensEq(rec.CompletionTokens, 15) {
+		t.Errorf("trace tokens = %s/%s, want 10/15",
+			tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
+	}
+	if rec.StatusCode != http.StatusOK {
+		t.Errorf("trace status = %d", rec.StatusCode)
+	}
+	if s := fmt.Sprintf("%+v", rec); strings.Contains(s, secretKey) || strings.Contains(s, "sk-ant") {
+		t.Errorf("trace record leaked the key: %s", s)
+	}
+}
+
+// TestAnthropicProxyToolUseTurn: a tool-calling turn meters like any other turn, and no part of the
+// tool call (its name, its id, its arguments) reaches the record. Tool arguments are user content.
+func TestAnthropicProxyToolUseTurn(t *testing.T) {
+	body := readFixture(t, "anthropic/message_tool_use.json")
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	front, sink := newAnthropicProxy(t, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages", strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if !tokensEq(rec.PromptTokens, 472) || !tokensEq(rec.CompletionTokens, 89) {
+		t.Errorf("trace tokens = %s/%s, want 472/89",
+			tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
+	}
+	s := fmt.Sprintf("%+v", rec)
+	for _, leak := range []string{"get_weather", "San Francisco", "toolu_"} {
+		if strings.Contains(s, leak) {
+			t.Errorf("trace record leaked tool content %q: %s", leak, s)
+		}
+	}
+}
+
+// TestAnthropicProxyStreamingSSE drives the published SSE event sequence.
+//
+// Two things are asserted, and one gap is recorded honestly. The stream is relayed byte-for-byte,
+// and the metadata stays UNKNOWN rather than being invented: anthropicMeta json.Unmarshals the
+// whole body, an SSE stream is not one JSON document, so the decode fails and the record carries
+// nils. That is the correct failure direction (a nil is a NULL downstream; a 0 would be a lie), but
+// it does mean a streamed Anthropic call is currently unattributed to a model, even though the
+// model and both token counts are right there in the message_start and message_delta events. The
+// gemini path avoids this only because it can recover the model from the request URL, and the
+// Anthropic path has no such fallback. Parsing SSE is a change to provider.go, which this
+// test-only change deliberately does not make; see the issue.
+func TestAnthropicProxyStreamingSSE(t *testing.T) {
+	for _, name := range []string{
+		"anthropic/stream_text.sse",
+		"anthropic/stream_tool_use.sse",
+		"anthropic/stream_midstream_error.sse",
+	} {
+		t.Run(name, func(t *testing.T) {
+			body := readFixture(t, name)
+			upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				// Flush per event so this is a real stream, not one buffered write.
+				for _, chunk := range strings.SplitAfter(string(body), "\n\n") {
+					_, _ = io.WriteString(w, chunk)
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+				}
+			})
+			front, sink := newAnthropicProxy(t, upstream)
+
+			req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages",
+				strings.NewReader(`{"stream":true}`))
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			got, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			if string(got) != string(body) {
+				t.Errorf("SSE stream altered in transit")
+			}
+
+			sink.waitFor(t, 1)
+			rec := sink.last()
+			if rec.StatusCode != http.StatusOK {
+				t.Errorf("trace status = %d, want 200 (a mid-stream error is still a 200 on the wire)",
+					rec.StatusCode)
+			}
+			// The gap, pinned: unknown, and specifically not fabricated.
+			if rec.PromptTokens != nil || rec.CompletionTokens != nil {
+				t.Errorf("streamed usage is not parsed today; expected unknown counts, got %s/%s",
+					tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
+			}
+			if rec.Model != "" {
+				t.Errorf("Model = %q; if the SSE parser landed, replace this test with one that "+
+					"asserts the model and the cumulative message_delta usage", rec.Model)
+			}
+		})
+	}
+}
+
+// TestAnthropicProxyErrorResponse: a 529 error envelope is recorded with its real status and no
+// invented usage. A failed call that reports 0 tokens would show up on the dashboard as a real,
+// free call rather than as a failure.
+func TestAnthropicProxyErrorResponse(t *testing.T) {
+	body := readFixture(t, "anthropic/error_overloaded.json")
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(529)
+		_, _ = w.Write(body)
+	})
+	front, sink := newAnthropicProxy(t, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages", strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != 529 {
+		t.Errorf("status = %d, want 529 relayed unchanged", resp.StatusCode)
+	}
+	if string(got) != string(body) {
+		t.Errorf("error body altered in transit")
+	}
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if rec.StatusCode != 529 {
+		t.Errorf("trace status = %d, want 529", rec.StatusCode)
+	}
+	if rec.Model != "" {
+		t.Errorf("Model = %q, want empty: the error envelope names no model", rec.Model)
+	}
+	if rec.PromptTokens != nil || rec.CompletionTokens != nil {
+		t.Errorf("expected unknown tokens on an error, got %s/%s",
+			tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
+	}
+}
+
+// TestAnthropicProviderDefaultUpstream records today's behavior, which is a wart found while
+// closing this issue: only gemini has a provider-specific default upstream, so
+// EDGE_PROXY_PROVIDER=anthropic with no EDGE_PROXY_UPSTREAM resolves to api.openai.com and
+// every request 404s against a protocol it was never meant for. Deployments always set the
+// upstream explicitly, so nothing is broken in practice, but the default is wrong. The assertion
+// is written so that adding a DefaultAnthropicUpstream fails here and the fix is a deliberate,
+// reviewed change rather than a silent one.
+func TestAnthropicProviderDefaultUpstream(t *testing.T) {
+	cfg, err := config.FromEnv(func(k string) string {
+		if k == "EDGE_PROXY_PROVIDER" {
+			return "anthropic"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	if got := cfg.Upstream.String(); got != config.DefaultUpstream {
+		t.Errorf("default upstream for provider=anthropic = %q, want %q; if an Anthropic-specific "+
+			"default was added, update this test to assert it", got, config.DefaultUpstream)
+	}
+}
+
+// ptr is a test helper for the nullable token counts; see responseMeta on why they are pointers.
+func ptr(v int64) *int64 { return &v }
+
+// assertTokens compares a nullable count against a nullable expectation, so "unknown" is a value
+// the table can express rather than something a test has to spell out case by case.
+func assertTokens(t *testing.T, field string, got, want *int64) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Errorf("%s = %s, want unknown", field, tokensStr(got))
+	case want != nil && !tokensEq(got, *want):
+		t.Errorf("%s = %s, want %d", field, tokensStr(got), *want)
+	}
+}

--- a/infra/edge-proxy/internal/proxy/provider_payload_variations_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_payload_variations_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// CTO-318: OpenAI and Gemini payload variations, from the providers' PUBLISHED schemas.
+//
+// The CTO-244/245 verification drove a fake upstream whose OpenAI and Gemini bodies were hand-built
+// by reading provider.go. That is the actual weakness the issue records: a fixture derived from our
+// own parser can only confirm the parser agrees with itself. The fixtures under testdata/openai/
+// and testdata/gemini/ are instead transcribed from OpenAI's published OpenAPI specification
+// (openai/openai-openapi, the CreateChatCompletionResponse / chunk examples and the CompletionUsage
+// schema) and Google's published GenerateContentResponse reference. They cover the variations that
+// realistically differ from the happy path: truncation, refusals, tool calls, a response with no
+// usage block at all, a safety-blocked prompt, streaming, and each provider's error envelope.
+//
+// This narrows the gap. It does not close it: no request here touches a real endpoint, and only
+// real traffic against a real key can prove a provider does not emit something its own docs omit.
+
+func TestOpenAIMetaFromPublishedResponses(t *testing.T) {
+	cases := []struct {
+		fixture    string
+		wantModel  string
+		wantPrompt *int64
+		wantComp   *int64
+	}{
+		// The documented happy path. The nested *_tokens_details objects the parser ignores must
+		// not disturb the two counts it does read.
+		{"openai/completion_stop.json", "gpt-4o-2024-08-06", ptr(19), ptr(10)},
+		// finish_reason "length": a truncated answer is still billed for what it produced.
+		{"openai/completion_length.json", "gpt-4o-2024-08-06", ptr(1204), ptr(8)},
+		// A refusal arrives as a normal 200 with message.refusal set. It costs real tokens and must
+		// meter like any other turn.
+		{"openai/completion_refusal.json", "gpt-4o-2024-08-06", ptr(331), ptr(12)},
+		// finish_reason "tool_calls" with NO usage object: the model is known, the counts are not.
+		// Unknown must stay unknown; a 0 would price this real call at nothing.
+		{"openai/completion_tool_calls_no_usage.json", "gpt-4o-2024-08-06", nil, nil},
+		// The error envelope has no top-level model and no usage.
+		{"openai/error_rate_limit.json", "", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			meta := extractMeta(config.ProviderOpenAI, "/v1/chat/completions", readFixture(t, tc.fixture))
+			if meta.Model != tc.wantModel {
+				t.Errorf("Model = %q, want %q", meta.Model, tc.wantModel)
+			}
+			assertTokens(t, "PromptTokens", meta.PromptTokens, tc.wantPrompt)
+			assertTokens(t, "CompletionTokens", meta.CompletionTokens, tc.wantComp)
+		})
+	}
+}
+
+// TestOpenAIStreamedUsageIsNotParsed pins a gap the same way the Anthropic streaming test does.
+// With stream_options.include_usage the final SSE chunk carries the full usage block, but the body
+// is a sequence of "data:" frames rather than one JSON document, so the parse fails and everything
+// stays unknown. Honest (unknown, not zero) and incomplete: a streamed OpenAI call is currently
+// unattributed even to a model, though both are present on the wire.
+func TestOpenAIStreamedUsageIsNotParsed(t *testing.T) {
+	meta := extractMeta(config.ProviderOpenAI, "/v1/chat/completions",
+		readFixture(t, "openai/stream_with_usage.sse"))
+	if meta.Model != "" || meta.PromptTokens != nil || meta.CompletionTokens != nil {
+		t.Errorf("streamed chunks are not parsed today; got %+v. If an SSE parser landed, replace "+
+			"this test with one asserting model gpt-4o-2024-08-06 and 19/10 tokens", meta)
+	}
+}
+
+func TestGeminiMetaFromPublishedResponses(t *testing.T) {
+	cases := []struct {
+		name       string
+		fixture    string
+		path       string
+		wantModel  string
+		wantPrompt *int64
+		wantComp   *int64
+	}{
+		{
+			// finishReason MAX_TOKENS, plus the thinking-model thoughtsTokenCount the parser does
+			// not read. candidatesTokenCount excludes thoughts, so 8 is the visible output only and
+			// the 96 thinking tokens are billed but unrecorded. Pinned here so the omission is
+			// visible rather than assumed away.
+			name: "max_tokens_with_thoughts", fixture: "gemini/response_max_tokens.json",
+			path:      "/v1beta/models/gemini-2.5-flash:generateContent",
+			wantModel: "gemini-2.5-flash", wantPrompt: ptr(1204), wantComp: ptr(8),
+		},
+		{
+			// A safety-blocked prompt returns no candidates and a usageMetadata carrying only
+			// promptTokenCount. The input was billed; there is no output count to report, and
+			// reporting 0 would claim the model answered for free.
+			name: "prompt_blocked", fixture: "gemini/response_prompt_blocked.json",
+			path:      "/v1beta/models/gemini-2.5-flash:generateContent",
+			wantModel: "gemini-2.5-flash", wantPrompt: ptr(42), wantComp: nil,
+		},
+		{
+			// An error body names no model, but the path still does, so the failed call stays
+			// attributable to a model with both counts unknown.
+			name: "error_envelope", fixture: "gemini/error_resource_exhausted.json",
+			path:      "/v1beta/models/gemini-1.5-pro:generateContent",
+			wantModel: "gemini-1.5-pro", wantPrompt: nil, wantComp: nil,
+		},
+		{
+			// alt=sse streaming: not one JSON document, so only the path-derived model survives.
+			name: "streaming_sse", fixture: "gemini/stream_generate_content.sse",
+			path:      "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+			wantModel: "gemini-2.5-flash", wantPrompt: nil, wantComp: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := extractMeta(config.ProviderGemini, tc.path, readFixture(t, tc.fixture))
+			if meta.Model != tc.wantModel {
+				t.Errorf("Model = %q, want %q", meta.Model, tc.wantModel)
+			}
+			assertTokens(t, "PromptTokens", meta.PromptTokens, tc.wantPrompt)
+			assertTokens(t, "CompletionTokens", meta.CompletionTokens, tc.wantComp)
+		})
+	}
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/error_overloaded.json
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/error_overloaded.json
@@ -1,0 +1,8 @@
+{
+  "type": "error",
+  "error": {
+    "type": "overloaded_error",
+    "message": "Overloaded"
+  },
+  "request_id": "req_011CSHoEeqs5C35K2UUqR7Fy"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/message_cache_read.json
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/message_cache_read.json
@@ -1,0 +1,20 @@
+{
+  "id": "msg_01CacheReadExampleIdentif",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "text",
+      "text": "Yes, that section covers it."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 21,
+    "output_tokens": 44,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 18923
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/message_end_turn.json
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/message_end_turn.json
@@ -1,0 +1,20 @@
+{
+  "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "text",
+      "text": "Hi, I'm Claude. How can I help you?"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 15,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/message_max_tokens.json
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/message_max_tokens.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_01AbCdEfGhIjKlMnOpQrStUv",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-5",
+  "content": [
+    {
+      "type": "text",
+      "text": "The three main causes are, first,"
+    }
+  ],
+  "stop_reason": "max_tokens",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 1204,
+    "output_tokens": 8
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/message_refusal.json
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/message_refusal.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_01RefusalExampleIdentifier",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [],
+  "stop_reason": "refusal",
+  "stop_sequence": null,
+  "stop_details": {
+    "type": "refusal",
+    "category": "cyber",
+    "explanation": "The request was declined by a safety classifier."
+  },
+  "usage": {
+    "input_tokens": 331,
+    "output_tokens": 0
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/message_tool_use.json
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/message_tool_use.json
@@ -1,0 +1,24 @@
+{
+  "id": "msg_014p7gG3wDgGV9EUtLvnow3U",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "text",
+      "text": "Okay, let's check the weather for San Francisco, CA:"
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01T1x1fJ34qAmk2tNTrN7Up6",
+      "name": "get_weather",
+      "input": { "location": "San Francisco, CA" }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 472,
+    "output_tokens": 89
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/stream_midstream_error.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/stream_midstream_error.sse
@@ -1,0 +1,11 @@
+event: message_start
+data: {"type": "message_start", "message": {"id": "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY", "type": "message", "role": "assistant", "content": [], "model": "claude-opus-5", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 25, "output_tokens": 1}}}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
+
+event: error
+data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/stream_text.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/stream_text.sse
@@ -1,0 +1,23 @@
+event: message_start
+data: {"type": "message_start", "message": {"id": "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY", "type": "message", "role": "assistant", "content": [], "model": "claude-opus-5", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 25, "output_tokens": 1}}}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "!"}}
+
+event: content_block_stop
+data: {"type": "content_block_stop", "index": 0}
+
+event: message_delta
+data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null}, "usage": {"output_tokens": 15}}
+
+event: message_stop
+data: {"type": "message_stop"}

--- a/infra/edge-proxy/internal/proxy/testdata/anthropic/stream_tool_use.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/anthropic/stream_tool_use.sse
@@ -1,0 +1,35 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_014p7gG3wDgGV9EUtLvnow3U","type":"message","role":"assistant","model":"claude-opus-5","stop_sequence":null,"usage":{"input_tokens":472,"output_tokens":2},"content":[],"stop_reason":null}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Okay"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", let's check the weather for San Francisco, CA"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" \"San Francisco, CA\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":89}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/infra/edge-proxy/internal/proxy/testdata/gemini/error_resource_exhausted.json
+++ b/infra/edge-proxy/internal/proxy/testdata/gemini/error_resource_exhausted.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": 429,
+    "message": "Resource has been exhausted (e.g. check quota).",
+    "status": "RESOURCE_EXHAUSTED"
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/gemini/response_max_tokens.json
+++ b/infra/edge-proxy/internal/proxy/testdata/gemini/response_max_tokens.json
@@ -1,0 +1,18 @@
+{
+  "candidates": [
+    {
+      "content": { "parts": [{ "text": "The three main causes are, first," }], "role": "model" },
+      "finishReason": "MAX_TOKENS",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 1204,
+    "candidatesTokenCount": 8,
+    "thoughtsTokenCount": 96,
+    "cachedContentTokenCount": 0,
+    "totalTokenCount": 1308
+  },
+  "modelVersion": "gemini-2.5-flash-002",
+  "responseId": "0bYFaJ2cKcOTz7IPvbHFqAo"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/gemini/response_prompt_blocked.json
+++ b/infra/edge-proxy/internal/proxy/testdata/gemini/response_prompt_blocked.json
@@ -1,0 +1,14 @@
+{
+  "promptFeedback": {
+    "blockReason": "SAFETY",
+    "safetyRatings": [
+      { "category": "HARM_CATEGORY_DANGEROUS_CONTENT", "probability": "HIGH" }
+    ]
+  },
+  "usageMetadata": {
+    "promptTokenCount": 42,
+    "totalTokenCount": 42
+  },
+  "modelVersion": "gemini-2.5-flash-002",
+  "responseId": "1cZGaK3dLdPUa8JQwcIGrBp"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/gemini/stream_generate_content.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/gemini/stream_generate_content.sse
@@ -1,0 +1,3 @@
+data: {"candidates": [{"content": {"parts": [{"text": "Hello"}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 25,"totalTokenCount": 25},"modelVersion": "gemini-2.5-flash-002"}
+
+data: {"candidates": [{"content": {"parts": [{"text": "!"}],"role": "model"},"finishReason": "STOP","index": 0}],"usageMetadata": {"promptTokenCount": 25,"candidatesTokenCount": 15,"totalTokenCount": 40},"modelVersion": "gemini-2.5-flash-002"}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/completion_length.json
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/completion_length.json
@@ -1,0 +1,25 @@
+{
+  "id": "chatcmpl-B9MBsTruncatedExampleIdent",
+  "object": "chat.completion",
+  "created": 1741569988,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The three main causes are, first,",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "length"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 1204,
+    "completion_tokens": 8,
+    "total_tokens": 1212
+  },
+  "service_tier": "default"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/completion_refusal.json
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/completion_refusal.json
@@ -1,0 +1,25 @@
+{
+  "id": "chatcmpl-B9MBsRefusalExampleIdenti",
+  "object": "chat.completion",
+  "created": 1741570021,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "refusal": "final refusal text",
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 331,
+    "completion_tokens": 12,
+    "total_tokens": 343
+  },
+  "service_tier": "default"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/completion_stop.json
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/completion_stop.json
@@ -1,0 +1,35 @@
+{
+  "id": "chatcmpl-B9MBs8CjcvOU2jLn4n570S5qMJKcT",
+  "object": "chat.completion",
+  "created": 1741569952,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello! How can I assist you today?",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 19,
+    "completion_tokens": 10,
+    "total_tokens": 29,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/completion_tool_calls_no_usage.json
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/completion_tool_calls_no_usage.json
@@ -1,0 +1,28 @@
+{
+  "id": "chatcmpl-B9MBsToolCallExampleIden",
+  "object": "chat.completion",
+  "created": 1741570090,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_62136354",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\":\"San Francisco, CA\"}"
+            }
+          }
+        ],
+        "refusal": null
+      },
+      "logprobs": null,
+      "finish_reason": "tool_calls"
+    }
+  ]
+}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/error_rate_limit.json
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/error_rate_limit.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Rate limit reached for gpt-4o in organization org-example on tokens per min (TPM): Limit 30000, Used 29999, Requested 1000.",
+    "type": "tokens",
+    "param": null,
+    "code": "rate_limit_exceeded"
+  }
+}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/stream_with_usage.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/stream_with_usage.sse
@@ -1,0 +1,9 @@
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[],"usage":{"prompt_tokens":19,"completion_tokens":10,"total_tokens":29}}
+
+data: [DONE]


### PR DESCRIPTION
Closes out most of #318, the deliberate record of what the CTO-244/245 end-to-end verification could **not** exercise. Stacked on #346 (revenue fan-out), which sits on #345 (auth boot guard); review against `fix/revenue-fanout-and-examples-ci`. **Do not merge.**

## Issue #318 status after this PR

| Item | Status |
| --- | --- |
| `ch-migrate-otel-engine` against a pre-existing install | closed earlier (#311 / #325 lineage) |
| Rollup double-count permanence | closed earlier |
| **`make chatbot-demo-backfill` and the `~$52,400/mo` corpus claim** | **closed here** |
| **The Anthropic protocol through the proxy** | **closed here** |
| Real provider traffic through the edge proxy | **narrowed, not closed** (see below) |

Nothing in this PR calls a paid API, and no provider key was used or looked for.

## 1. The backfill, run for real

`make chatbot-demo-backfill` had never actually been run end to end, so the corpus numbers in `RUNNING.md` were inherited. A full default run (`--seed 138`, 30 days) went to a real gateway against the live local stack:

```
✓ Backfill done. 512056 spans + 101799 events in 1229 batches.
```

**The `~$52,400/mo` claim holds.** Measured from what the **gateway** recomputed and ClickHouse stored, not from the figure the script printed:

| Layer | Spans | 30-day cost |
| --- | ---: | ---: |
| `chat` (LLM) | 293,352 | **$52,401.67** |
| `compute` | 150 | $2,351.71 |
| `tool` | 26,678 | $397.86 |
| `egress` | 150 | $209.04 |
| `embeddings` | 35,235 | $88.12 |
| `vector` | 156,491 | $45.00 |
| all-in | 512,056 | **$55,493.40** |

The feature mix lands on the documented split exactly (research_agent 54% / support_triage 17% / inline_writer 12% / smart_search 10% / chatbot 7%), and so do the run shapes: 4,162 of 121,660 runs failed without retry (3.4%, claimed ~3.5%), 2,953 failed then retried (2.4%, claimed ~2.5%), 9,914 unattributed (8.2%, claimed ~8%).

The script's own printed expectation was `$52,401.56`, eleven cents under what the gateway stored. That is per-span rounding, not catalog drift: the script's rates and `seed_catalog` still agree. `RUNNING.md` now records the measured figures instead of the inherited ones.

**The #315 / #324 retry and circuit-breaker code behaved.** This was its first run against a real gateway at full corpus size: 1,229 batches, **zero shed batches**, the run-level breaker never armed, and the progress lines tracked delivery exactly (512,056/512,056 posted, matching the ClickHouse row count). No misfire on a healthy stack. The fail-soft half was exercised incidentally too: `POST /v1/tenant/account-labels` returned 500 for all 12 accounts (the verification tenant has no Postgres row, so the FK rejects the label), the run warned and continued as designed, and account hashes still came from the gateway's HMAC.

**The live-realistic path (`chatbot-demo-realistic`) was NOT run.** It makes real OpenAI/Anthropic calls with a `--max-usd` cap; it belongs with item 2 below.

## 2. Real provider traffic: narrowed, still open

I could not close this and am not claiming otherwise. What I did instead attacks the specific weakness the issue names: the fake upstream's OpenAI and Gemini bodies were hand-built by reading `provider.go`, and a parser-derived fixture can only confirm the parser agrees with itself.

Every fixture under `internal/proxy/testdata/` is now transcribed from the provider's **published schema**: Anthropic's Messages API, streaming, and errors references; OpenAI's `openai-openapi` specification (the `CreateChatCompletionResponse` / chunk examples and the `CompletionUsage` schema); Google's `GenerateContentResponse` reference. They cover the variations that realistically differ from the happy path: streaming versus non-streaming, tool and function calls, refusals, `length` / `MAX_TOKENS` truncation, a response with no usage block at all, a safety-blocked prompt, and each provider's error envelope.

**What is still untested against a real endpoint, and what would close it:** a human running real traffic through the proxy with real OpenAI, Anthropic and Google keys and a small budget (a few dollars covers it), against each of the shapes above, and diffing the recorded `TraceRecord` against the provider's dashboard. Only that can prove a provider does not emit a field its own documentation omits, or emit a documented field in a shape the docs do not describe.

## 3. The Anthropic protocol, driven

`EDGE_PROXY_PROVIDER=anthropic` had exactly one unit assertion and had never been driven through the proxy. It now has:

- end-to-end `POST /v1/messages`: byte-for-byte relay, model and token counts on the `TraceRecord`, and the **`x-api-key`** credential forwarded upstream but absent from the record (a different auth header from the openai and gemini paths, which is why this needed its own test);
- a `tool_use` turn, asserting it meters identically and that the tool name, id and arguments never reach the record;
- `max_tokens` truncation, a `refusal` turn, and a `529` error envelope;
- the full published **SSE event sequence** (`message_start` -> `content_block_*` -> `message_delta` -> `message_stop`), plus the tool-use stream and a mid-stream `error` event. Anthropic's stream shape differs meaningfully from OpenAI's, so this is transcribed from the docs verbatim.

## Three gaps pinned, not asserted away

Each of these is a place where the record is honest (unknown stays `nil`, never a fabricated `0`) but incomplete. Each test says what to replace it with once the behavior changes, so a fix fails loudly rather than silently:

1. **Streamed usage is not parsed, on any provider.** `extractMeta` unmarshals the whole body as one JSON document; an SSE stream is not one. So a streamed call records neither model nor tokens, even though `message_start` / `message_delta` (Anthropic) and the `include_usage` final chunk (OpenAI) carry both. Gemini escapes only because it recovers the model from the request path. The counts staying `nil` is the correct failure direction, but a streamed call is currently unattributed.
2. **Anthropic `cache_read_input_tokens` / `cache_creation_input_tokens` are not folded into `PromptTokens`.** `input_tokens` excludes them, so a cache-hit call reports the uncached prompt only and pricing from that record alone under-reports the billable input.
3. **`EDGE_PROXY_PROVIDER=anthropic` with no `EDGE_PROXY_UPSTREAM` defaults to `api.openai.com`.** Only gemini has a provider-specific default. Deployments always set the upstream explicitly so nothing is broken in practice, but the default is wrong.

Fixing any of these touches `provider.go` / `config.go`, outside this test-only change's scope.

## The live stack was left as it was found

The backfill wrote under a fresh tenant id (`cf318318-…`) rather than into `local-dev` or the existing UUID tenant, so cleanup is provably scoped by `TenantId`.

| Table | Before | After my rows | After cleanup |
| --- | ---: | ---: | ---: |
| `otel_spans` | 1,542,996 | 2,055,052 | **1,542,996** |
| `business_events` | 687,400 | 789,199 | **687,400** |
| `daily_account_rollup` | 7,479 | 14,788 | **7,479** |
| `daily_feature_rollup` | 2,405 | 3,880 | **2,405** |
| `hourly_feature_rollup` | 48,838 | 72,597 | **48,838** |
| `last_touch_index` | 801,289 | 920,001 | 801,288 |
| `attribution_records` | 94,996 | 94,996 | 94,996 |
| `unattributed_events` | 613 | 613 | 613 |
| `otel_spans_cto245` | 1,542,971 | 1,542,971 | 1,542,971 |

Every table is back to its exact starting count except `last_touch_index`, one row low. That row was not mine and was not deleted by me: the per-tenant breakdown taken **before** my deletes already summed to 801,288 for the other tenants, so a background merge collapsed one un-merged duplicate during the run. It is a `ReplacingMergeTree` whose raw count is 801,288 against 513,850 under `FINAL`, so physical duplicates collapsing is ordinary behavior and the deduplicated view is unchanged. Every other tenant's per-table count is identical before and after.

Postgres is untouched: 1 tenant and 30 `tenant_account_labels` rows before and after (the verification tenant deliberately had no row, which is why label upsert fail-soft got exercised).

## Verification

- edge-proxy: `go build ./...`, `go test ./...` pass, `gofmt -l .` lists nothing.
- gateway: 940 passed, 8 skipped. `ruff` clean.
- sdk: 1,332 passed. `ruff` clean.
- web: 822 tests / 66 files, typecheck clean, lint clean apart from the pre-existing `lib/useLivePoll.ts:94` warning.

Issue #318 is deliberately left open for the real-traffic item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
