### PR TITLE
fix(deploy): three production deploy blockers, plus the unmounted eval_runs table

### DIFF
--- a/db/clickhouse/migrations/derived_table_retention.sql
+++ b/db/clickhouse/migrations/derived_table_retention.sql
@@ -140,13 +140,13 @@ ALTER TABLE business_events MODIFY COLUMN RawPayload String CODEC(ZSTD(3)) TTL t
 ALTER TABLE replay_samples MODIFY TTL toDateTime(CapturedAt) + INTERVAL 30 DAY DELETE;
 ALTER TABLE replay_runs MODIFY TTL toDateTime(RanAt) + INTERVAL 30 DAY DELETE;
 
--- eval_runs is LAST on purpose, and it is the one statement here that may legitimately fail.
--- db/clickhouse/eval_runs.sql is neither mounted into docker-entrypoint-initdb.d nor listed in the
--- Makefile's CH_DDL, so a stack that has not applied it by hand simply has no eval_runs table, and
--- ClickHouse has no ALTER TABLE IF EXISTS to express that. Ordering it after everything else means
--- an UNKNOWN_TABLE here aborts nothing that matters: every other TTL above is already recorded.
--- If it fails and you do run the eval harness, apply db/clickhouse/eval_runs.sql first (its CREATE
--- TABLE now carries the same TTL inline) and re-run this file.
+-- eval_runs is LAST on purpose, and it is the one statement here that may still legitimately fail.
+-- CTO-360 mounted db/clickhouse/eval_runs.sql into docker-entrypoint-initdb.d and added it to the
+-- Makefile's CH_DDL, so a fresh stack has the table and a running one gets it from `make ch-migrate`.
+-- A stack created before that and never migrated still has no eval_runs, and ClickHouse has no
+-- ALTER TABLE IF EXISTS to express that. Ordering it after everything else means an UNKNOWN_TABLE
+-- here aborts nothing that matters: every other TTL above is already recorded. If it fails, run
+-- `make ch-migrate` (its CREATE TABLE carries the same TTL inline) and re-run this file.
 ALTER TABLE eval_runs MODIFY TTL toDateTime(JudgedAt) + INTERVAL 400 DAY DELETE;
 
 -- ============================================================================================
@@ -165,7 +165,6 @@ ORDER BY name
 FORMAT PrettyCompactMonoBlock;
 
 -- Any table in that list with an empty ttl_clause did not take the ALTER. The usual cause is that
--- the table does not exist on this install: eval_runs in particular is NOT mounted into
--- docker-entrypoint-initdb.d and is NOT in the Makefile's CH_DDL list, so a stack that never ran
--- the eval harness has no such table and its ALTER above will have failed. That gap predates this
--- change and is not fixed here.
+-- the table does not exist on this install. eval_runs used to be that case permanently, because it
+-- was in neither the compose mounts nor CH_DDL; CTO-360 added it to both, so the answer now is to
+-- run `make ch-migrate` and re-run this file.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -455,6 +455,26 @@ The IRSA role also needs the Secrets Store CSI driver's AWS provider installed (
 
 ## 7. Deploy
 
+### First, the preflight (CTO-360)
+
+```bash
+cd infra && make prod-preflight ENV=../prod.env      # or: scripts/prod-preflight.sh --env prod.env
+```
+
+Put both sides in the file: the gateway's settings and the Vercel project's. It checks the handful
+of settings whose failures are confusing and unrelated-looking, and each finding names the symptom
+it prevents: `TALLY_REQUIRE_API_KEY` false leaves the control plane ungated so an unauthenticated
+`POST /v1/tenant/provision` creates a real tenant; the web tier's `GATEWAY_SERVICE_TOKEN` and the
+gateway's `TALLY_GATEWAY_SERVICE_TOKEN` differing 401s every control-plane call; a leftover
+`TALLY_DEV_TENANT` pins one tenant for whoever loads the dashboard; `TALLY_HMAC_KEY_PROVIDER` unset
+falls back to the local provider, which holds per-tenant key material in configuration rather than
+by reference; a missing Clerk svix signing secret rejects `organization.created` so no tenant is
+ever provisioned; and an unreachable ClickHouse does not error but paints mock data.
+
+It uses no AWS credentials, makes no AWS API call, and never prints a secret value: secrets are
+compared and reported by SHA-256 prefix and length. It exits non-zero and says exactly what to fix.
+`ARGS=--no-probe` skips the outbound reachability check.
+
 ### Option A — ECS-Fargate (primary)
 
 Create the cluster and the CloudWatch log groups, then register the task defs and create the

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -31,13 +31,17 @@ the local dev flow. It reuses the **same images** the GCP path uses: the gateway
 > what that leaves unproven. This runbook stays the reference for what each resource is for, which
 > IAM grants to delete, and how to do it by hand.
 >
-> One warning that applies to the by-hand path only. The `sed -e "s/REGION/$REGION/g"` recipes below
-> are a blanket substitution, and `gateway.taskdef.json` contains the environment variable **names**
-> `AWS_REGION` and `TALLY_REPLAY_S3_REGION`. The `sed` rewrites those names too, producing
-> `AWS_us-east-1`. The task definition registers, the task starts, and both settings are simply
-> absent, so the AWS default credential chain and the S3 replay store each lose their region with no
-> error naming the cause. Check the registered task definition, or substitute `:REGION:`,
-> `.REGION.` and `"REGION"` separately the way `terraform/modules/compute/taskdefs.tf` does.
+> **Placeholder tokens are delimited, and that is load-bearing (CTO-360).** Every placeholder in
+> `ecs/` is spelled `__LIKE_THIS__`: `__ACCOUNT__`, `__REGION__`, `__REPLAY_BUCKET__`,
+> `__KMS_KEY_ID__`, `__CLICKHOUSE_HOST__`, `__CLICKHOUSE_URL__`, `__GATEWAY_URL__`. They used to be
+> the bare words `ACCOUNT` and `REGION`, and the `sed` recipes below are blanket substitutions, so
+> `s/REGION/$REGION/g` also rewrote the environment variable **names** `AWS_REGION` and
+> `TALLY_REPLAY_S3_REGION` in `gateway.taskdef.json` into `AWS_us-east-1` and
+> `TALLY_REPLAY_S3_us-east-1`. The output stayed valid JSON, `register-task-definition` accepted it,
+> the task started, and both settings were simply absent: the AWS default credential chain lost its
+> region and the S3 replay store lost its, with no error naming the cause. `__REGION__` cannot occur
+> inside an identifier, so a blanket replace is now safe in every file. If you add a placeholder,
+> give it the same delimiters.
 
 ## What's in this directory
 
@@ -157,13 +161,13 @@ aws iam create-open-id-connect-provider \
 
 # The trust policy restricts the role to this repository's main branch and its vX.Y.Z tags, so a
 # fork or a pull-request run cannot assume it. Substitute ACCOUNT before applying.
-sed "s/ACCOUNT/$ACCOUNT/g" deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json \
+sed "s/__ACCOUNT__/$ACCOUNT/g" deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json \
   > /tmp/gha-trust.json
 aws iam create-role --role-name ai-tally-ci-ecr-push \
   --assume-role-policy-document file:///tmp/gha-trust.json
 
 # Push rights on exactly the three repositories, and nothing else in the account.
-sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
+sed -e "s/__ACCOUNT__/$ACCOUNT/g" -e "s/__REGION__/$REGION/g" \
   deploy/aws/ecs/iam/github-actions-ecr-policy.json > /tmp/gha-ecr.json
 aws iam put-role-policy --role-name ai-tally-ci-ecr-push \
   --policy-name ai-tally-ci-ecr-push --policy-document file:///tmp/gha-ecr.json
@@ -346,8 +350,8 @@ secrets + KMS + connector role assumption + Cost Explorer + Bedrock + Secrets Ma
 verbatim for both paths, only the **trust** differs.
 
 **Every IAM document here carries placeholders and none of them is usable unedited.** They are the
-same tokens the task definitions use, so one `sed` line covers a file: `ACCOUNT`, `REGION`,
-`REPLACE_REPLAY_BUCKET` (the same bucket `gateway.taskdef.json` names) and `REPLACE_KMS_KEY_ID`. The
+same tokens the task definitions use, so one `sed` line covers a file: `__ACCOUNT__`, `__REGION__`,
+`__REPLAY_BUCKET__` (the same bucket `gateway.taskdef.json` names) and `__KMS_KEY_ID__`. The
 bucket used to be spelled `my-org-ai-tally-replay`, which reads like a real name and is not one; it
 is a placeholder now so nobody grants their role access to somebody else's bucket.
 
@@ -356,9 +360,9 @@ export KMS_KEY_ID=YOUR_CMK_KEY_ID            # see "Which KMS key" below
 export REPLAY_BUCKET=$ACCOUNT-ai-tally-replay
 
 # The permissions policy (shared by both paths):
-sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
-    -e "s/REPLACE_REPLAY_BUCKET/$REPLAY_BUCKET/g" \
-    -e "s/REPLACE_KMS_KEY_ID/$KMS_KEY_ID/g" \
+sed -e "s/__ACCOUNT__/$ACCOUNT/g" -e "s/__REGION__/$REGION/g" \
+    -e "s/__REPLAY_BUCKET__/$REPLAY_BUCKET/g" \
+    -e "s/__KMS_KEY_ID__/$KMS_KEY_ID/g" \
     deploy/aws/ecs/iam/task-role-policy.json > /tmp/ai-tally-workload.json
 aws iam create-policy --policy-name ai-tally-workload \
   --policy-document file:///tmp/ai-tally-workload.json
