### PR TITLE
fix(sdk): fold Anthropic's cache buckets into the prompt total

### DIFF
--- a/sdk/python/src/tally/instrumentation/anthropic.py
+++ b/sdk/python/src/tally/instrumentation/anthropic.py
@@ -4,9 +4,13 @@
 Mirrors :mod:`tally.instrumentation.openai`. A pure function over a provider response object,
 testable with fakes and no network. Reads only ``usage`` / ``model`` metadata:
 
-* ``usage.input_tokens``            -> ``gen_ai.usage.input_tokens``
+* ``usage.input_tokens`` + ``cache_creation_input_tokens`` + ``cache_read_input_tokens``
+                                    -> ``gen_ai.usage.input_tokens``
 * ``usage.output_tokens``           -> ``gen_ai.usage.output_tokens``
 * ``usage.cache_read_input_tokens`` -> ``gen_ai.usage.cached_input_tokens`` (where present)
+
+Anthropic's ``input_tokens`` is NOT a total: it excludes both cache buckets. See
+``docs/anthropic-cache-tokens.md`` and :func:`_prompt_tokens` (CTO-374).
 
 Streaming: Anthropic reports input tokens on the ``message_start`` event and the running output
 count on ``message_delta`` events, so :meth:`accumulate` folds both and :meth:`finalize` returns
@@ -32,14 +36,72 @@ def _get(obj: object, key: str, default: object = None) -> object:
     return getattr(obj, key, default)
 
 
+def _prompt_tokens(usage: object) -> int:
+    """Total prompt tokens for an Anthropic response (CTO-374).
+
+    Anthropic bills a prompt in three separately reported pieces, and ``input_tokens`` is only the
+    first of them: it EXCLUDES ``cache_creation_input_tokens`` and ``cache_read_input_tokens``
+    rather than totalling them. Reading it as the whole prompt made a call that served 18923 tokens
+    from cache and 21 fresh ones record 21.
+
+    Worse, it did not surface as a missing number. ``Usage.cached_input_tokens`` is defined
+    repo-wide as a SUBSET of ``input_tokens`` (the edge proxy's ``CachedInputTokens``, and the
+    ``min(cached, input)`` in :func:`tally.pricing.compute_cost_micro_usd`), so passing a bucket
+    that is disjoint from ``input_tokens`` into it meant the clamp silently priced the entire
+    18944-token prompt as 21 cached tokens.
+
+    This mirrors ``anthropicPrompt`` in ``infra/edge-proxy/internal/proxy/provider.go`` so the two
+    implementations agree on the same response. Folding the cache-write bucket into the total is a
+    documented approximation, not a guess: the token count is then right, and the write share
+    prices at the standard input rate instead of the write premium because there is no
+    ``PriceType.CACHE_WRITE`` to bill it at. ``docs/anthropic-cache-tokens.md`` records why that
+    trade is the better of the two available errors, and what closing it properly requires.
+    """
+    total = 0
+    for key in ("input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"):
+        total += int(_get(usage, key, 0) or 0)
+    return total
+
+
+# The three separately billed pieces of an Anthropic prompt, in the order the API reports them.
+# input_tokens is only the first: see _prompt_tokens.
+_PROMPT_KEYS = ("input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens")
+
+
+def _fold_usage(state: dict, usage: object) -> None:
+    """Fold one streamed usage block into the accumulator, last-wins per field (CTO-374).
+
+    Mirrors ``foldAnthropicUsage`` in ``infra/edge-proxy/internal/proxy/stream.go``. The buckets are
+    kept apart in the state and summed once in :meth:`AnthropicInstrumentor.finalize`, because the
+    cache buckets arrive on either message_start or message_delta, so totalling at the first event
+    that carries a prompt would drop whatever the second one reports.
+
+    A field the provider did not mention is left absent rather than written as 0, so an unreported
+    bucket stays distinguishable from a reported zero for as long as the state holds it.
+    """
+    if usage is None:
+        return
+    for key in _PROMPT_KEYS:
+        value = _get(usage, key)
+        if value is not None:
+            state[key] = int(value or 0)
+    # message_start reports the output tokens generated so far (typically 1) and message_delta the
+    # cumulative total, so last-wins lands on the final count. A stream cut off after message_start
+    # keeps the partial count the provider actually reported rather than discarding it.
+    output = _get(usage, "output_tokens")
+    if output is not None:
+        state["output_tokens"] = int(output or 0)
+
+
 def _usage_from(usage: object) -> Usage | None:
     if usage is None:
         return None
