### PR TITLE
fix(deploy): skip the synthetic backfill when the tenant already has spans

### DIFF
--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -183,6 +183,17 @@ URL:   https://demo.example.com
 Login: tester  (password: the plaintext you hashed)
 ```
 
+Re-running `deploy.sh` (to pick up a code change, say) does **not** re-post the backfill: it counts
+the tenant's existing spans in ClickHouse first and skips the step when there are any. Two overrides:
+
+| Variable | Effect |
+| --- | --- |
+| `SKIP_BACKFILL=1` | Never back-fill, even on an empty tenant. |
+| `FORCE_BACKFILL=1` | Back-fill anyway, on top of what is already there. |
+
+Use `./deploy/demo/reseed.sh` rather than `FORCE_BACKFILL=1` when you want a clean dataset: it
+truncates first, so the spans are replaced instead of doubled.
+
 ### 5. Share privately
 
 Send the link and the shared password to testers **privately** (DM / password manager share). This

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -144,6 +144,24 @@ else
   pin_dashboard_tenant "${TENANT_UUID}"
 fi
 
+# CTO-373: skip the backfill when this tenant already has spans. Re-running deploy.sh to pick up a
+# code change should not re-post a 30-day corpus: it takes minutes and ships 512k spans over the wire
+# for a tenant that already holds them. The generator is deterministic and the gateway dedupes a
+# replayed batch_id, so a second run is not corrupting, just slow and confusing.
+#
+# The count comes from ClickHouse rather than a marker file, so it stays right across a repo re-clone
+# and a `make nuke`. SKIP_BACKFILL=1 forces the skip, FORCE_BACKFILL=1 runs it anyway.
+EXISTING_SPANS="$("${COMPOSE[@]}" exec -T clickhouse clickhouse-client \
+  --user "${CLICKHOUSE_USER:-tally}" --password "${CLICKHOUSE_PASSWORD:-tally}" \
+  -q "SELECT count() FROM otel_spans WHERE TenantId='${TENANT_UUID}'" 2>/dev/null | tr -d '[:space:]')"
+EXISTING_SPANS="${EXISTING_SPANS:-0}"
+
+if [ "${SKIP_BACKFILL:-}" = "1" ]; then
+  echo "==> Skipping the backfill (SKIP_BACKFILL=1). Tenant holds ${EXISTING_SPANS} spans."
+elif [ "${EXISTING_SPANS}" != "0" ] && [ "${FORCE_BACKFILL:-}" != "1" ]; then
+  echo "==> Skipping the backfill: tenant ${TENANT_UUID} already holds ${EXISTING_SPANS} spans."
+  echo "    Re-post it anyway with: FORCE_BACKFILL=1 ./deploy/demo/deploy.sh"
+else
 echo "==> Backfilling 30 days of SYNTHETIC demo spans"
 # The `make chatbot-demo-backfill` target runs on the HOST and POSTs to localhost:8080 - neither
 # works on a locked-down single VM (no host Node, and the gateway publishes no host port in prod).
@@ -169,15 +187,25 @@ docker run --rm \
   -e GATEWAY_SERVICE_TOKEN="${TALLY_GATEWAY_SERVICE_TOKEN:-}" \
   node:22-bookworm-slim \
   npx --yes tsx /scripts/backfill-spans.ts --tenant "${TENANT_UUID}"
+fi
 
 # --- Done ---------------------------------------------------------------------------------------
+# CTO-373: the login line depends on the auth mode. In clerk mode there is no BASIC_AUTH_USER, and
+# printing "Login:  (password: the plaintext you hashed...)" told the operator to use a credential
+# that does not exist in that mode.
+if [ "${AUTH_MODE:-basic}" = "clerk" ]; then
+  LOGIN_LINE="  Login: Clerk sign-in at https://${DOMAIN}/sign-in"
+else
+  LOGIN_LINE="  Login: ${BASIC_AUTH_USER}  (password: the plaintext you hashed into BASIC_AUTH_HASH)"
+fi
+
 cat <<EOF
 
 ==================================================================
   ai-tally demo is up.
 
   URL:   https://${DOMAIN}
-  Login: ${BASIC_AUTH_USER}  (password: the plaintext you hashed into BASIC_AUTH_HASH)
+${LOGIN_LINE}
 
   The dataset is SYNTHETIC (seeded + backfilled), safe to share with testers.
   Share the link and password privately. Reset the data with deploy/demo/reseed.sh.


### PR DESCRIPTION
## Why

Re-running `deploy/demo/deploy.sh` (to pick up a code change) re-posted the entire 30-day synthetic corpus every time. On the production droplet that is 512k spans over the wire and several minutes of a deploy meant to be a rebuild. Not corrupting (the generator is deterministic, the gateway dedupes a replayed `batch_id`) but slow and confusing.

## What

- `deploy.sh` counts the tenant's spans in ClickHouse before the backfill step and skips it when the count is non-zero. The count comes from the store rather than a marker file, so it stays correct across a repo re-clone and a `make nuke`.
- `SKIP_BACKFILL=1` forces the skip even on an empty tenant; `FORCE_BACKFILL=1` runs it regardless. `reseed.sh` remains the right tool for a clean dataset, since it truncates first instead of doubling.
- Closing banner is now mode-aware. In `AUTH_MODE=clerk` there is no `BASIC_AUTH_USER`, so it was printing `Login:  (password: the plaintext you hashed...)` and pointing the operator at a credential that does not exist in that mode.
- README documents both overrides.

## Verification

`bash -n deploy/demo/deploy.sh` parses. No source code in the four projects is touched, so the language suites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)