### PR TITLE
feat(deploy): run the single-VM kit with real Clerk auth

### DIFF
--- a/deploy/demo/.env.example
+++ b/deploy/demo/.env.example
@@ -51,3 +51,36 @@ MINIO_ROOT_PASSWORD=tally-minio
 # Generate a real one (never commit it, and never reuse the infra/.env.example placeholder):
 #   echo "TALLY_GATEWAY_SERVICE_TOKEN=$(openssl rand -hex 32)" >> deploy/demo/.env
 # TALLY_GATEWAY_SERVICE_TOKEN=
+
+# ---------------------------------------------------------------------------------------------
+# AUTH_MODE (CTO-367). Which of the two mutually exclusive shapes this VM runs.
+#
+#   basic  (default, unchanged)  The synthetic-data demo. The dashboard's own authentication is OFF
+#                                and Caddy HTTP basic-auth is the only thing in front of it. Needs
+#                                BASIC_AUTH_USER and BASIC_AUTH_HASH above.
+#   clerk                        A real instance. Clerk resolves the tenant from the signed-in
+#                                organization, TALLY_DEV_TENANT stays unset, and Caddy is TLS only.
+#                                Needs the four values below.
+#
+# They are exclusive on purpose: setting the dev tenant in clerk mode would silently turn auth off
+# on an instance you believe is protected.
+# ---------------------------------------------------------------------------------------------
+# AUTH_MODE=clerk
+
+# From the Clerk dashboard, Configure > API Keys, for the PRODUCTION instance. Development
+# instances only work against localhost.
+#
+# The publishable key is inlined into the client bundle by `next build`, so changing it needs a
+# rebuild rather than a restart. deploy.sh passes it as a build arg for exactly that reason.
+# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
+# CLERK_SECRET_KEY=sk_live_...
+
+# From Clerk > Configure > Webhooks, after adding an endpoint at https://${DOMAIN}/api/webhooks/clerk
+# subscribed to organization.created ONLY. Without it sign-in works but no tenant is ever
+# provisioned, and a new user sits on "setting up your workspace" until it gives up.
+# The variable name is CLERK_WEBHOOK_SIGNING_SECRET, not CLERK_WEBHOOK_SECRET.
+# CLERK_WEBHOOK_SIGNING_SECRET=whsec_...
+
+# Shared secret between the web tier and the gateway control plane. Must be byte-identical to the
+# gateway's TALLY_GATEWAY_SERVICE_TOKEN. Generate with: openssl rand -hex 32
+# GATEWAY_SERVICE_TOKEN=

--- a/deploy/demo/Caddyfile.clerk
+++ b/deploy/demo/Caddyfile.clerk
@@ -1,0 +1,30 @@
+# ai-tally demo-deploy-kit - Caddy site config for CLERK auth (CTO-367).
+#
+# The sibling `Caddyfile` fronts the synthetic-data demo: authentication is off inside the app and
+# Caddy's HTTP basic-auth is the only thing standing in front of it. This file is for the other
+# mode, where the dashboard runs with real Clerk sign-in and Caddy is TLS and nothing else.
+#
+# WHY BASIC-AUTH IS ABSENT RATHER THAN ADDITIONAL. Clerk's flows are redirects: the hosted sign-in
+# page, the OAuth round trip to Google, and the `organization.created` webhook Clerk POSTs to
+# /api/webhooks/clerk. A basic-auth challenge in front of those either breaks them or prompts the
+# user twice for two unrelated credentials. The webhook is the one that fails silently: Clerk gets a
+# 401, no tenant is ever provisioned, and the symptom is a signed-in user whose workspace never
+# appears.
+#
+# Env used (set by docker-compose.prod.yml from .env):
+#   ${DOMAIN}   e.g. app.example.com
+
+{$DOMAIN} {
+	# The browser talks only to the dashboard. ClickHouse, Postgres and the gateway stay on the
+	# compose network with no published ports, exactly as in the basic-auth mode.
+	reverse_proxy web:3000
+
+	# ---- OPTIONAL: expose the gateway ingest endpoint ------------------------------------------
+	# Uncomment to let an app POST its own telemetry. Note this endpoint authenticates with a tally
+	# API key, not with a Clerk session, so it is safe to expose without a browser login. Everything
+	# else on the gateway (the control plane in particular) stays internal.
+	#
+	# handle /v1/batches* {
+	# 	reverse_proxy gateway:8080
+	# }
+}

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -28,6 +28,59 @@ keep talking to each other over the compose network but are not reachable from t
 | `reseed.sh` | Reset + re-seed the synthetic data (run nightly via cron). |
 | `lib-tenant.sh` | Sourced by both scripts: tenant-UUID resolution and the service-token preflight. |
 
