### PR TITLE
feat(deploy): publish container images in CI and ship the edge-proxy ECS artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+    # Release tags publish a semver-tagged image (CTO-334). The four test jobs run on a tag push too,
+    # so nothing is ever published from a commit whose suites were not green.
+    tags: ["v*"]
   pull_request:
+  # Lets an operator rebuild and republish the images for a ref without an empty commit, which
+  # matters the first time the ECR role exists and the last green merge predates it.
+  workflow_dispatch:
 
 jobs:
   python-sdk:
@@ -93,3 +99,189 @@ jobs:
         run: npm run build
         env:
           TALLY_DEV_TENANT: "00000000-0000-0000-0000-000000000000"
+
+  # CTO-334: publish container images with a provenance. Until this job existed, every deploy began
+  # with "build it on your laptop" and no running container could be traced back to a commit.
+  #
+  # Registries, and why both. GHCR is the public distribution channel: it is the registry
+  # `infra/edge-proxy/deploy/helm/edge-proxy/values.yaml` already pointed at, it needs no AWS account
+  # to pull from, and self-hosted installs are its audience. ECR is the deployment registry for our
+  # own ECS Fargate services: tasks pull it over a VPC endpoint with no NAT egress, and the execution
+  # role in `deploy/aws/ecs/iam/` already grants exactly that pull. Publishing to only one would
+  # leave the other half of the tree pointing at an artifact nothing produces, which is the bug this
+  # job closes.
+  #
+  # Architecture. Fargate ARM64 is cheaper per vCPU-hour than X86_64 and the edge proxy is
+  # deliberately kept warm, so the lever is worth pulling; the three task definitions under
+  # `deploy/aws/ecs/` are pinned to ARM64 to match. The job runs on GitHub's native ARM runners
+  # rather than emulating, because QEMU would make `next build` and the pip install unreasonably
+  # slow. The edge proxy is additionally published for amd64, because its Helm chart targets customer
+  # clusters that are mostly x86 and a stdlib-only Go binary cross-compiles for free.
+  images:
+    name: images
+    needs: [python-sdk, gateway, edge-proxy, web]
+    # Free for public repositories, and native for the arm64 images we ship (see above).
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+      # Required for the OIDC token exchanged for the ECR push role. No long-lived AWS access key
+      # exists in this repository and none should be added.
+      id-token: write
+    strategy:
+      # One image failing should not hide the state of the other two.
+      fail-fast: false
+      matrix:
+        include:
+          # The gateway Dockerfile COPYs both the gateway and the SDK it depends on, so its build
+          # context is the repo root (the same as `infra/docker-compose.yml` uses).
+          - name: gateway
+            context: .
+            dockerfile: infra/gateway/Dockerfile
+            platforms: linux/arm64
+            ghcr: ai-tally-gateway
+            ecr: ai-tally/gateway
+          - name: edge-proxy
+            context: infra/edge-proxy
+            dockerfile: infra/edge-proxy/Dockerfile
+            platforms: linux/amd64,linux/arm64
+            ghcr: ai-tally-edge-proxy
+            ecr: ai-tally/edge-proxy
+          - name: web
+            context: web
+            dockerfile: web/Dockerfile
+            platforms: linux/arm64
+            ghcr: ai-tally-web
+            ecr: ai-tally/web
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The pull-request gate below diffs against the base commit, which a shallow clone lacks.
+          fetch-depth: 0
+
+      # When this runs, and why not always. Building three images for every push on every PR branch
+      # spends runner minutes on changes that cannot affect an image. So: always on a merge to main
+      # and on a release tag, which are the artifacts anyone deploys; on demand via
+      # workflow_dispatch; and on a pull request ONLY when that PR touches a Dockerfile, a
+      # .dockerignore or this workflow. That last case builds without pushing, so a Dockerfile change
+      # is proven buildable in review rather than after it lands on main.
+      - name: Decide whether to build and whether to push
+        id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IMAGE: ${{ matrix.name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "push=true"  >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "push=false" >> "$GITHUB_OUTPUT"
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          if printf '%s\n' "$changed" | grep -Eq '(^|/)(Dockerfile|\.dockerignore)$|^\.github/workflows/ci\.yml$'; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "Build inputs changed; building $IMAGE without pushing."
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "No Dockerfile or workflow change in this PR; skipping the $IMAGE image."
+          fi
+
+      # Tags, and why these. The commit SHA is the point: it is the one tag that cannot be moved, and
+      # it is what a task definition should pin, so every image gets it. `main` is additionally
+      # published on a merge so a chart or a compose file has a working default to pull; it moves, so
+      # production pins a SHA or a release instead. A `vX.Y.Z` git tag additionally publishes
+      # `X.Y.Z`, which is what the Helm chart's appVersion and the task definitions' readable pin
+      # refer to. No `latest`: that is the tag that makes a running container untraceable, which is
+      # the whole complaint here.
+      - name: Compute image tags
+        id: tags
+        if: steps.gate.outputs.build == 'true'
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          SHA: ${{ github.sha }}
+          GHCR_REPO: ghcr.io/${{ github.repository_owner }}/${{ matrix.ghcr }}
+          ECR_REGISTRY: ${{ vars.AWS_ECR_REGISTRY }}
+          ECR_REPO: ${{ matrix.ecr }}
+        run: |
+          set -euo pipefail
+          suffixes="$SHA"
+          if [ "$REF_TYPE" = "tag" ] && [ "${REF_NAME#v}" != "$REF_NAME" ]; then
+            suffixes="$suffixes ${REF_NAME#v}"
+          elif [ "$REF_NAME" = "main" ]; then
+            suffixes="$suffixes main"
+          fi
+          out="$RUNNER_TEMP/image-tags"
+          : > "$out"
+          for s in $suffixes; do
+            printf '%s:%s\n' "$GHCR_REPO" "$s" >> "$out"
+            if [ -n "$ECR_REGISTRY" ]; then
+              printf '%s/%s:%s\n' "$ECR_REGISTRY" "$ECR_REPO" "$s" >> "$out"
+            fi
+          done
+          {
+            echo "tags<<TAGS_EOF"
+            cat "$out"
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          cat "$out"
+
+      - name: Set up buildx
+        if: steps.gate.outputs.build == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          # The workflow's own short-lived token, not a stored credential.
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # OIDC only. `AWS_ECR_ROLE_ARN`, `AWS_ECR_REGISTRY` and `AWS_REGION` are repository *variables*,
+      # not secrets: a role ARN and a registry hostname are not credentials, and keeping them visible
+      # makes it auditable which role CI can assume. While they are unset the ECR half is skipped and
+      # the GHCR half still publishes, which is the state of the world until an operator creates the
+      # role (there is no IaC in this repository yet, CTO-335). See
+      # `deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json` and its sibling policy for exactly
+      # what to create. There is deliberately no access-key fallback.
+      - name: Configure AWS credentials (OIDC)
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && vars.AWS_ECR_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ECR_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-session-name: ai-tally-ci-${{ github.run_id }}
+
+      - name: Log in to ECR
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && vars.AWS_ECR_ROLE_ARN != ''
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Report that ECR is not configured
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && vars.AWS_ECR_ROLE_ARN == ''
+        env:
+          IMAGE: ${{ matrix.name }}
+        run: |
+          echo "::notice::AWS_ECR_ROLE_ARN is unset, so $IMAGE is published to GHCR only."
+          echo "::notice::Create the OIDC role in deploy/aws/README.md section 1 to enable the ECR push."
+
+      - name: Build and push
+        if: steps.gate.outputs.build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
+          push: ${{ steps.gate.outputs.push == 'true' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          # Provenance attestations wrap even a single-platform push in an index, which older pullers
+          # handle badly. The immutable SHA tag is the provenance that matters here.
+          provenance: false
+          cache-from: type=gha,scope=${{ matrix.name }}
+          # ignore-error so a cache-service hiccup degrades the build to slow rather than red. The
+          # image is the deliverable; the cache is an optimisation.
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }},ignore-error=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,9 @@ jobs:
   # slow. The edge proxy is additionally published for amd64, because its Helm chart targets customer
   # clusters that are mostly x86 and a stdlib-only Go binary cross-compiles for free.
   images:
-    name: images
+    # Named off the matrix entry, or GitHub builds the check name out of every matrix value and the
+    # required-check list becomes unreadable.
+    name: image (${{ matrix.name }})
     needs: [python-sdk, gateway, edge-proxy, web]
     # Free for public repositories, and native for the arm64 images we ship (see above).
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
   # leave the other half of the tree pointing at an artifact nothing produces, which is the bug this
   # job closes.
   #
+  # What is published. The gateway and the edge proxy. The web image is built here but deliberately
+  # not pushed; the matrix entry says why.
+  #
   # Architecture. Fargate ARM64 is cheaper per vCPU-hour than X86_64 and the edge proxy is
   # deliberately kept warm, so the lever is worth pulling; the three task definitions under
   # `deploy/aws/ecs/` are pinned to ARM64 to match. The job runs on GitHub's native ARM runners
@@ -143,18 +146,36 @@ jobs:
             platforms: linux/arm64
             ghcr: ai-tally-gateway
             ecr: ai-tally/gateway
+            publish: "true"
+            build_args: ""
           - name: edge-proxy
             context: infra/edge-proxy
             dockerfile: infra/edge-proxy/Dockerfile
             platforms: linux/amd64,linux/arm64
             ghcr: ai-tally-edge-proxy
             ecr: ai-tally/edge-proxy
+            publish: "true"
+            build_args: ""
+          # Built on every publish run, never pushed. A web image cannot be a tenant-neutral registry
+          # artifact: Clerk's NEXT_PUBLIC_ publishable key is inlined into the client bundle at build
+          # time, so an image built without one can never sign anybody in and an image built with one
+          # belongs to a single deployment. The dashboard's production home is Vercel anyway
+          # (docs/self-hosted-scope.md), and docs/aws-bundle-scope.md keeps web.taskdef.json only as
+          # an escape hatch the bundle does not use, so the operator builds that one themselves with
+          # their own keys (deploy/aws/README.md section 1). Building it here still earns its place:
+          # the first run of this job caught web/Dockerfile silently dropping .npmrc, which had made
+          # the image unbuildable, and nothing else in CI would have noticed.
           - name: web
             context: web
             dockerfile: web/Dockerfile
             platforms: linux/arm64
             ghcr: ai-tally-web
             ecr: ai-tally/web
+            publish: "false"
+            # Same placeholder UUID the `web` job above builds with, and for the same reason: the
+            # static prerender of /_not-found would otherwise need a Clerk publishable key.
+            build_args: |
+              TALLY_DEV_TENANT=00000000-0000-0000-0000-000000000000
     steps:
       - uses: actions/checkout@v4
         with:
@@ -236,7 +257,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true'
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && matrix.publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -252,7 +273,7 @@ jobs:
       # `deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json` and its sibling policy for exactly
       # what to create. There is deliberately no access-key fallback.
       - name: Configure AWS credentials (OIDC)
-        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && vars.AWS_ECR_ROLE_ARN != ''
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && matrix.publish == 'true' && vars.AWS_ECR_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ECR_ROLE_ARN }}
@@ -260,11 +281,11 @@ jobs:
           role-session-name: ai-tally-ci-${{ github.run_id }}
 
       - name: Log in to ECR
-        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && vars.AWS_ECR_ROLE_ARN != ''
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && matrix.publish == 'true' && vars.AWS_ECR_ROLE_ARN != ''
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Report that ECR is not configured
-        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && vars.AWS_ECR_ROLE_ARN == ''
+        if: steps.gate.outputs.build == 'true' && steps.gate.outputs.push == 'true' && matrix.publish == 'true' && vars.AWS_ECR_ROLE_ARN == ''
         env:
           IMAGE: ${{ matrix.name }}
         run: |
@@ -278,8 +299,9 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
-          push: ${{ steps.gate.outputs.push == 'true' }}
+          push: ${{ steps.gate.outputs.push == 'true' && matrix.publish == 'true' }}
           tags: ${{ steps.tags.outputs.tags }}
+          build-args: ${{ matrix.build_args }}
           # Provenance attestations wrap even a single-platform push in an index, which older pullers
           # handle badly. The immutable SHA tag is the provenance that matters here.
           provenance: false

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -32,13 +32,17 @@ deploy/aws/
 ├── ecs/                            PRIMARY — ECS-on-Fargate task/service definitions
 │   ├── gateway.taskdef.json        gateway task definition (Secrets Manager injection, task role)
 │   ├── web.taskdef.json            web task definition
+│   ├── edge-proxy.taskdef.json     edge-proxy task definition (no container health check, see §7A)
 │   ├── gateway.service.json        gateway ECS service (Fargate, ALB target group)
 │   ├── web.service.json            web ECS service
+│   ├── edge-proxy.service.json     edge-proxy ECS service (two warm tasks, never scales to zero)
 │   └── iam/
 │       ├── task-role-policy.json          workload identity: S3 replay + Cost Explorer + Bedrock (+Secrets)
 │       ├── execution-role-policy.json     ECS execution role: ECR pull + logs + secret injection
 │       ├── ecs-tasks-trust-policy.json    trust policy for the ECS task/execution roles
-│       └── irsa-trust-policy.json         trust policy for the EKS IRSA role (OIDC)
+│       ├── irsa-trust-policy.json         trust policy for the EKS IRSA role (OIDC)
+│       ├── github-actions-oidc-trust-policy.json  trust policy for the CI image-push role (§1)
+│       └── github-actions-ecr-policy.json         push rights on the three ECR repositories (§1)
 └── helm/ai-tally-eks/              SECONDARY — EKS Helm chart (gateway + web + optional ClickHouse)
     ├── Chart.yaml
     ├── values.yaml                 all knobs, documented
@@ -96,20 +100,89 @@ export ECR=$ACCOUNT.dkr.ecr.$REGION.amazonaws.com
 export IMAGE_TAG=1.0.0                         # or a git sha
 ```
 
-## 1. ECR — build & push images
+## 1. ECR and the images
 
-The gateway build context is the **repo root** (its Dockerfile COPYs both the gateway and the SDK it
-depends on); the web build context is `web/`.
+CI builds and publishes all three images (CTO-334), so the ordinary path is to create the
+repositories and the push role once and then never build an image by hand again.
+
+The images are **ARM64** for ECS, because Fargate on ARM64 is cheaper per vCPU-hour and the edge
+proxy is deliberately kept warm. All three task definitions under `ecs/` set
+`runtimePlatform.cpuArchitecture: ARM64` to match; changing one without the other gives you tasks
+that never start. The edge-proxy image is additionally published for amd64 for the Helm chart's
+audience.
 
 ```bash
-aws ecr create-repository --repository-name ai-tally/gateway --region "$REGION"
-aws ecr create-repository --repository-name ai-tally/web --region "$REGION"
-aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ECR"
+for repo in gateway web edge-proxy; do
+  aws ecr create-repository --repository-name "ai-tally/$repo" --region "$REGION"
+done
+```
 
-docker build -t "$ECR/ai-tally/gateway:$IMAGE_TAG" -f infra/gateway/Dockerfile .
-docker build -t "$ECR/ai-tally/web:$IMAGE_TAG" web/
-docker push "$ECR/ai-tally/gateway:$IMAGE_TAG"
-docker push "$ECR/ai-tally/web:$IMAGE_TAG"
+### The CI push role (OIDC, no access keys)
+
+The `images` job in `.github/workflows/ci.yml` assumes a role through GitHub's OIDC provider. No
+long-lived AWS access key is created, stored, or accepted; the job has no access-key fallback and is
+supposed to have none. Create the provider and the role once:
+
+```bash
+# One OIDC provider per account. Skip if `aws iam list-open-id-connect-providers` already lists it.
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com
+
+# The trust policy restricts the role to this repository's main branch and its vX.Y.Z tags, so a
+# fork or a pull-request run cannot assume it. Substitute ACCOUNT before applying.
+sed "s/ACCOUNT/$ACCOUNT/g" deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json \
+  > /tmp/gha-trust.json
+aws iam create-role --role-name ai-tally-ci-ecr-push \
+  --assume-role-policy-document file:///tmp/gha-trust.json
+
+# Push rights on exactly the three repositories, and nothing else in the account.
+sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+  deploy/aws/ecs/iam/github-actions-ecr-policy.json > /tmp/gha-ecr.json
+aws iam put-role-policy --role-name ai-tally-ci-ecr-push \
+  --policy-name ai-tally-ci-ecr-push --policy-document file:///tmp/gha-ecr.json
+```
+
+Then set three **repository variables** (Settings → Secrets and variables → Actions → Variables).
+They are variables and not secrets on purpose: a role ARN and a registry hostname are not
+credentials, and leaving them readable makes it auditable which role CI can assume.
+
+| Variable | Value |
+|---|---|
+| `AWS_ECR_ROLE_ARN` | `arn:aws:iam::$ACCOUNT:role/ai-tally-ci-ecr-push` |
+| `AWS_ECR_REGISTRY` | `$ACCOUNT.dkr.ecr.$REGION.amazonaws.com` |
+| `AWS_REGION` | `$REGION` |
+
+While `AWS_ECR_ROLE_ARN` is unset the job still publishes to GHCR and prints a notice saying the ECR
+half was skipped, so CI is green from the first merge and gains the ECR push the moment the role
+exists. Re-run the job for an already-merged commit with **Actions → CI → Run workflow** rather than
+pushing an empty commit.
+
+### Tags
+
+Every image carries the **commit SHA**, which is the tag a task definition should pin: it is the only
+one that cannot be moved, and it is what makes a running container traceable back to a commit. On a
+merge to `main` the image is additionally tagged `main` (moving, for charts and local pulls), and on
+a `vX.Y.Z` git tag it is additionally tagged `X.Y.Z`. There is no `latest`.
+
+```bash
+export IMAGE_TAG=$(git rev-parse HEAD)     # what the task definitions below should reference
+```
+
+### Building by hand (only if you must)
+
+The gateway build context is the **repo root** (its Dockerfile COPYs both the gateway and the SDK it
+depends on); the web context is `web/`; the edge-proxy context is `infra/edge-proxy/`. Pass
+`--platform linux/arm64` or the task will not start on the ARM64 platform the task definitions pin.
+
+```bash
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ECR"
+docker buildx build --platform linux/arm64 --push \
+  -t "$ECR/ai-tally/gateway:$IMAGE_TAG" -f infra/gateway/Dockerfile .
+docker buildx build --platform linux/arm64 --push \
+  -t "$ECR/ai-tally/web:$IMAGE_TAG" web/
+docker buildx build --platform linux/amd64,linux/arm64 --push \
+  -t "$ECR/ai-tally/edge-proxy:$IMAGE_TAG" infra/edge-proxy/
 ```
 
 ## 2. Networking (shared)
@@ -281,9 +354,19 @@ web pointed at it.
 ```bash
 aws ecs create-cluster --cluster-name ai-tally
 
+# Log groups, WITH A RETENTION. The task definitions set `awslogs-create-group: false` on purpose:
+# the awslogs driver has no retention option, so a group it auto-creates keeps every line forever at
+# full price and nobody notices. Create the groups yourself and set a retention once.
+for g in gateway web edge-proxy; do
+  aws logs create-log-group --log-group-name "/ecs/ai-tally-$g" --region "$REGION"
+  aws logs put-retention-policy --log-group-name "/ecs/ai-tally-$g" \
+    --retention-in-days 30 --region "$REGION"
+done
+
 # Substitute placeholders and register the gateway task def:
 sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
     -e "s/REPLACE_CLICKHOUSE_HOST/YOUR_CLICKHOUSE_HOST/g" \
+    -e "s/REPLACE_REPLAY_BUCKET/$ACCOUNT-ai-tally-replay/g" \
     deploy/aws/ecs/gateway.taskdef.json > /tmp/gateway.taskdef.json
 aws ecs register-task-definition --cli-input-json file:///tmp/gateway.taskdef.json
 
@@ -299,15 +382,53 @@ aws ecs register-task-definition --cli-input-json file:///tmp/web.taskdef.json
 aws ecs create-service --cli-input-json file://deploy/aws/ecs/web.service.json
 ```
 
+Then the edge proxy (CTO-339). It sits in the customer's LLM request path, so it runs on its own
+listener rule, at two tasks minimum, and never scales to zero: its outage is an outage of someone
+else's product, unlike the gateway (whose SDK buffers and retries) or the dashboard (whose outage
+loses nothing).
+
+```bash
+sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+    -e "s#REPLACE_GATEWAY_URL#https://ingest.YOUR_DOMAIN#g" \
+    deploy/aws/ecs/edge-proxy.taskdef.json > /tmp/edge-proxy.taskdef.json
+aws ecs register-task-definition --cli-input-json file:///tmp/edge-proxy.taskdef.json
+aws ecs create-service --cli-input-json file://deploy/aws/ecs/edge-proxy.service.json
+```
+
 Notes on the task defs:
 - **Secrets** are injected from Secrets Manager by Fargate at task start via `secrets[].valueFrom`
   (a secret ARN) — the value never appears in the file or in the registered task def. The **execution
   role** must be able to read them (`execution-role-policy.json`).
 - Provider-key secret entries are optional — delete them from `gateway.taskdef.json` if you did not
   create those secrets (or if you use Bedrock via the task role instead).
+- **All three pin `cpuArchitecture: ARM64`.** Push ARM64 images (step 1) or every task fails to
+  start with an image-manifest error.
+- **The edge proxy has no container `healthCheck`, deliberately.** Its image is `FROM scratch`: the
+  static binary and the CA roots, and nothing else. There is no `/bin/sh` for `CMD-SHELL` and no
+  `curl`, `wget` or `python` for `CMD`, so any container health check copied from
+  `gateway.taskdef.json` fails on every attempt, the task is killed as unhealthy, and the service
+  cycles forever with nothing in the logs that names the cause. Liveness is the ALB target group's
+  job instead, against `GET /healthz` on 8088, which
+  `infra/edge-proxy/cmd/edge-proxy/main.go` serves as a plain `200 ok`. The same note is carried in
+  the task definition's `dockerLabels` so it is visible in the file being edited.
 - Fronting is an **ALB**: create a target group per tier (`ai-tally-gateway` on 8080, `ai-tally-web`
-  on 3000, health-check paths `/healthz` and `/`), an HTTPS listener, and put the target-group ARNs
-  into the `*.service.json` files. For internal-only, use an internal ALB.
+  on 3000, `ai-tally-edge-proxy` on 8088; health-check paths `/healthz`, `/` and `/healthz`), an
+  HTTPS listener, and put the target-group ARNs into the `*.service.json` files. For internal-only,
+  use an internal ALB. Keep the proxy on its own host-based rule
+  (`llm.<domain>`, separate from `ingest.<domain>`): it forwards to provider APIs with real keys and
+  should never share a rule with ingest.
+
+```bash
+# The proxy's health check is shallow and fast on purpose, so a bad task drains quickly out of a
+# path that is somebody's production LLM traffic.
+aws elbv2 create-target-group \
+  --name ai-tally-edge-proxy --protocol HTTP --port 8088 \
+  --vpc-id vpc-YOURS --target-type ip \
+  --health-check-protocol HTTP --health-check-path /healthz \
+  --health-check-interval-seconds 10 --health-check-timeout-seconds 5 \
+  --healthy-threshold-count 2 --unhealthy-threshold-count 2 \
+  --matcher HttpCode=200
+```
 
 ### Option B — EKS (Helm)
 
@@ -343,6 +464,7 @@ set `serviceAccount.create=false` so Helm reuses it.
 ```bash
 # ECS (behind the ALB):
 curl -s "https://YOUR_GATEWAY_ALB/healthz"          # {"status":"ok"}
+curl -s "https://llm.YOUR_DOMAIN/healthz"           # ok      (the edge proxy, plain text)
 
 # EKS:
 kubectl -n ai-tally port-forward svc/ai-tally-gateway 8080:8080 &
@@ -382,10 +504,10 @@ Two things follow from that, and both bite silently if you get them wrong:
 
 ```bash
 # ECS
-aws ecs update-service --cluster ai-tally --service ai-tally-web --desired-count 0
-aws ecs update-service --cluster ai-tally --service ai-tally-gateway --desired-count 0
-aws ecs delete-service --cluster ai-tally --service ai-tally-web --force
-aws ecs delete-service --cluster ai-tally --service ai-tally-gateway --force
+for s in ai-tally-web ai-tally-gateway ai-tally-edge-proxy; do
+  aws ecs update-service --cluster ai-tally --service "$s" --desired-count 0
+  aws ecs delete-service --cluster ai-tally --service "$s" --force
+done
 aws ecs delete-cluster --cluster ai-tally
 
 # EKS
@@ -395,11 +517,18 @@ eksctl delete cluster --name ai-tally --region "$REGION"
 # Shared backing stores + identity (irreversible — deletes data):
 aws rds delete-db-instance --db-instance-identifier ai-tally-pg --skip-final-snapshot
 aws s3 rb "s3://$ACCOUNT-ai-tally-replay" --force
-for s in ai-tally-postgres-dsn ai-tally-clickhouse-password ai-tally-openai-api-key ai-tally-anthropic-api-key; do
+for s in ai-tally-postgres-dsn ai-tally-clickhouse-password ai-tally-gateway-service-token \
+         ai-tally-openai-api-key ai-tally-anthropic-api-key; do
   aws secretsmanager delete-secret --secret-id "$s" --force-delete-without-recovery
 done
 aws iam delete-role --role-name ai-tally-workload
 aws iam delete-role --role-name ai-tally-ecs-execution
+# CI push role (§1). Unset AWS_ECR_ROLE_ARN in the repository variables too, or CI fails on assume.
+aws iam delete-role-policy --role-name ai-tally-ci-ecr-push --policy-name ai-tally-ci-ecr-push
+aws iam delete-role --role-name ai-tally-ci-ecr-push
+for g in gateway web edge-proxy; do
+  aws logs delete-log-group --log-group-name "/ecs/ai-tally-$g"
+done
 # (detach/delete the ai-tally-workload policy and any ECR repos / ALB / target groups you created.)
 ```
 
@@ -410,10 +539,6 @@ aws iam delete-role --role-name ai-tally-ecs-execution
 - **Terraform/CloudFormation IaC** — this ticket ships ECS task defs + a Helm chart + `aws` CLI docs
   for v1; codify the account bootstrap (VPC, RDS, ClickHouse, Secrets Manager, IAM, ALB) as IaC in a
   follow-up.
-- **S3 replay wiring** — the bucket + IAM are provisioned here and the gateway exposes
-  `TALLY_REPLAY_BLOB_BACKEND`/`TALLY_REPLAY_S3_BUCKET` knobs, but an S3 replay blob-store backend
-  itself (the AWS analog of the GCS backend added under CTO-152) is a follow-up; today the supported
-  backends are `memory` and `gcs`.
 - **In-cluster ClickHouse DDL bootstrap (EKS)** — the StatefulSet path expects you to mount
   `db/clickhouse` as an initdb ConfigMap; a chart hook to build/apply it automatically is a follow-up.
 - **ALB Ingress / TLS + custom domain** — the ECS services expect an ALB target group you create; the

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -102,8 +102,15 @@ export IMAGE_TAG=1.0.0                         # or a git sha
 
 ## 1. ECR and the images
 
-CI builds and publishes all three images (CTO-334), so the ordinary path is to create the
-repositories and the push role once and then never build an image by hand again.
+CI builds all three images and publishes two of them (CTO-334), so the ordinary path is to create the
+repositories and the push role once and then never build the gateway or the proxy by hand again.
+
+**The web image is the exception and you build it yourself.** Clerk's `NEXT_PUBLIC_` publishable key
+is inlined into the client bundle at build time, so a web image built without one can never sign
+anybody in, and one built with yours belongs to your deployment and has no business in a shared
+registry. CI builds it on every publish run purely to catch the Dockerfile rotting, and pushes it
+nowhere. If you are using `ecs/web.taskdef.json` at all (the dashboard's supported home is Vercel,
+see `deploy/vercel/README.md`), see "Building by hand" below.
 
 The images are **ARM64** for ECS, because Fargate on ARM64 is cheaper per vCPU-hour and the edge
 proxy is deliberately kept warm. All three task definitions under `ecs/` set
@@ -169,21 +176,35 @@ a `vX.Y.Z` git tag it is additionally tagged `X.Y.Z`. There is no `latest`.
 export IMAGE_TAG=$(git rev-parse HEAD)     # what the task definitions below should reference
 ```
 
-### Building by hand (only if you must)
+### Building by hand
 
-The gateway build context is the **repo root** (its Dockerfile COPYs both the gateway and the SDK it
-depends on); the web context is `web/`; the edge-proxy context is `infra/edge-proxy/`. Pass
-`--platform linux/arm64` or the task will not start on the ARM64 platform the task definitions pin.
+Required for the web tier, optional for the other two. The gateway build context is the **repo root**
+(its Dockerfile COPYs both the gateway and the SDK it depends on); the web context is `web/`; the
+edge-proxy context is `infra/edge-proxy/`. Pass `--platform linux/arm64` or the task will not start
+on the ARM64 platform the task definitions pin.
 
 ```bash
 aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ECR"
+
+# The web image, with YOUR Clerk publishable key baked in. Without a key here `next build` fails
+# prerendering /_not-found; with the TALLY_DEV_TENANT build arg instead it builds but ships an
+# unauthenticated dashboard, which is only ever right for a demo. Push it to a repository only you
+# pull from.
+docker buildx build --platform linux/arm64 --push \
+  --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_... \
+  -t "$ECR/ai-tally/web:$IMAGE_TAG" web/
+
+# The two CI already publishes, if you would rather not wait for a merge.
 docker buildx build --platform linux/arm64 --push \
   -t "$ECR/ai-tally/gateway:$IMAGE_TAG" -f infra/gateway/Dockerfile .
-docker buildx build --platform linux/arm64 --push \
-  -t "$ECR/ai-tally/web:$IMAGE_TAG" web/
 docker buildx build --platform linux/amd64,linux/arm64 --push \
   -t "$ECR/ai-tally/edge-proxy:$IMAGE_TAG" infra/edge-proxy/
 ```
+
+> `web/Dockerfile` does not declare a `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` build arg today, so that
+> first command needs one added. It is left out of this change on purpose: `web/app/layout.tsx` and
+> the `TALLY_DEV_TENANT` guard around it are owned by another in-flight PR, and the web tier is not
+> part of the bundle. Track it with the Vercel path, which is where the dashboard actually ships.
 
 ## 2. Networking (shared)
 

--- a/deploy/aws/ecs/edge-proxy.service.json
+++ b/deploy/aws/ecs/edge-proxy.service.json
@@ -1,0 +1,28 @@
+{
+  "cluster": "ai-tally",
+  "serviceName": "ai-tally-edge-proxy",
+  "taskDefinition": "ai-tally-edge-proxy",
+  "desiredCount": 2,
+  "launchType": "FARGATE",
+  "platformVersion": "LATEST",
+  "deploymentConfiguration": {
+    "minimumHealthyPercent": 100,
+    "maximumPercent": 200
+  },
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["subnet-PRIVATE_A", "subnet-PRIVATE_B"],
+      "securityGroups": ["sg-AI_TALLY_EDGE_PROXY"],
+      "assignPublicIp": "DISABLED"
+    }
+  },
+  "loadBalancers": [
+    {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/ai-tally-edge-proxy/REPLACE",
+      "containerName": "edge-proxy",
+      "containerPort": 8088
+    }
+  ],
+  "healthCheckGracePeriodSeconds": 30,
+  "enableExecuteCommand": false
+}

--- a/deploy/aws/ecs/edge-proxy.taskdef.json
+++ b/deploy/aws/ecs/edge-proxy.taskdef.json
@@ -1,0 +1,50 @@
+{
+  "family": "ai-tally-edge-proxy",
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "512",
+  "memory": "1024",
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-workload",
+  "containerDefinitions": [
+    {
+      "name": "edge-proxy",
+      "image": "ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/edge-proxy:1.0.0",
+      "essential": true,
+      "portMappings": [
+        { "containerPort": 8088, "protocol": "tcp", "name": "http" }
+      ],
+      "environment": [
+        { "name": "EDGE_PROXY_LISTEN", "value": ":8088" },
+        { "name": "EDGE_PROXY_UPSTREAM", "value": "https://api.openai.com" },
+        { "name": "EDGE_PROXY_PROVIDER", "value": "openai" },
+        { "name": "EDGE_PROXY_MODE", "value": "passthrough" },
+        { "name": "EDGE_PROXY_REQUIRE_TENANT", "value": "true" },
+        { "name": "EDGE_PROXY_UPSTREAM_TIMEOUT", "value": "10m" },
+        { "name": "EDGE_PROXY_SELF_HOSTED", "value": "false" },
+        { "name": "EDGE_PROXY_TELEMETRY_URL", "value": "REPLACE_GATEWAY_URL/v1/batches" },
+        { "name": "EDGE_PROXY_KEYS_URL", "value": "REPLACE_GATEWAY_URL/v1/edge/keys" }
+      ],
+      "secrets": [
+        { "name": "EDGE_PROXY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" }
+      ],
+      "dockerLabels": {
+        "com.ai-tally.no-container-healthcheck": "Deliberate (CTO-339). Do NOT add a healthCheck block here. The image is FROM scratch: it carries the static binary and CA roots and nothing else, so there is no /bin/sh for CMD-SHELL and no curl, wget or python for CMD. Any container health check fails every attempt, the task is killed as unhealthy, and the service cycles forever with no error that names the cause. Liveness is checked by the ALB target group against GET /healthz on 8088 instead (see edge-proxy.service.json and deploy/aws/README.md section 7A).",
+        "com.ai-tally.health-path": "/healthz"
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ai-tally-edge-proxy",
+          "awslogs-region": "REGION",
+          "awslogs-stream-prefix": "edge-proxy",
+          "awslogs-create-group": "false"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aws/ecs/gateway.taskdef.json
+++ b/deploy/aws/ecs/gateway.taskdef.json
@@ -5,7 +5,7 @@
   "cpu": "512",
   "memory": "1024",
   "runtimePlatform": {
-    "cpuArchitecture": "X86_64",
+    "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
   "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
@@ -25,7 +25,9 @@
         { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },
         { "name": "TALLY_REQUIRE_API_KEY", "value": "true" },
         { "name": "AWS_REGION", "value": "REGION" },
-        { "name": "TALLY_REPLAY_BLOB_BACKEND", "value": "memory" }
+        { "name": "TALLY_REPLAY_BLOB_BACKEND", "value": "s3" },
+        { "name": "TALLY_REPLAY_S3_BUCKET", "value": "REPLACE_REPLAY_BUCKET" },
+        { "name": "TALLY_REPLAY_S3_REGION", "value": "REGION" }
       ],
       "secrets": [
         { "name": "TALLY_POSTGRES_DSN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-postgres-dsn" },
@@ -47,7 +49,7 @@
           "awslogs-group": "/ecs/ai-tally-gateway",
           "awslogs-region": "REGION",
           "awslogs-stream-prefix": "gateway",
-          "awslogs-create-group": "true"
+          "awslogs-create-group": "false"
         }
       }
     }

--- a/deploy/aws/ecs/iam/execution-role-policy.json
+++ b/deploy/aws/ecs/iam/execution-role-policy.json
@@ -29,6 +29,7 @@
       "Resource": [
         "arn:aws:secretsmanager:*:*:secret:ai-tally-postgres-dsn*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-clickhouse-password*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-gateway-service-token*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-openai-api-key*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-anthropic-api-key*"
       ]

--- a/deploy/aws/ecs/iam/github-actions-ecr-policy.json
+++ b/deploy/aws/ecs/iam/github-actions-ecr-policy.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuth",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrPushThreeRepositories",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:CompleteLayerUpload",
+        "ecr:DescribeRepositories",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart"
+      ],
+      "Resource": [
+        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/gateway",
+        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/edge-proxy",
+        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/web"
+      ]
+    }
+  ]
+}

--- a/deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json
+++ b/deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GitHubActionsOidc",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:jain-aanchal/ai-tally:ref:refs/heads/main",
+            "repo:jain-aanchal/ai-tally:ref:refs/tags/v*"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aws/ecs/iam/task-role-policy.json
+++ b/deploy/aws/ecs/iam/task-role-policy.json
@@ -43,6 +43,7 @@
       "Resource": [
         "arn:aws:secretsmanager:*:*:secret:ai-tally-postgres-dsn*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-clickhouse-password*",
+        "arn:aws:secretsmanager:*:*:secret:ai-tally-gateway-service-token*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-openai-api-key*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-anthropic-api-key*"
       ]

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -5,7 +5,7 @@
   "cpu": "512",
   "memory": "1024",
   "runtimePlatform": {
-    "cpuArchitecture": "X86_64",
+    "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
   "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
@@ -43,7 +43,7 @@
           "awslogs-group": "/ecs/ai-tally-web",
           "awslogs-region": "REGION",
           "awslogs-stream-prefix": "web",
-          "awslogs-create-group": "true"
+          "awslogs-create-group": "false"
         }
       }
     }

--- a/infra/edge-proxy/Dockerfile
+++ b/infra/edge-proxy/Dockerfile
@@ -5,14 +5,23 @@
 # running inside a regulated customer's VPC.
 
 # --- build ------------------------------------------------------------------------------------
-FROM golang:1.26 AS build
+# Pinned to BUILDPLATFORM so the compiler always runs natively and only the OUTPUT is cross-targeted
+# (CTO-334). The image is published for both linux/amd64 and linux/arm64: ECS Fargate runs it on
+# ARM64 for the cost lever, while the Helm chart's audience is mostly x86 nodes. A stdlib-only Go
+# binary cross-compiles for free, so a QEMU-emulated build stage would be pure waste.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS build
 WORKDIR /src
+
+# Set by buildx for every target in a multi-platform build; defaulted so a plain `docker build`
+# (no buildx) still works and produces a binary for the host architecture.
+ARG TARGETOS=linux
+ARG TARGETARCH
 
 # The module is stdlib-only (no go.sum / no external deps), so copying the source is enough.
 COPY . .
 
 # CGO off + static linking so the binary runs on scratch with no libc.
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \
     -o /out/edge-proxy ./cmd/edge-proxy
 
 # --- runtime ----------------------------------------------------------------------------------

--- a/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
+++ b/infra/edge-proxy/deploy/helm/edge-proxy/values.yaml
@@ -5,10 +5,17 @@
 replicaCount: 2
 
 image:
+  # Published by the `images` job in .github/workflows/ci.yml on every merge to main (CTO-334).
+  # Before that job existed this default pointed at a registry nothing in the repo pushed to, so a
+  # `helm install` with defaults pulled an image that had never been built. Multi-arch: linux/amd64
+  # and linux/arm64.
   repository: ghcr.io/jain-aanchal/ai-tally-edge-proxy
   pullPolicy: IfNotPresent
-  # Defaults to .Chart.AppVersion when empty.
-  tag: ""
+  # `main` is the moving tag CI publishes on each merge, so the chart works out of the box. It moves,
+  # which is exactly wrong for production: pin the commit SHA (CI tags every image with it) or a
+  # release `X.Y.Z` there. Set to "" to fall back to .Chart.AppVersion, which only resolves once a
+  # matching vX.Y.Z tag has been pushed.
+  tag: "main"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -32,6 +32,21 @@ FROM node:22-bookworm-slim AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1 \
     NEXT_PRIVATE_STANDALONE=true
+
+# `next build` statically prerenders /_not-found, which evaluates app/layout.tsx, which mounts
+# ClerkProvider and throws "Missing publishableKey" unless it is in the dev escape hatch. So the
+# build needs one of the two, and this ARG supplies the second, exactly as the `web` job in
+# .github/workflows/ci.yml does for its own `npm run build` (CTO-334).
+#
+# It is a BUILD arg and nothing more: this stage is discarded, the runner stage below sets its own
+# environment, and deploy/aws/ecs/web.taskdef.json sets TALLY_DEV_TENANT to "" at runtime. It does
+# leave the prerendered 404 page rendered in escape-hatch form, which is why CI builds this image but
+# does not publish it. See deploy/aws/README.md section 1 for the real constraint: Clerk's
+# NEXT_PUBLIC_ publishable key is inlined at build time, so a web image is per-deployment and cannot
+# be a tenant-neutral registry artifact.
+ARG TALLY_DEV_TENANT=""
+ENV TALLY_DEV_TENANT=${TALLY_DEV_TENANT}
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -18,7 +18,13 @@
 FROM node:22-bookworm-slim AS deps
 WORKDIR /app
 # Only the manifests, so this layer is reused whenever source (but not deps) changes.
-COPY package.json package-lock.json ./
+#
+# .npmrc belongs here too (CTO-334). It carries legacy-peer-deps=true, which the repo needs because
+# @clerk/nextjs pins its React peer above the exact react 19.0.0 the app is built against. Without it
+# `npm ci` dies with ERESOLVE and the image cannot be built at all. That went unnoticed until CI
+# started building this image, because the `web` CI job runs npm ci in the checkout, where .npmrc is
+# simply present.
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 
 # ---- builder ------------------------------------------------------------------------------------


### PR DESCRIPTION
Phase 0 of `docs/aws-bundle-scope.md`. Closes #334 and #339. First PR in a stack; later PRs branch off this one.

## #334, CI builds no container images

Verified on `main`: `.github/workflows/ci.yml` had four jobs and all four lint and test. Nothing tagged or pushed a container. Meanwhile `infra/edge-proxy/deploy/helm/edge-proxy/values.yaml` defaulted its image to `ghcr.io/jain-aanchal/ai-tally-edge-proxy`, which nothing in this repo published, so a `helm install` with defaults pulled an image that had never been built.

A fifth `images` job, `needs`-gated on all four existing suites, now builds the gateway, the edge proxy and the web tier, and publishes the first two. The four test jobs are untouched.

### Registry: both, and why

**GHCR and ECR.** They are not redundant, they are two different consumers.

GHCR is the public distribution channel. It is the registry the chart already pointed at, it needs no AWS account to pull from, and self-hosted installs (`docs/self-hosted-scope.md`'s audience) are its users. ECR is the deployment registry for our own ECS Fargate services: tasks pull it inside the VPC with no NAT egress, and `deploy/aws/ecs/iam/execution-role-policy.json` already grants exactly that pull and nothing else.

Publishing to only one would leave the other half of the tree pointing at an artifact nothing produces, which is the bug being closed. Both now agree with what is published: the chart default resolves, and the ECS task definitions keep their `ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/*` references, which section 1 of the runbook now tells you how to fill.

### Authentication: OIDC, or nothing

`aws-actions/configure-aws-credentials@v4` with `role-to-assume` and `id-token: write`. No access key is stored, and there is no fallback path that would use one.

The role does not exist yet, because there is no IaC in this repository at all (#335). Rather than pretend otherwise, the ECR half is gated on the `AWS_ECR_ROLE_ARN` repository variable: while it is unset the job publishes to GHCR, prints a `::notice::` saying the ECR push was skipped, and stays green. The moment an operator creates the role and sets the variable, the same job starts pushing to ECR with no code change. `workflow_dispatch` is on the trigger list precisely so that first run does not need an empty commit.

Two new documents say what to create, in the voice of the existing IAM docs:

- `deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json`: trust for `token.actions.githubusercontent.com`, `aud` pinned to `sts.amazonaws.com`, `sub` restricted to `repo:jain-aanchal/ai-tally:ref:refs/heads/main` and `refs/tags/v*`. A fork or a pull-request run cannot assume it.
- `deploy/aws/ecs/iam/github-actions-ecr-policy.json`: `ecr:GetAuthorizationToken` plus push on exactly the three repositories.

Section 1 of `deploy/aws/README.md` has the `aws iam` commands and the three repository variables. They are **variables, not secrets**, on purpose: a role ARN and a registry hostname are not credentials, and leaving them readable makes it auditable which role CI can assume.

### Tagging: SHA always, plus `main` and semver

Every image carries the **commit SHA**. That is the tag a task definition should pin: the only one that cannot be moved, and the one that makes a running container traceable.

Two more, each earning its place. On a merge to `main` the image is also tagged `main`, so a chart or a compose file has a working default; the chart's `image.tag` now defaults to `main` with a comment saying production pins a SHA or a release instead. On a `vX.Y.Z` git tag the image is also tagged `X.Y.Z`, which is the form the chart's `appVersion` and the task definitions' human-readable `:1.0.0` pin refer to.

No `latest`. That is the tag that makes a deployed container untraceable.

### When it runs

Not on every PR. On a merge to `main`, on a `v*` tag, on `workflow_dispatch`, and on a pull request **only when that PR touches a Dockerfile, a `.dockerignore` or this workflow**, in which case it builds without pushing. That last case is the point, and it paid for itself immediately: see the two bugs it caught below. Every other PR pays nothing.

### ARM64: yes

`docs/aws-bundle-scope.md` calls `cpuArchitecture: X86_64` "a standing cost lever the bundle currently forecloses" and it is right, most sharply for the edge proxy, which is deliberately kept warm and so is a fixed floor rather than a variable.

All three task definitions move to `ARM64` and the job builds `linux/arm64`, natively on GitHub's `ubuntu-24.04-arm` runners (free for public repositories) rather than under QEMU, which would make `next build` and the pip install unreasonably slow. The two must move together, which is why they are in one PR: ARM64 task definitions pulling amd64 images would fail to start every task.

The edge proxy is additionally published for **amd64**, because its Helm chart targets customer clusters that are mostly x86 and a stdlib-only Go binary cross-compiles for free. Its Dockerfile now pins the build stage to `--platform=$BUILDPLATFORM` and passes `GOARCH=$TARGETARCH`, so the compiler always runs natively and only the output is cross-targeted.

### The web image is built and deliberately not pushed

This is the one place I did not do what the ticket asked, and it is worth arguing with me about.

CI's first two runs found that `web/Dockerfile` could not build at all, then found why the fixed build still failed: `next build` statically prerenders `/_not-found`, which evaluates `app/layout.tsx`, which mounts `ClerkProvider` and throws `Missing publishableKey`. That is not a packaging detail. Clerk's `NEXT_PUBLIC_` publishable key is **inlined into the client bundle at build time**, so a web image built without one can never sign anybody in, and one built with a key belongs to a single deployment and has no business in a shared registry.

Pushing it anyway would put a container in a registry that cannot do the one thing the dashboard exists to do, which is the honest-under-uncertainty invariant with the labels swapped. So the matrix entry builds it and pushes nothing. That build still earns its place: it is what caught both bugs, and nothing else in CI builds this image. `web/Dockerfile` takes a `TALLY_DEV_TENANT` build arg for it, mirroring what the `web` CI job already does for its own `npm run build`; the arg lives in the discarded builder stage and never reaches the runtime image.

This is consistent with the settled architecture. The dashboard ships on Vercel, and `docs/aws-bundle-scope.md` keeps `web.taskdef.json` only as "the escape hatch for anyone who does not want Vercel, and the bundle does not use them". Section 1 of the runbook now says the web image is yours to build, with your key, and flags that `web/Dockerfile` still needs a publishable-key build arg added, which I left to the in-flight PR that owns `app/layout.tsx` and the `TALLY_DEV_TENANT` guard.

## #339, the edge proxy has no AWS deploy artifact

Adds `deploy/aws/ecs/edge-proxy.taskdef.json` and `edge-proxy.service.json`, following the shape of the gateway pair: same placeholder conventions, same secret-by-ARN injection, same `assignPublicIp: DISABLED`, `minimumHealthyPercent: 100`, two tasks across two private subnets. `enableExecuteCommand` is `false` rather than `true`, because ECS Exec cannot work in an image with no shell.

Env vars are the real `EDGE_PROXY_*` names from `internal/config/config.go`, and `EDGE_PROXY_KEYS_URL` points at `GET /v1/edge/keys`, which `infra/gateway/src/gateway/app.py:2270` serves.

### The trap, proven rather than asserted

I read `infra/edge-proxy/cmd/edge-proxy/main.go` rather than taking the path on trust: line 134 registers `mux.HandleFunc("/healthz", ...)` writing `200` and the body `ok\n`, and the comment there says it is the one path the proxy owns. So `/healthz` on 8088 is right, and the response is **plain text `ok`**, not the gateway's `{"status":"ok"}` JSON, which matters when you write the target group's `--matcher`.

Then I built the scratch runtime layer and ran the probes against it:

```
=== The CMD-SHELL health check gateway.taskdef.json uses, against this image
docker: Error response from daemon: ... exec: "/bin/sh": stat /bin/sh: no such file or directory
exit=127

=== Every probe binary a container health check could plausibly use
    /bin/sh ABSENT      /bin/bash ABSENT      /usr/bin/env ABSENT
    /usr/bin/curl ABSENT  /usr/bin/wget ABSENT  /usr/bin/python3 ABSENT  /bin/busybox ABSENT

=== The whole filesystem of the image (docker export | tar -t)
.dockerenv  dev/  dev/console  dev/pts/  dev/shm/  edge-proxy
etc/  etc/hostname  etc/hosts  etc/mtab  etc/resolv.conf
etc/ssl/  etc/ssl/certs/  etc/ssl/certs/ca-certificates.crt  proc/  sys/

=== The container runs, and /healthz answers
    GET /healthz -> HTTP 200 body: ok
    container state: running
```

Every attempt exits 127, so ECS marks the task unhealthy and kills it, forever, with nothing in the logs naming the cause. The task definition therefore has no `healthCheck` block and carries the reason in `dockerLabels`, where the next person editing the file will see it:

> Deliberate (CTO-339). Do NOT add a healthCheck block here. The image is FROM scratch [...] Liveness is checked by the ALB target group against GET /healthz on 8088 instead.

The runbook has the matching `aws elbv2 create-target-group` with a deliberately shallow, short-interval check, because a bad task in somebody's production LLM path should drain fast.

## Two smaller fixes from the same review

**`cpuArchitecture`.** Switched to ARM64, with matching images. See above.

**`awslogs-create-group: true` with no retention.** The honest fix is not what the ticket assumed: **the awslogs driver has no retention option at all**, so retention cannot be set in a task definition. Auto-creation is the actual problem, because a group created that way keeps every line forever at full price and nobody notices. So `awslogs-create-group` is now `false` on all three task definitions, and the runbook creates the three groups with `aws logs put-retention-policy --retention-in-days 30` before the first deploy. A missing group is now a loud task failure instead of a silent unbounded bill.

## The three stale facts

`S3ReplayBlobStore` shipped under CTO-158 (`infra/gateway/src/gateway/replay_store.py`), so:

- `gateway.taskdef.json` sets `TALLY_REPLAY_BLOB_BACKEND=s3` with `TALLY_REPLAY_S3_BUCKET` and `TALLY_REPLAY_S3_REGION`, and the runbook's `sed` fills the bucket.
- The README's "today the supported backends are `memory` and `gcs`" Open TODO is deleted.
- `ai-tally-gateway-service-token` is added to the ARN lists in `task-role-policy.json` and `execution-role-policy.json`. `gateway.taskdef.json` already referenced that secret, so the three places that must agree now do.

## What I proved by running, and what I could not

**Proved locally:**

- All four existing suites on this branch: gateway 940 passed / 8 skipped and ruff clean; sdk 1332 passed and ruff clean; web typecheck clean, lint clean except the known pre-existing `lib/useLivePoll.ts:94` warning, 801 tests / 65 files passed; edge-proxy `go build` clean and `gofmt -l` silent.
- **The gateway image**, built with the workflow's exact command (`docker buildx build --platform linux/arm64 -f infra/gateway/Dockerfile .`), reports `arm64 linux`, boots, answers `GET /healthz` with `{"status":"ok"}`, and passes its own `CMD-SHELL` health check run inside the container (exit 0). The gateway's container health check is fine and stays.
- **The edge-proxy scratch runtime**, as quoted above.
- The cross-compile the new edge-proxy Dockerfile performs: `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-s -w"` produces an `ELF 64-bit LSB executable, ARM aarch64, statically linked, stripped`.
- `actionlint` v1.7.12 on the workflow: zero findings, on each revision.
- `docker compose -f infra/docker-compose.yml config -q`: clean.
- Structural comparison of the new JSON against the existing gateway pair: task definition top-level keys identical, service keys identical, container keys differing only by `healthCheck` (gateway has it, proxy deliberately does not) and `dockerLabels` (the note).

**Proved by CI on this PR** (the PR touches Dockerfiles, so the gate built all three without pushing, which is itself the trigger logic working). The final run is green end to end:

```
✓ gateway  ✓ python-sdk  ✓ edge-proxy  ✓ web
✓ image (gateway)  ✓ image (edge-proxy)  ✓ image (web)
```

- `image (edge-proxy)`: the **`linux/amd64,linux/arm64` multi-arch build** succeeded, so the `$BUILDPLATFORM` / `$TARGETARCH` change is executed, not just reasoned.
- `image (gateway)`: `linux/arm64` build succeeded on `ubuntu-24.04-arm`.
- `image (web)`: builds, after the two bugs below.
- `edge-proxy` passing in 21 to 37s settles the local `TestOverheadBudget` failure noted below as a loaded-laptop artefact.

**Two latent bugs the new job caught on its first two runs**, both pre-existing and neither about architecture:

1. `web/Dockerfile`'s deps stage copied only `package.json` and `package-lock.json`, so `npm ci` ran without `web/.npmrc` and died with `ERESOLVE` on `@clerk/nextjs`'s React peer. That image has been unbuildable since `.npmrc` was added; nothing noticed because nothing built it. The `web` CI job never hit it because it runs `npm ci` in the checkout, where `.npmrc` is simply present.
2. `next build` then failed on the Clerk publishable key, which is the finding that decided the web-image question above.

**Could not verify, and I am not implying otherwise:**

- **Anything on the AWS side.** I have no AWS account. The task definitions have never been through `aws ecs register-task-definition`, no service has been created, no ALB target group exists, no ARM64 Fargate task has ever been scheduled, and the OIDC role and its trust policy have never been assumed. The structural comparison above is a shape check against files that themselves have never been demonstrably run end to end. Budget for first-run friction.
- **A push to any registry.** Nothing has been pushed anywhere: this PR builds with `push: false` throughout. GHCR gets its first push on merge, and ECR gets nothing at all until the role exists and the variables are set.
- **The edge-proxy and web images from their real Dockerfiles, locally.** Both need a registry pull (`golang:1.26`, `node:22-bookworm-slim`) and this machine's Docker daemon wedged partway through: `docker pull hello-world` hangs indefinitely while `curl https://registry-1.docker.io/v2/` from the host returns instantly. `python:3.12-slim` happened to be in the local cache, which is exactly why the gateway is the one image that finished locally. The scratch proof above therefore used the same `go build` invocation on the host plus a runtime layer with byte-identical contents (CA bundle, binary, same `EXPOSE`/`USER`/`ENTRYPOINT`), not the two-stage Dockerfile end to end. CI covered both of these.

One more thing worth flagging: `go test ./...` in `infra/edge-proxy` fails `TestOverheadBudget` on my machine (p99 added overhead around 5ms against a 3ms budget). It is not a regression from this PR, which changes no `.go` file at all (`git diff --stat HEAD -- '*.go'` is empty). Confirmed two ways: by copying the tree at the base commit with the original Dockerfile restored and running the same test there, where it fails identically, and by CI, where the `edge-proxy` job passes. It is a latency budget losing to a laptop that is also running the local compose stack.

## Anything in the scope docs I found wrong

Three things, all in `docs/aws-bundle-scope.md`, which I have not edited since it is a merged proposal:

1. "the task defs use `awslogs-create-group`, which creates groups that never expire. **Set retention in the Terraform**" reads as if retention were a log-configuration setting. It is not available in the awslogs driver at all, so it can only ever be a `put-retention-policy` call or an `aws_cloudwatch_log_group` resource, and auto-creation has to be turned off for that to be authoritative. The fix here reflects that.
2. The edge-proxy note says the scratch image "has no shell for `CMD-SHELL` and no `wget`". Accurate as far as it goes, and the export above shows it is stronger: there is no `/usr/bin` and no `/bin` at all, so no `CMD`-form probe is possible either, not only no `CMD-SHELL` one.
3. "**Both application images build today.**" The gateway and the edge proxy do. The web image, which that sentence does not count but which the phased plan expects CI to publish, did not: it had been unbuildable since `web/.npmrc` was added, and even fixed it cannot be a shared artifact. Phase 0's "a fifth job [...] that builds `infra/gateway/Dockerfile` [...] and `infra/edge-proxy/Dockerfile`" is right to name only those two; the web tier needs its own answer and does not have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
