### PR TITLE
fix(deploy): require make up front, it is not part of a Docker install

### DIFF
--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -91,11 +91,17 @@ RAM, so size for it:
 - **4 vCPU / 8-16 GB RAM**, ~40 GB disk.
 - Open inbound TCP **80** and **443** only. Nothing else needs a public port.
 
-Install Docker Engine + the Compose plugin (Docker's official convenience script is fine):
+Install Docker Engine + the Compose plugin (Docker's official convenience script is fine), and
+`make`, which deploy.sh uses for the ClickHouse DDL and seed targets in `infra/Makefile`:
 
 ```
 curl -fsSL https://get.docker.com | sh
+apt-get update && apt-get install -y make
 ```
+
+`make` is worth calling out because it is NOT part of a Docker install. DigitalOcean's Docker
+marketplace image does not ship it, and neither does a minimal Ubuntu. deploy.sh now checks for it
+before building anything rather than failing three minutes in.
 
 Then clone this repo onto the VM (e.g. into `/opt/ai-tally`).
 

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -36,6 +36,18 @@ set +a
 
 : "${DOMAIN:?DOMAIN must be set in ${ENV_FILE}}"
 
+# CTO-370: `make` is a hard dependency of this script (the ch-migrate and seed targets live in
+# infra/Makefile), and it is NOT part of a Docker install. DigitalOcean's Docker marketplace image
+# and a minimal Ubuntu plus get.docker.com both lack it, so the failure used to land AFTER two image
+# builds and seven containers, roughly three minutes in, as a bare "make: command not found".
+command -v make >/dev/null 2>&1 || {
+  echo "make is required but not installed. It is not part of Docker." >&2
+  echo "  Debian/Ubuntu:  apt-get update && apt-get install -y make" >&2
+  echo "  RHEL/Alma:      dnf install -y make" >&2
+  exit 1
+}
+
+
 # CTO-367 follow-up: the basic-auth pair is required by `basic` mode ONLY, and this check used to be
 # unconditional, which made AUTH_MODE=clerk impossible to run: the script exited before it ever read
 # AUTH_MODE. The per-mode requirements are asserted together further down, next to the line that

--- a/deploy/demo/reseed.sh
+++ b/deploy/demo/reseed.sh
@@ -51,6 +51,17 @@ set -a
 source "${ENV_FILE}"
 set +a
 
+# CTO-370: `make` is a hard dependency of this script (the ch-migrate and seed targets live in
+# infra/Makefile), and it is NOT part of a Docker install. DigitalOcean's Docker marketplace image
+# and a minimal Ubuntu plus get.docker.com both lack it, so the failure used to land AFTER two image
+# builds and seven containers, roughly three minutes in, as a bare "make: command not found".
+command -v make >/dev/null 2>&1 || {
+  echo "make is required but not installed. It is not part of Docker." >&2
+  echo "  Debian/Ubuntu:  apt-get update && apt-get install -y make" >&2
+  echo "  RHEL/Alma:      dnf install -y make" >&2
+  exit 1
+}
+
 COMPOSE=(docker compose --env-file "${ENV_FILE}" -f "${BASE_COMPOSE}" -f "${PROD_COMPOSE}")
 
 # Tenant-UUID resolution and the service-token preflight, shared with deploy.sh.


### PR DESCRIPTION
A first deploy on DigitalOcean's Docker marketplace image dies with:

```
==> Applying ClickHouse DDL (make ch-migrate)
./deploy/demo/deploy.sh: line 94: make: command not found
```

That lands **after** two image builds and seven healthy containers, roughly three minutes in, as a bare `command not found` with no indication of what to do.

`make` is a hard dependency of the script: the `ch-migrate` and `seed` targets live in `infra/Makefile`. But the README only told you to install Docker Engine and the Compose plugin, and **neither DigitalOcean's Docker marketplace image nor a minimal Ubuntu ships make**. `curl get.docker.com | sh` does not bring it either.

## The fix

Both `deploy.sh` and `reseed.sh` now check alongside the other preflights, before anything is built:

```
make is required but not installed. It is not part of Docker.
  Debian/Ubuntu:  apt-get update && apt-get install -y make
  RHEL/Alma:      dnf install -y make
```

The README lists it as a prerequisite and explains why it is easy to miss.

## Verified

- The guard fires with `make` absent from `PATH`, passes with it present
- It sits at line 43, ahead of the build at line 85, so the failure is now immediate rather than three minutes in
- `bash -n` clean on both scripts

Found standing up the first real deployment. The stack itself came up fine, all seven containers healthy, so this is purely the missing tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)