+## Two modes: `basic` and `clerk`
+
+This kit was written to host a synthetic-data demo, and that is still the default. CTO-367 adds a
+second shape for a real instance. They are mutually exclusive, chosen by `AUTH_MODE` in `.env`.
+
+| | `basic` (default) | `clerk` |
+|---|---|---|
+| Dashboard auth | **off** (`TALLY_DEV_TENANT` pins the tenant) | real Clerk sign-in |
+| What guards it | Caddy HTTP basic-auth | Clerk; Caddy is TLS only |
+| Tenant | the seeded demo tenant | resolved from the signed-in organization |
+| Data | synthetic backfill | whatever the tenant has |
+| `.env` needs | `BASIC_AUTH_USER`, `BASIC_AUTH_HASH` | the four Clerk values |
+
+The exclusivity is the point rather than a convenience. `TALLY_DEV_TENANT` does not only pin a
+tenant, it turns the dashboard's authentication off completely, so setting it in `clerk` mode would
+leave an instance you believe is protected serving every number to anyone who reaches the URL.
+`deploy.sh` sets one or the other, never both.
+
+### Why `clerk` mode drops basic-auth rather than keeping both
+
+Clerk's flows are redirects: its hosted sign-in page, the OAuth round trip to your identity
+provider, and the `organization.created` webhook Clerk POSTs to `/api/webhooks/clerk`. A basic-auth
+challenge in front of those either breaks them or asks the user for two unrelated credentials.
+
+The webhook is the one that fails quietly. Clerk gets a 401, retries, gives up. No tenant is ever
+provisioned, and the symptom is a signed-in user whose workspace never appears, which reads as a
+broken product rather than a misconfigured proxy.
+
+### Running in `clerk` mode
+
+1. Create a **production** Clerk instance (development instances only work against `localhost`),
+   verify its DNS, and supply your own Google OAuth credentials if you want social sign-in.
+   Production instances do not get Clerk's shared ones.
+2. Put `AUTH_MODE=clerk`, the publishable key, the secret key and `GATEWAY_SERVICE_TOKEN` in `.env`.
+3. Run `./deploy.sh`. It will warn that the webhook secret is missing, which is expected: the
+   endpoint cannot exist until this deployment has a URL.
+4. In Clerk, add a webhook at `https://${DOMAIN}/api/webhooks/clerk` subscribed to
+   `organization.created` only. Put the `whsec_` value in `.env` as
+   `CLERK_WEBHOOK_SIGNING_SECRET` and re-run `./deploy.sh`.
+5. Sign up, create an organization, and you get a fresh empty tenant. To put that organization in
+   front of the seeded demo corpus instead, use `gateway.adopt_org`; see
+   [docs/runbook-tenants.md](../../docs/runbook-tenants.md).
+
+Run `make prod-preflight` from `infra/` before step 3. It checks both sides of the configuration and
+names the symptom each missing value produces.
+
+### What this kit is not
+
+One VM, one disk, no replicas and no managed backups. That is a reasonable first production instance
+and a poor long-term one. The retention policy applied by `make ch-apply-retention` is the only data
+lifecycle here, so put a snapshot schedule on the volume. `deploy/aws/terraform/` is the managed
+alternative when you outgrow this.
+
 ## Operator runbook
 
 ### 1. Provision a VM

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -49,7 +49,19 @@ source "${SCRIPT_DIR}/lib-tenant.sh"
 require_service_token_if_auth_on
 warn_backfill_unsupported_if_auth_on
 