@@ -370,7 +374,7 @@ trust policy pins `aws:SourceAccount` so no other account's ECS can assume these
 why it needs substituting too:
 
 ```bash
-sed "s/ACCOUNT/$ACCOUNT/g" deploy/aws/ecs/iam/ecs-tasks-trust-policy.json > /tmp/ecs-trust.json
+sed "s/__ACCOUNT__/$ACCOUNT/g" deploy/aws/ecs/iam/ecs-tasks-trust-policy.json > /tmp/ecs-trust.json
 
 # Task role = the app's own identity (S3 / tenant HMAC secrets / Cost Explorer / Bedrock).
 aws iam create-role --role-name ai-tally-workload \
@@ -378,8 +382,8 @@ aws iam create-role --role-name ai-tally-workload \
 aws iam attach-role-policy --role-name ai-tally-workload --policy-arn "$WORKLOAD_POLICY_ARN"
 
 # Execution role = what Fargate needs to START a task (ECR pull, logs, secret injection).
-sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
-    -e "s/REPLACE_KMS_KEY_ID/$KMS_KEY_ID/g" \
+sed -e "s/__ACCOUNT__/$ACCOUNT/g" -e "s/__REGION__/$REGION/g" \
+    -e "s/__KMS_KEY_ID__/$KMS_KEY_ID/g" \
     deploy/aws/ecs/iam/execution-role-policy.json > /tmp/ai-tally-execution.json
 aws iam create-role --role-name ai-tally-ecs-execution \
   --assume-role-policy-document file:///tmp/ecs-trust.json
@@ -403,7 +407,7 @@ The execution role's ECR grants are now scoped to the three `ai-tally/*` reposit
 
 ### Which KMS key
 
-`REPLACE_KMS_KEY_ID` is the customer-managed key your Secrets Manager secrets are encrypted with. If
+`__KMS_KEY_ID__` is the customer-managed key your Secrets Manager secrets are encrypted with. If
 you left them on the AWS-managed `aws/secretsmanager` key, delete the `SecretsManagerKmsUse` and
 `SecretsInjectionKmsDecrypt` statements instead of substituting: the AWS-managed key is usable by
 principals in the account that hold the Secrets Manager permission, so a grant would be redundant,
@@ -470,9 +474,9 @@ for g in gateway web edge-proxy; do
 done
 
 # Substitute placeholders and register the gateway task def:
-sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
-    -e "s/REPLACE_CLICKHOUSE_HOST/YOUR_CLICKHOUSE_HOST/g" \
-    -e "s/REPLACE_REPLAY_BUCKET/$ACCOUNT-ai-tally-replay/g" \
+sed -e "s/__ACCOUNT__/$ACCOUNT/g" -e "s/__REGION__/$REGION/g" \
+    -e "s/__CLICKHOUSE_HOST__/YOUR_CLICKHOUSE_HOST/g" \
+    -e "s/__REPLAY_BUCKET__/$ACCOUNT-ai-tally-replay/g" \
     deploy/aws/ecs/gateway.taskdef.json > /tmp/gateway.taskdef.json
 aws ecs register-task-definition --cli-input-json file:///tmp/gateway.taskdef.json
 
@@ -480,9 +484,9 @@ aws ecs register-task-definition --cli-input-json file:///tmp/gateway.taskdef.js
 aws ecs create-service --cli-input-json file://deploy/aws/ecs/gateway.service.json
 
 # After the gateway is reachable behind its ALB, capture GATEWAY_URL (the ALB DNS/HTTPS URL), then:
-sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
-    -e "s#REPLACE_GATEWAY_URL#https://YOUR_GATEWAY_ALB#g" \
-    -e "s#REPLACE_CLICKHOUSE_URL#https://YOUR_CLICKHOUSE_HOST:8443#g" \
+sed -e "s/__ACCOUNT__/$ACCOUNT/g" -e "s/__REGION__/$REGION/g" \
+    -e "s#__GATEWAY_URL__#https://YOUR_GATEWAY_ALB#g" \
+    -e "s#__CLICKHOUSE_URL__#https://YOUR_CLICKHOUSE_HOST:8443#g" \
     deploy/aws/ecs/web.taskdef.json > /tmp/web.taskdef.json
 aws ecs register-task-definition --cli-input-json file:///tmp/web.taskdef.json
 aws ecs create-service --cli-input-json file://deploy/aws/ecs/web.service.json
@@ -494,8 +498,8 @@ else's product, unlike the gateway (whose SDK buffers and retries) or the dashbo
 loses nothing).
 
 ```bash
-sed -e "s/ACCOUNT/$ACCOUNT/g" -e "s/REGION/$REGION/g" \
-    -e "s#REPLACE_GATEWAY_URL#https://ingest.YOUR_DOMAIN#g" \
+sed -e "s/__ACCOUNT__/$ACCOUNT/g" -e "s/__REGION__/$REGION/g" \
+    -e "s#__GATEWAY_URL__#https://ingest.YOUR_DOMAIN#g" \
     deploy/aws/ecs/edge-proxy.taskdef.json > /tmp/edge-proxy.taskdef.json
 aws ecs register-task-definition --cli-input-json file:///tmp/edge-proxy.taskdef.json
 aws ecs create-service --cli-input-json file://deploy/aws/ecs/edge-proxy.service.json

--- a/deploy/aws/ecs/edge-proxy.service.json
+++ b/deploy/aws/ecs/edge-proxy.service.json
@@ -18,7 +18,7 @@
   },
   "loadBalancers": [
     {
-      "targetGroupArn": "arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/ai-tally-edge-proxy/REPLACE",
+      "targetGroupArn": "arn:aws:elasticloadbalancing:__REGION__:__ACCOUNT__:targetgroup/ai-tally-edge-proxy/REPLACE",
       "containerName": "edge-proxy",
       "containerPort": 8088
     }

--- a/deploy/aws/ecs/edge-proxy.taskdef.json
+++ b/deploy/aws/ecs/edge-proxy.taskdef.json
@@ -8,12 +8,12 @@
     "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
-  "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
-  "taskRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-workload",
+  "executionRoleArn": "arn:aws:iam::__ACCOUNT__:role/ai-tally-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::__ACCOUNT__:role/ai-tally-workload",
   "containerDefinitions": [
     {
       "name": "edge-proxy",
-      "image": "ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/edge-proxy:1.0.0",
+      "image": "__ACCOUNT__.dkr.ecr.__REGION__.amazonaws.com/ai-tally/edge-proxy:1.0.0",
       "essential": true,
       "portMappings": [
         { "containerPort": 8088, "protocol": "tcp", "name": "http" }
@@ -26,11 +26,11 @@
         { "name": "EDGE_PROXY_REQUIRE_TENANT", "value": "true" },
         { "name": "EDGE_PROXY_UPSTREAM_TIMEOUT", "value": "10m" },
         { "name": "EDGE_PROXY_SELF_HOSTED", "value": "false" },
-        { "name": "EDGE_PROXY_TELEMETRY_URL", "value": "REPLACE_GATEWAY_URL/v1/batches" },
-        { "name": "EDGE_PROXY_KEYS_URL", "value": "REPLACE_GATEWAY_URL/v1/edge/keys" }
+        { "name": "EDGE_PROXY_TELEMETRY_URL", "value": "__GATEWAY_URL__/v1/batches" },
+        { "name": "EDGE_PROXY_KEYS_URL", "value": "__GATEWAY_URL__/v1/edge/keys" }
       ],
       "secrets": [
-        { "name": "EDGE_PROXY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" }
+        { "name": "EDGE_PROXY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-gateway-service-token" }
       ],
       "dockerLabels": {
         "com.ai-tally.no-container-healthcheck": "Deliberate (CTO-339). Do NOT add a healthCheck block here. The image is FROM scratch: it carries the static binary and CA roots and nothing else, so there is no /bin/sh for CMD-SHELL and no curl, wget or python for CMD. Any container health check fails every attempt, the task is killed as unhealthy, and the service cycles forever with no error that names the cause. Liveness is checked by the ALB target group against GET /healthz on 8088 instead (see edge-proxy.service.json and deploy/aws/README.md section 7A).",
@@ -40,7 +40,7 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "/ecs/ai-tally-edge-proxy",
-          "awslogs-region": "REGION",
+          "awslogs-region": "__REGION__",
           "awslogs-stream-prefix": "edge-proxy",
           "awslogs-create-group": "false"
         }

--- a/deploy/aws/ecs/gateway.service.json
+++ b/deploy/aws/ecs/gateway.service.json
@@ -18,7 +18,7 @@
   },
   "loadBalancers": [
     {
-      "targetGroupArn": "arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/ai-tally-gateway/REPLACE",
+      "targetGroupArn": "arn:aws:elasticloadbalancing:__REGION__:__ACCOUNT__:targetgroup/ai-tally-gateway/REPLACE",
       "containerName": "gateway",
       "containerPort": 8080
     }

--- a/deploy/aws/ecs/gateway.taskdef.json
+++ b/deploy/aws/ecs/gateway.taskdef.json
@@ -8,33 +8,33 @@
     "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
-  "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
-  "taskRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-workload",
+  "executionRoleArn": "arn:aws:iam::__ACCOUNT__:role/ai-tally-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::__ACCOUNT__:role/ai-tally-workload",
   "containerDefinitions": [
     {
       "name": "gateway",
-      "image": "ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/gateway:1.0.0",
+      "image": "__ACCOUNT__.dkr.ecr.__REGION__.amazonaws.com/ai-tally/gateway:1.0.0",
       "essential": true,
       "portMappings": [
         { "containerPort": 8080, "protocol": "tcp", "name": "http" }
       ],
       "environment": [
-        { "name": "TALLY_CLICKHOUSE_HOST", "value": "REPLACE_CLICKHOUSE_HOST" },
+        { "name": "TALLY_CLICKHOUSE_HOST", "value": "__CLICKHOUSE_HOST__" },
         { "name": "TALLY_CLICKHOUSE_PORT", "value": "8123" },
         { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
         { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },
         { "name": "TALLY_REQUIRE_API_KEY", "value": "true" },
-        { "name": "AWS_REGION", "value": "REGION" },
+        { "name": "AWS_REGION", "value": "__REGION__" },
         { "name": "TALLY_REPLAY_BLOB_BACKEND", "value": "s3" },
-        { "name": "TALLY_REPLAY_S3_BUCKET", "value": "REPLACE_REPLAY_BUCKET" },
-        { "name": "TALLY_REPLAY_S3_REGION", "value": "REGION" }
+        { "name": "TALLY_REPLAY_S3_BUCKET", "value": "__REPLAY_BUCKET__" },
+        { "name": "TALLY_REPLAY_S3_REGION", "value": "__REGION__" }
       ],
       "secrets": [
-        { "name": "TALLY_POSTGRES_DSN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-postgres-dsn" },
-        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" },
-        { "name": "TALLY_GATEWAY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-gateway-service-token" },
-        { "name": "OPENAI_API_KEY", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-openai-api-key" },
-        { "name": "ANTHROPIC_API_KEY", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-anthropic-api-key" }
+        { "name": "TALLY_POSTGRES_DSN", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-postgres-dsn" },
+        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-clickhouse-password" },
+        { "name": "TALLY_GATEWAY_SERVICE_TOKEN", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-gateway-service-token" },
+        { "name": "OPENAI_API_KEY", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-openai-api-key" },
+        { "name": "ANTHROPIC_API_KEY", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-anthropic-api-key" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/healthz').status==200 else 1)\""],
@@ -47,7 +47,7 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "/ecs/ai-tally-gateway",
-          "awslogs-region": "REGION",
+          "awslogs-region": "__REGION__",
           "awslogs-stream-prefix": "gateway",
           "awslogs-create-group": "false"
         }

--- a/deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
+++ b/deploy/aws/ecs/iam/ecs-tasks-trust-policy.json
@@ -7,7 +7,7 @@
       "Action": "sts:AssumeRole",
       "Condition": {
         "StringEquals": {
-          "aws:SourceAccount": "ACCOUNT"
+          "aws:SourceAccount": "__ACCOUNT__"
         }
       }
     }

--- a/deploy/aws/ecs/iam/execution-role-policy.json
+++ b/deploy/aws/ecs/iam/execution-role-policy.json
@@ -16,9 +16,9 @@
         "ecr:BatchGetImage"
       ],
       "Resource": [
-        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/gateway",
-        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/edge-proxy",
-        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/web"
+        "arn:aws:ecr:__REGION__:__ACCOUNT__:repository/ai-tally/gateway",
+        "arn:aws:ecr:__REGION__:__ACCOUNT__:repository/ai-tally/edge-proxy",
+        "arn:aws:ecr:__REGION__:__ACCOUNT__:repository/ai-tally/web"
       ]
     },
     {
@@ -47,10 +47,10 @@
       "Sid": "SecretsInjectionKmsDecrypt",
       "Effect": "Allow",
       "Action": "kms:Decrypt",
-      "Resource": "arn:aws:kms:REGION:ACCOUNT:key/REPLACE_KMS_KEY_ID",
+      "Resource": "arn:aws:kms:__REGION__:__ACCOUNT__:key/__KMS_KEY_ID__",
       "Condition": {
         "StringEquals": {
-          "kms:ViaService": "secretsmanager.REGION.amazonaws.com"
+          "kms:ViaService": "secretsmanager.__REGION__.amazonaws.com"
         }
       }
     }

--- a/deploy/aws/ecs/iam/github-actions-ecr-policy.json
+++ b/deploy/aws/ecs/iam/github-actions-ecr-policy.json
@@ -21,9 +21,9 @@
         "ecr:UploadLayerPart"
       ],
       "Resource": [
-        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/gateway",
-        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/edge-proxy",
-        "arn:aws:ecr:REGION:ACCOUNT:repository/ai-tally/web"
+        "arn:aws:ecr:__REGION__:__ACCOUNT__:repository/ai-tally/gateway",
+        "arn:aws:ecr:__REGION__:__ACCOUNT__:repository/ai-tally/edge-proxy",
+        "arn:aws:ecr:__REGION__:__ACCOUNT__:repository/ai-tally/web"
       ]
     }
   ]

--- a/deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json
+++ b/deploy/aws/ecs/iam/github-actions-oidc-trust-policy.json
@@ -5,7 +5,7 @@
       "Sid": "GitHubActionsOidc",
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/token.actions.githubusercontent.com"
+        "Federated": "arn:aws:iam::__ACCOUNT__:oidc-provider/token.actions.githubusercontent.com"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {

--- a/deploy/aws/ecs/iam/irsa-trust-policy.json
+++ b/deploy/aws/ecs/iam/irsa-trust-policy.json
@@ -4,13 +4,13 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/oidc.eks.REGION.amazonaws.com/id/OIDC_ID"
+        "Federated": "arn:aws:iam::__ACCOUNT__:oidc-provider/oidc.eks.__REGION__.amazonaws.com/id/OIDC_ID"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:sub": "system:serviceaccount:ai-tally:ai-tally",
-          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:aud": "sts.amazonaws.com"
+          "oidc.eks.__REGION__.amazonaws.com/id/OIDC_ID:sub": "system:serviceaccount:ai-tally:ai-tally",
+          "oidc.eks.__REGION__.amazonaws.com/id/OIDC_ID:aud": "sts.amazonaws.com"
         }
       }
     }

--- a/deploy/aws/ecs/iam/task-role-policy.json
+++ b/deploy/aws/ecs/iam/task-role-policy.json
@@ -11,8 +11,8 @@
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::REPLACE_REPLAY_BUCKET",
-        "arn:aws:s3:::REPLACE_REPLAY_BUCKET/*"
+        "arn:aws:s3:::__REPLAY_BUCKET__",
+        "arn:aws:s3:::__REPLAY_BUCKET__/*"
       ]
     },
     {
@@ -35,10 +35,10 @@
         "kms:Decrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": "arn:aws:kms:REGION:ACCOUNT:key/REPLACE_KMS_KEY_ID",
+      "Resource": "arn:aws:kms:__REGION__:__ACCOUNT__:key/__KMS_KEY_ID__",
       "Condition": {
         "StringEquals": {
-          "kms:ViaService": "secretsmanager.REGION.amazonaws.com"
+          "kms:ViaService": "secretsmanager.__REGION__.amazonaws.com"
         }
       }
     },

--- a/deploy/aws/ecs/web.service.json
+++ b/deploy/aws/ecs/web.service.json
@@ -18,7 +18,7 @@
   },
   "loadBalancers": [
     {
-      "targetGroupArn": "arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/ai-tally-web/REPLACE",
+      "targetGroupArn": "arn:aws:elasticloadbalancing:__REGION__:__ACCOUNT__:targetgroup/ai-tally-web/REPLACE",
       "containerName": "web",
       "containerPort": 3000
     }

--- a/deploy/aws/ecs/web.taskdef.json
+++ b/deploy/aws/ecs/web.taskdef.json
@@ -8,28 +8,28 @@
     "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
   },
-  "executionRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-ecs-execution",
-  "taskRoleArn": "arn:aws:iam::ACCOUNT:role/ai-tally-workload",
+  "executionRoleArn": "arn:aws:iam::__ACCOUNT__:role/ai-tally-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::__ACCOUNT__:role/ai-tally-workload",
   "containerDefinitions": [
     {
       "name": "web",
-      "image": "ACCOUNT.dkr.ecr.REGION.amazonaws.com/ai-tally/web:1.0.0",
+      "image": "__ACCOUNT__.dkr.ecr.__REGION__.amazonaws.com/ai-tally/web:1.0.0",
       "essential": true,
       "portMappings": [
         { "containerPort": 3000, "protocol": "tcp", "name": "http" }
       ],
       "environment": [
         { "name": "PORT", "value": "3000" },
-        { "name": "TALLY_GATEWAY_URL", "value": "REPLACE_GATEWAY_URL" },
+        { "name": "TALLY_GATEWAY_URL", "value": "__GATEWAY_URL__" },
         { "name": "TALLY_DEV_TENANT", "value": "" },
         { "name": "TALLY_ALLOW_INSECURE_NO_AUTH", "value": "" },
-        { "name": "TALLY_CLICKHOUSE_URL", "value": "REPLACE_CLICKHOUSE_URL" },
+        { "name": "TALLY_CLICKHOUSE_URL", "value": "__CLICKHOUSE_URL__" },
         { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
         { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },
         { "name": "NEXT_PUBLIC_TALLY_DASHBOARD_REFRESH_MS", "value": "5000" }
       ],
       "secrets": [
-        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:ai-tally-clickhouse-password" }
+        { "name": "TALLY_CLICKHOUSE_PASSWORD", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-clickhouse-password" }
       ],
       "healthCheck": {
         "command": ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/ || exit 1"],
@@ -42,7 +42,7 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "/ecs/ai-tally-web",
-          "awslogs-region": "REGION",
+          "awslogs-region": "__REGION__",
           "awslogs-stream-prefix": "web",
           "awslogs-create-group": "false"
         }

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -29,9 +29,29 @@ What that does **not** establish, and what will therefore break first:
 - No plan has ever been produced against a real provider, so nothing here has been checked against
   live API validation: name-length limits, ACM and ELB naming rules, RDS engine version
   availability, and instance class availability per region are all unverified.
-- **`db_engine_version = "16.4"` is a guess about what RDS offers.** Check
-  `aws rds describe-db-engine-versions --engine postgres` and set it to a version that exists in
-  your region, or the first apply fails on the RDS instance after creating the VPC.
+- **`db_engine_version` and `db_instance_class` have no defaults, on purpose (CTO-360).** They used
+  to default to `"16.4"` and `"db.t4g.medium"`, which were guesses: nobody had run a plan against a
+  real account, and a Postgres minor version RDS has retired, or an instance class the region does
+  not offer for that version, fails at APPLY, on the RDS instance, after the VPC and the NAT gateway
+  exist. Terraform now refuses to plan until you supply both, so the failure is at the front instead
+  of halfway through. Look them up:
+
+  ```bash
+  aws rds describe-db-engine-versions --engine postgres --region "$REGION" \
+    --query 'DBEngineVersions[].EngineVersion' --output text | tr '\t' '\n' | sort -V
+
+  aws rds describe-orderable-db-instance-options --engine postgres \
+    --engine-version "$DB_ENGINE_VERSION" --region "$REGION" \
+    --query 'OrderableDBInstanceOptions[].DBInstanceClass' --output text | tr '\t' '\n' | sort -u
+  ```
+
+  The variable validations only check the shape of what you typed. Neither can prove the value
+  exists in your region without an account, and they do not pretend to.
+- **`availability_zones` is validated against `aws_region`, and that is all it is.** AZ names are
+  account-scoped, so list yours with
+  `aws ec2 describe-availability-zones --region "$REGION" --query 'AvailabilityZones[?State==`available`].ZoneName' --output text`.
+  The validation catches an AZ from the wrong region and fewer than two distinct AZs. It cannot
+  tell you whether a given AZ offers Fargate ARM64 or your chosen RDS instance class.
 - **Fargate ARM64 availability per region is unverified.** All three task definitions pin
   `cpuArchitecture: ARM64` (PR #351). If ARM64 Fargate is not offered in your region, or the images
   in ECR are not arm64 manifests, every task fails to start with an image-manifest error and the

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -360,11 +360,12 @@ NAT is in an AZ that is having a bad day and `single_nat_gateway = true`. Interf
 help here; see the section above.
 
 **The gateway logs region errors, or the replay store writes nowhere.** Check that `AWS_REGION` and
-`TALLY_REPLAY_S3_REGION` are still spelled that way in the registered task definition. The runbook's
-`sed -e "s/REGION/$REGION/g"` recipe rewrites those variable NAMES as well as their values, giving
-you `AWS_us-east-1`. The task registers and starts, and both settings are simply absent. This module
-substitutes by shape rather than as a bare word specifically to avoid that, so seeing it means
-something registered a task definition by hand.
+`TALLY_REPLAY_S3_REGION` are still spelled that way in the registered task definition. Before
+CTO-360 the placeholder was the bare word `REGION`, and the runbook's `sed -e "s/REGION/$REGION/g"`
+rewrote those variable NAMES as well as their values, giving you `AWS_us-east-1`; the task
+registered and started, and both settings were simply absent. The placeholders are `__REGION__` and
+`__ACCOUNT__` now, which cannot occur inside an identifier, so seeing this means an older recipe or
+an older copy of the files is still in use somewhere.
 
 **The edge proxy service cycles forever with nothing useful in the logs.** Somebody added a
 container `healthCheck` to `edge-proxy.taskdef.json`. The image is `FROM scratch`: no shell, no

--- a/deploy/aws/terraform/modules/compute/taskdefs.tf
+++ b/deploy/aws/terraform/modules/compute/taskdefs.tf
@@ -25,40 +25,35 @@
 locals {
   taskdef_dir = var.ecs_dir
 
-  # Placeholder substitution, and REGION is NOT done as a blanket replace.
+  # Placeholder substitution (CTO-360).
   #
-  # deploy/aws/README.md section 7A substitutes with `sed -e "s/REGION/$REGION/g"`, which also
-  # rewrites the environment variable NAMES `AWS_REGION` and `TALLY_REPLAY_S3_REGION` into
-  # `AWS_us-east-1` and `TALLY_REPLAY_S3_us-east-1`. The task registers fine and the gateway then
-  # runs with neither variable set, so the AWS default chain loses its region and the S3 replay
-  # store loses its. Matching the three shapes REGION actually appears in avoids that: inside an
-  # ARN, inside a service hostname, and as a whole quoted value. ACCOUNT is safe as a blanket
-  # replace because no identifier in these files contains that substring.
+  # Every placeholder in deploy/aws/ecs/ is delimited `__LIKE_THIS__`, which is what makes a blanket
+  # replace safe here and in the runbook's `sed`. It did not used to be. The tokens were the bare
+  # words `REGION` and `ACCOUNT`, and a blanket `s/REGION/$REGION/g` also rewrote the environment
+  # variable NAMES `AWS_REGION` and `TALLY_REPLAY_S3_REGION` into `AWS_us-east-1` and
+  # `TALLY_REPLAY_S3_us-east-1`. The task registered fine and the gateway then ran with neither
+  # variable set, so the AWS default credential chain lost its region and the S3 replay store lost
+  # its, with no error naming the cause. `__REGION__` cannot occur inside an identifier, so the
+  # shape-matching this block used to do is no longer needed.
   render_taskdef = {
     for name in ["gateway", "edge-proxy"] :
     name => replace(
       replace(
         replace(
           replace(
-            replace(
-              replace(
-                file("${local.taskdef_dir}/${name}.taskdef.json"),
-                "REPLACE_REPLAY_BUCKET", var.replay_bucket_name
-              ),
-              "REPLACE_CLICKHOUSE_HOST", var.clickhouse_host
-            ),
-            "ACCOUNT", data.aws_caller_identity.current.account_id
+            file("${local.taskdef_dir}/${name}.taskdef.json"),
+            "__REPLAY_BUCKET__", var.replay_bucket_name
           ),
-          ":REGION:", ":${var.aws_region}:"
+          "__CLICKHOUSE_HOST__", var.clickhouse_host
         ),
-        ".REGION.", ".${var.aws_region}."
+        "__ACCOUNT__", data.aws_caller_identity.current.account_id
       ),
-      "\"REGION\"", "\"${var.aws_region}\""
+      "__REGION__", var.aws_region
     )
   }
 
-  gateway_raw    = jsondecode(replace(local.render_taskdef["gateway"], "REPLACE_GATEWAY_URL", local.gateway_url))
-  edge_proxy_raw = jsondecode(replace(local.render_taskdef["edge-proxy"], "REPLACE_GATEWAY_URL", local.gateway_url))
+  gateway_raw    = jsondecode(replace(local.render_taskdef["gateway"], "__GATEWAY_URL__", local.gateway_url))
+  edge_proxy_raw = jsondecode(replace(local.render_taskdef["edge-proxy"], "__GATEWAY_URL__", local.gateway_url))
 
   gateway_container_raw    = local.gateway_raw.containerDefinitions[0]
   edge_proxy_container_raw = local.edge_proxy_raw.containerDefinitions[0]

--- a/deploy/aws/terraform/modules/compute/variables.tf
+++ b/deploy/aws/terraform/modules/compute/variables.tf
@@ -99,7 +99,7 @@ variable "edge_proxy_image" {
 }
 
 variable "clickhouse_host" {
-  description = "ClickHouse Cloud hostname, substituted for REPLACE_CLICKHOUSE_HOST. Created by hand in the ClickHouse Cloud console; see the README's prerequisites."
+  description = "ClickHouse Cloud hostname, substituted for __CLICKHOUSE_HOST__. Created by hand in the ClickHouse Cloud console; see the README's prerequisites."
   type        = string
 }
 

--- a/deploy/aws/terraform/modules/data/outputs.tf
+++ b/deploy/aws/terraform/modules/data/outputs.tf
@@ -7,7 +7,7 @@ output "kms_key_arn" {
 }
 
 output "kms_key_id" {
-  description = "Substituted for REPLACE_KMS_KEY_ID in the two IAM policy documents."
+  description = "Substituted for __KMS_KEY_ID__ in the two IAM policy documents."
   value       = local.kms_key_id
 }
 

--- a/deploy/aws/terraform/modules/data/variables.tf
+++ b/deploy/aws/terraform/modules/data/variables.tf
@@ -31,7 +31,7 @@ variable "create_kms_key" {
 }
 
 variable "replay_bucket_name" {
-  description = "Globally unique bucket for replay bodies. Substituted for REPLACE_REPLAY_BUCKET in task-role-policy.json and in gateway.taskdef.json."
+  description = "Globally unique bucket for replay bodies. Substituted for __REPLAY_BUCKET__ in task-role-policy.json and in gateway.taskdef.json."
   type        = string
 }
 

--- a/deploy/aws/terraform/modules/data/variables.tf
+++ b/deploy/aws/terraform/modules/data/variables.tf
@@ -74,14 +74,17 @@ variable "secret_recovery_window_days" {
   default     = 30
 }
 
+# No defaults here either, for the reason the root module's variables.tf spells out: both are facts
+# about the target region that this repository cannot know, and a wrong one fails at apply after the
+# VPC exists. A default here would quietly reintroduce the guess the root module removed.
 variable "db_engine_version" {
-  type    = string
-  default = "16.4"
+  description = "RDS for PostgreSQL engine version. Discover with: aws rds describe-db-engine-versions --engine postgres --region <region> --query 'DBEngineVersions[].EngineVersion' --output text"
+  type        = string
 }
 
 variable "db_instance_class" {
-  type    = string
-  default = "db.t4g.medium"
+  description = "RDS instance class. Confirm it is orderable for db_engine_version in this region with: aws rds describe-orderable-db-instance-options --engine postgres --engine-version <version> --region <region> --query 'OrderableDBInstanceOptions[].DBInstanceClass' --output text"
+  type        = string
 }
 
 variable "db_allocated_storage" {

--- a/deploy/aws/terraform/modules/iam/main.tf
+++ b/deploy/aws/terraform/modules/iam/main.tf
@@ -26,29 +26,26 @@ locals {
   dropped_task_sids      = distinct(concat(local.auto_dropped_sids, var.drop_task_policy_sids))
   dropped_execution_sids = local.auto_dropped_sids
 
-  # `replace` on a file, not `templatefile`: the JSON carries bare placeholder words rather than
-  # ${...} interpolation, and rewriting them into Terraform syntax would break the `sed` recipes in
-  # deploy/aws/README.md that operate on the same files.
+  # `replace` on a file, not `templatefile`: the JSON carries `__DELIMITED__` placeholder words
+  # rather than ${...} interpolation, and rewriting them into Terraform syntax would break the `sed`
+  # recipes in deploy/aws/README.md that operate on the same files.
   #
-  # Order matters, and REGION is matched by shape rather than as a bare word. The runbook's
-  # `sed -e "s/REGION/$REGION/g"` is a blanket replace, which is harmless in these three documents
-  # and is NOT harmless in the task definitions (see modules/compute/taskdefs.tf, where it would
-  # rewrite the AWS_REGION environment variable's name). Doing it the same careful way in both
-  # places means nobody has to remember which files the shortcut is safe in.
+  # The delimiters are the point (CTO-360). A bare `REGION` token is a substring of the environment
+  # variable names `AWS_REGION` and `TALLY_REPLAY_S3_REGION`, so a blanket replace corrupted those
+  # names in the task definitions. `__REGION__` cannot occur inside an identifier, so one blanket
+  # replace per token is correct in every file and nobody has to remember which files the shortcut
+  # is safe in.
   render = {
     for name in ["task-role-policy", "execution-role-policy", "ecs-tasks-trust-policy"] :
     name => replace(
       replace(
         replace(
-          replace(
-            replace(file("${local.iam_dir}/${name}.json"), "REPLACE_REPLAY_BUCKET", var.replay_bucket_name),
-            "REPLACE_KMS_KEY_ID", var.kms_key_id == null ? "" : var.kms_key_id
-          ),
-          "ACCOUNT", data.aws_caller_identity.current.account_id
+          replace(file("${local.iam_dir}/${name}.json"), "__REPLAY_BUCKET__", var.replay_bucket_name),
+          "__KMS_KEY_ID__", var.kms_key_id == null ? "" : var.kms_key_id
         ),
-        ":REGION:", ":${var.aws_region}:"
+        "__ACCOUNT__", data.aws_caller_identity.current.account_id
       ),
-      ".REGION.", ".${var.aws_region}."
+      "__REGION__", var.aws_region
     )
   }
 

--- a/deploy/aws/terraform/modules/iam/variables.tf
+++ b/deploy/aws/terraform/modules/iam/variables.tf
@@ -14,7 +14,7 @@ variable "ecs_dir" {
 }
 
 variable "replay_bucket_name" {
-  description = "Substituted for REPLACE_REPLAY_BUCKET in task-role-policy.json, which is the placeholder PR #352 left in place of the old hard-coded my-org-ai-tally-replay."
+  description = "Substituted for __REPLAY_BUCKET__ in task-role-policy.json, which is the placeholder PR #352 left in place of the old hard-coded my-org-ai-tally-replay."
   type        = string
 }
 

--- a/deploy/aws/terraform/terraform.tfvars.example
+++ b/deploy/aws/terraform/terraform.tfvars.example
@@ -4,8 +4,25 @@
 # name, an id or a hostname. Secret VALUES are written to Secrets Manager out of band, never here,
 # because a .tfvars file becomes state and state is readable by anyone who can read the bucket.
 
-aws_region         = "us-east-1"
+aws_region = "us-east-1"
+
+# AZ names are account-scoped. List yours:
+#   aws ec2 describe-availability-zones --region "$REGION" \
+#     --query 'AvailabilityZones[?State==`available`].ZoneName' --output text
 availability_zones = ["us-east-1a", "us-east-1b"]
+
+# REQUIRED AND UNGUESSABLE (CTO-360). These two are facts about your region, they have no defaults
+# on purpose, and a wrong value fails at APPLY, after the VPC and the NAT gateway already exist.
+# The values below are placeholders, not knowns. Look yours up first:
+#
+#   aws rds describe-db-engine-versions --engine postgres --region "$REGION" \
+#     --query 'DBEngineVersions[].EngineVersion' --output text | tr '\t' '\n' | sort -V
+#
+#   aws rds describe-orderable-db-instance-options --engine postgres \
+#     --engine-version "$DB_ENGINE_VERSION" --region "$REGION" \
+#     --query 'OrderableDBInstanceOptions[].DBInstanceClass' --output text | tr '\t' '\n' | sort -u
+db_engine_version = "16.8"
+db_instance_class = "db.t4g.medium"
 
 # Globally unique. Convention: <account-id>-ai-tally-replay.
 replay_bucket_name = "123456789012-ai-tally-replay"

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -29,8 +29,27 @@ variable "vpc_cidr" {
 }
 
 variable "availability_zones" {
-  description = "Two AZs in aws_region. Named explicitly rather than read from a data source so that a plan is stable across account-specific AZ shuffling."
+  description = <<-EOT
+    Two AZs in aws_region. Named explicitly rather than read from a data source so that a plan is
+    stable across account-specific AZ shuffling. AZ names are account-scoped, and not every AZ in a
+    region offers every service, so list the ones your account actually has:
+
+      aws ec2 describe-availability-zones --region "$REGION" \
+        --query 'AvailabilityZones[?State==`available`].ZoneName' --output text
+  EOT
   type        = list(string)
+
+  validation {
+    # An AZ from another region is a mistake nobody catches by reading: the subnet create fails
+    # partway through the network module, leaving a VPC and a half-built subnet set behind.
+    condition     = alltrue([for az in var.availability_zones : startswith(az, var.aws_region)])
+    error_message = "Every availability_zones entry must be in aws_region, e.g. [\"us-east-1a\", \"us-east-1b\"] for aws_region = \"us-east-1\"."
+  }
+
+  validation {
+    condition     = length(var.availability_zones) >= 2 && length(distinct(var.availability_zones)) == length(var.availability_zones)
+    error_message = "availability_zones needs at least two distinct AZs: the RDS subnet group and the ALB both require two."
+  }
 }
 
 variable "enable_nat_gateway" {
@@ -90,15 +109,58 @@ variable "create_provider_key_secrets" {
   default = true
 }
 
+# REQUIRED, AND DELIBERATELY WITHOUT A DEFAULT (CTO-360).
+#
+# Both of these are facts about your region and your account, not preferences, and neither can be
+# known from this repository. This module had `db_engine_version = "16.4"` and
+# `db_instance_class = "db.t4g.medium"` as defaults; nobody had ever run a plan against a real
+# account, so both were guesses. A Postgres minor version that RDS has deprecated, or an instance
+# class that region does not offer for that engine version, fails at APPLY time, after the VPC, the
+# NAT gateway and the KMS key already exist. That is the worst moment to find out, and the recovery
+# is a half-built stack and a `terraform destroy`.
+#
+# Requiring them moves the failure to the front: Terraform refuses to plan at all until you have
+# looked the values up, and the lookup is one command each. The validation blocks catch a
+# malformed value in the same breath. Neither can prove the value exists in your region, and this
+# comment does not pretend otherwise.
+
 variable "db_engine_version" {
-  type    = string
-  default = "16.4"
+  description = <<-EOT
+    RDS for PostgreSQL engine version, e.g. "16.8". No default: a version that does not exist in
+    aws_region fails at apply, after the VPC exists. Discover the valid values for your region:
+
+      aws rds describe-db-engine-versions --engine postgres --region "$REGION" \
+        --query 'DBEngineVersions[].EngineVersion' --output text | tr '\t' '\n' | sort -V
+
+    Add --default-only for the one AWS would pick, or filter with
+    --engine-version 16 to list only the 16.x line.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]+(\\.[0-9]+)?$", var.db_engine_version))
+    error_message = "db_engine_version must be a Postgres version like \"16\" or \"16.8\". Run: aws rds describe-db-engine-versions --engine postgres --region <region> --query 'DBEngineVersions[].EngineVersion' --output text"
+  }
 }
 
 variable "db_instance_class" {
-  description = "db.t4g.* is the Graviton family, which matches the ARM64 posture of the task definitions. The runbook suggests db.t3.medium; t4g.medium is the same size on cheaper hardware."
+  description = <<-EOT
+    RDS instance class, e.g. "db.t4g.medium". No default: an instance class this region does not
+    offer for this engine version fails at apply, in the same place db_engine_version does. The
+    db.t4g.* Graviton family matches the ARM64 posture of the task definitions and is the same size
+    as the runbook's db.t3.medium on cheaper hardware, so it is the one to try first. Confirm the
+    combination is orderable before you apply:
+
+      aws rds describe-orderable-db-instance-options --engine postgres \
+        --engine-version "$DB_ENGINE_VERSION" --region "$REGION" \
+        --query 'OrderableDBInstanceOptions[].DBInstanceClass' --output text | tr '\t' '\n' | sort -u
+  EOT
   type        = string
-  default     = "db.t4g.medium"
+
+  validation {
+    condition     = can(regex("^db\\.[a-z0-9]+\\.[a-z0-9]+$", var.db_instance_class))
+    error_message = "db_instance_class must look like db.t4g.medium. Run: aws rds describe-orderable-db-instance-options --engine postgres --engine-version <version> --region <region> --query 'OrderableDBInstanceOptions[].DBInstanceClass' --output text"
+  }
 }
 
 variable "db_allocated_storage" {

--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -110,6 +110,22 @@ encrypted env store and mark it **Sensitive** — Vercel encrypts it at rest and
 after save. **Never commit a secret**; `web/vercel.json` contains config only, no values. A changed
 `NEXT_PUBLIC_*` value requires a **redeploy** to take effect (it is baked into the client bundle).
 
+## 2b. Run the preflight before you deploy
+
+```bash
+cd infra && make prod-preflight ENV=../prod.env      # or: scripts/prod-preflight.sh --env prod.env
+```
+
+Put BOTH sides in the file: the Vercel settings from §2 and the gateway's own settings. They use
+different variable names (`GATEWAY_SERVICE_TOKEN` on the web tier, `TALLY_GATEWAY_SERVICE_TOKEN` on
+the gateway), and one merged environment is what lets the check compare them, which is the point:
+a token that differs between the two 401s every control-plane call and reaches a signed-in user as
+a broken dashboard with nothing naming the cause.
+
+It needs no AWS credentials and never prints a secret value; secrets are compared and reported by
+SHA-256 prefix and length. It exits non-zero and says what to fix. Read §4 below before dismissing
+the ClickHouse URL check: an unreachable ClickHouse does not error, it paints mock data.
+
 ## 3. Deploy
 
 - **Production:** push to `main` (or click **Deploy**). Vercel runs `npm ci` → `next build` in `web/`
@@ -159,6 +175,7 @@ leave them unset to preview against mock data). Never point Preview at productio
 
 ## Quick checklist
 
+- [ ] `make prod-preflight` is green (§2b).
 - [ ] Project imported, **Root Directory = `web/`**.
 - [ ] Node.js Version = **22.x** (Project Settings).
 - [ ] Env vars set for Production + Preview; ClickHouse password marked **Sensitive**.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -68,7 +68,8 @@ pg-migrate: ## Apply db/postgres migrations to a RUNNING stack (initdb only fire
 CH_DDL := ../db/clickhouse/otel_spans.sql ../db/clickhouse/rollups.sql \
           ../db/clickhouse/account_rollups.sql \
           ../db/clickhouse/last_touch_index.sql ../db/clickhouse/attribution.sql \
-          ../db/clickhouse/replay_samples.sql
+          ../db/clickhouse/replay_samples.sql \
+          ../db/clickhouse/eval_runs.sql
 
 ch-migrate: ## Apply db/clickhouse DDL to a RUNNING stack (initdb only fires on a fresh volume)
 	@# The /docker-entrypoint-initdb.d mounts in docker-compose.yml run ONLY on a first boot

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,7 +2,7 @@
 COMPOSE := docker compose
 GATEWAY := ai-tally-gateway
 
-.PHONY: help up down nuke logs ps seed demo pg-migrate ch-migrate ch-migrate-otel-engine ch-apply-retention ch-rollup-check ch-rollup-rebuild ch-priced-zero-check ch-repair-priced-zero aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test ch psql
+.PHONY: help up down nuke logs ps seed demo pg-migrate ch-migrate ch-migrate-otel-engine ch-apply-retention ch-rollup-check ch-rollup-rebuild ch-priced-zero-check ch-repair-priced-zero aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test prod-preflight ch psql
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
@@ -279,6 +279,17 @@ chatbot-demo-stop: ## Stop the background chatbot dev server started by chatbot-
 
 test: ## Run gateway unit tests (pure mapping logic, no infra)
 	cd gateway && uv run --extra dev pytest -q
+
+prod-preflight: ## Validate a PRODUCTION deployment's config before deploying (CTO-360). ENV=file.env
+	@# Deliberately touches nothing in this Makefile's world: no compose, no containers, no local
+	@# stack, no AWS credentials. It reads the environment the operator has just filled in for
+	@# Vercel and for the gateway, and it never prints a secret value. The target lives here only
+	@# because this is the repository's one Makefile; the script runs standalone from anywhere.
+	@#
+	@# Pass ENV=path/to/file (repeatable via ENV="a.env b.env") to read settings from dotenv files
+	@# instead of, or on top of, the exported environment. Add ARGS=--no-probe to skip the outbound
+	@# reachability check on a network that blocks egress.
+	../scripts/prod-preflight.sh $(foreach f,$(ENV),--env $(f)) $(ARGS)
 
 ch: ## Open a ClickHouse SQL shell
 	$(COMPOSE) exec clickhouse clickhouse-client -u tally --password tally -d default

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -61,6 +61,12 @@ services:
       # re-hydrates its in-memory corpus from this table on boot, so replay-backed Compare/eval
       # survives a restart. No dependency on the tables above, so any tail number is fine.
       - ../db/clickhouse/replay_samples.sql:/docker-entrypoint-initdb.d/06_replay_samples.sql:ro
+      # CTO-114: pairwise LLM-judge verdicts, written by the eval executor and read by /compare.
+      # It was never mounted and never in the Makefile's CH_DDL, so the table did not exist on a
+      # fresh stack at all; `make ch-apply-retention` failed on its last statement for that reason.
+      # Same class of miss as the four unmounted Postgres migrations fixed in #323. No dependency
+      # on the tables above, so any tail number is fine.
+      - ../db/clickhouse/eval_runs.sql:/docker-entrypoint-initdb.d/07_eval_runs.sql:ro
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
       interval: 5s

--- a/infra/gateway/tests/test_deploy_placeholders.py
+++ b/infra/gateway/tests/test_deploy_placeholders.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The deploy/aws/ placeholder tokens are delimited, and a blanket substitution is safe (CTO-360).
+
+The bug this suite exists to hold shut. ``deploy/aws/README.md`` tells an operator to render the
+task definitions with a blanket ``sed``. The placeholders used to be the bare words ``ACCOUNT`` and
+``REGION``, and ``gateway.taskdef.json`` carries the environment variable NAMES ``AWS_REGION`` and
+``TALLY_REPLAY_S3_REGION``, so ``s/REGION/us-east-1/g`` rewrote those names into ``AWS_us-east-1``
+and ``TALLY_REPLAY_S3_us-east-1``. The output was still valid JSON, ``register-task-definition``
+accepted it, the task started, and both settings were simply absent: the AWS default credential
+chain ran with no region and the S3 replay store with no region, with nothing in the logs naming
+the cause.
+
+The fix is the delimiters, not a cleverer ``sed``, so the test asserts the property rather than the
+recipe: every placeholder is ``__DELIMITED__``, and substituting every one of them with a blanket
+replace leaves a document whose variable names are untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+ECS_DIR = REPO_ROOT / "deploy" / "aws" / "ecs"
+
+# What an operator substitutes. Values are deliberately the shapes that used to collide: a region
+# and an account id that appear as substrings of nothing, and a bucket name built from the account.
+SUBSTITUTIONS = {
+    "__ACCOUNT__": "123456789012",
+    "__REGION__": "us-east-1",
+    "__REPLAY_BUCKET__": "123456789012-ai-tally-replay",
+    "__KMS_KEY_ID__": "abcd1234-1111-2222-3333-444455556666",
+    "__CLICKHOUSE_HOST__": "abc123.us-east-1.aws.clickhouse.cloud",
+    "__CLICKHOUSE_URL__": "https://abc123.us-east-1.aws.clickhouse.cloud:8443",
+    "__GATEWAY_URL__": "https://ingest.example.com",
+}
+
+# Anything that looks like a placeholder: a run of capitals/underscores standing alone as a word.
+# The point is to catch a NEW bare-word token being added, not to enumerate today's tokens.
+BARE_TOKEN = re.compile(r"(?<![A-Za-z0-9_])(ACCOUNT|REGION|REPLACE_[A-Z0-9_]+)(?![A-Za-z0-9_])")
+
+DOCUMENTS = sorted(ECS_DIR.rglob("*.json"))
+
+
+def test_documents_are_present() -> None:
+    # A path typo would otherwise make every parametrised test below vacuously pass.
+    assert DOCUMENTS, f"no JSON documents under {ECS_DIR}"
+
+
+@pytest.mark.parametrize("path", DOCUMENTS, ids=lambda p: p.name)
+def test_no_bare_word_placeholders(path: pathlib.Path) -> None:
+    text = path.read_text()
+    found = sorted(set(BARE_TOKEN.findall(text)))
+    assert not found, (
+        f"{path.relative_to(REPO_ROOT)} carries the bare-word placeholder(s) {found}. "
+        "Use the delimited form (__ACCOUNT__, __REGION__, ...): a bare word is a substring of real "
+        "identifiers such as AWS_REGION, and the README's blanket sed rewrites those names."
+    )
+
+
+@pytest.mark.parametrize("path", DOCUMENTS, ids=lambda p: p.name)
+def test_blanket_substitution_renders_valid_json_and_leaves_nothing_behind(
+    path: pathlib.Path,
+) -> None:
+    text = path.read_text()
+    for token, value in SUBSTITUTIONS.items():
+        text = text.replace(token, value)
+
+    rendered = json.loads(text)
+    leftover = re.findall(r"__[A-Z0-9_]+__", json.dumps(rendered))
+    assert not leftover, (
+        f"{path.relative_to(REPO_ROOT)} has placeholder(s) {sorted(set(leftover))} that no "
+        "documented substitution fills in. Add it to the README recipe and to SUBSTITUTIONS here."
+    )
+
+
+def test_gateway_region_variables_survive_substitution() -> None:
+    """The specific regression: both region settings keep their names and gain their values."""
+    text = (ECS_DIR / "gateway.taskdef.json").read_text()
+    for token, value in SUBSTITUTIONS.items():
+        text = text.replace(token, value)
+
+    container = json.loads(text)["containerDefinitions"][0]
+    environment = {entry["name"]: entry["value"] for entry in container["environment"]}
+
+    for name in ("AWS_REGION", "TALLY_REPLAY_S3_REGION"):
+        assert name in environment, f"{name} was renamed by the substitution"
+        assert environment[name] == SUBSTITUTIONS["__REGION__"]
+
+    corrupted = [name for name in environment if SUBSTITUTIONS["__REGION__"] in name]
+    assert not corrupted, f"substitution rewrote variable NAMES: {corrupted}"

--- a/scripts/prod-preflight.sh
+++ b/scripts/prod-preflight.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Production deployment preflight (CTO-360). Run it BEFORE deploying anything.
+#
+# WHY THIS IS A SHELL SCRIPT AND NOT A PYTHON MODULE OR A TEST. The person running it has just
+# filled in a Vercel project and an ECS task definition and has not necessarily got a repo checkout,
+# a uv venv, node_modules, docker, or AWS credentials. The only things it may assume are bash,
+# coreutils and (for the optional reachability probe) curl. It also has to see BOTH sides of the
+# deployment at once, because the single most confusing failure here is a service token that differs
+# between the web tier and the gateway, and no check that runs inside one of them can catch that.
+#
+# WHAT IT DELIBERATELY DOES NOT DO:
+#   * It needs no AWS credentials and makes no AWS API call.
+#   * It never prints a secret. Secrets are compared and reported by SHA-256 prefix and length.
+#   * It does not connect to Postgres or authenticate to anything. The optional probe is an
+#     unauthenticated GET whose only question is "does this host answer at all".
+#
+# Every check names the SYMPTOM it prevents, because these fail in confusing and unrelated-looking
+# ways: a silently-open control plane, a dashboard that 401s everywhere, a sign-in that never
+# resolves a tenant, and a dashboard that paints mock numbers at a real customer.
+
+set -uo pipefail
+
+FAILURES=0
+WARNINGS=0
+PROBE=1
+ENV_FILES=()
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prod-preflight.sh [--env FILE]... [--no-probe]
+
+Validates the deployment configuration for a production ai-tally before anything is deployed.
+Reads settings from the current environment, plus any --env dotenv files (repeatable, later files
+win). Pass BOTH sides: the web tier's Vercel settings and the gateway's settings. They use
+different variable names, so one merged environment is unambiguous.
+
+  --env FILE    A dotenv-format file (KEY=value per line). Values are read, never executed.
+  --no-probe    Skip the outbound HTTPS reachability probe (offline checks still run).
+  -h, --help    This text.
+
+Exits non-zero if any check fails. Never prints a secret value.
+
+Variables it looks at
+  gateway:  TALLY_ENV  TALLY_REQUIRE_API_KEY  TALLY_GATEWAY_SERVICE_TOKEN
+            TALLY_HMAC_KEY_PROVIDER  TALLY_ALLOW_INSECURE_NO_AUTH
+  web:      TALLY_GATEWAY_URL  GATEWAY_SERVICE_TOKEN  TALLY_CLICKHOUSE_URL  TALLY_DEV_TENANT
+            CLERK_WEBHOOK_SIGNING_SECRET  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY  CLERK_SECRET_KEY
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) [ $# -ge 2 ] || { echo "--env needs a file" >&2; exit 2; }; ENV_FILES+=("$2"); shift 2 ;;
+    --env=*) ENV_FILES+=("${1#--env=}"); shift ;;
+    --no-probe) PROBE=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# Dotenv loading, by parsing rather than by sourcing. Sourcing an operator's env file executes
+# whatever is in it, and these files hold production credentials pasted from a console; a stray
+# backtick should not run a command.
+load_env_file() {
+  local file="$1" line key value
+  if [ ! -r "$file" ]; then
+    echo "cannot read env file: $file" >&2
+    exit 2
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"          # ltrim
+    case "$line" in ''|'#'*) continue ;; esac
+    line="${line#export }"
+    case "$line" in *=*) : ;; *) continue ;; esac
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "$key" in [A-Za-z_]*) : ;; *) continue ;; esac
+    value="${value%"${value##*[![:space:]]}"}"       # rtrim
+    # Strip one layer of matching quotes, which is how a console-pasted value usually arrives.
+    case "$value" in
+      \"*\") value="${value%\"}"; value="${value#\"}" ;;
+      \'*\') value="${value%\'}"; value="${value#\'}" ;;
+    esac
+    export "$key=$value"
+  done < "$file"
+}
+
+for f in ${ENV_FILES+"${ENV_FILES[@]}"}; do
+  load_env_file "$f"
+  echo "loaded $f"
+done
+
+# --- reporting -----------------------------------------------------------------------------------
+
+pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  printf '  \033[31mFAIL\033[0m  %s\n' "$1"
+  printf '        symptom if shipped: %s\n' "$2"
+  printf '        fix:                %s\n' "$3"
+}
+
+warn() {
+  WARNINGS=$((WARNINGS + 1))
+  printf '  \033[33mWARN\033[0m  %s\n' "$1"
+  printf '        symptom if shipped: %s\n' "$2"
+  printf '        fix:                %s\n' "$3"
+}
+
+# Secret fingerprint: enough to compare two values and to tell them apart in a transcript, and not
+# enough to reconstruct either. Never the value itself.
+fingerprint() {
+  local value="$1" digest=""
+  if command -v shasum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$value" | shasum -a 256 | cut -d' ' -f1)
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$value" | sha256sum | cut -d' ' -f1)
+  elif command -v openssl >/dev/null 2>&1; then
+    digest=$(printf '%s' "$value" | openssl dgst -sha256 | awk '{print $NF}')
+  else
+    printf 'len=%d sha256=unavailable' "${#value}"
+    return
+  fi
+  printf 'len=%d sha256=%s...' "${#value}" "${digest:0:8}"
+}
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+echo
+echo "ai-tally production preflight"
+echo "no AWS credentials are used, and no secret value is printed"
+echo
+
+# --- 1. the control plane is actually gated ------------------------------------------------------
+
+echo "1. control-plane authentication"
+require_api_key=$(lower "${TALLY_REQUIRE_API_KEY:-}")
+case "$require_api_key" in
+  true|1|yes|on)
+    pass "TALLY_REQUIRE_API_KEY is ${TALLY_REQUIRE_API_KEY}"
+    ;;
+  "")
+    fail "TALLY_REQUIRE_API_KEY is unset (the gateway default is false)" \
+         "the control-plane service-token gate is not enforced at all, so anyone who can reach the gateway can POST /v1/tenant/provision and create a real tenant, unauthenticated" \
+         "set TALLY_REQUIRE_API_KEY=true on the gateway"
+    ;;
+  *)
+    fail "TALLY_REQUIRE_API_KEY is ${TALLY_REQUIRE_API_KEY}" \
+         "the control-plane service-token gate is not enforced at all, so anyone who can reach the gateway can POST /v1/tenant/provision and create a real tenant, unauthenticated" \
+         "set TALLY_REQUIRE_API_KEY=true on the gateway"
+    ;;
+esac
+
+# TALLY_ENV is the backstop that makes the setting above LOUD instead of silent: with it set the
+# gateway refuses to boot when authentication is off (app.py assert_auth_config). Without it the
+# dangerous combination just serves.
+if [ "$(lower "${TALLY_ENV:-}")" = "production" ]; then
+  pass "TALLY_ENV=production (the gateway refuses to boot with authentication off)"
+else
+  fail "TALLY_ENV is '${TALLY_ENV:-<unset>}', not production" \
+       "the gateway's boot guard is inactive, so a later edit turning TALLY_REQUIRE_API_KEY off starts a wide-open control plane silently instead of refusing to start" \
+       "set TALLY_ENV=production on the gateway task"
+fi
+
+if [ -n "${TALLY_ALLOW_INSECURE_NO_AUTH:-}" ]; then
+  fail "TALLY_ALLOW_INSECURE_NO_AUTH is set" \
+       "it is the explicit opt-out of both boot guards, web and gateway; with it set, a production build serves with authentication off instead of refusing to start" \
+       "unset TALLY_ALLOW_INSECURE_NO_AUTH everywhere except the synthetic-data demo kit"
+else
+  pass "TALLY_ALLOW_INSECURE_NO_AUTH is unset"
+fi
+
+# --- 2. the two halves of the service token agree ------------------------------------------------
+
+echo
+echo "2. control-plane service token (web <-> gateway)"
+web_token="${GATEWAY_SERVICE_TOKEN:-}"
+gw_token="${TALLY_GATEWAY_SERVICE_TOKEN:-}"
+
+if [ -z "$web_token" ] && [ -z "$gw_token" ]; then
+  fail "neither GATEWAY_SERVICE_TOKEN (web) nor TALLY_GATEWAY_SERVICE_TOKEN (gateway) is set" \
+       "with TALLY_REQUIRE_API_KEY=true the gateway refuses to boot; with it false the control plane is unauthenticated" \
+       "generate one value with 'openssl rand -hex 32' and set it in BOTH places"
+elif [ -z "$web_token" ]; then
+  fail "GATEWAY_SERVICE_TOKEN (web, Vercel) is empty; the gateway has one ($(fingerprint "$gw_token"))" \
+       "the dashboard sends no Authorization header, so every control-plane call 401s and a signed-in user sees a broken dashboard with nothing naming the cause" \
+       "set GATEWAY_SERVICE_TOKEN in the Vercel project to the gateway's TALLY_GATEWAY_SERVICE_TOKEN"
+elif [ -z "$gw_token" ]; then
+  fail "TALLY_GATEWAY_SERVICE_TOKEN (gateway) is empty; the web tier has one ($(fingerprint "$web_token"))" \
+       "the gateway refuses to boot when TALLY_REQUIRE_API_KEY is true and no token is configured" \
+       "set TALLY_GATEWAY_SERVICE_TOKEN on the gateway to the same value the Vercel project holds"
+elif [ "$web_token" = "$gw_token" ]; then
+  pass "GATEWAY_SERVICE_TOKEN == TALLY_GATEWAY_SERVICE_TOKEN ($(fingerprint "$gw_token"))"
+else
+  fail "the two service tokens differ: web $(fingerprint "$web_token"), gateway $(fingerprint "$gw_token")" \
+       "every control-plane call 401s, which surfaces to a signed-in user as a broken dashboard with no obvious cause" \
+       "copy one value into both. A trailing newline or a quote pasted from a console counts as a difference"
+fi
+
+# --- 3. no dev escape hatch ----------------------------------------------------------------------
+
+echo
+echo "3. dev escape hatch"
+if [ -n "${TALLY_DEV_TENANT:-}" ]; then
+  fail "TALLY_DEV_TENANT is set" \
+       "it pins one tenant and short-circuits Clerk, so the dashboard serves that tenant's data to whoever loads it. A production build already refuses to boot with it set unless TALLY_ALLOW_INSECURE_NO_AUTH is also set (PR #345); this catches it before the deploy rather than during it" \
+       "remove TALLY_DEV_TENANT from the Vercel project. It is for keyless local dev and CI only"
+else
+  pass "TALLY_DEV_TENANT is unset (Clerk resolves the tenant)"
+fi
+
+# --- 4. HMAC key material is held by reference ---------------------------------------------------
+
+echo
+echo "4. per-tenant HMAC key provider"
+hmac_provider="$(lower "${TALLY_HMAC_KEY_PROVIDER:-}")"
+case "$hmac_provider" in
+  "")
+    fail "TALLY_HMAC_KEY_PROVIDER is unset (the gateway default is 'local')" \
+         "per-tenant HMAC key material is then derived from a root secret in configuration rather than held by reference, against the identifiers-by-hash / credentials-by-reference invariant" \
+         "set TALLY_HMAC_KEY_PROVIDER=kms on AWS (Secrets Manager), or set it to 'local' explicitly if this is a single-tenant instance and you mean it"
+    ;;
+  local)
+    warn "TALLY_HMAC_KEY_PROVIDER=local, set explicitly" \
+         "the root secret in configuration IS the key material for every tenant, so a config leak is a leak of every tenant's hashing key. Acceptable only on a single-tenant instance" \
+         "use TALLY_HMAC_KEY_PROVIDER=kms on any instance that will hold more than one tenant"
+    ;;
+  *)
+    pass "TALLY_HMAC_KEY_PROVIDER=${TALLY_HMAC_KEY_PROVIDER}"
+    ;;
+esac
+
+# --- 5. Clerk can actually provision a tenant ----------------------------------------------------
+
+echo
+echo "5. Clerk"
+if [ -z "${CLERK_WEBHOOK_SIGNING_SECRET:-}" ]; then
+  fail "CLERK_WEBHOOK_SIGNING_SECRET is unset" \
+       "the svix signature on organization.created cannot be verified, so the webhook is rejected and no tenant is ever provisioned. It presents as sign-in succeeding and then failing to resolve a tenant, which looks like a dashboard bug rather than a missing secret" \
+       "copy the signing secret from the Clerk webhook endpoint (it starts whsec_) into the Vercel project"
+elif [ "${CLERK_WEBHOOK_SIGNING_SECRET:0:6}" != "whsec_" ]; then
+  warn "CLERK_WEBHOOK_SIGNING_SECRET does not start with whsec_ ($(fingerprint "${CLERK_WEBHOOK_SIGNING_SECRET}"))" \
+       "if this is the API key rather than the endpoint's signing secret, every webhook fails signature verification and no tenant is provisioned" \
+       "take the value from the webhook ENDPOINT in the Clerk dashboard, not from the API keys page"
+else
+  pass "CLERK_WEBHOOK_SIGNING_SECRET is set ($(fingerprint "${CLERK_WEBHOOK_SIGNING_SECRET}"))"
+fi
+
+for var in NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY CLERK_SECRET_KEY; do
+  if [ -z "${!var:-}" ]; then
+    fail "$var is unset" \
+         "nobody can sign in at all, and the publishable key in particular is inlined into the client bundle at BUILD time, so setting it later needs a rebuild rather than a restart" \
+         "set $var in the Vercel project before the build"
+  else
+    pass "$var is set ($(fingerprint "${!var}"))"
+  fi
+done
+
+# --- 6. URLs are public HTTPS --------------------------------------------------------------------
+
+echo
+echo "6. URLs reachable from Vercel"
+
+check_url() {
+  local var="$1" url="${2:-}" symptom="$3"
+  if [ -z "$url" ]; then
+    fail "$var is unset" "$symptom" "set $var in the Vercel project"
+    return
+  fi
+  case "$url" in
+    https://*) : ;;
+    *)
+      fail "$var is not https ($url)" "$symptom" \
+           "Vercel functions egress to the public internet; use an https:// URL"
+      return
+      ;;
+  esac
+  local host="${url#https://}"; host="${host%%/*}"; host="${host%%:*}"
+  case "$host" in
+    localhost|127.*|0.0.0.0|10.*|192.168.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|*.internal|*.local)
+      fail "$var points at a private or loopback host ($host)" "$symptom" \
+           "Vercel functions run outside your VPC, so the host must resolve and be reachable publicly"
+      return
+      ;;
+  esac
+  pass "$var is public https ($host)"
+}
+
+check_url TALLY_GATEWAY_URL "${TALLY_GATEWAY_URL:-}" \
+  "every control-plane call from the dashboard fails, so tenant resolution, settings and connector writes are all dead"
+
+# This one is silent by design and that is exactly why it is here. tryLive() in web/lib/clickhouse.ts
+# catches a ClickHouse query failure and returns null so the caller falls back to MOCK data. An
+# unreachable ClickHouse therefore does not render an error; it renders somebody else's demo numbers
+# in front of a real customer, which is what the honest-under-uncertainty invariant exists to forbid.
+check_url TALLY_CLICKHOUSE_URL "${TALLY_CLICKHOUSE_URL:-}" \
+  "the dashboard does NOT error. web/lib/clickhouse.ts tryLive() swallows the failure and falls back to MOCK data, so a real customer is shown fabricated numbers with no indication they are fake"
+
+if [ "$PROBE" = "1" ] && command -v curl >/dev/null 2>&1; then
+  probe() {
+    local label="$1" url="$2" path="$3" symptom="$4"
+    [ -n "$url" ] || return 0
+    case "$url" in https://*) : ;; *) return 0 ;; esac
+    local target="${url%/}$path" code
+    # No credentials are sent. Any HTTP status means the host answered, which is the whole question;
+    # only a transport failure (DNS, TLS, connect, timeout) is a finding.
+    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$target" 2>/dev/null)
+    if [ -z "$code" ] || [ "$code" = "000" ]; then
+      fail "$label did not answer at $target" "$symptom" \
+           "check DNS, the certificate, and that the listener is public. Re-run with --no-probe if you are on a network that blocks egress"
+    else
+      pass "$label answered $target with HTTP $code"
+    fi
+  }
+  probe "gateway" "${TALLY_GATEWAY_URL:-}" "/healthz" \
+    "the dashboard cannot reach the gateway from Vercel, so tenant resolution fails for every signed-in user"
+  probe "ClickHouse" "${TALLY_CLICKHOUSE_URL:-}" "/ping" \
+    "the dashboard falls back to MOCK data rather than erroring, showing fabricated numbers to a real customer"
+elif [ "$PROBE" = "1" ]; then
+  warn "curl is not installed, so the reachability probe was skipped" \
+       "an unreachable ClickHouse shows mock data instead of an error, and nothing offline can detect that" \
+       "install curl and re-run, or check both URLs from outside your network by hand"
+fi
+
+# --- summary -------------------------------------------------------------------------------------
+
+echo
+echo "-------------------------------------------------------------------------------"
+echo "What this CANNOT check: whether your AWS region offers Fargate ARM64 or your RDS"
+echo "engine version and instance class (see deploy/aws/terraform/README.md), whether"
+echo "the Clerk webhook endpoint URL points at this deployment, or whether the Postgres"
+echo "schema has been migrated. A green run is a floor, not a guarantee."
+echo
+
+if [ "$FAILURES" -gt 0 ]; then
+  printf '\033[31mPREFLIGHT FAILED\033[0m: %d failure(s), %d warning(s). Fix the FAIL lines above before deploying.\n' \
+    "$FAILURES" "$WARNINGS"
+  exit 1
+fi
+
+printf '\033[32mPREFLIGHT PASSED\033[0m: 0 failures, %d warning(s).\n' "$WARNINGS"


### PR DESCRIPTION
Three things that would have wasted a production deploy day, plus one small fix. Four separate
commits, reviewable in order.

**DO NOT MERGE** while the deploy is in flight; this is here for review.

## 1. The `sed` recipe in `deploy/aws/README.md` corrupted environment variable NAMES

`deploy/aws/README.md` tells an operator to render the task definitions with a blanket
`sed -e "s/REGION/$REGION/g"`. `gateway.taskdef.json` carries the environment variable **names**
`AWS_REGION` and `TALLY_REPLAY_S3_REGION`, so that substitution rewrote the names as well as the
values:

```
"AWS_REGION"             -> "AWS_us-east-1"
"TALLY_REPLAY_S3_REGION" -> "TALLY_REPLAY_S3_us-east-1"
```

The output stayed valid JSON, `aws ecs register-task-definition` accepted it, the task started, and
both settings were simply absent. The gateway ran with no AWS region and no replay S3 region, with
nothing in the logs naming the cause.

**Fix: delimit the tokens rather than write a cleverer `sed`.** Every placeholder under
`deploy/aws/ecs/` is now `__ACCOUNT__`, `__REGION__`, `__REPLAY_BUCKET__`, `__KMS_KEY_ID__`,
`__CLICKHOUSE_HOST__`, `__CLICKHOUSE_URL__`, `__GATEWAY_URL__`. A delimited token cannot occur
inside an identifier, so a blanket replace is now correct in every file.

`ACCOUNT` was checked too. It did not collide with anything in these files, and it is delimited
anyway, because one rule beats a rule plus an exception nobody remembers. The `REPLACE_*` tokens
were already collision-proof but were folded into the same spelling so the bundle has one
convention rather than two.

**What had to move with it, to keep it consistent:**

- The twelve JSON documents under `deploy/aws/ecs/` (task defs, service defs, six IAM documents).
- Every `sed` recipe and every prose mention of a token in `deploy/aws/README.md`, plus the warning
  paragraph at the top, which described a hazard that no longer exists.
- `deploy/aws/terraform/modules/compute/taskdefs.tf` and `modules/iam/main.tf`, which had each
  worked around the bug by matching `:REGION:`, `.REGION.` and `"REGION"` separately. That
  workaround is now unnecessary and is gone, replaced by one blanket replace per token.
- Four Terraform variable descriptions that named the old tokens, and the troubleshooting entry in
  `deploy/aws/terraform/README.md` that told an operator to look for `AWS_us-east-1`.

**Verified by running it.** `scripts/` has no fixture for this, so it was run by hand and diffed
against the input. Only the intended values changed:

```
$ sed -e "s/__ACCOUNT__/123456789012/g" -e "s/__REGION__/us-east-1/g" ... gateway.taskdef.json
-        { "name": "AWS_REGION", "value": "__REGION__" },
+        { "name": "AWS_REGION", "value": "us-east-1" },
-        { "name": "TALLY_REPLAY_S3_REGION", "value": "__REGION__" }
+        { "name": "TALLY_REPLAY_S3_REGION", "value": "us-east-1" }

  all outputs parse as JSON
  AWS_REGION survives with value us-east-1
  TALLY_REPLAY_S3_REGION survives with value us-east-1
  no environment variable NAME contains the substituted region
  no placeholder left unsubstituted
```

`infra/gateway/tests/test_deploy_placeholders.py` (26 cases) holds it shut: no bare-word placeholder
survives anywhere under `deploy/aws/ecs/`, a blanket substitution of every token renders valid JSON
with nothing left over, and both region variables keep their names.

## 2. `db_engine_version = "16.4"` and the other guesses

`16.4` was a guess in a module that has never been planned against a real AWS account. A Postgres
minor version that RDS has retired fails at **apply**, on the RDS instance, after the VPC, the NAT
gateway and the KMS key already exist. That is the worst possible moment.

Real AWS availability cannot be checked here without an account, and no credentials were used and
nothing was spent. So the fix is to stop pretending to know: `db_engine_version` is now a **required
input with no default**, in the root module and in `modules/data`, so Terraform refuses to plan
until the operator has looked it up. The variable description, `terraform.tfvars.example` and the
Terraform README all carry the discovery command:

```bash
aws rds describe-db-engine-versions --engine postgres --region "$REGION" \
  --query 'DBEngineVersions[].EngineVersion' --output text | tr '\t' '\n' | sort -V
```

**Other guesses found, and what was done about each:**

| Value | Was | Now |
|---|---|---|
| `db_instance_class` | defaulted `db.t4g.medium`; class availability varies by region and engine version, and a wrong one fails at apply in the same place | required input, with `aws rds describe-orderable-db-instance-options` documented |
| `availability_zones` | already required, but nothing checked the names belonged to `aws_region`; an AZ from another region fails partway through the network module, leaving a VPC and a partial subnet set | validated against `aws_region`, and against needing two distinct entries; discovery command documented |
| Fargate ARM64 availability per region | documented in a variable description, never asserted | still unasserted. It cannot be checked offline, and the README says so rather than implying a guarantee |
| `vpc_cidr`, `alb_ingress_cidrs`, backup and maintenance windows, `db_multi_az` | defaults | left alone. These are **choices**, not facts about a region, and a default is the right shape for a choice |

The validation blocks only check the shape of what was typed. They cannot prove a value exists in a
region without an account, and the README states that rather than implying otherwise.

Exercised in a standalone harness with no AWS account: the missing-variable refusal, a malformed
engine version, a malformed instance class, an AZ from the wrong region, and a passing set. Sample:

```
Error: Invalid value for variable
    var.db_engine_version is "sixteen"
db_engine_version must be a Postgres version like "16" or "16.8". Run: aws
rds describe-db-engine-versions --engine postgres --region <region> --query
'DBEngineVersions[].EngineVersion' --output text
```

## 3. `make prod-preflight`

New: `scripts/prod-preflight.sh`, with `make prod-preflight` in `infra/Makefile` as the front door.

**Why a bash script and not a pytest case or a Python module.** The person running it has just
filled in a Vercel project and an ECS task definition. They may have no uv venv, no `node_modules`,
no docker and no AWS credentials. Bash, coreutils and optionally curl are the only assumptions. It
also has to see **both sides at once**: the single most confusing failure here is a service token
that differs between the web tier and the gateway, and no check running inside either service can
detect that.

It uses no AWS credentials and makes no AWS API call. It never prints a secret: values are compared
and reported by SHA-256 prefix and length. Dotenv files are **parsed, not sourced**, because these
files hold production credentials pasted from a console and a stray backtick should not run a
command. Exit is non-zero on any failure.

Checks, each naming the symptom it prevents:

- `TALLY_REQUIRE_API_KEY` must be true. False leaves the control-plane service-token gate
  unenforced, so anyone who can reach the gateway can `POST /v1/tenant/provision`. The gateway does
  fail closed at boot when `require_api_key` is TRUE and no token is set, so the dangerous
  combination is specifically require_api_key **false**, which fails silently. `TALLY_ENV=production`
  is the backstop that makes it loud, so that is checked too, along with
  `TALLY_ALLOW_INSECURE_NO_AUTH` being unset.
- `GATEWAY_SERVICE_TOKEN` (web) must equal `TALLY_GATEWAY_SERVICE_TOKEN` (gateway) byte for byte.
- `TALLY_DEV_TENANT` must be unset. PR #345's guard is explained, not duplicated: the point of
  catching it here is that it lands before the deploy rather than during it.
- `TALLY_HMAC_KEY_PROVIDER` must be set deliberately. Unset is a FAIL (it silently defaults to
  `local`); an explicit `local` is a WARN with the single-tenant caveat spelled out.
- The Clerk svix signing secret must be present, and a value not starting `whsec_` is flagged as
  probably the API key rather than the endpoint secret.
- Gateway and ClickHouse URLs must be public HTTPS, with an optional unauthenticated reachability
  probe (`ARGS=--no-probe` to skip). The ClickHouse one is the loud warning: `tryLive()` in
  `web/lib/clickhouse.ts` swallows a query failure and the route falls back to `web/lib/mock.ts`, so
  an unreachable ClickHouse does not error, it paints **mock numbers in front of a real customer**,
  which is what the honest-under-uncertainty invariant exists to forbid.

The epilogue says what it cannot cover, so a green run reads as a floor and not a guarantee.

### Failing run (exit 1)

```
1. control-plane authentication
  FAIL  TALLY_REQUIRE_API_KEY is false
        symptom if shipped: the control-plane service-token gate is not enforced at all, so anyone
                            who can reach the gateway can POST /v1/tenant/provision and create a
                            real tenant, unauthenticated
        fix:                set TALLY_REQUIRE_API_KEY=true on the gateway
  FAIL  TALLY_ENV is 'staging', not production
  PASS  TALLY_ALLOW_INSECURE_NO_AUTH is unset

2. control-plane service token (web <-> gateway)
  FAIL  the two service tokens differ: web len=32 sha256=83053ef1..., gateway len=32 sha256=ad784371...
        symptom if shipped: every control-plane call 401s, which surfaces to a signed-in user as a
                            broken dashboard with no obvious cause

3. dev escape hatch
  FAIL  TALLY_DEV_TENANT is set

4. per-tenant HMAC key provider
  FAIL  TALLY_HMAC_KEY_PROVIDER is unset (the gateway default is 'local')

5. Clerk
  FAIL  CLERK_WEBHOOK_SIGNING_SECRET is unset
        symptom if shipped: the svix signature on organization.created cannot be verified, so the
                            webhook is rejected and no tenant is ever provisioned. It presents as
                            sign-in succeeding and then failing to resolve a tenant
  PASS  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is set (len=23 sha256=f75b6098...)
  FAIL  CLERK_SECRET_KEY is unset

6. URLs reachable from Vercel
  FAIL  TALLY_GATEWAY_URL is not https (http://ingest.example.com)
  FAIL  TALLY_CLICKHOUSE_URL is not https (http://localhost:8123)
        symptom if shipped: the dashboard does NOT error. web/lib/clickhouse.ts tryLive() swallows
                            the failure and falls back to MOCK data, so a real customer is shown
                            fabricated numbers with no indication they are fake

PREFLIGHT FAILED: 9 failure(s), 0 warning(s). Fix the FAIL lines above before deploying.
```

(Full output including every `fix:` line is in the commit; trimmed here for width.)

### Passing run (exit 0)

```
1. control-plane authentication
  PASS  TALLY_REQUIRE_API_KEY is true
  PASS  TALLY_ENV=production (the gateway refuses to boot with authentication off)
  PASS  TALLY_ALLOW_INSECURE_NO_AUTH is unset
2. control-plane service token (web <-> gateway)
  PASS  GATEWAY_SERVICE_TOKEN == TALLY_GATEWAY_SERVICE_TOKEN (len=32 sha256=ad784371...)
3. dev escape hatch
  PASS  TALLY_DEV_TENANT is unset (Clerk resolves the tenant)
4. per-tenant HMAC key provider
  PASS  TALLY_HMAC_KEY_PROVIDER=kms
5. Clerk
  PASS  CLERK_WEBHOOK_SIGNING_SECRET is set (len=36 sha256=3b0921e7...)
  PASS  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is set (len=23 sha256=f75b6098...)
  PASS  CLERK_SECRET_KEY is set (len=27 sha256=689c4e5a...)
6. URLs reachable from Vercel
  PASS  TALLY_GATEWAY_URL is public https (example.com)
  PASS  TALLY_CLICKHOUSE_URL is public https (example.com)
  PASS  gateway answered https://example.com/healthz with HTTP 404
  PASS  ClickHouse answered https://example.com/ping with HTTP 404

PREFLIGHT PASSED: 0 failures, 0 warning(s).
```

Note the fingerprints: the two service tokens in the failing run differ by one character, and the
hash prefixes make that visible without either value appearing anywhere.

## 4. `eval_runs.sql`

Fixed. It was in neither `infra/docker-compose.yml`'s initdb mounts nor the Makefile's `CH_DDL`, so
the table did not exist on a fresh stack at all, which is why `make ch-apply-retention` failed its
last statement. Now mounted as `07_eval_runs.sql` and last in `CH_DDL`; its `CREATE TABLE` is
`IF NOT EXISTS` with the TTL inline, so replaying it is idempotent. The two comments in
`derived_table_retention.sql` that documented the gap as permanent now point at `make ch-migrate`.

`db/clickhouse/storage_tiering.sql` is also unmounted and stays that way on purpose: it is a
reference document describing the cluster-side storage policy, not executable DDL.

## Verification

| Suite | Result |
|---|---|
| gateway | 1037 passed / 8 skipped (baseline 1011/8, +26 from the new placeholder test), ruff clean |
| sdk | all passed, ruff clean |
| web | 837 passed / 69 files, typecheck clean, one pre-existing lint warning at `lib/useLivePoll.ts:94` |
| edge-proxy | build, test and `gofmt -l` all clean |
| compose | `docker compose -f infra/docker-compose.yml config -q` clean |
| terraform | `fmt -check -recursive`, `init -backend=false` and `validate` clean on both roots (run with OpenTofu 1.12.6; no `terraform` binary on this machine) |
| preflight | run in a failing configuration (9 failures, exit 1) and a passing one (exit 0) |
| eval_runs DDL | applied cleanly in a throwaway database on a live ClickHouse, then dropped |

The running local stack was not modified: no data written, no schema changed, the dev server on
:3000 left alone. The scratch database used to check the DDL was dropped and the span counts are
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
