### PR TITLE
feat(gateway): Secrets Manager HMAC keys, a CORS allowlist, and the auth boot guard

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -322,30 +322,96 @@ same value as `TALLY_GATEWAY_SERVICE_TOKEN`; the two must match exactly, or the 
 ## 6. Identity — task role (ECS) / IRSA (EKS)
 
 Create **one workload IAM role** and grant it exactly what the app needs. No static access key is
-ever created. The permissions policy is `ecs/iam/task-role-policy.json` (S3 replay + Cost Explorer +
-Bedrock + Secrets Manager read); reuse it verbatim for both paths — only the **trust** differs.
+ever created. The permissions policy is `ecs/iam/task-role-policy.json` (S3 replay + per-tenant HMAC
+secrets + KMS + connector role assumption + Cost Explorer + Bedrock + Secrets Manager read); reuse it
+verbatim for both paths, only the **trust** differs.
+
+**Every IAM document here carries placeholders and none of them is usable unedited.** They are the
+same tokens the task definitions use, so one `sed` line covers a file: `ACCOUNT`, `REGION`,
+`REPLACE_REPLAY_BUCKET` (the same bucket `gateway.taskdef.json` names) and `REPLACE_KMS_KEY_ID`. The
+bucket used to be spelled `my-org-ai-tally-replay`, which reads like a real name and is not one; it
+is a placeholder now so nobody grants their role access to somebody else's bucket.
 
 ```bash
+export KMS_KEY_ID=YOUR_CMK_KEY_ID            # see "Which KMS key" below
+export REPLAY_BUCKET=$ACCOUNT-ai-tally-replay
+
 # The permissions policy (shared by both paths):
+sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+    -e "s/REPLACE_REPLAY_BUCKET/$REPLAY_BUCKET/g" \
+    -e "s/REPLACE_KMS_KEY_ID/$KMS_KEY_ID/g" \
+    deploy/aws/ecs/iam/task-role-policy.json > /tmp/ai-tally-workload.json
 aws iam create-policy --policy-name ai-tally-workload \
-  --policy-document file://deploy/aws/ecs/iam/task-role-policy.json
+  --policy-document file:///tmp/ai-tally-workload.json
 export WORKLOAD_POLICY_ARN=arn:aws:iam::$ACCOUNT:policy/ai-tally-workload
 ```
 
-**ECS** — create the task role (trusted by `ecs-tasks.amazonaws.com`) and the execution role:
+**ECS** — create the task role (trusted by `ecs-tasks.amazonaws.com`) and the execution role. The
+trust policy pins `aws:SourceAccount` so no other account's ECS can assume these roles, which is
+why it needs substituting too:
 
 ```bash
-# Task role = the app's own identity (S3 / Cost Explorer / Bedrock).
+sed "s/ACCOUNT/$ACCOUNT/g" deploy/aws/ecs/iam/ecs-tasks-trust-policy.json > /tmp/ecs-trust.json
+
+# Task role = the app's own identity (S3 / tenant HMAC secrets / Cost Explorer / Bedrock).
 aws iam create-role --role-name ai-tally-workload \
-  --assume-role-policy-document file://deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+  --assume-role-policy-document file:///tmp/ecs-trust.json
 aws iam attach-role-policy --role-name ai-tally-workload --policy-arn "$WORKLOAD_POLICY_ARN"
 
 # Execution role = what Fargate needs to START a task (ECR pull, logs, secret injection).
+sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+    -e "s/REPLACE_KMS_KEY_ID/$KMS_KEY_ID/g" \
+    deploy/aws/ecs/iam/execution-role-policy.json > /tmp/ai-tally-execution.json
 aws iam create-role --role-name ai-tally-ecs-execution \
-  --assume-role-policy-document file://deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+  --assume-role-policy-document file:///tmp/ecs-trust.json
 aws iam put-role-policy --role-name ai-tally-ecs-execution --policy-name ai-tally-ecs-execution \
-  --policy-document file://deploy/aws/ecs/iam/execution-role-policy.json
+  --policy-document file:///tmp/ai-tally-execution.json
 ```
+
+### What each grant is for, and what to delete
+
+| Statement | Who uses it | Drop it when |
+|---|---|---|
+| `ReplayBucketS3` | `S3ReplayBlobStore` (`TALLY_REPLAY_BLOB_BACKEND=s3`) | you run the `memory` backend |
+| `TenantHmacSecrets` | `SecretManagerKeyProvider` (`TALLY_HMAC_KEY_PROVIDER=kms`) | never, on a multi-tenant instance: this is what holds the identifiers-by-hash invariant up |
+| `SecretsManagerKmsUse` | the same provider, and any CMK-encrypted secret | your secrets use the AWS-managed `aws/secretsmanager` key (then delete the statement rather than leaving a dangling key id) |
+| `AssumeTenantConnectorRoles` | a per-tenant `credentials_ref` holding a role ARN (`docs/connector-aws-cost-explorer.md`) | every tenant uses `aws-default-chain` |
+| `CostExplorerRead` | the AWS Cost Explorer compute connector | no tenant enables it |
+| `BedrockInvoke` | nothing in the codebase today | now, unless you are staging for Bedrock: it is an unearned privilege |
+
+The execution role's ECR grants are now scoped to the three `ai-tally/*` repositories rather than
+`*`; `ecr:GetAuthorizationToken` stays on `*` because it does not support resource-level permissions.
+
+### Which KMS key
+
+`REPLACE_KMS_KEY_ID` is the customer-managed key your Secrets Manager secrets are encrypted with. If
+you left them on the AWS-managed `aws/secretsmanager` key, delete the `SecretsManagerKmsUse` and
+`SecretsInjectionKmsDecrypt` statements instead of substituting: the AWS-managed key is usable by
+principals in the account that hold the Secrets Manager permission, so a grant would be redundant,
+and a policy naming a key that does not exist is a policy nobody can read. If you DO use a CMK, both
+statements are required, they carry a `kms:ViaService` condition so the roles cannot use the key for
+anything but Secrets Manager, and the key policy must also allow the account root or these roles.
+
+### Per-tenant HMAC keys (CTO-336)
+
+With `TALLY_HMAC_KEY_PROVIDER=kms`, provisioning a tenant creates one Secrets Manager secret named
+`ai-tally/tenant-hmac/<uuid>` holding 32 random bytes, and stores **only** its ARN plus a version
+selector (`.../v1`) in `tenants.hash_salt_kek_ref`, whose `no_raw_secret` CHECK bounds it to under
+512 characters. That is the credentials-by-reference invariant in `CLAUDE.md`, made real: the
+control-plane database holds a pointer that is useless without IAM permission on the ARN.
+
+Two operational notes:
+
+- **Do not enable AWS managed rotation on these secrets.** Rotating a tenant's HMAC key changes every
+  hash computed after it, so it is a product decision about historical joins, not a key-store
+  operation, and ai-tally does not ship rotation yet. The reference deliberately pins the `v1`
+  staging label rather than `AWSCURRENT`, so a rotation that moved `AWSCURRENT` would not silently
+  break existing hashes, but it would also not do anything useful.
+- **Failure is honest.** If the gateway cannot reach Secrets Manager, or the role lacks
+  `TenantHmacSecrets`, `POST /v1/tenant/provision` returns **503** and writes no tenant row, and
+  `GET /v1/tenant/hmac-key` returns 503 rather than 404. There is deliberately no fallback to a
+  locally generated key: it would produce hashes that look valid and are not the tenant's own.
+  Clerk retries the webhook and provisioning is idempotent, so fix the IAM gap and the retry lands.
 
 **EKS** — bind the same permissions to the KSA the chart creates (`ai-tally` in namespace
 `ai-tally`) via IRSA. Easiest with `eksctl`, which writes the OIDC trust policy for you:
@@ -415,6 +481,21 @@ sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
 aws ecs register-task-definition --cli-input-json file:///tmp/edge-proxy.taskdef.json
 aws ecs create-service --cli-input-json file://deploy/aws/ecs/edge-proxy.service.json
 ```
+
+### Gateway settings this bundle expects (CTO-336 / CTO-337 / CTO-268)
+
+Three gateway environment variables belong on the ECS gateway task and are not in
+`gateway.taskdef.json` yet (that file is owned by the image-publishing PR; add them there, or set
+them in your IaC, before you rely on any of the three):
+
+| Variable | Set it to | Why |
+|---|---|---|
+| `TALLY_ENV` | `production` | The gateway had no notion of a deployment environment, so nothing stopped `TALLY_REQUIRE_API_KEY=false` from shipping. With this set, a gateway with authentication off refuses to boot unless you also set `TALLY_ALLOW_INSECURE_NO_AUTH=1`. It is the gateway half of the web tier's guard, and it reuses the same opt-in variable. `gateway.taskdef.json` already sets `TALLY_REQUIRE_API_KEY=true`, so this is a backstop against a later edit rather than today's exposure. |
+| `TALLY_HMAC_KEY_PROVIDER` | `kms` | Selects the AWS Secrets Manager provider above. Left unset, the gateway uses the LOCAL provider, whose per-tenant material is derived from a root secret in configuration, which is exactly what credentials-by-reference forbids on a multi-tenant instance. |
+| `TALLY_CORS_ALLOWED_ORIGINS` | your dashboard's origin, e.g. `https://app.YOUR_DOMAIN` | The dashboard runs on Vercel and the gateway behind this ALB, so they are different origins. No browser code calls the gateway directly today (the dashboard's gateway calls all run server-side), so this is preparation rather than a fix for a live break. Unset means the local dev origins only, which admits nobody in a deployment: fail closed, not open. A wildcard is refused at boot. |
+
+`TALLY_HMAC_SECRETS_KMS_KEY_ID` is optional and only needed if you want tenant HMAC secrets encrypted
+with your CMK rather than the AWS-managed key.
 
 Notes on the task defs:
 - **Secrets** are injected from Secrets Manager by Fargate at task start via `secrets[].valueFrom`

--- a/deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+++ b/deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
@@ -4,7 +4,12 @@
     {
       "Effect": "Allow",
       "Principal": { "Service": "ecs-tasks.amazonaws.com" },
-      "Action": "sts:AssumeRole"
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "ACCOUNT"
+        }
+      }
     }
   ]
 }

--- a/deploy/aws/ecs/iam/execution-role-policy.json
+++ b/deploy/aws/ecs/iam/execution-role-policy.json
@@ -2,15 +2,24 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "EcrPull",
+      "Sid": "EcrAuth",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrPullThreeRepositories",
       "Effect": "Allow",
       "Action": [
-        "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage"
       ],
-      "Resource": "*"
+      "Resource": [
+        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/gateway",
+        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/edge-proxy",
+        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/web"
+      ]
     },
     {
       "Sid": "CloudWatchLogs",
@@ -33,6 +42,17 @@
         "arn:aws:secretsmanager:*:*:secret:ai-tally-openai-api-key*",
         "arn:aws:secretsmanager:*:*:secret:ai-tally-anthropic-api-key*"
       ]
+    },
+    {
+      "Sid": "SecretsInjectionKmsDecrypt",
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "arn:aws:kms:REGION:ACCOUNT:key/REPLACE_KMS_KEY_ID",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "secretsmanager.REGION.amazonaws.com"
+        }
+      }
     }
   ]
 }

--- a/deploy/aws/ecs/iam/task-role-policy.json
+++ b/deploy/aws/ecs/iam/task-role-policy.json
@@ -11,9 +11,42 @@
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::my-org-ai-tally-replay",
-        "arn:aws:s3:::my-org-ai-tally-replay/*"
+        "arn:aws:s3:::REPLACE_REPLAY_BUCKET",
+        "arn:aws:s3:::REPLACE_REPLAY_BUCKET/*"
       ]
