### PR TITLE
fix(deploy): keep the web self-fetch on loopback, not out through Caddy

### DIFF
--- a/deploy/demo/docker-compose.prod.yml
+++ b/deploy/demo/docker-compose.prod.yml
@@ -54,6 +54,17 @@ services:
       TALLY_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-tally}
       TALLY_CLICKHOUSE_DB: default
       TALLY_GATEWAY_URL: http://gateway:8080
+      # CTO-371: where the server-rendered pages fetch their OWN route handlers. Without this,
+      # web/lib/api.ts derives the base from the incoming request's Host header, so the container
+      # tries to reach https://${DOMAIN} from inside itself: out to the public IP, back through
+      # Caddy. A droplet generally cannot hairpin to its own public address, so every page dies on
+      # UND_ERR_CONNECT_TIMEOUT after 10s. Loopback keeps the call inside the container, where the
+      # Next server is already listening, and skips TLS and the proxy for a request that never
+      # needed either.
+      #
+      # Despite the NEXT_PUBLIC_ prefix this is read only by api.ts on the server (grep confirms no
+      # client reference), so pointing it at loopback cannot leak into a browser bundle.
+      NEXT_PUBLIC_API_BASE_URL: http://127.0.0.1:3000
       # Initiative 1 §10: the dev escape hatch that pins the tenant, so the demo VM needs no Clerk
       # account. It MUST be the tenant UUID, not the name `local-dev`: the web binds this value
       # straight into the ClickHouse read filter (TenantId = ...) and the backfill tags spans with


### PR DESCRIPTION
Every server-rendered page fails on a real VM deployment. From the running production container:

```
TypeError: fetch failed
  at async p (.next/server/app/page.js)
[cause]: ConnectTimeoutError: Connect Timeout Error
  (attempted address: app.ai-tally.com:443, timeout: 10000ms)
  code: 'UND_ERR_CONNECT_TIMEOUT'
```

## Cause

`web/lib/api.ts` derives its base URL from the incoming request's `Host` header. In a container behind Caddy that resolves to `https://app.ai-tally.com`, so the web container tries to reach **its own public address from inside itself**: out to the droplet's public IP and back in through the proxy. Droplets generally cannot hairpin like that, so each call hangs for ten seconds and throws, and `app/error.tsx` catches it on every page.

It works locally only because there the `Host` header is `localhost:3000`, which happens to be the same server.

## Fix

`baseUrlFrom()` already checks `NEXT_PUBLIC_API_BASE_URL` first, so the deployment just has to set it. Loopback keeps the request inside the container, where the Next server is already listening, and skips TLS and the proxy for a call that never needed either.

Two things verified rather than assumed:

- **Port 3000** matches the Dockerfile's `PORT`/`EXPOSE` and Caddy's `reverse_proxy web:3000`.
- **No client code reads `NEXT_PUBLIC_API_BASE_URL`.** Despite the prefix, `api.ts` is its only reference and runs server-side, so loopback cannot leak into a browser bundle.

## Third in a family

This is the same shape as two earlier bugs, and worth naming as a pattern: **a server-to-self fetch is a brand new request and inherits nothing from the one that triggered it.**

- #362: it inherited no session cookie, so Clerk answered 404 on all thirteen pages
- #367: the publishable key was runtime-only, but `next build` inlines it, so the image could never sign anyone in
- here: it inherited no address, so it went out to the public internet and back

All three were invisible locally and fatal in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)