### PR TITLE
feat(gateway): adopt_org, point a Clerk org at an existing tenant

### DIFF
--- a/infra/gateway/src/gateway/adopt_org.py
+++ b/infra/gateway/src/gateway/adopt_org.py
@@ -1,0 +1,540 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Point a Clerk organization at an EXISTING tenant, disposing of the one its webhook created.
+
+WHY this exists (CTO-364, specced in ``docs/nova-demo-tenant.md``). Attaching a Clerk org to a
+tenant that already holds a corpus looks like one UPDATE, and locally it is, because Clerk cannot
+reach ``localhost`` so ``organization.created`` never fires and nothing claims the org id. In
+production it fires within seconds, ``tenant_provisioning`` INSERTs a fresh empty tenant that claims
+the org id, and the UPDATE then dies on ``uq_tenants_clerk_org_id`` (a partial unique index on
+non-null values). Recovering by hand means a cascading DELETE followed by an UPDATE, in order,
+against production Postgres, where the DELETE is one typo away from the corpus itself. This module
+is that procedure, written once, checked, and run inside a single transaction.
+
+WHY A COMMAND AND NOT AN ENDPOINT. ``CLAUDE.md``'s "control-plane writes go through gateway
+endpoints" governs the request path: the web app must never open Postgres itself. Operator
+maintenance already has a different established shape here, ``gateway/seed.py``, and this follows it.
+Moving ``clerk_org_id`` between tenants is a tenant-takeover primitive: an endpoint for it would let
+anyone holding the control-plane service token, which the web app holds, point their own Clerk org at
+any customer's data. Shell access to the gateway task is the right privilege level for something run
+once under supervision.
+
+THE INVARIANTS THIS MODULE HOLDS.
+
+* **One transaction.** The DELETE of the incumbent and the UPDATE of the target commit together or
+  not at all. An org pointing nowhere is worse than an adoption that failed and changed nothing.
+
+* **Dry run by default.** Nothing is written without ``--confirm``. The census below is the operator's
+  evidence that the row about to be deleted is the empty one.
+
+* **Honest under uncertainty.** Emptiness is measured, never assumed: the census is derived from the
+  live catalog, so a migration that adds a table cannot leave this tool silently checking a stale
+  list. A telemetry count that could not be read is reported as unknown and refuses the adoption
+  rather than being treated as zero.
+
+* **The target's HMAC key is never touched.** Every account and user hash in the target's corpus was
+  computed under ``tenants.hash_salt_kek_ref`` as it stands. Adoption rewrites ``clerk_org_id`` and
+  nothing else, so the corpus stays joinable to itself. The DISCARDED tenant's key set is deleted
+  after commit, and only because the census proved nothing was ever hashed under it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import logging
+import sys
+import uuid
+from dataclasses import dataclass, field
+
+import psycopg
+
+from gateway.config import Settings, get_settings
+from gateway.tenant_provisioning import KeyMaterialProvider, build_key_provider
+
+logger = logging.getLogger(__name__)
+
+
+class AdoptError(RuntimeError):
+    """The adoption was refused. The message says why, and nothing was written."""
+
+
+#: Tables whose rows for the incumbent tenant are what provisioning itself creates, so finding them
+#: is expected and does not block disposal. ``tenant_provisioning.provision`` writes exactly one
+#: ``usage_limits`` row alongside the tenant; everything else on a freshly provisioned tenant is
+#: empty, including its ingest keys (the provisioning checklist's finding #6).
+DISPOSABLE_TABLES = frozenset({"usage_limits"})
+
+
+@dataclass(frozen=True, slots=True)
+class TenantRow:
+    """The columns of ``tenants`` this command reasons about."""
+
+    id: str
+    name: str
+    clerk_org_id: str | None
+    plan: str
+    hash_salt_kek_ref: str
+    created_at: _dt.datetime
+
+    def describe(self) -> str:
+        org = self.clerk_org_id or "(none)"
+        return f"{self.id}  name={self.name!r}  clerk_org_id={org}  plan={self.plan}"
+
+
+@dataclass(frozen=True, slots=True)
+class CensusRow:
+    """One table's row count for the tenant about to be discarded."""
+
+    table: str
+    rows: int
+    #: True when a FK to ``tenants`` carries the rows away on DELETE. False means the rows would be
+    #: ORPHANED by a delete, which is why they are counted separately and why any non-zero refuses.
+    cascades: bool
+
+
+@dataclass(slots=True)
+class AdoptReport:
+    """What the command found and, when confirmed, what it did. Rendered for an incident log."""
+
+    clerk_org_id: str
+    target_before: TenantRow
+    target_after: TenantRow | None = None
+    incumbent: TenantRow | None = None
+    census: list[CensusRow] = field(default_factory=list)
+    tables_examined: int = 0
+    span_count: int | None = None
+    span_count_error: str = ""
+    applied: bool = False
+    already_adopted: bool = False
+    key_ref_deleted: str = ""
+    key_ref_orphaned: str = ""
+    notes: list[str] = field(default_factory=list)
+
+
+def _parse_uuid(value: str) -> str:
+    """Accept the tenant UUID and ONLY the UUID.
+
+    ``tenant_lookup.resolve_tenant_uuid`` would also take a name or a Clerk org id, which is right for
+    a control-plane read and wrong here. This command deletes a row; a name that resolves to a
+    neighbouring tenant is precisely the accident it exists to prevent, so the operator has to type
+    the canonical identifier.
+    """
+    try:
+        return str(uuid.UUID(value))
+    except (ValueError, AttributeError, TypeError):
+        raise AdoptError(
+            f"--tenant must be the tenant UUID, not {value!r}. This command deletes a row, so it "
+            "does not accept a name or an org id that could resolve to the wrong tenant."
+        ) from None
+
+
+def _clean_org(value: str) -> str:
+    trimmed = (value or "").strip()
+    if not trimmed:
+        raise AdoptError("--clerk-org must be non-empty")
+    return trimmed
+
+
+def _row(record: tuple) -> TenantRow:
+    return TenantRow(
+        id=str(record[0]),
+        name=str(record[1]),
+        clerk_org_id=record[2],
+        plan=str(record[3]),
+        hash_salt_kek_ref=str(record[4]),
+        created_at=record[5],
+    )
+
+
+_TENANT_COLUMNS = "id, name, clerk_org_id, plan, hash_salt_kek_ref, created_at"
+
+
+def clickhouse_span_count(settings: Settings, tenant_id: str) -> int:
+    """Spans stored under ``tenant_id`` in ClickHouse. Raises if ClickHouse cannot be read.
+
+    Deliberately raises rather than returning 0 on failure: "we could not reach ClickHouse" and "this
+    tenant has no telemetry" are different answers, and only one of them makes a tenant safe to
+    delete.
+    """
+    import clickhouse_connect
+
+    client = clickhouse_connect.get_client(
+        host=settings.clickhouse_host,
+        port=settings.clickhouse_port,
+        username=settings.clickhouse_user,
+        password=settings.clickhouse_password,
+        database=settings.clickhouse_db,
+    )
+    try:
+        result = client.query(
+            "SELECT count() FROM otel_spans WHERE TenantId = {tid:String}",
+            parameters={"tid": tenant_id},
+        )
+        return int(result.result_rows[0][0])
+    finally:
+        client.close()
+
+
+class OrgAdopter:
+    """Runs the adoption. The key provider and the span counter are injected so tests can drive it."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        key_provider: KeyMaterialProvider | None = None,
+        span_counter=None,
+    ) -> None:
+        self._settings = settings
+        self._dsn = settings.postgres_dsn
+        self._key_provider = key_provider
+        self._span_counter = span_counter or (
+            lambda tenant_id: clickhouse_span_count(settings, tenant_id)
+        )
+
+    def _keys(self) -> KeyMaterialProvider:
+        # Built lazily: a dry run never needs a key provider, and building the AWS one can fail on a
+        # box with no credentials. Refusing to preview because of that would be wrong.
+        if self._key_provider is None:
+            self._key_provider = build_key_provider(self._settings)
+        return self._key_provider
+
+    # -- catalog -------------------------------------------------------------------------------
+
+    @staticmethod
+    def _cascading_children(cur) -> list[str]:
+        """Tables carried away when a ``tenants`` row is deleted, read from the live catalog.
+
+        Read rather than hardcoded so a migration that adds a per-tenant table is covered the day it
+        lands. ``docs/nova-demo-tenant.md`` says "about thirty tables" from a manual count; the
+        catalog is the only figure that stays true.
+        """
+        cur.execute(
+            """
+            SELECT c.conrelid::regclass::text
+            FROM pg_constraint c
+            WHERE c.contype = 'f'
+              AND c.confrelid = 'public.tenants'::regclass
+              AND c.confdeltype = 'c'
+            ORDER BY 1
+            """
+        )
+        return [str(r[0]) for r in cur.fetchall()]
+
+    @staticmethod
+    def _unlinked_tenant_tables(cur) -> list[str]:
+        """Tables carrying a ``tenant_id`` with NO foreign key to ``tenants``.
+
+        These exist (the export watermarks, the scheduler and reconciliation run logs, the ingest
+        cursors and the batch idempotency ledger) and they hold ``tenant_id`` as TEXT, so a DELETE of
+        the tenant leaves their rows behind as orphans. The manual count that produced "about thirty
+        tables" missed them entirely. They cannot be cascaded, so any row here refuses the disposal
+        instead of quietly orphaning it.
+        """
+        cur.execute(
+            """
+            SELECT c.table_name
+            FROM information_schema.columns c
+            WHERE c.table_schema = 'public'
+              AND c.column_name = 'tenant_id'
+              AND c.table_name NOT IN (
+                SELECT f.conrelid::regclass::text
+                FROM pg_constraint f
+                WHERE f.contype = 'f' AND f.confrelid = 'public.tenants'::regclass
+              )
+            ORDER BY 1
+            """
+        )
+        return [str(r[0]) for r in cur.fetchall()]
+
+    def _census(self, cur, tenant_id: str) -> tuple[list[CensusRow], int]:
+        """Count every per-tenant row the incumbent owns. Returns the non-empty ones and the total
+        number of tables examined."""
+        found: list[CensusRow] = []
+        cascading = self._cascading_children(cur)
+        unlinked = self._unlinked_tenant_tables(cur)
+        for table in cascading:
+            cur.execute(f'SELECT count(*) FROM "{table}" WHERE tenant_id = %s', (tenant_id,))
+            rows = int(cur.fetchone()[0])
+            if rows:
+                found.append(CensusRow(table=table, rows=rows, cascades=True))
+        for table in unlinked:
+            # tenant_id is TEXT on these, so compare as text rather than casting to uuid.
+            cur.execute(f'SELECT count(*) FROM "{table}" WHERE tenant_id = %s', (tenant_id,))
+            rows = int(cur.fetchone()[0])
+            if rows:
+                found.append(CensusRow(table=table, rows=rows, cascades=False))
+        return found, len(cascading) + len(unlinked)
+
+    # -- the operation -------------------------------------------------------------------------
+
+    def run(
+        self,
+        *,
+        clerk_org_id: str,
+        target_tenant_id: str,
+        confirm: bool = False,
+        allow_reassign: bool = False,
+        check_telemetry: bool = True,
+    ) -> AdoptReport:
+        org = _clean_org(clerk_org_id)
+        target_id = _parse_uuid(target_tenant_id)
+
+        conn = psycopg.connect(self._dsn)
+        try:
+            with conn.cursor() as cur:
+                # EXCLUSIVE blocks writers, including a webhook provisioning this very org id
+                # between our DELETE and our UPDATE, while still allowing plain SELECTs so the
+                # dashboard keeps reading. Serialising against provisioning is the whole point:
+                # the race is what breaks the hand-written version.
+                cur.execute("LOCK TABLE tenants IN EXCLUSIVE MODE")
+
+                cur.execute(f"SELECT {_TENANT_COLUMNS} FROM tenants WHERE id = %s", (target_id,))
+                record = cur.fetchone()
+                if record is None:
+                    raise AdoptError(
+                        f"no tenant {target_id}. Nothing was written. Check the UUID against "
+                        "`SELECT id, name FROM tenants`."
+                    )
+                target = _row(record)
+                report = AdoptReport(clerk_org_id=org, target_before=target)
+
+                cur.execute(
+                    f"SELECT {_TENANT_COLUMNS} FROM tenants WHERE clerk_org_id = %s", (org,)
+                )
+                record = cur.fetchone()
+                incumbent = _row(record) if record is not None else None
+
+                # Idempotent exit: the org already points where it should. No writes, no lock held
+                # any longer than the read, exit 0.
+                if incumbent is not None and incumbent.id == target.id:
+                    report.already_adopted = True
+                    report.notes.append(
+                        f"{org} already resolves to {target.id}. Nothing to do."
+                    )
+                    conn.rollback()
+                    return report
+
+                # Ambiguity: the target already answers to a DIFFERENT org. Moving it would silently
+                # orphan that org's workspace, so it takes an explicit flag.
+                if target.clerk_org_id is not None and target.clerk_org_id != org:
+                    if not allow_reassign:
+                        raise AdoptError(
+                            f"tenant {target.id} already carries clerk_org_id "
+                            f"{target.clerk_org_id}, not {org}. Adopting would take that "
+                            "organization's workspace away from it. Nothing was written. If the "
+                            "move is intended, re-run with --allow-reassign."
+                        )
+                    report.notes.append(
+                        f"--allow-reassign: {target.clerk_org_id} is being moved off "
+                        f"{target.id} and replaced by {org}. That organization now resolves to "
+                        "no tenant and its next sign-in provisions a fresh empty one."
+                    )
+
+                if incumbent is not None:
+                    report.incumbent = incumbent
+                    census, examined = self._census(cur, incumbent.id)
+                    report.census = census
+                    report.tables_examined = examined
+
+                    blocking = [c for c in census if c.table not in DISPOSABLE_TABLES]
+                    if blocking:
+                        detail = ", ".join(f"{c.table}={c.rows}" for c in blocking)
+                        raise AdoptError(
+                            f"tenant {incumbent.id} holds {org} and is NOT empty ({detail}). "
+                            "This command only disposes of a tenant that provisioning just "
+                            "created. Nothing was written. Work out what that tenant is before "
+                            "going further."
+                        )
+
+                    if check_telemetry:
+                        try:
+                            report.span_count = self._span_counter(incumbent.id)
+                        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+                            report.span_count_error = f"{type(exc).__name__}: {exc}"
+                            raise AdoptError(
+                                f"could not count spans for {incumbent.id} in ClickHouse "
+                                f"({report.span_count_error}). An unreadable count is not a zero "
+                                "count, so the tenant cannot be shown to be disposable. Nothing "
+                                "was written. Fix the connection, or pass "
+                                "--skip-telemetry-check if you have established another way that "
+                                "the tenant has no telemetry."
+                            ) from exc
+                        if report.span_count:
+                            raise AdoptError(
+                                f"tenant {incumbent.id} holds {org} and has "
+                                f"{report.span_count:,} spans in ClickHouse. Deleting it would "
+                                "strand that telemetry with no control-plane row. Nothing was "
+                                "written."
+                            )
+                    else:
+                        report.notes.append(
+                            "--skip-telemetry-check: the ClickHouse span count for the discarded "
+                            "tenant was NOT checked."
+                        )
+
+                if not confirm:
+                    conn.rollback()
+                    return report
+
+                if incumbent is not None:
+                    cur.execute("DELETE FROM tenants WHERE id = %s", (incumbent.id,))
+                    if cur.rowcount != 1:
+                        raise AdoptError(
+                            f"expected to delete exactly 1 tenant row for {incumbent.id}, "
+                            f"deleted {cur.rowcount}. Rolled back."
+                        )
+                cur.execute(
+                    "UPDATE tenants SET clerk_org_id = %s WHERE id = %s", (org, target.id)
+                )
+                if cur.rowcount != 1:
+                    raise AdoptError(
+                        f"expected to update exactly 1 tenant row for {target.id}, updated "
+                        f"{cur.rowcount}. Rolled back."
+                    )
+                cur.execute(f"SELECT {_TENANT_COLUMNS} FROM tenants WHERE id = %s", (target.id,))
+                report.target_after = _row(cur.fetchone())
+                conn.commit()
+                report.applied = True
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        # After commit, and only here. The key set belongs to a tenant that the census proved held no
+        # rows and no spans, so nothing was ever hashed under it and deleting it destroys no ability
+        # to reproduce a hash. Doing it before the commit would delete live key material if the
+        # transaction then rolled back; a failure here leaves recoverable material, not a broken
+        # tenant, so it is reported and not raised (the shape tenant_provisioning uses too).
+        if report.incumbent is not None:
+            ref = report.incumbent.hash_salt_kek_ref
+            try:
+                self._keys().delete(ref)
+                report.key_ref_deleted = ref
+            except Exception as exc:  # noqa: BLE001 - cleanup must not undo a committed adoption
+                report.key_ref_orphaned = ref
+                logger.error(
+                    "adopted %s but the discarded tenant's HMAC key reference %s could not be "
+                    "deleted (%s): delete it by hand",
+                    org,
+                    ref,
+                    exc,
+                )
+        return report
+
+
+def render(report: AdoptReport) -> str:
+    """The operator's record of the run, written to be pasted into an incident log."""
+    stamp = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+    lines: list[str] = [
+        f"adopt_org {stamp}",
+        f"  clerk org      : {report.clerk_org_id}",
+        f"  target tenant  : {report.target_before.describe()}",
+    ]
+    if report.already_adopted:
+        lines.append("  result         : ALREADY ADOPTED, nothing written")
+        for note in report.notes:
+            lines.append(f"  note           : {note}")
+        return "\n".join(lines)
+
+    if report.incumbent is None:
+        lines.append(f"  incumbent      : none, {report.clerk_org_id} is unclaimed")
+    else:
+        lines.append(f"  incumbent      : {report.incumbent.describe()}")
+        lines.append(f"                   created {report.incumbent.created_at.isoformat()}")
+        lines.append(
+            f"  census         : {report.tables_examined} per-tenant tables examined, "
+            f"{len(report.census)} non-empty"
+        )
+        for entry in report.census:
+            carry = "cascades on delete" if entry.cascades else "NO FK, would orphan"
+            lines.append(f"                   {entry.table}: {entry.rows} row(s), {carry}")
+        if report.span_count is not None:
+            lines.append(f"  clickhouse     : {report.span_count:,} spans under the incumbent")
+        elif report.span_count_error:
+            lines.append(f"  clickhouse     : UNKNOWN ({report.span_count_error})")
+        else:
+            lines.append("  clickhouse     : not checked (--skip-telemetry-check)")
+
+    if not report.applied:
+        lines.append("  result         : DRY RUN, nothing written. Re-run with --confirm to apply.")
+        if report.incumbent is not None:
+            lines.append(f"                   would DELETE tenant {report.incumbent.id}")
+        lines.append(
+            f"                   would SET clerk_org_id={report.clerk_org_id} on "
+            f"{report.target_before.id}"
+        )
+    else:
+        lines.append("  result         : ADOPTED, committed")
+        if report.incumbent is not None:
+            lines.append(f"                   deleted tenant {report.incumbent.id}")
+        after = report.target_after
+        if after is not None:
+            lines.append(f"                   tenant after: {after.describe()}")
+        lines.append(
+            f"                   target hash_salt_kek_ref unchanged: "
+            f"{report.target_before.hash_salt_kek_ref}"
+        )
+        if report.key_ref_deleted:
+            lines.append(f"                   discarded HMAC key deleted: {report.key_ref_deleted}")
+        if report.key_ref_orphaned:
+            lines.append(
+                f"                   HMAC key {report.key_ref_orphaned} could NOT be deleted; "
+                "delete it by hand"
+            )
+    for note in report.notes:
+        lines.append(f"  note           : {note}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m gateway.adopt_org",
+        description=(
+            "Point a Clerk organization at an existing tenant, deleting the empty tenant its "
+            "webhook created. Dry run unless --confirm is given."
+        ),
+    )
+    parser.add_argument("--clerk-org", required=True, help="the Clerk organization id (org_...)")
+    parser.add_argument(
+        "--tenant", required=True, help="the target tenant UUID, the one holding the corpus"
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="actually write. Without it the command reports what it would do and exits.",
+    )
+    parser.add_argument(
+        "--allow-reassign",
+        action="store_true",
+        help="permit adopting a target that already carries a DIFFERENT clerk_org_id",
+    )
+    parser.add_argument(
+        "--skip-telemetry-check",
+        action="store_true",
+        help="do not count the discarded tenant's spans in ClickHouse before deleting it",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    adopter = OrgAdopter(get_settings())
+    try:
+        report = adopter.run(
+            clerk_org_id=args.clerk_org,
+            target_tenant_id=args.tenant,
+            confirm=args.confirm,
+            allow_reassign=args.allow_reassign,
+            check_telemetry=not args.skip_telemetry_check,
+        )
+    except AdoptError as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 1
+    print(render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/gateway/tests/test_adopt_org.py
+++ b/infra/gateway/tests/test_adopt_org.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Clerk org adoption (CTO-364), against an in-memory fake of the statements the command runs.
+
+The decision logic lives here: which cases refuse, which are idempotent, what the dry run does and
+does not write, and that a mid-operation failure leaves nothing behind. The claims that are
+properties of Postgres rather than of this Python (the cascade, the partial unique index, the
+transaction boundary) are asserted in ``test_adopt_org_pg.py`` against a real database, because a
+dict cannot prove them.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+
+from gateway import adopt_org
+from gateway.adopt_org import (
+    DISPOSABLE_TABLES,
+    AdoptError,
+    OrgAdopter,
+    render,
+)
+from gateway.config import Settings
+
+NOW = _dt.datetime(2026, 9, 9, 22, 40, tzinfo=_dt.timezone.utc)
+
+#: Stands in for the catalog read. The real list comes from pg_constraint; the fake only needs
+#: enough tables to exercise the "cascading" and "would orphan" branches.
+CASCADING = ["api_keys", "usage_limits", "value_events"]
+UNLINKED = ["ingest_batch_idempotency", "scheduler_runs"]
+
+
+class SpyKeyProvider:
+    def __init__(self, fail: bool = False) -> None:
+        self.deleted: list[str] = []
+        self._fail = fail
+
+    def mint(self) -> str:  # pragma: no cover - adoption never mints
+        raise AssertionError("adopt_org must never mint key material")
+
+    def delete(self, ref: str) -> None:
+        if self._fail:
+            raise RuntimeError("secrets manager throttled")
+        self.deleted.append(ref)
+
+
+class _Tenant:
+    def __init__(self, name: str, org: str | None, ref: str) -> None:
+        self.id = str(uuid.uuid4())
+        self.name = name
+        self.clerk_org_id = org
+        self.plan = "free"
+        self.hash_salt_kek_ref = ref
+        self.created_at = NOW
+
+    def as_row(self) -> tuple:
+        return (
+            self.id,
+            self.name,
+            self.clerk_org_id,
+            self.plan,
+            self.hash_salt_kek_ref,
+            self.created_at,
+        )
+
+
+class _FakeDB:
+    """The mutable world the fake connection reads and writes."""
+
+    def __init__(self) -> None:
+        self.tenants: dict[str, _Tenant] = {}
+        #: table -> tenant_id -> row count
+        self.rows: dict[str, dict[str, int]] = {}
+        self.committed = False
+        self.rolled_back = False
+        #: set to raise on the statement whose prefix matches, to test mid-operation failure
+        self.fail_on: str = ""
+
+    def add(self, tenant: _Tenant) -> _Tenant:
+        self.tenants[tenant.id] = tenant
+        return tenant
+
+    def count(self, table: str, tenant_id: str) -> int:
+        return self.rows.get(table, {}).get(tenant_id, 0)
+
+
+class _FakeCursor:
+    def __init__(self, db: _FakeDB) -> None:
+        self._db = db
+        self._result: list[tuple] = []
+        self.rowcount = -1
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *_a: object) -> bool:
+        return False
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        s = " ".join(sql.split())
+        if self._db.fail_on and s.startswith(self._db.fail_on):
+            raise RuntimeError("injected failure")
+        self._result = []
+        self.rowcount = -1
+        if s.startswith("LOCK TABLE tenants"):
+            return
+        if s.startswith("SELECT id, name, clerk_org_id") and "WHERE id =" in s:
+            found = self._db.tenants.get(str(params[0]))
+            self._result = [found.as_row()] if found else []
+            return
+        if s.startswith("SELECT id, name, clerk_org_id") and "WHERE clerk_org_id =" in s:
+            self._result = [
+                t.as_row() for t in self._db.tenants.values() if t.clerk_org_id == params[0]
+            ]
+            return
+        if "FROM pg_constraint" in s and "confdeltype = 'c'" in s:
+            self._result = [(t,) for t in CASCADING]
+            return
+        if "FROM information_schema.columns" in s:
+            self._result = [(t,) for t in UNLINKED]
+            return
+        if s.startswith("SELECT count(*) FROM"):
+            table = s.split('"')[1]
+            self._result = [(self._db.count(table, str(params[0])),)]
+            return
+        if s.startswith("DELETE FROM tenants"):
+            removed = self._db.tenants.pop(str(params[0]), None)
+            self.rowcount = 1 if removed else 0
+            return
+        if s.startswith("UPDATE tenants SET clerk_org_id"):
+            found = self._db.tenants.get(str(params[1]))
+            if found is None:
+                self.rowcount = 0
+                return
+            found.clerk_org_id = params[0]
+            self.rowcount = 1
+            return
+        raise AssertionError(f"fake cursor saw an unexpected statement: {s}")
+
+    def fetchone(self) -> tuple | None:
+        return self._result[0] if self._result else None
+
+    def fetchall(self) -> list[tuple]:
+        return self._result
+
+
+class _FakeConn:
+    def __init__(self, db: _FakeDB) -> None:
+        self._db = db
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self._db)
+
+    def commit(self) -> None:
+        self._db.committed = True
+
+    def rollback(self) -> None:
+        self._db.rolled_back = True
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def db(monkeypatch: pytest.MonkeyPatch) -> _FakeDB:
+    world = _FakeDB()
+    monkeypatch.setattr(adopt_org.psycopg, "connect", lambda _dsn: _FakeConn(world))
+    return world
+
+
+def _adopter(keys: SpyKeyProvider | None = None, spans: int = 0) -> OrgAdopter:
+    return OrgAdopter(
+        Settings(postgres_dsn="postgresql://fake/fake"),
+        key_provider=keys or SpyKeyProvider(),
+        span_counter=lambda _tid: spans,
+    )
+
+
+def _corpus(db: _FakeDB) -> _Tenant:
+    tenant = db.add(_Tenant("Nova corpus", None, "local://hmac/corpus/v1"))
+    db.rows.setdefault("value_events", {})[tenant.id] = 4200
+    db.rows.setdefault("api_keys", {})[tenant.id] = 1
+    return tenant
+
+
+def _webhook_tenant(db: _FakeDB, org: str) -> _Tenant:
+    """What provisioning creates: a tenant row, one usage_limits row, and nothing else."""
+    tenant = db.add(_Tenant("Nova", org, "local://hmac/fresh/v1"))
+    db.rows.setdefault("usage_limits", {})[tenant.id] = 1
+    return tenant
+
+
+# -- the happy path ------------------------------------------------------------------------------
+
+
+def test_dry_run_writes_nothing(db: _FakeDB) -> None:
+    target = _corpus(db)
+    incumbent = _webhook_tenant(db, "org_nova")
+
+    report = _adopter().run(clerk_org_id="org_nova", target_tenant_id=target.id)
+
+    assert report.applied is False
+    assert db.committed is False
+    assert db.rolled_back is True
+    assert incumbent.id in db.tenants, "dry run must not delete the incumbent"
+    assert target.clerk_org_id is None, "dry run must not move the org"
+    assert report.incumbent is not None and report.incumbent.id == incumbent.id
+    assert report.tables_examined == len(CASCADING) + len(UNLINKED)
+    assert "DRY RUN" in render(report)
+
+
+def test_confirm_deletes_the_incumbent_and_moves_the_org(db: _FakeDB) -> None:
+    target = _corpus(db)
+    incumbent = _webhook_tenant(db, "org_nova")
+    keys = SpyKeyProvider()
+
+    report = _adopter(keys).run(
+        clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True
+    )
+
+    assert report.applied is True
+    assert db.committed is True
+    assert incumbent.id not in db.tenants
+    assert db.tenants[target.id].clerk_org_id == "org_nova"
+    assert report.target_after is not None
+    # The corpus keeps its OWN key: every account hash in it was computed under this reference, and
+    # replacing it would make the corpus unjoinable to itself.
+    assert report.target_after.hash_salt_kek_ref == "local://hmac/corpus/v1"
+    assert keys.deleted == ["local://hmac/fresh/v1"], "the discarded tenant's key must be released"
+    assert "ADOPTED, committed" in render(report)
+
+
+def test_unclaimed_org_is_a_plain_update(db: _FakeDB) -> None:
+    """Local, or production before the webhook lands: nothing to dispose of."""
+    target = _corpus(db)
+    keys = SpyKeyProvider()
+
+    report = _adopter(keys).run(
+        clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True
+    )
+
+    assert report.incumbent is None
+    assert db.tenants[target.id].clerk_org_id == "org_nova"
+    assert keys.deleted == [], "no incumbent means no key to delete"
+
+
+def test_usage_limits_alone_does_not_block(db: _FakeDB) -> None:
+    """A freshly provisioned tenant has exactly one usage_limits row. That is expected, not data."""
+    target = _corpus(db)
+    incumbent = _webhook_tenant(db, "org_nova")
+
+    report = _adopter().run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+
+    assert report.applied is True
+    assert [c.table for c in report.census] == ["usage_limits"]
+    assert "usage_limits" in DISPOSABLE_TABLES
+    assert incumbent.id not in db.tenants
+
+
+# -- idempotence ---------------------------------------------------------------------------------
+
+
+def test_already_adopted_is_a_no_op(db: _FakeDB) -> None:
+    target = _corpus(db)
+    target.clerk_org_id = "org_nova"
+    keys = SpyKeyProvider()
+
+    report = _adopter(keys).run(
+        clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True
+    )
+
+    assert report.already_adopted is True
+    assert report.applied is False
+    assert db.committed is False
+    assert keys.deleted == []
+    assert "ALREADY ADOPTED" in render(report)
+
+
+def test_running_twice_is_safe(db: _FakeDB) -> None:
+    target = _corpus(db)
+    _webhook_tenant(db, "org_nova")
+    adopter = _adopter()
+
+    first = adopter.run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+    second = adopter.run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+
+    assert first.applied is True
+    assert second.already_adopted is True and second.applied is False
+    assert db.tenants[target.id].clerk_org_id == "org_nova"
+    assert len(db.tenants) == 1
+
+
+# -- refusals ------------------------------------------------------------------------------------
+
+
+def test_missing_target_refuses(db: _FakeDB) -> None:
+    with pytest.raises(AdoptError, match="no tenant"):
+        _adopter().run(
+            clerk_org_id="org_nova", target_tenant_id=str(uuid.uuid4()), confirm=True
+        )
+    assert db.committed is False
+
+
+def test_a_name_is_not_accepted_as_a_target(db: _FakeDB) -> None:
+    """CLAUDE.md: never feed a name into a UUID column. Here it is also the deletion hazard."""
+    with pytest.raises(AdoptError, match="must be the tenant UUID"):
+        _adopter().run(clerk_org_id="org_nova", target_tenant_id="local-dev", confirm=True)
+
+
+def test_empty_org_refuses(db: _FakeDB) -> None:
+    target = _corpus(db)
+    with pytest.raises(AdoptError, match="non-empty"):
+        _adopter().run(clerk_org_id="   ", target_tenant_id=target.id, confirm=True)
+
+
+def test_target_with_a_different_org_refuses(db: _FakeDB) -> None:
+    target = _corpus(db)
+    target.clerk_org_id = "org_other"
+    _webhook_tenant(db, "org_nova")
+
+    with pytest.raises(AdoptError, match="--allow-reassign"):
+        _adopter().run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+
+    assert db.tenants[target.id].clerk_org_id == "org_other"
+    assert db.committed is False
+
+
+def test_allow_reassign_permits_it_and_says_so(db: _FakeDB) -> None:
+    target = _corpus(db)
+    target.clerk_org_id = "org_other"
+    _webhook_tenant(db, "org_nova")
+
+    report = _adopter().run(
+        clerk_org_id="org_nova",
+        target_tenant_id=target.id,
+        confirm=True,
+        allow_reassign=True,
+    )
+
+    assert report.applied is True
+    assert db.tenants[target.id].clerk_org_id == "org_nova"
+    assert any("org_other" in note for note in report.notes)
+
+
+def test_non_empty_incumbent_refuses_and_names_the_tables(db: _FakeDB) -> None:
+    target = _corpus(db)
+    incumbent = _webhook_tenant(db, "org_nova")
+    db.rows.setdefault("value_events", {})[incumbent.id] = 17
+
+    with pytest.raises(AdoptError, match="value_events=17"):
+        _adopter().run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+
+    assert incumbent.id in db.tenants
+    assert db.committed is False
+
+
+def test_rows_in_an_unlinked_table_refuse_too(db: _FakeDB) -> None:
+    """These have no FK, so a DELETE would orphan them rather than cascade them away."""
+    target = _corpus(db)
+    incumbent = _webhook_tenant(db, "org_nova")
+    db.rows.setdefault("scheduler_runs", {})[incumbent.id] = 3
+
+    with pytest.raises(AdoptError, match="scheduler_runs=3"):
+        _adopter().run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+
+    assert incumbent.id in db.tenants
+
+
+def test_incumbent_with_spans_refuses(db: _FakeDB) -> None:
+    target = _corpus(db)
+    incumbent = _webhook_tenant(db, "org_nova")
+
+    with pytest.raises(AdoptError, match="512,081 spans"):
+        _adopter(spans=512081).run(
+            clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True
+        )
+
+    assert incumbent.id in db.tenants
+
+
+def test_unreadable_span_count_refuses_rather_than_assuming_zero(db: _FakeDB) -> None:
+    """Honest under uncertainty: unknown is not zero, and only zero makes a tenant disposable."""
+    target = _corpus(db)
+    _webhook_tenant(db, "org_nova")
+
+    def unreachable(_tid: str) -> int:
+        raise ConnectionError("clickhouse unreachable")
+
+    adopter = OrgAdopter(
+        Settings(postgres_dsn="postgresql://fake/fake"),
+        key_provider=SpyKeyProvider(),
+        span_counter=unreachable,
+    )
+    with pytest.raises(AdoptError, match="not a zero count"):
+        adopter.run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+    assert db.committed is False
+
+
+def test_skip_telemetry_check_proceeds_and_records_that_it_skipped(db: _FakeDB) -> None:
+    target = _corpus(db)
+    _webhook_tenant(db, "org_nova")
+
+    def unreachable(_tid: str) -> int:  # pragma: no cover - must never be called
+        raise AssertionError("the span count must not be attempted when skipped")
+
+    adopter = OrgAdopter(
+        Settings(postgres_dsn="postgresql://fake/fake"),
+        key_provider=SpyKeyProvider(),
+        span_counter=unreachable,
+    )
+    report = adopter.run(
+        clerk_org_id="org_nova",
+        target_tenant_id=target.id,
+        confirm=True,
+        check_telemetry=False,
+    )
+    assert report.applied is True
+    assert report.span_count is None
+    assert "not checked" in render(report)
+
+
+# -- failure in the middle -----------------------------------------------------------------------
+
+
+def test_failure_between_the_delete_and_the_update_rolls_back(db: _FakeDB) -> None:
+    """The whole reason this is one transaction: an org pointing nowhere is the bad outcome."""
+    target = _corpus(db)
+    # The incumbent is created for its side effect: it is what the DELETE half of the transaction
+    # removes. Nothing here needs to name it, matching the sibling test below.
+    _webhook_tenant(db, "org_nova")
+    keys = SpyKeyProvider()
+    db.fail_on = "UPDATE tenants SET clerk_org_id"
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        _adopter(keys).run(clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True)
+
+    assert db.committed is False
+    assert db.rolled_back is True
+    # A real Postgres rolls the DELETE back with the transaction; the fake mutates eagerly, so what
+    # matters here is that nothing was committed and no key material was destroyed.
+    assert keys.deleted == [], "a rolled-back adoption must not delete the incumbent's key"
+
+
+def test_key_delete_failure_does_not_undo_a_committed_adoption(db: _FakeDB) -> None:
+    """The adoption is done. Report the orphan rather than turn a success into an exception."""
+    target = _corpus(db)
+    _webhook_tenant(db, "org_nova")
+
+    report = _adopter(SpyKeyProvider(fail=True)).run(
+        clerk_org_id="org_nova", target_tenant_id=target.id, confirm=True
+    )
+
+    assert report.applied is True
+    assert db.tenants[target.id].clerk_org_id == "org_nova"
+    assert report.key_ref_orphaned == "local://hmac/fresh/v1"
+    assert "delete it by hand" in render(report)
+
+
+# -- the CLI shell -------------------------------------------------------------------------------
+
+
+def test_main_returns_1_and_prints_the_refusal(
+    db: _FakeDB, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(adopt_org, "OrgAdopter", lambda _s: _adopter())
+    code = adopt_org.main(["--clerk-org", "org_nova", "--tenant", str(uuid.uuid4())])
+    assert code == 1
+    assert "REFUSED" in capsys.readouterr().err
+
+
+def test_main_defaults_to_a_dry_run(
+    db: _FakeDB, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = _corpus(db)
+    _webhook_tenant(db, "org_nova")
+    monkeypatch.setattr(adopt_org, "OrgAdopter", lambda _s: _adopter())
+
+    code = adopt_org.main(["--clerk-org", "org_nova", "--tenant", target.id])
+
+    assert code == 0
+    assert "DRY RUN" in capsys.readouterr().out
+    assert db.committed is False
+    assert target.clerk_org_id is None

--- a/infra/gateway/tests/test_adopt_org_pg.py
+++ b/infra/gateway/tests/test_adopt_org_pg.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Clerk org adoption against a REAL Postgres (CTO-364).
+
+Separate from ``test_adopt_org.py`` because these assert the three things a fake cannot:
+
+* the DELETE really does cascade, so no child row survives its tenant;
+* ``uq_tenants_clerk_org_id`` really is what makes the hand-written UPDATE fail, and the command
+  really does get past it;
+* the DELETE and the UPDATE really are one transaction, so an injected failure between them leaves
+  the incumbent alive and the org exactly where it was.
+
+Every tenant these create is named ``adopt-org-test-*`` and is removed in teardown, so the file is
+safe to point at a stack that also holds a demo corpus. Skipped unless ``TALLY_TEST_POSTGRES_DSN``
+is set, so a checkout with no infrastructure still runs the suite green:
+
+    TALLY_TEST_POSTGRES_DSN=postgresql://tally:tally@localhost:5432/tally \\
+      uv run --extra dev pytest -q tests/test_adopt_org_pg.py
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+
+from gateway.adopt_org import AdoptError, OrgAdopter
+from gateway.config import Settings
+
+DSN = os.environ.get("TALLY_TEST_POSTGRES_DSN", "")
+
+pytestmark = pytest.mark.skipif(
+    not DSN, reason="set TALLY_TEST_POSTGRES_DSN to a migrated control-plane database"
+)
+
+NAME_PREFIX = "adopt-org-test-"
+
+
+class SpyKeyProvider:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    def mint(self) -> str:  # pragma: no cover - adoption never mints
+        raise AssertionError("adopt_org must never mint key material")
+
+    def delete(self, ref: str) -> None:
+        self.deleted.append(ref)
+
+
+@pytest.fixture
+def conn() -> Iterator[psycopg.Connection]:
+    with psycopg.connect(DSN, autocommit=True) as connection:
+        yield connection
+        # Teardown targets the name prefix only, never a UUID, so a typo cannot reach the corpus.
+        with connection.cursor() as cur:
+            cur.execute("DELETE FROM tenants WHERE name LIKE %s", (NAME_PREFIX + "%",))
+
+
+def _make_tenant(conn: psycopg.Connection, *, org: str | None, ref: str) -> str:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO tenants (name, region, plan, hash_salt_kek_ref, clerk_org_id)
+            VALUES (%s, 'local', 'free', %s, %s) RETURNING id
+            """,
+            (f"{NAME_PREFIX}{uuid.uuid4().hex[:8]}", ref, org),
+        )
+        tenant_id = str(cur.fetchone()[0])
+        cur.execute(
+            "INSERT INTO usage_limits (tenant_id, plan) VALUES (%s, 'free') "
+            "ON CONFLICT (tenant_id) DO NOTHING",
+            (tenant_id,),
+        )
+    return tenant_id
+
+
+def _org(conn: psycopg.Connection, tenant_id: str) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT clerk_org_id FROM tenants WHERE id = %s", (tenant_id,))
+        row = cur.fetchone()
+        return None if row is None else row[0]
+
+
+def _exists(conn: psycopg.Connection, tenant_id: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM tenants WHERE id = %s", (tenant_id,))
+        return cur.fetchone() is not None
+
+
+def _adopter(keys: SpyKeyProvider | None = None, spans: int = 0) -> OrgAdopter:
+    return OrgAdopter(
+        Settings(postgres_dsn=DSN),
+        key_provider=keys or SpyKeyProvider(),
+        span_counter=lambda _tid: spans,
+    )
+
+
+def test_the_hand_written_update_really_does_fail(conn: psycopg.Connection) -> None:
+    """The premise. Without this the whole command is solving an imagined problem."""
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+
+    with psycopg.connect(DSN) as isolated, isolated.cursor() as cur:
+        with pytest.raises(psycopg.errors.UniqueViolation, match="uq_tenants_clerk_org_id"):
+            cur.execute("UPDATE tenants SET clerk_org_id = %s WHERE id = %s", (org, target))
+        isolated.rollback()
+
+    assert _org(conn, target) is None
+
+
+def test_adoption_gets_past_the_index(conn: psycopg.Connection) -> None:
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    keys = SpyKeyProvider()
+
+    report = _adopter(keys).run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+
+    assert report.applied is True
+    assert _org(conn, target) == org
+    assert not _exists(conn, incumbent)
+    assert keys.deleted == ["local://hmac/incumbent/v1"]
+    # The target's own key set is what its corpus was hashed under. It must be untouched.
+    with conn.cursor() as cur:
+        cur.execute("SELECT hash_salt_kek_ref FROM tenants WHERE id = %s", (target,))
+        assert cur.fetchone()[0] == "local://hmac/target/v1"
+
+
+def test_the_delete_cascades_every_child_row(conn: psycopg.Connection) -> None:
+    """usage_limits is the row provisioning creates. Prove the cascade actually takes it."""
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM usage_limits WHERE tenant_id = %s", (incumbent,))
+        assert cur.fetchone()[0] == 1
+
+    _adopter().run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM usage_limits WHERE tenant_id = %s", (incumbent,))
+        assert cur.fetchone()[0] == 0
+
+
+def test_the_census_reads_the_live_catalog(conn: psycopg.Connection) -> None:
+    """Not a hardcoded list: the count must match what the database actually declares today."""
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+
+    report = _adopter().run(clerk_org_id=org, target_tenant_id=target)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+              (SELECT count(*) FROM pg_constraint
+                 WHERE contype='f' AND confrelid='public.tenants'::regclass AND confdeltype='c')
+            + (SELECT count(*) FROM information_schema.columns
+                 WHERE table_schema='public' AND column_name='tenant_id'
+                   AND table_name NOT IN (
+                     SELECT conrelid::regclass::text FROM pg_constraint
+                     WHERE contype='f' AND confrelid='public.tenants'::regclass))
+            """
+        )
+        expected = int(cur.fetchone()[0])
+    assert report.tables_examined == expected
+    assert [c.table for c in report.census] == ["usage_limits"]
+
+
+def test_dry_run_changes_nothing(conn: psycopg.Connection) -> None:
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    keys = SpyKeyProvider()
+
+    report = _adopter(keys).run(clerk_org_id=org, target_tenant_id=target)
+
+    assert report.applied is False
+    assert _org(conn, target) is None
+    assert _exists(conn, incumbent)
+    assert keys.deleted == []
+
+
+def test_a_failed_update_rolls_the_delete_back(
+    conn: psycopg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One transaction. The incumbent must survive a failure after its DELETE was issued."""
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    keys = SpyKeyProvider()
+
+    real_execute = psycopg.Cursor.execute
+
+    def exploding(self, query, params=None, **kwargs):  # type: ignore[no-untyped-def]
+        text = query if isinstance(query, str) else query.decode()
+        if text.strip().startswith("UPDATE tenants SET clerk_org_id"):
+            raise RuntimeError("injected failure between the delete and the update")
+        return real_execute(self, query, params, **kwargs)
+
+    monkeypatch.setattr(psycopg.Cursor, "execute", exploding)
+    with pytest.raises(RuntimeError, match="injected failure"):
+        _adopter(keys).run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+    monkeypatch.undo()
+
+    assert _exists(conn, incumbent), "the DELETE must have rolled back with the transaction"
+    assert _org(conn, incumbent) == org, "the org must still point where it did"
+    assert _org(conn, target) is None
+    assert keys.deleted == [], "no key material may be destroyed by a rolled-back adoption"
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM usage_limits WHERE tenant_id = %s", (incumbent,))
+        assert cur.fetchone()[0] == 1, "the cascade must have rolled back too"
+
+
+def test_running_it_twice_against_postgres_is_safe(conn: psycopg.Connection) -> None:
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    adopter = _adopter()
+
+    first = adopter.run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+    second = adopter.run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+
+    assert first.applied is True
+    assert second.already_adopted is True and second.applied is False
+    assert _org(conn, target) == org
+
+
+def test_a_populated_incumbent_refuses(conn: psycopg.Connection) -> None:
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO feature_tags (tenant_id, tag, description) VALUES (%s, 'x', 'y')",
+            (incumbent,),
+        )
+
+    with pytest.raises(AdoptError, match="feature_tags=1"):
+        _adopter().run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+
+    assert _exists(conn, incumbent)
+    assert _org(conn, target) is None
+
+
+def test_rows_in_an_unlinked_table_refuse(conn: psycopg.Connection) -> None:
+    """No FK carries these away, so a delete would orphan them. Counted, and blocking."""
+    org = f"org_{uuid.uuid4().hex}"
+    target = _make_tenant(conn, org=None, ref="local://hmac/target/v1")
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO scheduler_runs (tenant_id, job_name, status) "
+            "VALUES (%s, 'stitcher', 'failed')",
+            (incumbent,),
+        )
+    try:
+        with pytest.raises(AdoptError, match="scheduler_runs=1"):
+            _adopter().run(clerk_org_id=org, target_tenant_id=target, confirm=True)
+        assert _exists(conn, incumbent)
+    finally:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM scheduler_runs WHERE tenant_id = %s", (incumbent,))
+
+
+def test_missing_target_refuses_against_postgres(conn: psycopg.Connection) -> None:
+    org = f"org_{uuid.uuid4().hex}"
+    incumbent = _make_tenant(conn, org=org, ref="local://hmac/incumbent/v1")
+
+    with pytest.raises(AdoptError, match="no tenant"):
+        _adopter().run(clerk_org_id=org, target_tenant_id=str(uuid.uuid4()), confirm=True)
+
+    assert _exists(conn, incumbent), "a bad target must not cost the incumbent its life"
+    assert _org(conn, incumbent) == org


### PR DESCRIPTION
Builds the tool specced in `docs/nova-demo-tenant.md`. Needed before the demo corpus can appear under a real Clerk organization in production.

## The problem, reproduced

Attaching a Clerk org to a tenant that already holds a corpus looks like one UPDATE, and locally it is, because Clerk cannot reach `localhost` so `organization.created` never fires and nothing claims the org id. In production it fires within seconds, `tenant_provisioning` INSERTs a fresh empty tenant that claims the org id, and the UPDATE dies:

```
ERROR:  duplicate key value violates unique constraint "uq_tenants_clerk_org_id"
DETAIL:  Key (clerk_org_id)=(org_cli_demo_001) already exists.
```

That is a real run against the live stack, after provisioning through the real endpoint to reproduce the race. Recovering by hand means a cascading DELETE followed by an UPDATE, in order, against production Postgres, where the DELETE is one typo away from the corpus itself.

## A command, not an endpoint

`CLAUDE.md`'s "control-plane writes go through gateway endpoints" governs the request path: the web app must never open Postgres itself. Operator maintenance already has a different established shape here, `gateway/seed.py`, and this follows it.

Moving `clerk_org_id` between tenants is a tenant-takeover primitive. An endpoint for it would let anyone holding the control-plane service token, which the web app holds, point their own Clerk org at any customer's data. Shell access to the gateway task is the right privilege level for something run once under supervision.

## The invariants it holds

- **One transaction.** The DELETE and the UPDATE commit together or not at all. An org pointing nowhere is worse than an adoption that changed nothing.
- **The census reads the live catalog** (`pg_constraint`, `information_schema`) rather than a hardcoded table list, so a migration that adds a per-tenant table cannot leave the tool silently checking a stale one. It found **39** per-tenant tables, not the "roughly thirty" a manual count had estimated.
- **An unreadable count is not a zero count.** A telemetry count it cannot read is reported as unknown and REFUSES the adoption. Verified by running it against a misconfigured ClickHouse: it refused and wrote nothing.
- **Dry run by default.** Nothing is written without `--confirm`.
- **The target's HMAC key is never touched**, since every account and user hash in its corpus was computed under it. The discarded tenant's key set is deleted after commit, and only because the census proved nothing was ever hashed under it.

## Verified against the live stack

A full CLI run reproducing the production race, on throwaway tenants:

```
  census         : 39 per-tenant tables examined, 1 non-empty
                   usage_limits: 1 row(s), cascades on delete
  clickhouse     : 0 spans under the incumbent
  result         : ADOPTED, committed
                   deleted tenant 400543a9-...
                   target hash_salt_kek_ref unchanged: local://cli-demo
                   discarded HMAC key deleted: local://hmac/59cc563f-.../v1
```

`by-clerk-org` then returned the corpus tenant with a 200, and a second run reported `ALREADY ADOPTED, nothing written` and exited 0.

**Tests: 1058 passed / 18 skipped**, ruff clean. That includes **10 Postgres integration tests run against a real database**, which assert the three things a fake cannot: that the DELETE really cascades, that `uq_tenants_clerk_org_id` really is what defeats the hand-written UPDATE, and that an injected failure between the DELETE and the UPDATE leaves the incumbent alive and the org where it was.

The stack was left as found: 2 tenants, span counts 512,081 / 600,000 / 430,915 unchanged, no test residue.

## Note on provenance

The bulk of this was written by an agent that stalled during final verification. I reviewed the implementation, fixed one lint error (an unused variable in a rollback test), ran the full suite and the Postgres integration tests, and did the live end-to-end CLI run it never reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)