+    },
+    {
+      "Sid": "TenantHmacSecrets",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecretVersionStage",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:TagResource"
+      ],
+      "Resource": "arn:aws:secretsmanager:*:*:secret:ai-tally/tenant-hmac/*"
+    },
+    {
+      "Sid": "SecretsManagerKmsUse",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": "arn:aws:kms:REGION:ACCOUNT:key/REPLACE_KMS_KEY_ID",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "secretsmanager.REGION.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "AssumeTenantConnectorRoles",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::*:role/ai-tally-connector-*"
     },
     {
       "Sid": "CostExplorerRead",

--- a/infra/gateway/pyproject.toml
+++ b/infra/gateway/pyproject.toml
@@ -24,6 +24,13 @@ gcs = [
 s3 = [
     "boto3>=1.34",
 ]
+# AWS Secrets Manager HMAC key provider (CTO-336). Only needed by a deployment that sets
+# TALLY_HMAC_KEY_PROVIDER=kms; `SecretManagerKeyProvider` lazy-imports boto3 at construction, so the
+# gateway imports and boots fine without this extra on the default `local` provider. The test suite
+# injects a fake client and needs neither this extra nor an AWS account.
+secrets = [
+    "boto3>=1.34",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.6,<0.16",

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -148,10 +148,17 @@ from gateway.tenant_api_keys import (
     TenantApiKeyStore,
     TenantNotFound as ApiKeyTenantNotFound,
 )
+from gateway.auth_guard import assert_auth_config
+from gateway.cors import install_cors
 from gateway.tenant_connectors import ALLOWED_LAYERS, TenantConnectorStore
 from gateway.edge_keys import EdgeKeyStore
 from gateway.tenant_hmac_key import HmacKeyUnavailableError, TenantHmacKeyStore
-from gateway.tenant_provisioning import ProvisionError, TenantProvisioner, build_key_provider
+from gateway.tenant_provisioning import (
+    KeyProviderUnavailableError,
+    ProvisionError,
+    TenantProvisioner,
+    build_key_provider,
+)
 from gateway.tenant_eval import TenantEvalStore
 from gateway.tenant_feature_value_events import TenantFeatureValueEventStore
 from gateway.tenant_identity import TenantIdentityResolver
@@ -278,6 +285,12 @@ async def lifespan(app: FastAPI):
     # Configure logging first so the startup INFO line below (and every other gateway logger.info)
     # is captured rather than dropped by uvicorn's WARNING-only root (CTO-218).
     _configure_logging(settings.log_level)
+    # Fail CLOSED at boot (CTO-268, gateway half): TALLY_REQUIRE_API_KEY=false turns authentication
+    # off for ingest AND for the control plane, so a deployed gateway may not start that way without
+    # the operator's explicit TALLY_ALLOW_INSECURE_NO_AUTH. Runs FIRST, before any store is built:
+    # the point is that the process never serves, and the message is the only useful output. See
+    # gateway/auth_guard.py for why the deployment-environment notion had to be introduced here.
+    assert_auth_config(settings)
     # Fail CLOSED at boot (Initiative 1 §6): if auth is required but no control-plane service token is
     # configured, the /v1/tenant/* gate would have nothing to check and every control-plane endpoint
     # would be unauthenticated. Refuse to start rather than come up wide open.
@@ -595,6 +608,17 @@ async def _in_flight_gauge(request: Request, call_next: Any) -> Any:
     finally:
         if is_ingest:
             app.state.in_flight = max(0, getattr(app.state, "in_flight", 1) - 1)
+
+
+# CTO-337: cross-origin policy, installed AFTER the middleware above so it is the OUTERMOST layer
+# (``add_middleware`` inserts at the front of the stack, so the last one added runs first). That
+# ordering matters twice: a preflight OPTIONS is answered without touching the routes underneath,
+# and an error response still carries the CORS headers a browser needs to report the real status
+# instead of an opaque network failure. Configured by TALLY_CORS_ALLOWED_ORIGINS, defaulting to the
+# local dashboard origins; a wildcard is refused here, at import, rather than served. Read at import
+# because the middleware stack is built once per process, which is also when a 12-factor env var is
+# already fixed; ``gateway.cors.resolve_allowed_origins`` holds the decision so it stays testable.
+_CORS_ORIGINS = install_cors(app, get_settings())
 
 
 def _parse_batch(payload: dict[str, Any]) -> BatchRequest:
@@ -2099,6 +2123,16 @@ async def provision_tenant(
         result = provisioner.provision(clerk_org_id=clerk_org_id, name=name)
     except ProvisionError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except KeyProviderUnavailableError as exc:
+        # CTO-336. The per-org HMAC key set could not be minted (Secrets Manager unreachable, or the
+        # task role lacks the grant). No tenant row was written and none will be: a tenant that
+        # cannot hash its identifiers must not exist, and a locally-derived key would be a fabricated
+        # answer that looks valid. 503, not 422: the caller sent nothing wrong. Clerk retries the
+        # webhook, and provisioning is idempotent, so the retry succeeds once the cause is fixed.
+        logger.error("provision failed: HMAC key provider unavailable (%s)", exc)
+        raise HTTPException(
+            status_code=503, detail="tenant key provider unavailable; provisioning was not performed"
+        ) from exc
     return JSONResponse(result.as_dict(), status_code=200)
 
 
@@ -2262,6 +2296,14 @@ def get_tenant_hmac_key(
     except HmacKeyUnavailableError as exc:
         # Honest under uncertainty: no fabricated bytes. The SDK degrades to unattributed (§3.3).
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except KeyProviderUnavailableError as exc:
+        # CTO-336. "We could not ask the key store" is a different answer from "there is no key
+        # here", and answering 404 for it would tell the SDK to give up permanently on a transient
+        # outage. 503 says retryable, and still returns no bytes.
+        logger.error("hmac-key fetch failed: key provider unavailable (%s)", exc)
+        raise HTTPException(
+            status_code=503, detail="hmac key provider unavailable; no key material was returned"
+        ) from exc
     # No log line here: the only interesting thing to report is the material, which must not be
     # recorded. The access log may keep the request line; the body never appears in a log.
     return JSONResponse(material.as_dict(), status_code=200)

--- a/infra/gateway/src/gateway/auth_guard.py
+++ b/infra/gateway/src/gateway/auth_guard.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Boot-time guard on the gateway's authentication escape hatch (CTO-268, gateway half).
+
+WHY this file exists. ``TALLY_REQUIRE_API_KEY=false`` is one environment variable that turns
+authentication OFF for the whole gateway: ``/v1/batches`` accepts whatever ``tenant_id`` the caller
+puts in the body, and the control-plane service-token gate on ``/v1/tenant/*`` goes quiet too,
+because that gate is active only when auth is ON and a token is configured (see
+``app._require_service_token``). Anyone who can reach the port can then write spans against any
+tenant and read and rewrite any tenant's control-plane configuration. That is correct and wanted for
+``make up``, for the test suite and for a laptop; it is a catastrophe on a reachable deployment.
+
+The web tier got this guard first (``web/lib/authGuard.ts``, PR #345) and its author deferred the
+gateway half for a stated reason: ``gateway/config.py`` had no notion of a deployment environment,
+so there was nothing to test ``TALLY_REQUIRE_API_KEY`` against, and introducing that notion is a
+design decision rather than a line of code. This module makes that decision.
+
+THE DECISION, and the honest limitation in it. The web tier gets ``NODE_ENV=production`` for free:
+``next start`` and the standalone server set it, so the guard fires without an operator doing
+anything. A Python process has no equivalent signal, and there is nothing in the gateway's existing
+configuration that reliably means "this is a real deployment" (a Postgres DSN pointing at a remote
+host is a guess, and guessing is exactly what the honest-under-uncertainty invariant forbids). So
+this introduces an explicit one, ``TALLY_ENV``, defaulting to ``development``:
+
+* ``development`` / ``dev`` / ``local`` / ``test``: no guard. ``make up``, CI and pytest are
+  unaffected and need no new variable.
+* ``production`` / ``prod`` / ``staging`` / ``stage``: auth must be on, OR the operator must say
+  ``TALLY_ALLOW_INSECURE_NO_AUTH=1`` and live with a warning banner on every boot.
+* anything else: treated as a deployment, because an unrecognized value is far more likely to be a
+  typo in a deployment manifest than a laptop, and the fail-closed direction is the safe one.
+
+The limitation is that an operator who never sets ``TALLY_ENV`` is not protected. That is real, and
+it is why the deployment manifests must set it (``deploy/aws/README.md`` says so, and the ECS task
+definition already sets ``TALLY_REQUIRE_API_KEY=true`` so the guard is a backstop there, not the
+thing that saves it). A guard that defaulted the other way would refuse to start every developer's
+``make up`` and every CI run, which is how guards get deleted.
+
+WHY THIS DOES NOT BREAK THE AUTH-DISABLED SHAPE. ``infra/edge-proxy/README.md`` documents
+``EDGE_PROXY_TENANT_ID`` as "Required when the gateway runs with auth disabled", so an auth-disabled
+gateway is a supported configuration somewhere and must keep working. It does: it is untouched in
+every development environment, and it remains available in a deployment behind the same explicit
+opt-in the web tier introduced. We deliberately reuse ``TALLY_ALLOW_INSECURE_NO_AUTH`` rather than
+inventing a second spelling, so one operator sentence covers both tiers of one deployment.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+#: Env keys this guard reads. Named once so the message and the checks cannot drift.
+ENV_VAR = "TALLY_ENV"
+REQUIRE_API_KEY_ENV = "TALLY_REQUIRE_API_KEY"
+ALLOW_INSECURE_ENV = "TALLY_ALLOW_INSECURE_NO_AUTH"
+
+#: Environment names that mean "a laptop, CI, or the test suite": the guard stands down.
+LOCAL_ENVIRONMENTS: frozenset[str] = frozenset({"development", "dev", "local", "test", "ci"})
+
+#: Environment names that mean "a real, reachable deployment". Anything unrecognized joins them.
+DEPLOYED_ENVIRONMENTS: frozenset[str] = frozenset({"production", "prod", "staging", "stage"})
+
+
+class InsecureAuthConfigError(RuntimeError):
+    """Auth is off in a deployed environment with no explicit opt-in. Raised at boot."""
+
+
+def is_truthy(value: object) -> bool:
+    """Same truthiness spelling ``web/lib/authGuard.ts`` and ``deploy/demo/lib-tenant.sh`` accept."""
+    if isinstance(value, bool):
+        return value
+    if not isinstance(value, str):
+        return False
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def is_deployed_environment(env: object) -> bool:
+    """Whether ``TALLY_ENV`` names a real deployment. Unrecognized values fail closed (deployed)."""
+    name = (env if isinstance(env, str) else "").strip().lower()
+    if not name:
+        # Empty is the default and means "unset", which is a laptop until someone says otherwise.
+        return False
+    return name not in LOCAL_ENVIRONMENTS
+
+
+@dataclass(frozen=True, slots=True)
+class AuthGuardVerdict:
+    """What the guard decided. ``kind`` is one of ``ok`` / ``insecure-allowed`` / ``refuse``."""
+
+    kind: str
+    message: str = ""
+
+
+def _refusal_message(env_name: str) -> str:
+    return f"""
+================================================================================
+ai-tally gateway REFUSES TO START: authentication is disabled in {ENV_VAR}={env_name}.
+
+{REQUIRE_API_KEY_ENV} is false, which turns authentication OFF for the whole
+gateway, not just for ingest:
+
+  * POST /v1/batches trusts the tenant_id in the request body, so any caller can
+    write spans, cost and business events against ANY tenant.
+  * The control-plane service-token gate on /v1/tenant/* is inert (it is enforced
+    only when auth is on), so any caller can read and rewrite any tenant's
+    connectors, budgets, guardrails and ingest keys.
+
+There is no safe fallback here, so this process stops instead of serving.
+
+You are in ONE OF TWO situations:
+
+  1. You want a REAL deployment. This is the normal case.
+
+         {REQUIRE_API_KEY_ENV}=true
+         TALLY_GATEWAY_SERVICE_TOKEN=<a long random server-only secret>
+
+     The service token authenticates the WEB SERVER on /v1/tenant/* calls; the
+     gateway already refuses to boot with auth on and that token empty.
+     deploy/aws/ecs/gateway.taskdef.json sets both.
+
+  2. You genuinely want an OPEN gateway, the way a laptop or the public demo runs.
+
+     Then say so, explicitly:
+
+         {ALLOW_INSECURE_ENV}=1
+
+     Only do this on a port nobody else can reach, or behind access control you
+     supply yourself. Note that the edge proxy's EDGE_PROXY_TENANT_ID exists for
+     exactly this shape (infra/edge-proxy/README.md), and it keeps working.
+
+     Or set {ENV_VAR}=development, which is what a laptop is.
+
+Checked: {ENV_VAR}={env_name}, {REQUIRE_API_KEY_ENV}=false, {ALLOW_INSECURE_ENV} not set.
+================================================================================
+""".strip()
+
+
+def _insecure_warning(env_name: str) -> str:
+    return f"""
+================================================================================
+ai-tally gateway WARNING: serving with NO AUTHENTICATION.
+
+{ENV_VAR}={env_name} and {REQUIRE_API_KEY_ENV} is false, with
+{ALLOW_INSECURE_ENV} set, so this gateway starts wide open: ingest trusts the
+tenant_id in the body and the control plane is ungated.
+
+This is a deliberate configuration. If you did not mean it, set
+{REQUIRE_API_KEY_ENV}=true and give the gateway a service token.
+================================================================================
+""".strip()
+
+
+def check_auth_config(
+    *, env: object, require_api_key: object, allow_insecure: object
+) -> AuthGuardVerdict:
+    """Decide whether this process may serve. Pure, so the decision table is testable.
+
+    ``assert_auth_config`` is the one that stops the boot; this is separated out so tests and the
+    allowed-but-insecure log path can inspect the decision without catching an exception.
+    """
+    if require_api_key is True or is_truthy(require_api_key):
+        return AuthGuardVerdict("ok")
+    if not is_deployed_environment(env):
+        return AuthGuardVerdict("ok")
+    env_name = (env if isinstance(env, str) else "").strip()
+    if is_truthy(allow_insecure):
+        return AuthGuardVerdict("insecure-allowed", _insecure_warning(env_name))
+    return AuthGuardVerdict("refuse", _refusal_message(env_name))
+
+
+def assert_auth_config(settings: object) -> AuthGuardVerdict:
+    """Raise :class:`InsecureAuthConfigError` on a refusal, warn loudly on an opted-in open gateway.
+
+    Called from the FastAPI lifespan, which is the gateway's equivalent of the web tier's
+    ``instrumentation.ts``: it runs once, before the first request is served, in every way this
+    process is started (uvicorn, the container entrypoint, a TestClient). A per-request check would
+    be skippable by any route that forgot it.
+    """
+    verdict = check_auth_config(
+        env=getattr(settings, "env", ""),
+        require_api_key=getattr(settings, "require_api_key", False),
+        allow_insecure=getattr(settings, "allow_insecure_no_auth", ""),
+    )
+    if verdict.kind == "refuse":
+        raise InsecureAuthConfigError(verdict.message)
+    if verdict.kind == "insecure-allowed":
+        logger.warning("%s", verdict.message)
+    return verdict

--- a/infra/gateway/src/gateway/config.py
+++ b/infra/gateway/src/gateway/config.py
@@ -27,9 +27,31 @@ class Settings(BaseSettings):
     # Postgres (control plane): used for API-key auth lookups.
     postgres_dsn: str = "postgresql://tally:tally@localhost:5432/tally"
 
+    # Deployment environment (CTO-268, gateway half). The gateway had NO notion of one, which is why
+    # PR #345 could guard the web tier's auth escape hatch (NODE_ENV=production is free there) and
+    # deliberately deferred the gateway's. This is that notion, and it exists for exactly one
+    # purpose today: `gateway.auth_guard` refuses to boot a deployment with authentication off
+    # unless the operator says TALLY_ALLOW_INSECURE_NO_AUTH. `development` (the default) keeps
+    # `make up`, CI and pytest working with no new variable; `production` / `staging` turn the guard
+    # on; an unrecognized value is treated as a deployment, because a typo in a manifest is likelier
+    # than a laptop and that is the fail-closed direction. Deployment manifests must set it.
+    env: str = "development"
+    # Explicit operator consent to run a DEPLOYED gateway with authentication off. Same variable
+    # name and same truthy spelling the web tier uses (web/lib/authGuard.ts), on purpose: one
+    # sentence covers both tiers of one deployment rather than two unrelated spellings.
+    allow_insecure_no_auth: str = ""
+
     # Auth. When false, the gateway trusts the batch's tenant_id (local dev). When true, requests
     # must carry `Authorization: Bearer <key>` whose SHA-256 is registered in api_keys.
     require_api_key: bool = False
+
+    # Browser origins allowed to read a gateway response (CTO-337). Comma-separated exact origins
+    # (`https://app.example.com,https://staging.example.com`); a wildcard is REFUSED at boot. Empty
+    # (the default) means the local dashboard origins, so `make up` needs no configuration. See
+    # gateway/cors.py for why the policy is an allowlist, why credentials mode stays off, and why
+    # the preflight cache is short. Local compose never needs this: the dashboard calls the gateway
+    # from its own server process, so no browser is involved there at all.
+    cors_allowed_origins: str = ""
 
     # Per-org HMAC key-material provider (Initiative 2, §3.2). Selects HOW the provisioner mints, and
     # the /v1/tenant/hmac-key bootstrap reads back, a tenant's active HMAC key set:
@@ -45,6 +67,18 @@ class Settings(BaseSettings):
     # across restarts (that is the point), so it must be overridden in any shared/staging environment
     # and is NEVER used by the ``kms`` provider. Not a production key.
     hmac_local_root_secret: str = "tally-local-dev-hmac-root-secret-do-not-use-in-prod"
+    # AWS Secrets Manager settings for the `kms` provider (CTO-336). Only the NAME PREFIX, an
+    # optional customer-managed KMS key id and a region live here: no credential and no key material.
+    # The client resolves the ECS task role / IRSA / instance profile through boto3's default chain.
+    # The prefix is what the IAM policy scopes on (deploy/aws/ecs/iam/task-role-policy.json), so
+    # changing it means changing that policy too; keep it short, because the minted reference
+    # (secret ARN + version selector) has to fit the length-bounded CHECK on
+    # tenants.hash_salt_kek_ref.
+    hmac_secrets_name_prefix: str = "ai-tally/tenant-hmac/"
+    hmac_secrets_kms_key_id: str = ""
+    # Empty means "resolve from the AWS default chain" (AWS_REGION / config / instance metadata),
+    # matching how the S3 replay backend treats its region.
+    hmac_secrets_region: str = ""
 
     # Control-plane service token (Initiative 1, §6). The web server is the ONLY legitimate caller of
     # the control-plane endpoints (`/v1/tenant/*`); it authenticates with this server-only shared

--- a/infra/gateway/src/gateway/cors.py
+++ b/infra/gateway/src/gateway/cors.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-origin policy for the gateway (CTO-337).
+
+WHY this exists. Local `make up` puts the dashboard and the gateway behind one compose network and
+the dashboard reaches the gateway from its OWN server process, so no browser ever performs a
+cross-origin request and the gateway needed no CORS policy to work. The decided hosting shape
+(`docs/aws-bundle-scope.md`) splits them: web on Vercel, gateway on ECS behind its own ALB, two
+different origins. Nothing in the dashboard calls the gateway from the browser TODAY (every
+`TALLY_GATEWAY_URL` fetch in `web/lib` runs in a route handler or a server action, and the variable
+is deliberately not `NEXT_PUBLIC_`), so this is a policy the gateway is missing rather than a fire it
+is currently on. It has to exist before the first browser-originated call, and it has to exist as an
+ALLOWLIST from the start, because the moment a wildcard ships it is very hard to take back.
+
+WHAT A CORS POLICY IS AND IS NOT. It is a browser-enforced rule about which page origins may READ a
+response. It is not authentication and it is not CSRF protection: a browser can still SEND a simple
+cross-origin POST regardless of what we answer here, and non-browser clients (the SDK, the edge
+proxy, curl) ignore CORS entirely. Every endpoint stays gated by its own bearer key or the
+control-plane service token; this module only decides whose page JavaScript may see the answer.
+
+THE THREE DECISIONS, and why:
+
+* **Allowlist, never ``*``.** The gateway holds per-tenant credentials and hands back HMAC key
+  material on ``GET /v1/tenant/hmac-key``. A wildcard would let any page on the internet script a
+  request from a visitor's browser and read the reply. :func:`resolve_allowed_origins` REFUSES a
+  configured ``*`` at boot rather than honoring it.
+
+* **Credentials mode off.** The gateway authenticates with an ``Authorization: Bearer`` header, not
+  with cookies. ``allow_credentials`` governs cookies / TLS client certs / HTTP-auth, none of which
+  this API uses, so turning it on would buy nothing and would make a future ``*`` (which the spec
+  then forbids the browser from honoring, silently) look like it works. An explicitly listed
+  ``authorization`` request header is what makes the bearer flow work, and that is unrelated to
+  credentials mode.
+
+* **A short preflight cache.** ``Access-Control-Max-Age`` caches a POSITIVE preflight in the browser
+  per (origin, method, header set). Removing an origin from the allowlist therefore does not take
+  effect in an already-warmed browser until the cached preflight expires, so this is a revocation
+  delay, not just a performance knob. Ten minutes keeps the preflight off the hot path (one OPTIONS
+  per browser per ten minutes, not per request) while bounding that delay; Chromium caps it at two
+  hours and Firefox at 24, so a larger value would mostly buy a longer stale window.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fastapi import FastAPI
+
+#: Origins allowed when nothing is configured. These are the `make up` / `npm run dev` dashboard
+#: (RUNNING.md: dashboard on :3000), spelled both ways because a browser treats `localhost` and
+#: `127.0.0.1` as different origins and operators reach for either. They are loopback-only, so a
+#: deployment that forgets to configure the allowlist gets a policy that admits nobody on the
+#: internet rather than one that admits everybody: wrong-by-default here fails closed.
+DEFAULT_DEV_ORIGINS: tuple[str, ...] = (
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+)
+
+#: Methods the gateway actually routes (plus the preflight's own OPTIONS). Enumerated rather than
+#: ``*`` so a new verb is a deliberate edit.
+ALLOWED_METHODS: tuple[str, ...] = ("GET", "POST", "DELETE", "OPTIONS")
+
+#: Request headers a browser caller may send. ``authorization`` carries the ingest key or the
+#: control-plane service token; ``x-tenant-id`` / ``x-clerk-user-id`` are the control-plane's
+#: resolved-tenant and audit headers; ``protocol-version`` is the ingest wire-version header.
+#: ``stripe-signature`` is deliberately ABSENT: Stripe posts server-to-server and never from a page.
+ALLOWED_HEADERS: tuple[str, ...] = (
+    "authorization",
+    "content-type",
+    "protocol-version",
+    "x-tenant-id",
+    "x-clerk-user-id",
+)
+
+#: Seconds a browser may cache a successful preflight. See the module docstring: this is also how
+#: long an origin removed from the allowlist can keep working in a warmed browser.
+PREFLIGHT_MAX_AGE_S = 600
+
+
+class CorsConfigError(ValueError):
+    """The configured allowlist cannot be honored. Raised at boot, never at request time."""
+
+
+def resolve_allowed_origins(settings: object) -> list[str]:
+    """Resolve ``TALLY_CORS_ALLOWED_ORIGINS`` into the exact origin list to allow.
+
+    Empty (the default) means :data:`DEFAULT_DEV_ORIGINS`, so `make up` keeps working with no
+    configuration at all. Otherwise the value is a comma-separated list of origins, each of which
+    must be a bare scheme://host[:port] with no path: browsers compare origins, not URLs, and a
+    trailing path in the config would silently match nothing.
+
+    ``*`` anywhere in the list is refused (see the module docstring), as is an empty explicit list.
+    """
+    raw = (getattr(settings, "cors_allowed_origins", "") or "").strip()
+    if not raw:
+        return list(DEFAULT_DEV_ORIGINS)
+
+    origins: list[str] = []
+    for piece in raw.split(","):
+        origin = piece.strip()
+        if not origin:
+            continue
+        if origin == "*" or "*" in origin:
+            raise CorsConfigError(
+                "TALLY_CORS_ALLOWED_ORIGINS must list exact origins, never a wildcard: the gateway "
+                "serves per-tenant credentials and HMAC key material, so any page on the internet "
+                f"could read them. Got {origin!r}."
+            )
+        if "://" not in origin:
+            raise CorsConfigError(
+                f"TALLY_CORS_ALLOWED_ORIGINS entry {origin!r} is not an origin: it needs a scheme, "
+                "e.g. https://app.example.com"
+            )
+        scheme, _, host = origin.partition("://")
+        if scheme not in ("http", "https"):
+            raise CorsConfigError(
+                f"TALLY_CORS_ALLOWED_ORIGINS entry {origin!r} must be http:// or https://"
+            )
+        if not host or "/" in host:
+            raise CorsConfigError(
+                f"TALLY_CORS_ALLOWED_ORIGINS entry {origin!r} must be a bare origin with no path: "
+                "a browser sends scheme://host[:port] in the Origin header and nothing else"
+            )
+        if origin not in origins:
+            origins.append(origin)
+
+    if not origins:
+        raise CorsConfigError(
+            "TALLY_CORS_ALLOWED_ORIGINS was set but lists no origin. Leave it unset for the local "
+            "dev default, or list the dashboard's origin."
+        )
+    return origins
+
+
+def install_cors(app: "FastAPI", settings: object) -> list[str]:
+    """Install the CORS policy on ``app`` and return the origins it allows.
+
+    Kept as one call so the policy is described in exactly one place. A misconfiguration raises
+    :class:`CorsConfigError` here, at import/boot, rather than producing a gateway that answers
+    cross-origin requests in a way nobody intended.
+    """
+    from starlette.middleware.cors import CORSMiddleware
+
+    origins = resolve_allowed_origins(settings)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        # See the module docstring: bearer header, not cookies. Off is the honest setting.
+        allow_credentials=False,
+        allow_methods=list(ALLOWED_METHODS),
+        allow_headers=list(ALLOWED_HEADERS),
+        max_age=PREFLIGHT_MAX_AGE_S,
+    )
+    return origins

--- a/infra/gateway/src/gateway/tenant_provisioning.py
+++ b/infra/gateway/src/gateway/tenant_provisioning.py
@@ -26,6 +26,9 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import logging
+import re
+import secrets
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -35,9 +38,19 @@ import psycopg
 
 from gateway.config import Settings
 
+logger = logging.getLogger(__name__)
+
 #: Data-residency region stamped on a provisioned tenant. Initiative 1 does no residency routing on
 #: ``region`` (§1 non-goals); the column stays and defaults here, matching how the seed defaults it.
 DEFAULT_REGION = "auto"
+
+#: Upper bound the ``no_raw_secret`` CHECK on ``tenants.hash_salt_kek_ref`` enforces
+#: (``length(hash_salt_kek_ref) < 512``, db/postgres/0001_control_plane.sql). Every provider
+#: validates its own reference against this BEFORE the insert, so a provider whose naming grew too
+#: long fails where the operator can read the reason instead of as a constraint violation mid-
+#: provision. The column is never widened to make a reference fit: a reference that does not fit is
+#: a naming bug, and the CHECK is what encodes "this column holds a pointer, not a secret".
+MAX_KEK_REF_LENGTH = 512
 
 #: Scheme for the local-dev HMAC key reference. It must satisfy the ``no_raw_secret`` CHECK on
 #: ``tenants.hash_salt_kek_ref`` (not ``sk-%``, length < 512). The trailing ``/v1`` leaves room for a
@@ -47,6 +60,41 @@ _LOCAL_KEK_SCHEME = "local"
 
 class ProvisionError(ValueError):
     """Caller-facing validation error on the provision request. Surfaces as HTTP 422."""
+
+
+class KeyProviderUnavailableError(RuntimeError):
+    """The key provider could not be reached, or refused the call (CTO-336).
+
+    Distinct from :class:`ProvisionError` on purpose. A ProvisionError says the CALLER sent something
+    wrong (422). This says our own dependency is unavailable or misconfigured: the request was fine
+    and we cannot answer it, which is a 503. Honest under uncertainty, both ways: the provisioner
+    writes no tenant row when a mint raises this, and the HMAC bootstrap serves an error rather than
+    fabricated or locally-derived bytes. There is deliberately NO fallback to the local provider,
+    because locally-derived material would produce hashes that look valid while being derived from a
+    process secret rather than the tenant's own key, which is the exact property the
+    identifiers-by-hash invariant promises.
+    """
+
+
+def assert_reference_fits(ref: str) -> str:
+    """Validate a key reference against the ``no_raw_secret`` CHECK before it reaches Postgres.
+
+    Returns the reference so call sites can ``return assert_reference_fits(...)``.
+    """
+    if not ref:
+        raise KeyProviderUnavailableError("key provider returned an empty reference")
+    if ref.startswith("sk-"):
+        # The CHECK's shape test for "somebody pasted a raw secret in here".
+        raise KeyProviderUnavailableError(
+            "key reference looks like a raw secret (starts with 'sk-'); the column stores a "
+            "pointer, never key material"
+        )
+    if len(ref) >= MAX_KEK_REF_LENGTH:
+        raise KeyProviderUnavailableError(
+            f"key reference is {len(ref)} chars, which does not fit tenants.hash_salt_kek_ref "
+            f"(< {MAX_KEK_REF_LENGTH}). Shorten the secret name prefix; do not widen the column."
+        )
+    return ref
 
 
 @runtime_checkable
@@ -129,50 +177,287 @@ class LocalDevKeyProvider:
         return hmac.new(self.root_secret, ref.encode("utf-8"), hashlib.sha256).digest()
 
 
-class SecretManagerKeyProvider:
-    """Production HMAC key provider seam, backed by KMS / Secret Manager (Initiative 2 §3.2).
+#: Length of a minted HMAC key set, in bytes. 32 bytes is HMAC-SHA256's block-optimal key size and
+#: matches what :class:`LocalDevKeyProvider` derives, so the SDK sees one shape from either provider.
+HMAC_KEY_BYTES = 32
 
-    This is the prod path selected by ``TALLY_HMAC_KEY_PROVIDER=kms``. The raw key set lives in the
-    cloud secret store; only its resource reference is persisted to ``tenants.hash_salt_kek_ref``, and
-    ``material`` fetches the active version back through the cloud client. The concrete client is
-    supplied by the deployment (Workload Identity / IAM, never a raw credential in config), so it is
-    injected rather than constructed here; selecting this provider without wiring a client fails fast
-    instead of silently falling back to dev-derived material.
+#: A reference's trailing version selector: ``.../v1``. Parsed here and by
+#: ``tenant_hmac_key._version_from_ref``, which surfaces it to the SDK as ``key_version``.
+_VERSION_SELECTOR = re.compile(r"^v\d+$")
+
+#: The first version a minted key set carries. Rotation (see the class docstring) mints a higher one.
+_FIRST_VERSION = "v1"
+
+
+class SecretManagerKeyProvider:
+    """Per-tenant HMAC key sets held in AWS Secrets Manager (CTO-336, Initiative 2 §3.2).
+
+    Selected by ``TALLY_HMAC_KEY_PROVIDER=kms`` (also spelled ``secret-manager``). Until CTO-336
+    every method here raised ``NotImplementedError``, so a real deployment either could not provision
+    a tenant at all or had to fall back to :class:`LocalDevKeyProvider`, whose material is derived
+    from a process-wide root secret sitting in config. That fallback is what the credentials-by-
+    reference invariant forbids, so this class exists to make the honest path the working one.
+
+    WHAT IS STORED WHERE, and why the reference stays a reference.
+      The 32 random bytes are generated in memory, written straight to Secrets Manager, and dropped.
+      What is persisted to ``tenants.hash_salt_kek_ref`` is the secret's ARN plus a version selector:
+
+          arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally/tenant-hmac/<uuid>-AbCdEf/v1
+
+      That is roughly 120 characters, well inside the ``no_raw_secret`` CHECK
+      (``NOT LIKE 'sk-%' AND length < 512``), and :func:`assert_reference_fits` proves it before the
+      insert rather than letting Postgres discover it. The reference is a pointer in the strict
+      sense: it is useless to anyone without IAM permission on that ARN, it contains no key material
+      and no entropy from the key, and it is safe to log (we still do not log it needlessly).
+
+    ROTATION IS OUT OF SCOPE FOR CTO-336, and this design does not preclude it.
+      Rotating a tenant's HMAC key changes every hash computed after it, so it is not a key-store
+      operation but a product decision about historical joins: the SDK stamps ``key_version`` on
+      spans (``GET /v1/tenant/hmac-key``) precisely so old and new hashes can coexist, and nothing
+      yet reads that column at query time. Shipping a rotation button before that read path exists
+      would silently break account attribution, so this PR ships none.
+
+      What it does ship is a design a rotation can land on without a schema change or a migration of
+      existing references:
+
+      * The reference names a STAGING LABEL (``v1``), not an immutable version id, and ``mint``
+        attaches that label to the version it creates. So ``material`` asks for the version labelled
+        ``v1`` forever, and an operator (or AWS managed rotation) moving ``AWSCURRENT`` onto a new
+        version cannot silently swap the bytes under hashes that already exist. Pinning
+        ``AWSCURRENT`` instead would have made rotation a data-corruption event; pinning an immutable
+        ``VersionId`` would have worked too but would have put an opaque 36-character id in the
+        column and made the human-readable ``vN`` selector a lie.
+      * A future rotation is then: ``put_secret_value`` on the SAME secret, label the new version
+        ``v2``, and update that tenant's ``hash_salt_kek_ref`` to ``.../v2``. That is one UPDATE of
+        an existing column, still inside the CHECK, and ``v1`` keeps resolving for historical hashes.
+
+    FAILURE IS HONEST, NEVER A FALLBACK.
+      Every AWS failure becomes :class:`KeyProviderUnavailableError`, which the provisioner lets
+      propagate WITHOUT writing a tenant row: a tenant that cannot hash is never created, and a
+      failed provision emits nothing rather than a locally-derived key that would look valid.
+      ``material`` distinguishes the two honest outcomes: a secret (or label) that genuinely does not
+      exist raises ``KeyError``, which the HMAC bootstrap turns into a 404 and the SDK degrades on;
+      anything else (unreachable endpoint, ``AccessDeniedException``, a throttle) raises
+      ``KeyProviderUnavailableError``, which is a 503, because "we could not ask" is not "there is
+      nothing there".
+
+    TESTABILITY WITHOUT AWS.
+      The ``client`` seam follows :class:`gateway.replay_store.S3ReplayBlobStore` exactly: pass a
+      client and it is used as-is; pass none and ``boto3`` is lazily imported and constructed with no
+      explicit credentials, so it resolves the AWS default chain (ECS task role / IRSA / instance
+      profile / env), and no raw credential is ever handled here. The tests inject a fake covering
+      the four calls this class makes, so the suite needs neither ``boto3`` nor an AWS account.
     """
 
-    def __init__(self, client: object | None = None) -> None:
+    __slots__ = ("_client", "_name_prefix", "_kms_key_id", "_region")
+
+    def __init__(
+        self,
+        client: object | None = None,
+        *,
+        name_prefix: str = "ai-tally/tenant-hmac/",
+        kms_key_id: str = "",
+        region: str = "",
+    ) -> None:
         if client is None:
-            raise ProvisionError(
-                "hmac_key_provider='kms' selected but no Secret Manager / KMS client was wired. "
-                "Inject the deployment's client; do not fall back to the local dev provider in prod."
-            )
+            client = self._build_client(region)
         self._client = client
+        self._name_prefix = name_prefix
+        self._kms_key_id = kms_key_id
+        self._region = region
 
-    def mint(self) -> str:  # pragma: no cover - exercised only in a cloud deployment
-        raise NotImplementedError("wire the deployment's Secret Manager / KMS client")
+    @staticmethod
+    def _build_client(region: str) -> object:
+        """Construct a real Secrets Manager client, or fail with a message an operator can act on."""
+        try:
+            import boto3  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - depends on the install's extras
+            raise ProvisionError(
+                "TALLY_HMAC_KEY_PROVIDER=kms needs boto3: install the gateway's [secrets] extra, "
+                "or inject a client. Falling back to the local dev provider is not an option: its "
+                "material is derived from a config root secret, not from the tenant's own key."
+            ) from exc
+        try:
+            # No explicit credentials: boto3 resolves the ECS task role / IRSA / instance profile /
+            # environment, in its normal order. A missing region is a real misconfiguration and
+            # boto3 says so, at boot, which is where we want it.
+            return boto3.client("secretsmanager", region_name=region or None)
+        except Exception as exc:  # noqa: BLE001 - normalise botocore's NoRegionError and friends
+            raise ProvisionError(
+                f"could not construct a Secrets Manager client: {exc}. Set AWS_REGION (or "
+                "TALLY_HMAC_SECRETS_REGION) on the gateway task."
+            ) from exc
 
-    def delete(self, ref: str) -> None:  # pragma: no cover - cloud-only
-        raise NotImplementedError("wire the deployment's Secret Manager / KMS client")
+    # --- reference parsing ---------------------------------------------------------------------
 
-    def material(self, ref: str) -> bytes:  # pragma: no cover - cloud-only
-        raise NotImplementedError("wire the deployment's Secret Manager / KMS client")
+    @staticmethod
+    def _split_ref(ref: str) -> tuple[str, str]:
+        """Split ``<secret-arn>/<vN>`` into its two halves, rejecting anything else.
+
+        The ARN itself contains slashes (the secret name does), so this splits on the LAST one and
+        insists the tail is a ``vN`` selector. A reference we cannot parse is never guessed at.
+        """
+        secret_id, _, version = ref.rpartition("/")
+        if not secret_id or not _VERSION_SELECTOR.match(version):
+            raise KeyProviderUnavailableError(
+                f"malformed Secrets Manager key reference {ref!r}: expected "
+                "'<secret-arn>/v<n>'"
+            )
+        return secret_id, version
+
+    # --- KeyMaterialProvider -------------------------------------------------------------------
+
+    def mint(self) -> str:
+        """Create a per-tenant secret holding 32 random bytes and return its versioned reference."""
+        name = f"{self._name_prefix}{uuid.uuid4()}"
+        material = secrets.token_bytes(HMAC_KEY_BYTES)
+        create_kwargs: dict[str, object] = {
+            "Name": name,
+            # SecretBinary, not SecretString: the key is bytes, and a base64 SecretString would make
+            # "is this value encoded or raw" a guess on the read path. Guessing is what we do not do.
+            "SecretBinary": material,
+            "Description": "ai-tally per-tenant HMAC key set (identifiers-by-hash). Do not rotate "
+            "with AWS managed rotation: see gateway/tenant_provisioning.py.",
+            "Tags": [
+                {"Key": "app", "Value": "ai-tally"},
+                {"Key": "purpose", "Value": "tenant-hmac"},
+            ],
+        }
+        if self._kms_key_id:
+            # Optional customer-managed key. Absent, Secrets Manager uses the AWS-managed
+            # aws/secretsmanager key, which still encrypts at rest.
+            create_kwargs["KmsKeyId"] = self._kms_key_id
+
+        created = self._call("create_secret", **create_kwargs)
+        arn = str(created.get("ARN") or "")
+        version_id = str(created.get("VersionId") or "")
+        if not arn or not version_id:
+            raise KeyProviderUnavailableError(
+                "Secrets Manager create_secret returned no ARN/VersionId; refusing to store a "
+                "reference we cannot resolve"
+            )
+        try:
+            # Label the version we just wrote so the reference pins THIS material rather than
+            # whatever AWSCURRENT happens to be later. See the rotation note in the class docstring.
+            self._call(
+                "update_secret_version_stage",
+                SecretId=arn,
+                VersionStage=_FIRST_VERSION,
+                MoveToVersionId=version_id,
+            )
+            return assert_reference_fits(f"{arn}/{_FIRST_VERSION}")
+        except Exception:
+            # A secret whose version carries no label can never be resolved, so it is orphaned key
+            # material the moment we return. Remove it before re-raising rather than leaving it to
+            # bill and to confuse an auditor.
+            self._delete_secret_quietly(arn)
+            raise
+
+    def delete(self, ref: str) -> None:
+        """Delete the secret behind ``ref``.
+
+        Called only for orphan cleanup: the loser of a provisioning race, or a failure after the
+        mint. In both cases no tenant row references this material, so it is deleted without a
+        recovery window; leaving it in Secrets Manager's 7-to-30-day window would bill for a secret
+        nothing can ever use and would leave key material behind, which the module docstring's
+        no-orphaned-key invariant exists to prevent.
+        """
+        secret_id, _ = self._split_ref(ref)
+        self._call(
+            "delete_secret", SecretId=secret_id, ForceDeleteWithoutRecovery=True
+        )
+
+    def material(self, ref: str) -> bytes:
+        """Fetch the key bytes the reference's version selector names.
+
+        ``KeyError`` when the secret or that labelled version genuinely does not exist (an honest
+        404 on the bootstrap endpoint); :class:`KeyProviderUnavailableError` for every other failure.
+        """
+        secret_id, version = self._split_ref(ref)
+        response = self._call("get_secret_value", SecretId=secret_id, VersionStage=version)
+        blob = response.get("SecretBinary")
+        if blob is None:
+            # A SecretString means somebody created this secret by hand in a shape we did not write.
+            # We do not try to interpret it (base64? utf-8? raw?), because a wrong guess yields
+            # hashes that look fine and are wrong for every account in that tenant.
+            raise KeyProviderUnavailableError(
+                f"secret {secret_id} holds a SecretString; ai-tally writes SecretBinary. Recreate "
+                "it with `aws secretsmanager put-secret-value --secret-binary fileb://key.bin`."
+            )
+        material = bytes(blob)
+        if len(material) < HMAC_KEY_BYTES:
+            raise KeyProviderUnavailableError(
+                f"secret {secret_id} holds {len(material)} bytes; an ai-tally HMAC key set is "
+                f"{HMAC_KEY_BYTES}. Refusing to hash under a short key."
+            )
+        return material
+
+    # --- AWS error translation -----------------------------------------------------------------
+
+    def _call(self, operation: str, **kwargs: object) -> dict:
+        """Invoke one boto3 operation, translating every failure into our own two error kinds."""
+        method = getattr(self._client, operation, None)
+        if method is None:
+            raise KeyProviderUnavailableError(
+                f"the wired Secrets Manager client has no {operation!r} operation"
+            )
+        try:
+            result = method(**kwargs)
+        except Exception as exc:  # noqa: BLE001 - botocore is optional; classify by shape
+            if _is_aws_not_found(exc):
+                # Genuinely absent, which is a different answer from "we could not ask".
+                raise KeyError(f"{operation}: {_aws_error_code(exc) or exc}") from exc
+            raise KeyProviderUnavailableError(
+                f"Secrets Manager {operation} failed ({_aws_error_code(exc) or type(exc).__name__}): "
+                f"{exc}"
+            ) from exc
+        return result if isinstance(result, dict) else {}
+
+    def _delete_secret_quietly(self, secret_id: str) -> None:
+        """Best-effort cleanup on a partially-created secret. Never masks the original failure."""
+        try:
+            self._call("delete_secret", SecretId=secret_id, ForceDeleteWithoutRecovery=True)
+        except Exception as exc:  # noqa: BLE001 - the caller is already raising something better
+            logger.error(
+                "orphaned HMAC secret %s could not be deleted (%s): delete it by hand",
+                secret_id,
+                exc,
+            )
+
+
+def _aws_error_code(exc: BaseException) -> str:
+    """Pull ``response['Error']['Code']`` off a botocore ClientError without importing botocore."""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error")
+        if isinstance(error, dict):
+            return str(error.get("Code") or "")
+    return ""
+
+
+def _is_aws_not_found(exc: BaseException) -> bool:
+    """Whether an AWS failure means "no such secret / no such version", rather than "we failed"."""
+    return _aws_error_code(exc) == "ResourceNotFoundException"
 
 
 def build_key_provider(settings: Settings) -> KeyMaterialProvider:
     """Select the HMAC key-material provider from settings (Initiative 2 §3.2 review).
 
-    ``local`` (default) returns the restart-durable dev provider; ``kms`` / ``secret-manager`` selects
-    the production seam. An unknown value fails fast rather than guessing, so a typo in a prod
-    deployment cannot silently drop to dev-derived material.
+    ``local`` (default) returns the restart-durable dev provider; ``kms`` / ``secret-manager``
+    returns the AWS Secrets Manager provider (CTO-336). An unknown value fails fast rather than
+    guessing, so a typo in a prod deployment cannot silently drop to dev-derived material.
     """
     choice = (getattr(settings, "hmac_key_provider", "local") or "local").strip().lower()
     if choice == "local":
         root = getattr(settings, "hmac_local_root_secret", "") or ""
         return LocalDevKeyProvider(root_secret=root.encode("utf-8"))
     if choice in ("kms", "secret-manager", "secretmanager"):
-        # The concrete client is injected by the deployment (see SecretManagerKeyProvider); this
-        # factory does not construct cloud credentials.
-        return SecretManagerKeyProvider()
+        return SecretManagerKeyProvider(
+            name_prefix=getattr(settings, "hmac_secrets_name_prefix", "")
+            or "ai-tally/tenant-hmac/",
+            kms_key_id=getattr(settings, "hmac_secrets_kms_key_id", "") or "",
+            region=getattr(settings, "hmac_secrets_region", "") or "",
+        )
     raise ProvisionError(f"unknown hmac_key_provider {choice!r} (expected 'local' or 'kms')")
 
 
@@ -210,6 +495,22 @@ class TenantProvisioner:
     ) -> None:
         self._dsn = settings.postgres_dsn
         self._keys: KeyMaterialProvider = key_provider or LocalDevKeyProvider()
+
+    def _delete_key_quietly(self, ref: str) -> None:
+        """Orphan-cleanup delete that logs instead of raising (CTO-336).
+
+        Cleanup runs on paths where the outcome is already decided: the race is lost, or the insert
+        already failed. A cloud provider's delete can itself fail (a throttle, a permission gap), and
+        turning that into the caller's exception would replace a correct answer with a 500, or mask
+        the real error. The orphan is recorded at ERROR with its reference so it can be deleted by
+        hand, which is the honest handling: we say what we could not clean up rather than pretend.
+        """
+        try:
+            self._keys.delete(ref)
+        except Exception as exc:  # noqa: BLE001 - cleanup must not change the caller's outcome
+            logger.error(
+                "orphaned HMAC key reference %s could not be deleted (%s): delete it by hand", ref, exc
+            )
 
     def provision(
         self, *, clerk_org_id: object, name: object, region: str = DEFAULT_REGION
@@ -273,7 +574,7 @@ class TenantProvisioner:
                     "SELECT id, plan FROM tenants WHERE clerk_org_id = %s", (clerk_org_id,)
                 )
                 winner = cur.fetchone()
-                self._keys.delete(kek_ref)
+                self._delete_key_quietly(kek_ref)
                 if winner is None:
                     # Extremely unlikely: the conflicting row vanished between the failed insert and
                     # this read. Surface it rather than fabricate a tenant id.
@@ -284,7 +585,7 @@ class TenantProvisioner:
             except Exception:
                 # Any failure after minting must not leak the key set.
                 conn.rollback()
-                self._keys.delete(kek_ref)
+                self._delete_key_quietly(kek_ref)
                 raise
 
     def tenant_for_clerk_org(self, clerk_org_id: object) -> ProvisionResult | None:

--- a/infra/gateway/tests/test_app_hmac_and_edge_keys.py
+++ b/infra/gateway/tests/test_app_hmac_and_edge_keys.py
@@ -23,6 +23,7 @@ from gateway.app import app
 from gateway.auth import AuthResult
 from gateway.edge_keys import KeyChange
 from gateway.tenant_hmac_key import HmacKeyMaterial, HmacKeyUnavailableError
+from gateway.tenant_provisioning import KeyProviderUnavailableError
 
 SERVICE_TOKEN = "svc-secret-token"
 TENANT_A = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
@@ -195,6 +196,21 @@ def test_hmac_key_404_when_material_unavailable() -> None:
     ):
         r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer wk"})
         assert r.status_code == 404
+
+
+def test_hmac_key_503_when_the_key_provider_cannot_be_reached() -> None:
+    # CTO-336. "We could not ask the key store" is a different answer from "this tenant has no
+    # key". A 404 tells the SDK to stop asking, which would be a permanent-looking reply to a
+    # transient outage or a fixable IAM gap, so the unavailable case is a retryable 503. Either
+    # way no bytes are returned and none are invented.
+    with _client(auth_on=True, tokens={"wk": _write(TENANT_A)}) as (c, hmac_store, _e):
+        def _boom(tenant_id: str):
+            raise KeyProviderUnavailableError("Secrets Manager get_secret_value failed")
+
+        hmac_store.active_key = _boom
+        r = c.get("/v1/tenant/hmac-key", headers={"Authorization": "Bearer wk"})
+        assert r.status_code == 503
+        assert "key_material_b64" not in r.text
 
 
 # --- /v1/edge/keys ------------------------------------------------------------------------------

--- a/infra/gateway/tests/test_app_orgs_access.py
+++ b/infra/gateway/tests/test_app_orgs_access.py
@@ -20,7 +20,7 @@ from gateway.app import app
 from gateway.config import get_settings
 from gateway.tenant_api_keys import ApiKeyMeta, MintedKey
 from gateway.tenant_budgets import Budget
-from gateway.tenant_provisioning import ProvisionResult
+from gateway.tenant_provisioning import KeyProviderUnavailableError, ProvisionResult
 
 TENANT_UUID = "8f14e45f-ceea-467a-9a3c-2f0e4d1b7c60"
 SERVICE_TOKEN = "svc-secret-token"
@@ -166,6 +166,28 @@ def test_provision_is_idempotent() -> None:
         second = r2.json()
         assert second["created"] is False
         assert second["tenant_id"] == first["tenant_id"]
+
+
+def test_provision_reports_503_when_the_key_provider_is_unavailable() -> None:
+    # CTO-336. Secrets Manager unreachable, or the task role missing the grant: the request was
+    # fine, so this is a 503 and not a 422, no tenant was created, and the response carries no
+    # invented identifier. Clerk retries the webhook and provisioning is idempotent, so the retry
+    # succeeds once the cause is fixed.
+    class _DeadProvisioner(FakeProvisioner):
+        def provision(self, *, clerk_org_id, name, region="auto"):
+            raise KeyProviderUnavailableError("Secrets Manager create_secret failed")
+
+    with _client(auth_on=True) as c:
+        app.state.tenant_provisioner = _DeadProvisioner()
+        r = c.post(
+            "/v1/tenant/provision",
+            json={"data": {"id": "org_dead", "name": "Dead Co"}},
+            headers=_svc_headers(),
+        )
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert "tenant_id" not in body
+    assert "key provider unavailable" in body["detail"]
 
 
 def test_provision_rejects_without_service_token() -> None:

--- a/infra/gateway/tests/test_auth_guard.py
+++ b/infra/gateway/tests/test_auth_guard.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Boot-time guard on the gateway's auth escape hatch (CTO-268, gateway half).
+
+The decision table is the test: `make up` and the suite must be untouched, a deployed gateway with
+authentication off must refuse to boot, and the documented auth-disabled shape (the edge proxy's
+EDGE_PROXY_TENANT_ID case) must remain reachable behind the same explicit opt-in the web tier
+introduced in PR #345.
+"""
+
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+
+from gateway.auth_guard import (
+    ALLOW_INSECURE_ENV,
+    InsecureAuthConfigError,
+    assert_auth_config,
+    check_auth_config,
+    is_deployed_environment,
+    is_truthy,
+)
+
+
+def _verdict(env: str, require_api_key: bool, allow: str = "") -> str:
+    return check_auth_config(
+        env=env, require_api_key=require_api_key, allow_insecure=allow
+    ).kind
+
+
+# --- the decision table -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", ["", "development", "dev", "DEV", "local", "test", "ci"])
+def test_local_environments_are_never_guarded(env: str) -> None:
+    # `make up`, CI and pytest all run auth-off and must need no new variable.
+    assert _verdict(env, require_api_key=False) == "ok"
+
+
+@pytest.mark.parametrize("env", ["production", "prod", "staging", "stage", "PRODUCTION"])
+def test_auth_on_is_always_fine(env: str) -> None:
+    assert _verdict(env, require_api_key=True) == "ok"
+
+
+@pytest.mark.parametrize("env", ["production", "staging"])
+def test_deployed_with_auth_off_and_no_opt_in_refuses(env: str) -> None:
+    assert _verdict(env, require_api_key=False) == "refuse"
+
+
+@pytest.mark.parametrize("opt_in", ["1", "true", "yes", "on", " TRUE "])
+def test_deployed_with_auth_off_and_the_opt_in_is_allowed_but_warned(opt_in: str) -> None:
+    assert _verdict("production", require_api_key=False, allow=opt_in) == "insecure-allowed"
+
+
+@pytest.mark.parametrize("not_consent", ["0", "false", "off", "no", "", "maybe"])
+def test_a_non_truthy_opt_in_is_not_consent(not_consent: str) -> None:
+    assert _verdict("production", require_api_key=False, allow=not_consent) == "refuse"
+
+
+def test_an_unrecognized_environment_is_treated_as_deployed() -> None:
+    # A typo in a deployment manifest is likelier than a laptop, and this is the fail-closed
+    # direction: the cost of being wrong is a refused boot with a message, not an open gateway.
+    assert _verdict("prod-eu-west-1", require_api_key=False) == "refuse"
+    assert is_deployed_environment("prod-eu-west-1") is True
+    assert is_deployed_environment("development") is False
+    assert is_deployed_environment(None) is False
+
+
+def test_truthiness_matches_the_web_tier_spelling() -> None:
+    # Same spelling web/lib/authGuard.ts and deploy/demo/lib-tenant.sh accept, so one operator
+    # sentence covers both tiers of one deployment.
+    assert [is_truthy(v) for v in ("1", "true", "yes", "on")] == [True] * 4
+    assert [is_truthy(v) for v in ("0", "false", "off", "", None, 3)] == [False] * 6
+
+
+# --- the messages -----------------------------------------------------------------------------
+
+
+def test_the_refusal_names_the_cause_the_consequence_and_both_fixes() -> None:
+    message = check_auth_config(
+        env="production", require_api_key=False, allow_insecure=""
+    ).message
+    assert "TALLY_ENV=production" in message
+    assert "TALLY_REQUIRE_API_KEY" in message
+    assert ALLOW_INSECURE_ENV in message
+    # The consequence is the control plane too, not just ingest: that is the part an operator
+    # reading "require api key" would not guess.
+    assert "/v1/tenant/" in message
+    assert "/v1/batches" in message
+    # And it must not break the documented auth-disabled shape blind.
+    assert "EDGE_PROXY_TENANT_ID" in message
+
+
+def test_the_opted_in_warning_says_what_is_open() -> None:
+    message = check_auth_config(
+        env="production", require_api_key=False, allow_insecure="1"
+    ).message
+    assert "NO AUTHENTICATION" in message
+
+
+# --- the boot-time assertion ------------------------------------------------------------------
+
+
+def test_assert_raises_only_on_a_refusal(caplog) -> None:
+    with pytest.raises(InsecureAuthConfigError):
+        assert_auth_config(
+            SimpleNamespace(env="production", require_api_key=False, allow_insecure_no_auth="")
+        )
+
+    with caplog.at_level("WARNING"):
+        verdict = assert_auth_config(
+            SimpleNamespace(env="production", require_api_key=False, allow_insecure_no_auth="1")
+        )
+    assert verdict.kind == "insecure-allowed"
+    assert "NO AUTHENTICATION" in caplog.text
+
+    assert assert_auth_config(
+        SimpleNamespace(env="development", require_api_key=False, allow_insecure_no_auth="")
+    ).kind == "ok"
+
+
+def test_the_default_settings_boot_cleanly() -> None:
+    # The real defaults, not a hand-built namespace: a fresh checkout must start.
+    from gateway.config import Settings
+
+    assert assert_auth_config(Settings()).kind == "ok"

--- a/infra/gateway/tests/test_cors.py
+++ b/infra/gateway/tests/test_cors.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-origin policy (CTO-337).
+
+Two halves, deliberately:
+
+* the allowlist resolution, which is ours and is where every judgement call lives, and
+* the installed middleware's actual browser-visible behaviour, exercised through a real Starlette
+  app so the preflight is answered by the same code path a browser would hit.
+
+The second half runs against a small app rather than the gateway's own ``app`` object because the
+middleware stack is built once per process and the gateway's is already built (and configured from
+the environment) by the time any test runs. ``test_gateway_app_installs_the_policy`` closes that gap
+by asserting the real app carries the middleware with the options this module chose, so "we forgot
+to install it" cannot pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware
+from types import SimpleNamespace
+
+from gateway.cors import (
+    ALLOWED_HEADERS,
+    ALLOWED_METHODS,
+    DEFAULT_DEV_ORIGINS,
+    PREFLIGHT_MAX_AGE_S,
+    CorsConfigError,
+    install_cors,
+    resolve_allowed_origins,
+)
+
+DASHBOARD = "https://app.example.com"
+STRANGER = "https://evil.example.net"
+
+
+def _settings(value: str) -> object:
+    return SimpleNamespace(cors_allowed_origins=value)
+
+
+# --- allowlist resolution ---------------------------------------------------------------------
+
+
+def test_unset_falls_back_to_the_local_dashboard_origins() -> None:
+    # `make up` must keep working with no configuration at all, and the fallback must be loopback
+    # only: a deployment that forgets to configure this admits nobody rather than everybody.
+    assert resolve_allowed_origins(_settings("")) == list(DEFAULT_DEV_ORIGINS)
+    assert resolve_allowed_origins(_settings("   ")) == list(DEFAULT_DEV_ORIGINS)
+    assert all(o.startswith("http://localhost") or o.startswith("http://127.0.0.1") for o in DEFAULT_DEV_ORIGINS)
+
+
+def test_configured_origins_replace_the_default_and_are_deduped() -> None:
+    resolved = resolve_allowed_origins(
+        _settings(f" {DASHBOARD} , https://staging.example.com,{DASHBOARD} ,")
+    )
+    assert resolved == [DASHBOARD, "https://staging.example.com"]
+
+
+@pytest.mark.parametrize("value", ["*", f"{DASHBOARD},*", "https://*.example.com"])
+def test_a_wildcard_is_refused_at_boot(value: str) -> None:
+    # The gateway serves per-tenant credentials and HMAC key material. A wildcard would let any page
+    # on the internet script a request from a visitor's browser and read the reply.
+    with pytest.raises(CorsConfigError):
+        resolve_allowed_origins(_settings(value))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "app.example.com",  # no scheme: not an origin
+        "ftp://app.example.com",  # not a browser scheme
+        "https://app.example.com/dashboard",  # a URL, not an origin: would match nothing
+        " , ",  # set, but naming nothing
+    ],
+)
+def test_malformed_configuration_fails_loudly(value: str) -> None:
+    with pytest.raises(CorsConfigError):
+        resolve_allowed_origins(_settings(value))
+
+
+# --- installed behaviour ----------------------------------------------------------------------
+
+
+def _app(origins: str) -> TestClient:
+    app = FastAPI()
+
+    @app.post("/v1/tenant/budgets")
+    def _write() -> dict:
+        return {"ok": True}
+
+    install_cors(app, _settings(origins))
+    return TestClient(app)
+
+
+def test_preflight_from_a_configured_origin_is_allowed() -> None:
+    client = _app(DASHBOARD)
+    res = client.options(
+        "/v1/tenant/budgets",
+        headers={
+            "Origin": DASHBOARD,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type,x-tenant-id",
+        },
+    )
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == DASHBOARD
+    assert "POST" in res.headers["access-control-allow-methods"]
+    allowed = res.headers["access-control-allow-headers"].lower()
+    assert "authorization" in allowed and "x-tenant-id" in allowed
+    # Bounded preflight cache: this is also how long a REMOVED origin keeps working in a warmed
+    # browser, so it is a revocation delay and not only a performance knob.
+    assert res.headers["access-control-max-age"] == str(PREFLIGHT_MAX_AGE_S)
+    # Credentials mode stays off: the gateway authenticates with a bearer header, not cookies.
+    assert "access-control-allow-credentials" not in res.headers
+
+
+def test_preflight_from_an_unconfigured_origin_is_rejected() -> None:
+    client = _app(DASHBOARD)
+    res = client.options(
+        "/v1/tenant/budgets",
+        headers={
+            "Origin": STRANGER,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+    # Starlette answers the preflight itself with a 400 and, crucially, no allow-origin header:
+    # the browser refuses to send the real request.
+    assert res.status_code == 400
+    assert "access-control-allow-origin" not in res.headers
+
+
+def test_actual_request_from_an_unconfigured_origin_gets_no_allow_origin_header() -> None:
+    # The response body is still produced (CORS is a browser-enforced read restriction, not an
+    # authorization control: every endpoint keeps its own bearer gate). What the stranger's page
+    # does NOT get is permission to read it.
+    client = _app(DASHBOARD)
+    res = client.post("/v1/tenant/budgets", headers={"Origin": STRANGER}, json={})
+    assert res.status_code == 200
+    assert "access-control-allow-origin" not in res.headers
+
+    allowed = client.post("/v1/tenant/budgets", headers={"Origin": DASHBOARD}, json={})
+    assert allowed.headers["access-control-allow-origin"] == DASHBOARD
+
+
+def test_default_configuration_admits_the_local_dashboard_only() -> None:
+    client = _app("")
+    ok = client.options(
+        "/v1/tenant/budgets",
+        headers={"Origin": "http://localhost:3000", "Access-Control-Request-Method": "POST"},
+    )
+    assert ok.status_code == 200
+    assert ok.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+    blocked = client.options(
+        "/v1/tenant/budgets",
+        headers={"Origin": DASHBOARD, "Access-Control-Request-Method": "POST"},
+    )
+    assert blocked.status_code == 400
+
+
+def test_gateway_app_installs_the_policy() -> None:
+    from gateway.app import app as gateway_app
+
+    installed = [m for m in gateway_app.user_middleware if m.cls is CORSMiddleware]
+    assert len(installed) == 1
+    options = installed[0].kwargs
+    assert options["allow_credentials"] is False
+    assert "*" not in options["allow_origins"]
+    assert options["allow_methods"] == list(ALLOWED_METHODS)
+    assert options["allow_headers"] == list(ALLOWED_HEADERS)
+    assert options["max_age"] == PREFLIGHT_MAX_AGE_S

--- a/infra/gateway/tests/test_tenant_provisioning.py
+++ b/infra/gateway/tests/test_tenant_provisioning.py
@@ -16,6 +16,7 @@ carry the acceptance criteria:
 
 from __future__ import annotations
 
+import sys
 import uuid
 
 import pytest
@@ -170,6 +171,42 @@ def test_provision_lost_race_cleans_up_orphaned_key(monkeypatch) -> None:
     assert spy.minted == spy.deleted
 
 
+def test_provision_writes_no_tenant_when_the_key_provider_is_unavailable(monkeypatch) -> None:
+    # CTO-336, honest under uncertainty: a mint that cannot reach Secrets Manager fails the whole
+    # provision. A tenant that cannot hash its identifiers must not exist, and there is deliberately
+    # no fallback to a locally generated key, which would look valid and would not be the tenant's.
+    tenants: dict = {}
+    _patch_connect(monkeypatch, tenants)
+
+    class _DeadProvider(SpyKeyProvider):
+        def mint(self) -> str:
+            raise tenant_provisioning.KeyProviderUnavailableError("endpoint unreachable")
+
+    prov = TenantProvisioner(_Settings(), key_provider=_DeadProvider())
+    with pytest.raises(tenant_provisioning.KeyProviderUnavailableError):
+        prov.provision(clerk_org_id="org_dead", name="Dead Co")
+    assert tenants == {}
+
+
+def test_a_failed_cleanup_delete_is_logged_not_raised(monkeypatch, caplog) -> None:
+    # CTO-336: cleanup runs on paths whose outcome is already decided (the race is lost). A cloud
+    # delete that fails must not turn a correct answer into a 500; it must name the orphan instead.
+    winner = str(uuid.uuid4())
+    tenants = {"org_race": (winner, "free")}
+    _patch_connect(monkeypatch, tenants, race=True)
+
+    class _UndeletableProvider(SpyKeyProvider):
+        def delete(self, ref: str) -> None:
+            raise tenant_provisioning.KeyProviderUnavailableError("throttled")
+
+    prov = TenantProvisioner(_Settings(), key_provider=_UndeletableProvider())
+    with caplog.at_level("ERROR"):
+        result = prov.provision(clerk_org_id="org_race", name="Racer")
+
+    assert result.tenant_id == winner
+    assert "orphaned HMAC key reference" in caplog.text
+
+
 def test_provision_rejects_blank_fields(monkeypatch) -> None:
     _patch_connect(monkeypatch, {})
     prov = TenantProvisioner(_Settings(), key_provider=SpyKeyProvider())
@@ -233,21 +270,51 @@ def test_build_key_provider_selects_by_setting() -> None:
     ref = local.mint()
     assert local.material(ref) == other.material(ref)
 
-    # The prod seam is selectable but fails fast without a wired client, never silently local.
-    with pytest.raises(ProvisionError):
-        build_key_provider(
-            SimpleNamespace(hmac_key_provider="kms", hmac_local_root_secret="rs")
-        )
+    # An unknown value fails fast rather than guessing a provider.
     with pytest.raises(ProvisionError):
         build_key_provider(
             SimpleNamespace(hmac_key_provider="bogus", hmac_local_root_secret="rs")
         )
 
 
-def test_secret_manager_provider_requires_a_client() -> None:
-    with pytest.raises(ProvisionError):
+def test_build_key_provider_selects_secrets_manager_for_kms(monkeypatch) -> None:
+    # CTO-336: 'kms' now builds a working AWS Secrets Manager provider (it used to raise). The AWS
+    # client itself is stubbed here, so this asserts the wiring and the settings pass-through
+    # without boto3, credentials or an account.
+    built: dict[str, object] = {}
+
+    def _fake_build_client(region: str) -> object:
+        built["region"] = region
+        return object()
+
+    monkeypatch.setattr(
+        tenant_provisioning.SecretManagerKeyProvider, "_build_client", staticmethod(_fake_build_client)
+    )
+    provider = build_key_provider(
+        SimpleNamespace(
+            hmac_key_provider="kms",
+            hmac_local_root_secret="rs",
+            hmac_secrets_name_prefix="acme/hmac/",
+            hmac_secrets_kms_key_id="alias/ai-tally",
+            hmac_secrets_region="eu-west-1",
+        )
+    )
+    assert isinstance(provider, SecretManagerKeyProvider)
+    assert built["region"] == "eu-west-1"
+
+
+def test_secret_manager_provider_without_boto3_says_so_and_does_not_fall_back(monkeypatch) -> None:
+    # The one thing that must never happen on a misconfigured prod install is a silent drop to
+    # LocalDevKeyProvider, whose material comes from a config root secret rather than the tenant's
+    # own key. A missing dependency is a loud, named failure instead.
+    monkeypatch.setitem(sys.modules, "boto3", None)
+    with pytest.raises(ProvisionError) as excinfo:
         SecretManagerKeyProvider()
-    # With a client wired it constructs; the concrete cloud calls are a deployment concern.
+    assert "boto3" in str(excinfo.value)
+
+
+def test_secret_manager_provider_accepts_an_injected_client() -> None:
+    # The seam the tests (and any deployment wanting its own client) use. Mirrors S3ReplayBlobStore.
     assert SecretManagerKeyProvider(client=object()) is not None
 
 

--- a/infra/gateway/tests/test_tenant_provisioning_secretsmanager.py
+++ b/infra/gateway/tests/test_tenant_provisioning_secretsmanager.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AWS Secrets Manager HMAC key provider (CTO-336).
+
+These use an in-memory fake mimicking the four ``boto3`` Secrets Manager operations the provider
+touches (``create_secret`` / ``update_secret_version_stage`` / ``get_secret_value`` /
+``delete_secret``), following the same injected-client pattern as
+``tests/test_replay_store_s3.py``. No AWS account, no credentials, no network, and ``boto3`` need
+not be installed to run the suite.
+
+The three failure shapes the ticket calls out each have their own case: success, unreachable
+(a botocore-style connection error with no ``response`` dict), and permission denied
+(``AccessDeniedException``). The distinction that matters is that only a genuine
+``ResourceNotFoundException`` becomes a ``KeyError`` (an honest 404 on the bootstrap endpoint);
+everything else becomes ``KeyProviderUnavailableError`` (a 503), because "we could not ask" is not
+"there is nothing there".
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from gateway.tenant_hmac_key import _version_from_ref
+from gateway.tenant_provisioning import (
+    HMAC_KEY_BYTES,
+    MAX_KEK_REF_LENGTH,
+    KeyProviderUnavailableError,
+    SecretManagerKeyProvider,
+    assert_reference_fits,
+)
+
+ACCOUNT_ARN_PREFIX = "arn:aws:secretsmanager:us-east-1:123456789012:secret:"
+
+
+class _FakeAwsError(Exception):
+    """Stand-in for ``botocore.exceptions.ClientError``: carries a ``response`` dict."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+class _FakeEndpointError(Exception):
+    """Stand-in for ``botocore.exceptions.EndpointConnectionError``: no ``response`` at all."""
+
+
+class _FakeSecretsManager:
+    """Enough of the Secrets Manager surface to exercise the provider end to end."""
+
+    def __init__(self, *, fail_on: dict[str, Exception] | None = None) -> None:
+        # name -> {"arn", "versions": {version_id: bytes}, "stages": {label: version_id}}
+        self.secrets: dict[str, dict] = {}
+        self.by_arn: dict[str, dict] = {}
+        self.deleted: list[str] = []
+        self.calls: list[str] = []
+        self.kms_key_ids: list[str] = []
+        self.tags: list[list] = []
+        self._fail_on = fail_on or {}
+
+    def _maybe_fail(self, op: str) -> None:
+        self.calls.append(op)
+        exc = self._fail_on.get(op)
+        if exc is not None:
+            raise exc
+
+    def create_secret(self, **kwargs) -> dict:
+        self._maybe_fail("create_secret")
+        name = kwargs["Name"]
+        if name in self.secrets:
+            raise _FakeAwsError("ResourceExistsException")
+        arn = f"{ACCOUNT_ARN_PREFIX}{name}-AbCdEf"
+        version_id = str(uuid.uuid4())
+        record = {
+            "arn": arn,
+            "name": name,
+            "versions": {version_id: kwargs["SecretBinary"]},
+            "stages": {"AWSCURRENT": version_id},
+        }
+        self.secrets[name] = record
+        self.by_arn[arn] = record
+        if "KmsKeyId" in kwargs:
+            self.kms_key_ids.append(kwargs["KmsKeyId"])
+        self.tags.append(kwargs.get("Tags", []))
+        return {"ARN": arn, "Name": name, "VersionId": version_id}
+
+    def update_secret_version_stage(self, **kwargs) -> dict:
+        self._maybe_fail("update_secret_version_stage")
+        record = self.by_arn.get(kwargs["SecretId"])
+        if record is None:
+            raise _FakeAwsError("ResourceNotFoundException")
+        record["stages"][kwargs["VersionStage"]] = kwargs["MoveToVersionId"]
+        return {"ARN": record["arn"]}
+
+    def get_secret_value(self, **kwargs) -> dict:
+        self._maybe_fail("get_secret_value")
+        record = self.by_arn.get(kwargs["SecretId"])
+        if record is None:
+            raise _FakeAwsError("ResourceNotFoundException")
+        version_id = record["stages"].get(kwargs.get("VersionStage", "AWSCURRENT"))
+        if version_id is None:
+            raise _FakeAwsError("ResourceNotFoundException")
+        return {"ARN": record["arn"], "SecretBinary": record["versions"][version_id]}
+
+    def delete_secret(self, **kwargs) -> dict:
+        self._maybe_fail("delete_secret")
+        record = self.by_arn.pop(kwargs["SecretId"], None)
+        if record is None:
+            raise _FakeAwsError("ResourceNotFoundException")
+        self.secrets.pop(record["name"], None)
+        self.deleted.append(record["arn"])
+        return {"ARN": record["arn"]}
+
+
+def _provider(client: _FakeSecretsManager, **kwargs) -> SecretManagerKeyProvider:
+    return SecretManagerKeyProvider(client=client, **kwargs)
+
+
+# --- success ----------------------------------------------------------------------------------
+
+
+def test_mint_stores_material_in_aws_and_returns_only_a_reference() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+
+    ref = provider.mint()
+
+    # The reference is a pointer: an ARN plus a version selector, and nothing else.
+    assert ref.startswith(ACCOUNT_ARN_PREFIX)
+    assert ref.endswith("/v1")
+    # The key bytes live in AWS, and no part of them appears in what we would persist.
+    (record,) = list(client.secrets.values())
+    material = record["versions"][record["stages"]["v1"]]
+    assert len(material) == HMAC_KEY_BYTES
+    assert material.hex() not in ref
+    # The version selector is the same one the HMAC bootstrap parses back out for the SDK.
+    assert _version_from_ref(ref) == "v1"
+
+
+def test_minted_reference_satisfies_the_no_raw_secret_check() -> None:
+    client = _FakeSecretsManager()
+    ref = _provider(client).mint()
+    # tenants.hash_salt_kek_ref CHECK: NOT LIKE 'sk-%' AND length < 512.
+    assert not ref.startswith("sk-")
+    assert len(ref) < MAX_KEK_REF_LENGTH
+    assert assert_reference_fits(ref) == ref
+
+
+def test_material_round_trips_through_the_labelled_version() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+
+    material = provider.material(ref)
+    assert len(material) == HMAC_KEY_BYTES
+    # Stable across calls, and distinct per tenant (the whole point of a per-tenant key).
+    assert provider.material(ref) == material
+    assert provider.material(provider.mint()) != material
+
+
+def test_material_pins_the_labelled_version_not_awscurrent() -> None:
+    # The rotation-safety property: moving AWSCURRENT onto new bytes (AWS managed rotation, or an
+    # operator) must NOT change what an existing reference resolves to, or every hash already
+    # written under it silently stops matching.
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    original = provider.material(ref)
+
+    record = client.by_arn[ref.rsplit("/", 1)[0]]
+    rotated_version = str(uuid.uuid4())
+    record["versions"][rotated_version] = b"\xff" * HMAC_KEY_BYTES
+    record["stages"]["AWSCURRENT"] = rotated_version
+
+    assert provider.material(ref) == original
+
+
+def test_mint_uses_the_configured_prefix_and_customer_managed_key() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client, name_prefix="acme/hmac/", kms_key_id="alias/ai-tally")
+    ref = provider.mint()
+    assert "acme/hmac/" in ref
+    assert client.kms_key_ids == ["alias/ai-tally"]
+    # Tagged so an auditor can find every per-tenant key set.
+    assert {"Key": "purpose", "Value": "tenant-hmac"} in client.tags[0]
+
+
+def test_delete_removes_the_secret_outright() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    provider.delete(ref)
+    assert client.by_arn == {}
+    assert len(client.deleted) == 1
+
+
+# --- unreachable ------------------------------------------------------------------------------
+
+
+def test_mint_when_secrets_manager_is_unreachable_raises_and_stores_nothing() -> None:
+    client = _FakeSecretsManager(
+        fail_on={"create_secret": _FakeEndpointError("Could not connect to the endpoint URL")}
+    )
+    provider = _provider(client)
+
+    with pytest.raises(KeyProviderUnavailableError) as excinfo:
+        provider.mint()
+
+    # No secret, and emphatically no fallback to a locally generated key.
+    assert client.secrets == {}
+    assert "create_secret" in str(excinfo.value)
+
+
+def test_material_when_unreachable_is_unavailable_not_missing() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    client._fail_on = {"get_secret_value": _FakeEndpointError("connection timed out")}
+
+    with pytest.raises(KeyProviderUnavailableError):
+        provider.material(ref)
+
+
+# --- permission denied ------------------------------------------------------------------------
+
+
+def test_mint_permission_denied_raises_unavailable() -> None:
+    client = _FakeSecretsManager(fail_on={"create_secret": _FakeAwsError("AccessDeniedException")})
+    with pytest.raises(KeyProviderUnavailableError) as excinfo:
+        _provider(client).mint()
+    assert "AccessDeniedException" in str(excinfo.value)
+    assert client.secrets == {}
+
+
+def test_material_permission_denied_raises_unavailable_not_keyerror() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    client._fail_on = {"get_secret_value": _FakeAwsError("AccessDeniedException")}
+
+    # Deliberately NOT a KeyError: an IAM gap must not be reported to the SDK as "this tenant has
+    # no key", which is a permanent-looking answer to a fixable misconfiguration.
+    with pytest.raises(KeyProviderUnavailableError):
+        provider.material(ref)
+
+
+def test_missing_secret_is_a_keyerror() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    provider.delete(ref)
+
+    # Genuinely absent: the HMAC bootstrap turns this into an honest 404.
+    with pytest.raises(KeyError):
+        provider.material(ref)
+
+
+def test_mint_cleans_up_when_labelling_the_version_fails() -> None:
+    # A secret whose version carries no label can never be resolved by a reference, so it is
+    # orphaned material the moment mint returns. It must be removed, and the failure surfaced.
+    client = _FakeSecretsManager(
+        fail_on={"update_secret_version_stage": _FakeAwsError("AccessDeniedException")}
+    )
+    provider = _provider(client)
+
+    with pytest.raises(KeyProviderUnavailableError):
+        provider.mint()
+
+    assert client.by_arn == {}
+    assert len(client.deleted) == 1
+
+
+# --- reference handling -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "",
+        "not-an-arn",
+        f"{ACCOUNT_ARN_PREFIX}ai-tally/tenant-hmac/abc-AbCdEf",  # no version selector
+        f"{ACCOUNT_ARN_PREFIX}ai-tally/tenant-hmac/abc-AbCdEf/latest",  # not a vN selector
+    ],
+)
+def test_malformed_reference_is_refused_rather_than_guessed(ref: str) -> None:
+    with pytest.raises(KeyProviderUnavailableError):
+        _provider(_FakeSecretsManager()).material(ref)
+
+
+def test_a_prefix_too_long_for_the_check_fails_at_mint() -> None:
+    # The column is never widened to fit a reference. A naming choice that would not fit has to
+    # fail where an operator reads the reason, not as a constraint violation mid-provision.
+    client = _FakeSecretsManager()
+    provider = _provider(client, name_prefix="x" * MAX_KEK_REF_LENGTH)
+    with pytest.raises(KeyProviderUnavailableError) as excinfo:
+        provider.mint()
+    assert "hash_salt_kek_ref" in str(excinfo.value)
+
+
+def test_secret_string_is_refused_rather_than_decoded() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    record = client.by_arn[ref.rsplit("/", 1)[0]]
+    record["versions"][record["stages"]["v1"]] = None
+
+    with pytest.raises(KeyProviderUnavailableError) as excinfo:
+        provider.material(ref)
+    assert "SecretBinary" in str(excinfo.value)
+
+
+def test_a_short_key_is_refused() -> None:
+    client = _FakeSecretsManager()
+    provider = _provider(client)
+    ref = provider.mint()
+    record = client.by_arn[ref.rsplit("/", 1)[0]]
+    record["versions"][record["stages"]["v1"]] = b"tooshort"
+
+    with pytest.raises(KeyProviderUnavailableError):
+        provider.material(ref)
+
+
+def test_assert_reference_fits_rejects_a_raw_looking_secret() -> None:
+    with pytest.raises(KeyProviderUnavailableError):
+        assert_reference_fits("sk-live-abcdef")
+    with pytest.raises(KeyProviderUnavailableError):
+        assert_reference_fits("")


### PR DESCRIPTION
Stacked on #351 (`feat/ci-publish-images`); merge that first. The reviewable diff is this PR's own commit.

Three gateway blockers on the hosting epic (#333), plus the IAM gaps the AWS scope doc recorded. They travel together because they are the same subject: what a reachable deployment needs that a laptop does not.

## #336 SecretManagerKeyProvider

`mint`, `delete` and `material` raised `NotImplementedError`. So a real deployment could either not provision a tenant at all, or fall back to `LocalDevKeyProvider`, whose per-tenant material is `HMAC-SHA256(config_root_secret, reference)`. That fallback is the thing CLAUDE.md forbids: the hashes look fine and their isolation rests on a process-wide config value rather than on a per-tenant key held by reference.

**The stored thing stays a reference.** `mint` generates 32 bytes in memory, writes them to a per-tenant Secrets Manager secret named `ai-tally/tenant-hmac/<uuid>`, and drops them. What reaches `tenants.hash_salt_kek_ref` is:

```
arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally/tenant-hmac/<uuid>-AbCdEf/v1
```

About 120 characters, inside the `no_raw_secret` CHECK (`NOT LIKE 'sk-%' AND length < 512`) with room to spare. **No column was widened.** `assert_reference_fits` proves the bound before the INSERT rather than letting Postgres discover it, and there is a test that a name prefix too long to fit fails at mint with a message saying to shorten the prefix, not to widen the column. The reference carries no entropy from the key and is useless without IAM permission on the ARN.

**Rotation: out of scope, deliberately, and not precluded.** Rotating a tenant's HMAC key changes every hash computed after it, so it is a product decision about historical joins, not a key-store operation. The SDK already stamps `key_version` on spans for exactly this, but nothing reads that column at query time yet, so shipping a rotation button now would silently break account attribution. What is shipped is a design a rotation can land on:

* The reference names a **staging label** (`v1`), not `AWSCURRENT` and not an immutable `VersionId`. `mint` attaches that label to the version it writes, and `material` asks for it by name. So an operator, or AWS managed rotation, moving `AWSCURRENT` cannot swap the bytes under hashes that already exist. There is a test for exactly that.
* A future rotation is then `put_secret_value`, label the new version `v2`, and `UPDATE` that tenant's `hash_salt_kek_ref` to `.../v2`. One existing column, still inside the CHECK, no migration. `v1` keeps resolving for historical hashes.
* Pinning `AWSCURRENT` would have made rotation a data-corruption event; pinning a `VersionId` would have worked but would have put an opaque id in the column and made the human-readable `vN` selector a lie.

The README tells operators not to enable AWS managed rotation on these secrets, and says why.

**Failure is honest, in both directions.** Every AWS failure becomes `KeyProviderUnavailableError`. A mint that raises it fails the whole provision: no tenant row, no locally generated key, `POST /v1/tenant/provision` answers **503** (not 422, because the caller sent nothing wrong), logs the cause, and Clerk's retry succeeds once the IAM gap or outage is fixed, since provisioning is idempotent. On the read side the two honest outcomes stay distinct: a secret or label that genuinely does not exist is a `KeyError` and still a 404 the SDK degrades on, while unreachable / `AccessDeniedException` / throttled is a **503**, because "we could not ask" is not "there is nothing there" and a 404 tells the SDK to stop asking. Cleanup deletes that themselves fail are logged at ERROR naming the orphaned reference rather than turning a correct answer into a 500.

**Testability without AWS.** Injected-client seam copied from `S3ReplayBlobStore`: `client=None` lazily imports boto3 and constructs it with no explicit credentials, so it resolves the task role / IRSA / instance profile. No `moto`, because the repo already has this pattern and `tests/test_replay_store_s3.py` fakes the boto3 surface directly; following it beats adding a second convention and a dependency. boto3 is a new optional `[secrets]` extra and is **not installed in the test venv**, which is a feature: the suite proves the no-boto3 path says so loudly instead of falling back.

## #337 CORSMiddleware

Added as an allowlist: `TALLY_CORS_ALLOWED_ORIGINS`, comma-separated exact origins, **wildcard refused at boot** (the gateway serves per-tenant credentials and hands back HMAC key material). The local dev default is `http://localhost:3000` and `http://127.0.0.1:3000`, both spellings because a browser treats them as different origins, so `make up` needs no configuration. That default is also the right failure mode for a deployment that forgets to configure it: loopback-only admits nobody rather than everybody.

Credentials mode is **off**, on purpose. The gateway authenticates with `Authorization: Bearer`, not cookies, and `allow_credentials` governs cookies / client certs / HTTP-auth. Turning it on would buy nothing here and would make a future `*` look like it works while browsers silently refuse it. The bearer flow works because `authorization` is in the explicit allowed-header list, which is unrelated to credentials mode. `max_age` is 600s and is documented as what it actually is: a **revocation delay**, since removing an origin from the allowlist does not take effect in a warmed browser until the cached positive preflight expires. It is installed last so it is the outermost middleware, so preflights short-circuit and error responses still carry the headers a browser needs to report a real status instead of an opaque network failure.

**A correction to the ticket's blast radius, and it cuts the other way.** The ticket says every browser-originated control-plane write fails preflight, and notes this is easy to miss because pages render and only mutations fail. I could not reproduce it, because **there are no browser-originated gateway calls today at all**. Every `TALLY_GATEWAY_URL` fetch lives in `web/lib/*` and runs in a route handler or a server action; the variable is deliberately not `NEXT_PUBLIC_`, so its value does not exist in the browser bundle. `web/lib/api.ts` fetches the Next app's own `/api/*` routes, same origin. On Vercel those server-side fetches go function-to-ALB, where CORS does not apply.

So this is a missing policy, not a live break: the mutations keep working on Vercel. It still belongs here, because the first browser-originated call must not be the thing that decides the policy, and because a wildcard is very hard to take back once shipped. The module docstring also states plainly what CORS is not: a browser-enforced read restriction, not authentication and not CSRF protection (a browser can still send a simple cross-origin POST regardless), so every endpoint keeps its own bearer or service-token gate.

## The gateway half of the auth guard: implemented

#345's author deferred it for two stated reasons, and both had to be answered rather than worked around.

**"There is nothing to test against."** True, and the fix is a deployment-environment notion, so this adds one: `TALLY_ENV`, defaulting to `development`. The honest limitation is stated in the module docstring: the web tier gets `NODE_ENV=production` for free from `next start`, a Python process has no equivalent, so an operator who never sets `TALLY_ENV` is not protected. I rejected deriving it (a remote-looking Postgres DSN is a guess, and guessing is what the honest-under-uncertainty invariant forbids) and rejected defaulting to production (it would refuse every `make up` and every CI run, which is how guards get deleted). An **unrecognized** value is treated as deployed, because a typo in a manifest is likelier than a laptop and that is the fail-closed direction.

**"Auth-off is a supported shape somewhere."** It is, and it keeps working. `infra/edge-proxy/README.md`'s `EDGE_PROXY_TENANT_ID` case is untouched in every development environment and remains available in a deployment behind the opt-in. The refusal message names `EDGE_PROXY_TENANT_ID` explicitly so an operator who hits it knows their shape is still supported, and a test asserts the message says so.

The opt-in is **`TALLY_ALLOW_INSECURE_NO_AUTH`**, the same variable and the same truthy spelling (`1/true/yes/on`) #345 introduced, not a second one: one operator sentence covers both tiers of one deployment. The verdict shape mirrors `authGuard.ts` (`ok` / `insecure-allowed` / `refuse`, pure decision separated from the assertion), and it runs first in the FastAPI lifespan, which is the gateway's `instrumentation.ts`: once, before the first request, in every way the process is started.

The message names the whole consequence, not the obvious half: with auth off, `/v1/batches` trusts the body's `tenant_id` **and** the `/v1/tenant/*` service-token gate is inert, because that gate is only enforced when auth is on. An operator reading "require api key" would not guess the second part.

`deploy/aws/ecs/gateway.taskdef.json` already sets `TALLY_REQUIRE_API_KEY=true`, so on the AWS bundle this is a backstop against a later edit rather than today's exposure.

## IAM

One of the four recorded gaps was already closed: **#351 added `ai-tally-gateway-service-token` to both ARN lists**, so the taskdef and the two roles now agree. The rest:

- `my-org-ai-tally-replay` is now `REPLACE_REPLAY_BUCKET`, the same token `gateway.taskdef.json` uses. The old value reads like a real bucket name and is not one, which is exactly the failure the scope doc described.
- **Tenant HMAC secrets**: `CreateSecret` / `PutSecretValue` / `UpdateSecretVersionStage` / `GetSecretValue` / `DeleteSecret` / `TagResource` scoped to `arn:aws:secretsmanager:*:*:secret:ai-tally/tenant-hmac/*`, which is what #336's provider needs and nothing more.
- **KMS**: `kms:Decrypt` + `kms:GenerateDataKey` on the task role and `kms:Decrypt` on the execution role, both with a `kms:ViaService` condition so neither role can use the key for anything but Secrets Manager. The README says to delete both statements if you stayed on the AWS-managed key, rather than substituting a key id that does not exist.
- **`sts:AssumeRole`** on `arn:aws:iam::*:role/ai-tally-connector-*`, for a `credentials_ref` holding a role ARN (`docs/connector-aws-cost-explorer.md`).
- ECR pulls narrowed from `*` to the three `ai-tally/*` repositories, following #351's `github-actions-ecr-policy.json` split (`GetAuthorizationToken` stays on `*`: it has no resource-level form).
- `aws:SourceAccount` on the ECS trust policy.

Placeholders follow #351's convention (`ACCOUNT`, `REGION`) plus the taskdefs' `REPLACE_*`, and `deploy/aws/README.md` now carries the `sed` lines, a table of what each grant is for and when to delete it (including Bedrock, which nothing in the codebase uses and which the scope doc called unearned privilege), and the tenant-HMAC operational notes.

**I did not touch the task definitions.** `TALLY_ENV=production`, `TALLY_HMAC_KEY_PROVIDER=kms` and `TALLY_CORS_ALLOWED_ORIGINS` all belong on the gateway task and #351 owns that file, so the README documents them in a table and says to add them there or in IaC. That is the one deliberate loose end.

## Verification

- gateway: **1011 passed, 8 skipped** (baseline 940 / 8, so 71 new), `ruff check` clean.
- Not run: sdk, web, edge-proxy. Untouched by this PR.

**Run against the real app, not only unit tests** (a uvicorn on a spare port, nothing near the local stack):

- Preflight from a configured origin: `200`, `access-control-allow-origin: https://app.example.com`, `access-control-max-age: 600`, `authorization` and `x-tenant-id` in the allowed headers, and no `access-control-allow-credentials`.
- Preflight from an unconfigured origin: `400` with **no** allow-origin header.
- `TALLY_ENV=production` + `TALLY_REQUIRE_API_KEY=false`: startup failed, process **exited 3**, message printed in full. It never bound the port.
- The same plus `TALLY_ALLOW_INSECURE_NO_AUTH=1`: booted, `/healthz` 200, warning banner logged once.

**Local stack untouched.** I did not exercise provisioning against it (that path needs AWS), so no tenant was created and nothing needed cleaning up. Counts before and after are the same because nothing wrote: `default.otel_spans` = **1,542,996**, `tenants` = **1**.

## What is unverifiable without an AWS account

Stated plainly, because the tests cannot cover it:

1. **Every real Secrets Manager call.** The fake matches the documented request and response shapes for `create_secret`, `update_secret_version_stage`, `get_secret_value` and `delete_secret`, but no real API was called. A wrong parameter name or a shape drift would pass here and fail in AWS.
2. **The staging-label behaviour**, which is the load-bearing rotation-safety property. The fake implements labels the way the docs describe. That AWS moves `AWSCURRENT` while leaving a custom label pinned is documented behaviour I have not observed.
3. **That the IAM policies are sufficient and minimal.** Not simulated (no `iam simulate-principal-policy`, no account). In particular: `secretsmanager:CreateSecret` against a name-pattern resource ARN, whether `TagResource` is genuinely required for `create_secret` with `Tags`, and whether the `kms:ViaService` conditions are spelled right for both roles.
4. **`boto3.client("secretsmanager")` credential resolution under a real ECS task role**, and the `NoRegionError` message path.
5. **Force-delete semantics**, including whether deleting without a recovery window can collide with a name we would reuse (it cannot in practice: names are random UUIDs).
6. **The ALB / Vercel origin pairing.** The CORS policy was exercised against a local uvicorn, not through an ALB, so anything an ALB or CloudFront does to `Origin` or `Vary` headers is untested.

No AWS credentials were used and nothing was spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
