### PR TITLE
fix(edge-proxy): parse usage from streamed responses, fold Anthropic cache tokens (#349)

### DIFF
--- a/docs/anthropic-cache-tokens.md
+++ b/docs/anthropic-cache-tokens.md
@@ -1,0 +1,67 @@
+# Anthropic prompt-cache tokens: what we record, and what we still cannot price (CTO-349)
+
+Written while fixing the edge proxy's streamed-usage parsing. It records a decision and a known
+limit, so the next person reading `anthropicPrompt` does not have to reconstruct either.
+
+## The three buckets
+
+Anthropic's Messages API reports a prompt in three separately billed pieces:
+
+| Field | What it is | Billed at |
+|---|---|---|
+| `usage.input_tokens` | fresh prompt tokens, neither written to nor read from cache | standard input rate |
+| `usage.cache_creation_input_tokens` | tokens written into the prompt cache | a premium over the input rate |
+| `usage.cache_read_input_tokens` | tokens served from the cache | a fraction of the input rate |
+
+The trap is that `input_tokens` **excludes** the other two. It is not a total. A request that reads
+18923 tokens from cache and sends 21 fresh ones reports `input_tokens: 21`, and the proxy used to
+record 21 as the whole prompt: a call with an 18944-token prompt showing up as a rounding error.
+
+## What the proxy records now
+
+- `TraceRecord.PromptTokens` is the sum of all three buckets, which is the honest token count for
+  the call.
+- `TraceRecord.CachedInputTokens` carries the `cache_read_input_tokens` share and ships as
+  `gen_ai.usage.cached_input_tokens`. The gateway and the price catalog already read that attribute
+  as a **subset** of the input tokens: they bill `(input - cached)` at the standard rate and
+  `cached` at the cached rate (`sdk/python/src/tally/pricing.py`). So the split prices correctly
+  without any schema change.
+- Both stay `nil` when the provider did not report them. A response that never mentions the cache
+  reports the cache share as unknown; one that reports `0` reports `0`. Those are different facts
+  and the pointer types keep them apart.
+
+## What we still cannot represent
+
+**Cache creation tokens have nowhere to go.** There is no `gen_ai.usage.cache_creation_input_tokens`
+attribute, no `PriceType.CACHE_WRITE` in the catalog, and no column in `otel_spans`. Two options
+were on the table:
+
+1. Leave them out of `PromptTokens`. The call is then under-counted by 100% of the cache write,
+   and a cache-warming request (which is mostly cache writes) reads as nearly free.
+2. Include them in `PromptTokens`. The token count is then right, and the write share prices at the
+   standard input rate instead of the write premium, so the call is under-priced by the premium on
+   that slice only.
+
+We do (2), because it is wrong by a rate multiplier on one slice rather than wrong by the whole
+slice, and because the token count itself, which is what the record claims to be, is then accurate.
+
+This is an approximation, not an unknown, so it is not a violation of the honest-under-uncertainty
+invariant: no number is fabricated and no blank is filled in with a guess. It is a fidelity limit,
+and it is written down here rather than left for someone to find in a variance report.
+
+**Closing it properly** needs, in this order: a `gen_ai.usage.cache_creation_input_tokens` span
+attribute in `tally.schema`, a nullable column on `otel_spans`, a `CACHE_WRITE` price type with the
+per-model rates, and then a one-line change in `anthropicPrompt` to stop folding the bucket in. Until
+all four exist, adding a field to `TraceRecord` alone would only move the loss to a value nothing
+reads.
+
+## Other providers
+
+- **OpenAI** reports `usage.prompt_tokens_details.cached_tokens`, and its `prompt_tokens` already
+  **includes** the cached share. The proxy reads it straight into `CachedInputTokens` and adds
+  nothing to the total. OpenAI does not bill a separate cache-write rate, so there is no equivalent
+  gap.
+- **Gemini** reports `usageMetadata.cachedContentTokenCount` for context caching. The proxy does not
+  read it yet; a Gemini call using an explicit cached context therefore prices its cached tokens at
+  the standard input rate. It is the same shape of fix as the OpenAI one and is not covered here
+  because CTO-349 had no Gemini cache fixture to verify the semantics against.

--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -47,7 +47,8 @@ These are enforced by tests, not just documented:
 | Var | Default | Meaning |
 |-----|---------|---------|
 | `EDGE_PROXY_LISTEN` | `:8088` | bind address |
-| `EDGE_PROXY_UPSTREAM` | `https://api.openai.com` | provider origin |
+| `EDGE_PROXY_UPSTREAM` | per provider (see `EDGE_PROXY_PROVIDER`) | provider origin |
+| `EDGE_PROXY_PROVIDER` | (none) | `openai` / `anthropic` / `gemini`: read model and token usage off each response into the span. Empty is pure pass-through with no response inspection. It also picks the default upstream when `EDGE_PROXY_UPSTREAM` is unset: `https://api.openai.com`, `https://api.anthropic.com`, `https://generativelanguage.googleapis.com`. A provider with no registered default refuses to start rather than falling back to the wrong vendor |
 | `EDGE_PROXY_TENANT_HEADER` | `X-Tenant-Key` | control header carrying the tenant id (stripped before upstream) |
 | `EDGE_PROXY_FEATURE_TAG_HEADER` | `X-Tally-Feature-Tag` | optional control header carrying a per-request feature/agent tag (stripped before upstream) |
 | `EDGE_PROXY_ACCOUNT_ID_HASH_HEADER` | `X-Tally-Account-Id-Hash` | optional control header carrying the **already-hashed** account id (stripped before upstream), see below |
@@ -122,6 +123,36 @@ never forwarded unauthenticated; a brand-new key can miss the cache until the ne
 is honest and bounded, not a fabricated success. A transient feed error keeps the last good map:
 resolution never fails open. `GET /v1/edge/keys` is delivered by a separate gateway PR; only the
 SHA-256 hash is ever sent over it, never a raw or reversible token.
+
+## Usage extraction, including streamed responses (CTO-167 / CTO-349)
+
+With a provider protocol configured, the proxy reads the model id and the token counts off each
+response and hangs them on the span. It reads **only** scalars: no prompt, completion, or retrieved
+text is parsed, kept, or logged.
+
+Streamed (SSE) responses are folded event by event as they pass, not buffered. Each provider puts
+the numbers somewhere different:
+
+- **OpenAI**: one final chunk carries the whole `usage` block, and every chunk carries the model.
+  That chunk is only sent when the request set `stream_options.include_usage`. **Without the opt-in
+  the counts are on no chunk at all**, so the span is recorded with the model and unknown counts.
+  The proxy does not estimate them and deliberately does not inject `stream_options` into the
+  customer's request body, which it forwards byte-for-byte. Set `include_usage` in your client to
+  get streamed OpenAI calls priced.
+- **Anthropic**: `message_start` carries the model and the input tokens, `message_delta` the final
+  cumulative output count, so both events are needed. Cache buckets fold in from either (see
+  `docs/anthropic-cache-tokens.md`).
+- **Gemini**: `usageMetadata` repeats on every chunk with running totals; the last chunk to report
+  each count wins. The model still comes from the request path.
+
+Nothing is buffered and nothing is retained: the scan holds one SSE line, so a completion that
+streams for minutes costs the same memory as one that streams for a second, and `FlushInterval = -1`
+still hands every byte to the client immediately. An event larger than the 1 MiB line bound is
+skipped rather than half-parsed, and a stream that ends early (client disconnect, mid-stream `error`
+event) keeps whatever the provider actually reported before the cut.
+
+Where a count is not on the wire it stays **unknown**, never `0`: an unpriced span reads as a blank,
+not as a call that cost nothing.
 
 ## Account attribution (CTO-182)
 

--- a/infra/edge-proxy/internal/config/config.go
+++ b/infra/edge-proxy/internal/config/config.go
@@ -181,9 +181,14 @@ const (
 	DefaultUpstream   = "https://api.openai.com"
 	// DefaultGeminiUpstream is the origin used when Provider is gemini and EDGE_PROXY_UPSTREAM is
 	// unset, Google's Generative Language API (CTO-167).
-	DefaultGeminiUpstream   = "https://generativelanguage.googleapis.com"
-	DefaultTenantHeader     = "X-Tenant-Key"
-	DefaultFeatureTagHeader = "X-Tally-Feature-Tag"
+	DefaultGeminiUpstream = "https://generativelanguage.googleapis.com"
+	// DefaultAnthropicUpstream is the origin used when Provider is anthropic and EDGE_PROXY_UPSTREAM
+	// is unset (CTO-349). Before this, an anthropic proxy with no explicit upstream inherited
+	// DefaultUpstream and sent every Messages request to api.openai.com, which is a misconfiguration
+	// that looks configured: the traffic leaves for the wrong vendor and fails there.
+	DefaultAnthropicUpstream = "https://api.anthropic.com"
+	DefaultTenantHeader      = "X-Tenant-Key"
+	DefaultFeatureTagHeader  = "X-Tally-Feature-Tag"
 	// DefaultAccountIdHashHeader carries the pre-hashed account id (CTO-182). Named to match the
 	// existing X-Tally-* control-header convention and the gen_ai.account_id_hash wire attribute.
 	DefaultAccountIdHashHeader = "X-Tally-Account-Id-Hash"
@@ -226,9 +231,9 @@ func FromEnv(lookup Env) (Config, error) {
 		}
 	}
 
-	defaultUpstream := DefaultUpstream
-	if cfg.Provider == ProviderGemini {
-		defaultUpstream = DefaultGeminiUpstream
+	defaultUpstream, err := defaultUpstreamFor(cfg.Provider)
+	if err != nil {
+		return Config{}, err
 	}
 	rawUpstream := firstNonEmpty(lookup("EDGE_PROXY_UPSTREAM"), defaultUpstream)
 	u, err := url.Parse(rawUpstream)
@@ -348,6 +353,33 @@ func FromEnv(lookup Env) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// defaultUpstreamFor returns the origin a provider's traffic goes to when EDGE_PROXY_UPSTREAM is
+// unset, and refuses to boot for a provider that has no registered default (CTO-349).
+//
+// The failure branch is the point. The old code took DefaultUpstream (OpenAI's origin) as the
+// fallback for everything except gemini, so provider=anthropic with no upstream configured silently
+// pointed Anthropic traffic at api.openai.com: a wrong answer dressed as a working configuration,
+// and one that any future provider added here would inherit by default. Every provider now names
+// its own origin or the proxy refuses to start, in the same spirit as the gateway failing closed at
+// boot rather than guessing (infra/gateway/src/gateway/app.py). An operator who genuinely wants a
+// non-standard origin (a gateway, a regional endpoint, a test double) still sets EDGE_PROXY_UPSTREAM
+// and never reaches this.
+func defaultUpstreamFor(p Provider) (string, error) {
+	switch p {
+	case "", ProviderOpenAI:
+		return DefaultUpstream, nil
+	case ProviderAnthropic:
+		return DefaultAnthropicUpstream, nil
+	case ProviderGemini:
+		return DefaultGeminiUpstream, nil
+	default:
+		return "", fmt.Errorf(
+			"EDGE_PROXY_PROVIDER=%q has no default upstream: set EDGE_PROXY_UPSTREAM explicitly "+
+				"(refusing to fall back to %s, which would send %s traffic to the wrong vendor)",
+			p, DefaultUpstream, p)
+	}
 }
 
 // Warnings returns operator-facing problems with a configuration that parses cleanly but will not

--- a/infra/edge-proxy/internal/config/config_test.go
+++ b/infra/edge-proxy/internal/config/config_test.go
@@ -199,9 +199,39 @@ func TestProviderSelection(t *testing.T) {
 		t.Errorf("Upstream = %q, want explicit override", cfg.Upstream)
 	}
 
+	// anthropic with no explicit upstream defaults to Anthropic's origin (CTO-349). It used to
+	// inherit DefaultUpstream and point Messages traffic at api.openai.com.
+	cfg, err = FromEnv(envMap(map[string]string{"EDGE_PROXY_PROVIDER": "anthropic"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Upstream.String() != DefaultAnthropicUpstream {
+		t.Errorf("Upstream = %q, want %q", cfg.Upstream, DefaultAnthropicUpstream)
+	}
+
 	// An unknown provider is rejected.
 	if _, err := FromEnv(envMap(map[string]string{"EDGE_PROXY_PROVIDER": "bard"})); err == nil {
 		t.Error("expected error for unknown provider")
+	}
+}
+
+// TestDefaultUpstreamForRefusesUnknownProvider covers the guard behind CTO-349's third defect. The
+// original bug was not that anthropic lacked an entry, it was that everything without one fell
+// through to OpenAI's origin, so the next provider added would inherit the same silent
+// mis-routing. A provider with no registered default now refuses to boot, and the message says
+// which env var fixes it.
+func TestDefaultUpstreamForRefusesUnknownProvider(t *testing.T) {
+	for _, p := range []Provider{"", ProviderOpenAI, ProviderAnthropic, ProviderGemini} {
+		if _, err := defaultUpstreamFor(p); err != nil {
+			t.Errorf("provider %q should have a default upstream: %v", p, err)
+		}
+	}
+	_, err := defaultUpstreamFor(Provider("bedrock"))
+	if err == nil {
+		t.Fatal("expected a provider with no registered default to be refused, not defaulted")
+	}
+	if !strings.Contains(err.Error(), "EDGE_PROXY_UPSTREAM") {
+		t.Errorf("error should name the env var that fixes it, got %q", err)
 	}
 }
 

--- a/infra/edge-proxy/internal/proxy/provider.go
+++ b/infra/edge-proxy/internal/proxy/provider.go
@@ -30,6 +30,13 @@ type responseMeta struct {
 	Model            string
 	PromptTokens     *int64
 	CompletionTokens *int64
+	// CachedInputTokens is the portion of PromptTokens the provider served from a prompt cache
+	// (Anthropic usage.cache_read_input_tokens, OpenAI usage.prompt_tokens_details.cached_tokens).
+	// It is a SUBSET of PromptTokens, not an addition to it, which is the semantics the rest of the
+	// product already uses (sdk/python/src/tally/pricing.py prices input - cached at the standard
+	// rate and cached at the cached rate). Nil when the provider did not report it, which is not the
+	// same fact as a reported 0 (CTO-349).
+	CachedInputTokens *int64
 }
 
 // metaCaptureCap bounds how many response bytes we tee aside for parsing. A generateContent /
@@ -44,26 +51,62 @@ const metaCaptureCap = 1 << 20
 // is best-effort and must never fail the proxied request.
 func extractMeta(p config.Provider, path string, body []byte) responseMeta {
 	switch p {
+	case config.ProviderOpenAI, config.ProviderAnthropic, config.ProviderGemini:
+	default:
+		return responseMeta{}
+	}
+	// A body that turns out to be an event stream is folded event by event (CTO-349). The request
+	// path normally decides from the response Content-Type before any bytes arrive; this is the
+	// fallback for an upstream that streamed without the header, and the entry point the fixture
+	// tests use.
+	if looksLikeSSE(body) {
+		m := scanSSE(p, body)
+		if p == config.ProviderGemini {
+			m.Model = geminiModel(path, m.Model)
+		}
+		return m
+	}
+	switch p {
 	case config.ProviderOpenAI:
 		return openAIMeta(body)
 	case config.ProviderAnthropic:
 		return anthropicMeta(body)
-	case config.ProviderGemini:
-		return geminiMeta(path, body)
 	default:
-		return responseMeta{}
+		return geminiMeta(path, body)
 	}
 }
 
+// openAIUsageDoc is the OpenAI usage block, shared by the single-document and streamed paths.
+// Pointer fields throughout: an absent "usage" object, or an absent count inside it, must stay
+// absent rather than decode to 0 (see responseMeta).
+type openAIUsageDoc struct {
+	PromptTokens        *int64 `json:"prompt_tokens"`
+	CompletionTokens    *int64 `json:"completion_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens *int64 `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+}
+
+// anthropicUsageDoc is the Anthropic usage block. input_tokens counts ONLY the uncached prompt
+// tokens: the two cache buckets are reported alongside it and are not included in it, which is why
+// anthropicPrompt has to add them up (CTO-349).
+type anthropicUsageDoc struct {
+	InputTokens              *int64 `json:"input_tokens"`
+	OutputTokens             *int64 `json:"output_tokens"`
+	CacheCreationInputTokens *int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     *int64 `json:"cache_read_input_tokens"`
+}
+
+// geminiUsageDoc is the Generative Language usageMetadata block.
+type geminiUsageDoc struct {
+	PromptTokenCount     *int64 `json:"promptTokenCount"`
+	CandidatesTokenCount *int64 `json:"candidatesTokenCount"`
+}
+
 func openAIMeta(body []byte) responseMeta {
-	// Pointer fields throughout: an absent "usage" object, or an absent count inside it, must stay
-	// absent rather than decode to 0 (see responseMeta).
 	var r struct {
-		Model string `json:"model"`
-		Usage *struct {
-			PromptTokens     *int64 `json:"prompt_tokens"`
-			CompletionTokens *int64 `json:"completion_tokens"`
-		} `json:"usage"`
+		Model string          `json:"model"`
+		Usage *openAIUsageDoc `json:"usage"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
 		return responseMeta{}
@@ -72,51 +115,86 @@ func openAIMeta(body []byte) responseMeta {
 	if r.Usage != nil {
 		m.PromptTokens = r.Usage.PromptTokens
 		m.CompletionTokens = r.Usage.CompletionTokens
+		if r.Usage.PromptTokensDetails != nil {
+			m.CachedInputTokens = r.Usage.PromptTokensDetails.CachedTokens
+		}
 	}
 	return m
 }
 
 func anthropicMeta(body []byte) responseMeta {
 	var r struct {
-		Model string `json:"model"`
-		Usage *struct {
-			InputTokens  *int64 `json:"input_tokens"`
-			OutputTokens *int64 `json:"output_tokens"`
-		} `json:"usage"`
+		Model string             `json:"model"`
+		Usage *anthropicUsageDoc `json:"usage"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
 		return responseMeta{}
 	}
 	m := responseMeta{Model: r.Model}
 	if r.Usage != nil {
-		m.PromptTokens = r.Usage.InputTokens
+		m.PromptTokens = anthropicPrompt(
+			r.Usage.InputTokens, r.Usage.CacheCreationInputTokens, r.Usage.CacheReadInputTokens)
 		m.CompletionTokens = r.Usage.OutputTokens
+		m.CachedInputTokens = r.Usage.CacheReadInputTokens
 	}
 	return m
 }
 
+// anthropicPrompt totals the three buckets Anthropic bills a prompt under (CTO-349).
+//
+// usage.input_tokens excludes both cache buckets, so reporting it alone under-counts a cached
+// prompt by however much the cache served: a request that read 18923 tokens from cache and sent 21
+// fresh ones was reported as 21 prompt tokens. The total is the honest token count, and
+// CachedInputTokens carries the cache-read share so the gateway prices that share at the cached
+// rate rather than the standard one.
+//
+// The bucket the record CANNOT represent is cache CREATION, which Anthropic bills at a premium over
+// standard input. It is counted in this total (those tokens really were prompt input, and omitting
+// them would under-count by 100% of the write rather than mis-rate it) but priced at the standard
+// input rate, so a cache-write-heavy call is under-priced by the write premium. Representing it
+// honestly needs a wire attribute and a price type that do not exist yet; see
+// docs/anthropic-cache-tokens.md rather than a forced approximation here.
+//
+// Returns nil when the provider reported none of the three, because "no usage" and "zero prompt
+// tokens" are different facts.
+func anthropicPrompt(input, cacheCreate, cacheRead *int64) *int64 {
+	if input == nil && cacheCreate == nil && cacheRead == nil {
+		return nil
+	}
+	var total int64
+	for _, v := range []*int64{input, cacheCreate, cacheRead} {
+		if v != nil {
+			total += *v
+		}
+	}
+	return &total
+}
+
 func geminiMeta(path string, body []byte) responseMeta {
 	var r struct {
-		ModelVersion  string `json:"modelVersion"`
-		UsageMetadata *struct {
-			PromptTokenCount     *int64 `json:"promptTokenCount"`
-			CandidatesTokenCount *int64 `json:"candidatesTokenCount"`
-		} `json:"usageMetadata"`
+		ModelVersion  string          `json:"modelVersion"`
+		UsageMetadata *geminiUsageDoc `json:"usageMetadata"`
 	}
 	// The body may be missing/unparseable (e.g. an error response); still return the path-derived
 	// model so an errored call is at least attributable to a model.
 	_ = json.Unmarshal(body, &r)
 
-	model := geminiModelFromPath(path)
-	if model == "" {
-		model = r.ModelVersion
-	}
-	m := responseMeta{Model: model}
+	m := responseMeta{Model: geminiModel(path, r.ModelVersion)}
 	if r.UsageMetadata != nil {
 		m.PromptTokens = r.UsageMetadata.PromptTokenCount
 		m.CompletionTokens = r.UsageMetadata.CandidatesTokenCount
 	}
 	return m
+}
+
+// geminiModel prefers the model named in the request path, falling back to the one the response
+// reported. The path is authoritative for Generative Language calls and is available even when the
+// body carried nothing parseable (an error response, a stream past the cap).
+func geminiModel(path, fromBody string) string {
+	if m := geminiModelFromPath(path); m != "" {
+		return m
+	}
+	return fromBody
 }
 
 // geminiModelFromPath pulls the model id out of a Generative Language request path of the form
@@ -153,13 +231,39 @@ type metaCapture struct {
 
 	buf  []byte
 	over bool // capture exceeded the cap; stop teeing and skip body-derived metadata
+
+	// folder/scan are set instead of buf when the response is an event stream (CTO-349). A stream
+	// is folded incrementally as it passes, so nothing is accumulated: a completion that streams for
+	// minutes still yields its usage, and retained memory stays one SSE line rather than one body.
+	folder *streamFolder
+	scan   *sseScanner
+}
+
+// newMetaCapture wraps body for the given provider. stream selects the incremental SSE fold (the
+// caller decides from the response Content-Type) over the buffered single-document scan.
+func newMetaCapture(
+	inner io.ReadCloser, p config.Provider, path string, stream bool, out *responseMeta,
+) *metaCapture {
+	m := &metaCapture{inner: inner, provider: p, path: path, out: out}
+	if stream {
+		m.folder = newStreamFolder(p)
+		m.scan = m.folder.scanner()
+	}
+	return m
 }
 
 func (m *metaCapture) Read(p []byte) (int, error) {
 	n, err := m.inner.Read(p)
-	if n > 0 && !m.over {
+	if n <= 0 {
+		return n, err
+	}
+	if m.scan != nil {
+		m.scan.write(p[:n])
+		return n, err
+	}
+	if !m.over {
 		if len(m.buf)+n > metaCaptureCap {
-			// Oversized/streaming response: drop the partial capture rather than grow unbounded.
+			// Oversized response: drop the partial capture rather than grow unbounded.
 			m.over = true
 			m.buf = nil
 		} else {
@@ -171,10 +275,21 @@ func (m *metaCapture) Read(p []byte) (int, error) {
 
 func (m *metaCapture) Close() error {
 	if m.out != nil {
-		if m.over {
+		switch {
+		case m.scan != nil:
+			// Flush a final event that arrived without its trailing newline, which is what a stream
+			// cut short mid-event looks like. Whatever the provider reported before the cut stands;
+			// what it never reported stays nil.
+			m.scan.close()
+			meta := m.folder.meta()
+			if m.provider == config.ProviderGemini {
+				meta.Model = geminiModel(m.path, meta.Model)
+			}
+			*m.out = meta
+		case m.over:
 			// We never saw the whole body; still try path-based metadata (Gemini model).
 			*m.out = extractMeta(m.provider, m.path, nil)
-		} else {
+		default:
 			*m.out = extractMeta(m.provider, m.path, m.buf)
 		}
 	}

--- a/infra/edge-proxy/internal/proxy/provider_anthropic_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_anthropic_test.go
@@ -89,8 +89,9 @@ func TestAnthropicMetaFromPublishedResponses(t *testing.T) {
 		// A refusal (stop_reason "refusal", empty content) bills the input and produces no output.
 		// The 0 here is the provider's own reported figure, not a proxy-invented one.
 		{"anthropic/message_refusal.json", "claude-opus-5", ptr(331), ptr(0)},
-		// Cache hit: see TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens below.
-		{"anthropic/message_cache_read.json", "claude-opus-5", ptr(21), ptr(44)},
+		// Cache hit: input_tokens (21) EXCLUDES the 18923 tokens served from cache, so the billable
+		// prompt is the sum. See TestAnthropicCacheTokensFoldIntoPromptTokens below.
+		{"anthropic/message_cache_read.json", "claude-opus-5", ptr(18944), ptr(44)},
 		// The error envelope carries neither model nor usage. Everything stays unknown.
 		{"anthropic/error_overloaded.json", "", nil, nil},
 	}
@@ -106,24 +107,42 @@ func TestAnthropicMetaFromPublishedResponses(t *testing.T) {
 	}
 }
 
-// TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens pins a real fidelity limit rather than
-// asserting it away. Anthropic reports cache_read_input_tokens and cache_creation_input_tokens
-// alongside input_tokens, and input_tokens EXCLUDES them, so PromptTokens on a cache hit is the
-// uncached prompt only. That is honest (it is the field the provider labels input tokens) but it
-// is not the whole billable input, and pricing a cached call from this record alone under-reports
-// it. Recording the cache counts is a schema change beyond this proxy, so the test exists to make
-// the gap visible instead of letting a future reader assume the number is complete.
-func TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens(t *testing.T) {
+// TestAnthropicCacheTokensFoldIntoPromptTokens covers CTO-349's second defect.
+//
+// Anthropic reports cache_creation_input_tokens and cache_read_input_tokens alongside
+// input_tokens, and input_tokens EXCLUDES both. Reporting input_tokens alone therefore under-counts
+// a cached prompt by everything the cache served: this fixture's real prompt is 18944 tokens and
+// the record used to claim 21. The cache-read share rides along separately, because it is billed at
+// a lower rate than fresh input and the price catalog can express exactly that split.
+//
+// What is still approximate is recorded rather than hidden: cache CREATION tokens are inside the
+// total but have no separate field, so they price at the standard input rate instead of the write
+// premium. See docs/anthropic-cache-tokens.md.
+func TestAnthropicCacheTokensFoldIntoPromptTokens(t *testing.T) {
 	meta := extractMeta(config.ProviderAnthropic, "/v1/messages",
 		readFixture(t, "anthropic/message_cache_read.json"))
-	if !tokensEq(meta.PromptTokens, 21) {
-		t.Fatalf("PromptTokens = %s, want 21 (input_tokens only)", tokensStr(meta.PromptTokens))
-	}
-	// If this ever starts reporting 18944 (21 + 18923), the proxy learned about cache tokens and
-	// this test should be replaced by one that asserts the new, richer record.
-	if tokensEq(meta.PromptTokens, 18944) {
-		t.Errorf("cache tokens are now folded into PromptTokens; update this test and the pricing path")
-	}
+	// 21 fresh + 0 cache writes + 18923 cache reads.
+	assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(18944))
+	assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, ptr(18923))
+}
+
+// TestAnthropicCacheTokenAbsenceVsZero is the honesty half of the fold, and the distinction the
+// pointer counts exist for. A response that omits the cache fields reports the cache share as
+// UNKNOWN; one that reports them as 0 reports 0. Collapsing the two would make the proxy assert
+// "prompt caching saved this tenant nothing" on every payload that simply did not mention it.
+func TestAnthropicCacheTokenAbsenceVsZero(t *testing.T) {
+	// message_tool_use.json carries usage with no cache fields at all.
+	absent := extractMeta(config.ProviderAnthropic, "/v1/messages",
+		readFixture(t, "anthropic/message_tool_use.json"))
+	assertTokens(t, "PromptTokens", absent.PromptTokens, ptr(472))
+	assertTokens(t, "CachedInputTokens", absent.CachedInputTokens, nil)
+
+	// message_end_turn.json reports both cache buckets as an explicit 0, which is the provider's
+	// own figure and is preserved as 0.
+	reported := extractMeta(config.ProviderAnthropic, "/v1/messages",
+		readFixture(t, "anthropic/message_end_turn.json"))
+	assertTokens(t, "PromptTokens", reported.PromptTokens, ptr(10))
+	assertTokens(t, "CachedInputTokens", reported.CachedInputTokens, ptr(0))
 }
 
 // TestAnthropicProxyRecordsMetadataAndHidesKey is the end-to-end acceptance: a POST /v1/messages
@@ -223,25 +242,35 @@ func TestAnthropicProxyToolUseTurn(t *testing.T) {
 	}
 }
 
-// TestAnthropicProxyStreamingSSE drives the published SSE event sequence.
+// TestAnthropicProxyStreamingSSE drives the published SSE event sequence end to end (CTO-349).
 //
-// Two things are asserted, and one gap is recorded honestly. The stream is relayed byte-for-byte,
-// and the metadata stays UNKNOWN rather than being invented: anthropicMeta json.Unmarshals the
-// whole body, an SSE stream is not one JSON document, so the decode fails and the record carries
-// nils. That is the correct failure direction (a nil is a NULL downstream; a 0 would be a lie), but
-// it does mean a streamed Anthropic call is currently unattributed to a model, even though the
-// model and both token counts are right there in the message_start and message_delta events. The
-// gemini path avoids this only because it can recover the model from the request URL, and the
-// Anthropic path has no such fallback. Parsing SSE is a change to provider.go, which this
-// test-only change deliberately does not make; see the issue.
+// Anthropic splits the usage across events: message_start carries the model and the input tokens,
+// message_delta the final cumulative output count, so a parser that reads either one alone gets
+// half the answer. The stream must still reach the client byte-for-byte and unbuffered, which is
+// asserted here too: the fold happens on the bytes as they pass, never by holding them.
+//
+// The mid-stream error case is the interesting one for honesty. That stream ends after
+// message_start with an error event and no message_delta, so the input count and the 1 output token
+// message_start reported are real and are kept, while the final output count never existed and
+// stays at what was actually reported rather than being completed with a guess.
 func TestAnthropicProxyStreamingSSE(t *testing.T) {
-	for _, name := range []string{
-		"anthropic/stream_text.sse",
-		"anthropic/stream_tool_use.sse",
-		"anthropic/stream_midstream_error.sse",
-	} {
-		t.Run(name, func(t *testing.T) {
-			body := readFixture(t, name)
+	cases := []struct {
+		fixture    string
+		wantModel  string
+		wantPrompt *int64
+		wantComp   *int64
+	}{
+		// message_start input 25, message_delta cumulative output 15.
+		{"anthropic/stream_text.sse", "claude-opus-5", ptr(25), ptr(15)},
+		// A tool-use stream meters like any other: input 472, final output 89. The partial_json
+		// deltas carrying the tool arguments are content and are never retained.
+		{"anthropic/stream_tool_use.sse", "claude-opus-5", ptr(472), ptr(89)},
+		// Cut short by an error event: what message_start reported stands, nothing is invented.
+		{"anthropic/stream_midstream_error.sse", "claude-opus-5", ptr(25), ptr(1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			body := readFixture(t, tc.fixture)
 			upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
@@ -274,17 +303,54 @@ func TestAnthropicProxyStreamingSSE(t *testing.T) {
 				t.Errorf("trace status = %d, want 200 (a mid-stream error is still a 200 on the wire)",
 					rec.StatusCode)
 			}
-			// The gap, pinned: unknown, and specifically not fabricated.
-			if rec.PromptTokens != nil || rec.CompletionTokens != nil {
-				t.Errorf("streamed usage is not parsed today; expected unknown counts, got %s/%s",
-					tokensStr(rec.PromptTokens), tokensStr(rec.CompletionTokens))
+			if rec.Model != tc.wantModel {
+				t.Errorf("Model = %q, want %q", rec.Model, tc.wantModel)
 			}
-			if rec.Model != "" {
-				t.Errorf("Model = %q; if the SSE parser landed, replace this test with one that "+
-					"asserts the model and the cumulative message_delta usage", rec.Model)
+			assertTokens(t, "PromptTokens", rec.PromptTokens, tc.wantPrompt)
+			assertTokens(t, "CompletionTokens", rec.CompletionTokens, tc.wantComp)
+			// None of these streams mentions the prompt cache, so the cache share is unknown.
+			assertTokens(t, "CachedInputTokens", rec.CachedInputTokens, nil)
+			// The fold reads counts only; no fragment of the streamed content may survive on the
+			// record (the tool-use stream carries a location argument, the text stream "Hello").
+			for _, leak := range []string{"San Francisco", "Hello", "get_weather"} {
+				if strings.Contains(fmt.Sprintf("%+v", rec), leak) {
+					t.Errorf("trace record leaked streamed content %q", leak)
+				}
 			}
 		})
 	}
+}
+
+// TestAnthropicStreamClientDisconnect covers the stream that ends early because the CLIENT walked
+// away mid-event, not because the provider finished. The proxy reports what the provider managed to
+// send before the cut and nothing more: a truncated final event is not parsed at all (a half-read
+// JSON object could decode to a plausible wrong number), so the counts from complete earlier events
+// stand and the rest is whatever was last reported.
+func TestAnthropicStreamClientDisconnect(t *testing.T) {
+	full := string(readFixture(t, "anthropic/stream_text.sse"))
+	// Cut in the middle of the message_delta event that carries the final output count.
+	cut := strings.Index(full, `"stop_reason": "end_turn"`)
+	if cut < 0 {
+		t.Fatal("fixture no longer contains the message_delta stop_reason")
+	}
+	truncated := full[:cut]
+
+	var meta responseMeta
+	mc := newMetaCapture(io.NopCloser(strings.NewReader(truncated)),
+		config.ProviderAnthropic, "/v1/messages", true, &meta)
+	if _, err := io.Copy(io.Discard, mc); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if err := mc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if meta.Model != "claude-opus-5" {
+		t.Errorf("Model = %q, want claude-opus-5", meta.Model)
+	}
+	// message_start completed, so its counts are real; the final output count never arrived.
+	assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(25))
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(1))
 }
 
 // TestAnthropicProxyErrorResponse: a 529 error envelope is recorded with its real status and no
@@ -328,13 +394,9 @@ func TestAnthropicProxyErrorResponse(t *testing.T) {
 	}
 }
 
-// TestAnthropicProviderDefaultUpstream records today's behavior, which is a wart found while
-// closing this issue: only gemini has a provider-specific default upstream, so
-// EDGE_PROXY_PROVIDER=anthropic with no EDGE_PROXY_UPSTREAM resolves to api.openai.com and
-// every request 404s against a protocol it was never meant for. Deployments always set the
-// upstream explicitly, so nothing is broken in practice, but the default is wrong. The assertion
-// is written so that adding a DefaultAnthropicUpstream fails here and the fix is a deliberate,
-// reviewed change rather than a silent one.
+// TestAnthropicProviderDefaultUpstream covers CTO-349's third defect: EDGE_PROXY_PROVIDER=anthropic
+// with no EDGE_PROXY_UPSTREAM used to resolve to api.openai.com, quietly pointing a customer's
+// Anthropic traffic at the wrong vendor. Each provider now names its own origin.
 func TestAnthropicProviderDefaultUpstream(t *testing.T) {
 	cfg, err := config.FromEnv(func(k string) string {
 		if k == "EDGE_PROXY_PROVIDER" {
@@ -345,9 +407,54 @@ func TestAnthropicProviderDefaultUpstream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config: %v", err)
 	}
-	if got := cfg.Upstream.String(); got != config.DefaultUpstream {
-		t.Errorf("default upstream for provider=anthropic = %q, want %q; if an Anthropic-specific "+
-			"default was added, update this test to assert it", got, config.DefaultUpstream)
+	if got := cfg.Upstream.String(); got != config.DefaultAnthropicUpstream {
+		t.Errorf("default upstream for provider=anthropic = %q, want %q", got,
+			config.DefaultAnthropicUpstream)
+	}
+}
+
+// TestProviderDefaultUpstreamIsExplicit checks the whole mapping, because the bug was not really
+// "anthropic is missing" but "anything that is not gemini silently becomes OpenAI". An explicit
+// EDGE_PROXY_UPSTREAM still wins everywhere.
+func TestProviderDefaultUpstreamIsExplicit(t *testing.T) {
+	cases := []struct{ provider, want string }{
+		{"", config.DefaultUpstream},
+		{"openai", config.DefaultUpstream},
+		{"anthropic", config.DefaultAnthropicUpstream},
+		{"gemini", config.DefaultGeminiUpstream},
+	}
+	for _, tc := range cases {
+		t.Run("default/"+tc.provider, func(t *testing.T) {
+			cfg, err := config.FromEnv(func(k string) string {
+				if k == "EDGE_PROXY_PROVIDER" {
+					return tc.provider
+				}
+				return ""
+			})
+			if err != nil {
+				t.Fatalf("config: %v", err)
+			}
+			if got := cfg.Upstream.String(); got != tc.want {
+				t.Errorf("provider %q default upstream = %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+		t.Run("explicit/"+tc.provider, func(t *testing.T) {
+			cfg, err := config.FromEnv(func(k string) string {
+				switch k {
+				case "EDGE_PROXY_PROVIDER":
+					return tc.provider
+				case "EDGE_PROXY_UPSTREAM":
+					return "https://llm.internal.example"
+				}
+				return ""
+			})
+			if err != nil {
+				t.Fatalf("config: %v", err)
+			}
+			if got := cfg.Upstream.String(); got != "https://llm.internal.example" {
+				t.Errorf("explicit upstream for provider %q = %q", tc.provider, got)
+			}
+		})
 	}
 }
 

--- a/infra/edge-proxy/internal/proxy/provider_payload_variations_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_payload_variations_test.go
@@ -54,18 +54,50 @@ func TestOpenAIMetaFromPublishedResponses(t *testing.T) {
 	}
 }
 
-// TestOpenAIStreamedUsageIsNotParsed pins a gap the same way the Anthropic streaming test does.
-// With stream_options.include_usage the final SSE chunk carries the full usage block, but the body
-// is a sequence of "data:" frames rather than one JSON document, so the parse fails and everything
-// stays unknown. Honest (unknown, not zero) and incomplete: a streamed OpenAI call is currently
-// unattributed even to a model, though both are present on the wire.
-func TestOpenAIStreamedUsageIsNotParsed(t *testing.T) {
+// TestOpenAIStreamedUsage covers CTO-349 on the OpenAI protocol. With
+// stream_options.include_usage the final chunk (the one whose choices array is empty) carries the
+// whole usage block, and every chunk carries the model, so a streamed call now meters exactly like
+// a buffered one.
+func TestOpenAIStreamedUsage(t *testing.T) {
 	meta := extractMeta(config.ProviderOpenAI, "/v1/chat/completions",
 		readFixture(t, "openai/stream_with_usage.sse"))
-	if meta.Model != "" || meta.PromptTokens != nil || meta.CompletionTokens != nil {
-		t.Errorf("streamed chunks are not parsed today; got %+v. If an SSE parser landed, replace "+
-			"this test with one asserting model gpt-4o-2024-08-06 and 19/10 tokens", meta)
+	if meta.Model != "gpt-4o-2024-08-06" {
+		t.Errorf("Model = %q, want gpt-4o-2024-08-06", meta.Model)
 	}
+	assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(19))
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(10))
+	// The fixture's usage block has no prompt_tokens_details, so the cached share is unknown.
+	assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, nil)
+}
+
+// TestOpenAIStreamedWithoutUsageOptIn is the case the proxy cannot fix and must not paper over.
+//
+// OpenAI emits the usage chunk only when the request set stream_options.include_usage. Without it
+// the counts are on no chunk at all, so they stay unknown: the proxy does not estimate them from
+// the streamed text, and deliberately does not inject the opt-in into the customer's request body,
+// which it forwards byte-for-byte. The model is still recovered from the chunks, so the span is
+// attributable to a model and reads as an unpriced call rather than a free one. The fix for those
+// spans is for the caller to set stream_options.include_usage.
+func TestOpenAIStreamedWithoutUsageOptIn(t *testing.T) {
+	meta := extractMeta(config.ProviderOpenAI, "/v1/chat/completions",
+		readFixture(t, "openai/stream_no_usage.sse"))
+	if meta.Model != "gpt-4o-2024-08-06" {
+		t.Errorf("Model = %q, want gpt-4o-2024-08-06", meta.Model)
+	}
+	assertTokens(t, "PromptTokens", meta.PromptTokens, nil)
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, nil)
+	assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, nil)
+}
+
+// TestOpenAIStreamedCachedPromptTokens reads prompt_tokens_details.cached_tokens off the streamed
+// usage block. OpenAI's prompt_tokens INCLUDES the cached share (unlike Anthropic's input_tokens),
+// so the cached count is reported as the subset it is and nothing is added to the prompt total.
+func TestOpenAIStreamedCachedPromptTokens(t *testing.T) {
+	meta := extractMeta(config.ProviderOpenAI, "/v1/chat/completions",
+		readFixture(t, "openai/stream_cached_prompt.sse"))
+	assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(2048))
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(12))
+	assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, ptr(1920))
 }
 
 func TestGeminiMetaFromPublishedResponses(t *testing.T) {
@@ -102,10 +134,13 @@ func TestGeminiMetaFromPublishedResponses(t *testing.T) {
 			wantModel: "gemini-1.5-pro", wantPrompt: nil, wantComp: nil,
 		},
 		{
-			// alt=sse streaming: not one JSON document, so only the path-derived model survives.
+			// alt=sse streaming (CTO-349): usageMetadata repeats on every chunk with the running
+			// totals, so the counts come from the last chunk that reported each one. The early
+			// chunks carry promptTokenCount with no candidatesTokenCount yet, and that absence must
+			// not overwrite the final count nor read as an output of 0.
 			name: "streaming_sse", fixture: "gemini/stream_generate_content.sse",
 			path:      "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
-			wantModel: "gemini-2.5-flash", wantPrompt: nil, wantComp: nil,
+			wantModel: "gemini-2.5-flash", wantPrompt: ptr(25), wantComp: ptr(15),
 		},
 	}
 	for _, tc := range cases {

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -190,13 +190,17 @@ func (p *Proxy) captureMeta(resp *http.Response) error {
 	if holder == nil {
 		return nil
 	}
-	resp.Body = &metaCapture{
-		inner:    resp.Body,
-		provider: rt.provider,
-		path:     resp.Request.URL.Path,
-		out:      holder,
-	}
+	// CTO-349: a streamed response puts its usage in the event sequence rather than in one JSON
+	// document, so it is folded incrementally as it passes. Deciding from the response Content-Type
+	// means the choice is made before any body byte arrives, and a stream is never accumulated.
+	resp.Body = newMetaCapture(
+		resp.Body, rt.provider, resp.Request.URL.Path, isEventStream(resp.Header), holder)
 	return nil
+}
+
+// isEventStream reports whether the upstream is streaming SSE back to the client.
+func isEventStream(h http.Header) bool {
+	return strings.Contains(strings.ToLower(h.Get("Content-Type")), "text/event-stream")
 }
 
 // ServeHTTP forwards the request and records a telemetry copy.
@@ -304,22 +308,23 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.rp.ServeHTTP(rec, r.WithContext(ctx))
 
 	p.sink.Record(TraceRecord{
-		TenantKey:        tenant,
-		TenantId:         tenantID,
-		FeatureTag:       featureTag,
-		AccountIdHash:    accountIdHash,
-		Method:           r.Method,
-		Path:             r.URL.Path,
-		Provider:         string(route.provider),
-		Model:            meta.Model,
-		PromptTokens:     meta.PromptTokens,
-		CompletionTokens: meta.CompletionTokens,
-		StatusCode:       rec.status,
-		ReqBytes:         reqBytes,
-		RespBytes:        rec.written,
-		Duration:         p.now().Sub(start),
-		StartedAt:        start,
-		Failed:           rec.failed,
+		TenantKey:         tenant,
+		TenantId:          tenantID,
+		FeatureTag:        featureTag,
+		AccountIdHash:     accountIdHash,
+		Method:            r.Method,
+		Path:              r.URL.Path,
+		Provider:          string(route.provider),
+		Model:             meta.Model,
+		PromptTokens:      meta.PromptTokens,
+		CompletionTokens:  meta.CompletionTokens,
+		CachedInputTokens: meta.CachedInputTokens,
+		StatusCode:        rec.status,
+		ReqBytes:          reqBytes,
+		RespBytes:         rec.written,
+		Duration:          p.now().Sub(start),
+		StartedAt:         start,
+		Failed:            rec.failed,
 	})
 }
 

--- a/infra/edge-proxy/internal/proxy/stream.go
+++ b/infra/edge-proxy/internal/proxy/stream.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// CTO-349: usage extraction from streamed (SSE) responses.
+//
+// Streaming is the common case for chat, so before this the majority of proxied traffic reached
+// storage with no counts at all: the metadata scanner only understood a single JSON document, and a
+// stream is a sequence of events whose usage arrives in one or two of them. The counts were never
+// fabricated (the invariant held), but a blank where real spend belongs is still the wrong answer
+// when the number IS on the wire.
+//
+// The scan is incremental rather than buffered. A completion can stream for minutes and run to
+// megabytes, so the body is never accumulated: bytes pass through to the client untouched and the
+// scanner keeps only the current SSE line, parsing each event's small JSON payload as the line
+// completes and folding the scalar counts into a running responseMeta. Retained memory is therefore
+// one event, not one response, and a stream of any length still yields its usage. Content never
+// outlives the line buffer: only the scalar counts and the model id are kept.
+
+// maxSSELineBytes bounds the single-event line buffer. Published event payloads are a few KB at the
+// outside (a tool-use input_json_delta is the largest), so 1 MiB is generous headroom while keeping
+// a pathological or non-SSE body from growing the buffer without limit. A line past the cap is
+// skipped, not truncated-and-parsed: a half-read JSON object could decode to a plausible-looking
+// wrong number, and a missing count is the honest answer where a wrong one is not.
+const maxSSELineBytes = metaCaptureCap
+
+// sseScanner feeds provider event payloads to fold as they arrive. It is not safe for concurrent
+// use; one scanner belongs to one response body.
+type sseScanner struct {
+	fold func(payload []byte)
+
+	line    []byte
+	dropped bool // current line exceeded maxSSELineBytes; skip it to the next newline
+	// capHit records that at least one event was skipped for length, so a caller can tell "the
+	// provider sent no usage" apart from "we declined to scan the event that may have held it".
+	capHit bool
+}
+
+// write feeds the next chunk of response bytes. It copies nothing beyond the current partial line.
+func (s *sseScanner) write(p []byte) {
+	for len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			s.appendLine(p)
+			return
+		}
+		s.appendLine(p[:i])
+		s.emit()
+		p = p[i+1:]
+	}
+}
+
+func (s *sseScanner) appendLine(b []byte) {
+	if s.dropped {
+		return
+	}
+	if len(s.line)+len(b) > maxSSELineBytes {
+		s.dropped = true
+		s.capHit = true
+		s.line = s.line[:0]
+		return
+	}
+	s.line = append(s.line, b...)
+}
+
+// emit hands the completed line to fold when it is a data: field, then resets the line buffer.
+func (s *sseScanner) emit() {
+	line, dropped := s.line, s.dropped
+	s.line, s.dropped = s.line[:0], false
+	if dropped {
+		return
+	}
+	line = bytes.TrimSuffix(line, []byte("\r"))
+	rest, ok := bytes.CutPrefix(line, []byte("data:"))
+	if !ok {
+		// event:, id:, retry:, a comment, or the blank line between events. Only data carries the
+		// JSON payload; the event: name is redundant with the payload's own "type" field.
+		return
+	}
+	rest = bytes.TrimSpace(rest)
+	// OpenAI terminates with a literal "data: [DONE]" sentinel, which is not JSON.
+	if len(rest) == 0 || bytes.Equal(rest, []byte("[DONE]")) {
+		return
+	}
+	s.fold(rest)
+}
+
+// close flushes a trailing line that arrived without its newline, which is what a stream cut short
+// mid-event looks like (client disconnect, upstream reset).
+func (s *sseScanner) close() {
+	if len(s.line) > 0 || s.dropped {
+		s.emit()
+	}
+}
+
+// looksLikeSSE reports whether a body is an event stream rather than a single JSON document. It is
+// the fallback for a response whose Content-Type did not say text/event-stream; the streaming path
+// normally decides from the header, before any body arrives.
+func looksLikeSSE(body []byte) bool {
+	b := bytes.TrimLeft(body, " \t\r\n")
+	return bytes.HasPrefix(b, []byte("data:")) || bytes.HasPrefix(b, []byte("event:"))
+}
+
+// streamFolder accumulates the scalar usage a provider spreads across its event sequence.
+//
+// Every count is a pointer and starts nil, and a field the provider never sent stays nil all the way
+// to the TraceRecord: a stream the client abandoned, a provider that omitted usage, and an event we
+// skipped for length are all "unknown", never 0.
+type streamFolder struct {
+	provider config.Provider
+	model    string
+
+	// OpenAI / Gemini report the totals directly; last event carrying the field wins, since these
+	// counts are cumulative-final rather than incremental.
+	prompt     *int64
+	completion *int64
+	cached     *int64
+
+	// Anthropic splits the prompt across three separately billed buckets, folded in anthropicPrompt.
+	anthInput       *int64
+	anthCacheCreate *int64
+	anthCacheRead   *int64
+}
+
+func newStreamFolder(p config.Provider) *streamFolder { return &streamFolder{provider: p} }
+
+func (f *streamFolder) scanner() *sseScanner { return &sseScanner{fold: f.feed} }
+
+// feed parses one event payload. An unparseable payload is skipped rather than failing the scan:
+// metadata is best-effort and must never affect the proxied request.
+func (f *streamFolder) feed(payload []byte) {
+	switch f.provider {
+	case config.ProviderOpenAI:
+		f.feedOpenAI(payload)
+	case config.ProviderAnthropic:
+		f.feedAnthropic(payload)
+	case config.ProviderGemini:
+		f.feedGemini(payload)
+	}
+}
+
+// feedOpenAI reads a chat.completion.chunk. The model is on every chunk; the usage block rides on a
+// single final chunk, the one whose choices array is empty.
+//
+// That final chunk exists ONLY when the request set stream_options.include_usage. Without the
+// opt-in the counts are on no chunk at all, so they stay nil and the span lands unpriced with its
+// model known. That is the honest answer and the only available one: we do not estimate tokens from
+// the streamed text, and we deliberately do not rewrite the customer's request to add the opt-in,
+// which would mutate a body the proxy promises to forward byte-for-byte and change what their own
+// SDK sees on the stream. Getting those spans priced is a one-line change at the caller.
+func (f *streamFolder) feedOpenAI(payload []byte) {
+	var c struct {
+		Model string          `json:"model"`
+		Usage *openAIUsageDoc `json:"usage"`
+	}
+	if json.Unmarshal(payload, &c) != nil {
+		return
+	}
+	if c.Model != "" {
+		f.model = c.Model
+	}
+	// "usage": null rides on every non-final chunk, so an absent object must not clear what a
+	// previous event established.
+	if c.Usage != nil {
+		setIfNotNil(&f.prompt, c.Usage.PromptTokens)
+		setIfNotNil(&f.completion, c.Usage.CompletionTokens)
+		if c.Usage.PromptTokensDetails != nil {
+			setIfNotNil(&f.cached, c.Usage.PromptTokensDetails.CachedTokens)
+		}
+	}
+}
+
+// feedAnthropic reads one Messages SSE event. Input tokens and the model arrive on message_start,
+// the final output count on message_delta, and the two cache buckets on either, so the fold has to
+// span events rather than read one of them.
+func (f *streamFolder) feedAnthropic(payload []byte) {
+	var e struct {
+		Message *struct {
+			Model string             `json:"model"`
+			Usage *anthropicUsageDoc `json:"usage"`
+		} `json:"message"`
+		Usage *anthropicUsageDoc `json:"usage"`
+	}
+	if json.Unmarshal(payload, &e) != nil {
+		return
+	}
+	if e.Message != nil {
+		if e.Message.Model != "" {
+			f.model = e.Message.Model
+		}
+		f.foldAnthropicUsage(e.Message.Usage)
+	}
+	f.foldAnthropicUsage(e.Usage)
+}
+
+func (f *streamFolder) foldAnthropicUsage(u *anthropicUsageDoc) {
+	if u == nil {
+		return
+	}
+	setIfNotNil(&f.anthInput, u.InputTokens)
+	setIfNotNil(&f.anthCacheCreate, u.CacheCreationInputTokens)
+	setIfNotNil(&f.anthCacheRead, u.CacheReadInputTokens)
+	// message_start reports the output tokens generated so far (typically 1) and message_delta the
+	// cumulative total, so last-wins lands on the final count. A stream cut off after message_start
+	// keeps the partial count the provider actually reported rather than discarding it.
+	setIfNotNil(&f.completion, u.OutputTokens)
+}
+
+// feedGemini reads a streamGenerateContent chunk. usageMetadata repeats on every chunk with the
+// running totals, and the trailing chunk carries the final ones.
+func (f *streamFolder) feedGemini(payload []byte) {
+	var c struct {
+		ModelVersion  string          `json:"modelVersion"`
+		UsageMetadata *geminiUsageDoc `json:"usageMetadata"`
+	}
+	if json.Unmarshal(payload, &c) != nil {
+		return
+	}
+	if c.ModelVersion != "" {
+		f.model = c.ModelVersion
+	}
+	if c.UsageMetadata != nil {
+		setIfNotNil(&f.prompt, c.UsageMetadata.PromptTokenCount)
+		// The first chunks carry promptTokenCount with no candidatesTokenCount yet; an absent count
+		// must not overwrite one a later chunk supplied (nor invent a 0 for the early chunks).
+		setIfNotNil(&f.completion, c.UsageMetadata.CandidatesTokenCount)
+	}
+}
+
+// meta renders the folded state as a responseMeta.
+func (f *streamFolder) meta() responseMeta {
+	m := responseMeta{Model: f.model, CompletionTokens: f.completion}
+	if f.provider == config.ProviderAnthropic {
+		m.PromptTokens = anthropicPrompt(f.anthInput, f.anthCacheCreate, f.anthCacheRead)
+		m.CachedInputTokens = f.anthCacheRead
+		return m
+	}
+	m.PromptTokens = f.prompt
+	m.CachedInputTokens = f.cached
+	return m
+}
+
+// setIfNotNil copies v into *dst when the provider actually reported it, leaving a previously
+// established value (and the nil-means-unknown default) alone otherwise.
+func setIfNotNil(dst **int64, v *int64) {
+	if v != nil {
+		*dst = v
+	}
+}
+
+// scanSSE folds a complete SSE body in one pass. Used for the non-streaming fallback in extractMeta
+// and by the tests that feed a recorded fixture; the request path uses the incremental scanner.
+func scanSSE(p config.Provider, body []byte) responseMeta {
+	f := newStreamFolder(p)
+	s := f.scanner()
+	s.write(body)
+	s.close()
+	return f.meta()
+}

--- a/infra/edge-proxy/internal/proxy/stream_test.go
+++ b/infra/edge-proxy/internal/proxy/stream_test.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// CTO-349: the streamed-usage scanner itself, independent of any one provider's schema.
+//
+// The fixture-driven per-provider expectations live in provider_anthropic_test.go and
+// provider_payload_variations_test.go. What is tested here is the machinery around them: that the
+// fold survives arbitrary chunk boundaries, that it never accumulates the body, that the bounded
+// line buffer drops an event rather than half-parsing it, and that an absent count stays nil
+// through every one of those paths.
+
+// newProviderProxy builds a proxy speaking the given protocol in front of upstream. Mirrors
+// newAnthropicProxy / newGeminiProxy for the providers those helpers do not cover.
+func newProviderProxy(
+	t *testing.T, p config.Provider, upstream http.Handler,
+) (*httptest.Server, *recordingSink) {
+	t.Helper()
+	origin := httptest.NewServer(upstream)
+	t.Cleanup(origin.Close)
+
+	cfg, err := config.FromEnv(func(k string) string {
+		switch k {
+		case "EDGE_PROXY_UPSTREAM":
+			return origin.URL
+		case "EDGE_PROXY_PROVIDER":
+			return string(p)
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	sink := &recordingSink{}
+	front := httptest.NewServer(New(cfg, WithSink(sink)))
+	t.Cleanup(front.Close)
+	return front, sink
+}
+
+// sseUpstream serves body as an event stream, flushing after each write so the client sees the
+// events as they are produced rather than as one buffered response.
+func sseUpstream(body []byte, chunk int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < len(body); i += chunk {
+			end := i + chunk
+			if end > len(body) {
+				end = len(body)
+			}
+			_, _ = w.Write(body[i:end])
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	})
+}
+
+// TestStreamFoldIsChunkBoundaryIndependent feeds the same stream at every plausible packet size,
+// down to one byte at a time. TCP decides where a response splits, so a scanner that only works
+// when an event happens to land whole in one Read would meter correctly in tests and drop usage at
+// random in production.
+func TestStreamFoldIsChunkBoundaryIndependent(t *testing.T) {
+	body := readFixture(t, "anthropic/stream_text.sse")
+	for _, chunk := range []int{1, 7, 64, 512, len(body)} {
+		var meta responseMeta
+		mc := newMetaCapture(io.NopCloser(&chunkedReader{body: body, chunk: chunk}),
+			config.ProviderAnthropic, "/v1/messages", true, &meta)
+		if _, err := io.Copy(io.Discard, mc); err != nil {
+			t.Fatalf("chunk %d: copy: %v", chunk, err)
+		}
+		if err := mc.Close(); err != nil {
+			t.Fatalf("chunk %d: close: %v", chunk, err)
+		}
+		if meta.Model != "claude-opus-5" {
+			t.Errorf("chunk %d: Model = %q", chunk, meta.Model)
+		}
+		assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(25))
+		assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(15))
+	}
+}
+
+// chunkedReader hands out at most chunk bytes per Read, standing in for a stream that arrives in
+// small packets.
+type chunkedReader struct {
+	body  []byte
+	chunk int
+	off   int
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.body) {
+		return 0, io.EOF
+	}
+	n := r.chunk
+	if n > len(p) {
+		n = len(p)
+	}
+	if r.off+n > len(r.body) {
+		n = len(r.body) - r.off
+	}
+	copy(p, r.body[r.off:r.off+n])
+	r.off += n
+	return n, nil
+}
+
+// TestStreamIsNotBuffered is the request-path guarantee: the proxy must not hold a streamed
+// response back while it looks for usage. The upstream here refuses to send its second event until
+// the client has already received the first, so a proxy that buffered the body would deadlock and
+// fail on the timeout rather than quietly adding latency to every chat token.
+func TestStreamIsNotBuffered(t *testing.T) {
+	gotFirst := make(chan struct{})
+	released := make(chan struct{})
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":"+
+			"{\"model\":\"claude-opus-5\",\"usage\":{\"input_tokens\":25,\"output_tokens\":1}}}\n\n")
+		w.(http.Flusher).Flush()
+		select {
+		case <-released:
+		case <-time.After(5 * time.Second):
+		}
+		_, _ = io.WriteString(w, "event: message_delta\ndata: {\"type\":\"message_delta\","+
+			"\"usage\":{\"output_tokens\":15}}\n\n")
+		w.(http.Flusher).Flush()
+	})
+	front, sink := newProviderProxy(t, config.ProviderAnthropic, upstream)
+
+	resp, err := http.Post(front.URL+"/v1/messages", "application/json",
+		strings.NewReader(`{"stream":true}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	go func() {
+		buf := make([]byte, 256)
+		if _, err := resp.Body.Read(buf); err == nil {
+			close(gotFirst)
+		}
+	}()
+	select {
+	case <-gotFirst:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first event did not reach the client before the upstream sent the second: " +
+			"the response is being buffered")
+	}
+	close(released)
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	assertTokens(t, "PromptTokens", rec.PromptTokens, ptr(25))
+	assertTokens(t, "CompletionTokens", rec.CompletionTokens, ptr(15))
+}
+
+// TestStreamLineCapSkipsEventAndLeavesCountsUnknown exercises the bound. An event larger than the
+// line buffer is skipped whole rather than truncated and parsed, so if it was the event carrying
+// the usage the counts stay UNKNOWN. That is the deliberate trade: a missing number is recoverable,
+// a number parsed out of half a JSON object is a wrong one nobody would question.
+func TestStreamLineCapSkipsEventAndLeavesCountsUnknown(t *testing.T) {
+	// A message_start whose (meaningless) padding field pushes the single data line past the cap.
+	var b bytes.Buffer
+	b.WriteString(`data: {"type":"message_start","message":{"model":"claude-opus-5","usage":` +
+		`{"input_tokens":25,"output_tokens":1}},"pad":"`)
+	b.Write(bytes.Repeat([]byte("x"), maxSSELineBytes))
+	b.WriteString("\"}\n\n")
+	// A following, ordinary event proves the scanner recovers rather than giving up on the stream.
+	b.WriteString(`data: {"type":"message_delta","usage":{"output_tokens":15}}` + "\n\n")
+
+	f := newStreamFolder(config.ProviderAnthropic)
+	s := f.scanner()
+	s.write(b.Bytes())
+	s.close()
+
+	if !s.capHit {
+		t.Error("scanner did not record that an event was skipped for length")
+	}
+	meta := f.meta()
+	// The oversized event held the model and the input count, so both stay unknown. Nothing is
+	// salvaged from a partially read event.
+	if meta.Model != "" {
+		t.Errorf("Model = %q, want unknown", meta.Model)
+	}
+	assertTokens(t, "PromptTokens", meta.PromptTokens, nil)
+	// The event after the oversized one still parsed.
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(15))
+}
+
+// TestStreamWithNoUsageAtAll is the blanket honesty case across providers: a stream that never
+// reports usage yields nil counts, never 0. This is the shape of an OpenAI stream without
+// stream_options.include_usage, and of any stream the client abandoned early.
+func TestStreamWithNoUsageAtAll(t *testing.T) {
+	for _, p := range []config.Provider{
+		config.ProviderOpenAI, config.ProviderAnthropic, config.ProviderGemini,
+	} {
+		t.Run(string(p), func(t *testing.T) {
+			meta := scanSSE(p, []byte("data: {\"type\":\"ping\"}\n\ndata: [DONE]\n\n"))
+			assertTokens(t, "PromptTokens", meta.PromptTokens, nil)
+			assertTokens(t, "CompletionTokens", meta.CompletionTokens, nil)
+			assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, nil)
+		})
+	}
+}
+
+// TestEmptyStreamLeavesEverythingUnknown: a 200 with a text/event-stream content type and no bytes
+// at all (an upstream that died before its first event) must not produce counts.
+func TestEmptyStreamLeavesEverythingUnknown(t *testing.T) {
+	var meta responseMeta
+	mc := newMetaCapture(io.NopCloser(strings.NewReader("")),
+		config.ProviderOpenAI, "/v1/chat/completions", true, &meta)
+	_, _ = io.Copy(io.Discard, mc)
+	if err := mc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if meta.Model != "" {
+		t.Errorf("Model = %q, want unknown", meta.Model)
+	}
+	assertTokens(t, "PromptTokens", meta.PromptTokens, nil)
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, nil)
+}
+
+// TestOpenAIProxyStreamingEndToEnd drives the OpenAI protocol through the real proxy, including the
+// "data: [DONE]" sentinel, which is not JSON and must not disturb the fold.
+func TestOpenAIProxyStreamingEndToEnd(t *testing.T) {
+	body := readFixture(t, "openai/stream_with_usage.sse")
+	front, sink := newProviderProxy(t, config.ProviderOpenAI, sseUpstream(body, 41))
+
+	resp, err := http.Post(front.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"stream":true,"stream_options":{"include_usage":true}}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Equal(got, body) {
+		t.Error("SSE stream altered in transit")
+	}
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if rec.Model != "gpt-4o-2024-08-06" {
+		t.Errorf("Model = %q", rec.Model)
+	}
+	assertTokens(t, "PromptTokens", rec.PromptTokens, ptr(19))
+	assertTokens(t, "CompletionTokens", rec.CompletionTokens, ptr(10))
+}
+
+// TestGeminiProxyStreamingEndToEnd drives alt=sse streaming. Gemini repeats usageMetadata on every
+// chunk, so the last chunk to report each count wins; the model comes from the request path as it
+// does for a buffered call.
+func TestGeminiProxyStreamingEndToEnd(t *testing.T) {
+	body := readFixture(t, "gemini/stream_generate_content.sse")
+	front, sink := newProviderProxy(t, config.ProviderGemini, sseUpstream(body, 97))
+
+	path := "/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+	resp, err := http.Post(front.URL+path, "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Equal(got, body) {
+		t.Error("SSE stream altered in transit")
+	}
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	if rec.Model != "gemini-2.5-flash" {
+		t.Errorf("Model = %q, want gemini-2.5-flash", rec.Model)
+	}
+	assertTokens(t, "PromptTokens", rec.PromptTokens, ptr(25))
+	assertTokens(t, "CompletionTokens", rec.CompletionTokens, ptr(15))
+}
+
+// TestNonStreamResponseStillUsesTheBufferedScan guards the path that was already working: a normal
+// JSON response through a provider proxy must keep parsing exactly as before, whatever the
+// streaming code does.
+func TestNonStreamResponseStillUsesTheBufferedScan(t *testing.T) {
+	body := readFixture(t, "anthropic/message_end_turn.json")
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	front, sink := newProviderProxy(t, config.ProviderAnthropic, upstream)
+
+	resp, err := http.Post(front.URL+"/v1/messages", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	assertTokens(t, "PromptTokens", rec.PromptTokens, ptr(10))
+	assertTokens(t, "CompletionTokens", rec.CompletionTokens, ptr(15))
+}
+
+// TestSSEFallbackWhenContentTypeIsWrong: the request path picks the streaming scan from the
+// response Content-Type, but an upstream (or an intermediary) that streams SSE while labelling it
+// application/json should still be metered. The buffered scan recognizes the body as an event
+// stream and folds it, subject to the ordinary capture cap.
+func TestSSEFallbackWhenContentTypeIsWrong(t *testing.T) {
+	body := readFixture(t, "anthropic/stream_text.sse")
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	front, sink := newProviderProxy(t, config.ProviderAnthropic, upstream)
+
+	resp, err := http.Post(front.URL+"/v1/messages", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	sink.waitFor(t, 1)
+	rec := sink.last()
+	assertTokens(t, "PromptTokens", rec.PromptTokens, ptr(25))
+	assertTokens(t, "CompletionTokens", rec.CompletionTokens, ptr(15))
+}

--- a/infra/edge-proxy/internal/proxy/testdata/openai/stream_cached_prompt.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/stream_cached_prompt.sse
@@ -1,0 +1,10 @@
+data: {"id":"chatcmpl-125","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-125","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"content":"Yes"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-125","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+data: {"id":"chatcmpl-125","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[],"usage":{"prompt_tokens":2048,"completion_tokens":12,"total_tokens":2060,"prompt_tokens_details":{"cached_tokens":1920,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+
+data: [DONE]
+

--- a/infra/edge-proxy/internal/proxy/testdata/openai/stream_no_usage.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/openai/stream_no_usage.sse
@@ -1,0 +1,8 @@
+data: {"id":"chatcmpl-124","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-124","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-124","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-2024-08-06","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+data: [DONE]
+

--- a/infra/edge-proxy/internal/proxy/trace.go
+++ b/infra/edge-proxy/internal/proxy/trace.go
@@ -57,6 +57,20 @@ type TraceRecord struct {
 	// never persists or logs the body they came from.
 	PromptTokens     *int64
 	CompletionTokens *int64
+	// CachedInputTokens is the share of PromptTokens the provider served from its prompt cache
+	// (Anthropic usage.cache_read_input_tokens, OpenAI usage.prompt_tokens_details.cached_tokens).
+	// It is a SUBSET of PromptTokens, matching how the price catalog reads it: the gateway bills
+	// (input - cached) at the standard rate and cached at the cheaper cached rate, so shipping it
+	// is what stops a cache-heavy call being priced as if every prompt token were fresh (CTO-349).
+	// Nil like the other counts when the provider did not report it; a provider that reported an
+	// explicit 0 is a different fact and is preserved as 0.
+	//
+	// Anthropic's cache CREATION tokens have no field here. They are included in PromptTokens (they
+	// are prompt input, and dropping them would under-count the call outright) but are billed at a
+	// premium the wire has no way to express, so a cache-write-heavy call is under-priced by that
+	// premium. Adding a field would be dishonest without the matching gen_ai attribute, price type
+	// and column downstream; see docs/anthropic-cache-tokens.md.
+	CachedInputTokens *int64
 	// StatusCode is the upstream response status relayed to the client (0 if the upstream failed
 	// before any status, e.g. connection refused, see Failed).
 	StatusCode int

--- a/infra/edge-proxy/internal/telemetry/telemetry.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry.go
@@ -102,6 +102,11 @@ type wireSpan struct {
 	// tracked separately; this encoder is the half of it that can be honest without one.
 	InputTokens  *int64 `json:"gen_ai.usage.input_tokens,omitempty"`
 	OutputTokens *int64 `json:"gen_ai.usage.output_tokens,omitempty"`
+	// CachedInputTokens is the cache-served share of InputTokens (a subset, not an addition). The
+	// gateway maps this attribute to otel_spans.CachedInputTokens and prices the remainder at the
+	// standard input rate, so omitting it prices a cached prompt as if every token were fresh
+	// (CTO-349). Nil is omitted like the other counts: unknown stays unknown.
+	CachedInputTokens *int64 `json:"gen_ai.usage.cached_input_tokens,omitempty"`
 	// FeatureTag / AccountIdHash mirror the same span attributes the Python SDK emits, so a proxied
 	// request lands in the same FeatureTag / AccountIdHash columns (CTO-104, CTO-182). Omitted when
 	// the caller did not tag or attribute the request: the unattributed bucket, not a customer
@@ -187,27 +192,28 @@ func toWire(dep Deployment, rec proxy.TraceRecord, id ids) wireBatch {
 		status = statusError
 	}
 	span := wireSpan{
-		TimestampNs:    rec.StartedAt.UnixNano(),
-		TraceId:        id.newHex(16),
-		SpanId:         id.newHex(8),
-		ServiceName:    ServiceName,
-		SpanName:       "llm.call",
-		StatusCode:     status,
-		DurationNs:     rec.Duration.Nanoseconds(),
-		Operation:      "chat",
-		System:         genAISystem(rec.Provider),
-		ResponseModel:  rec.Model,
-		InputTokens:    rec.PromptTokens,
-		OutputTokens:   rec.CompletionTokens,
-		FeatureTag:     rec.FeatureTag,
-		AccountIdHash:  rec.AccountIdHash,
-		Deployment:     dep,
-		Method:         rec.Method,
-		Path:           rec.Path,
-		HTTPStatus:     rec.StatusCode,
-		ReqBytes:       rec.ReqBytes,
-		RespBytes:      rec.RespBytes,
-		UpstreamFailed: rec.Failed,
+		TimestampNs:       rec.StartedAt.UnixNano(),
+		TraceId:           id.newHex(16),
+		SpanId:            id.newHex(8),
+		ServiceName:       ServiceName,
+		SpanName:          "llm.call",
+		StatusCode:        status,
+		DurationNs:        rec.Duration.Nanoseconds(),
+		Operation:         "chat",
+		System:            genAISystem(rec.Provider),
+		ResponseModel:     rec.Model,
+		InputTokens:       rec.PromptTokens,
+		OutputTokens:      rec.CompletionTokens,
+		CachedInputTokens: rec.CachedInputTokens,
+		FeatureTag:        rec.FeatureTag,
+		AccountIdHash:     rec.AccountIdHash,
+		Deployment:        dep,
+		Method:            rec.Method,
+		Path:              rec.Path,
+		HTTPStatus:        rec.StatusCode,
+		ReqBytes:          rec.ReqBytes,
+		RespBytes:         rec.RespBytes,
+		UpstreamFailed:    rec.Failed,
 	}
 	return wireBatch{
 		TenantId:       rec.TenantId,

--- a/infra/edge-proxy/internal/telemetry/telemetry_test.go
+++ b/infra/edge-proxy/internal/telemetry/telemetry_test.go
@@ -216,6 +216,49 @@ func TestUnknownTokensSerializeAsNullNeverZero(t *testing.T) {
 	}
 }
 
+// TestCachedInputTokensReachTheWire covers the CTO-349 cache share. The gateway maps
+// gen_ai.usage.cached_input_tokens onto its own column and prices (input - cached) at the standard
+// rate, so a record that folded Anthropic's cache_read_input_tokens into the prompt total but did
+// not ship the share would price every cached token as fresh: worse than the under-count it
+// replaced. Absent stays absent, like every other count.
+func TestCachedInputTokensReachTheWire(t *testing.T) {
+	rec := sampleRecord()
+	rec.PromptTokens = i64(18944)
+	rec.CachedInputTokens = i64(18923)
+
+	span := decodeSpan(t, mustEncode(t, rec))
+	if v := span["gen_ai.usage.cached_input_tokens"]; v != float64(18923) {
+		t.Errorf("cached input tokens = %v, want 18923", v)
+	}
+
+	rec.CachedInputTokens = nil
+	body := mustEncode(t, rec)
+	if v, present := decodeSpan(t, body)[GenAICachedInputTokens]; present {
+		t.Errorf("unknown cache share present as %#v; it must be omitted, never 0", v)
+	}
+	if strings.Contains(string(body), `"gen_ai.usage.cached_input_tokens":0`) {
+		t.Fatalf("unknown cache share serialized as 0: %s", body)
+	}
+
+	// A provider that reported an explicit 0 said something real and must keep saying it.
+	rec.CachedInputTokens = i64(0)
+	if v, ok := decodeSpan(t, mustEncode(t, rec))[GenAICachedInputTokens]; !ok || v != float64(0) {
+		t.Errorf("a reported 0 cache share must serialize, got %#v (present=%v)", v, ok)
+	}
+}
+
+// GenAICachedInputTokens is the wire key under test, spelled once.
+const GenAICachedInputTokens = "gen_ai.usage.cached_input_tokens"
+
+func mustEncode(t *testing.T, rec proxy.TraceRecord) []byte {
+	t.Helper()
+	body, err := Encode(DeploymentCloud, rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
 // TestZeroTokensStillSerialize: a count the provider genuinely reported as 0 is a fact and must
 // survive. This is the other half of the nullable contract: omitempty keys off nil, not off 0.
 func TestZeroTokensStillSerialize(t *testing.T) {


### PR DESCRIPTION
Fixes #349. Three defects, all in the edge proxy's response-metadata path.

## 1. Streamed responses are now parsed for usage

The scanner understood one JSON document, and a stream is a sequence of events. Streaming is the common case for chat, so a customer routing streaming traffic saw blanks where most of their spend belongs. The counts were never fabricated, which is why this showed up as missing rather than wrong.

`internal/proxy/stream.go` folds an SSE stream event by event as it passes:

| Provider | Where the usage is | How it is folded |
|---|---|---|
| OpenAI | one final `chat.completion.chunk` whose `choices` is empty | last chunk reporting each field wins; model from any chunk; `data: [DONE]` skipped |
| Anthropic | `message_start` (model, input tokens) and `message_delta` (final cumulative output) | both events folded; `message_start`'s partial output count is superseded by `message_delta` |
| Gemini | `usageMetadata` repeated on every chunk | last chunk reporting each count wins; model still from the request path |

**Where it is bounded.** The body is never accumulated. Retained memory is the current SSE line, so a completion that streams for minutes costs the same as one that streams for a second, and `FlushInterval = -1` still hands the client every byte immediately. A single event line past 1 MiB is dropped whole rather than truncated and parsed (a half-read JSON object could decode to a plausible wrong number), the scanner recovers on the next event, and a skipped usage event leaves the counts unknown. The buffered path for ordinary JSON responses is untouched, including its existing 1 MiB capture cap.

**OpenAI's opt-in usage.** The final usage chunk exists only when the request set `stream_options.include_usage`. Without it the counts are on no chunk at all, so they stay `nil` and the span is recorded with its model and unknown counts. The proxy does **not** inject `stream_options` into the request: it forwards bodies byte-for-byte, and rewriting the customer's request would also change what their own SDK sees on the stream. Documented in the README so the fix (set it at the caller) is discoverable.

## 2. Anthropic cache tokens

`usage.input_tokens` **excludes** both cache buckets, so a cached prompt was under-counted by everything the cache served: the fixture with 18923 cache-read tokens was recorded as a 21-token prompt.

- `PromptTokens` is now `input + cache_creation + cache_read`, the honest token count.
- The cache-read share ships separately as `gen_ai.usage.cached_input_tokens`. **`TraceRecord` could represent this honestly**: the gateway already maps that attribute to its own column and the catalog prices `(input - cached)` at the standard rate and `cached` at the cached rate, so the split prices correctly with no schema change. `TraceRecord.CachedInputTokens` and one wire field were all that was missing.
- **Cache CREATION tokens are the part the record cannot represent.** There is no `cache_creation_input_tokens` attribute, no `CACHE_WRITE` price type and no column. They are counted in the total (they are prompt input; dropping them under-counts by 100% of the write rather than mis-rating it) and therefore price at the standard input rate, so a cache-write-heavy call is under-priced by the write premium on that slice. That is an approximation of a known number, not an invented one, and it is written down in `docs/anthropic-cache-tokens.md` with the four changes needed to close it properly, rather than forced into a field nothing reads.

Absence and zero stay distinct throughout: a payload that never mentions the cache reports unknown, one that reports `0` reports `0`.

## 3. provider=anthropic defaulting to api.openai.com

Fails loudly by construction: each provider names its own default origin (`api.anthropic.com` for Anthropic), and `defaultUpstreamFor` refuses to boot for a provider with no registered default instead of falling through to OpenAI's. The original bug was not that Anthropic lacked an entry but that anything without one silently became OpenAI, which the next provider added would have inherited.

## Verification

`go build ./... && go test ./... && gofmt -l .` all clean (gofmt lists nothing), plus `go vet` and `-race`. The gateway suite is unchanged at 1058 passed.

The three tests that pinned these gaps (`TestAnthropicProxyStreamingSSE`, `TestOpenAIStreamedUsageIsNotParsed`, `TestAnthropicCacheTokensAreNotFoldedIntoPromptTokens`, the Gemini `streaming_sse` row, `TestAnthropicProviderDefaultUpstream`) now assert the fixed behavior. New coverage:

- usage present, on all three providers, end to end through the real proxy
- usage absent: OpenAI without the opt-in, a stream with no usage event on every provider, an empty stream. All assert `nil`, not `0`
- a stream that ends early: client disconnect mid-event, and the published mid-stream `error` fixture (what `message_start` reported stands, nothing is completed with a guess)
- the cap being hit: an oversized event is skipped, its counts stay unknown, the next event still parses
- chunk-boundary independence, fed one byte at a time
- a non-buffering proof: the upstream withholds its second event until the client has received the first, so a buffering proxy deadlocks instead of quietly adding latency
- cache fields absent vs. explicitly `0`, and the cached share reaching the wire

Two fixtures added in the PR #348 style from OpenAI's published schema: a stream without the usage opt-in, and one with `prompt_tokens_details.cached_tokens`.

**Latency.** `TestOverheadBudget` still passes. p99 added overhead is unchanged within run-to-run noise (baseline 114-871µs across runs, after 217-846µs; the harness is noisy at this scale). The steadier signal is `BenchmarkProxyOverhead`: 155 allocs/op and ~46.5 KB/op before and after, ns/op medians 68µs vs 64µs, fully overlapping. Expected, since the non-streaming hot path is byte-identical and the fold only runs on a `text/event-stream` response.

## Found along the way, not in the issue

- **The Python SDK has the mirror-image cache bug.** `sdk/python/src/tally/instrumentation/anthropic.py` maps `input_tokens` straight through and sets `cached_input_tokens = cache_read_input_tokens`, but pricing treats cached as a *subset* of input (`min(cached, input)`), so an SDK-instrumented Anthropic call with a cache hit under-counts its prompt exactly as the proxy did, and its cache read is then clamped away. Out of scope here; worth its own issue.
- **Gemini context caching** (`usageMetadata.cachedContentTokenCount`) is still unread, so those tokens price at the standard input rate. Left alone because #348 has no Gemini cache fixture to verify the semantics against, and a guess is not worth shipping.
- OpenAI's `prompt_tokens_details.cached_tokens` was unread on the buffered path too, not just the streamed one. Now read on both.
- `TraceRecord` has no home for Gemini's `thoughtsTokenCount` either (already pinned by an existing test comment); thinking tokens are billed and unrecorded.

Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
