### PR TITLE
Exercise the Clerk provisioning chain end to end, and fix what it found (CTO-359)

### DIFF
--- a/docs/clerk-provisioning-checklist.md
+++ b/docs/clerk-provisioning-checklist.md
@@ -1,0 +1,89 @@
+# Clerk provisioning: what it does, and what to set before you deploy
+
+**Status: exercised end to end against the local stack on 2026-09-09, at `74c308c`.** Every status
+code below was observed, not read off the source. The one thing that could not be checked here is
+`SecretManagerKeyProvider` against real AWS; see "Not verified" at the bottom.
+
+This is the companion to `docs/onboarding-flow-audit.md`. The audit says what the path does and what
+is missing. This says what to set so the path works, and what each variable does when it is wrong.
+
+## The chain, with the statuses it actually returns
+
+```
+Clerk organization.created
+  -> POST /api/webhooks/clerk       web, svix-verified   200 | 400 | 401 | 500 | 502
+  -> POST /v1/tenant/provision      gateway, svc-token   200 | 401 | 422 | 503
+  -> tenant row + HMAC key ref      tenant_provisioning.py
+  -> GET /v1/tenant/by-clerk-org/ID gateway, svc-token   200 | 401 | 404
+  -> getTenant() resolves           web/lib/getTenant.ts
+  -> Home renders
+```
+
+Observed on a clean run: `by-clerk-org` 404 before the event, webhook 200, `by-clerk-org` 200
+returning a fresh tenant UUID with `plan: free`, one `tenants` row carrying its own
+`hash_salt_kek_ref`, and one `usage_limits` row. A brand-new tenant has **zero ingest API keys**;
+that is still the audit's finding #6, not something provisioning does.
+
+## The environment, both sides
+
+Set these together. The pairs are pairs: half of one is worse than neither.
+
+### Gateway
+
+| Variable | Set it to | What a wrong value does |
+| --- | --- | --- |
+| `TALLY_REQUIRE_API_KEY` | `true` | Left `false` in production, the control plane is **unauthenticated**: anyone who can reach the gateway can provision tenants, read `by-clerk-org`, and mint ingest keys. The local stack runs it `false` on purpose, so this is the single most important line to change. |
+| `TALLY_GATEWAY_SERVICE_TOKEN` | a shared secret (`openssl rand -hex 32`) | Empty while `TALLY_REQUIRE_API_KEY=true` and the gateway **refuses to boot**: `RuntimeError: ... the control-plane service-token gate cannot be enforced. Refusing to start.` (`app.py:298`). That is deliberate and correct. Observed. |
+| `TALLY_HMAC_KEY_PROVIDER` | `kms` | Left at the default `local`, per-tenant HMAC material is derived from a root secret sitting in config, which is what the credentials-by-reference invariant forbids on a multi-tenant instance. It will appear to work, which is the danger. `kms` also needs the gateway's `[secrets]` extra installed (boto3) and Secrets Manager grants on the task role; without boto3 the provider raises a `ProvisionError` naming the missing extra. |
+| `TALLY_POSTGRES_DSN` | the control-plane DSN | Provision raises and the webhook route returns 502, so Clerk retries forever and no org ever gets a workspace. |
+| `TALLY_SCHEDULER_ENABLED` | `true`, if you want attribution | Off by default. Feature-level attribution, cost connectors and reconciliation never run. Not a provisioning failure, but a new tenant's dashboard stays thin without it. |
+
+### Web
+
+| Variable | Set it to | What a wrong value does |
+| --- | --- | --- |
+| `CLERK_WEBHOOK_SIGNING_SECRET` | the svix secret from the Clerk dashboard's webhook endpoint | Unset, the route returns **500** with `webhook signing secret not configured`, so Clerk retries and nothing provisions. Wrong value, every delivery is **401 `invalid signature`** and no tenant is ever created, silently, because Clerk's retries all fail the same way. Observed both. |
+| `GATEWAY_SERVICE_TOKEN` | **exactly** the gateway's `TALLY_GATEWAY_SERVICE_TOKEN` | A mismatch is the most likely production misconfiguration and it is quiet: the webhook forwards, the gateway answers **401**, the route turns that into a **502**, and Clerk retries forever. On the dashboard side every control-plane read 401s too, so a signed-in customer gets the error boundary ("This page could not be loaded") on Home. Observed. |
+| `TALLY_GATEWAY_URL` | the private gateway URL | Unreachable, the route returns **502 `provision unreachable`** within 10s and Clerk retries (CTO-359; before that fix it was an unhandled `TypeError: fetch failed` and a bare 500). |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY` | the Clerk instance's keys | Without them the product path cannot authenticate anyone. |
+| `TALLY_DEV_TENANT` | **unset** | Set, the dashboard pins one tenant and Clerk is never consulted, so every visitor sees that tenant's data. A production build refuses to start on this alone (CTO-268); turning it on for real additionally needs `TALLY_ALLOW_INSECURE_NO_AUTH=1`. Do not set either on anything holding real data. |
+
+In the Clerk dashboard, the webhook endpoint must point at
+`https://<dashboard-host>/api/webhooks/clerk` and subscribe to `organization.created`. That route is
+public in `web/middleware.ts` by design and is authenticated solely by its svix signature.
+
+## Failure modes, and what each one does
+
+All observed against the live stack.
+
+| Scenario | Result |
+| --- | --- |
+| Valid signature, new org | 200. One tenant, one key reference, one `usage_limits` row. |
+| **Redelivery** (Clerk retries) | 200, `created: false`. Same tenant id, **same** `hash_salt_kek_ref`: the fast path mints nothing, so a retry cannot roll a tenant's HMAC key. |
+| **Concurrent first delivery** | Eight threads against real Postgres settle on one tenant: one `created: true`, eight key references minted, seven deleted by the loser-cleanup, one kept. No orphaned key material, no second tenant. |
+| **Bad signature / wrong secret** | 401, and `fetch` is never called, so nothing reaches the gateway. |
+| **Missing svix headers** | 400. |
+| **Non-`organization.created` event** | 200 ack, no provision. |
+| **Key provider unavailable** | Gateway 503 `tenant key provider unavailable; provisioning was not performed`, webhook 502, and **zero** tenant rows written. A tenant that cannot hash is never created. |
+| **Gateway unreachable** | Webhook 502 `provision unreachable` (CTO-359). |
+| **The race** (browser beats the webhook) | `by-clerk-org` 404, and Home renders "Setting up your workspace" and polls until the workspace appears (#358). Before #358 this was a 500 crash page. |
+
+One thing worth knowing about the race: a permanently failing provision produces the **same** 404
+from `by-clerk-org` as the transient race, because in both cases no row exists. `#358` distinguishes
+the 404 from other statuses, so a 401 or 503 gets the failure screen, but "provisioning has been
+failing for ten minutes" still presents as "setting up". The 45-second bound in
+`WorkspaceProvisioning` is what stops that being forever.
+
+## Not verified here
+
+- **`SecretManagerKeyProvider` against real AWS.** It has unit tests against an injected fake and it
+  was exercised here only through a deliberately failing provider. Whether `create_secret` plus
+  `update_secret_version_stage` succeed under a real task role, and whether the resulting ARN fits
+  the `no_raw_secret` CHECK in practice, has still never been observed. Do this first in a scratch
+  account.
+- **Real Clerk.** No Clerk account was used. Deliveries were signed with the real svix scheme and a
+  local secret, and the Clerk session was stubbed, so `auth()` returning an active org is the one
+  hop taken on trust. Clerk's actual delivery latency, which is what sets the width of the race
+  window, is still unmeasured.
+- **Clerk's retry behaviour end to end.** The route returns the retriable codes; that Clerk then
+  retries on the schedule its docs describe was not watched.

--- a/docs/nova-demo-tenant.md
+++ b/docs/nova-demo-tenant.md
@@ -1,0 +1,110 @@
+# Putting the demo corpus under a real Clerk org ("Nova")
+
+**Recommendation: attach, via a supported admin command that does not exist yet. Do not hand-write
+the UPDATE, and do not backfill a fresh tenant.** The reasoning, and the measurements behind it,
+are below. Written 2026-09-09 against the live local stack.
+
+## What the corpus actually is
+
+Measured, not assumed:
+
+| TenantId spelling | Spans | Range | Spans carrying an account hash | `daily_account_rollup` rows |
+| --- | --- | --- | --- | --- |
+| `38a6c264-9ca4-411c-92bb-b75433fe509c` (the UUID) | 512,081 | 2026-08-08 to 2026-09-08 | 470,303 | 6,711 |
+| `local-dev` (the name) | 430,915 | 2026-08-04 to 2026-09-04 | 0 | 745 |
+| `live-cto219` | 600,000 | 2026-08-12 to 2026-08-26 | 0 | 15 |
+
+The UUID spelling is the only one that is a complete demo: it is the only one whose spans carry
+account hashes, and it is the only one with a per-account rollup worth showing. That matters for the
+choice, because per-customer attribution is the thing the product is differentiated on.
+
+## Why attach, and not backfill
+
+**Attach wins on the merits, and the margin is bigger than "no data movement".** The 6,711 rollup
+rows under the UUID already cover the full month. `daily_account_rollup` is fed by a ClickHouse
+materialized view that is an INSERT trigger on `otel_spans`, so it is forward-only: it captures what
+arrives after it exists. Attaching keeps a rollup that is already built and already correct.
+
+Backfilling a fresh tenant means re-inserting roughly 512,000 spans and rebuilding that rollup from
+scratch. #348 verified that path at full corpus size, so it works, but it is a lot of moving parts
+to re-run for a demo, and it doubles the storage for a corpus that is already right.
+
+The usual argument for backfill is that it is the path a real customer takes. That argument is worth
+less here than it looks: Nova is a demo of the product's numbers, not a rehearsal of onboarding, and
+the onboarding path is exercised properly by the checks in `docs/clerk-provisioning-checklist.md`.
+
+## Why attach needs a mechanism, and cannot be a hand-written UPDATE
+
+The obvious form, `UPDATE tenants SET clerk_org_id = 'org_nova' WHERE id = '38a6c264-...'`, **fails**.
+Verified against the live stack:
+
+```
+ERROR:  duplicate key value violates unique constraint "uq_tenants_clerk_org_id"
+DETAIL:  Key (clerk_org_id)=(org_e2etest_nova_018) already exists.
+```
+
+Creating the Clerk org is what fires `organization.created`, and provisioning has no adopt path: it
+sees no existing mapping and INSERTs a brand-new tenant with a new UUID, which **claims the org id**
+before anyone can type the UPDATE. So the real manual procedure is not one statement, it is:
+
+1. Create the Clerk org. A new empty tenant appears.
+2. Find it, and `DELETE FROM tenants WHERE clerk_org_id = 'org_nova'`, which cascades across about
+   thirty tables.
+3. `UPDATE tenants SET clerk_org_id = 'org_nova' WHERE id = '38a6c264-...'`.
+
+That is two destructive statements against production Postgres, in order, under time pressure,
+where step 2 targets a row that is one typo away from being the corpus itself. It is a bad story,
+and it is bad for exactly the reason the task suspected.
+
+## The mechanism to build
+
+**An admin command in the gateway, not an HTTP endpoint.**
+
+`CLAUDE.md`'s "control-plane writes go through gateway endpoints" is about the request path: the web
+app must never touch Postgres directly. Operator-run maintenance already has a different, established
+shape in this repo, `gateway/seed.py`, which opens `psycopg.connect(settings.postgres_dsn)` and
+writes `tenants` directly, run as `make seed` -> `docker compose exec gateway python -m gateway.seed`.
+An adopt command belongs there, next to it.
+
+It should **not** be an HTTP endpoint. An endpoint that moves `clerk_org_id` from one tenant to
+another is a tenant-takeover primitive: whoever can call it can point their own Clerk org at any
+customer's data. Putting that on the service-token surface, which the web app holds, widens the blast
+radius of a leaked service token from "read the control plane" to "steal a tenant". A command that
+requires shell access to the gateway task is the right privilege level for something run once.
+
+Sketch, following the seed pattern:
+
+- `python -m gateway.adopt_org --tenant <uuid> --clerk-org <org_id>`, one transaction.
+- Refuse unless the target tenant currently has `clerk_org_id IS NULL`, so it can never move an org
+  off a tenant that already has one.
+- If another tenant already holds that org id, require it to be **empty** (no api_keys, no
+  connector_configs, no value_events) and delete it in the same transaction; otherwise refuse and say
+  which tenant holds it. That is what makes step 2 above safe instead of terrifying.
+- Print the before and after rows.
+
+This has not been built. It is the one thing standing between the current state and a Nova demo that
+does not involve hand-written SQL.
+
+## The spellings problem, and what it means for the demo
+
+If Nova resolves to `38a6c264-...`, the dashboard binds `TenantId = '38a6c264-...'` into every
+ClickHouse read, so the **430,915 spans written under the name `local-dev` stay invisible**, as do
+the 600,000 under `live-cto219`. This is the `CLAUDE.md` trap: `/v1/batches` stores `TenantId` as
+whatever spelling the caller posted, and the ingest path does not fold a name onto a UUID.
+
+**For the demo, this is fine, and it should not be reconciled.** The UUID spelling is the corpus with
+account attribution; the other two have none (0 spans carrying an account hash between them). Folding
+them in would add a million spans of cost with no per-customer story attached, which would make the
+"cost per account" screens look *worse*, not better, because the account-attributed share of total
+spend would fall from most of it to about a third. The demo is stronger without them.
+
+What should happen instead:
+
+- Leave the rows alone. They are real telemetry from earlier work and deleting them destroys history.
+- Know that any span count quoted from ClickHouse without a `TenantId` filter is roughly triple what
+  the dashboard shows, which is a trap for anyone sanity-checking the demo.
+- Treat this as evidence for fixing the ingest path rather than the data. A `/v1/batches` that
+  resolved a posted name to the tenant UUID before storing, the way the control plane already does
+  via `gateway.tenant_lookup.resolve_tenant_uuid`, would stop new instances of this. That is a real
+  change with a migration question attached (what to do about the existing rows) and it is out of
+  scope here, but it is the actual fix.

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -2120,7 +2120,16 @@ async def provision_tenant(
 
     provisioner: TenantProvisioner = app.state.tenant_provisioner
     try:
-        result = provisioner.provision(clerk_org_id=clerk_org_id, name=name)
+        # CTO-359: on a worker thread, never inline on the event loop. `provision` is fully blocking
+        # (psycopg round trips, plus a key-provider mint that is two Secrets Manager calls under
+        # TALLY_HMAC_KEY_PROVIDER=kms, at botocore's tens-of-seconds default timeouts). Awaiting it
+        # inline stalled every other request on the worker: measured against the local stack, an
+        # unrelated /healthz went from 0.04s to 2.71s while one provision with a 3s mint was in
+        # flight. Clerk retries webhooks, so a Secrets Manager slowdown arrives as a burst of these,
+        # and the gateway that stops answering is the one taking the tenant's ingest.
+        result = await asyncio.to_thread(
+            provisioner.provision, clerk_org_id=clerk_org_id, name=name
+        )
     except ProvisionError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except KeyProviderUnavailableError as exc:

--- a/infra/gateway/tests/test_app_orgs_access.py
+++ b/infra/gateway/tests/test_app_orgs_access.py
@@ -9,6 +9,7 @@ the resolver-backed by-clerk-org lookup, and the ``GATEWAY_SERVICE_TOKEN`` gate.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -188,6 +189,46 @@ def test_provision_reports_503_when_the_key_provider_is_unavailable() -> None:
     body = r.json()
     assert "tenant_id" not in body
     assert "key provider unavailable" in body["detail"]
+
+
+def test_provision_runs_off_the_event_loop() -> None:
+    """CTO-359. ``provision`` is fully blocking and must not be awaited inline.
+
+    It does psycopg round trips and a key-provider mint that, under
+    ``TALLY_HMAC_KEY_PROVIDER=kms``, is two Secrets Manager calls at botocore's tens-of-seconds
+    default timeouts. Run on the event loop it stalls every other request on that worker: measured
+    against the local stack, an unrelated ``/healthz`` went from 0.04s to 2.71s while one provision
+    with a 3s mint was in flight. Clerk retries webhooks, so a Secrets Manager slowdown arrives as a
+    burst of these, and the worker that stops answering is the one taking the tenant's ingest.
+
+    Asserted by identity rather than by timing, so it cannot flake: ``asyncio.get_running_loop()``
+    succeeds on the loop thread and raises ``RuntimeError`` on a worker thread. A regression that
+    reinstates the inline await turns this green assertion red.
+    """
+
+    class _ThreadRecordingProvisioner(FakeProvisioner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.on_event_loop: bool | None = None
+
+        def provision(self, *, clerk_org_id, name, region="auto"):
+            try:
+                asyncio.get_running_loop()
+                self.on_event_loop = True
+            except RuntimeError:
+                self.on_event_loop = False
+            return super().provision(clerk_org_id=clerk_org_id, name=name, region=region)
+
+    provisioner = _ThreadRecordingProvisioner()
+    with _client(auth_on=True) as c:
+        app.state.tenant_provisioner = provisioner
+        r = c.post(
+            "/v1/tenant/provision",
+            json={"data": {"id": "org_thread", "name": "Thread Co"}},
+            headers=_svc_headers(),
+        )
+    assert r.status_code == 200, r.text
+    assert provisioner.on_event_loop is False
 
 
 def test_provision_rejects_without_service_token() -> None:

--- a/web/app/api/webhooks/clerk/route.test.ts
+++ b/web/app/api/webhooks/clerk/route.test.ts
@@ -75,4 +75,38 @@ describe("POST /api/webhooks/clerk", () => {
     const res = await POST(req({}));
     expect(res.status).toBeGreaterThanOrEqual(500);
   });
+
+  // CTO-359. The gateway is private and a deploy cycles its tasks, so "could not reach it at all" is
+  // a routine outcome, not an exotic one. Before the fix it escaped as an unhandled `fetch failed`
+  // and Next served a bare 500, which is indistinguishable from a bug in this route.
+  it("returns a retriable 502, not an unhandled 500, when the gateway is unreachable", async () => {
+    verify.mockReturnValue({ type: "organization.created", data: { id: "org_1", name: "Acme" } });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      Object.assign(new TypeError("fetch failed"), { cause: { code: "ECONNREFUSED" } }),
+    );
+    const res = await POST(req({}));
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("provision unreachable");
+  });
+
+  it("returns a retriable 502 when the gateway does not answer in time", async () => {
+    verify.mockReturnValue({ type: "organization.created", data: { id: "org_1", name: "Acme" } });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      Object.assign(new Error("The operation was aborted due to timeout"), {
+        name: "TimeoutError",
+      }),
+    );
+    const res = await POST(req({}));
+    expect(res.status).toBe(502);
+  });
+
+  it("bounds the provision call with an abort signal", async () => {
+    verify.mockReturnValue({ type: "organization.created", data: { id: "org_1", name: "Acme" } });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    await POST(req({}));
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/web/app/api/webhooks/clerk/route.ts
+++ b/web/app/api/webhooks/clerk/route.ts
@@ -13,6 +13,9 @@ import { serviceTokenHeader } from "@/lib/getTenant";
 
 const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
 
+/** How long to wait on the gateway's provision call before giving Clerk a retriable 502. */
+const PROVISION_TIMEOUT_MS = 10_000;
+
 interface ClerkOrgEvent {
   type: string;
   data: { id?: string; name?: string };
@@ -55,11 +58,31 @@ export async function POST(req: Request): Promise<Response> {
     return new Response("event missing organization id", { status: 400 });
   }
 
-  const res = await fetch(`${GATEWAY_URL}/v1/tenant/provision`, {
-    method: "POST",
-    headers: { "content-type": "application/json", ...serviceTokenHeader() },
-    body: JSON.stringify({ clerk_org_id: org.id, name: org.name ?? org.id }),
-  });
+  // CTO-359. Bound the call and own its failure. Reaching the gateway is the step most likely to
+  // fail in the hosted topology (it is private, and a deploy cycles its tasks), and an unhandled
+  // rejection here surfaced as a bare 500 with a stack in the logs, indistinguishable from a bug in
+  // this route. Verified against the local stack: with nothing listening on the gateway port this
+  // route returned 500 from a `TypeError: fetch failed` rather than the deliberate 502 below.
+  //
+  // The timeout matters separately. Provision is synchronous all the way to the key provider, which
+  // under TALLY_HMAC_KEY_PROVIDER=kms is two Secrets Manager calls at botocore's tens-of-seconds
+  // defaults. Without a bound, a slow gateway holds this invocation until the platform kills it,
+  // which on Vercel bills the full duration and gives Clerk a 504 instead of an answer. 10s is well
+  // clear of a healthy provision (single-digit milliseconds locally) and well under Clerk's own
+  // delivery timeout, so a stall becomes a prompt, retriable 502.
+  let res: Response;
+  try {
+    res = await fetch(`${GATEWAY_URL}/v1/tenant/provision`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...serviceTokenHeader() },
+      body: JSON.stringify({ clerk_org_id: org.id, name: org.name ?? org.id }),
+      signal: AbortSignal.timeout(PROVISION_TIMEOUT_MS),
+    });
+  } catch {
+    // Unreachable, or it did not answer in time. Same contract as a gateway error: a 5xx so Clerk
+    // retries, and provisioning is idempotent so the retry is safe. Never fabricate a success.
+    return new Response("provision unreachable", { status: 502 });
+  }
 
   if (!res.ok) {
     // Return a 5xx so Clerk's own retry/backoff applies (the provision is idempotent, so a retry is


### PR DESCRIPTION
**DO NOT MERGE.** Opened for review of the findings.

The Clerk provisioning chain had unit tests but had never been run end to end. This ran it against
the live local stack: a genuinely svix-signed `organization.created` posted at the web webhook route,
forwarded to `POST /v1/tenant/provision`, through to a resolved tenant on a rendered Home. The
signature verification is part of what was tested, so nothing was bypassed.

## What the chain did

| Hop | Result |
| --- | --- |
| `GET /v1/tenant/by-clerk-org/{org}` before the event | **404** `no tenant for clerk org ...` |
| `POST /api/webhooks/clerk`, valid svix signature | **200** |
| `POST /v1/tenant/provision` | **200** `{tenant_id, plan: free, created: true}` |
| Postgres | one `tenants` row, its own `hash_salt_kek_ref`, one `usage_limits` row, **zero** ingest keys |
| `GET /v1/tenant/by-clerk-org/{org}` after | **200** `{tenant_id, plan}` |
| Home | renders |

The route is genuinely public through the real `clerkMiddleware`, confirmed with the product-path
middleware live and no session.

## Failure modes

Passed as written: redelivery (same tenant, **same** key reference, mints nothing), concurrent first
delivery (8 threads into real Postgres settle on one tenant, 8 refs minted, 7 cleaned up, 0 orphans),
bad signature and wrong secret (401, `fetch` never called), missing svix headers (400), non-org event
(200 ack), key provider unavailable (gateway 503, webhook 502, **zero** tenant rows).

Broke, and fixed here:

- **A provision stalled the whole gateway worker.** `provision_tenant` was an `async def` awaiting a
  fully blocking call inline. With a 3s mint, an unrelated `/healthz` went from 0.04s to **2.71s**;
  on the fix, **0.0018s**. Moved to `asyncio.to_thread`, the pattern the scheduler and ingest buffer
  already use. Pinned by thread identity rather than timing, and the test fails with the fix reverted.
- **An unreachable gateway produced a bare 500.** No timeout, no catch, so a transport failure
  escaped as an unhandled `TypeError: fetch failed` rather than the deliberate retriable 502 the
  route already returns for a bad answer. Now bounded at 10s and owned.

Not fixed here, by design: the provisioning race. #358 landed while this was running and its
`WorkspaceProvisioning` screen was verified against the live stack in a production build. Before it,
the race returned **HTTP 500** on `/` and `/api/home`; after it, **200** and "Setting up your
workspace", healing on the next request because the 404 is never negatively cached.

## Docs

- `docs/clerk-provisioning-checklist.md`: the env vars on both sides and the failure each produces
  when wrong, every status observed rather than read off the source.
- `docs/nova-demo-tenant.md`: attach versus backfill for the demo corpus. Recommends **attach**, and
  shows why it needs a supported admin command: creating the Clerk org fires the webhook, which
  claims the org id first, so the naive `UPDATE` fails on `uq_tenants_clerk_org_id` (reproduced).

## Suites

gateway 1012 passed / 8 skipped (+1), ruff clean. web 840 passed / 69 files (+3), typecheck and lint
clean. edge-proxy build, tests and gofmt clean.

## Stack

Left as found: ClickHouse span counts byte-identical to baseline, one `tenants` row
(`38a6c264-...`, `clerk_org_id` NULL), no container restarted. All nine test tenants deleted.

`SecretManagerKeyProvider` against real AWS remains unverified, and no real Clerk account was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)