### PR TITLE
fix(clickhouse): wrap the retention preview UNION before ORDER BY

### DIFF
--- a/db/clickhouse/migrations/derived_table_retention.sql
+++ b/db/clickhouse/migrations/derived_table_retention.sql
@@ -79,6 +79,10 @@
 -- 0. LOOK BEFORE YOU LEAP. Read-only. How many rows are already past each proposed horizon?
 --    Run this first, on its own. It deletes nothing.
 -- ============================================================================================
+-- NOTE: the UNION must be wrapped before ORDER BY. In ClickHouse an ORDER BY written after a
+-- UNION ALL binds to the LAST SELECT only, not to the union result, and the alias from the
+-- first SELECT is not in scope there, so the bare form fails with UNKNOWN_IDENTIFIER (47).
+SELECT * FROM (
 SELECT 'daily_feature_rollup'  AS table, count() AS rows_past_horizon FROM daily_feature_rollup  WHERE toDateTime(Day)               < now() - INTERVAL 2555 DAY
 UNION ALL SELECT 'daily_account_rollup',  count() FROM daily_account_rollup  WHERE toDateTime(Day)               < now() - INTERVAL 2555 DAY
 UNION ALL SELECT 'business_events',       count() FROM business_events       WHERE toDateTime(OccurredAt)        < now() - INTERVAL 2555 DAY
@@ -91,7 +95,7 @@ UNION ALL SELECT 'business_events.RawPayload (column blanked, row kept)',
                                           count() FROM business_events       WHERE toDateTime(OccurredAt)        < now() - INTERVAL 90 DAY
 UNION ALL SELECT 'replay_samples',        count() FROM replay_samples        WHERE toDateTime(CapturedAt)        < now() - INTERVAL 30 DAY
 UNION ALL SELECT 'replay_runs',           count() FROM replay_runs           WHERE toDateTime(RanAt)             < now() - INTERVAL 30 DAY
-ORDER BY rows_past_horizon DESC
+) ORDER BY rows_past_horizon DESC
 FORMAT PrettyCompactMonoBlock;
 
 -- ============================================================================================


### PR DESCRIPTION
Found by running `make ch-apply-retention` against the live stack.

The read-only preview block in `db/clickhouse/migrations/derived_table_retention.sql` failed with `Code: 47 UNKNOWN_IDENTIFIER`. It is the first statement in the script and the one the runbook tells an operator to run before deciding anything.

Cause: in ClickHouse an `ORDER BY` written after a `UNION ALL` binds to the **last** SELECT rather than to the union result, so `rows_past_horizon` (aliased only in the first SELECT) is not in scope there. The error names the last branch, `replay_runs`, which makes it look like a problem with that table rather than with the ordering.

```
DB::Exception: Unknown expression identifier 'rows_past_horizon' in scope
SELECT 'replay_runs', count() FROM replay_runs WHERE ... ORDER BY rows_past_horizon DESC
```

It fails safe. `--multiquery` aborts on the first error, so no `ALTER` ran and no TTL was recorded (verified before fixing). But an operator following the runbook hits a hard error on the safety check, which reads as a broken migration rather than a syntax problem in a preview.

## Verified on the live stack

With the fix, the preview returns:

| table | rows past horizon |
|---|---|
| `last_touch_index` | 2159 |
| everything else | 0 |

which matches a count I took independently beforehand. The full target then applied TTLs to all ten tables present on the stack, with the `business_events` split landing correctly: the row keeps `toIntervalDay(2555)` while the `RawPayload` column carries `toIntervalDay(90)`.

Nothing was deleted, as intended by `materialize_ttl_after_modify = 0`: `otel_spans` 1,542,996, `business_events` 687,400, `last_touch_index` 801,288, `replay_samples` 903,081 before and after, and the revenue total held at $11,568,630.62.

The `eval_runs` failure at the end of the run is **not** a bug. That table is not mounted on this stack, and the script deliberately orders that statement last with a comment saying it is the one that may legitimately fail.

No application source is touched, so no test suite is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)