### PR TITLE
fix(web): stop fixtures reaching a real tenant, empty or unavailable

### DIFF
--- a/deploy/vercel/README.md
+++ b/deploy/vercel/README.md
@@ -58,7 +58,8 @@ The dashboard's Route Handlers run on the Node.js runtime and read two backing s
 
 Add these under **Project Settings → Environment Variables**. Set them for **Production** and
 **Preview** (and **Development** if you use `vercel dev`). Every default below is the app's built-in
-fallback — the dashboard boots without any of them (it just renders the mock/`—` state, see §4).
+fallback: the dashboard boots without any of them, and says on every page that it could not read the
+stores rather than painting a number (see §4).
 
 **Backing-store config (server-side, never exposed to the browser):**
 
@@ -123,8 +124,10 @@ a token that differs between the two 401s every control-plane call and reaches a
 a broken dashboard with nothing naming the cause.
 
 It needs no AWS credentials and never prints a secret value; secrets are compared and reported by
-SHA-256 prefix and length. It exits non-zero and says what to fix. Read §4 below before dismissing
-the ClickHouse URL check: an unreachable ClickHouse does not error, it paints mock data.
+SHA-256 prefix and length. It exits non-zero and says what to fix. Do not dismiss the ClickHouse URL
+check: an unreachable ClickHouse does not error, it renders a dashboard that says it has no answer
+(§4). That is honest, and it is also useless to a customer, so the check is the thing that catches
+it before they do.
 
 ## 3. Deploy
 
@@ -151,24 +154,40 @@ backing stores must be reachable from Vercel:
 - Provisioning those stores is **out of scope** (see the [GCP](../gcp/README.md) deploy).
 
 **Fail-soft (no crash when unreachable).** The dashboard is designed to render cleanly even when the
-stores can't be reached — this is intentional, not a bug:
+stores can't be reached. What it renders is a statement that it could not read them, never a figure:
 
 - Every ClickHouse query goes through `tryLive()` in `web/lib/clickhouse.ts`, which catches any error
-  (connection refused, timeout, DNS) and returns `null`. The Route Handlers then fall back to the
-  typed mock in `web/lib/mock.ts` (`live ?? mock`), and honest-null fields render as `—` in the UI.
-- Every gateway helper (reconciliation / integrations / guardrails / replay) does the same: a 2s
-  timeout, non-2xx, or unreachable host returns `null`, and the route falls back to its static mock.
+  (connection refused, timeout, DNS) and returns `null`. Each Route Handler classifies that with
+  `readState()` (`web/lib/dataState.ts`) as **unavailable**, and the page renders "Source
+  unavailable" with the reason. Honest-null fields still render as `—`.
+- A read that SUCCEEDS and finds nothing is a different answer: **empty**, which the page renders as
+  "No … yet" pointing at `/onboarding`. This is the normal state of a workspace that has not sent
+  its first span, and it is a fact the product knows, not an outage.
+- Every gateway helper (reconciliation / integrations / guardrails / replay) makes the same
+  distinction: a 2s timeout, non-2xx, or unreachable host is unavailable; an empty, well-formed
+  answer is empty.
 
-So a fresh Vercel deploy with **no env vars set** still boots and paints the whole dashboard against
-mock data — nothing throws, no page 500s. As you wire real, reachable env values in §2, the pages
-switch to live data. This is the same fail-soft path exercised by `web/`'s test suite and by a fresh
-`npm run dev`, so "stores unreachable from Vercel" degrades to the exact mock/`—` state by design.
+So a fresh Vercel deploy with **no env vars set** still boots, and no page 500s. It does not paint
+numbers. Until #364, an unreachable store was answered with `web/lib/mock.ts` on nine paths across
+six routes, which was a reasonable demo affordance for an unconfigured deploy and precisely the wrong
+answer once a real customer signed in: a workspace with zero spans was shown a `research_agent` it
+had never run, paying back in 7 days, as its own data.
+
+**The fixtures still exist, and they are now unreachable on the product path.** `sampleDataAllowed()`
+in `web/lib/mock.ts` serves them only when BOTH `NEXT_PUBLIC_DEMO_MODE=1` and `TALLY_DEV_TENANT` are
+set. The second is the dev escape hatch, and it is the only way the dashboard serves a tenant with no
+Clerk organization resolved (`web/lib/getTenant.ts`), so "a real tenant is signed in" and "fixtures
+render" are mutually exclusive by construction. A production build refuses to boot on that hatch
+alone (CTO-268, `web/instrumentation.ts`), which closes it a second time. Where fixtures do render
+they stay behind the SAMPLE DATA banner. The synthetic-data demo kit in `deploy/demo/` is the
+supported way to show a populated dashboard with no real stores behind it.
 
 ## 5. Preview deploys
 
 Every pull request gets an automatic **Preview Deployment** at a unique URL. Previews use the
-**Preview**-scoped Environment Variables from §2 — point them at a **staging** ClickHouse/gateway (or
-leave them unset to preview against mock data). Never point Preview at production credentials.
+**Preview**-scoped Environment Variables from §2: point them at a **staging** ClickHouse/gateway.
+Leaving them unset previews the "source unavailable" state, not a populated dashboard; for that, use
+the `deploy/demo/` kit. Never point Preview at production credentials.
 `web/vercel.json` sets `git.deploymentEnabled.main = true`; PR previews remain on by default.
 
 ---
@@ -179,6 +198,6 @@ leave them unset to preview against mock data). Never point Preview at productio
 - [ ] Project imported, **Root Directory = `web/`**.
 - [ ] Node.js Version = **22.x** (Project Settings).
 - [ ] Env vars set for Production + Preview; ClickHouse password marked **Sensitive**.
-- [ ] `TALLY_CLICKHOUSE_URL` / `TALLY_GATEWAY_URL` point at **publicly reachable** HTTPS endpoints
-      (or left unset to run on mock data).
-- [ ] Deploy is green; pages render (live where reachable, `—`/mock otherwise).
+- [ ] `TALLY_CLICKHOUSE_URL` / `TALLY_GATEWAY_URL` point at **publicly reachable** HTTPS endpoints.
+      Unset is not a demo mode: every page will say the source is unavailable.
+- [ ] Deploy is green; pages render (live where reachable, "Source unavailable" / `—` otherwise).

--- a/web/app/Live.states.test.tsx
+++ b/web/app/Live.states.test.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// #364, the render half. `three-states.test.ts` pins what each route ANSWERS; this pins what Home
+// DRAWS for each of those answers, because the bug was never in the query: the ClickHouse read was
+// already returning an honest null, and the page turned it into somebody else's ROI table.
+//
+// The three assertions that matter are the same on every surface:
+//   unavailable -> no figure, and the copy does not claim there is no data.
+//   empty       -> no figure, and the copy DOES say nothing has arrived (a real answer).
+//   live        -> the tenant's own figures, and no fixture anywhere near them.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HomeLive, type HomePayload } from "./Live";
+import type { ForecastPayload } from "@/lib/burndown";
+import { LAYERS } from "@/lib/cost";
+import { mockRoi } from "@/lib/mock";
+import type { SourceState } from "@/lib/dataState";
+import type { SpendByLayer, SpendSummary } from "@/lib/types";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/lib/useLivePoll", () => ({
+  useLivePoll: (_endpoint: string, initial: unknown) => ({ data: initial, updatedAt: new Date() }),
+}));
+
+function zeroLayers(): SpendByLayer {
+  const out = {} as SpendByLayer;
+  for (const l of LAYERS) out[l] = 0;
+  return out;
+}
+
+// The forecast is read separately from /api/cost/budget and carries its own honest-unavailable
+// reason, so it is orthogonal to what is under test here. Pin it to "no section, and here is why".
+const FORECAST: ForecastPayload = {
+  section: null,
+  unavailable: "the telemetry store could not be read",
+};
+
+function payload(sources: Partial<Record<keyof HomePayload["sources"], SourceState>>, spend: SpendSummary | null, roi: HomePayload["roi"] = []): HomePayload {
+  return {
+    spend,
+    roi,
+    perProviderConversion: [],
+    sources: { spend: "live", roi: "live", dq: "live", attribution: "live", ...sources },
+  };
+}
+
+function renderHome(data: HomePayload) {
+  return render(
+    <HomeLive initialData={data} enabledLayers={LAYERS} forecast={FORECAST} priorMonthMicroUsd={null} />,
+  );
+}
+
+describe("Home renders the source state it was given (#364)", () => {
+  it("says the source could not be read, and does not claim there is no data", () => {
+    renderHome(payload({ spend: "unavailable" }, null));
+
+    expect(screen.getByText(/Source unavailable/i)).toBeTruthy();
+    expect(screen.getByText(/This is not a statement that there is no data/i)).toBeTruthy();
+    // The page keeps its identity, and prints no money at all.
+    expect(screen.getByText("Home")).toBeTruthy();
+    expect(screen.queryByText(/\$/)).toBeNull();
+  });
+
+  it("says nothing has arrived yet when the read succeeded over zero spans", () => {
+    renderHome(payload({ spend: "empty" }, { ...EMPTY_SPEND }));
+
+    expect(screen.getByText(/No AI spend yet/i)).toBeTruthy();
+    expect(screen.getByText(/This is what we measured, not a placeholder/i)).toBeTruthy();
+    // Not the unavailable copy: an empty read is an answer, not an unknown.
+    expect(screen.queryByText(/Source unavailable/i)).toBeNull();
+    // And emphatically not a confident $0.00 headline next to a fabricated ROI table.
+    expect(screen.queryByText("$0.00")).toBeNull();
+    expect(screen.queryByText("research_agent")).toBeNull();
+    // Home defers the setup link to SetupCallout, which sits directly above it on the page.
+    expect(screen.queryByRole("link", { name: /Finish setup/i })).toBeNull();
+  });
+
+  it("draws the tenant's own figures when the rows are real", () => {
+    renderHome(
+      payload({}, { ...EMPTY_SPEND, totalMicroUsd: 12_340_000, spanCount: 99, reconciledThrough: "1970-01-01" }, [
+        { feature: "checkout_helper", costPerUserMicroUsd: 1_000, valuePerUserMicroUsd: null, paybackDays: null, attributionRate: null },
+      ]),
+    );
+
+    expect(screen.getByText("$12.34")).toBeTruthy();
+    expect(screen.getByText("checkout_helper")).toBeTruthy();
+    expect(screen.queryByText(/Source unavailable/i)).toBeNull();
+    expect(screen.queryByText(/No AI spend yet/i)).toBeNull();
+    // No SAMPLE DATA wrapper on a live read: that banner is now reachable only from `sample`.
+    expect(screen.queryByText(/SAMPLE DATA/i)).toBeNull();
+  });
+
+  it("labels fixtures as sample data on the one path that may still serve them", () => {
+    renderHome(
+      payload(
+        { spend: "sample", roi: "sample" },
+        { ...EMPTY_SPEND, totalMicroUsd: 52_400_000_000, spanCount: 1 },
+        mockRoi,
+      ),
+    );
+
+    // The label is necessary and was never sufficient: what makes this safe is that
+    // `sampleDataAllowed()` cannot be true while a Clerk organization is resolved.
+    expect(screen.getByText(/SAMPLE DATA/i)).toBeTruthy();
+    expect(screen.getByText("research_agent")).toBeTruthy();
+  });
+});
+
+const EMPTY_SPEND: SpendSummary = {
+  totalMicroUsd: 0,
+  estimatedMicroUsd: 0,
+  reconciledMicroUsd: 0,
+  reconciledThrough: "1970-01-01",
+  byLayer: zeroLayers(),
+  unpricedSpanCount: 0,
+  spanCount: 0,
+};