-    input_tokens = int(_get(usage, "input_tokens", 0) or 0)
     output_tokens = int(_get(usage, "output_tokens", 0) or 0)
     cached = int(_get(usage, "cache_read_input_tokens", 0) or 0)
     return Usage(
-        input_tokens=input_tokens, output_tokens=output_tokens, cached_input_tokens=cached
+        input_tokens=_prompt_tokens(usage),
+        output_tokens=output_tokens,
+        cached_input_tokens=cached,
     )
 
 
@@ -61,41 +123,31 @@ class AnthropicInstrumentor:
 
     # --- streaming (CTO-260 §4.3) ---
     def accumulate(self, state: dict, chunk: object) -> None:
-        event_type = _get(chunk, "type")
-        # message_start carries the input tokens and the model on a nested message object.
+        # message_start carries the model and the prompt buckets on a nested message object.
         message = _get(chunk, "message")
         if message is not None:
             model = _get(message, "model")
             if isinstance(model, str) and model:
                 state["model"] = model
-            start_usage = _get(message, "usage")
-            if start_usage is not None:
-                state["input_tokens"] = int(_get(start_usage, "input_tokens", 0) or 0)
-                cached = _get(start_usage, "cache_read_input_tokens")
-                if cached is not None:
-                    state["cached_input_tokens"] = int(cached or 0)
-                # A final message (used to seed usage when the caller never iterated events)
-                # carries the full output count on the same usage object.
-                message_output = _get(start_usage, "output_tokens")
-                if message_output is not None:
-                    state["output_tokens"] = int(message_output or 0)
-        # message_delta carries the running output token count.
-        delta_usage = _get(chunk, "usage")
-        if delta_usage is not None and event_type != "message_start":
-            output = _get(delta_usage, "output_tokens")
-            if output is not None:
-                state["output_tokens"] = int(output or 0)
+            _fold_usage(state, _get(message, "usage"))
+        # message_delta carries the cumulative output count, and may carry cache buckets too.
+        if _get(chunk, "usage") is not None:
+            _fold_usage(state, _get(chunk, "usage"))
             model = _get(chunk, "model")
             if isinstance(model, str) and model:
                 state.setdefault("model", model)
 
     def finalize(self, state: dict) -> tuple[str | None, Usage | None]:
-        if "input_tokens" not in state and "output_tokens" not in state:
+        # CTO-374: a stream whose only usage event reported cache buckets (a fully cached prompt
+        # reports input_tokens alongside them, but a fold that saw only a cache field must still
+        # count as having seen usage) has real tokens to report. Keying this on input_tokens alone
+        # would finalize it to None and lose the whole prompt.
+        if not any(k in state for k in (*_PROMPT_KEYS, "output_tokens")):
             return state.get("model"), None
         usage = Usage(
-            input_tokens=int(state.get("input_tokens", 0)),
+            input_tokens=sum(int(state.get(k, 0)) for k in _PROMPT_KEYS),
             output_tokens=int(state.get("output_tokens", 0)),
-            cached_input_tokens=int(state.get("cached_input_tokens", 0)),
+            cached_input_tokens=int(state.get("cache_read_input_tokens", 0)),
         )
         return state.get("model"), usage
 

