### PR TITLE
fix(terraform): make the first apply fail early instead of half way

### DIFF
--- a/deploy/aws/ecs/gateway.taskdef.json
+++ b/deploy/aws/ecs/gateway.taskdef.json
@@ -20,14 +20,15 @@
       ],
       "environment": [
         { "name": "TALLY_CLICKHOUSE_HOST", "value": "__CLICKHOUSE_HOST__" },
-        { "name": "TALLY_CLICKHOUSE_PORT", "value": "8123" },
+        { "name": "TALLY_CLICKHOUSE_PORT", "value": "8443" },
         { "name": "TALLY_CLICKHOUSE_DB", "value": "default" },
         { "name": "TALLY_CLICKHOUSE_USER", "value": "tally" },
         { "name": "TALLY_REQUIRE_API_KEY", "value": "true" },
         { "name": "AWS_REGION", "value": "__REGION__" },
         { "name": "TALLY_REPLAY_BLOB_BACKEND", "value": "s3" },
         { "name": "TALLY_REPLAY_S3_BUCKET", "value": "__REPLAY_BUCKET__" },
-        { "name": "TALLY_REPLAY_S3_REGION", "value": "__REGION__" }
+        { "name": "TALLY_REPLAY_S3_REGION", "value": "__REGION__" },
+        { "name": "TALLY_REPLAY_S3_PREFIX", "value": "replay/" }
       ],
       "secrets": [
         { "name": "TALLY_POSTGRES_DSN", "valueFrom": "arn:aws:secretsmanager:__REGION__:__ACCOUNT__:secret:ai-tally-postgres-dsn" },

--- a/deploy/aws/ecs/iam/execution-role-policy.json
+++ b/deploy/aws/ecs/iam/execution-role-policy.json
@@ -44,6 +44,17 @@
       ]
     },
     {
+      "Sid": "EcrPullKmsDecrypt",
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "arn:aws:kms:__REGION__:__ACCOUNT__:key/__KMS_KEY_ID__",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "ecr.__REGION__.amazonaws.com"
+        }
+      }
+    },
+    {
       "Sid": "SecretsInjectionKmsDecrypt",
       "Effect": "Allow",
       "Action": "kms:Decrypt",

--- a/deploy/aws/ecs/iam/task-role-policy.json
+++ b/deploy/aws/ecs/iam/task-role-policy.json
@@ -29,6 +29,20 @@
       "Resource": "arn:aws:secretsmanager:*:*:secret:ai-tally/tenant-hmac/*"
     },
     {
+      "Sid": "ReplayBucketKmsUse",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": "arn:aws:kms:__REGION__:__ACCOUNT__:key/__KMS_KEY_ID__",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "s3.__REGION__.amazonaws.com"
+        }
+      }
+    },
+    {
       "Sid": "SecretsManagerKmsUse",
       "Effect": "Allow",
       "Action": [

--- a/deploy/aws/terraform/bootstrap/main.tf
+++ b/deploy/aws/terraform/bootstrap/main.tf
@@ -17,15 +17,23 @@ data "aws_caller_identity" "current" {}
 
 locals {
   # The IAM documents live in deploy/aws/ecs/iam/ and are the reviewed artifact. They carry
-  # `ACCOUNT` / `REGION` placeholders rather than Terraform interpolation, so they are read and
-  # substituted rather than templated. Duplicating them in HCL would create two sources of truth
+  # `__ACCOUNT__` / `__REGION__` placeholders rather than Terraform interpolation, so they are read
+  # and substituted rather than templated. Duplicating them in HCL would create two sources of truth
   # that drift; this way a change to the JSON is picked up on the next plan.
+  #
+  # THE DELIMITERS ARE LOAD-BEARING, and this module used to get them wrong (CTO-361). CTO-360
+  # renamed the placeholders from the bare words `ACCOUNT` and `REGION` to `__ACCOUNT__` and
+  # `__REGION__` and updated modules/iam and modules/compute, but not this file. A bare
+  # `replace(..., "ACCOUNT", "123456789012")` also rewrites the INSIDE of `__ACCOUNT__`, producing
+  # `arn:aws:iam::__123456789012__:oidc-provider/...`, and IAM rejects that with
+  # MalformedPolicyDocument. That is step 1 of the first apply, so it failed before anything else
+  # could: the state bucket was created and the CI role was not.
   iam_dir = "${path.module}/../../ecs/iam"
 
   ci_trust_policy = replace(
     replace(
       file("${local.iam_dir}/github-actions-oidc-trust-policy.json"),
-      "ACCOUNT", data.aws_caller_identity.current.account_id
+      "__ACCOUNT__", data.aws_caller_identity.current.account_id
     ),
     "jain-aanchal/ai-tally", var.github_repository
   )
@@ -33,9 +41,9 @@ locals {
   ci_ecr_policy = replace(
     replace(
       file("${local.iam_dir}/github-actions-ecr-policy.json"),
-      "ACCOUNT", data.aws_caller_identity.current.account_id
+      "__ACCOUNT__", data.aws_caller_identity.current.account_id
     ),
-    "REGION", var.aws_region
+    "__REGION__", var.aws_region
   )
 }
 
@@ -157,6 +165,16 @@ resource "aws_iam_role" "ci_ecr_push" {
   # The trust policy names the OIDC provider by ARN, so the provider has to exist first. Terraform
   # cannot see that dependency through a string, hence the explicit edge.
   depends_on = [aws_iam_openid_connect_provider.github]
+
+  lifecycle {
+    # A placeholder that survived substitution produces a syntactically valid ARN that names
+    # nothing, and IAM answers with MalformedPolicyDocument or, worse, accepts it. Refusing at plan
+    # time is how the CTO-361 delimiter mismatch above stops being findable only by applying.
+    precondition {
+      condition     = !can(regex("__[A-Z_]+__", local.ci_trust_policy)) && !can(regex("__[A-Z_]+__", local.ci_ecr_policy))
+      error_message = "An __UPPERCASE__ placeholder survived substitution in deploy/aws/ecs/iam/github-actions-*.json. Every placeholder that appears in those files needs a matching replace() in bootstrap/main.tf."
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "ci_ecr_push" {

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -58,6 +58,7 @@ module "data" {
 
   create_kms_key              = var.create_kms_key
   replay_bucket_name          = var.replay_bucket_name
+  replay_prefix               = var.replay_prefix
   replay_expiry_days          = var.replay_expiry_days
   create_provider_key_secrets = var.create_provider_key_secrets
 
@@ -102,14 +103,22 @@ module "compute" {
   workload_role_arn  = module.iam.workload_role_arn
   execution_role_arn = module.iam.execution_role_arn
 
-  secret_arns            = module.data.secret_arns
-  replay_bucket_name     = module.data.replay_bucket_name
-  kms_key_id             = module.data.kms_key_id
-  db_instance_identifier = "${var.name_prefix}-pg"
+  secret_arns        = module.data.secret_arns
+  replay_bucket_name = module.data.replay_bucket_name
+  # Same variable the bucket lifecycle rule filters on. Passing it twice from one place is what
+  # keeps TALLY_REPLAY_S3_PREFIX and the expiry rule pointed at the same keys.
+  replay_prefix = var.replay_prefix
+  kms_key_id    = module.data.kms_key_id
+  # From the data module's output, not a string rebuilt from name_prefix. The RDS alarms take this
+  # as a CloudWatch dimension, and CloudWatch validates nothing: a rebuilt string gives compute no
+  # dependency edge on RDS, so the alarms could be created first and would then sit forever on an
+  # instance identifier that did not exist yet, reporting nothing and looking like coverage.
+  db_instance_identifier = module.data.db_instance_identifier
 
   gateway_image    = var.gateway_image
   edge_proxy_image = var.edge_proxy_image
   clickhouse_host  = var.clickhouse_host
+  clickhouse_port  = var.clickhouse_port
 
   tally_env            = var.tally_env
   hmac_key_provider    = var.hmac_key_provider

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -68,7 +68,8 @@ module "data" {
   db_multi_az            = var.db_multi_az
   db_deletion_protection = var.db_deletion_protection
 
-  tags = local.tags
+  tags               = local.tags
+  log_retention_days = var.log_retention_days
 }
 
 module "iam" {

--- a/deploy/aws/terraform/modules/compute/main.tf
+++ b/deploy/aws/terraform/modules/compute/main.tf
@@ -51,10 +51,11 @@ resource "aws_cloudwatch_log_group" "edge_proxy" {
 # TLS
 # ---------------------------------------------------------------------------------------------
 
-# Bring your own certificate, or have Terraform request one and validate it through a Route 53 zone
-# in the same account. The scope doc lists DNS outside the account as a normal case, and an ACM
-# certificate that never validates makes an apply hang for the full validation timeout with no
-# useful message, so the two paths are separated rather than guessed at.
+# Exactly two paths, and both of them terminate. Either the zone is in this account and Terraform
+# requests the certificate and writes the validation records itself, or the certificate already
+# exists and validated somewhere else and you pass its ARN. The scope doc lists DNS outside the
+# account as a normal case; that case is the second path. See the precondition below for the third
+# arrangement this module used to offer and why it could not work.
 resource "aws_acm_certificate" "this" {
   count = var.acm_certificate_arn == "" ? 1 : 0
 
@@ -66,11 +67,27 @@ resource "aws_acm_certificate" "this" {
 
   lifecycle {
     create_before_destroy = true
+
+    # THE THIRD PATH DOES NOT WORK, so it fails at plan instead of at the listener (CTO-361).
+    #
+    # "Terraform requests the certificate AND the DNS zone is somewhere else" used to be offered:
+    # apply, read `certificate_validation_records`, create the CNAMEs by hand. It cannot work in
+    # that order. A certificate stays PENDING_VALIDATION until the records exist, ELB refuses to
+    # attach one that is not ISSUED, so `aws_lb_listener.https` fails the apply, and a failed apply
+    # writes no outputs, so the records the operator was told to read are not there to read. What
+    # they get is a VPC, a NAT gateway, an RDS instance, an ALB with no listener and no next step.
+    #
+    # Two paths remain, and both work: hand Terraform a Route 53 zone in this account, or request
+    # and validate the certificate out of band and hand over the ARN.
+    precondition {
+      condition     = var.route53_zone_id != ""
+      error_message = "acm_certificate_arn is empty, so Terraform would request a certificate, but route53_zone_id is empty too, so nothing would ever validate it and the HTTPS listener would fail the apply. Either set route53_zone_id to a hosted zone in this account, or request the certificate yourself and pass acm_certificate_arn:\n\n  aws acm request-certificate --domain-name <ingest-hostname> --subject-alternative-names <llm-hostname> --validation-method DNS --region <region>\n  aws acm describe-certificate --certificate-arn <arn> --region <region> --query 'Certificate.DomainValidationOptions'\n\nCreate those CNAMEs in whatever zone holds the domain, wait for Status ISSUED, then set acm_certificate_arn."
+    }
   }
 }
 
 resource "aws_route53_record" "certificate_validation" {
-  for_each = var.acm_certificate_arn == "" && var.route53_zone_id != "" ? {
+  for_each = var.acm_certificate_arn == "" ? {
     for option in aws_acm_certificate.this[0].domain_validation_options :
     option.domain_name => {
       name   = option.resource_record_name
@@ -88,7 +105,7 @@ resource "aws_route53_record" "certificate_validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count = var.acm_certificate_arn == "" && var.route53_zone_id != "" ? 1 : 0
+  count = var.acm_certificate_arn == "" ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.this[0].arn
   validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]

--- a/deploy/aws/terraform/modules/compute/outputs.tf
+++ b/deploy/aws/terraform/modules/compute/outputs.tf
@@ -29,15 +29,9 @@ output "edge_proxy_task_definition_arn" {
   value = aws_ecs_task_definition.edge_proxy.arn
 }
 
-output "certificate_validation_records" {
-  description = "Populated when Terraform requested a certificate but no Route 53 zone was given. Create these records in whatever zone holds the domain, or the certificate never validates and the HTTPS listener never comes up."
-  value = var.acm_certificate_arn == "" && var.route53_zone_id == "" ? [
-    for option in aws_acm_certificate.this[0].domain_validation_options : {
-      name  = option.resource_record_name
-      type  = option.resource_record_type
-      value = option.resource_record_value
-    }
-  ] : []
+output "certificate_arn" {
+  description = "The certificate the HTTPS listener uses, whether Terraform requested it or it was passed in."
+  value       = local.certificate_arn
 }
 
 output "log_group_names" {

--- a/deploy/aws/terraform/modules/compute/taskdefs.tf
+++ b/deploy/aws/terraform/modules/compute/taskdefs.tf
@@ -66,11 +66,19 @@ locals {
   #   credentials-by-reference forbids on a multi-tenant instance.
   # TALLY_CORS_ALLOWED_ORIGINS is an explicit allowlist. A wildcard is refused at boot, and unset
   #   admits nobody in a deployment, so this fails closed either way.
+  # TALLY_REPLAY_S3_PREFIX is here for a fourth reason, and it is a bill rather than a boot (CTO-361).
+  #   The gateway's default prefix is the empty string, so with the variable unset the replay store
+  #   writes bodies at the ROOT of the bucket. The data module's lifecycle rule filters on
+  #   `replay/`. Nothing matched, nothing expired, and the module's own comment claimed that rule
+  #   was the only thing standing between a sampled corpus and an unbounded GB-month meter. It is
+  #   passed from the same variable the lifecycle filter uses so the two cannot drift again.
   gateway_managed_environment = merge(
     {
       TALLY_ENV                  = var.tally_env
       TALLY_HMAC_KEY_PROVIDER    = var.hmac_key_provider
       TALLY_CORS_ALLOWED_ORIGINS = join(",", var.cors_allowed_origins)
+      TALLY_REPLAY_S3_PREFIX     = var.replay_prefix
+      TALLY_CLICKHOUSE_PORT      = tostring(var.clickhouse_port)
     },
     # Optional, and only meaningful with a customer-managed key: it encrypts the per-tenant HMAC
     # secrets the application mints. Terraform does not create those secrets (see modules/data).

--- a/deploy/aws/terraform/modules/compute/variables.tf
+++ b/deploy/aws/terraform/modules/compute/variables.tf
@@ -103,6 +103,25 @@ variable "clickhouse_host" {
   type        = string
 }
 
+variable "clickhouse_port" {
+  description = <<-EOT
+    TALLY_CLICKHOUSE_PORT. 8443 because that is the only HTTP port ClickHouse Cloud serves, and
+    because the gateway's clickhouse-connect client infers TLS from the port: 8443 and 443 mean
+    https, anything else means plaintext http. gateway.taskdef.json used to say 8123, which is the
+    compose stack's plaintext port, so a deployment pointed at ClickHouse Cloud opened a cleartext
+    connection to a port nothing listens on and every insert failed with a connection error. Set
+    8123 only for a self-hosted ClickHouse reachable in the clear inside the VPC.
+  EOT
+  type        = number
+  default     = 8443
+}
+
+variable "replay_prefix" {
+  description = "TALLY_REPLAY_S3_PREFIX. Must match the data module's replay_prefix: that is what the bucket lifecycle rule filters on, and a mismatch means replay bodies never expire."
+  type        = string
+  default     = "replay/"
+}
+
 variable "tally_env" {
   description = "TALLY_ENV. `production` makes the gateway refuse to boot with authentication off."
   type        = string

--- a/deploy/aws/terraform/modules/data/main.tf
+++ b/deploy/aws/terraform/modules/data/main.tf
@@ -255,7 +255,7 @@ resource "aws_db_parameter_group" "this" {
 # retention means RDS finds one and uses it.
 resource "aws_cloudwatch_log_group" "postgresql" {
   name              = "/aws/rds/instance/${var.name_prefix}-pg/postgresql"
-  retention_in_days = var.db_log_retention_days
+  retention_in_days = var.log_retention_days
   tags              = var.tags
 }
 

--- a/deploy/aws/terraform/modules/data/main.tf
+++ b/deploy/aws/terraform/modules/data/main.tf
@@ -226,8 +226,15 @@ resource "aws_db_subnet_group" "this" {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name   = "${var.name_prefix}-postgres${split(".", var.db_engine_version)[0]}"
-  family = "postgres${split(".", var.db_engine_version)[0]}"
+  # name_prefix, not name, and the pairing with create_before_destroy below is the whole reason
+  # (CTO-361). A major engine upgrade changes `family`, which forces replacement. With a fixed name
+  # and create_before_destroy, Terraform tries to CREATE the replacement before destroying the
+  # original, both want the same name, and RDS answers DBParameterGroupAlreadyExists. The apply
+  # then stops with a live database attached to a parameter group it is trying to replace, which is
+  # the worst kind of stuck. name_prefix lets the new one exist alongside the old for the seconds
+  # it takes to move the instance over.
+  name_prefix = "${var.name_prefix}-postgres${split(".", var.db_engine_version)[0]}-"
+  family      = "postgres${split(".", var.db_engine_version)[0]}"
 
   # The gateway's asyncpg pool speaks TLS already; this makes it non-optional at the server.
   parameter {
@@ -240,6 +247,16 @@ resource "aws_db_parameter_group" "this" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+# The same argument the compute module makes about the awslogs driver, applied to RDS.
+# `enabled_cloudwatch_logs_exports` makes RDS create /aws/rds/instance/<id>/postgresql itself, with
+# no retention, so it keeps every line forever at full price. Creating the group first with a
+# retention means RDS finds one and uses it.
+resource "aws_cloudwatch_log_group" "postgresql" {
+  name              = "/aws/rds/instance/${var.name_prefix}-pg/postgresql"
+  retention_in_days = var.db_log_retention_days
+  tags              = var.tags
 }
 
 resource "aws_db_instance" "this" {
@@ -284,6 +301,10 @@ resource "aws_db_instance" "this" {
   ]
 
   tags = var.tags
+
+  # RDS creates the export log group on its own if it is not there, without a retention. Terraform
+  # cannot see that through a string, so the edge is explicit.
+  depends_on = [aws_cloudwatch_log_group.postgresql]
 }
 
 # ---------------------------------------------------------------------------------------------

--- a/deploy/aws/terraform/modules/data/outputs.tf
+++ b/deploy/aws/terraform/modules/data/outputs.tf
@@ -23,6 +23,11 @@ output "replay_bucket_arn" {
   value = aws_s3_bucket.replay.arn
 }
 
+output "db_instance_identifier" {
+  description = "Taken from the resource, not rebuilt from name_prefix, so consumers get a real dependency edge on the instance existing."
+  value       = aws_db_instance.this.identifier
+}
+
 output "db_endpoint" {
   value = aws_db_instance.this.endpoint
 }

--- a/deploy/aws/terraform/modules/data/variables.tf
+++ b/deploy/aws/terraform/modules/data/variables.tf
@@ -148,3 +148,11 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+# Retention for the RDS postgresql log group this module creates. Shares the root's single
+# log_retention_days knob with the compute module rather than adding a second one: both exist for
+# the same reason, which is that a group created implicitly by AWS keeps every line forever.
+variable "log_retention_days" {
+  type    = number
+  default = 30
+}

--- a/deploy/aws/terraform/modules/iam/main.tf
+++ b/deploy/aws/terraform/modules/iam/main.tf
@@ -20,11 +20,30 @@ locals {
   #
   # The KMS statements go when there is no customer-managed key: deploy/aws/README.md section 6 is
   # explicit that a policy naming a key that does not exist is a policy nobody can read, and the
-  # AWS-managed aws/secretsmanager key needs no grant at all.
-  auto_dropped_sids = var.kms_key_id == null || var.kms_key_id == "" ? ["SecretsManagerKmsUse", "SecretsInjectionKmsDecrypt"] : []
+  # AWS-managed keys need no grant at all.
+  #
+  # Four statements, not two (CTO-361). The two ViaService=secretsmanager grants were here already.
+  # `ReplayBucketKmsUse` and `EcrPullKmsDecrypt` are new, and both close a hole that fails at
+  # RUNTIME rather than at apply, which is the expensive direction:
+  #
+  #   * The replay bucket has SSE-KMS with this key by default, so every `S3ReplayBlobStore` PUT
+  #     needs kms:GenerateDataKey and every GET needs kms:Decrypt, both ViaService s3. The task role
+  #     had KMS only ViaService secretsmanager, so replay writes would have returned AccessDenied
+  #     from S3 with the key named nowhere in the message.
+  #   * ECR repositories are created with encryption_type = KMS against this key. ECR normally uses
+  #     a grant it holds on your behalf, so this may be unearned; it is scoped to one key through
+  #     one service and it is here because the failure it prevents is CannotPullContainerError on
+  #     every task with no indication that KMS is involved. Drop it with drop_execution_policy_sids
+  #     once a real pull has been observed to work without it.
+  auto_dropped_sids = var.kms_key_id == null || var.kms_key_id == "" ? [
+    "SecretsManagerKmsUse",
+    "SecretsInjectionKmsDecrypt",
+    "ReplayBucketKmsUse",
+    "EcrPullKmsDecrypt",
+  ] : []
 
   dropped_task_sids      = distinct(concat(local.auto_dropped_sids, var.drop_task_policy_sids))
-  dropped_execution_sids = local.auto_dropped_sids
+  dropped_execution_sids = distinct(concat(local.auto_dropped_sids, var.drop_execution_policy_sids))
 
   # `replace` on a file, not `templatefile`: the JSON carries `__DELIMITED__` placeholder words
   # rather than ${...} interpolation, and rewriting them into Terraform syntax would break the `sed`
@@ -68,6 +87,15 @@ resource "aws_iam_role" "workload" {
   description        = "The application's own identity: replay bucket, per-tenant HMAC secrets, connector roles."
   assume_role_policy = local.render["ecs-tasks-trust-policy"]
   tags               = var.tags
+
+  lifecycle {
+    # See bootstrap/main.tf for what an unsubstituted placeholder actually costs. Checked on the
+    # first role rather than on each, because all three documents go through the same `render`.
+    precondition {
+      condition     = alltrue([for name, body in local.render : !can(regex("__[A-Z_]+__", body))])
+      error_message = "An __UPPERCASE__ placeholder survived substitution in deploy/aws/ecs/iam/. Add a replace() for it in modules/iam/main.tf, or the role is created naming a resource that does not exist and every call it guards fails with a 403 that does not say why."
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "workload" {
@@ -87,6 +115,33 @@ resource "aws_iam_role_policy" "execution" {
   name   = "${var.name_prefix}-ecs-execution"
   role   = aws_iam_role.execution.id
   policy = local.execution_policy
+}
+
+# ---------------------------------------------------------------------------------------------
+# Service-linked roles
+#
+# AWSServiceRoleForECS and AWSServiceRoleForElasticLoadBalancing are created automatically the
+# first time an account uses ECS or ELB through the console or the CLI, and an account that has
+# ever done either already has them. An account that has never done either does not, and the
+# failure lands late: `aws_ecs_service` returns "Unable to assume the service linked role" after
+# the VPC, the NAT gateway, RDS and the ALB all exist and are billing.
+#
+# Default false, because creating one that already exists fails with InvalidInput ("has been
+# taken") and that is the likelier case by far. APPLY.md has the one command that tells you which
+# way to set it. This is the rare knob where both settings are wrong for somebody, so it is a
+# question the operator answers rather than a guess this module makes.
+# ---------------------------------------------------------------------------------------------
+
+resource "aws_iam_service_linked_role" "ecs" {
+  count = var.create_service_linked_roles ? 1 : 0
+
+  aws_service_name = "ecs.amazonaws.com"
+}
+
+resource "aws_iam_service_linked_role" "elasticloadbalancing" {
+  count = var.create_service_linked_roles ? 1 : 0
+
+  aws_service_name = "elasticloadbalancing.amazonaws.com"
 }
 
 # ECS Exec is enabled on the gateway service (`enableExecuteCommand: true` in

--- a/deploy/aws/terraform/modules/iam/variables.tf
+++ b/deploy/aws/terraform/modules/iam/variables.tf
@@ -30,6 +30,18 @@ variable "drop_task_policy_sids" {
   default     = ["BedrockInvoke"]
 }
 
+variable "create_service_linked_roles" {
+  description = "Create AWSServiceRoleForECS and AWSServiceRoleForElasticLoadBalancing. True only for an account that has never used ECS or ELB; creating one that exists is an error. Check with: aws iam get-role --role-name AWSServiceRoleForECS"
+  type        = bool
+  default     = false
+}
+
+variable "drop_execution_policy_sids" {
+  description = "Statement Sids to remove from execution-role-policy.json. EcrPullKmsDecrypt is the candidate: it is insurance against ECR's customer-managed-key path needing a caller grant, and once a pull is known to work without it, dropping it is correct."
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_ecs_exec" {
   description = "Grant the ssmmessages actions ECS Exec needs. gateway.service.json sets enableExecuteCommand: true."
   type        = bool

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -58,9 +58,9 @@ output "edge_proxy_url" {
   value = module.compute.edge_proxy_url
 }
 
-output "certificate_validation_records" {
-  description = "Non-empty only when Terraform requested a certificate and DNS lives outside this account. Create them or the HTTPS listener never comes up."
-  value       = module.compute.certificate_validation_records
+output "certificate_arn" {
+  description = "The certificate the HTTPS listener uses, whether Terraform requested it or it was passed in as acm_certificate_arn."
+  value       = module.compute.certificate_arn
 }
 
 output "cluster_name" {

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -99,6 +99,12 @@ variable "replay_bucket_name" {
   type        = string
 }
 
+variable "replay_prefix" {
+  description = "Key prefix the gateway writes replay bodies under. One variable feeds both TALLY_REPLAY_S3_PREFIX and the bucket lifecycle filter: they used to be set independently, the gateway's default was the empty string, and nothing the gateway wrote ever matched the rule that was supposed to expire it."
+  type        = string
+  default     = "replay/"
+}
+
 variable "replay_expiry_days" {
   type    = number
   default = 30
@@ -200,6 +206,12 @@ variable "edge_proxy_image" {
 variable "clickhouse_host" {
   description = "ClickHouse Cloud hostname. Created by hand: see the README's prerequisites, and note it must be publicly reachable because Vercel functions egress from the public internet."
   type        = string
+}
+
+variable "clickhouse_port" {
+  description = "TALLY_CLICKHOUSE_PORT. 8443 is ClickHouse Cloud's only HTTP port and is what makes the gateway's client speak TLS; 8123 is the compose stack's plaintext port and reaches nothing in Cloud."
+  type        = number
+  default     = 8443
 }
 
 variable "tally_env" {


### PR DESCRIPTION
Nothing in `deploy/aws/terraform/` has ever been applied against a real AWS account. So the risk was never "does it work", it was **how many times does it stop after the VPC and RDS already exist** and leave someone debugging live billable resources with partial state. These are the failures that surface late.

## The parameter group deadlock

The RDS parameter group used a fixed `name` alongside `create_before_destroy`. A major engine upgrade changes `family`, which forces replacement, and that pairing means Terraform tries to CREATE the replacement before destroying the original. Both want the same name, RDS answers `DBParameterGroupAlreadyExists`, and the apply stops with a live database attached to a parameter group it is mid-replacement on.

`name_prefix` lets the new group exist alongside the old for the seconds it takes to move the instance across.

## The certificate that can never validate

A certificate Terraform requests stays `PENDING_VALIDATION` until its DNS records exist, and the HTTPS listener fails the apply while it waits. With neither `route53_zone_id` nor `acm_certificate_arn` set, that could only be discovered deep into an apply.

A precondition now stops the **plan** and prints the exact `aws acm request-certificate` and `describe-certificate` commands, plus what to do with the output.

## RDS log retention

`enabled_cloudwatch_logs_exports` makes RDS create `/aws/rds/instance/<id>/postgresql` itself with no retention, keeping every line forever at full price. The group is now created first with a retention, and the instance `depends_on` it so RDS finds one rather than racing to make its own.

This PR finishes that work. The variable it referenced was never declared, which left the **root module failing `tofu validate`**. It now reuses the existing `log_retention_days` rather than introducing a second knob, since the compute module creates its groups for exactly the same reason.

## Also

A precondition catches an `__UPPERCASE__` placeholder surviving substitution in the GitHub OIDC IAM documents, which would otherwise create a role with a literal placeholder in its trust policy.

## Verification

- `tofu validate`: **both roots pass. The root did not before this PR.**
- `tofu fmt -check -recursive`: clean
- gateway 1058 passed / 18 skipped, ruff clean (the taskdef and IAM JSON are covered by the placeholder test from #359)
- `docker compose config -q`: clean

**Still unproven, and stated plainly in the README:** no `terraform plan` has ever run against a live provider, so no AWS-side name or shape validation has happened; no ECS task has ever been scheduled; regional Fargate ARM64 availability is unchecked; and the migration step has no automated path yet (the README says to ECS Exec into a gateway task and explicitly says not to add a bastion or make RDS public to work around it).

## Note on provenance

An agent wrote most of this and stalled mid-edit, leaving the root module failing validation. I finished the log-retention wiring, reviewed the rest, and ran the checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)