### PR TITLE
fix(web): forward the session cookie on server-to-self API fetches

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -4,24 +4,56 @@
 // Pages fetch over HTTP so swapping to a real backend later is just a base-URL change. In server
 // components we derive the base URL from the incoming request (`headers()`); in dev/build with no
 // request we fall back to NEXT_PUBLIC_API_BASE_URL or localhost.
+//
+// THE SESSION HAS TO RIDE ALONG (CTO-269). This is a server-to-self fetch: the page is already
+// running on the server, and it calls its own route handler over HTTP. That second request is a
+// brand new one, so it carries nothing from the browser unless we put it there. `clerkMiddleware`
+// runs on `/api/*` and answers an unauthenticated non-document request with 404 rather than a
+// redirect, so without the cookie every server-rendered page fails with
+// `API /api/home failed: 404` no matter who is signed in.
+//
+// It went unnoticed because the only configuration anyone ran locally set TALLY_DEV_TENANT, which
+// makes the middleware a no-op, so the credential-less self-fetch sailed through. The first
+// deployment with real auth would have hit it on all thirteen pages at once.
+//
+// Only the cookie is forwarded, deliberately. It is what carries the Clerk session, the request is
+// same-origin back into this app, and forwarding the whole header set would drag along host,
+// content-length and encoding headers that describe the ORIGINAL request and misdescribe this one.
 
 import { headers } from "next/headers";
 
-async function baseUrl(): Promise<string> {
-  if (process.env.NEXT_PUBLIC_API_BASE_URL) return process.env.NEXT_PUBLIC_API_BASE_URL;
+/** The incoming request's headers, or null when there is no request (build time, some tests). */
+async function incoming(): Promise<Headers | null> {
   try {
-    const h = await headers();
-    const host = h.get("host") ?? "localhost:3217";
-    const proto = h.get("x-forwarded-proto") ?? "http";
-    return `${proto}://${host}`;
+    return await headers();
   } catch {
-    return process.env.PORT ? `http://localhost:${process.env.PORT}` : "http://localhost:3217";
+    return null;
   }
 }
 
+function baseUrlFrom(h: Headers | null): string {
+  if (process.env.NEXT_PUBLIC_API_BASE_URL)
+    return process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (h) {
+    const host = h.get("host") ?? "localhost:3217";
+    const proto = h.get("x-forwarded-proto") ?? "http";
+    return `${proto}://${host}`;
+  }
+  return process.env.PORT
+    ? `http://localhost:${process.env.PORT}`
+    : "http://localhost:3217";
+}
+
 export async function apiGet<T>(path: string): Promise<T> {
-  const base = await baseUrl();
-  const res = await fetch(`${base}${path}`, { cache: "no-store" });
+  const h = await incoming();
+  const base = baseUrlFrom(h);
+  // No cookie means no request context (build time) or a genuinely anonymous caller. Send the
+  // request either way and let the route decide: fabricating a session here would be worse.
+  const cookie = h?.get("cookie");
+  const res = await fetch(`${base}${path}`, {
+    cache: "no-store",
+    ...(cookie ? { headers: { cookie } } : {}),
+  });
   if (!res.ok) throw new Error(`API ${path} failed: ${res.status}`);
   return (await res.json()) as T;
 }


### PR DESCRIPTION
Found by signing in against a real Clerk development instance on the local stack. This is a **production-blocking bug**, not a configuration problem.

## What was wrong

`web/lib/api.ts`'s `apiGet` did:

```ts
const res = await fetch(`${base}${path}`, { cache: "no-store" });
```

No headers. The page is already running on the server and calls its own route handler over HTTP, so that second request is brand new and carries nothing from the browser unless we put it there.

`clerkMiddleware` runs on `/api/*` and answers an unauthenticated **non-document** request with a 404 rather than a redirect. So with real auth on, every server-rendered page failed:

```
Error: API /api/home failed: 404
    at apiGet (lib/api.ts:25:22)
    at async HomePage (app/page.tsx:29:80)
```

**Thirteen pages use `apiGet`**: Home, cost, waste, compare, attribution, unit-economics, connectors, guardrails, data-quality, settings, estimate, agents/runs/[runId] and cost-per-customer.

## Why nobody caught it

Every local configuration sets `TALLY_DEV_TENANT`, which makes `middleware.ts` a no-op, so the credential-less self-fetch sailed straight through. The suite passes for the same reason. The first deployment with real auth would have hit this on all thirteen pages simultaneously, and it would have looked like a broken app rather than a missing header.

## The fix

Forward the incoming request's `cookie` header, and only that header. It is what carries the Clerk session, the request is same-origin back into this app, and copying the whole header set would drag along `host`, `content-length` and encoding headers that describe the ORIGINAL request and misdescribe this one.

With no cookie (build time, or a genuinely anonymous caller) the request still goes out and the route decides. Fabricating a session here would be worse.

`baseUrl()` was reworked to take the already-fetched `Headers` rather than calling `headers()` a second time, so there is one request-context lookup per call.

## Verification

Against a real Clerk session on the running stack, from the dev server log:

```
GET /api/cost/budget 404   <- before
GET /api/home        404   <- before
GET /                500

GET /api/cost/budget 200   <- after
GET /api/home        200   <- after
GET /                200
```

typecheck clean, lint clean apart from the pre-existing `lib/useLivePoll.ts:94` warning, 840 passed / 69 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)