### PR TITLE
fix(web): make onboarding reachable, catch the provisioning race, scope the onboarding store per tenant

### DIFF
--- a/web/app/SetupCallout.test.tsx
+++ b/web/app/SetupCallout.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// #358: the setup page was unreachable. These tests pin the two things that make it reachable:
+// the Home callout renders for a tenant with no data (and, separately, for one whose data we could
+// not check), and the shell carries a permanent nav entry pointing at it.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SetupCallout, setupCalloutCopy } from "./SetupCallout";
+
+describe("SetupCallout", () => {
+  it("says nothing once a span has landed", () => {
+    expect(setupCalloutCopy("connected")).toBeNull();
+    const { container } = render(<SetupCallout status="connected" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("points a tenant with no telemetry at setup", () => {
+    render(<SetupCallout status="waiting" />);
+    expect(screen.getByText(/No telemetry has arrived yet/)).toBeTruthy();
+    const link = screen.getByRole("link", { name: /Finish setup/ });
+    expect(link.getAttribute("href")).toBe("/onboarding");
+  });
+
+  // The honest-under-uncertainty case. A probe we could not read is not evidence that the tenant is
+  // new, so the callout must not claim it is: it says we could not tell, and still offers the link.
+  it("does not claim a tenant is new when the probe could not be read", () => {
+    render(<SetupCallout status="unknown" />);
+    expect(screen.getByText(/could not tell whether your telemetry has arrived/)).toBeTruthy();
+    expect(screen.queryByText(/No telemetry has arrived yet/)).toBeNull();
+    expect(screen.getByRole("link", { name: /Open setup/ }).getAttribute("href")).toBe("/onboarding");
+  });
+});
+
+describe("shell reachability", () => {
+  // A source-text guard, the same shape as the FINAL guard in clickhouse.test.ts. Rendering the
+  // shell would prove the link exists in one pathname state; what actually regressed here is the
+  // nav table, so the test reads the nav table.
+  it("keeps a nav entry pointing at /onboarding", () => {
+    const src = readFileSync(resolve(__dirname, "../components/Shell.tsx"), "utf8");
+    expect(src).toMatch(/href:\s*"\/onboarding"/);
+  });
+});

--- a/web/app/SetupCallout.tsx
+++ b/web/app/SetupCallout.tsx
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Home's entry point into /onboarding (#358).
+//
+// The two-step setup experience, the coverage probe and the honest-blank work behind them existed
+// with nothing linking to them: no href in the app, no nav entry, no mention in the docs. A page
+// nobody can reach is the same as a page that does not exist.
+//
+// The callout is driven by the ONE signal the product already has for "has any data arrived":
+// queryFirstEventSeen (a tenant-scoped existence probe). It has three states and all three are
+// rendered differently, because collapsing them is how a product ends up telling a tenant with a
+// broken ClickHouse read that they have not connected anything:
+//
+//   connected -> nothing at all. A tenant with data flowing does not need setup in their face.
+//   waiting   -> the probe ran and found no span. That is a real, definite negative, so we say it
+//                and point at setup.
+//   unknown   -> the probe could not be read. We do NOT assume the tenant is new. The callout says
+//                we cannot tell and still offers the link, which is the honest version of the same
+//                affordance (CLAUDE.md, honest under uncertainty).
+//
+// The permanent way back in is the "Setup" nav item in the shell; this callout is the prominent
+// one, and it disappears on its own once a span lands.
+
+import Link from "next/link";
+
+import type { FirstEventStatus } from "@/lib/firstEvent";
+
+/** Copy for each state the callout renders. `null` for a tenant whose data is already flowing. */
+export function setupCalloutCopy(
+  status: FirstEventStatus,
+): { heading: string; body: string; cta: string } | null {
+  if (status === "connected") return null;
+  if (status === "waiting") {
+    return {
+      heading: "No telemetry has arrived yet",
+      body:
+        "We checked and found no spans for this workspace. Connect your app and the dashboards below fill in.",
+      cta: "Finish setup",
+    };
+  }
+  return {
+    heading: "We could not tell whether your telemetry has arrived",
+    body:
+      "The first-event probe could not be read, so this is not a report that nothing has arrived. " +
+      "If the dashboards below are blank, setup is the place to start.",
+    cta: "Open setup",
+  };
+}
+
+export function SetupCallout({ status }: { status: FirstEventStatus }) {
+  const copy = setupCalloutCopy(status);
+  if (!copy) return null;
+  return (
+    <section
+      className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-accent/40 bg-accent/10 px-4 py-3"
+      aria-label="Setup"
+    >
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-fg">{copy.heading}</div>
+        <p className="mt-0.5 text-sm text-muted">{copy.body}</p>
+      </div>
+      <Link
+        href="/onboarding"
+        className="inline-flex shrink-0 items-center rounded-md border border-accent/50 bg-accent/15 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/25"
+      >
+        {copy.cta}
+      </Link>
+    </section>
+  );
+}

--- a/web/app/WorkspaceProvisioning.test.tsx
+++ b/web/app/WorkspaceProvisioning.test.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// #358: the provisioning race and a genuine provisioning failure looked identical to a customer,
+// because neither was caught at all. These tests pin the distinction the recovery screen draws.
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PROVISIONING_WAIT_MS,
+  WorkspaceProvisioning,
+  provisioningScreen,
+} from "./WorkspaceProvisioning";
+
+describe("provisioningScreen", () => {
+  it("says the workspace is still being set up inside the wait window", () => {
+    const s = provisioningScreen("pending", 4_000, null);
+    expect(s.waiting).toBe(true);
+    expect(s.heading).toMatch(/Setting up your workspace/);
+  });
+
+  // The bounded half of "bounded retry". Past the window we stop implying it is nearly done, since
+  // a wait this long is no longer the race, and a customer parked on a spinner is told nothing.
+  it("stops claiming progress once the wait window has passed", () => {
+    const s = provisioningScreen("pending", PROVISIONING_WAIT_MS + 1_000, null);
+    expect(s.waiting).toBe(false);
+    expect(s.heading).toMatch(/has not finished being set up/);
+    expect(s.body).toMatch(/contact support/);
+  });
+
+  // A non-404 resolution failure is not the race. It does not self-heal, so it is reported at once
+  // with the reason rather than hidden behind another 40 seconds of "nearly there".
+  it("reports a real failure immediately, with its reason and no waiting", () => {
+    const s = provisioningScreen(
+      "failed",
+      1_000,
+      "the control plane answered HTTP 503 when we asked which workspace this organization belongs to",
+    );
+    expect(s.waiting).toBe(false);
+    expect(s.heading).toMatch(/could not be set up/);
+    expect(s.body).toMatch(/HTTP 503/);
+    expect(s.body).toMatch(/will not clear on its own/);
+  });
+});
+
+describe("WorkspaceProvisioning", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("polls and switches to the failure copy when the poll says failed", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ state: "failed", reason: "the control plane answered HTTP 503" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<WorkspaceProvisioning pollMs={5} />);
+    expect(screen.getByText(/Setting up your workspace/)).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not be set up/)).toBeTruthy();
+    });
+    expect(screen.getByText(/HTTP 503/)).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith("/api/tenant/provisioning-status", {
+      cache: "no-store",
+    });
+  });
+
+  it("keeps waiting rather than reporting a failure when the poll request itself drops", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    render(<WorkspaceProvisioning pollMs={5} />);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    // A dropped request is not evidence about provisioning either way.
+    expect(screen.getByText(/Setting up your workspace/)).toBeTruthy();
+    expect(screen.queryByText(/could not be set up/)).toBeNull();
+  });
+});

