### PR TITLE
fix(web): match Clerk's auto-proxy path in the middleware matcher

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -59,5 +59,10 @@ export const config = {
   matcher: [
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     "/(api|trpc)(.*)",
+    // Clerk's auto-proxy path. The first pattern above excludes anything containing a dot, and it
+    // is a negative lookahead on the whole path, so a proxied request is not reliably matched by
+    // it. Clerk documents this entry explicitly, after the API matcher, and without it those
+    // requests bypass clerkMiddleware entirely.
+    "/__clerk/:path*",
   ],
 };


### PR DESCRIPTION
One line, found while auditing the Clerk setup against Clerk's own CLI guidance ahead of the production deploy.

`web/middleware.ts`'s `config.matcher` had the two standard entries but was missing `/__clerk/:path*`.

The first pattern is a negative lookahead across the whole path that excludes anything containing a dot, so it does not reliably match a proxied Clerk request. Clerk documents the explicit entry as required, placed after the `/(api|trpc)(.*)` matcher, which is where it now sits. Without it those requests bypass `clerkMiddleware` entirely.

## Why this and nothing else

Clerk's CLI flow would run `clerk init`, which applies "providers, middleware, auth routes, and environment configuration". All four already exist here, and the middleware and provider carry work that a scaffold would overwrite: the `TALLY_DEV_TENANT` bypass, the no-org redirect to `/select-org`, and the boot guard from #345. So `init` was deliberately skipped and only the genuine gap fixed.

Checked at the same time and already correct, so untouched: `@clerk/nextjs` ^6.9.6, `ClerkProvider` inside `<body>`, catch-all routes at `sign-in/[[...sign-in]]` and `sign-up/[[...sign-up]]`, and the auth controls (`OrganizationSwitcher` and `UserButton` at `Shell.tsx:205-210`). There is no `components.json`, so the shadcn theme step does not apply.

## Verification

typecheck clean, lint clean apart from the pre-existing `lib/useLivePoll.ts:94` warning, 840 passed / 69 files (unchanged). Middleware touches every request, so I also confirmed the running dev server still serves `/`, `/waste`, `/cost-per-customer` and `/onboarding` at 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)