--- a/sdk/python/tests/test_anthropic_cache_tokens.py
+++ b/sdk/python/tests/test_anthropic_cache_tokens.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CTO-374 - the SDK and the edge proxy must agree on Anthropic's three prompt buckets.
+
+The proxy learned this in CTO-349 (`docs/anthropic-cache-tokens.md`); the SDK did not, and the
+divergence was invisible because `min(cached, input)` in `compute_cost_micro_usd` clamped the
+resulting nonsense into a plausible-looking small number instead of raising.
+
+These tests read the PROXY's fixtures rather than defining their own, so the two implementations are
+asserted against the same bytes. A fixture edited on one side now breaks the other side's test,
+which is the point: the failure mode being guarded is the two paths quietly drifting apart.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tally.instrumentation.anthropic import AnthropicInstrumentor
+from tally.pricing import Usage
+
+_FIXTURES = (
+    Path(__file__).resolve().parents[3]
+    / "infra"
+    / "edge-proxy"
+    / "internal"
+    / "proxy"
+    / "testdata"
+    / "anthropic"
+)
+
+
+def _fixture(name: str) -> dict:
+    path = _FIXTURES / name
+    if not path.exists():  # pragma: no cover - a moved fixture should say so, not silently pass
+        pytest.skip(f"proxy fixture not present at {path}")
+    return json.loads(path.read_text())
+
+
+def _usage_for(name: str) -> Usage | None:
+    return AnthropicInstrumentor().extract_usage(_fixture(name))
+
+
+def test_cache_read_folds_into_prompt_total():
+    """The bug's headline case: 21 fresh + 0 writes + 18923 reads is an 18944-token prompt.
+
+    The SDK used to report 21, and pricing then billed 21 CACHED tokens (min(18923, 21)), so a call
+    costing roughly a cent was recorded at a fraction of a cent with no error anywhere.
+
+    Mirrors TestAnthropicCacheTokensFoldIntoPromptTokens in provider_anthropic_test.go.
+    """
+    usage = _usage_for("message_cache_read.json")
+    assert usage is not None
+    assert usage.input_tokens == 18944
+    assert usage.cached_input_tokens == 18923
+    assert usage.output_tokens == 44
+
+
+def test_cached_share_is_a_subset_of_the_total():
+    """The invariant the whole repo's pricing math rests on.
+
+    `compute_cost_micro_usd` bills (input - cached) at the standard rate and cached at the cached
+    rate. That is only correct while cached <= input. Asserting it directly means a future edit that
+    reintroduces the disjoint-bucket bug fails here, on the invariant, rather than in a variance
+    report months later.
+    """
+    for name in (
+        "message_cache_read.json",
+        "message_end_turn.json",
+        "message_tool_use.json",
+    ):
+        usage = _usage_for(name)
+        assert usage is not None
+        assert usage.cached_input_tokens <= usage.input_tokens, name
+
+
+def test_uncached_response_totals_unchanged():
+    """A response with no cache activity must be untouched by the fold.
+
+    message_end_turn.json reports both buckets as an explicit 0, so the sum equals input_tokens and
+    the fix is a no-op on the common case.
+    """
+    doc = _fixture("message_end_turn.json")
+    usage = _usage_for("message_end_turn.json")
+    assert usage is not None
+    assert usage.input_tokens == doc["usage"]["input_tokens"]
+
+
+def test_missing_cache_fields_are_not_invented():
+    """message_tool_use.json omits the cache fields entirely.
+
+    The prompt total is then input_tokens alone, and the cached share is 0, which `base.py` maps to
+    a null `gen_ai.usage.cached_input_tokens` rather than asserting "caching saved nothing".
+    """
+    doc = _fixture("message_tool_use.json")
+    assert "cache_read_input_tokens" not in doc["usage"]
+    usage = _usage_for("message_tool_use.json")
+    assert usage is not None
+    assert usage.input_tokens == doc["usage"]["input_tokens"]
+    assert usage.cached_input_tokens == 0
+
+
+def test_streaming_folds_cache_buckets_from_message_delta():
+    """The cache buckets arrive on message_start OR message_delta, so the fold spans events.
+
+    This is why the accumulator keeps the three buckets apart and sums them in finalize: an earlier
+    draft totalled at message_start and lost whatever message_delta reported. Mirrors
+    foldAnthropicUsage in stream.go.
+    """
+    inst = AnthropicInstrumentor()
+    state: dict = {}
+    inst.accumulate(
+        state,
+        {
+            "type": "message_start",
+            "message": {"model": "claude-opus-5", "usage": {"input_tokens": 21}},
+        },
+    )
+    inst.accumulate(
+        state,
+        {
+            "type": "message_delta",
+            "usage": {
+                "output_tokens": 44,
+                "cache_creation_input_tokens": 100,
+                "cache_read_input_tokens": 18923,
+            },
+        },
+    )
+    model, usage = inst.finalize(state)
+    assert model == "claude-opus-5"
+    assert usage is not None
+    assert usage.input_tokens == 21 + 100 + 18923
+    assert usage.cached_input_tokens == 18923
+    assert usage.output_tokens == 44
+
+
+def test_stream_with_no_usage_event_stays_unknown():
+    """The honest-null half: no usage reported means no usage claimed, not a zero-token call."""
+    model, usage = AnthropicInstrumentor().finalize({"model": "claude-opus-5"})
+    assert model == "claude-opus-5"
+    assert usage is None
+
+
+def test_stream_reporting_only_a_cache_bucket_still_counts_as_usage():
+    """A fold that saw a cache field but no input_tokens has real tokens to report.
+
+    Keying the finalize guard on input_tokens alone would discard the entire prompt here.
+    """
+    inst = AnthropicInstrumentor()
+    state: dict = {}
+    inst.accumulate(state, {"type": "message_delta", "usage": {"cache_read_input_tokens": 512}})
+    _, usage = inst.finalize(state)
+    assert usage is not None
+    assert usage.input_tokens == 512
+    assert usage.cached_input_tokens == 512