--- a/web/app/WorkspaceProvisioning.tsx
+++ b/web/app/WorkspaceProvisioning.tsx
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// The recovery screen for the provisioning race (#358).
+//
+// What it replaces: a brand-new customer whose browser beat Clerk's `organization.created` webhook
+// got Next's generic "Application error: a server-side exception has occurred" with an opaque
+// digest, as their first screen, at the highest-stakes moment in the funnel. The throw was correct.
+// Nothing catching it was not.
+//
+// The screen is deliberately NOT an infinite spinner. The race and a genuine provisioning failure
+// look identical from the browser, and a customer parked forever on "setting up your workspace…"
+// while the HMAC key provider returns 503 is the worse of the two failures, because it never tells
+// them anything is wrong. So:
+//
+//   - We poll, bounded. Inside the window the wording is "still being set up", which is true.
+//   - The moment the poll answers `failed` (any resolution failure that is not the deliberate 404)
+//     we stop and say provisioning did not complete, with the reason. That is the distinguishing
+//     signal: 404 means "not yet", anything else means "not working".
+//   - When the window runs out with the answer still `pending`, we stop claiming it is nearly done.
+//     A wait this long is no longer the race we can point at, so the screen says provisioning has
+//     not completed, what we do know, and what to do next.
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ProvisioningState, ProvisioningStatusPayload } from "@/lib/provisioning";
+
+/** How often we re-ask. The race resolves in seconds; a 2s poll is a handful of requests. */
+export const PROVISIONING_POLL_MS = 2_000;
+
+/**
+ * How long "still being set up" stays true.
+ *
+ * There is no measurement behind this number: Clerk webhook delivery latency against a page load
+ * needs a deployed environment to observe, and the audit records that nobody has. It is a bound on
+ * how long we are willing to imply things are fine, not a claim about how long delivery takes, and
+ * the copy past it says exactly that.
+ */
+export const PROVISIONING_WAIT_MS = 45_000;
+
+interface Screen {
+  heading: string;
+  body: string;
+  /** Whether the customer is still being asked to wait (renders the progress affordance). */
+  waiting: boolean;
+}
+
+/**
+ * The pure state-to-copy mapping, so what the customer is told is unit-tested rather than tangled
+ * up in the poll. `reason` is the server's explanation and is rendered verbatim when present.
+ */
+export function provisioningScreen(
+  state: ProvisioningState,
+  elapsedMs: number,
+  reason: string | null,
+): Screen {
+  if (state === "failed") {
+    const why = reason ?? "the control plane did not answer";
+    return {
+      heading: "Your workspace could not be set up",
+      body:
+        why.charAt(0).toUpperCase() +
+        why.slice(1) +
+        ". This will not clear on its own. Reload to try again, and if it persists, contact support with the name of the organization you just created.",
+      waiting: false,
+    };
+  }
+  if (elapsedMs >= PROVISIONING_WAIT_MS) {
+    return {
+      heading: "Your workspace has not finished being set up",
+      body:
+        "We have been waiting " +
+        Math.round(elapsedMs / 1000) +
+        " seconds and this organization still has no workspace behind it. That is longer than setup should take, so we have stopped implying it is about to finish. Reload to check again, and if it persists, contact support with the name of the organization you just created.",
+      waiting: false,
+    };
+  }
+  return {
+    heading: "Setting up your workspace",
+    body:
+      "Your organization was created and we are waiting for its workspace to appear. This normally takes a few seconds and the page continues on its own.",
+    waiting: true,
+  };
+}
+
+export function WorkspaceProvisioning({
+  /** Test seam: the poll interval and the wait bound, so a test does not sit through 45 seconds. */
+  pollMs = PROVISIONING_POLL_MS,
+}: {
+  pollMs?: number;
+}) {
+  const [state, setState] = useState<ProvisioningState>("pending");
+  const [reason, setReason] = useState<string | null>(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const startedAt = useRef(Date.now());
+  const stopped = useRef(false);
+
+  const poll = useCallback(async () => {
+    try {
+      const res = await fetch("/api/tenant/provisioning-status", { cache: "no-store" });
+      const body = (await res.json()) as ProvisioningStatusPayload;
+      if (stopped.current) return;
+      if (body.state === "ready") {
+        stopped.current = true;
+        // A full navigation, not router.refresh(): the tenant resolves in the root layout, and a
+        // hard load is the one thing guaranteed to re-run it with the cache cold.
+        window.location.reload();
+        return;
+      }
+      if (body.state === "no_org") {
+        // NoActiveOrgError's own docstring: callers redirect to select-or-create-org.
+        stopped.current = true;
+        window.location.href = "/select-org";
+        return;
+      }
+      setState(body.state);
+      setReason(body.reason);
+      if (body.state === "failed") stopped.current = true;
+    } catch {
+      // A dropped request is not evidence that provisioning failed, so it changes nothing: the next
+      // tick asks again, and the elapsed bound below still applies.
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setElapsedMs(Date.now() - startedAt.current);
+      if (stopped.current) return;
+      if (Date.now() - startedAt.current >= PROVISIONING_WAIT_MS) return;
+      void poll();
+    }, pollMs);
+    void poll();
+    return () => clearInterval(id);
+  }, [poll, pollMs]);
+
+  const screen = provisioningScreen(state, elapsedMs, reason);
+
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center p-6">
+      <section
+        className="max-w-lg rounded-xl border border-edge bg-panel p-6"
+        aria-live="polite"
+        role="status"
+      >
+        <h1 className="text-base font-semibold text-fg">{screen.heading}</h1>
+        <p className="mt-2 text-sm text-muted">{screen.body}</p>
+        {screen.waiting ? (
+          <div className="mt-4 flex items-center gap-2 text-xs text-muted">
+            <span
+              aria-hidden
+              className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-accent"
+            />
+            Checking every {Math.round(pollMs / 1000)}s
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="mt-4 inline-flex items-center rounded-md border border-accent/50 bg-accent/15 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/25"
+          >
+            Reload
+          </button>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -110,10 +110,13 @@ describe("api routes", () => {
 
   it("GET /api/onboarding returns progress + creds (no OpenAI key leaked)", async () => {
     const body = await json<{
-      progress: { signedUpAt: number };
+      progress: Record<string, unknown>;
       creds: { tenantKey: string; proxyBaseUrl: string };
     }>(await OnboardingGET());
-    expect(body.progress.signedUpAt).toBeGreaterThan(0);
+    // #358: no signedUpAt. It was the moment the in-process record was built (server boot on the
+    // old process-global store), rendered as though it were the tenant's signup.
+    expect(body.progress).not.toHaveProperty("signedUpAt");
+    expect(body.progress.copiedConfigAt).toBeNull();
     expect(body.creds.tenantKey).toBeTypeOf("string");
     expect(body.creds.proxyBaseUrl).toContain("/v1");
   });

--- a/web/app/api/onboarding/route.ts
+++ b/web/app/api/onboarding/route.ts
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
+import { resolveTenantId } from "@/lib/getTenant";
 import { FUNNEL_STAGES, type FunnelStage } from "@/lib/onboarding";
 import { getCreds, getFunnel, getProgress, hasFunnelStage, recordFunnel } from "@/lib/onboardingStore";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+// #358: every read and write here is scoped to the caller's tenant UUID, resolved the same way as
+// every other read in the app. The store behind it used to be one record for the whole server, so
+// one organization's onboarding progress was another's.
 export async function GET() {
+  const tenantId = await resolveTenantId();
   return NextResponse.json({
-    progress: getProgress(),
-    creds: getCreds(),
-    funnel: getFunnel(),
+    progress: getProgress(tenantId),
+    creds: getCreds(tenantId),
+    funnel: getFunnel(tenantId),
   });
 }
 
@@ -33,10 +38,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "unknown funnel stage" }, { status: 400 });
   }
   const noticed = body.noticed === true;
+  const tenantId = await resolveTenantId();
   // A polled observation repeats on every page load, so only the first report is kept.
-  if (noticed && hasFunnelStage(stage)) {
-    return NextResponse.json({ event: null, progress: getProgress() });
+  if (noticed && hasFunnelStage(tenantId, stage)) {
+    return NextResponse.json({ event: null, progress: getProgress(tenantId) });
   }
-  const event = recordFunnel(stage, { noticed });
-  return NextResponse.json({ event, progress: getProgress() });
+  const event = recordFunnel(tenantId, stage, { noticed });
+  return NextResponse.json({ event, progress: getProgress(tenantId) });
 }

--- a/web/app/api/tenant/provisioning-status/route.test.ts
+++ b/web/app/api/tenant/provisioning-status/route.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import { provisioningFailureReason } from "@/lib/provisioning";
+
+import { GET } from "./route";
+
+describe("GET /api/tenant/provisioning-status", () => {
+  it("reports ready when the tenant resolves", async () => {
+    // The suite runs on the dev escape hatch, so resolution succeeds without Clerk.
+    const body = (await (await GET()).json()) as { state: string; reason: string | null };
+    expect(body.state).toBe("ready");
+    expect(body.reason).toBeNull();
+  });
+});
+
+describe("provisioningFailureReason", () => {
+  // The status code is the one detail worth keeping; the exception itself is not fit to render.
+  it("keeps the status code and nothing else from the error", () => {
+    const reason = provisioningFailureReason(new Error("by-clerk-org resolve failed: HTTP 503"));
+    expect(reason).toContain("HTTP 503");
+    expect(reason).not.toContain("by-clerk-org");
+  });
+
+  it("falls back to a generic sentence rather than echoing an unknown error message", () => {
+    const reason = provisioningFailureReason(new Error("ECONNREFUSED 10.0.0.4:8080"));
+    expect(reason).not.toContain("ECONNREFUSED");
+    expect(reason).toMatch(/could not be reached/);
+  });
+});

--- a/web/app/api/tenant/provisioning-status/route.ts
+++ b/web/app/api/tenant/provisioning-status/route.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Is this session's workspace provisioned yet (#358)?
+//
+// The recovery screen the root layout renders during the provisioning race polls this. It exists
+// so the browser can ask the question repeatedly without re-rendering a whole dashboard page, and
+// so the answer distinguishes the two cases a customer currently cannot tell apart:
+//
+//   pending  the org is real, the tenant row is not there YET. Clerk's organization.created webhook
+//            is asynchronous and the post-signup redirect is not, so this is the expected state for
+//            a few seconds after signup and it self-heals.
+//   failed   resolution broke in some other way (the gateway is down, or provisioning itself is
+//            failing, e.g. the HMAC key provider answering 503). This does NOT self-heal, and
+//            telling a customer to keep waiting for it would be a lie.
+//
+// The reason string is derived from the status code, never from an exception message or a stack:
+// this response reaches a browser. The shapes and the wording live in lib/provisioning.ts, because
+// a route file may export only route fields.
+import { NextResponse } from "next/server";
+
+import { NoActiveOrgError, TenantNotProvisionedError, getTenant } from "@/lib/getTenant";
+import {
+  PENDING_REASON,
+  type ProvisioningStatusPayload,
+  provisioningFailureReason,
+} from "@/lib/provisioning";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(): Promise<NextResponse<ProvisioningStatusPayload>> {
+  try {
+    await getTenant();
+    return NextResponse.json({ state: "ready" as const, reason: null });
+  } catch (err) {
+    if (err instanceof TenantNotProvisionedError) {
+      return NextResponse.json({ state: "pending" as const, reason: PENDING_REASON });
+    }
+    if (err instanceof NoActiveOrgError) {
+      // The docstring's own instruction: callers send the user to select-or-create-org.
+      return NextResponse.json({ state: "no_org" as const, reason: null });
+    }
+    return NextResponse.json({
+      state: "failed" as const,
+      reason: provisioningFailureReason(err),
+    });
+  }
+}

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// The app's error boundary (#358). There was none anywhere under web/app, so every uncaught render
+// error, including the provisioning race, rendered Next's built-in "Application error: a
+// server-side exception has occurred (see more info in server logs)" with a digest and nothing else.
+//
+// Two rules here, both from the audit:
+//
+//   1. The digest is not the message. In a production build Next redacts a server-side error before
+//      it reaches this component, so the digest is genuinely all we have; that makes it a reference
+//      to quote to support, not an explanation. It renders as small print under a sentence that
+//      says what actually happened in the customer's terms, and it is never the headline.
+//   2. No stack. `error.stack` is not rendered, in any environment. What a developer needs is in
+//      the server log, which the copy points at.
+//
+// The provisioning race does not arrive here: the root layout resolves the tenant and renders the
+// recovery screen for it, because that error is transient and recoverable and this one is neither.
+
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // The server log is where the un-redacted error lives; this puts the client half next to it.
+    console.error("unhandled app error", error.digest ?? "");
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-6">
+      <section className="max-w-lg rounded-xl border border-edge bg-panel p-6">
+        <h1 className="text-base font-semibold text-fg">This page could not be loaded</h1>
+        <p className="mt-2 text-sm text-muted">
+          Something went wrong while building this view. Nothing was changed, and your data is
+          unaffected. Try again, and if it keeps happening, contact support with the reference below.
+        </p>
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex items-center rounded-md border border-accent/50 bg-accent/15 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/25"
+          >
+            Try again
+          </button>
+          <Link href="/" className="text-sm text-muted underline hover:text-fg">
+            Back to Home
+          </Link>
+        </div>
+        {error.digest ? (
+          <p className="mt-4 text-xs text-muted">
+            Reference: <code className="font-mono">{error.digest}</code>
+          </p>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Last-resort boundary (#358). `app/error.tsx` sits INSIDE the root layout, so it cannot catch an
+// error thrown by the layout itself: that is what this file is for, and it has to render its own
+// <html>/<body> because the layout that would have provided them is the thing that failed.
+//
+// It is deliberately plain and dependency-free (inline styles, no shell, no Clerk): every richer
+// thing it could reach for is a thing that might be what broke. Same two rules as error.tsx, the
+// digest is a reference and not the message, and no stack is rendered.
+
+"use client";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, background: "#0b0d10", color: "#e6e8eb", fontFamily: "system-ui, sans-serif" }}>
+        <div style={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }}>
+          <section style={{ maxWidth: 520, border: "1px solid #23282e", borderRadius: 12, padding: 24 }}>
+            <h1 style={{ fontSize: 16, margin: 0 }}>ai-tally could not start this page</h1>
+            <p style={{ fontSize: 14, lineHeight: 1.5, color: "#9aa3ad" }}>
+              The application shell failed to load. This is on our side, not something you did, and
+              no data was changed. Try again, and if it keeps happening, contact support with the
+              reference below.
+            </p>
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                marginTop: 8,
+                padding: "6px 12px",
+                fontSize: 14,
+                borderRadius: 6,
+                border: "1px solid #3d6fe0",
+                background: "transparent",
+                color: "#7aa2f7",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            {error.digest ? (
+              <p style={{ fontSize: 12, color: "#6b7480" }}>Reference: {error.digest}</p>
+            ) : null}
+          </section>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Shell } from "@/components/Shell";
-import { devTenant } from "@/lib/getTenant";
+import { TenantNotProvisionedError, devTenant, getTenant } from "@/lib/getTenant";
+import { WorkspaceProvisioning } from "./WorkspaceProvisioning";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -15,9 +16,33 @@ export const metadata: Metadata = {
 // and no login, so `make up` and CI work with no Clerk account. In that mode we skip ClerkProvider
 // entirely (mounting it with no keys would throw) and hide the org controls in the shell. On the
 // product path ClerkProvider wraps the tree and the shell shows the org switcher.
-export default function RootLayout({ children }: { children: ReactNode }) {
+/**
+ * Is this request's org still waiting for its tenant row (#358)?
+ *
+ * The check lives in the layout because the race can hit ANY route (Home, onboarding, a bookmarked
+ * deep link), and one place that knows about it beats a try/catch on every page.
+ *
+ * It is deliberately narrow. Only {@link TenantNotProvisionedError}, the deliberate 404 from
+ * `by-clerk-org`, is handled here, because only that one is transient and recoverable. Everything
+ * else, including "no active org" (the middleware already redirects those to /select-org) and a
+ * gateway that is answering 503, is left exactly as it is: the page resolves the tenant too, and
+ * its throw lands in `app/error.tsx` with the shell intact. So this gate can only ADD a recovery,
+ * never swallow a failure.
+ */
+async function isAwaitingProvisioning(): Promise<boolean> {
+  try {
+    await getTenant();
+    return false;
+  } catch (err) {
+    return err instanceof TenantNotProvisionedError;
+  }
+}
+
+export default async function RootLayout({ children }: { children: ReactNode }) {
   const devTenantId = devTenant();
   const dev = devTenantId !== null;
+  // No Clerk, no webhook, no race: the escape hatch resolves its pinned tenant synchronously.
+  const awaitingProvisioning = dev ? false : await isAwaitingProvisioning();
   // In the dev escape hatch there is no Clerk org to read, so the shell names the tenant. Let a demo
   // or local deployment show a friendly organization name instead of the raw tenant id via
   // TALLY_DEV_ORG_NAME (CTO-262); falls back to the tenant value when unset.
@@ -29,7 +54,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         {/* On the dev escape hatch the shell names the pinned tenant (no Clerk org exists to read);
             on the product path it reads the active org name from Clerk (Initiative 1, §7/§10). */}
         <Shell showOrgControls={!dev} devTenantLabel={devLabel}>
-          {children}
+          {awaitingProvisioning ? <WorkspaceProvisioning /> : children}
         </Shell>
       </body>
     </html>

--- a/web/app/onboarding/Onboarding.test.tsx
+++ b/web/app/onboarding/Onboarding.test.tsx
@@ -19,7 +19,6 @@ const creds: TenantProxyCredentials = {
 };
 
 const progress: OnboardingProgress = {
-  signedUpAt: 1_000_000,
   copiedConfigAt: null,
   firstDashboardAt: null,
 };

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,6 +3,8 @@ import { apiGet } from "@/lib/api";
 import type { ForecastPayload } from "@/lib/burndown";
 import { queryFirstEventSeen, queryPriorMonthSpend } from "@/lib/clickhouse";
 import { filtersToQueryString, parseFilters } from "@/lib/filters";
+import { resolveTenantId } from "@/lib/getTenant";
+import { hasFunnelStage, recordFunnel } from "@/lib/onboardingStore";
 import { searchParamsFromRecord } from "@/lib/searchParams";
 import { queryEnabledConnectors } from "@/lib/tenant";
 import type { MicroUSD } from "@/lib/types";
@@ -36,6 +38,18 @@ export default async function HomePage({
     // funnel stage. Its `unknown` state is carried through, not folded into "nothing yet".
     queryFirstEventSeen(),
   ]);
+  // #358: the one place `first_dashboard` can honestly be recorded. Nothing anywhere posted it, so
+  // the onboarding checklist maxed out at 3 of 4 forever. The stage is "see your first dashboard",
+  // and this IS the dashboard being served with the tenant's own data behind it, so the moment is
+  // measured rather than noticed and the timestamp means what it says. The `connected` guard is
+  // load-bearing: rendering Home while the probe says `waiting` or `unknown` proves nothing about
+  // whether they ever saw data, and the store keeps only the first occurrence.
+  if (firstEvent === "connected") {
+    const tenantId = await resolveTenantId();
+    if (!hasFunnelStage(tenantId, "first_dashboard")) {
+      recordFunnel(tenantId, "first_dashboard");
+    }
+  }
   const forecast: ForecastPayload = budget.forecast;
   const priorMonth: MicroUSD | null = priorMonthMicroUsd;
   return (

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { apiGet } from "@/lib/api";
 import type { ForecastPayload } from "@/lib/burndown";
-import { queryPriorMonthSpend } from "@/lib/clickhouse";
+import { queryFirstEventSeen, queryPriorMonthSpend } from "@/lib/clickhouse";
 import { filtersToQueryString, parseFilters } from "@/lib/filters";
 import { searchParamsFromRecord } from "@/lib/searchParams";
 import { queryEnabledConnectors } from "@/lib/tenant";
 import type { MicroUSD } from "@/lib/types";
 import type { CostBudgetPayload } from "./cost/BurndownCard";
 import { HomeLive, type HomePayload } from "./Live";
+import { SetupCallout } from "./SetupCallout";
 
 export default async function HomePage({
   searchParams,
@@ -23,22 +24,29 @@ export default async function HomePage({
   // rather than joined to the 5-second poll: it moves on a daily cadence, and a forecast that
   // flickered every few seconds would read as far less trustworthy than it is. Tenant scope only on
   // Home (no ?scope=); the full scoped burn-down stays on /cost.
-  const [initialData, enabledLayers, budget, priorMonthMicroUsd] = await Promise.all([
+  const [initialData, enabledLayers, budget, priorMonthMicroUsd, firstEvent] = await Promise.all([
     apiGet<HomePayload>(endpoint),
     queryEnabledConnectors(),
     apiGet<CostBudgetPayload>("/api/cost/budget"),
     // Last full month's actual, for the forecast card's "vs last month" delta (CTO-227). Read once
     // here, not polled: it only changes at a month boundary.
     queryPriorMonthSpend(),
+    // Has anything ever landed for this tenant (#358)? The existing existence probe, reused rather
+    // than a second read of the same fact: it drives the setup callout below and the first_dashboard
+    // funnel stage. Its `unknown` state is carried through, not folded into "nothing yet".
+    queryFirstEventSeen(),
   ]);
   const forecast: ForecastPayload = budget.forecast;
   const priorMonth: MicroUSD | null = priorMonthMicroUsd;
   return (
-    <HomeLive
-      initialData={initialData}
-      enabledLayers={enabledLayers}
-      forecast={forecast}
-      priorMonthMicroUsd={priorMonth}
-    />
+    <div className="space-y-6">
+      <SetupCallout status={firstEvent} />
+      <HomeLive
+        initialData={initialData}
+        enabledLayers={enabledLayers}
+        forecast={forecast}
+        priorMonthMicroUsd={priorMonth}
+      />
+    </div>
   );
 }

--- a/web/app/select-org/page.tsx
+++ b/web/app/select-org/page.tsx
@@ -19,10 +19,14 @@ export default function SelectOrgPage() {
           Create one to get started, or pick an organization you already belong to.
         </p>
       </div>
+      {/* #358: creating an org used to land on Home, which for a tenant that has existed for four
+          seconds is a dashboard of blanks with no next step on it. It lands on /onboarding instead,
+          where the connect snippets and the coverage probe are. Selecting an existing org still
+          goes to Home: that org may already be flowing. */}
       <OrganizationList
         hidePersonal
         afterSelectOrganizationUrl="/"
-        afterCreateOrganizationUrl="/"
+        afterCreateOrganizationUrl="/onboarding"
       />
     </div>
   );

--- a/web/components/Shell.tsx
+++ b/web/components/Shell.tsx
@@ -53,6 +53,11 @@ const NAV_GROUPS: { caption: string; items: NavItem[] }[] = [
   {
     caption: "Configure",
     items: [
+      // The permanent way back into the two-step setup page (#358). It shipped unreachable: no
+      // href anywhere in the app, no nav entry, no mention in the docs. Home carries the prominent
+      // callout while a tenant has no data; this entry is the one that stays, because a team that
+      // adds a second service still needs the connect snippets and the coverage readout.
+      { label: "Setup", href: "/onboarding" },
       { label: "Connectors", href: "/connectors" },
       { label: "Guardrails", href: "/guardrails" },
       { label: "Budgets", href: "/settings/budgets" },
@@ -194,10 +199,13 @@ export function Shell({
 
         {showOrgControls && (
           <div className="flex items-center justify-between gap-2 border-t border-edge px-4 py-3">
+            {/* A brand-new org has no data by definition, so creating one lands on setup rather
+                than on an empty dashboard (#358). Selecting an EXISTING org still lands on Home:
+                that org may well be flowing, and forcing setup on a switch would be noise. */}
             <OrganizationSwitcher
               hidePersonal
               afterSelectOrganizationUrl="/"
-              afterCreateOrganizationUrl="/"
+              afterCreateOrganizationUrl="/onboarding"
             />
             <UserButton />
           </div>

--- a/web/lib/getTenant.test.ts
+++ b/web/lib/getTenant.test.ts
@@ -2,9 +2,10 @@
 // getTenant dev escape hatch + header helpers (Initiative 1, §7/§10). The vitest env sets
 // TALLY_DEV_TENANT (see vitest.config.ts), so these exercise the short-circuit that lets the app run
 // with no Clerk account: getTenant never imports Clerk and resolves to the pinned tenant.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  TenantNotProvisionedError,
   canManage,
   controlPlaneHeaders,
   devTenant,
@@ -12,6 +13,12 @@ import {
   resolveTenantId,
   serviceTokenHeader,
 } from "./getTenant";
+
+// The product path needs Clerk to answer with an active org. The real module is never installed in
+// this suite's environment (no keys), and getTenant imports it lazily, so a factory mock is enough.
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: async () => ({ orgId: "org_race", orgRole: "org:admin", userId: "user_1" }),
+}));
 
 describe("getTenant dev escape hatch", () => {
   it("short-circuits to the pinned dev tenant without consulting Clerk", async () => {
@@ -50,5 +57,37 @@ describe("control-plane headers", () => {
     delete process.env.GATEWAY_SERVICE_TOKEN;
     expect(serviceTokenHeader()).toEqual({});
     expect(controlPlaneHeaders("t-uuid")).toEqual({ "x-tenant-id": "t-uuid" });
+  });
+});
+
+// #358: the provisioning race. Clerk's organization.created webhook is asynchronous and the
+// post-signup redirect is not, so a browser that wins the race asks for an org the gateway has
+// never heard of. The gateway answers 404 deliberately. That 404 is transient and self-heals; any
+// other failure does not, and the two must not reach a customer as the same screen.
+describe("provisioning race resolution (product path)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("throws TenantNotProvisionedError on the deliberate 404", async () => {
+    vi.stubEnv("TALLY_DEV_TENANT", "");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }),
+    );
+    await expect(getTenant()).rejects.toBeInstanceOf(TenantNotProvisionedError);
+  });
+
+  it("keeps every other resolution failure a plain error carrying its status", async () => {
+    vi.stubEnv("TALLY_DEV_TENANT", "");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
+    );
+    const err = await getTenant().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(TenantNotProvisionedError);
+    expect((err as Error).message).toMatch(/HTTP 503/);
   });
 });

--- a/web/lib/getTenant.ts
+++ b/web/lib/getTenant.ts
@@ -97,6 +97,9 @@ async function resolveOrgToTenant(orgId: string): Promise<{ tenantId: string; pl
     `${GATEWAY_URL}/v1/tenant/by-clerk-org/${encodeURIComponent(orgId)}`,
     { headers: serviceTokenHeader(), cache: "no-store", signal: AbortSignal.timeout(2000) },
   );
+  if (res.status === 404) {
+    throw new TenantNotProvisionedError(orgId);
+  }
   if (!res.ok) {
     throw new Error(`by-clerk-org resolve failed: HTTP ${res.status}`);
   }
@@ -104,6 +107,27 @@ async function resolveOrgToTenant(orgId: string): Promise<{ tenantId: string; pl
   const resolved = { tenantId: body.tenant_id, plan: body.plan };
   _orgCache.set(orgId, { ...resolved, at: Date.now() });
   return resolved;
+}
+
+/**
+ * The org exists on the Clerk session but has no tenant behind it yet (#358).
+ *
+ * This is the provisioning race, and it is a DIFFERENT fact from every other resolution failure.
+ * `organization.created` is delivered asynchronously while the post-signup redirect is immediate,
+ * so a browser that beats the webhook asks for an org the gateway has never heard of and gets the
+ * deliberate 404 from `/v1/tenant/by-clerk-org/{orgId}` (there is no silent fallback, correctly).
+ * That 404 is transient and self-heals on the next attempt.
+ *
+ * Any OTHER status is not the race: a 503 from the HMAC key provider means provisioning is failing,
+ * not that it has not happened yet, and the two must not be presented to a customer as the same
+ * thing. So only the 404 gets this type; everything else stays a generic Error and reaches the
+ * error boundary.
+ */
+export class TenantNotProvisionedError extends Error {
+  constructor(readonly orgId: string) {
+    super(`no tenant provisioned for org ${orgId}`);
+    this.name = "TenantNotProvisionedError";
+  }
 }
 
 /**

--- a/web/lib/onboarding.test.ts
+++ b/web/lib/onboarding.test.ts
@@ -17,7 +17,6 @@ const creds = { tenantKey: "tk_test_123", proxyBaseUrl: "https://proxy.example/v
 
 function progress(over: Partial<OnboardingProgress> = {}): OnboardingProgress {
   return {
-    signedUpAt: 1_000_000,
     copiedConfigAt: null,
     firstDashboardAt: null,
     ...over,

--- a/web/lib/onboarding.ts
+++ b/web/lib/onboarding.ts
@@ -106,9 +106,13 @@ export interface ChecklistStep {
  * A timestamp with no source is not an unknown value we render as a blank, it is a measurement we
  * do not take, so the model does not carry a slot for it. Restoring it means restoring a real
  * arrival signal from ingest at the same time.
+ *
+ * There is deliberately no `signedUpAt` either (#358), for the same reason. It used to be stamped
+ * when the in-process store first built its record, which on a process-global store was server boot
+ * time and on a per-tenant store would be the first page view. Neither is a signup. Clerk holds the
+ * real one and nothing here reads it, so the slot is gone rather than filled with a stand-in.
  */
 export interface OnboardingProgress {
-  signedUpAt: number;
   copiedConfigAt: number | null;
   firstDashboardAt: number | null;
 }

--- a/web/lib/onboardingStore.test.ts
+++ b/web/lib/onboardingStore.test.ts
@@ -9,41 +9,69 @@ import {
   recordFunnel,
 } from "./onboardingStore";
 
+// Two tenant UUIDs, because the canonical identifier is the tenant UUID (CLAUDE.md) and the bug
+// this file now guards against was one record serving both of them.
+const TENANT_A = "11111111-1111-1111-1111-111111111111";
+const TENANT_B = "22222222-2222-2222-2222-222222222222";
+
 describe("onboarding store", () => {
   beforeEach(() => __resetOnboarding());
 
-  it("starts signed_up with no later milestones", () => {
-    const p = getProgress();
-    expect(p.signedUpAt).toBeGreaterThan(0);
+  it("starts with no milestones and no invented timestamps", () => {
+    const p = getProgress(TENANT_A);
     expect(p.copiedConfigAt).toBeNull();
+    expect(p.firstDashboardAt).toBeNull();
     // #329: there is no firstTraceAt. Nothing could measure it, so the store does not carry it.
     expect(p).not.toHaveProperty("firstTraceAt");
-    expect(getFunnel().map((e) => e.stage)).toEqual(["signed_up"]);
+    // #358: and no signedUpAt. It used to be stamped when the record was built, which was server
+    // boot time, presented as the tenant's signup.
+    expect(p).not.toHaveProperty("signedUpAt");
+    // The funnel starts empty rather than seeded with a signed_up event stamped Date.now().
+    expect(getFunnel(TENANT_A)).toEqual([]);
   });
 
   it("recordFunnel mirrors stages onto progress timestamps (first wins)", () => {
-    recordFunnel("copied_config");
-    const first = getProgress().copiedConfigAt;
+    recordFunnel(TENANT_A, "copied_config");
+    const first = getProgress(TENANT_A).copiedConfigAt;
     expect(first).not.toBeNull();
-    recordFunnel("copied_config"); // second occurrence must not overwrite
-    expect(getProgress().copiedConfigAt).toBe(first);
+    recordFunnel(TENANT_A, "copied_config"); // second occurrence must not overwrite
+    expect(getProgress(TENANT_A).copiedConfigAt).toBe(first);
   });
 
   // #329: the probe-received transition reports first_trace, and it is the page NOTICING the stage
   // rather than timing it. The event is flagged so nobody reads its clock as an arrival time, and
   // it stamps no progress timestamp at all.
   it("records a noticed stage without mirroring it onto progress", () => {
-    expect(hasFunnelStage("first_trace")).toBe(false);
-    const ev = recordFunnel("first_trace", { noticed: true });
+    expect(hasFunnelStage(TENANT_A, "first_trace")).toBe(false);
+    const ev = recordFunnel(TENANT_A, "first_trace", { noticed: true });
     expect(ev.noticed).toBe(true);
-    expect(hasFunnelStage("first_trace")).toBe(true);
-    expect(getProgress()).not.toHaveProperty("firstTraceAt");
-    expect(getFunnel().filter((e) => e.stage === "first_trace")).toHaveLength(1);
+    expect(hasFunnelStage(TENANT_A, "first_trace")).toBe(true);
+    expect(getProgress(TENANT_A)).not.toHaveProperty("firstTraceAt");
+    expect(getFunnel(TENANT_A).filter((e) => e.stage === "first_trace")).toHaveLength(1);
   });
 
   it("marks a performed stage as measured, not noticed", () => {
-    const ev = recordFunnel("copied_config");
+    const ev = recordFunnel(TENANT_A, "copied_config");
     expect(ev.noticed).toBeUndefined();
-    expect(getProgress().copiedConfigAt).toBe(ev.at);
+    expect(getProgress(TENANT_A).copiedConfigAt).toBe(ev.at);
+  });
+
+  // #358, the point of the change: the store was one `globalThis.__tallyOnboarding` record shared
+  // by every organization on the deployment, so one tenant's progress was visible to and
+  // overwritten by another's.
+  it("keeps one tenant's progress invisible to another", () => {
+    recordFunnel(TENANT_A, "copied_config");
+    recordFunnel(TENANT_A, "first_dashboard");
+
+    expect(getProgress(TENANT_B).copiedConfigAt).toBeNull();
+    expect(getProgress(TENANT_B).firstDashboardAt).toBeNull();
+    expect(getFunnel(TENANT_B)).toEqual([]);
+    expect(hasFunnelStage(TENANT_B, "copied_config")).toBe(false);
+
+    // And B's own progress does not disturb A's.
+    recordFunnel(TENANT_B, "copied_config");
+    expect(getProgress(TENANT_A).firstDashboardAt).not.toBeNull();
+    expect(getFunnel(TENANT_A).map((e) => e.stage)).toEqual(["copied_config", "first_dashboard"]);
+    expect(getFunnel(TENANT_B).map((e) => e.stage)).toEqual(["copied_config"]);
   });
 });

--- a/web/lib/onboardingStore.ts
+++ b/web/lib/onboardingStore.ts
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Server-only in-memory onboarding store backing the activation funnel sink.
+// Server-only in-memory onboarding store backing the activation funnel sink, keyed by tenant.
 //
-// In production these are control-plane rows. In the prototype we keep a single in-process record
-// so the funnel is real and demonstrable. State resets on server restart, which is fine for a mock;
-// `npm run dev/build/test` never need infra.
+// In production these are control-plane rows. This is still the prototype's in-process stand-in, so
+// state is per PROCESS and is lost on restart and on every deploy, and two web instances behind a
+// load balancer hold two different answers. That is a real limitation and it is written here rather
+// than implied: the funnel is a UI progress aid, not a source of truth anything else reads.
+//
+// #358: what it is NOT any more is a single record shared by everyone. It used to be one
+// `globalThis.__tallyOnboarding`, so on a multi-tenant deployment every organization saw and
+// overwrote the same onboarding progress. Keying by the resolved tenant UUID (the canonical
+// identifier, per CLAUDE.md) makes the isolation match the rest of the product; the honest caveat
+// above is what is left, and it is a deployment-lifetime caveat rather than a correctness bug.
 //
 // #329: there is no first-trace detector here any more, and no "Send a test trace" button behind
 // it. Whether a trace arrived is answered by the gateway coverage probe, which the onboarding page
@@ -25,11 +32,15 @@ interface StoreState {
 function freshState(): StoreState {
   return {
     progress: {
-      signedUpAt: Date.now(),
       copiedConfigAt: null,
       firstDashboardAt: null,
     },
-    funnel: [{ stage: "signed_up", at: Date.now() }],
+    // #358: the funnel starts EMPTY. It used to be seeded with a `signed_up` event stamped
+    // Date.now(), which on a process-global store meant server boot time and on a per-tenant store
+    // would mean the first time this process served the tenant. Neither is a signup, and Clerk owns
+    // the only real one. Same rule #329 applied to first-trace: a stage we cannot time is not
+    // recorded with a stand-in clock reading. The checklist's first step does not depend on it.
+    funnel: [],
     // #320: these are placeholders, not a provisioned key and endpoint, and they used to render in
     // step 1 as though they were the tenant's own. The provisioning path is control-plane work; in
     // the meantime the values carry `isExample` so every surface that shows them says what they are
@@ -42,35 +53,44 @@ function freshState(): StoreState {
   };
 }
 
-// Survive Next.js dev hot-reload by stashing on globalThis.
-const g = globalThis as unknown as { __tallyOnboarding?: StoreState };
-function state(): StoreState {
-  if (!g.__tallyOnboarding) g.__tallyOnboarding = freshState();
-  return g.__tallyOnboarding;
+// Survive Next.js dev hot-reload by stashing on globalThis. One entry per tenant UUID.
+const g = globalThis as unknown as { __tallyOnboarding?: Map<string, StoreState> };
+function state(tenantId: string): StoreState {
+  if (!g.__tallyOnboarding) g.__tallyOnboarding = new Map<string, StoreState>();
+  let s = g.__tallyOnboarding.get(tenantId);
+  if (!s) {
+    s = freshState();
+    g.__tallyOnboarding.set(tenantId, s);
+  }
+  return s;
 }
 
-export function getProgress(): OnboardingProgress {
-  return { ...state().progress };
+export function getProgress(tenantId: string): OnboardingProgress {
+  return { ...state(tenantId).progress };
 }
 
-export function getCreds(): TenantProxyCredentials {
-  return { ...state().creds };
+export function getCreds(tenantId: string): TenantProxyCredentials {
+  return { ...state(tenantId).creds };
 }
 
-export function getFunnel(): FunnelEvent[] {
-  return [...state().funnel];
+export function getFunnel(tenantId: string): FunnelEvent[] {
+  return [...state(tenantId).funnel];
 }
 
 /**
- * Record a funnel stage.
+ * Record a funnel stage for one tenant.
  *
  * `noticed` marks a stage we observed after the fact rather than timed (#329). The onboarding page
  * posts first_trace that way, off the coverage probe: the stage is real, the moment is only when we
  * spotted it, so the event carries the flag and is never mirrored onto a progress timestamp that
  * would then be read as a measured duration. A stage is recorded once; later reports are ignored.
  */
-export function recordFunnel(stage: FunnelStage, opts: { noticed?: boolean } = {}): FunnelEvent {
-  const s = state();
+export function recordFunnel(
+  tenantId: string,
+  stage: FunnelStage,
+  opts: { noticed?: boolean } = {},
+): FunnelEvent {
+  const s = state(tenantId);
   const ev: FunnelEvent = { stage, at: Date.now(), ...(opts.noticed ? { noticed: true } : {}) };
   s.funnel.push(ev);
   // Mirror the stage onto progress timestamps (first occurrence wins). Only stages the page itself
@@ -86,11 +106,11 @@ export function recordFunnel(stage: FunnelStage, opts: { noticed?: boolean } = {
 }
 
 /** Whether this stage has already been recorded, so a repeated report does not pile up events. */
-export function hasFunnelStage(stage: FunnelStage): boolean {
-  return state().funnel.some((e) => e.stage === stage);
+export function hasFunnelStage(tenantId: string, stage: FunnelStage): boolean {
+  return state(tenantId).funnel.some((e) => e.stage === stage);
 }
 
-/** Test-only: reset the in-memory store. */
+/** Test-only: drop every tenant's in-memory record. */
 export function __resetOnboarding(): void {
-  g.__tallyOnboarding = freshState();
+  g.__tallyOnboarding = new Map<string, StoreState>();
 }

--- a/web/lib/provisioning.ts
+++ b/web/lib/provisioning.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// The wire shape and the customer-facing wording for "is this session's workspace provisioned yet"
+// (#358). Pure, and separate from the route handler because a Next.js route file may export only
+// route fields, and separate from the client screen because the screen must not import a server
+// module. Both sides import it here.
+
+export type ProvisioningState = "ready" | "pending" | "no_org" | "failed";
+
+export interface ProvisioningStatusPayload {
+  state: ProvisioningState;
+  /** Why, for the states that need explaining. Null when the state speaks for itself. */
+  reason: string | null;
+}
+
+/** The `pending` explanation. The 404 is expected for a few seconds after signup, and only then. */
+export const PENDING_REASON =
+  "this organization has no workspace yet, which is expected for a few seconds after signup";
+
+/**
+ * Customer-facing reason for a resolution failure that is NOT the race.
+ *
+ * `resolveOrgToTenant` puts the status code in its message, which is the one detail worth keeping,
+ * so it is matched out deliberately and everything else about the error is dropped. An unmatched
+ * error yields the generic sentence rather than its own message, because an arbitrary exception
+ * message is exactly the sort of thing that turns into a leaked internal detail on a screen.
+ */
+export function provisioningFailureReason(err: unknown): string {
+  const message = err instanceof Error ? err.message : "";
+  const status = /HTTP (\d{3})/.exec(message)?.[1];
+  if (status) {
+    return `the control plane answered HTTP ${status} when we asked which workspace this organization belongs to`;
+  }
+  return "the control plane could not be reached to look up this organization's workspace";
+}


### PR DESCRIPTION
Three findings from `docs/onboarding-flow-audit.md`, one commit each. They are related but independent.

## 1. The onboarding page was unreachable

Zero `href="/onboarding"` anywhere in `web/`, nothing in the shell nav, nothing in the docs. The whole two-step setup experience, the coverage probe and the honest-blank work from #329 existed and no customer could find it.

Three entry points, chosen so it is findable when it is needed and out of the way when it is not:

- **A callout at the top of Home**, driven by the existing `queryFirstEventSeen` probe rather than a new read. All three of its states render differently. `waiting` (the probe ran and found no span) is a real negative and says so. `unknown` (the probe could not be read) does **not** claim the tenant is new: it says we could not tell and still offers the link. `connected` renders nothing, so a tenant with data flowing never sees it again. That is the "must not fabricate a state" requirement: an unreadable probe is not evidence of a new tenant.
- **A permanent "Setup" nav entry** under Configure. The callout disappears once data lands; a team wiring a second service still needs the snippets and the coverage readout, so there is a way back.
- **`afterCreateOrganizationUrl` now points at `/onboarding`**, on both the select-org screen and the org switcher. I did change it, and the reason is that a brand-new org has no data by definition, so the old destination was a dashboard of blanks with no next step on it. `afterSelectOrganizationUrl` is unchanged: switching to an existing org should not force setup on an org that may already be flowing.

`queryFirstEventSeen` is reused as-is. PR #326's deliberate `FINAL` exemption and the source-text guard in `clickhouse.test.ts` are untouched, and `lib/clickhouse.ts` is not modified.

I considered redirecting Home to `/onboarding` for a tenant with no data and did not: it would make Home unreachable for a tenant who is legitimately empty, and it would have to guess on the `unknown` state, which is exactly the fabrication to avoid.

## 2. There was no error boundary anywhere

Zero `error.tsx`, zero `global-error.tsx`. Every uncaught render error rendered Next's generic "Application error: a server-side exception has occurred" with an opaque digest, including the provisioning race at the single highest-stakes moment in the funnel.

**How the transient race is told apart from a real provisioning failure.** By the status code, at the source:

- `resolveOrgToTenant` now throws a new `TenantNotProvisionedError` for the **404 and only the 404**. That is the gateway's deliberate "no tenant for this org", which during the race means "not yet" and self-heals on the next attempt.
- Any other status stays a plain `Error`. A 503 from the HMAC key provider means provisioning is *failing*, not that it has not happened yet, and it does not self-heal.

Then, on top of that distinction:

- The root layout catches `TenantNotProvisionedError` and renders a recovery screen. The gate is deliberately narrow: "no active org" is left to the middleware's existing `/select-org` redirect, and every other failure is left to the page (which resolves the tenant too) and lands in `error.tsx`. So it can only add a recovery, never swallow a failure.
- The recovery screen polls `/api/tenant/provisioning-status`, **bounded**. Inside the window it says the workspace is still being set up, which is true. A `failed` answer stops it immediately and reports the reason. When the window expires still pending, it stops implying progress and says plainly that provisioning has not completed and what to do. A customer parked forever on a spinner while the key provider 503s is the failure this is designed not to produce.
- `app/error.tsx` handles everything else: no stack, and the digest is a small "Reference:" line, never the message. `app/global-error.tsx` is the last resort for a failure in the layout itself.

The `reason` string reaching the browser is derived from the status code, never from an exception message.

**Proved by running.** With a scratch route throwing from a server render, `app/error.tsx` caught it and rendered inside the shell (no "Application error", no stack, digest as small print). A second scratch route rendered the recovery screen in both its waiting and its failed states. Both scratch routes were removed before committing.

**Unverified without real Clerk.** The dev server runs under `TALLY_DEV_TENANT`, which bypasses Clerk entirely, so the race itself cannot be reproduced locally. What is untested against a real Clerk instance: that the webhook race actually produces the 404 in the field, how wide the window is, and that the layout gate fires on the product path (the gate short-circuits under the dev escape hatch). The 404-to-`TenantNotProvisionedError` mapping and the 503-stays-generic behaviour are covered by unit tests against a stubbed gateway, not against Clerk.

## 3. `onboardingStore` was a process-global shared by every tenant

One record on `globalThis` for the whole server: one organization's onboarding progress was visible to and overwritten by every other's, and `signedUpAt` was effectively server boot time.

**Decision: keyed in-process, not the control plane.** The end state is Postgres behind a gateway endpoint and that is still the right end state. I did not do it here. What is left in this store is two client-driven UI progress timestamps and the placeholder credentials; a numbered migration plus a control-plane store for a prototype progress aid is a larger change than the defect warrants, and it would land the schema for a model (`isExample` credentials, a funnel with `noticed` events) that is still moving. The defect the audit names is cross-tenant leakage, and keying by the resolved tenant UUID fixes that completely. What remains is a deployment-lifetime limitation, and the file now says so out loud instead of implying it: per-process, lost on restart and on deploy, and two web instances hold two different answers.

Two honesty fixes fall out:

- **`signedUpAt` is gone**, and the funnel no longer seeds a `signed_up` event stamped `Date.now()`. On the old store that timestamp was server boot presented as the tenant's signup; scoping it per tenant would have made it the first page view. Neither is a signup, Clerk holds the real one, nothing read it. This is the rule #329 applied to `firstTraceAt`: a measurement we do not take gets no slot rather than a stand-in clock.
- **`first_dashboard` is fixed.** Nothing anywhere posted it, so the checklist maxed at 3 of 4 forever. Home records it when it serves the dashboard with the first-event probe reporting `connected`. That is the stage actually happening at the moment it happens, so it is a measured timestamp, not a noticed one. The `connected` guard is load-bearing: serving Home while the probe says `waiting` or `unknown` proves nothing about whether the customer ever saw data.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run test`, plus `npm run build`. 837 passed / 69 files, up from the 822 / 66 baseline. The one pre-existing warning at `lib/useLivePoll.ts:94` is left alone.
- New tests: the callout's three states and the nav entry; the 404-vs-other-status split in `getTenant`; the recovery screen's waiting / expired / failed copy and its behaviour when the poll request itself drops; the failure-reason redaction; and, for the store, **a test that two tenant UUIDs cannot see each other's progress or funnel**.
- Visually, against a dev server on a spare port: the `waiting` callout and the "Setup" nav entry on a tenant with no spans, `/onboarding` reachable from it, no callout on a tenant with data, the checklist showing "See your first dashboard" ticked, and both error screens. The running stack's data was not modified and its dev server on :3000 was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
