### PR TITLE
fix(deploy): stop requiring basic-auth credentials in clerk mode

### DIFF
--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -35,8 +35,11 @@ source "${ENV_FILE}"
 set +a
 
 : "${DOMAIN:?DOMAIN must be set in ${ENV_FILE}}"
-: "${BASIC_AUTH_USER:?BASIC_AUTH_USER must be set in ${ENV_FILE}}"
-: "${BASIC_AUTH_HASH:?BASIC_AUTH_HASH must be set in ${ENV_FILE} (see .env.example for the generator)}"
+
+# CTO-367 follow-up: the basic-auth pair is required by `basic` mode ONLY, and this check used to be
+# unconditional, which made AUTH_MODE=clerk impossible to run: the script exited before it ever read
+# AUTH_MODE. The per-mode requirements are asserted together further down, next to the line that
+# picks the Caddy site file, so the two cannot drift apart again.
 
 # Compose reads the same .env for base-stack defaults; pass it explicitly so both files see it.
 COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
@@ -56,6 +59,11 @@ warn_backfill_unsupported_if_auth_on
 # never appears. Exported so Compose interpolates it into the caddy volume mount.
 if [ "${AUTH_MODE:-basic}" = "clerk" ]; then
   export CADDY_SITE_FILE=Caddyfile.clerk
+  # Asserted HERE, before the build, not after it. NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is a BUILD ARG
+  # (next build inlines it into the client bundle), so discovering it missing afterwards means an
+  # image that looks fine and can never sign anyone in, plus a wasted build on a small VM.
+  : "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?AUTH_MODE=clerk needs NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY in .env (Clerk dashboard, Configure > API Keys, production instance)}"
+  : "${CLERK_SECRET_KEY:?AUTH_MODE=clerk needs CLERK_SECRET_KEY in .env (Clerk dashboard, Configure > API Keys, production instance)}"
 else
   export CADDY_SITE_FILE=Caddyfile
   : "${BASIC_AUTH_USER:?AUTH_MODE=basic needs BASIC_AUTH_USER in .env}"
@@ -110,8 +118,6 @@ echo "    ${DEMO_TENANT_NAME} = ${TENANT_UUID}"
 # Setting TALLY_DEV_TENANT in clerk mode would silently disable auth on an instance the operator
 # believes is protected, so the modes are exclusive here rather than additive.
 if [ "${AUTH_MODE:-basic}" = "clerk" ]; then
-  : "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?AUTH_MODE=clerk needs NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY in .env (Clerk dashboard, API Keys)}"
-  : "${CLERK_SECRET_KEY:?AUTH_MODE=clerk needs CLERK_SECRET_KEY in .env (Clerk dashboard, API Keys)}"
   echo "==> Auth mode: CLERK. The dashboard requires sign-in; TALLY_DEV_TENANT stays unset."
   if [ -z "${CLERK_WEBHOOK_SIGNING_SECRET:-}" ]; then
     echo "    NOTE: CLERK_WEBHOOK_SIGNING_SECRET is unset. Sign-in will work, but organization.created"


### PR DESCRIPTION
Found by running it. `AUTH_MODE=clerk` could not start at all:

```
./deploy/demo/deploy.sh: line 39: BASIC_AUTH_HASH: BASIC_AUTH_HASH must be set in deploy/demo/.env
```

#367 added the per-mode guards further down the script but left the original unconditional pair at lines 38-39, so deploy.sh exited before it ever read `AUTH_MODE`, demanding a credential that mode does not use.

## Also moved: the Clerk assertions now run before the build

They were at line 115, after `docker compose up -d --build` at line 67. `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is a **build arg** because `next build` inlines it into the client bundle, so a missing key meant a fully built image that looks fine and can never sign anyone in, discovered only after the build had already run. On a small VM that is several minutes of `npm ci` and `next build` thrown away for an error that was knowable up front.

Both modes' requirements are now asserted in one place, next to the line that picks the Caddy site file, so they cannot drift apart again.

## Verified

- clerk mode passes with **no** basic-auth variables set
- basic mode still errors without them: `AUTH_MODE=basic needs BASIC_AUTH_USER in .env`
- `bash -n` clean on all three scripts

This is a real deployment being stood up right now, so the fix is the narrow one rather than a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)