### PR TITLE
fix(infra): pull MinIO from quay.io, Docker Hub no longer serves it

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -179,7 +179,11 @@ services:
 
   # --- Object / warm storage (S3 API) ----------------------------------------------------------
   minio:
-    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
+    # CTO-369: quay.io, not Docker Hub. MinIO removed the community images from Docker Hub, so
+    # `minio/minio` and `minio/mc` now answer "pull access denied ... repository does not exist",
+    # which reads as a typo or a private registry rather than a vendor moving. Same version, same
+    # image, published by MinIO at quay.io.
+    image: quay.io/minio/minio:RELEASE.2024-09-13T20-26-02Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-tally}
@@ -200,7 +204,8 @@ services:
   # target. Persistent MinIO storage is what stops a gateway restart from wiping replay bodies and
   # blanking the Recoverable Cost page. Idempotent (mb --ignore-existing), then exits 0.
   minio-setup:
-    image: minio/mc:RELEASE.2024-09-16T17-43-14Z
+    # CTO-369: see the note on the minio service above.
+    image: quay.io/minio/mc:RELEASE.2024-09-16T17-43-14Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
A first deploy on a clean VM dies at image pull:

```
✘ Image minio/mc:RELEASE.2024-09-16T17-43-14Z   Error pull access denied for minio/mc,
                                                 repository does not exist or may require 'docker login'
! Image postgres:16                              Interrupted
! Image clickhouse/clickhouse-server:24.8        Interrupted
! Image caddy:2                                  Interrupted
! Image redpandadata/redpanda:v24.2.7            Interrupted
! Image minio/minio:RELEASE...                   Interrupted
```

MinIO removed the community images from Docker Hub. Both `minio/minio` and `minio/mc` now answer "pull access denied", which reads as a typo or a private registry rather than a vendor changing where it publishes. Because one failure interrupts the other five pulls, the whole stack stops.

## Verified

| image | Docker Hub | quay.io |
|---|---|---|
| `minio/minio:RELEASE.2024-09-13T20-26-02Z` | denied | **pulls** |
| `minio/mc:RELEASE.2024-09-16T17-43-14Z` | denied | **pulls** |

Same pinned versions, so no functional change. Both actually pulled, not just manifest-checked.

The other four images were checked at the same time and remain fine on Docker Hub: `caddy:2`, `postgres:16`, `clickhouse/clickhouse-server:24.8`, `redpandadata/redpanda:v24.2.7`.

`docker compose config` clean.

Found while standing up the first real deployment on a fresh droplet. This would break every clean install, including CI on a cold cache, so it is not specific to that VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)