-echo "==> Building images and starting the stack"
+# CTO-367: pick the Caddy site file before anything starts. `basic` keeps the HTTP basic-auth block
+# this kit has always had; `clerk` mounts a file without one, because Clerk's redirects and its
+# organization.created webhook cannot pass a basic-auth challenge, and the webhook fails silently
+# when they try: Clerk gets a 401, no tenant is provisioned, and the user waits on a workspace that
+# never appears. Exported so Compose interpolates it into the caddy volume mount.
+if [ "${AUTH_MODE:-basic}" = "clerk" ]; then
+  export CADDY_SITE_FILE=Caddyfile.clerk
+else
+  export CADDY_SITE_FILE=Caddyfile
+  : "${BASIC_AUTH_USER:?AUTH_MODE=basic needs BASIC_AUTH_USER in .env}"
+  : "${BASIC_AUTH_HASH:?AUTH_MODE=basic needs BASIC_AUTH_HASH in .env (docker run --rm caddy:2 caddy hash-password --plaintext '...')}"
+fi
+echo "==> Building images and starting the stack (auth mode: ${AUTH_MODE:-basic})"
 "${COMPOSE[@]}" up -d --build
 
 # --- Wait for the gateway to be healthy before seeding ------------------------------------------
@@ -86,8 +98,33 @@ make -C infra COMPOSE="docker compose --env-file ${REPO_ROOT}/${ENV_FILE} -f ${R
 echo "==> Resolving the demo tenant UUID"
 TENANT_UUID="$(resolve_tenant_uuid)"
 echo "    ${DEMO_TENANT_NAME} = ${TENANT_UUID}"
-echo "==> Pointing the dashboard at it (auth OFF: synthetic demo data behind Caddy basic auth)"
-pin_dashboard_tenant "${TENANT_UUID}"
+
+# CTO-367: two mutually exclusive modes, and the whole point is that they cannot overlap.
+#
+#   basic (default)  The synthetic-data demo this kit was written for. TALLY_DEV_TENANT pins the
+#                    tenant, which turns the dashboard's own authentication off completely, and
+#                    Caddy basic-auth is the only thing in front of it.
+#   clerk            A real instance. TALLY_DEV_TENANT stays UNSET so Clerk resolves the tenant from
+#                    the signed-in organization, and Caddy is TLS only.
+#
+# Setting TALLY_DEV_TENANT in clerk mode would silently disable auth on an instance the operator
+# believes is protected, so the modes are exclusive here rather than additive.
+if [ "${AUTH_MODE:-basic}" = "clerk" ]; then
+  : "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?AUTH_MODE=clerk needs NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY in .env (Clerk dashboard, API Keys)}"
+  : "${CLERK_SECRET_KEY:?AUTH_MODE=clerk needs CLERK_SECRET_KEY in .env (Clerk dashboard, API Keys)}"
+  echo "==> Auth mode: CLERK. The dashboard requires sign-in; TALLY_DEV_TENANT stays unset."
+  if [ -z "${CLERK_WEBHOOK_SIGNING_SECRET:-}" ]; then
+    echo "    NOTE: CLERK_WEBHOOK_SIGNING_SECRET is unset. Sign-in will work, but organization.created"
+    echo "          cannot be verified, so no tenant is ever provisioned and a new user lands on the"
+    echo "          'setting up your workspace' screen forever. Add the webhook in Clerk once this"
+    echo "          deployment has a URL, then re-run with the whsec_ value set."
+  fi
+  echo "    Demo tenant ${TENANT_UUID} exists and holds the seeded data. To put a Clerk"
+  echo "    organization in front of it, run gateway.adopt_org after signing in (docs/runbook-tenants.md)."
+else
+  echo "==> Auth mode: BASIC. Pointing the dashboard at the demo tenant (dashboard auth OFF, Caddy basic-auth in front)"
+  pin_dashboard_tenant "${TENANT_UUID}"
+fi
 
 echo "==> Backfilling 30 days of SYNTHETIC demo spans"
 # The `make chatbot-demo-backfill` target runs on the HOST and POSTs to localhost:8080 - neither