### PR DESCRIPTION
Closes #374

## Why this was invisible

Anthropic's `usage.input_tokens` is not a total: it excludes `cache_creation_input_tokens` and `cache_read_input_tokens`. The edge proxy learned that in CTO-349 (`docs/anthropic-cache-tokens.md`); the Python instrumentor never did.

What made it a silent wrong number rather than a crash: `Usage.cached_input_tokens` means **a subset of `input_tokens`** everywhere else in the repo, and `compute_cost_micro_usd` clamps with `min(cached, input)`. Feeding it a disjoint bucket produced a small plausible figure.

Measured on the proxy's own `message_cache_read.json` fixture through `seed_catalog()`:

| | input | cached | cost |
|---|---|---|---|
| before | 21 | 18923 | 666 micro-USD |
| after | 18944 | 18923 | 6400 micro-USD |

Undercharged 9.6x, on precisely the workload prompt caching exists for.

## What changed

- `_prompt_tokens` mirrors `anthropicPrompt` in `provider.go`: all three buckets summed.
- `_fold_usage` mirrors `foldAnthropicUsage` in `stream.go`. The streamed path now keeps the buckets apart in the accumulator and sums in `finalize`, because the cache buckets arrive on **either** `message_start` or `message_delta` (the Go comment at `stream.go:180` is explicit about this). An earlier draft of mine totalled at `message_start` and would have dropped whatever `message_delta` reported.
- `finalize`'s "did we see any usage" guard now considers all three prompt keys, not `input_tokens` alone, so a fold that saw only a cache bucket does not discard the prompt.

## On the unknown-vs-zero distinction

The Go side uses `*int64` so absent and zero stay apart. The Python `Usage` dataclass is `int` with a `0` default and cannot represent absent, so within a present `usage` object an unreported bucket reads as 0. That is pre-existing and unchanged here; `base.py:110` maps `0` to a null span attribute (`usage.cached_input_tokens or None`), so the emitted span still says "unknown" rather than "caching saved nothing". Widening `Usage` to optional ints would touch every instrumentor and the pricing math, so it is not in this PR. Worth its own ticket if you want the two sides to match exactly.

## Out of scope

`PriceType.CACHE_WRITE` still does not exist, so cache-write tokens sit inside the total and price at the standard input rate instead of the write premium. That is the documented approximation from CTO-349, not a new one, and closing it needs the four-part change the doc lists.

## Verification

`cd sdk/python && uv run --extra dev pytest -q` passes (7 new tests), `uv run ruff check .` clean. The new tests read `infra/edge-proxy/internal/proxy/testdata/anthropic/*.json` directly, so the SDK and the proxy are asserted against the same bytes and a fixture edited on one side fails the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)