--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -237,6 +237,14 @@ export function HomeLive({
       <MonthlyForecastCard forecast={forecast} priorMonthMicroUsd={priorMonthMicroUsd} />
 
       <Card title="ROI snapshot">
+        {/* #364 review: an unreadable ROI source rendered as an empty table with no header row
+            explaining itself, which reads as "no features have ROI" rather than "we could not
+            look". Say which it is before drawing the table. */}
+        {sources.roi === "unavailable" && (
+          <p className="mb-2 text-sm text-muted">
+            ROI could not be read, so this is unknown rather than empty.
+          </p>
+        )}
         <table className="w-full text-sm">
           <thead className="text-xs uppercase text-muted">
             <tr>
@@ -274,7 +282,15 @@ export function HomeLive({
       </Card>
 
       <Card title="Per-provider · conversion">
-        {perProviderConversion.length === 0 ? (
+        {/* #364 review: an empty array and a read that failed are different facts, and asserting
+            "no sessions yet" over an unreadable source is the same collapse this change removes
+            from the API. `sources.attribution` is what separates them. */}
+        {sources.attribution === "unavailable" ? (
+          <p className="text-sm text-muted">
+            Conversion data could not be read, so this is unknown rather than empty. It is not a
+            statement that no sessions exist.
+          </p>
+        ) : perProviderConversion.length === 0 ? (
           <p className="text-sm text-muted">
             No sessions yet: drive traffic to populate (link out from{" "}
             <a className="text-good underline" href="/attribution">

--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -61,7 +61,7 @@ import { useLivePoll } from "@/lib/useLivePoll";
 
 export interface HomePayload {
   /**
-   * null when the telemetry source could not be read (#363). A zero-filled summary is what an
+   * null when the telemetry source could not be read (#364). A zero-filled summary is what an
    * empty tenant's window genuinely aggregates to, so the object's shape cannot carry "we do not
    * know"; `sources.spend` is what separates unknown from empty from real.
    */
@@ -178,7 +178,7 @@ export function HomeLive({
     { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 },
   );
   const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
-  // #363: `isEmpty` is gone from this derivation. Emptiness is now decided by the READ, above, and
+  // #364: `isEmpty` is gone from this derivation. Emptiness is now decided by the READ, above, and
   // an all-zero window is no longer evidence for it: a tenant whose spend genuinely rounds to zero
   // across every layer is not the same tenant as one that has sent nothing, and only the span count
   // tells them apart. What is left here is staleness and partial connector coverage.
@@ -341,7 +341,7 @@ export function HomeLive({
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
-      {/* #363: the SAMPLE DATA wrapper is now reachable ONLY from `sources.spend === "sample"`,
+      {/* #364: the SAMPLE DATA wrapper is now reachable ONLY from `sources.spend === "sample"`,
           which `sampleDataAllowed()` grants to a demo build with no Clerk organization behind it.
           It used to wrap the empty state, which is how fixture figures reached real tenants: the
           label was there, and it still said research_agent pays back in 7 days to a customer who

--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -128,7 +128,7 @@ export function HomeLive({
     />
   );
 
-  // #363. Three states, three answers, and the first two never render a figure.
+  // #364. Three states, three answers, and the first two never render a figure.
   //
   //   unavailable - the read failed. We do not know this tenant's spend, so nothing is claimed.
   //   empty       - the read succeeded over zero spans. We DO know: nothing has arrived. The zeros
@@ -150,9 +150,14 @@ export function HomeLive({
     return (
       <div className="space-y-6">
         {header()}
+        {/* `onboarding={false}` because SetupCallout (#358) sits directly above this on Home and
+            already carries the setup link off the first-event probe, which is a better signal than
+            an empty window: it knows whether a span has EVER landed, not just within the range.
+            Two "Finish setup" buttons in one viewport read as a broken page, not a clearer one. */}
         <NoDataYet
           what="AI spend"
           detail={`No spans have been received for this workspace in the last ${windowDays} days.`}
+          onboarding={false}
         />
       </div>
     );
@@ -165,7 +170,6 @@ export function HomeLive({
     s.byLayer.vector + s.byLayer.tools + s.byLayer.compute + s.byLayer.embeddings + s.byLayer.egress;
   const hiddenPct = s.totalMicroUsd === 0 ? 0 : Math.round((hidden / s.totalMicroUsd) * 100);
 
-  const layers: Record<string, number> = { ...s.byLayer };
   const layerTotals = LAYERS.reduce<Record<Layer, number>>(
     (acc, l) => {
       acc[l] = s.byLayer[l];

--- a/web/app/Live.tsx
+++ b/web/app/Live.tsx
@@ -27,10 +27,13 @@
 "use client";
 
 import Link from "next/link";
+import type { ReactNode } from "react";
 
 import { Card } from "@/components/Card";
 import {
+  NoDataYet,
   PartialDataBanner,
+  SourceUnavailable,
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
@@ -43,7 +46,13 @@ import { isDemoMode } from "@/lib/demoMode";
 import type { ProviderAttribution } from "@/lib/attribution";
 import type { BurndownSection, ForecastPayload } from "@/lib/burndown";
 import { LAYERS, type Layer } from "@/lib/cost";
-import { allZero, asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
+import {
+  asOfLabel,
+  deriveDataState,
+  relativeAge,
+  type SourceState,
+  zeroEnabledLayers,
+} from "@/lib/dataState";
 import { rangeDays } from "@/lib/filters";
 import type { FeatureRoi, SpendSummary } from "@/lib/types";
 import { formatUSD, type MicroUSD } from "@/lib/types";
@@ -51,10 +60,19 @@ import { useFilters } from "@/lib/useFilters";
 import { useLivePoll } from "@/lib/useLivePoll";
 
 export interface HomePayload {
-  spend: SpendSummary;
+  /**
+   * null when the telemetry source could not be read (#363). A zero-filled summary is what an
+   * empty tenant's window genuinely aggregates to, so the object's shape cannot carry "we do not
+   * know"; `sources.spend` is what separates unknown from empty from real.
+   */
+  spend: SpendSummary | null;
   roi: FeatureRoi[];
   perProviderConversion: ProviderAttribution[];
+  sources: { spend: SourceState; roi: SourceState; dq: SourceState; attribution: SourceState };
 }
+
+const SPEND_UNAVAILABLE =
+  "The telemetry store could not be read for this workspace.";
 
 export function HomeLive({
   initialData,
@@ -77,7 +95,7 @@ export function HomeLive({
   const windowDays = rangeDays(filterState.range);
   const endpoint = queryString ? `/api/home?${queryString}` : "/api/home";
   const { data, updatedAt } = useLivePoll<HomePayload>(endpoint, initialData);
-  const { spend: s, roi, perProviderConversion } = data;
+  const { spend, roi, perProviderConversion, sources } = data;
 
   const featureFilter = filterState.filters.feature;
   const providerFilter = filterState.filters.provider;
@@ -91,6 +109,55 @@ export function HomeLive({
     providerFilter.length > 0
       ? perProviderConversion.filter((p) => providerFilter.includes(p.provider))
       : perProviderConversion;
+
+  // One header for all four states: the page keeps its title, live indicator and filter bar whether
+  // or not there are figures under it. `badge` is the freshness badge, which only a real read earns.
+  const header = (badge?: ReactNode) => (
+    <PageHeader
+      title="Home"
+      subtitle={isDemoMode() ? undefined : "What your AI costs, and whether it pays for itself"}
+      actions={
+        <>
+          <LiveIndicator updatedAt={updatedAt} />
+          {badge}
+        </>
+      }
+      toolbar={
+        <FilterBar options={{ feature: featureOptions, provider: providerOptions }} hideGroupBy />
+      }
+    />
+  );
+
+  // #363. Three states, three answers, and the first two never render a figure.
+  //
+  //   unavailable - the read failed. We do not know this tenant's spend, so nothing is claimed.
+  //   empty       - the read succeeded over zero spans. We DO know: nothing has arrived. The zeros
+  //                 the aggregate produces are the absence of data, not a measurement of it, and a
+  //                 confident "$0.00 spend, 0% hidden cost" next to somebody else's ROI table is
+  //                 how a customer who has run nothing was told research_agent pays back in 7 days.
+  //
+  // The FilterBar comes off the payload's own rows, so it is empty in both cases and the header
+  // still renders: the page keeps its identity and its navigation while stating what it lacks.
+  if (spend === null || sources.spend === "unavailable") {
+    return (
+      <div className="space-y-6">
+        {header()}
+        <SourceUnavailable reason={SPEND_UNAVAILABLE} />
+      </div>
+    );
+  }
+  if (sources.spend === "empty") {
+    return (
+      <div className="space-y-6">
+        {header()}
+        <NoDataYet
+          what="AI spend"
+          detail={`No spans have been received for this workspace in the last ${windowDays} days.`}
+        />
+      </div>
+    );
+  }
+  const s = spend;
 
   // Hidden cost is every non-LLM layer: the "all-in" story the tile makes explicit. The percentage
   // and its zero-when-empty behaviour are carried over verbatim (CTO-222 keeps the meaning as-is).
@@ -107,8 +174,12 @@ export function HomeLive({
     { llm: 0, vector: 0, tools: 0, compute: 0, embeddings: 0, egress: 0 },
   );
   const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
+  // #363: `isEmpty` is gone from this derivation. Emptiness is now decided by the READ, above, and
+  // an all-zero window is no longer evidence for it: a tenant whose spend genuinely rounds to zero
+  // across every layer is not the same tenant as one that has sent nothing, and only the span count
+  // tells them apart. What is left here is staleness and partial connector coverage.
   const state = deriveDataState({
-    isEmpty: s.totalMicroUsd === 0 && allZero(layers),
+    isEmpty: false,
     isPartial: trippedLayers.length > 0,
     reconciledThrough: s.reconciledThrough,
   });
@@ -254,32 +325,24 @@ export function HomeLive({
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        title="Home"
-        subtitle={isDemoMode() ? undefined : "What your AI costs, and whether it pays for itself"}
-        actions={
-          <>
-            <LiveIndicator updatedAt={updatedAt} />
-            {state !== "empty" && asOf && (
-              <StaleBadge
-                asOf={asOf}
-                age={relativeAge(s.reconciledThrough)}
-                stale={state === "stale"}
-              />
-            )}
-          </>
-        }
-        toolbar={
-          <FilterBar
-            options={{ feature: featureOptions, provider: providerOptions }}
-            hideGroupBy
+      {header(
+        asOf ? (
+          <StaleBadge
+            asOf={asOf}
+            age={relativeAge(s.reconciledThrough)}
+            stale={state === "stale"}
           />
-        }
-      />
+        ) : undefined,
+      )}
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
-      {state === "empty" ? (
+      {/* #363: the SAMPLE DATA wrapper is now reachable ONLY from `sources.spend === "sample"`,
+          which `sampleDataAllowed()` grants to a demo build with no Clerk organization behind it.
+          It used to wrap the empty state, which is how fixture figures reached real tenants: the
+          label was there, and it still said research_agent pays back in 7 days to a customer who
+          has never run one. */}
+      {sources.spend === "sample" ? (
         <SyntheticPreviewBanner workflow="Home">{body}</SyntheticPreviewBanner>
       ) : (
         body

--- a/web/app/agents/Live.tsx
+++ b/web/app/agents/Live.tsx
@@ -23,7 +23,9 @@ import { Suspense } from "react";
 
 import { Card } from "@/components/Card";
 import {
+  NoDataYet,
   PartialDataBanner,
+  SourceUnavailable,
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
@@ -40,6 +42,7 @@ import {
   boundaryFromMinutesAgo,
   deriveDataState,
   relativeAge,
+  type SourceState,
 } from "@/lib/dataState";
 import { formatUSD, type MicroUSD } from "@/lib/types";
 import { useFilters } from "@/lib/useFilters";
@@ -76,6 +79,7 @@ export interface AgentsPayload {
   // Real reconciler last-run in minutes (CTO-169), or null when the reconciler has never run /
   // the source is unavailable, rendered as `—` (no freshness badge) rather than a fake number.
   reconcilerLastRunMinutesAgo: number | null;
+  sources: { agents: SourceState; runs: SourceState };
 }
 
 /** Max of a money field, or null when there is nothing to reduce (honest blank, never 0). */
@@ -102,14 +106,15 @@ export function AgentsLive({
   const { queryString } = useFilters();
   const endpoint = queryString ? `/api/agents?${queryString}` : "/api/agents";
   const { data, updatedAt } = useLivePoll<AgentsPayload>(endpoint, initialData);
-  const { agents, runs, reconcilerLastRunMinutesAgo } = data;
+  const { agents, runs, reconcilerLastRunMinutesAgo, sources } = data;
 
   const reconciledThrough = boundaryFromMinutesAgo(reconcilerLastRunMinutesAgo);
-  const noAgents = agents.length === 0 || agents.every((a) => a.costPerDayMicroUsd === 0);
   const someEmptyAgents =
     agents.some((a) => a.runsPerDay === 0) && agents.some((a) => a.runsPerDay > 0);
+  // #363: emptiness comes from the READ, not from "every agent costs zero per day". An agent roster
+  // that genuinely rounds to zero is not the same fact as a roster nobody has populated yet.
   const state = deriveDataState({
-    isEmpty: noAgents,
+    isEmpty: false,
     isPartial: someEmptyAgents,
     reconciledThrough,
   });
@@ -260,7 +265,7 @@ export function AgentsLive({
         actions={
           <>
             <LiveIndicator updatedAt={updatedAt} />
-            {state !== "empty" && asOf && (
+            {asOf && (
               <StaleBadge asOf={asOf} age={relativeAge(reconciledThrough)} stale={state === "stale"} />
             )}
           </>
@@ -278,7 +283,15 @@ export function AgentsLive({
 
       {state === "partial" && <PartialDataBanner missing="telemetry for some agents" />}
 
-      {state === "empty" ? (
+      {/* #363: unavailable, empty and sample are three answers, and only the last renders figures. */}
+      {sources.agents === "unavailable" ? (
+        <SourceUnavailable reason="The telemetry store could not be read for this workspace." />
+      ) : sources.agents === "empty" ? (
+        <NoDataYet
+          what="agent runs"
+          detail="No agent spans have been recorded for this workspace."
+        />
+      ) : sources.agents === "sample" ? (
         <SyntheticPreviewBanner workflow="Agents">{body}</SyntheticPreviewBanner>
       ) : (
         body

--- a/web/app/agents/Live.tsx
+++ b/web/app/agents/Live.tsx
@@ -111,7 +111,7 @@ export function AgentsLive({
   const reconciledThrough = boundaryFromMinutesAgo(reconcilerLastRunMinutesAgo);
   const someEmptyAgents =
     agents.some((a) => a.runsPerDay === 0) && agents.some((a) => a.runsPerDay > 0);
-  // #363: emptiness comes from the READ, not from "every agent costs zero per day". An agent roster
+  // #364: emptiness comes from the READ, not from "every agent costs zero per day". An agent roster
   // that genuinely rounds to zero is not the same fact as a roster nobody has populated yet.
   const state = deriveDataState({
     isEmpty: false,
@@ -283,7 +283,7 @@ export function AgentsLive({
 
       {state === "partial" && <PartialDataBanner missing="telemetry for some agents" />}
 
-      {/* #363: unavailable, empty and sample are three answers, and only the last renders figures. */}
+      {/* #364: unavailable, empty and sample are three answers, and only the last renders figures. */}
       {sources.agents === "unavailable" ? (
         <SourceUnavailable reason="The telemetry store could not be read for this workspace." />
       ) : sources.agents === "empty" ? (

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -8,7 +8,7 @@ import { parseFilters, rangeDays } from "@/lib/filters";
 import { sampleDataAllowed } from "@/lib/mock";
 
 // Read live data per request (never statically cached). A read that fails says so; it is not
-// answered with fixture numbers (#363).
+// answered with fixture numbers (#364).
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
@@ -40,7 +40,7 @@ export async function GET(req: Request) {
     queryReconcilerLastRun(),
   ]);
 
-  // #363: the fixture roster is a demo build's, and only a demo build's. It used to fill in for
+  // #364: the fixture roster is a demo build's, and only a demo build's. It used to fill in for
   // BOTH an unreachable ClickHouse and a tenant with no agents yet, which meant a new customer's
   // Cost explorer listed agents they have never run. The old `hasFilter` guard only ever covered
   // the filtered views; the unfiltered one, which is the one every new tenant lands on, was the

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,40 +1,66 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
-import { agents, runs } from "@/lib/agents";
+import { type AgentRun, type AgentSummary, agents, runs } from "@/lib/agents";
 import { queryAgents, queryReconcilerLastRun } from "@/lib/clickhouse";
+import { type SourceState, readState } from "@/lib/dataState";
 import { parseFilters, rangeDays } from "@/lib/filters";
+import { sampleDataAllowed } from "@/lib/mock";
 
-// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+// Read live data per request (never statically cached). A read that fails says so; it is not
+// answered with fixture numbers (#363).
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export interface AgentsResponse {
+  agents: AgentSummary[];
+  runs: AgentRun[];
+  reconcilerLastRunMinutesAgo: number | null;
+  sources: { agents: SourceState; runs: SourceState };
+}
+
 export async function GET(req: Request) {
   // Optional URL filters (CTO-104): /api/agents?tag=aider-demo&run=<trace>. Empty values pass
-  // through and the SQL clause is dropped. When a filter is set and live data is unavailable,
-  // return empty rather than the unfiltered mock (which would mislead the demo).
+  // through and the SQL clause is dropped.
   // Use the standard URL API rather than NextRequest.nextUrl so unit tests can pass plain Request.
   const { searchParams } = new URL(req.url);
   const tag = searchParams.get("tag") ?? "";
   const run = searchParams.get("run") ?? "";
   // ?agent=<ServiceName> (CTO-241): the unified Cost explorer requests one agent's detail when
-  // group-by=agent is narrowed to a single agent. Like ?tag=/?run=, a set filter with no live data
-  // returns empty rather than the unfiltered mock, so the inline detail never fabricates numbers.
+  // group-by=agent is narrowed to a single agent.
   const agent = searchParams.get("agent") ?? "";
-  const hasFilter = Boolean(tag || run || agent);
   // The time-range selector drives the windowed cost/day average (CTO-226): resolve the URL-synced
   // filter state to a day count the ClickHouse-derived window clamps and interpolates.
   const windowDays = rangeDays(parseFilters(searchParams).range);
   // Read agents telemetry and the reconciler's real last-run in parallel. The freshness signal is
   // the real reconciliation_runs value (CTO-169), or null when the reconciler has never run / the
-  // gateway is unavailable, which the page renders as `—` rather than a fabricated constant.
+  // gateway is unavailable, which the page renders as a blank rather than a fabricated constant.
   const [live, reconcilerLastRunMinutesAgo] = await Promise.all([
     queryAgents({ tag, run, agent }, windowDays),
     queryReconcilerLastRun(),
   ]);
+
+  // #363: the fixture roster is a demo build's, and only a demo build's. It used to fill in for
+  // BOTH an unreachable ClickHouse and a tenant with no agents yet, which meant a new customer's
+  // Cost explorer listed agents they have never run. The old `hasFilter` guard only ever covered
+  // the filtered views; the unfiltered one, which is the one every new tenant lands on, was the
+  // hole. Fixtures are never filter-scoped either, so they stay out of a filtered view regardless.
+  if (sampleDataAllowed() && !tag && !run && !agent) {
+    return NextResponse.json({
+      agents,
+      runs,
+      reconcilerLastRunMinutesAgo,
+      sources: { agents: "sample", runs: "sample" },
+    } satisfies AgentsResponse);
+  }
+
   return NextResponse.json({
-    agents: live && live.agents.length > 0 ? live.agents : hasFilter ? [] : agents,
-    runs: live && live.runs.length > 0 ? live.runs : hasFilter ? [] : runs,
+    agents: live?.agents ?? [],
+    runs: live?.runs ?? [],
     reconcilerLastRunMinutesAgo,
-  });
+    sources: {
+      agents: readState(live, (l) => l.agents.length === 0),
+      runs: readState(live, (l) => l.runs.length === 0),
+    },
+  } satisfies AgentsResponse);
 }

--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { mockSpend } from "@/lib/mock";
 import { GET as HomeGET } from "./home/route";
 import { GET as AgentsGET } from "./agents/route";
 import { GET as RunGET } from "./agents/runs/[runId]/route";
@@ -21,26 +22,57 @@ async function json<T = unknown>(res: Response): Promise<T> {
   return (await res.json()) as T;
 }
 
+/**
+ * The pinned test tenant (vitest.config.ts) has no telemetry, so every read below answers either
+ * `empty` (a stack is up and told us there is nothing) or `unavailable` (no stack to ask). Which one
+ * depends on whether the developer running the suite has `make up` going, and CLAUDE.md requires the
+ * suite to pass either way, so these smoke tests assert what is true in BOTH: no rows, no figures,
+ * and a state that is not `live` and not `sample`.
+ *
+ * The point of #364 is that those two states are now distinguishable, and each is pinned
+ * deterministically over a mocked ClickHouse in `three-states.test.ts`.
+ */
+function expectNoData(state: string) {
+  expect(["empty", "unavailable"]).toContain(state);
+}
+
 describe("api routes", () => {
+  // #364: these used to assert that rows WERE present, because each route substituted fixtures
+  // whenever the live read came back null or empty. That substitution is the bug: the same branch a
+  // fresh checkout hit is the branch a real signed-in tenant with no spans hit, and it answered them
+  // with another company's numbers. The routes now report the state instead.
   it("GET /api/home returns spend, ROI and data-quality", async () => {
     // CTO-227 dropped the cost-outliers card from Home (replaced by the month-end forecast, which is
     // served by /api/cost/budget), so /api/home no longer carries an `outliers` array.
-    const body = await json<{ spend: unknown; roi: unknown[]; dq: unknown }>(
+    const body = await json<{
+      spend: unknown;
+      roi: unknown[];
+      dq: unknown;
+      sources: Record<string, string>;
+    }>(
       // CTO-226: /api/home reads the time-range window from the request URL; the default (no range
       // param) preserves the historical 30-day view this smoke test asserts.
       await HomeGET(new Request("http://test/api/home")),
     );
-    expect(body.spend).toBeDefined();
     expect(Array.isArray(body.roi)).toBe(true);
-    expect(body.dq).toBeDefined();
+    expectNoData(body.sources.spend);
+    expectNoData(body.sources.roi);
+    // Never mockSpend's $52,400, and never mockRoi's research_agent paying back in 7 days.
+    expect(body.spend).not.toEqual(mockSpend);
+    expect(body.roi).toEqual([]);
   });
 
   it("GET /api/agents returns agents + runs + real-or-null reconciler freshness (CTO-169)", async () => {
-    const body = await json<{ agents: unknown[]; runs: unknown[]; reconcilerLastRunMinutesAgo: number | null }>(
-      await AgentsGET(new Request("http://test/api/agents") as never),
-    );
-    expect(body.agents.length).toBeGreaterThan(0);
-    expect(body.runs.length).toBeGreaterThan(0);
+    const body = await json<{
+      agents: unknown[];
+      runs: unknown[];
+      reconcilerLastRunMinutesAgo: number | null;
+      sources: { agents: string; runs: string };
+    }>(await AgentsGET(new Request("http://test/api/agents") as never));
+    expectNoData(body.sources.agents);
+    expectNoData(body.sources.runs);
+    expect(body.agents).toEqual([]);
+    expect(body.runs).toEqual([]);
     // No reconciler gateway runs in CI, so the route applies honest-null (renders `—`) rather than
     // the old hardcoded constant (23). Real value or null, never a fabricated number.
     expect(body.reconcilerLastRunMinutesAgo === null || typeof body.reconcilerLastRunMinutesAgo === "number").toBe(true);
@@ -82,17 +114,32 @@ describe("api routes", () => {
   });
 
   it("GET /api/cost returns series + featureRows + alerts", async () => {
-    const body = await json<{ series: unknown; featureRows: unknown[]; alerts: unknown[] }>(
-      await CostGET(new Request("http://test/api/cost") as never),
-    );
-    expect(body.series).toBeDefined();
-    expect(body.featureRows.length).toBeGreaterThan(0);
+    const body = await json<{
+      series: unknown;
+      featureRows: unknown[];
+      alerts: unknown[];
+      sources: { series: string; featureRows: string; alerts: string };
+    }>(await CostGET(new Request("http://test/api/cost") as never));
+    expectNoData(body.sources.series);
+    expectNoData(body.sources.featureRows);
+    expectNoData(body.sources.alerts);
+    // No canned feature table and no canned hidden-cost alerts, in either state.
+    expect(body.featureRows).toEqual([]);
+    expect(body.alerts).toEqual([]);
   });
 
   it("GET /api/features returns features + diagnostics", async () => {
-    const body = await json<{ features: unknown[]; diagnostics: unknown }>(await FeaturesGET());
-    expect(body.features.length).toBeGreaterThan(0);
-    expect(body.diagnostics).toBeDefined();
+    const body = await json<{
+      features: unknown[];
+      diagnostics: unknown;
+      sources: { features: string; diagnostics: string };
+    }>(await FeaturesGET());
+    expectNoData(body.sources.features);
+    expect(body.features).toEqual([]);
+    // No reconciler run behind the suite, so diagnostics are null rather than the fixture's 180
+    // late events and 4.2h median lag.
+    expectNoData(body.sources.diagnostics);
+    expect(body.diagnostics).toBeNull();
   });
 
   it("GET /api/data-quality returns a report", async () => {
@@ -155,23 +202,25 @@ describe("api routes", () => {
     expect(body.configRefreshSeconds).toBeGreaterThan(0);
   });
 
-  it("GET /api/attribution falls back to mock when ClickHouse is unreachable", async () => {
+  it("GET /api/attribution says the source is unavailable rather than serving the mock report", async () => {
     const body = await json<{
       isMock: boolean;
+      state: string;
       perProvider: { provider: string }[];
+      totals: { sessions: number };
       filters: { tag: string | null; outcome: string | null };
     }>(
       await AttributionGET(
         new Request("http://test/api/attribution?tag=chatbot-demo&outcome=positive_feedback"),
       ),
     );
-    // CI / fresh-clone: gateway isn't running, so the route falls back to the
-    // mock report. Real `make chatbot-demo` runs go through queryAttribution.
-    expect(body.isMock).toBe(true);
-    expect(body.perProvider.map((p) => p.provider).sort()).toEqual([
-      "anthropic",
-      "openai",
-    ]);
+    // #364: this used to be answered with the fixture's 5,300 sessions across openai + anthropic.
+    // That same branch is what a real tenant with no sessions hit, so it is gone: the state says
+    // which of the two no-data answers this is, and no provider row is invented for either.
+    expectNoData(body.state);
+    expect(body.isMock).toBe(false);
+    expect(body.perProvider).toEqual([]);
+    // The filters still echo, so the page can caption what it was asked for even with no answer.
     expect(body.filters.tag).toBe("chatbot-demo");
     expect(body.filters.outcome).toBe("positive_feedback");
   });

--- a/web/app/api/attribution/route.ts
+++ b/web/app/api/attribution/route.ts
@@ -16,6 +16,8 @@ import {
   parseFilters,
 } from "@/lib/attribution";
 import { queryAttribution } from "@/lib/clickhouse";
+import { type SourceState, readState } from "@/lib/dataState";
+import { sampleDataAllowed } from "@/lib/mock";
 // The design-foundation FilterBar (CTO-221) writes range/from/to and a `feature` multi-select into
 // the same query string. Reading it here (CTO-223) lets the time range and feature filter drive the
 // live attribution report, while the attribution-specific tag/provider/outcome params keep working.
@@ -32,11 +34,29 @@ export async function GET(req: Request): Promise<NextResponse> {
     windowDays: rangeDays(dashboard.range),
     features: dashboard.filters.feature,
   });
-  // Fall back to the mock report when the query failed (null) OR when there's
-  // no chatbot-demo data yet (live but empty). Mirrors the pattern used by
-  // /api/agents and /api/cost — and keeps the demo's attribution view useful
-  // before the user runs `make chatbot-demo` for the first time.
+  // #363: the mock report used to answer BOTH "the query failed" and "the query ran and this
+  // tenant has no sessions yet". The second is every tenant before its first trace, and it was
+  // being shown 5,300 sessions and two providers in production as its own attribution. The demo's
+  // pre-`make chatbot-demo` convenience is preserved where it belongs, behind an explicit demo
+  // build with no real tenant resolved.
+  if (sampleDataAllowed()) {
+    const sample = mockReport(filters);
+    return NextResponse.json({ ...sample, state: "sample" } satisfies AttributionResponse);
+  }
+  const state = readState(live, (r) => r.perProvider.length === 0);
+  // An empty report is the real, correct shape for a tenant with no sessions: no providers, no
+  // totals to divide, an empty daily series. It is built here rather than by nulling fields on the
+  // live report so `perProvider.length === 0` stays the single thing the page tests.
   const report: AttributionReport =
-    live && live.perProvider.length > 0 ? live : mockReport(filters);
-  return NextResponse.json(report);
+    live ?? {
+      filters,
+      perProvider: [],
+      totals: { sessions: 0, conversions: 0, costMicroUsd: 0, costPerConversionMicroUsd: null },
+      dailyByProvider: [],
+      isMock: false,
+    };
+  return NextResponse.json({ ...report, state } satisfies AttributionResponse);
 }
+
+/** The report plus which of the four states produced it. See lib/dataState.ts. */
+export type AttributionResponse = AttributionReport & { state: SourceState };

--- a/web/app/api/attribution/route.ts
+++ b/web/app/api/attribution/route.ts
@@ -34,7 +34,7 @@ export async function GET(req: Request): Promise<NextResponse> {
     windowDays: rangeDays(dashboard.range),
     features: dashboard.filters.feature,
   });
-  // #363: the mock report used to answer BOTH "the query failed" and "the query ran and this
+  // #364: the mock report used to answer BOTH "the query failed" and "the query ran and this
   // tenant has no sessions yet". The second is every tenant before its first trace, and it was
   // being shown 5,300 sessions and two providers in production as its own attribution. The demo's
   // pre-`make chatbot-demo` convenience is preserved where it belongs, behind an explicit demo

--- a/web/app/api/connectors/route.ts
+++ b/web/app/api/connectors/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
   // the UI render them as "Not connected" (no rows → no fabricated stats).
   const integrationsLive = integrations !== null && integrations.length > 0;
 
-  // #363: `activity ?? mockActivity` put 4,120 LLM-proxy records and 86 Stripe records with May
+  // #364: `activity ?? mockActivity` put 4,120 LLM-proxy records and 86 Stripe records with May
   // timestamps on a tenant that has connected nothing, and did it on the page whose entire job is
   // to tell you what you have connected. A source we cannot read is reported as unreadable; a
   // source with no records is reported as not connected. Neither is a reason to invent records.

--- a/web/app/api/connectors/route.ts
+++ b/web/app/api/connectors/route.ts
@@ -7,32 +7,52 @@ import {
   queryIntegrationStatus,
 } from "@/lib/clickhouse";
 import { CONNECTORS, applyActivity, mockActivity } from "@/lib/connectors";
+import { type SourceState, readState } from "@/lib/dataState";
+import { sampleDataAllowed } from "@/lib/mock";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+/** No observed activity at all: every catalog row renders as "Not connected", which is the truth. */
+const NO_ACTIVITY = { records: {}, lastAt: {} } as const;
 
 export async function GET() {
   const [activity, integrations] = await Promise.all([
     queryConnectorActivity(),
     queryIntegrationStatus(),
   ]);
-  const live = activity !== null;
   // CTO-117: prefer real per-tenant third-party integration status from the gateway. When the
   // gateway is unreachable OR a tenant has no rows yet, we still emit the catalog cards and let
-  // the UI render them as "Not connected" (no rows → no fabricated stats). The legacy
-  // mockActivity remains the cost/revenue source-of-activity fallback below.
+  // the UI render them as "Not connected" (no rows → no fabricated stats).
   const integrationsLive = integrations !== null && integrations.length > 0;
-  const baseActivity = activity ?? mockActivity;
-  const connectors = applyActivity(CONNECTORS, baseActivity);
+
+  // #363: `activity ?? mockActivity` put 4,120 LLM-proxy records and 86 Stripe records with May
+  // timestamps on a tenant that has connected nothing, and did it on the page whose entire job is
+  // to tell you what you have connected. A source we cannot read is reported as unreadable; a
+  // source with no records is reported as not connected. Neither is a reason to invent records.
+  const sample = sampleDataAllowed();
+  const state: SourceState = sample
+    ? "sample"
+    : readState(activity, (a) => Object.keys(a.records).length === 0);
+  const connectors = applyActivity(
+    CONNECTORS,
+    sample ? mockActivity : (activity ?? NO_ACTIVITY),
+  );
   return NextResponse.json({
     connectors,
-    live,
+    // `live` is kept for the existing consumers and now means exactly what it says: real observed
+    // activity was read. `activity` carries the state those consumers need to tell empty from down.
+    live: state === "live",
+    activity: state,
     integrations: integrations ?? [],
     integrationsLive,
+    integrationsState: readState(integrations, (i) => i.length === 0),
   } satisfies {
     connectors: ReturnType<typeof applyActivity>;
     live: boolean;
+    activity: SourceState;
     integrations: IntegrationStatusRow[];
     integrationsLive: boolean;
+    integrationsState: SourceState;
   });
 }

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -67,7 +67,10 @@ export async function GET(req: Request) {
   // else. They used to answer BOTH "ClickHouse is down" and "this tenant has no spend yet", and the
   // second is every new customer. The ?tag= guard that used to be the only protection here is gone
   // because it is no longer the thing standing between a real tenant and fixture numbers.
-  if (sampleDataAllowed()) {
+  // #364 review: fixtures are never filter-scoped, so answering a FILTERED request with the
+  // unfiltered canned series makes the filter look broken in a demo build. The agents route already
+  // guards this way and has a test for it; matching it keeps the two routes telling one story.
+  if (sampleDataAllowed() && !tag) {
     return NextResponse.json({
       series: costSeries,
       featureRows,

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -1,25 +1,58 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
-import { costSeries, featureRows, hiddenCostAlerts } from "@/lib/cost";
+import {
+  LAYERS,
+  type CostSeries,
+  type FeatureCostRow,
+  type HiddenCostAlert,
+  costSeries,
+  featureRows,
+  hiddenCostAlerts,
+} from "@/lib/cost";
 import {
   queryCostSeries,
   queryFeatureCostRows,
   queryHiddenCostAlerts,
 } from "@/lib/clickhouse";
+import { type SourceState, readState } from "@/lib/dataState";
 import { parseFilters, rangeDays } from "@/lib/filters";
+import { sampleDataAllowed } from "@/lib/mock";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+export interface CostSources {
+  series: SourceState;
+  featureRows: SourceState;
+  alerts: SourceState;
+}
+
+export interface CostResponse {
+  /** null when ClickHouse could not be read. `sources.series` distinguishes that from "no spend". */
+  series: CostSeries | null;
+  featureRows: FeatureCostRow[];
+  alerts: HiddenCostAlert[];
+  sources: CostSources;
+}
+
+/**
+ * A cost series is empty when every day in the window is zero across every layer (#363).
+ *
+ * The query always returns one point per calendar day, gaps filled with zero layers, so an empty
+ * tenant gets a full 30-point series of confident zeros rather than an empty array. The shape says
+ * nothing; the figures do.
+ */
+function seriesIsEmpty(s: CostSeries): boolean {
+  return s.days.every((d) => LAYERS.every((l) => d.byLayer[l] === 0));
+}
+
 export async function GET(req: Request) {
   // Optional ?tag=<feature> filter (CTO-104): narrows both the series and the feature-row table to
-  // a single feature tag. When the filter is set we never fall back to unfiltered mock; that would
-  // misrepresent the filtered view as real data.
+  // a single feature tag.
   // Use the standard URL API rather than NextRequest.nextUrl so unit tests can pass plain Request.
   const searchParams = new URL(req.url).searchParams;
   const tag = searchParams.get("tag") ?? "";
-  const hasFilter = Boolean(tag);
   // The time-range selector reshapes the headline tiles and the By-feature table (CTO-226): resolve
   // the URL-synced filter state to a day count the ClickHouse-derived window clamps and interpolates.
   // The interactive chart itself is served by /api/explore, so the chart contract is untouched.
@@ -29,14 +62,30 @@ export async function GET(req: Request) {
     queryFeatureCostRows({ tag }, windowDays),
     queryHiddenCostAlerts({ tag }),
   ]);
+
+  // #363: the canned series / feature rows / alerts are a demo build's fixtures now, and nothing
+  // else. They used to answer BOTH "ClickHouse is down" and "this tenant has no spend yet", and the
+  // second is every new customer. The ?tag= guard that used to be the only protection here is gone
+  // because it is no longer the thing standing between a real tenant and fixture numbers.
+  if (sampleDataAllowed()) {
+    return NextResponse.json({
+      series: costSeries,
+      featureRows,
+      alerts: hiddenCostAlerts,
+      sources: { series: "sample", featureRows: "sample", alerts: "sample" },
+    } satisfies CostResponse);
+  }
+
   return NextResponse.json({
-    series: series ?? costSeries,
-    featureRows: rows && rows.length > 0 ? rows : hasFilter ? [] : featureRows,
-    // Hidden-cost alerts now come from real detection over otel_spans (CTO-122). On the LIVE path
-    // we serve queryHiddenCostAlerts' result verbatim, including `[]` (honest-empty: nothing
-    // fired). The canned `hiddenCostAlerts` is served ONLY as the ClickHouse-unreachable fallback
-    // (query returns null → CI / fresh-clone still renders something), and never under a ?tag=
-    // filter (the canned set isn't tag-scoped, so it would misrepresent a filtered view).
-    alerts: alerts ?? (hasFilter ? [] : hiddenCostAlerts),
-  });
+    series,
+    featureRows: rows ?? [],
+    // Hidden-cost alerts come from real detection over otel_spans (CTO-122), and `[]` is an honest
+    // answer meaning nothing fired: distinct from the null the read returns when it could not run.
+    alerts: alerts ?? [],
+    sources: {
+      series: readState(series, seriesIsEmpty),
+      featureRows: readState(rows, (r) => r.length === 0),
+      alerts: readState(alerts, (a) => a.length === 0),
+    },
+  } satisfies CostResponse);
 }

--- a/web/app/api/cost/route.ts
+++ b/web/app/api/cost/route.ts
@@ -37,7 +37,7 @@ export interface CostResponse {
 }
 
 /**
- * A cost series is empty when every day in the window is zero across every layer (#363).
+ * A cost series is empty when every day in the window is zero across every layer (#364).
  *
  * The query always returns one point per calendar day, gaps filled with zero layers, so an empty
  * tenant gets a full 30-point series of confident zeros rather than an empty array. The shape says
@@ -63,7 +63,7 @@ export async function GET(req: Request) {
     queryHiddenCostAlerts({ tag }),
   ]);
 
-  // #363: the canned series / feature rows / alerts are a demo build's fixtures now, and nothing
+  // #364: the canned series / feature rows / alerts are a demo build's fixtures now, and nothing
   // else. They used to answer BOTH "ClickHouse is down" and "this tenant has no spend yet", and the
   // second is every new customer. The ?tag= guard that used to be the only protection here is gone
   // because it is no longer the thing standing between a real tenant and fixture numbers.

--- a/web/app/api/features/route.ts
+++ b/web/app/api/features/route.ts
@@ -1,16 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
-import { diagnostics, features } from "@/lib/features";
+import {
+  type AttributionDiagnostics,
+  type FeatureEconomics,
+  diagnostics,
+  features,
+} from "@/lib/features";
 import {
   queryAttributionDiagnostics,
   queryFeatureEconomics,
   queryFeatureValueEvents,
 } from "@/lib/clickhouse";
+import { type SourceState, readState } from "@/lib/dataState";
+import { sampleDataAllowed } from "@/lib/mock";
 
-// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+// Read live data per request (never statically cached). A read that fails says so; it is not
+// answered with fixture numbers (#363).
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+export interface FeaturesResponse {
+  features: FeatureEconomics[];
+  /** null when the diagnostics read failed. `sources.diagnostics` says which state this is. */
+  diagnostics: AttributionDiagnostics | null;
+  sources: { features: SourceState; diagnostics: SourceState };
+}
 
 export async function GET() {
   const [liveFeatures, liveDiagnostics, valueEvents] = await Promise.all([
@@ -18,15 +33,32 @@ export async function GET() {
     queryAttributionDiagnostics(),
     queryFeatureValueEvents(),
   ]);
-  const base = liveFeatures && liveFeatures.length > 0 ? liveFeatures : features;
+
   // Overlay the tenant's configured value events (CTO-140) so a just-configured feature reflects its
   // value event immediately, before attribution has produced economics for it.
   const configured = new Map((valueEvents ?? []).map((v) => [v.featureTag, v.eventName]));
-  const merged = base.map((f) =>
-    configured.has(f.feature) ? { ...f, valueEvent: configured.get(f.feature)! } : f,
-  );
+  const overlay = (rows: FeatureEconomics[]) =>
+    rows.map((f) => (configured.has(f.feature) ? { ...f, valueEvent: configured.get(f.feature)! } : f));
+
+  // #363: the fixture feature roster is a demo build's. It used to stand in whenever the live read
+  // came back empty, so a tenant with no features yet saw five priced features with margins as
+  // their own, on Home and in the Cost explorer's feature detail alike.
+  if (sampleDataAllowed()) {
+    return NextResponse.json({
+      features: overlay(features),
+      diagnostics,
+      sources: { features: "sample", diagnostics: "sample" },
+    } satisfies FeaturesResponse);
+  }
+
   return NextResponse.json({
-    features: merged,
-    diagnostics: liveDiagnostics ?? diagnostics,
-  });
+    features: overlay(liveFeatures ?? []),
+    // Already three-state at the source: the gateway distinguishes "no reconciler run for this
+    // tenant" from "the gateway could not be read", so this route does not have to guess.
+    diagnostics: liveDiagnostics.state === "live" ? liveDiagnostics.diagnostics : null,
+    sources: {
+      features: readState(liveFeatures, (f) => f.length === 0),
+      diagnostics: liveDiagnostics.state,
+    },
+  } satisfies FeaturesResponse);
 }

--- a/web/app/api/features/route.ts
+++ b/web/app/api/features/route.ts
@@ -16,7 +16,7 @@ import { type SourceState, readState } from "@/lib/dataState";
 import { sampleDataAllowed } from "@/lib/mock";
 
 // Read live data per request (never statically cached). A read that fails says so; it is not
-// answered with fixture numbers (#363).
+// answered with fixture numbers (#364).
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
@@ -40,7 +40,7 @@ export async function GET() {
   const overlay = (rows: FeatureEconomics[]) =>
     rows.map((f) => (configured.has(f.feature) ? { ...f, valueEvent: configured.get(f.feature)! } : f));
 
-  // #363: the fixture feature roster is a demo build's. It used to stand in whenever the live read
+  // #364: the fixture feature roster is a demo build's. It used to stand in whenever the live read
   // came back empty, so a tenant with no features yet saw five priced features with margins as
   // their own, on Home and in the Cost explorer's feature detail alike.
   if (sampleDataAllowed()) {

--- a/web/app/api/home/route.ts
+++ b/web/app/api/home/route.ts
@@ -14,7 +14,7 @@ import type { DataQuality, FeatureRoi, SpendSummary } from "@/lib/types";
 import type { ProviderAttribution } from "@/lib/attribution";
 
 // Read live data per request (never statically cached). A read that fails says so; it is not
-// answered with fixture numbers (#363).
+// answered with fixture numbers (#364).
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 

--- a/web/app/api/home/route.ts
+++ b/web/app/api/home/route.ts
@@ -1,18 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
-import { mockDataQuality, mockRoi, mockSpend } from "@/lib/mock";
+import { mockDataQuality, mockRoi, mockSpend, sampleDataAllowed } from "@/lib/mock";
 import {
   queryAttribution,
   queryDataQuality,
   queryRoi,
   querySpendSummary,
 } from "@/lib/clickhouse";
+import { type SourceState, readState } from "@/lib/dataState";
 import { parseFilters, rangeDays } from "@/lib/filters";
+import type { DataQuality, FeatureRoi, SpendSummary } from "@/lib/types";
+import type { ProviderAttribution } from "@/lib/attribution";
 
-// Read live data per request (never statically cached); fall back to mock when ClickHouse is down.
+// Read live data per request (never statically cached). A read that fails says so; it is not
+// answered with fixture numbers (#363).
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+export interface HomeSources {
+  spend: SourceState;
+  roi: SourceState;
+  dq: SourceState;
+  attribution: SourceState;
+}
+
+export interface HomeResponse {
+  /** null when the source could not be read. `sources.spend` says which of the four states this is. */
+  spend: SpendSummary | null;
+  roi: FeatureRoi[];
+  dq: DataQuality | null;
+  perProviderConversion: ProviderAttribution[];
+  sources: HomeSources;
+}
 
 export async function GET(request: Request) {
   // The Home time-range selector drives every headline (CTO-226): parse the URL-synced filter state
@@ -29,10 +49,30 @@ export async function GET(request: Request) {
     queryDataQuality(),
     queryAttribution(attributionFilters, { windowDays }),
   ]);
+
+  if (sampleDataAllowed()) {
+    return NextResponse.json({
+      spend: mockSpend,
+      roi: mockRoi,
+      dq: mockDataQuality,
+      perProviderConversion: attribution?.perProvider ?? [],
+      sources: { spend: "sample", roi: "sample", dq: "sample", attribution: "sample" },
+    } satisfies HomeResponse);
+  }
+
+  // A spend summary always comes back as an object, so "no rows" cannot be read off its shape: the
+  // aggregate over an empty window is a wall of confident zeros. `spanCount` is the number the read
+  // itself counted, so zero spans is the tenant having sent nothing, not a $0.00 measurement.
   return NextResponse.json({
-    spend: spend ?? mockSpend,
-    roi: roi && roi.length > 0 ? roi : mockRoi,
-    dq: dq ?? mockDataQuality,
+    spend,
+    roi: roi ?? [],
+    dq,
     perProviderConversion: attribution?.perProvider ?? [],
-  });
+    sources: {
+      spend: readState(spend, (s) => (s.spanCount ?? 0) === 0),
+      roi: readState(roi, (r) => r.length === 0),
+      dq: readState(dq, (d) => d.attributionRate === null),
+      attribution: readState(attribution, (a) => a.perProvider.length === 0),
+    },
+  } satisfies HomeResponse);
 }

--- a/web/app/api/three-states.test.ts
+++ b/web/app/api/three-states.test.ts
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: Apache-2.0
+// #364. The six dashboard routes must tell three facts apart, and answer each of them differently:
+//
+//   unavailable - the read threw or timed out. We do not know. Say so; claim no figure.
+//   empty       - the read succeeded over no rows. We DO know: nothing has arrived. This is the
+//                 normal state of every new customer, and it is a real answer, not an unknown one.
+//   live        - real rows, passed through untouched.
+//
+// They were one branch before this ticket (`live ?? mock`, or `live.length > 0 ? live : mock`), so a
+// brand new tenant with zero spans was served `lib/mock.ts` as its own numbers: a research_agent it
+// had never run, paying back in 7 days. Every case below pins one of the three, deterministically,
+// over a mocked ClickHouse: `api.test.ts` cannot, because whether a developer has `make up` running
+// decides which of empty/unavailable a real read produces there.
+//
+// The fourth state, `sample`, is a deployment choice rather than a read result, and its gate is
+// pinned at the bottom: it takes an explicit demo build AND no resolved Clerk organization, which
+// makes "a real tenant is signed in" and "fixtures render" mutually exclusive by construction.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted above the route imports below, so each route handler picks up these stubs.
+vi.mock("@/lib/clickhouse", () => ({
+  querySpendSummary: vi.fn(),
+  queryRoi: vi.fn(),
+  queryDataQuality: vi.fn(),
+  queryAttribution: vi.fn(),
+  queryAgents: vi.fn(),
+  queryReconcilerLastRun: vi.fn().mockResolvedValue(null),
+  queryCostSeries: vi.fn(),
+  queryFeatureCostRows: vi.fn(),
+  queryHiddenCostAlerts: vi.fn(),
+  queryFeatureEconomics: vi.fn(),
+  queryAttributionDiagnostics: vi.fn(),
+  queryFeatureValueEvents: vi.fn().mockResolvedValue([]),
+  queryConnectorActivity: vi.fn(),
+  queryIntegrationStatus: vi.fn().mockResolvedValue([]),
+}));
+
+import * as ch from "@/lib/clickhouse";
+import { agents as fixtureAgents, runs as fixtureRuns } from "@/lib/agents";
+import {
+  LAYERS,
+  costSeries as fixtureSeries,
+  featureRows as fixtureFeatureRows,
+  hiddenCostAlerts as fixtureAlerts,
+} from "@/lib/cost";
+import { features as fixtureFeatures } from "@/lib/features";
+import { mockActivity } from "@/lib/connectors";
+import { mockRoi, mockSpend } from "@/lib/mock";
+import type { SpendByLayer, SpendSummary } from "@/lib/types";
+
+import { GET as HomeGET } from "./home/route";
+import { GET as AgentsGET } from "./agents/route";
+import { GET as CostGET } from "./cost/route";
+import { GET as FeaturesGET } from "./features/route";
+import { GET as AttributionGET } from "./attribution/route";
+import { GET as ConnectorsGET } from "./connectors/route";
+
+const mocked = ch as unknown as Record<string, ReturnType<typeof vi.fn>>;
+
+/** Every layer at zero: what an aggregate over no spans genuinely produces. */
+function zeroLayers(): SpendByLayer {
+  const out = {} as SpendByLayer;
+  for (const l of LAYERS) out[l] = 0;
+  return out;
+}
+
+
+/** Every telemetry read fails. */
+function allUnavailable() {
+  for (const fn of Object.values(mocked)) fn.mockResolvedValue(null);
+  mocked.queryFeatureValueEvents.mockResolvedValue([]);
+  mocked.queryAttributionDiagnostics.mockResolvedValue({ state: "unavailable" });
+}
+
+/**
+ * Every read succeeds and finds nothing. The important shapes here are the ones that are NOT an
+ * empty array: a spend summary is always an object, and a cost series is always one point per day
+ * in the window, so both come back as a wall of confident zeros that only the counts disprove.
+ */
+const EMPTY_SPEND: SpendSummary = {
+  totalMicroUsd: 0,
+  estimatedMicroUsd: 0,
+  reconciledMicroUsd: 0,
+  reconciledThrough: "1970-01-01",
+  byLayer: zeroLayers(),
+  unpricedSpanCount: 0,
+  spanCount: 0,
+};
+
+function allEmpty() {
+  mocked.querySpendSummary.mockResolvedValue(EMPTY_SPEND);
+  mocked.queryRoi.mockResolvedValue([]);
+  mocked.queryDataQuality.mockResolvedValue({
+    attributionRate: null,
+    contextDropCount: null,
+    estimateCalibration: null,
+  });
+  mocked.queryAttribution.mockResolvedValue({
+    filters: { tag: null, provider: null, outcome: null },
+    perProvider: [],
+    totals: { sessions: 0, conversions: 0, costMicroUsd: 0, costPerConversionMicroUsd: null },
+    dailyByProvider: [],
+    isMock: false,
+  });
+  mocked.queryAgents.mockResolvedValue({ agents: [], runs: [] });
+  mocked.queryCostSeries.mockResolvedValue({
+    reconciledThrough: "1970-01-01",
+    days: Array.from({ length: 30 }, (_, i) => ({
+      date: `2026-06-${String(i + 1).padStart(2, "0")}`,
+      byLayer: zeroLayers(),
+    })),
+  });
+  mocked.queryFeatureCostRows.mockResolvedValue([]);
+  mocked.queryHiddenCostAlerts.mockResolvedValue([]);
+  mocked.queryFeatureEconomics.mockResolvedValue([]);
+  mocked.queryFeatureValueEvents.mockResolvedValue([]);
+  mocked.queryAttributionDiagnostics.mockResolvedValue({ state: "empty" });
+  mocked.queryConnectorActivity.mockResolvedValue({ records: {}, lastAt: {} });
+  mocked.queryIntegrationStatus.mockResolvedValue([]);
+}
+
+/** Real rows. The library fixtures stand in for them: what is asserted is pass-through, not content. */
+function allLive() {
+  allEmpty();
+  mocked.querySpendSummary.mockResolvedValue({ ...EMPTY_SPEND, totalMicroUsd: 12_000_000, spanCount: 4_211, reconciledThrough: "2026-06-12" });
+  mocked.queryRoi.mockResolvedValue([
+    { feature: "checkout_helper", costPerUserMicroUsd: 1_000, valuePerUserMicroUsd: 9_000, paybackDays: 3, attributionRate: 0.5 },
+  ]);
+  mocked.queryDataQuality.mockResolvedValue({
+    attributionRate: 0.5,
+    contextDropCount: null,
+    estimateCalibration: null,
+  });
+  mocked.queryAgents.mockResolvedValue({ agents: fixtureAgents, runs: fixtureRuns });
+  mocked.queryCostSeries.mockResolvedValue(fixtureSeries);
+  mocked.queryFeatureCostRows.mockResolvedValue(fixtureFeatureRows);
+  mocked.queryHiddenCostAlerts.mockResolvedValue(fixtureAlerts);
+  mocked.queryFeatureEconomics.mockResolvedValue(fixtureFeatures);
+  mocked.queryAttributionDiagnostics.mockResolvedValue({
+    state: "live",
+    diagnostics: { lateArrivalEvents7d: 4, lateArrivalMedianHours: 1.1, reconcilerLastRunMinutesAgo: 9 },
+  });
+  mocked.queryConnectorActivity.mockResolvedValue({
+    records: { llm_proxy: 7 },
+    lastAt: { llm_proxy: "2026-06-12T00:00:00Z" },
+  });
+  mocked.queryAttribution.mockResolvedValue({
+    filters: { tag: null, provider: null, outcome: null },
+    perProvider: [
+      { provider: "openai", sessions: 10, conversions: 2, conversionRate: 0.2, costMicroUsd: 500, costPerConversionMicroUsd: 250 },
+    ],
+    totals: { sessions: 10, conversions: 2, costMicroUsd: 500, costPerConversionMicroUsd: 250 },
+    dailyByProvider: [],
+    isMock: false,
+  });
+}
+
+async function body<T>(res: Response): Promise<T> {
+  return (await res.json()) as T;
+}
+
+const home = () => HomeGET(new Request("http://test/api/home"));
+const agents = () => AgentsGET(new Request("http://test/api/agents") as never);
+const cost = () => CostGET(new Request("http://test/api/cost") as never);
+const attribution = () => AttributionGET(new Request("http://test/api/attribution"));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the read failed: the routes say so and claim nothing", () => {
+  beforeEach(allUnavailable);
+
+  it("/api/home reports unavailable and returns no spend, no ROI, no data quality", async () => {
+    const b = await body<{ spend: unknown; roi: unknown[]; dq: unknown; sources: Record<string, string> }>(await home());
+    expect(b.sources).toEqual({ spend: "unavailable", roi: "unavailable", dq: "unavailable", attribution: "unavailable" });
+    // Null, not a zero-filled summary: a $0.00 headline is a measurement, and none was taken.
+    expect(b.spend).toBeNull();
+    expect(b.dq).toBeNull();
+    expect(b.roi).toEqual([]);
+    // The regression this ticket exists for.
+    expect(b.spend).not.toEqual(mockSpend);
+    expect(b.roi).not.toEqual(mockRoi);
+  });
+
+  it("/api/agents reports unavailable and lists no agents", async () => {
+    const b = await body<{ agents: unknown[]; runs: unknown[]; sources: Record<string, string> }>(await agents());
+    expect(b.sources).toEqual({ agents: "unavailable", runs: "unavailable" });
+    expect(b.agents).toEqual([]);
+    expect(b.runs).toEqual([]);
+  });
+
+  it("/api/cost reports unavailable and returns a null series rather than 30 zero days", async () => {
+    const b = await body<{ series: unknown; featureRows: unknown[]; alerts: unknown[]; sources: Record<string, string> }>(await cost());
+    expect(b.sources).toEqual({ series: "unavailable", featureRows: "unavailable", alerts: "unavailable" });
+    expect(b.series).toBeNull();
+    expect(b.featureRows).toEqual([]);
+    expect(b.alerts).toEqual([]);
+  });
+
+  it("/api/features reports unavailable and returns no economics and no diagnostics", async () => {
+    const b = await body<{ features: unknown[]; diagnostics: unknown; sources: Record<string, string> }>(await FeaturesGET());
+    expect(b.sources).toEqual({ features: "unavailable", diagnostics: "unavailable" });
+    expect(b.features).toEqual([]);
+    expect(b.diagnostics).toBeNull();
+  });
+
+  it("/api/attribution reports unavailable and invents no provider rows", async () => {
+    const b = await body<{ state: string; isMock: boolean; perProvider: unknown[]; totals: { sessions: number } }>(await attribution());
+    expect(b.state).toBe("unavailable");
+    expect(b.isMock).toBe(false);
+    expect(b.perProvider).toEqual([]);
+    expect(b.totals.sessions).toBe(0);
+  });
+
+  it("/api/connectors reports unavailable activity and credits no records to any connector", async () => {
+    const b = await body<{ activity: string; connectors: { records: number }[] }>(await ConnectorsGET());
+    expect(b.activity).toBe("unavailable");
+    // Every catalog row still renders, with no fabricated record count behind it.
+    expect(b.connectors.length).toBeGreaterThan(0);
+    expect(b.connectors.every((c) => c.records === 0)).toBe(true);
+  });
+});
+
+describe("the read succeeded over nothing: a real empty answer, distinct from unknown", () => {
+  beforeEach(allEmpty);
+
+  it("/api/home reports empty, not unavailable, and still returns no figures", async () => {
+    const b = await body<{ spend: SpendSummary | null; roi: unknown[]; sources: Record<string, string> }>(await home());
+    expect(b.sources.spend).toBe("empty");
+    expect(b.sources.roi).toBe("empty");
+    expect(b.sources.dq).toBe("empty");
+    expect(b.sources.attribution).toBe("empty");
+    // The zero-filled summary is carried, because it is what the read genuinely found. The page is
+    // told to render an empty state off `sources`, not to print these zeros as a measurement.
+    expect(b.spend?.spanCount).toBe(0);
+    expect(b.roi).toEqual([]);
+  });
+
+  it("/api/agents reports empty", async () => {
+    const b = await body<{ sources: Record<string, string> }>(await agents());
+    expect(b.sources).toEqual({ agents: "empty", runs: "empty" });
+  });
+
+  it("/api/cost reports empty for a full window of zero days", async () => {
+    const b = await body<{ series: { days: unknown[] } | null; sources: Record<string, string> }>(await cost());
+    expect(b.sources.series).toBe("empty");
+    expect(b.sources.featureRows).toBe("empty");
+    expect(b.sources.alerts).toBe("empty");
+    // The shape said nothing: 30 points came back. Only the figures in them make it empty.
+    expect(b.series?.days.length).toBe(30);
+  });
+
+  it("/api/features reports empty features and an empty (never-run) reconciler", async () => {
+    const b = await body<{ diagnostics: unknown; sources: Record<string, string> }>(await FeaturesGET());
+    expect(b.sources).toEqual({ features: "empty", diagnostics: "empty" });
+    // "The reconciler has never run" is not "the reconciler reported 180 late events".
+    expect(b.diagnostics).toBeNull();
+  });
+
+  it("/api/attribution reports empty", async () => {
+    const b = await body<{ state: string; perProvider: unknown[] }>(await attribution());
+    expect(b.state).toBe("empty");
+    expect(b.perProvider).toEqual([]);
+  });
+
+  it("/api/connectors reports empty activity: every row is honestly Not connected", async () => {
+    const b = await body<{ activity: string; connectors: { records: number }[] }>(await ConnectorsGET());
+    expect(b.activity).toBe("empty");
+    expect(b.connectors.every((c) => c.records === 0)).toBe(true);
+  });
+});
+
+describe("real rows: passed through untouched", () => {
+  beforeEach(allLive);
+
+  it("/api/home reports live and serves the tenant's own spend and ROI", async () => {
+    const b = await body<{ spend: SpendSummary; roi: { feature: string }[]; sources: Record<string, string> }>(await home());
+    expect(b.sources.spend).toBe("live");
+    expect(b.sources.roi).toBe("live");
+    expect(b.spend.totalMicroUsd).toBe(12_000_000);
+    expect(b.roi.map((r) => r.feature)).toEqual(["checkout_helper"]);
+  });
+
+  it("/api/agents reports live and serves the rows the query returned", async () => {
+    const b = await body<{ agents: unknown[]; runs: unknown[]; sources: Record<string, string> }>(await agents());
+    expect(b.sources).toEqual({ agents: "live", runs: "live" });
+    expect(b.agents).toEqual(JSON.parse(JSON.stringify(fixtureAgents)));
+    expect(b.runs).toEqual(JSON.parse(JSON.stringify(fixtureRuns)));
+  });
+
+  it("/api/cost reports live and serves the series, rows and alerts it read", async () => {
+    const b = await body<{ series: { days: unknown[] }; featureRows: unknown[]; alerts: unknown[]; sources: Record<string, string> }>(await cost());
+    expect(b.sources).toEqual({ series: "live", featureRows: "live", alerts: "live" });
+    expect(b.series.days.length).toBe(fixtureSeries.days.length);
+    expect(b.featureRows.length).toBe(fixtureFeatureRows.length);
+    expect(b.alerts.length).toBe(fixtureAlerts.length);
+  });
+
+  it("/api/features reports live and serves real diagnostics", async () => {
+    const b = await body<{ features: unknown[]; diagnostics: { reconcilerLastRunMinutesAgo: number }; sources: Record<string, string> }>(await FeaturesGET());
+    expect(b.sources).toEqual({ features: "live", diagnostics: "live" });
+    expect(b.features.length).toBe(fixtureFeatures.length);
+    expect(b.diagnostics.reconcilerLastRunMinutesAgo).toBe(9);
+  });
+
+  it("/api/attribution reports live", async () => {
+    const b = await body<{ state: string; perProvider: { provider: string }[] }>(await attribution());
+    expect(b.state).toBe("live");
+    expect(b.perProvider.map((p) => p.provider)).toEqual(["openai"]);
+  });
+
+  it("/api/connectors reports live activity", async () => {
+    const b = await body<{ activity: string; connectors: { id: string; records: number }[] }>(await ConnectorsGET());
+    expect(b.activity).toBe("live");
+    expect(b.connectors.find((c) => c.id === "llm_proxy")?.records).toBe(7);
+  });
+});
+
+/**
+ * The gate that makes the fixtures unreachable on the product path.
+ *
+ * `sampleDataAllowed()` needs BOTH an explicit demo build and the dev-tenant escape hatch, and the
+ * escape hatch is the ONLY way the dashboard serves a tenant with no Clerk organization resolved
+ * (lib/getTenant.ts), so a signed-in customer can never reach these branches. A production build
+ * refuses to boot on the escape hatch alone (instrumentation.ts, CTO-268), which closes it twice.
+ */
+describe("the sample gate", () => {
+  const originalDemo = process.env.NEXT_PUBLIC_DEMO_MODE;
+  const originalDev = process.env.TALLY_DEV_TENANT;
+
+  beforeEach(() => {
+    // Empty reads throughout: without the gate every route below would answer honestly.
+    allEmpty();
+  });
+
+  afterEach(() => {
+    if (originalDemo === undefined) delete process.env.NEXT_PUBLIC_DEMO_MODE;
+    else process.env.NEXT_PUBLIC_DEMO_MODE = originalDemo;
+    if (originalDev === undefined) delete process.env.TALLY_DEV_TENANT;
+    else process.env.TALLY_DEV_TENANT = originalDev;
+  });
+
+  it("serves fixtures, labelled, for a demo build with no organization resolved", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    process.env.TALLY_DEV_TENANT = "00000000-0000-0000-0000-000000000000";
+
+    const h = await body<{ spend: unknown; roi: unknown; sources: Record<string, string> }>(await home());
+    expect(h.sources.spend).toBe("sample");
+    expect(h.spend).toEqual(mockSpend);
+    expect(h.roi).toEqual(mockRoi);
+
+    const c = await body<{ activity: string; connectors: { id: string; records: number }[] }>(await ConnectorsGET());
+    expect(c.activity).toBe("sample");
+    expect(c.connectors.find((x) => x.id === "llm_proxy")?.records).toBe(mockActivity.records.llm_proxy);
+
+    const a = await body<{ state: string; isMock: boolean }>(await attribution());
+    expect(a.state).toBe("sample");
+    expect(a.isMock).toBe(true);
+
+    const co = await body<{ sources: Record<string, string> }>(await cost());
+    expect(co.sources.series).toBe("sample");
+    const ag = await body<{ sources: Record<string, string> }>(await agents());
+    expect(ag.sources.agents).toBe("sample");
+    const f = await body<{ sources: Record<string, string> }>(await FeaturesGET());
+    expect(f.sources.features).toBe("sample");
+  });
+
+  it("refuses fixtures for a demo build once a real organization resolves the tenant", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    delete process.env.TALLY_DEV_TENANT;
+
+    // This is the case the ticket is about: an authenticated customer with no spans. Demo mode is
+    // still on, and it buys them nothing, because there is a real tenant behind the request.
+    const h = await body<{ spend: SpendSummary | null; roi: unknown[]; sources: Record<string, string> }>(await home());
+    expect(h.sources.spend).toBe("empty");
+    expect(h.spend).not.toEqual(mockSpend);
+    expect(h.roi).toEqual([]);
+
+    const a = await body<{ state: string; isMock: boolean; perProvider: unknown[] }>(await attribution());
+    expect(a.state).toBe("empty");
+    expect(a.isMock).toBe(false);
+    expect(a.perProvider).toEqual([]);
+
+    const c = await body<{ activity: string; connectors: { records: number }[] }>(await ConnectorsGET());
+    expect(c.activity).toBe("empty");
+    expect(c.connectors.every((x) => x.records === 0)).toBe(true);
+  });
+
+  it("refuses fixtures for the dev escape hatch when demo mode is not switched on", async () => {
+    delete process.env.NEXT_PUBLIC_DEMO_MODE;
+    process.env.TALLY_DEV_TENANT = "00000000-0000-0000-0000-000000000000";
+
+    const h = await body<{ sources: Record<string, string> }>(await home());
+    expect(h.sources.spend).toBe("empty");
+  });
+
+  it("keeps fixtures out of a filtered view even in a demo build", async () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+    process.env.TALLY_DEV_TENANT = "00000000-0000-0000-0000-000000000000";
+
+    // The fixture roster is not tag-scoped, so serving it under ?tag= would present unfiltered
+    // fixtures as the answer to a filtered question. This guard predates the ticket and survives it.
+    const b = await body<{ agents: unknown[]; sources: Record<string, string> }>(
+      await AgentsGET(new Request("http://test/api/agents?tag=nothing-matches") as never),
+    );
+    expect(b.sources.agents).toBe("empty");
+    expect(b.agents).toEqual([]);
+  });
+});

--- a/web/app/attribution/Live.test.tsx
+++ b/web/app/attribution/Live.test.tsx
@@ -8,8 +8,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { AttributionLive } from "./Live";
-import { buildProviderRow, type AttributionReport } from "@/lib/attribution";
+import { AttributionLive, type AttributionPayload } from "./Live";
+import { buildProviderRow } from "@/lib/attribution";
 
 // The page's FilterBar drives the URL, so give it a router the way components/FilterBar.test.tsx does.
 vi.mock("next/navigation", () => ({
@@ -22,7 +22,7 @@ vi.mock("@/lib/useLivePoll", () => ({
   useLivePoll: (_endpoint: string, initial: unknown) => ({ data: initial, updatedAt: new Date() }),
 }));
 
-function report(): AttributionReport {
+function report(): AttributionPayload {
   const perProvider = [
     buildProviderRow("anthropic", 100, 20, 5_000_000),
     buildProviderRow("pinecone", 100, 20, 400_000),
@@ -37,6 +37,9 @@ function report(): AttributionReport {
       costPerConversionMicroUsd: 135_000,
     },
     isMock: false,
+    // #364: these rows are real, so the payload says so. The table below only renders at all under
+    // `state: "live"` (or the labelled `"sample"`), which is what keeps fixtures off a real tenant.
+    state: "live",
   };
 }
 

--- a/web/app/attribution/Live.test.tsx
+++ b/web/app/attribution/Live.test.tsx
@@ -43,15 +43,26 @@ function report(): AttributionPayload {
   };
 }
 
-function renderLive() {
+function renderLive(data: AttributionPayload = report()) {
   return render(
     <AttributionLive
       endpoint="/api/attribution"
-      initialData={report()}
+      initialData={data}
       outcome="conversion"
       featureTags={[]}
     />,
   );
+}
+
+/** The shape a tenant with no joined sessions genuinely gets back. */
+function emptyReport(state: AttributionPayload["state"]): AttributionPayload {
+  return {
+    filters: { tag: null, provider: null, outcome: null },
+    perProvider: [],
+    totals: { sessions: 0, conversions: 0, costMicroUsd: 0, costPerConversionMicroUsd: null },
+    isMock: false,
+    state,
+  };
 }
 
 describe("attribution breakdown dimension", () => {
@@ -81,5 +92,37 @@ describe("attribution breakdown dimension", () => {
     renderLive();
     expect(screen.getByText("Total cost")).toBeTruthy();
     expect(screen.queryByText("LLM cost")).toBeNull();
+  });
+});
+
+// #364. The old page had one branch (`isMock ? preview : body`) and so had no way to say "this
+// workspace has no sessions yet" other than by drawing the fixture's 5,300 of them behind a label.
+describe("attribution source states (#364)", () => {
+  it("says the source could not be read, and claims nothing about whether data exists", () => {
+    renderLive(emptyReport("unavailable"));
+    expect(screen.getByText(/Source unavailable/i)).toBeTruthy();
+    expect(screen.getByText(/This is not a statement that there is no data/i)).toBeTruthy();
+    expect(screen.queryByText("anthropic")).toBeNull();
+  });
+
+  it("says there are no attributed sessions yet when the read succeeded over nothing", () => {
+    renderLive(emptyReport("empty"));
+    expect(screen.getByText(/No attributed conversion sessions yet/i)).toBeTruthy();
+    expect(screen.queryByText(/Source unavailable/i)).toBeNull();
+    // Never a 0% conversion rate or a $0.00 per conversion: no session was measured to divide by.
+    expect(screen.queryByText("0.0%")).toBeNull();
+  });
+
+  it("draws the rows, with no sample banner, when they are real", () => {
+    renderLive();
+    expect(screen.getByText("anthropic")).toBeTruthy();
+    expect(screen.queryByText(/SAMPLE DATA/i)).toBeNull();
+    expect(screen.queryByText(/Source unavailable/i)).toBeNull();
+    expect(screen.queryByText(/No attributed/i)).toBeNull();
+  });
+
+  it("labels the fixture report as sample data on the demo-only path", () => {
+    renderLive({ ...report(), isMock: true, state: "sample" });
+    expect(screen.getByText(/SAMPLE DATA/i)).toBeTruthy();
   });
 });

--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -265,7 +265,7 @@ export function AttributionLive({
         actions={<LiveIndicator updatedAt={updatedAt} />}
         toolbar={<FilterBar hideGroupBy options={{ provider: PROVIDER_OPTIONS, feature: featureTags.map((f) => ({ value: f })) }} />}
       />
-      {/* #363. `state` replaces the old `isMock ? preview : body` pair, which had no way to say
+      {/* #364. `state` replaces the old `isMock ? preview : body` pair, which had no way to say
           "the tenant has no sessions yet" other than by showing the fixture's 5,300 of them behind
           a label. Unavailable and empty are now separate answers, and neither renders a figure. */}
       {report.state === "unavailable" ? (

--- a/web/app/attribution/Live.tsx
+++ b/web/app/attribution/Live.tsx
@@ -17,7 +17,11 @@
 import { useMemo } from "react";
 
 import { Card } from "@/components/Card";
-import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import {
+  NoDataYet,
+  SourceUnavailable,
+  SyntheticPreviewBanner,
+} from "@/components/DataStateBanner";
 import { DataTable, type Column } from "@/components/DataTable";
 import { FilterBar, type FilterOption } from "@/components/FilterBar";
 import { Money, Pct } from "@/components/HonestValue";
@@ -26,6 +30,7 @@ import { LiveIndicator } from "@/components/LiveIndicator";
 import { PageHeader } from "@/components/PageHeader";
 import { SummaryTile, TileGrid } from "@/components/SummaryTile";
 import { type AttributionReport, type ProviderAttribution, systemKind } from "@/lib/attribution";
+import type { SourceState } from "@/lib/dataState";
 import { useLivePoll } from "@/lib/useLivePoll";
 
 /**
@@ -51,6 +56,9 @@ const PROVIDER_OPTIONS: FilterOption[] = [
   { value: "anthropic", label: "Anthropic" },
 ];
 
+/** The report plus which of the four source states produced it (see lib/dataState.ts). */
+export type AttributionPayload = AttributionReport & { state: SourceState };
+
 export function AttributionLive({
   endpoint,
   initialData,
@@ -58,12 +66,12 @@ export function AttributionLive({
   featureTags,
 }: {
   endpoint: string;
-  initialData: AttributionReport;
+  initialData: AttributionPayload;
   outcome: string;
   /** Feature tags in the window, for the FilterBar's feature filter. Empty renders no such control. */
   featureTags: string[];
 }) {
-  const { data: report, updatedAt } = useLivePoll<AttributionReport>(endpoint, initialData);
+  const { data: report, updatedAt } = useLivePoll<AttributionPayload>(endpoint, initialData);
 
   // Columns close over `outcome`, which comes from the URL filters, so they are rebuilt only when
   // the filter changes rather than on every poll tick.
@@ -257,7 +265,17 @@ export function AttributionLive({
         actions={<LiveIndicator updatedAt={updatedAt} />}
         toolbar={<FilterBar hideGroupBy options={{ provider: PROVIDER_OPTIONS, feature: featureTags.map((f) => ({ value: f })) }} />}
       />
-      {report.isMock ? (
+      {/* #363. `state` replaces the old `isMock ? preview : body` pair, which had no way to say
+          "the tenant has no sessions yet" other than by showing the fixture's 5,300 of them behind
+          a label. Unavailable and empty are now separate answers, and neither renders a figure. */}
+      {report.state === "unavailable" ? (
+        <SourceUnavailable reason="The telemetry store could not be read for this workspace." />
+      ) : report.state === "empty" ? (
+        <NoDataYet
+          what={`attributed ${outcome} sessions`}
+          detail="No sessions have been joined to cost spans for this workspace."
+        />
+      ) : report.state === "sample" ? (
         <SyntheticPreviewBanner workflow="Attribution">{body}</SyntheticPreviewBanner>
       ) : (
         body

--- a/web/app/attribution/page.tsx
+++ b/web/app/attribution/page.tsx
@@ -12,10 +12,9 @@
 // keys all survive) and only defaulting `outcome`.
 
 import { apiGet } from "@/lib/api";
-import type { AttributionReport } from "@/lib/attribution";
 import { querySpanFeatureTags } from "@/lib/clickhouse";
 import { parseFilters, rangeDays } from "@/lib/filters";
-import { AttributionLive } from "./Live";
+import { AttributionLive, type AttributionPayload } from "./Live";
 
 interface PageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -48,7 +47,7 @@ export default async function AttributionPage({ searchParams }: PageProps) {
 
   const endpoint = `/api/attribution?${qs.toString()}`;
   const [initialData, featureTags] = await Promise.all([
-    apiGet<AttributionReport>(endpoint),
+    apiGet<AttributionPayload>(endpoint),
     querySpanFeatureTags(windowDays),
   ]);
 

--- a/web/app/connectors/ConnectorTable.tsx
+++ b/web/app/connectors/ConnectorTable.tsx
@@ -57,9 +57,16 @@ export function ConnectorTable({
   rows,
   enabledLayers,
   configs,
+  activityUnavailable = false,
 }: {
   rows: readonly ConnectorStatus[];
   enabledLayers: readonly string[];
+  /**
+   * #364 review: whether the per-source record counts could be read at all. Without it a zero
+   * count and an unreadable count render the same blank, and the row then contradicts the banner
+   * the page shows above it.
+   */
+  activityUnavailable?: boolean;
   /**
    * Flat list rather than the Map the page used to build. The page is a server component, so this
    * crosses the serialization boundary and a plain array is the least surprising thing to send.
@@ -103,8 +110,15 @@ export function ConnectorTable({
             r.records.toLocaleString()
           ) : (
             // Zero records is exactly how "connected" is decided, so an empty count is never a
-            // real zero: the source has not delivered anything we can count yet.
-            <Blank reason="this source has not delivered any records in the last 30 days" />
+            // real zero. #364 review: which blank it is depends on whether the counts could be
+            // read at all. Without that, this row contradicts the banner the page shows above it.
+            <Blank
+              reason={
+                activityUnavailable
+                  ? "the record counts could not be read, so this source's activity is unknown rather than zero"
+                  : "this source has not delivered any records in the last 30 days"
+              }
+            />
           ),
       },
       {
@@ -155,7 +169,10 @@ export function ConnectorTable({
         },
       },
     ],
-    [configByConnector, enabledLayers],
+    // activityUnavailable is read inside the records column's render, so it belongs here. Without
+    // it the memo keeps the reason string from the render it was first built in, and a source that
+    // became unreadable would go on claiming it delivered no records.
+    [configByConnector, enabledLayers, activityUnavailable],
   );
 
   return (

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -59,7 +59,12 @@ export default async function ConnectorsPage() {
         return (
           <Card key={s.category} title={`${s.title}: ${n}/${live} connected${suffix}`}>
             <p className="mb-3 max-w-prose text-xs text-muted">{s.blurb}</p>
-            <ConnectorTable rows={rows} enabledLayers={enabledLayers} configs={configs} />
+            <ConnectorTable
+              rows={rows}
+              enabledLayers={enabledLayers}
+              configs={configs}
+              activityUnavailable={activity === "unavailable"}
+            />
           </Card>
         );
       })}
@@ -83,7 +88,12 @@ export default async function ConnectorsPage() {
         }
         actions={
           <span className="rounded-full border border-edge bg-panel px-3 py-1 text-sm text-muted">
-            {connected} of {totalLive} sources connected
+            {/* #364 review: "connected" is derived from record counts, so when those could not be
+                read this is not a measurement. Printing "0 of 6 connected" over an unreadable
+                source states as fact the very thing the banner below calls unknown. */}
+            {activity === "unavailable"
+              ? `${totalLive} sources · connection unknown`
+              : `${connected} of ${totalLive} sources connected`}
             {totalSoon > 0 ? ` · ${totalSoon} coming soon` : ""}
           </span>
         }

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -21,7 +21,7 @@ import { RevenueUpload } from "./RevenueUpload";
 interface ConnectorsPayload {
   connectors: ConnectorStatus[];
   live: boolean;
-  /** Which of the four source states produced the per-connector record counts (#363). */
+  /** Which of the four source states produced the per-connector record counts (#364). */
   activity: SourceState;
 }
 
@@ -89,7 +89,7 @@ export default async function ConnectorsPage() {
         }
       />
 
-      {/* #363. The activity read decides how the catalog is captioned, and only a demo build ever
+      {/* #364. The activity read decides how the catalog is captioned, and only a demo build ever
           gets the fixture's 4,120 llm_proxy records. An unreadable source says so above the rows
           rather than dressing "Not connected" up as a measurement; a source that answered with no
           records IS the measurement, and every row correctly reads "Not connected". */}

--- a/web/app/connectors/page.tsx
+++ b/web/app/connectors/page.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Card } from "@/components/Card";
 import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { Blank } from "@/components/HonestValue";
 import { PageHeader } from "@/components/PageHeader";
 import { apiGet } from "@/lib/api";
 import {
@@ -12,6 +13,7 @@ import {
 } from "@/lib/connectors";
 import { queryCostConnectorConfigs } from "@/lib/costConnectors";
 import { queryRevenueUploads } from "@/lib/revenueUpload";
+import type { SourceState } from "@/lib/dataState";
 import { queryEnabledConnectors } from "@/lib/tenant";
 import { ConnectorTable } from "./ConnectorTable";
 import { RevenueUpload } from "./RevenueUpload";
@@ -19,6 +21,8 @@ import { RevenueUpload } from "./RevenueUpload";
 interface ConnectorsPayload {
   connectors: ConnectorStatus[];
   live: boolean;
+  /** Which of the four source states produced the per-connector record counts (#363). */
+  activity: SourceState;
 }
 
 const SECTIONS: { category: ConnectorCategory; title: string; blurb: string }[] = [
@@ -30,7 +34,7 @@ const SECTIONS: { category: ConnectorCategory; title: string; blurb: string }[] 
 ];
 
 export default async function ConnectorsPage() {
-  const [{ connectors, live }, enabledLayers, costConfigs, revenueUploads] = await Promise.all([
+  const [{ connectors, activity }, enabledLayers, costConfigs, revenueUploads] = await Promise.all([
     apiGet<ConnectorsPayload>("/api/connectors"),
     queryEnabledConnectors(),
     queryCostConnectorConfigs(),
@@ -85,7 +89,22 @@ export default async function ConnectorsPage() {
         }
       />
 
-      {live ? body : <SyntheticPreviewBanner workflow="Connectors">{body}</SyntheticPreviewBanner>}
+      {/* #363. The activity read decides how the catalog is captioned, and only a demo build ever
+          gets the fixture's 4,120 llm_proxy records. An unreadable source says so above the rows
+          rather than dressing "Not connected" up as a measurement; a source that answered with no
+          records IS the measurement, and every row correctly reads "Not connected". */}
+      {activity === "unavailable" && (
+        <p className="rounded-xl border border-warn/40 bg-warn/10 px-4 py-3 text-sm text-warn">
+          <Blank reason="the telemetry store could not be read, so no record counts were returned" />{" "}
+          Per-source record counts could not be read. The rows below show the catalog and its
+          configuration; their activity is unknown, not zero.
+        </p>
+      )}
+      {activity === "sample" ? (
+        <SyntheticPreviewBanner workflow="Connectors">{body}</SyntheticPreviewBanner>
+      ) : (
+        body
+      )}
 
       {/*
         Revenue is the other half of margin, and for plenty of B2B companies it has no API worth

--- a/web/app/cost/AgentDetail.tsx
+++ b/web/app/cost/AgentDetail.tsx
@@ -79,7 +79,7 @@ export function AgentDetail({ agent, queryString }: { agent: string; queryString
     );
   }
 
-  // #363: the route now answers 200 with an empty roster when the READ failed too, so a landed
+  // #364: the route now answers 200 with an empty roster when the READ failed too, so a landed
   // fetch is no longer proof that we have an answer. Without this the branch below would report
   // "no runs for this agent" on the strength of a ClickHouse outage.
   if (status === "unavailable" || data === null || data.sources.agents === "unavailable") {

--- a/web/app/cost/AgentDetail.tsx
+++ b/web/app/cost/AgentDetail.tsx
@@ -27,6 +27,7 @@ import {
   boundaryFromMinutesAgo,
   deriveDataState,
   relativeAge,
+  type SourceState,
 } from "@/lib/dataState";
 import { formatUSD } from "@/lib/types";
 
@@ -34,6 +35,7 @@ interface AgentsDetailPayload {
   agents: AgentSummary[];
   runs: AgentRun[];
   reconcilerLastRunMinutesAgo: number | null;
+  sources: { agents: SourceState; runs: SourceState };
 }
 
 type FetchStatus = "loading" | "ready" | "unavailable";
@@ -77,7 +79,10 @@ export function AgentDetail({ agent, queryString }: { agent: string; queryString
     );
   }
 
-  if (status === "unavailable" || data === null) {
+  // #363: the route now answers 200 with an empty roster when the READ failed too, so a landed
+  // fetch is no longer proof that we have an answer. Without this the branch below would report
+  // "no runs for this agent" on the strength of a ClickHouse outage.
+  if (status === "unavailable" || data === null || data.sources.agents === "unavailable") {
     return (
       <Card title={title}>
         <p className="py-6 text-center text-sm text-muted">

--- a/web/app/cost/FeatureDetail.tsx
+++ b/web/app/cost/FeatureDetail.tsx
@@ -27,13 +27,21 @@ import {
   type AttributionDiagnostics,
   type FeatureEconomics,
 } from "@/lib/features";
-import { asOfLabel, deriveDataState, relativeAge, STALE_AFTER_MS } from "@/lib/dataState";
+import {
+  asOfLabel,
+  deriveDataState,
+  relativeAge,
+  type SourceState,
+  STALE_AFTER_MS,
+} from "@/lib/dataState";
 
 import { FeatureValueEvents } from "../features/FeatureValueEvents";
 
 interface FeaturesDetailPayload {
   features: FeatureEconomics[];
-  diagnostics: AttributionDiagnostics;
+  /** null when the reconciler status could not be read, or has never run (#363). */
+  diagnostics: AttributionDiagnostics | null;
+  sources: { features: SourceState; diagnostics: SourceState };
 }
 
 type FetchStatus = "loading" | "ready" | "unavailable";
@@ -75,7 +83,11 @@ export function FeatureDetail({ feature }: { feature: string }) {
     );
   }
 
-  if (status === "unavailable" || data === null) {
+  // #363: the route answers 200 with an empty roster when the read FAILED as well as when there is
+  // genuinely nothing, so the fetch succeeding is no longer enough to know we have an answer. The
+  // payload's own state is what decides, and an unreadable source reads the same here as a fetch
+  // that never landed.
+  if (status === "unavailable" || data === null || data.sources.features === "unavailable") {
     return (
       <Card title={title}>
         <p className="py-6 text-center text-sm text-muted">
@@ -101,13 +113,21 @@ export function FeatureDetail({ feature }: { feature: string }) {
   }
 
   // Features has no reconciliation date; the reconciler's last-run minutes is its freshness signal,
-  // rendered exactly as the /features view did.
-  const reconciledThrough = new Date(
-    Date.now() - data.diagnostics.reconcilerLastRunMinutesAgo * 60_000,
-  ).toISOString();
-  const asOf = asOfLabel(reconciledThrough);
-  const dataState = deriveDataState({ isEmpty: false, isPartial: false, reconciledThrough });
-  const reconcilerStale = data.diagnostics.reconcilerLastRunMinutesAgo * 60_000 > STALE_AFTER_MS;
+  // rendered exactly as the /features view did. #363: with no reconciler run, or none we could
+  // read, there is no boundary to render, so the badge is omitted rather than anchored on now().
+  const lastRunMinutesAgo = data.diagnostics?.reconcilerLastRunMinutesAgo ?? null;
+  const reconciledThrough =
+    lastRunMinutesAgo === null
+      ? null
+      : new Date(Date.now() - lastRunMinutesAgo * 60_000).toISOString();
+  const asOf = reconciledThrough === null ? null : asOfLabel(reconciledThrough);
+  const dataState = deriveDataState({
+    isEmpty: false,
+    isPartial: false,
+    reconciledThrough: reconciledThrough ?? undefined,
+  });
+  const reconcilerStale =
+    lastRunMinutesAgo !== null && lastRunMinutesAgo * 60_000 > STALE_AFTER_MS;
 
   return (
     <div className="space-y-6">
@@ -115,7 +135,7 @@ export function FeatureDetail({ feature }: { feature: string }) {
         <div className="flex justify-end">
           <StaleBadge
             asOf={asOf}
-            age={relativeAge(reconciledThrough)}
+            age={relativeAge(reconciledThrough!)}
             stale={dataState === "stale"}
           />
         </div>
@@ -153,24 +173,36 @@ export function FeatureDetail({ feature }: { feature: string }) {
 
           <div>
             <h3 className="mb-2 text-xs uppercase text-muted">Tenant-wide</h3>
-            <dl className="space-y-1.5 text-sm">
-              <Diag
-                k="late-arriving events (7d)"
-                v={data.diagnostics.lateArrivalEvents7d.toLocaleString()}
-                row
-              />
-              <Diag
-                k="median lag"
-                v={`${data.diagnostics.lateArrivalMedianHours.toFixed(1)}h`}
-                row
-              />
-              <Diag
-                k="reconciler last ran"
-                v={`${data.diagnostics.reconcilerLastRunMinutesAgo} min ago`}
-                good={!reconcilerStale}
-                row
-              />
-            </dl>
+            {/* #363: these three used to be filled from a fixture whenever the reconciler status
+                could not be read OR had never run, so a workspace that has never reconciled was
+                told 180 late events and a 4.2h median lag. The two cases are now separate, and
+                neither of them is a number. */}
+            {data.diagnostics === null ? (
+              <p className="text-sm text-muted">
+                {data.sources.diagnostics === "unavailable"
+                  ? "The reconciler status could not be read, so its diagnostics are not shown."
+                  : "The reconciler has not run for this workspace yet, so there is nothing to report."}
+              </p>
+            ) : (
+              <dl className="space-y-1.5 text-sm">
+                <Diag
+                  k="late-arriving events (7d)"
+                  v={data.diagnostics.lateArrivalEvents7d.toLocaleString()}
+                  row
+                />
+                <Diag
+                  k="median lag"
+                  v={`${data.diagnostics.lateArrivalMedianHours.toFixed(1)}h`}
+                  row
+                />
+                <Diag
+                  k="reconciler last ran"
+                  v={`${data.diagnostics.reconcilerLastRunMinutesAgo} min ago`}
+                  good={!reconcilerStale}
+                  row
+                />
+              </dl>
+            )}
           </div>
         </div>
       </Card>

--- a/web/app/cost/FeatureDetail.tsx
+++ b/web/app/cost/FeatureDetail.tsx
@@ -113,7 +113,7 @@ export function FeatureDetail({ feature }: { feature: string }) {
   }
 
   // Features has no reconciliation date; the reconciler's last-run minutes is its freshness signal,
-  // rendered exactly as the /features view did. #363: with no reconciler run, or none we could
+  // rendered exactly as the /features view did. #364: with no reconciler run, or none we could
   // read, there is no boundary to render, so the badge is omitted rather than anchored on now().
   const lastRunMinutesAgo = data.diagnostics?.reconcilerLastRunMinutesAgo ?? null;
   const reconciledThrough =
@@ -131,11 +131,11 @@ export function FeatureDetail({ feature }: { feature: string }) {
 
   return (
     <div className="space-y-6">
-      {asOf && (
+      {reconciledThrough !== null && asOf !== null && (
         <div className="flex justify-end">
           <StaleBadge
             asOf={asOf}
-            age={relativeAge(reconciledThrough!)}
+            age={relativeAge(reconciledThrough)}
             stale={dataState === "stale"}
           />
         </div>

--- a/web/app/cost/FeatureDetail.tsx
+++ b/web/app/cost/FeatureDetail.tsx
@@ -39,7 +39,7 @@ import { FeatureValueEvents } from "../features/FeatureValueEvents";
 
 interface FeaturesDetailPayload {
   features: FeatureEconomics[];
-  /** null when the reconciler status could not be read, or has never run (#363). */
+  /** null when the reconciler status could not be read, or has never run (#364). */
   diagnostics: AttributionDiagnostics | null;
   sources: { features: SourceState; diagnostics: SourceState };
 }
@@ -83,7 +83,7 @@ export function FeatureDetail({ feature }: { feature: string }) {
     );
   }
 
-  // #363: the route answers 200 with an empty roster when the read FAILED as well as when there is
+  // #364: the route answers 200 with an empty roster when the read FAILED as well as when there is
   // genuinely nothing, so the fetch succeeding is no longer enough to know we have an answer. The
   // payload's own state is what decides, and an unreadable source reads the same here as a fetch
   // that never landed.
@@ -173,7 +173,7 @@ export function FeatureDetail({ feature }: { feature: string }) {
 
           <div>
             <h3 className="mb-2 text-xs uppercase text-muted">Tenant-wide</h3>
-            {/* #363: these three used to be filled from a fixture whenever the reconciler status
+            {/* #364: these three used to be filled from a fixture whenever the reconciler status
                 could not be read OR had never run, so a workspace that has never reconciled was
                 told 180 late events and a 4.2h median lag. The two cases are now separate, and
                 neither of them is a number. */}

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -27,7 +27,9 @@
 import { useEffect, useMemo, useState } from "react";
 
 import {
+  NoDataYet,
   PartialDataBanner,
+  SourceUnavailable,
   StaleBadge,
   SyntheticPreviewBanner,
 } from "@/components/DataStateBanner";
@@ -53,7 +55,13 @@ import {
   reconciledTotal,
   totalRange,
 } from "@/lib/cost";
-import { asOfLabel, deriveDataState, relativeAge, zeroEnabledLayers } from "@/lib/dataState";
+import {
+  asOfLabel,
+  deriveDataState,
+  relativeAge,
+  type SourceState,
+  zeroEnabledLayers,
+} from "@/lib/dataState";
 import { isDemoMode } from "@/lib/demoMode";
 import type {
   CostSliceTotals,
@@ -81,10 +89,19 @@ import { BudgetVsActualCard } from "./BudgetVsActualCard";
 import { BurndownCard, type CostBudgetPayload } from "./BurndownCard";
 
 export interface CostPayload {
-  series: CostSeries;
+  /**
+   * null when ClickHouse could not be read (#363). An empty window still comes back as a full
+   * 30-point series of zeros, so the shape cannot distinguish "no spend" from "no answer";
+   * `sources.series` is what does.
+   */
+  series: CostSeries | null;
   featureRows: FeatureCostRow[];
   alerts: HiddenCostAlert[];
+  sources: { series: SourceState; featureRows: SourceState; alerts: SourceState };
 }
+
+/** The shape the derivations below reduce over when there is no series to reduce. */
+const NO_SERIES: CostSeries = { reconciledThrough: "1970-01-01", days: [] };
 
 function sumLayer(rows: FeatureCostRow[], layer: Layer) {
   return rows.reduce((s, r) => s + r.byLayer[layer], 0);
@@ -142,7 +159,12 @@ export function CostLive({
   const endpoint = queryString ? `/api/cost?${queryString}` : "/api/cost";
   const windowDays = rangeDays(filterState.range);
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
-  const { series: costSeries, featureRows, alerts: hiddenCostAlerts } = data;
+  const { featureRows, alerts: hiddenCostAlerts, sources } = data;
+  // #363: the derivations below all reduce over the series, and every one of them produces a
+  // confident zero from an absent one. They still run (the hooks under them must not be skipped)
+  // but nothing they produce is rendered unless `sources.series` says there was a real read; see
+  // the guards above the return.
+  const costSeries: CostSeries = data.series ?? NO_SERIES;
 
   // The default slice keeps the shipped per-layer chart + tile numbers where /api/explore is idle or
   // unreachable; every slice still fetches /api/explore for the filter-aware totals and breakdown.
@@ -212,8 +234,11 @@ export function CostLive({
     return acc;
   }, zeroLayerRecord());
   const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
+  // #363: `isEmpty` no longer comes from "the total is zero". A window that genuinely cost nothing
+  // and a window nothing was recorded in are different facts, and the read is what tells them
+  // apart. This derivation is left with staleness and partial connector coverage.
   const state = deriveDataState({
-    isEmpty: total === 0,
+    isEmpty: false,
     isPartial: trippedLayers.length > 0,
     reconciledThrough: costSeries.reconciledThrough,
   });
@@ -500,33 +525,70 @@ export function CostLive({
     </div>
   );
 
+  const header = (
+    <PageHeader
+      title="Cost Explorer"
+      subtitle="Where the spend goes, by layer and by feature"
+      actions={
+        <>
+          <LiveIndicator updatedAt={updatedAt} />
+          {asOf && (
+            <StaleBadge
+              asOf={asOf}
+              age={relativeAge(costSeries.reconciledThrough)}
+              stale={state === "stale"}
+            />
+          )}
+        </>
+      }
+      toolbar={
+        <FilterBar
+          options={{ feature: featureOptions, layer: layerOptions, agent: agentOptions }}
+        />
+      }
+    />
+  );
+
+  // #363. The read failed: say so, and draw no chart. The stacked chart over a null series was a
+  // flat run of zero days, which is a picture of a month with no spend, not a picture of a month we
+  // could not read.
+  if (sources.series === "unavailable") {
+    return (
+      <div className="space-y-6">
+        {header}
+        <SourceUnavailable reason="The telemetry store could not be read for this workspace." />
+      </div>
+    );
+  }
+  // The read succeeded over nothing. A ?tag= filter that matched nothing is a different sentence
+  // from a workspace that has sent nothing, and only the second one is an onboarding problem.
+  if (sources.series === "empty") {
+    return (
+      <div className="space-y-6">
+        {header}
+        <NoDataYet
+          what={tag ? `spend for ${tag}` : "AI spend"}
+          detail={
+            tag
+              ? `No spans tagged ${tag} were recorded in the last ${windowDays} days.`
+              : `No spans have been recorded for this workspace in the last ${windowDays} days.`
+          }
+          onboarding={!tag}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
-      <PageHeader
-        title="Cost Explorer"
-        subtitle="Where the spend goes, by layer and by feature"
-        actions={
-          <>
-            <LiveIndicator updatedAt={updatedAt} />
-            {state !== "empty" && asOf && (
-              <StaleBadge
-                asOf={asOf}
-                age={relativeAge(costSeries.reconciledThrough)}
-                stale={state === "stale"}
-              />
-            )}
-          </>
-        }
-        toolbar={
-          <FilterBar
-            options={{ feature: featureOptions, layer: layerOptions, agent: agentOptions }}
-          />
-        }
-      />
+      {header}
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
-      {state === "empty" ? (
+      {/* #363: reachable only from `sources.series === "sample"`, which a demo build with no Clerk
+          organization behind it earns. It used to wrap the EMPTY state, so a real tenant's first
+          visit was a labelled tour of another company's spend. */}
+      {sources.series === "sample" ? (
         <SyntheticPreviewBanner workflow="Cost">{body}</SyntheticPreviewBanner>
       ) : (
         body

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -233,7 +233,12 @@ export function CostLive({
     acc[l] = sumLayer(featureRows, l);
     return acc;
   }, zeroLayerRecord());
-  const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
+  // #364 review: a layer reads zero either because it genuinely cost nothing or because the
+  // feature-rows read failed and `featureRows` is the empty fallback. Only the first is a finding.
+  // Claiming "llm, vector, tools are reporting zero, that connector isn't producing data" over an
+  // unreadable source is the same collapse this change removes from the API.
+  const trippedLayers =
+    sources.featureRows === "unavailable" ? [] : zeroEnabledLayers(layerTotals, enabledLayers);
   // #364: `isEmpty` no longer comes from "the total is zero". A window that genuinely cost nothing
   // and a window nothing was recorded in are different facts, and the read is what tells them
   // apart. This derivation is left with staleness and partial connector coverage.
@@ -568,10 +573,14 @@ export function CostLive({
         {header}
         <NoDataYet
           what={tag ? `spend for ${tag}` : "AI spend"}
+          // #364 review: this state is reached when every day in the window is zero across every
+          // layer, which is a statement about COST, not about spans. A window whose spans were all
+          // unpriced reaches it too, and claiming "no spans have been recorded" there is the same
+          // inference this change removes from Home, which uses a real span count.
           detail={
             tag
-              ? `No spans tagged ${tag} were recorded in the last ${windowDays} days.`
-              : `No spans have been recorded for this workspace in the last ${windowDays} days.`
+              ? `No cost was recorded for ${tag} in the last ${windowDays} days.`
+              : `No cost has been recorded for this workspace in the last ${windowDays} days. Spans that arrived but could not be priced show as unpriced rather than as spend.`
           }
           onboarding={!tag}
         />

--- a/web/app/cost/Live.tsx
+++ b/web/app/cost/Live.tsx
@@ -90,7 +90,7 @@ import { BurndownCard, type CostBudgetPayload } from "./BurndownCard";
 
 export interface CostPayload {
   /**
-   * null when ClickHouse could not be read (#363). An empty window still comes back as a full
+   * null when ClickHouse could not be read (#364). An empty window still comes back as a full
    * 30-point series of zeros, so the shape cannot distinguish "no spend" from "no answer";
    * `sources.series` is what does.
    */
@@ -160,7 +160,7 @@ export function CostLive({
   const windowDays = rangeDays(filterState.range);
   const { data, updatedAt } = useLivePoll<CostPayload>(endpoint, initialData);
   const { featureRows, alerts: hiddenCostAlerts, sources } = data;
-  // #363: the derivations below all reduce over the series, and every one of them produces a
+  // #364: the derivations below all reduce over the series, and every one of them produces a
   // confident zero from an absent one. They still run (the hooks under them must not be skipped)
   // but nothing they produce is rendered unless `sources.series` says there was a real read; see
   // the guards above the return.
@@ -234,7 +234,7 @@ export function CostLive({
     return acc;
   }, zeroLayerRecord());
   const trippedLayers = zeroEnabledLayers(layerTotals, enabledLayers);
-  // #363: `isEmpty` no longer comes from "the total is zero". A window that genuinely cost nothing
+  // #364: `isEmpty` no longer comes from "the total is zero". A window that genuinely cost nothing
   // and a window nothing was recorded in are different facts, and the read is what tells them
   // apart. This derivation is left with staleness and partial connector coverage.
   const state = deriveDataState({
@@ -549,7 +549,7 @@ export function CostLive({
     />
   );
 
-  // #363. The read failed: say so, and draw no chart. The stacked chart over a null series was a
+  // #364. The read failed: say so, and draw no chart. The stacked chart over a null series was a
   // flat run of zero days, which is a picture of a month with no spend, not a picture of a month we
   // could not read.
   if (sources.series === "unavailable") {
@@ -585,7 +585,7 @@ export function CostLive({
 
       {state === "partial" && <PartialDataBanner trippedLayers={trippedLayers} />}
 
-      {/* #363: reachable only from `sources.series === "sample"`, which a demo build with no Clerk
+      {/* #364: reachable only from `sources.series === "sample"`, which a demo build with no Clerk
           organization behind it earns. It used to wrap the EMPTY state, so a real tenant's first
           visit was a labelled tour of another company's spend. */}
       {sources.series === "sample" ? (

--- a/web/components/DataStateBanner.tsx
+++ b/web/components/DataStateBanner.tsx
@@ -55,7 +55,7 @@ export function SyntheticPreviewBanner({
 }
 
 /**
- * "The read succeeded and there is nothing yet" (#363).
+ * "The read succeeded and there is nothing yet" (#364).
  *
  * This is the state every new customer is in, and it is a real answer rather than an unknown one,
  * so it is neither a blank nor a preview of somebody else's numbers. It says what has not arrived
@@ -102,7 +102,7 @@ export function NoDataYet({
 }
 
 /**
- * "We could not read the source, so we do not know" (#363).
+ * "We could not read the source, so we do not know" (#364).
  *
  * The counterpart to {@link NoDataYet}, and deliberately worded so the two can never be mistaken
  * for each other: this one makes no claim about whether data exists. The reason travels with it for

--- a/web/components/DataStateBanner.tsx
+++ b/web/components/DataStateBanner.tsx
@@ -55,6 +55,74 @@ export function SyntheticPreviewBanner({
 }
 
 /**
+ * "The read succeeded and there is nothing yet" (#363).
+ *
+ * This is the state every new customer is in, and it is a real answer rather than an unknown one,
+ * so it is neither a blank nor a preview of somebody else's numbers. It says what has not arrived
+ * and points at the one action that changes that.
+ *
+ * `what` names the data, not the page: "no spend", "no agents", "no attributed sessions". The
+ * sentence reads "No <what> yet." so it stays short enough to sit inside a card.
+ */
+export function NoDataYet({
+  what,
+  detail,
+  onboarding = true,
+}: {
+  what: string;
+  /** One clause of context, when the bare noun is not enough to act on. */
+  detail?: string;
+  /**
+   * Whether nothing at all has arrived for the workspace (the new-tenant case), which is what makes
+   * onboarding the next step. A slice that is empty because a FILTER matched nothing passes false:
+   * pointing a customer with 500k spans at the install guide because they picked a quiet feature
+   * tag is its own kind of wrong answer.
+   */
+  onboarding?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-edge px-4 py-10 text-center">
+      <p className="text-sm font-medium">No {what} yet.</p>
+      <p className="max-w-prose text-sm text-muted">
+        {detail ?? "Nothing has arrived for this workspace."}{" "}
+        {onboarding
+          ? "This is what we measured, not a placeholder: no telemetry has reached ai-tally for this workspace."
+          : "This is what we measured, not a placeholder."}
+      </p>
+      {onboarding && (
+        <Link
+          href="/onboarding"
+          className="inline-flex items-center rounded-md border border-accent/50 bg-accent/15 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/25"
+        >
+          Finish setup
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/**
+ * "We could not read the source, so we do not know" (#363).
+ *
+ * The counterpart to {@link NoDataYet}, and deliberately worded so the two can never be mistaken
+ * for each other: this one makes no claim about whether data exists. The reason travels with it for
+ * the same purpose the `Blank` primitive carries one.
+ */
+export function SourceUnavailable({ reason }: { reason: string }) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-warn/40 bg-warn/5 px-4 py-10 text-center">
+      <p className="text-sm font-medium text-warn">
+        <span aria-hidden>—</span> Source unavailable
+      </p>
+      <p className="max-w-prose text-sm text-muted">
+        {reason} Nothing is shown here rather than a number we cannot stand behind. This is not a
+        statement that there is no data.
+      </p>
+    </div>
+  );
+}
+
+/**
  * Partial-data state. A banner pointing at the missing connector, rendered above whatever real
  * data does exist.
  *

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -461,10 +461,15 @@ export async function queryDataQuality(): Promise<DataQuality | null> {
     const attributed = parseInt(out[0]?.attributed ?? "0", 10);
     const total = parseInt(out[0]?.total ?? "0", 10);
     return {
-      // No value events yet → nothing to miss, rate is vacuously 1.0.
-      attributionRate: total > 0 ? attributed / total : 1,
-      contextDropCount: 0,
-      estimateCalibration: 0,
+      // #363: no business events used to mean a vacuous 1.0, which a caller cannot tell apart from
+      // a tenant whose every event really did attribute. Null is the only honest answer over an
+      // empty population, and it is also how the route recognises the empty state as empty.
+      attributionRate: total > 0 ? attributed / total : null,
+      // #363: both were hardcoded zeros. Nothing measures a context drop or an estimate-versus
+      // -invoice calibration on this path, so a 0 here asserted "no drops" and "perfectly
+      // calibrated" on no evidence. The /data-quality report is the surface that measures its own.
+      contextDropCount: null,
+      estimateCalibration: null,
     };
   });
 }
@@ -2000,9 +2005,26 @@ interface ReconciliationRun {
  * reflect one truth instead of independent hardcoded constants.
  *
  * Returns null when no reconciler run exists yet (`run` is null), or the gateway is unreachable /
- * non-2xx, so callers can apply honest-null (`—`) rather than fabricate a value.
+ * non-2xx, so callers can apply honest-null (`—`) rather than fabricate a value. Callers that need
+ * to tell those two apart use {@link fetchLatestReconciliationRunResult} instead.
  */
 async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null> {
+  const result = await fetchLatestReconciliationRunResult();
+  return result.state === "live" ? result.run : null;
+}
+
+/**
+ * The boxed form of {@link fetchLatestReconciliationRun}, keeping the two nulls apart (#363).
+ *
+ * "The gateway could not be read" and "the gateway answered, this tenant has never run the
+ * reconciler" both used to collapse to `null`, and a caller reading that null had no way to choose
+ * between an honest blank and an honest empty state. A new tenant is always the second case, so the
+ * collapse guaranteed the wrong one. This is the seam `queryAccountDetailResult` already opens for
+ * the account detail, and it is opened the same way here rather than by a second mechanism.
+ */
+async function fetchLatestReconciliationRunResult(): Promise<
+  { state: "live"; run: ReconciliationRun } | { state: "empty" } | { state: "unavailable" }
+> {
   try {
     const res = await fetch(`${GATEWAY_URL}/v1/tenant/reconciliation/status`, {
       headers: controlPlaneHeaders(await resolveTenantId()),
@@ -2010,15 +2032,15 @@ async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null>
       signal: AbortSignal.timeout(2000),
     });
     if (!res.ok) {
-      console.warn(`[reconciliation] /v1/tenant/reconciliation/status HTTP ${res.status}; falling back`);
-      return null;
+      console.warn(`[reconciliation] /v1/tenant/reconciliation/status HTTP ${res.status}; unavailable`);
+      return { state: "unavailable" };
     }
     const body = (await res.json()) as { run?: ReconciliationRun | null };
-    // No reconciler run yet → null so callers render the honest "no data" state.
-    return body.run ?? null;
+    // No reconciler run yet is an ANSWER, not a failure: the gateway told us there is none.
+    return body.run ? { state: "live", run: body.run } : { state: "empty" };
   } catch (err) {
     console.warn("[reconciliation] gateway unreachable:", (err as Error).message);
-    return null;
+    return { state: "unavailable" };
   }
 }
 
@@ -2043,16 +2065,24 @@ export async function queryReconcilerLastRun(): Promise<number | null> {
  * convert to the page's units (hours / minutes-ago). Reads the same real source as
  * {@link queryReconcilerLastRun} so the freshness signal agrees across surfaces.
  *
- * Honest-null: when no reconciler run exists yet, or the gateway is unreachable / non-2xx, we
- * return null so the /api/features route falls back to its mock via `?? diagnostics`.
+ * Three states, not two (#363). `unavailable` is the gateway failing, which is genuinely unknown;
+ * `empty` is the gateway reporting that this tenant has never run the reconciler, which is a real
+ * answer and the normal state of a tenant that has not sent anything yet. The /api/features route
+ * renders a different thing for each, and used to render fixture diagnostics for both.
  */
-export async function queryAttributionDiagnostics(): Promise<AttributionDiagnostics | null> {
-  const run = await fetchLatestReconciliationRun();
-  if (!run) return null;
+export async function queryAttributionDiagnostics(): Promise<
+  { state: "live"; diagnostics: AttributionDiagnostics } | { state: "empty" | "unavailable" }
+> {
+  const result = await fetchLatestReconciliationRunResult();
+  if (result.state !== "live") return { state: result.state };
+  const { run } = result;
   return {
-    lateArrivalEvents7d: run.events_late,
-    lateArrivalMedianHours: Math.round((run.lag_seconds_median / 3600) * 10) / 10,
-    reconcilerLastRunMinutesAgo: minutesSince(run.finished_at),
+    state: "live",
+    diagnostics: {
+      lateArrivalEvents7d: run.events_late,
+      lateArrivalMedianHours: Math.round((run.lag_seconds_median / 3600) * 10) / 10,
+      reconcilerLastRunMinutesAgo: minutesSince(run.finished_at),
+    },
   };
 }
 

--- a/web/lib/clickhouse.ts
+++ b/web/lib/clickhouse.ts
@@ -461,11 +461,11 @@ export async function queryDataQuality(): Promise<DataQuality | null> {
     const attributed = parseInt(out[0]?.attributed ?? "0", 10);
     const total = parseInt(out[0]?.total ?? "0", 10);
     return {
-      // #363: no business events used to mean a vacuous 1.0, which a caller cannot tell apart from
+      // #364: no business events used to mean a vacuous 1.0, which a caller cannot tell apart from
       // a tenant whose every event really did attribute. Null is the only honest answer over an
       // empty population, and it is also how the route recognises the empty state as empty.
       attributionRate: total > 0 ? attributed / total : null,
-      // #363: both were hardcoded zeros. Nothing measures a context drop or an estimate-versus
+      // #364: both were hardcoded zeros. Nothing measures a context drop or an estimate-versus
       // -invoice calibration on this path, so a 0 here asserted "no drops" and "perfectly
       // calibrated" on no evidence. The /data-quality report is the surface that measures its own.
       contextDropCount: null,
@@ -2014,7 +2014,7 @@ async function fetchLatestReconciliationRun(): Promise<ReconciliationRun | null>
 }
 
 /**
- * The boxed form of {@link fetchLatestReconciliationRun}, keeping the two nulls apart (#363).
+ * The boxed form of {@link fetchLatestReconciliationRun}, keeping the two nulls apart (#364).
  *
  * "The gateway could not be read" and "the gateway answered, this tenant has never run the
  * reconciler" both used to collapse to `null`, and a caller reading that null had no way to choose
@@ -2065,7 +2065,7 @@ export async function queryReconcilerLastRun(): Promise<number | null> {
  * convert to the page's units (hours / minutes-ago). Reads the same real source as
  * {@link queryReconcilerLastRun} so the freshness signal agrees across surfaces.
  *
- * Three states, not two (#363). `unavailable` is the gateway failing, which is genuinely unknown;
+ * Three states, not two (#364). `unavailable` is the gateway failing, which is genuinely unknown;
  * `empty` is the gateway reporting that this tenant has never run the reconciler, which is a real
  * answer and the normal state of a tenant that has not sent anything yet. The /api/features route
  * renders a different thing for each, and used to render fixture diagnostics for both.

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -134,7 +134,18 @@ export function someZero(values: Record<string, number>): boolean {
  * the banner for vector/tools/etc., because they were never expected to fire. With the empty
  * input (no enabled connectors declared) we return [], i.e. nothing partial, by design.
  */
-// --- Source state: unavailable vs empty vs live (#363) -------------------------------------------
+export function zeroEnabledLayers<L extends string>(
+  // Keys are decoupled from L: byLayer carries every layer the system knows
+  // about (LLM/vector/tools/…); `enabled` is just the subset we're checking.
+  // Without the widening the call site would have to narrow byLayer to the
+  // exact enabled set, which is the opposite of how the data flows.
+  byLayer: Readonly<Record<string, number>>,
+  enabled: readonly L[],
+): L[] {
+  return enabled.filter((l) => (byLayer[l] ?? 0) === 0);
+}
+
+// --- Source state: unavailable vs empty vs live (#364) -------------------------------------------
 //
 // The three states below used to be two. Every route wrote `live ?? mock` or
 // `live && live.length > 0 ? live : mock`, which folds "the query threw" and "the query answered,
@@ -144,7 +155,7 @@ export function someZero(values: Record<string, number>): boolean {
 // They are different facts and only one of them is unknown:
 //
 //   unavailable - ClickHouse or the gateway could not be read. We do not know the answer. This is
-//                 the honest-blank case: render the blank with its reason (components/HonestValue).
+//                 the honest-blank case: say so, and render no figure.
 //   empty       - the read succeeded and returned no rows. We DO know the answer: nothing has
 //                 arrived yet. This is the normal state of every new customer, and it deserves a
 //                 real empty state pointing at onboarding, never a blank and never a fabricated 0.
@@ -152,6 +163,9 @@ export function someZero(values: Record<string, number>): boolean {
 //   sample      - fixture data, which `sampleDataAllowed()` in lib/mock.ts permits only for a demo
 //                 build with no real tenant behind it. Always rendered behind the SAMPLE DATA
 //                 banner, never reachable while a Clerk organization is resolved.
+//
+// This is the same three-way split `SetupCallout` already makes over the first-event probe (#358),
+// applied to every read the dashboards do rather than to one existence check.
 
 export type SourceState = "live" | "empty" | "unavailable" | "sample";
 
@@ -170,20 +184,4 @@ export type ReadState = Exclude<SourceState, "sample">;
 export function readState<T>(value: T | null, isEmpty: (v: T) => boolean): ReadState {
   if (value === null) return "unavailable";
   return isEmpty(value) ? "empty" : "live";
-}
-
-/** True when a surface may render figures: only `live`, and `sample`, which is labelled as such. */
-export function hasFigures(state: SourceState): boolean {
-  return state === "live" || state === "sample";
-}
-
-export function zeroEnabledLayers<L extends string>(
-  // Keys are decoupled from L: byLayer carries every layer the system knows
-  // about (LLM/vector/tools/…); `enabled` is just the subset we're checking.
-  // Without the widening the call site would have to narrow byLayer to the
-  // exact enabled set, which is the opposite of how the data flows.
-  byLayer: Readonly<Record<string, number>>,
-  enabled: readonly L[],
-): L[] {
-  return enabled.filter((l) => (byLayer[l] ?? 0) === 0);
 }

--- a/web/lib/dataState.ts
+++ b/web/lib/dataState.ts
@@ -134,6 +134,49 @@ export function someZero(values: Record<string, number>): boolean {
  * the banner for vector/tools/etc., because they were never expected to fire. With the empty
  * input (no enabled connectors declared) we return [], i.e. nothing partial, by design.
  */
+// --- Source state: unavailable vs empty vs live (#363) -------------------------------------------
+//
+// The three states below used to be two. Every route wrote `live ?? mock` or
+// `live && live.length > 0 ? live : mock`, which folds "the query threw" and "the query answered,
+// there are no rows" onto the same branch and answers both with fixture numbers. A brand new tenant
+// with zero spans is the second case, and it was being shown another company's ROI table as its own.
+//
+// They are different facts and only one of them is unknown:
+//
+//   unavailable - ClickHouse or the gateway could not be read. We do not know the answer. This is
+//                 the honest-blank case: render the blank with its reason (components/HonestValue).
+//   empty       - the read succeeded and returned no rows. We DO know the answer: nothing has
+//                 arrived yet. This is the normal state of every new customer, and it deserves a
+//                 real empty state pointing at onboarding, never a blank and never a fabricated 0.
+//   live        - real rows.
+//   sample      - fixture data, which `sampleDataAllowed()` in lib/mock.ts permits only for a demo
+//                 build with no real tenant behind it. Always rendered behind the SAMPLE DATA
+//                 banner, never reachable while a Clerk organization is resolved.
+
+export type SourceState = "live" | "empty" | "unavailable" | "sample";
+
+/** The three states a real read can produce. `sample` is a deployment choice, not a read result. */
+export type ReadState = Exclude<SourceState, "sample">;
+
+/**
+ * Classify a `tryLive`-shaped result. `null` is the source failing, which is the only unknown here;
+ * anything else is an answer, and `isEmpty` decides whether that answer is "no data yet".
+ *
+ * `isEmpty` is a predicate rather than a length check because emptiness is not the same fact on
+ * every surface: a row list is empty when it has no rows, but a spend summary always comes back as
+ * an object and is empty when it covered no spans (its zeros are then the absence of data, not a
+ * measurement of it).
+ */
+export function readState<T>(value: T | null, isEmpty: (v: T) => boolean): ReadState {
+  if (value === null) return "unavailable";
+  return isEmpty(value) ? "empty" : "live";
+}
+
+/** True when a surface may render figures: only `live`, and `sample`, which is labelled as such. */
+export function hasFigures(state: SourceState): boolean {
+  return state === "live" || state === "sample";
+}
+
 export function zeroEnabledLayers<L extends string>(
   // Keys are decoupled from L: byLayer carries every layer the system knows
   // about (LLM/vector/tools/…); `enabled` is just the subset we're checking.

--- a/web/lib/mock.ts
+++ b/web/lib/mock.ts
@@ -6,7 +6,37 @@
 // with two providers in production (OpenAI + Anthropic) and Stripe revenue attributed back.
 // Numbers chosen to be believable for screenshots / a LinkedIn demo, not real telemetry.
 
+import { isDemoMode } from "./demoMode";
 import type { CostOutlier, DataQuality, FeatureRoi, SpendSummary } from "./types";
+
+/**
+ * The one gate every fixture fallback in `app/api/**` passes through (#363).
+ *
+ * Fixtures used to be the answer to "the read failed" AND to "the read came back empty", so a real
+ * signed-in customer with zero spans was shown this file's storyline as their own numbers: a
+ * research_agent they have never run, paying back in 7 days. That is the honesty invariant's
+ * headline failure, and no banner makes it acceptable, so the fixtures are now unreachable on the
+ * product path rather than merely labelled there.
+ *
+ * TWO conditions, and both are load-bearing:
+ *
+ *   NEXT_PUBLIC_DEMO_MODE=1  an explicit, deliberate opt-in. Nobody sets it by accident, and it is
+ *                            already the flag a demo build sets for the rest of its presentation.
+ *   TALLY_DEV_TENANT set     no Clerk organization was resolved. This is the ONLY way the dashboard
+ *                            serves a tenant without an authenticated org (see lib/getTenant.ts), so
+ *                            requiring it makes "a real tenant is signed in" and "fixtures render"
+ *                            mutually exclusive by construction, not by review vigilance.
+ *
+ * Deliberately NOT read here: whether ClickHouse is configured. An unreachable store is a reason to
+ * say so, not a licence to invent numbers, which is what `deploy/vercel/README.md` used to document.
+ *
+ * Read at call time rather than hoisted to a module constant so a test can set the environment per
+ * case; `NEXT_PUBLIC_*` is inlined at build time on the client, and this is only ever called from a
+ * Route Handler on the server, where both values are live.
+ */
+export function sampleDataAllowed(): boolean {
+  return isDemoMode() && Boolean(process.env.TALLY_DEV_TENANT?.trim());
+}
 
 export const mockSpend: SpendSummary = {
   totalMicroUsd: 52_400_000_000, // $52,400 over the last 30 days

--- a/web/lib/mock.ts
+++ b/web/lib/mock.ts
@@ -10,7 +10,7 @@ import { isDemoMode } from "./demoMode";
 import type { CostOutlier, DataQuality, FeatureRoi, SpendSummary } from "./types";
 
 /**
- * The one gate every fixture fallback in `app/api/**` passes through (#363).
+ * The one gate every fixture fallback in `app/api/**` passes through (#364).
  *
  * Fixtures used to be the answer to "the read failed" AND to "the read came back empty", so a real
  * signed-in customer with zero spans was shown this file's storyline as their own numbers: a

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -81,7 +81,7 @@ export interface FeatureRoi {
 
 export interface DataQuality {
   /**
-   * 0..1, or null when there is nothing to rate (#363).
+   * 0..1, or null when there is nothing to rate (#364).
    *
    * The live read used to answer "no business events at all" with a vacuous 1.0, i.e. a confident
    * 100% attribution for a tenant that has attributed nothing. A rate over an empty population is

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -80,7 +80,16 @@ export interface FeatureRoi {
 }
 
 export interface DataQuality {
-  attributionRate: number; // 0..1
-  contextDropCount: number;
-  estimateCalibration: number; // fractional error, e.g. 0.021 = 2.1%
+  /**
+   * 0..1, or null when there is nothing to rate (#363).
+   *
+   * The live read used to answer "no business events at all" with a vacuous 1.0, i.e. a confident
+   * 100% attribution for a tenant that has attributed nothing. A rate over an empty population is
+   * not a rate.
+   */
+  attributionRate: number | null; // 0..1
+  /** null when no source measures this. It was a hardcoded 0, which claimed zero drops. */
+  contextDropCount: number | null;
+  /** Fractional error, e.g. 0.021 = 2.1%. null when nothing has reconciled to calibrate against. */
+  estimateCalibration: number | null;
 }


### PR DESCRIPTION
Found by signing in as a real Clerk organization. A tenant provisioned through the real flow has **zero spans**, and its Home page rendered this repo's fixture storyline as the customer's own numbers:

```
research_agent   $0.320/user   $4.20/user   7d payback
support_triage   $0.012/user   $0.310/user  1d payback
```

A customer who has never run `research_agent` was being told it pays back in 7 days. Nine fallbacks across six routes had that shape: `home` (spend, roi, dq), `connectors`, `cost`, `agents`, `features`, `attribution`.

## The cause

Three states collapsed into one:

1. **Source unavailable.** The query threw or timed out, `tryLive()` returned null. We do not know.
2. **Query succeeded, zero rows.** We DO know: there is no data. The normal state of every new customer.
3. **Real data.**

State 2 was treated as state 1, and state 1 was answered with fixtures. They now render differently: an empty state that says what was measured, and the honest blank with a reason.

## Fixtures are unreachable, not labelled

`sampleDataAllowed()` requires **both** `NEXT_PUBLIC_DEMO_MODE=1` **and** `TALLY_DEV_TENANT`.

The second condition is the load-bearing one. `TALLY_DEV_TENANT` is the only way the dashboard serves a tenant without an authenticated Clerk org, so requiring it makes "a real tenant is signed in" and "fixtures render" **mutually exclusive by construction rather than by review vigilance**.

Deliberately *not* part of the gate: whether ClickHouse is configured. An unreachable store is a reason to say so, not a licence to invent numbers, which is what `deploy/vercel/README.md` used to document as intended behaviour.

Also: `attributionRate` returned a vacuous `1.0` when a tenant had no business events, which a caller cannot tell apart from a real 100%. It returns `null`.

## Verified against both tenants on the live stack

**Empty tenant** (`Silk Route`, 0 spans): Home shows *"No AI spend yet. No spans have been received for this workspace in the last 30 days. This is what we measured, not a placeholder."* with a Finish setup route out. Every waste detector shows a dash with "Every detector ran and flagged nothing". Cost per Account shows a true `$0.00` for **measured** spend while the no-account **rate** shows a dash, which is the right distinction: the sum is known, the ratio is not.

**Populated tenant** (`Nova`, 512,081 spans): unchanged. $51,879.09, 479,074 spans, six ROI rows.

`attributionRate: 0` on Nova is a genuine measurement, not a regression: its attribution records live under the `local-dev` spelling while its business events are under the UUID, so the ratio really is zero. That is the two-spellings problem reporting itself honestly.

**870 tests / 71 files** (up from 840), typecheck clean, lint clean apart from the pre-existing `lib/useLivePoll.ts:94` warning.

## Note on provenance

Two agents wrote this and both stalled during verification, the second leaving a type error and four failures which it had actually fixed in a later commit. I merged main in, reviewed the gating design, ran the suites, and did the visual verification against both tenants that neither reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)