--- a/deploy/demo/docker-compose.prod.yml
+++ b/deploy/demo/docker-compose.prod.yml
@@ -43,6 +43,9 @@ services:
       # Always invoke as: docker compose -f infra/docker-compose.yml -f deploy/demo/docker-compose.prod.yml
       context: ..
       dockerfile: deploy/demo/web.Dockerfile
+      args:
+        # Inlined by `next build`, so it must be a build arg. See the Dockerfile.
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}
     container_name: ai-tally-web
     environment:
       # EXACT env var names the web reads (web/lib/clickhouse.ts, web/lib/tenant.ts, etc.).
@@ -61,6 +64,18 @@ services:
       # empty on the very first `up` (before seeding), where the dashboard errors loudly rather
       # than rendering a blank page for an unknown tenant.
       TALLY_DEV_TENANT: ${TALLY_DEV_TENANT:-}
+      # CTO-367: Clerk, for AUTH_MODE=clerk. All four are empty in the basic-auth demo mode, where
+      # TALLY_DEV_TENANT pins the tenant and Clerk is never consulted. In clerk mode TALLY_DEV_TENANT
+      # is empty instead and these carry the sign-in: the two modes are mutually exclusive by
+      # construction, which is the same property web/lib/mock.ts relies on to keep fixtures away from
+      # a real tenant.
+      #
+      # NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is inlined into the client bundle at BUILD time, so it is
+      # also a build arg below. Changing it needs a rebuild, not a restart.
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}
+      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
+      CLERK_WEBHOOK_SIGNING_SECRET: ${CLERK_WEBHOOK_SIGNING_SECRET:-}
+
       # CTO-268: the explicit "yes, serve this with no authentication" opt-in. TALLY_DEV_TENANT does
       # not only pin the tenant, it turns the dashboard's auth off completely, and this kit is the
       # thing operators copy when standing up a REAL instance. So the web image refuses to boot on
@@ -93,11 +108,18 @@ services:
       - "443:443"  # the private demo link
     environment:
       DOMAIN: ${DOMAIN:?set DOMAIN in .env}
-      BASIC_AUTH_USER: ${BASIC_AUTH_USER:?set BASIC_AUTH_USER in .env}
-      # bcrypt hash, generated with: docker run --rm caddy:2 caddy hash-password --plaintext '...'
-      BASIC_AUTH_HASH: ${BASIC_AUTH_HASH:?set BASIC_AUTH_HASH in .env}
+      # CTO-367: only the basic-auth site file reads these, so they are optional. AUTH_MODE=clerk
+      # mounts Caddyfile.clerk, which has no basic_auth block; leaving them unset there is correct
+      # rather than an omission. Caddy fails to start on an unset variable a site file DOES use, so
+      # a mismatch between AUTH_MODE and .env surfaces immediately instead of serving unprotected.
+      BASIC_AUTH_USER: ${BASIC_AUTH_USER:-}
+      BASIC_AUTH_HASH: ${BASIC_AUTH_HASH:-}
     volumes:
-      - ../deploy/demo/Caddyfile:/etc/caddy/Caddyfile:ro   # path is relative to infra/ (first -f file)
+      # CTO-367: which site file depends on AUTH_MODE. `basic` (the default, unchanged) fronts the
+      # synthetic demo with HTTP basic-auth because the app itself runs with auth off. `clerk` mounts
+      # a file with no basic_auth block, because Clerk's redirects and its organization.created
+      # webhook cannot pass a basic-auth challenge. deploy.sh exports CADDY_SITE_FILE.
+      - ../deploy/demo/${CADDY_SITE_FILE:-Caddyfile}:/etc/caddy/Caddyfile:ro   # relative to infra/ (first -f file)
       - caddy_data:/data    # ACME account + issued certs; persist so restarts do not re-issue
       - caddy_config:/config
     restart: unless-stopped

--- a/deploy/demo/web.Dockerfile
+++ b/deploy/demo/web.Dockerfile
@@ -22,7 +22,11 @@
 FROM node:22-bookworm-slim AS deps
 WORKDIR /app
 # Only the manifests, so this layer is reused whenever source (but not deps) changes.
-COPY web/package.json web/package-lock.json ./
+# CTO-367: .npmrc carries legacy-peer-deps=true, which @clerk/nextjs's React peer pin needs. Without
+# it `npm ci` dies with ERESOLVE and this image cannot be built at all. The same omission was fixed
+# in web/Dockerfile (#351); it went unnoticed in both because CI runs npm ci in the checkout, where
+# .npmrc is present.
+COPY web/package.json web/package-lock.json web/.npmrc ./
 RUN npm ci
 
 # ---- builder ------------------------------------------------------------------------------------
@@ -32,6 +36,12 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
     NEXT_PRIVATE_STANDALONE=true
 COPY --from=deps /app/node_modules ./node_modules
 COPY web/ .
+# CTO-367: Clerk's publishable key is inlined into the client bundle by `next build`, so it has to be
+# present AT BUILD TIME, not merely in the container's environment. Passing it as a runtime env var
+# alone produces an image that can never sign anyone in. Empty in the basic-auth demo mode, where
+# TALLY_DEV_TENANT turns Clerk off entirely and no provider is mounted.
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 RUN npm run build
 
 # ---- runner -------------------------------------------------------------------------------------


### PR DESCRIPTION
`deploy/demo/` hosts the whole stack on one VM behind Caddy with automatic HTTPS, and it is by some distance the easiest way to get ai-tally running: seven services, one script, no Terraform, no VPC, no ACM. But it was written for a synthetic demo, where the dashboard's own authentication is **off**, `TALLY_DEV_TENANT` pins a tenant, and Caddy basic-auth is the only thing in front.

That is the wrong shape for a real instance, and this kit is precisely what an operator copies when standing one up.

## `AUTH_MODE`

| | `basic` (default, unchanged) | `clerk` |
|---|---|---|
| Dashboard auth | off, `TALLY_DEV_TENANT` pins the tenant | real Clerk sign-in |
| What guards it | Caddy HTTP basic-auth | Clerk; Caddy is TLS only |
| Tenant | the seeded demo tenant | resolved from the signed-in organization |

The modes are **mutually exclusive**, for the same reason `web/lib/mock.ts` gates fixtures the way it does: `TALLY_DEV_TENANT` does not only pin a tenant, it turns authentication off completely. Allowing both would let an operator serve every number to anyone who reaches the URL while believing the instance was protected.

## Why clerk mode drops basic-auth rather than keeping both

Clerk's flows are redirects: its hosted sign-in page, the OAuth round trip, and the `organization.created` webhook it POSTs to `/api/webhooks/clerk`.

The webhook is the one that fails **silently**. A basic-auth challenge answers it 401, Clerk retries and gives up, no tenant is ever provisioned, and the symptom is a signed-in user whose workspace never appears. That reads as a broken product rather than a misconfigured proxy.

## Two bugs found while wiring it

**`web.Dockerfile` never copied `web/.npmrc`**, whose `legacy-peer-deps=true` is what `@clerk/nextjs`'s React peer pin needs. `npm ci` dies with ERESOLVE and the image cannot be built at all. This is the same omission #351 fixed in `web/Dockerfile`, and it went unnoticed in both for the same reason: CI runs `npm ci` in the checkout, where `.npmrc` is present.

**The publishable key is inlined by `next build`**, so passing it only as a runtime env var produces an image that can never sign anyone in. It is a build arg now, and the compose file passes it through.

## Verification

Both modes render under `docker compose config`: `basic` mounts `Caddyfile` with the basic-auth vars and empty Clerk keys, `clerk` mounts `Caddyfile.clerk` with the keys and empty basic-auth. A duplicate `GATEWAY_SERVICE_TOKEN` key was caught by the YAML parser while wiring and removed. All three scripts pass `bash -n`, and `infra/docker-compose.yml` is unaffected.

Not run end to end: standing up an actual VM with a real domain and a production Clerk instance. The README is explicit that this kit is one VM, one disk, no replicas and no managed backups, that `make ch-apply-retention` is the only data lifecycle on it, and that `deploy/aws/terraform/` is the managed alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)