### PR TITLE
fix(edge-proxy): read Gemini's cached-content and thinking token counts

### DIFF
--- a/docs/anthropic-cache-tokens.md
+++ b/docs/anthropic-cache-tokens.md
@@ -61,7 +61,25 @@ reads.
   **includes** the cached share. The proxy reads it straight into `CachedInputTokens` and adds
   nothing to the total. OpenAI does not bill a separate cache-write rate, so there is no equivalent
   gap.
-- **Gemini** reports `usageMetadata.cachedContentTokenCount` for context caching. The proxy does not
-  read it yet; a Gemini call using an explicit cached context therefore prices its cached tokens at
-  the standard input rate. It is the same shape of fix as the OpenAI one and is not covered here
-  because CTO-349 had no Gemini cache fixture to verify the semantics against.
+- **Gemini** reports `usageMetadata.cachedContentTokenCount` for context caching, and
+  `promptTokenCount` **includes** it: the API reference says it "is still the total effective prompt
+  size meaning this includes the number of tokens in the cached content". So it is the OpenAI shape,
+  read straight into `CachedInputTokens` with nothing added to the total (CTO-375). Closed.
+
+  Gemini also reports `usageMetadata.thoughtsTokenCount` on thinking models, and those tokens are
+  billed: the thinking docs state "response pricing is the sum of output tokens and thinking tokens".
+  They are folded into `CompletionTokens` (CTO-376). Unlike the Anthropic cache-write case this is
+  **not** an approximation, because thinking tokens bill at the ordinary output rate, so no new price
+  type is needed to represent them.
+
+  **The one subtlety worth carrying forward.** `geminiCompletion` is not a plain
+  `candidates + thoughts` sum. The reference defines `totalTokenCount` as
+  `prompt + thoughts + candidates`, which makes the two disjoint, and the captured
+  `testdata/gemini/response_max_tokens.json` fixture confirms it arithmetically (1204 + 96 + 8 =
+  1308). But the convention is not uniform in the field: Vertex AI excludes thinking tokens from
+  `candidatesTokenCount` while the Generative Language API has been observed including them, and
+  some models omit `thoughtsTokenCount` entirely while still charging for thinking. So the sum is
+  cross-checked against `totalTokenCount - promptTokenCount`, which is `thoughts + candidates` under
+  either convention and therefore the authority whenever the provider supplied a total. Without that
+  guard, a payload that had already folded thoughts into candidates would be over-billed by the
+  entire thinking share, which on a reasoning-heavy call is most of the cost.

--- a/infra/edge-proxy/internal/proxy/provider.go
+++ b/infra/edge-proxy/internal/proxy/provider.go
@@ -98,9 +98,59 @@ type anthropicUsageDoc struct {
 }
 
 // geminiUsageDoc is the Generative Language usageMetadata block.
+//
+// promptTokenCount and candidatesTokenCount are not the whole story, which is what CTO-375 and
+// CTO-376 were about. See geminiCompletion for why totalTokenCount is carried too.
 type geminiUsageDoc struct {
 	PromptTokenCount     *int64 `json:"promptTokenCount"`
 	CandidatesTokenCount *int64 `json:"candidatesTokenCount"`
+	// CachedContentTokenCount is the context-cache share of the prompt (CTO-375). The API reference
+	// is explicit that promptTokenCount "is still the total effective prompt size meaning this
+	// includes the number of tokens in the cached content", so this is the OpenAI shape, not the
+	// Anthropic one: it is a SUBSET of the prompt and must not be added to it.
+	CachedContentTokenCount *int64 `json:"cachedContentTokenCount"`
+	// ThoughtsTokenCount is reasoning tokens on thinking models (CTO-376). Billed: the thinking
+	// docs state "response pricing is the sum of output tokens and thinking tokens".
+	ThoughtsTokenCount *int64 `json:"thoughtsTokenCount"`
+	// TotalTokenCount is documented as prompt + thoughts + candidates. Carried as the cross-check
+	// in geminiCompletion rather than for its own sake.
+	TotalTokenCount *int64 `json:"totalTokenCount"`
+}
+
+// geminiCompletion returns the billable output token count: generated candidates plus the thinking
+// tokens billed at the same rate (CTO-376).
+//
+// WHY THIS IS NOT JUST candidates+thoughts. The API reference defines totalTokenCount as
+// "prompt + thoughts + response candidates", which makes the two disjoint and the sum correct. But
+// the inclusion is reported inconsistently in the field: Vertex AI excludes thinking tokens from
+// candidatesTokenCount while the Generative Language API has been observed including them, and
+// some models omit thoughtsTokenCount entirely while still charging for thinking. A blind sum
+// therefore double-counts on whichever platform already folded them in, and double-counting a
+// reasoning-heavy call is a large error in the direction of over-billing.
+//
+// So the sum is cross-checked against the provider's own total when it gave us one. total-prompt is
+// thoughts+candidates by definition, whatever the reporting convention, so it is the authority: if
+// candidates+thoughts exceeds it, candidates already contained the thoughts and adding them again
+// would invent tokens.
+//
+// Returns nil when the provider reported no output count at all, which stays unknown rather than 0.
+func geminiCompletion(candidates, thoughts, total, prompt *int64) *int64 {
+	if candidates == nil && thoughts == nil {
+		return nil
+	}
+	var summed int64
+	if candidates != nil {
+		summed += *candidates
+	}
+	if thoughts != nil {
+		summed += *thoughts
+	}
+	if total != nil && prompt != nil {
+		if billable := *total - *prompt; billable >= 0 && billable < summed {
+			return &billable
+		}
+	}
+	return &summed
 }
 
 func openAIMeta(body []byte) responseMeta {
@@ -180,9 +230,15 @@ func geminiMeta(path string, body []byte) responseMeta {
 	_ = json.Unmarshal(body, &r)
 
 	m := responseMeta{Model: geminiModel(path, r.ModelVersion)}
-	if r.UsageMetadata != nil {
-		m.PromptTokens = r.UsageMetadata.PromptTokenCount
-		m.CompletionTokens = r.UsageMetadata.CandidatesTokenCount
+	if u := r.UsageMetadata; u != nil {
+		m.PromptTokens = u.PromptTokenCount
+		// CTO-375: promptTokenCount already includes the cached share, so this is recorded as the
+		// subset it is and nothing is added to the total. Without it a 100k-token cached context
+		// priced at the full input rate.
+		m.CachedInputTokens = u.CachedContentTokenCount
+		m.CompletionTokens = geminiCompletion(
+			u.CandidatesTokenCount, u.ThoughtsTokenCount, u.TotalTokenCount, u.PromptTokenCount,
+		)
 	}
 	return m
 }

--- a/infra/edge-proxy/internal/proxy/provider_gemini_cache_thoughts_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_gemini_cache_thoughts_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// TestGeminiCachedContentIsASubsetOfThePrompt covers CTO-375.
+//
+// Gemini's promptTokenCount already contains the context-cache share: the API reference says it "is
+// still the total effective prompt size meaning this includes the number of tokens in the cached
+// content". So this is the OpenAI shape, not the Anthropic one, and the fix is to record the share
+// without touching the total.
+//
+// Before the fix CachedInputTokens was always nil on Gemini, so compute_cost_micro_usd billed all
+// 100200 tokens at the standard input rate instead of 200 standard + 100000 cached. Gemini's cached
+// rate is a fraction of input, so the dashboard over-charged a cached call several times over: the
+// opposite direction from the Anthropic bug in CTO-349, and just as confidently wrong.
+func TestGeminiCachedContentIsASubsetOfThePrompt(t *testing.T) {
+	meta := extractMeta(config.ProviderGemini, "/v1beta/models/gemini-2.5-pro:generateContent",
+		readFixture(t, "gemini/response_cached_context.json"))
+	// The total is NOT 100200+100000. Adding the cached share would be the Anthropic mistake.
+	assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(100200))
+	assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, ptr(100000))
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(31))
+}
+
+// TestGeminiCachedAbsenceVsZero is the honesty half, matching the Anthropic case in
+// provider_anthropic_test.go. A response that never mentions the cache reports the share as UNKNOWN;
+// one reporting 0 reports 0. Collapsing them would assert "context caching saved this tenant
+// nothing" on every payload that simply did not mention it.
+func TestGeminiCachedAbsenceVsZero(t *testing.T) {
+	// response_prompt_blocked.json carries usageMetadata with no cache field at all.
+	absent := extractMeta(config.ProviderGemini, "/v1beta/models/gemini-2.5-flash:generateContent",
+		readFixture(t, "gemini/response_prompt_blocked.json"))
+	assertTokens(t, "CachedInputTokens", absent.CachedInputTokens, nil)
+
+	// response_max_tokens.json reports an explicit 0, which is a measurement.
+	zero := extractMeta(config.ProviderGemini, "/v1beta/models/gemini-2.5-flash:generateContent",
+		readFixture(t, "gemini/response_max_tokens.json"))
+	assertTokens(t, "CachedInputTokens", zero.CachedInputTokens, ptr(0))
+}
+
+// TestGeminiThinkingTokensFoldIntoOutput covers CTO-376 on the streamed path, which is where
+// reasoning-heavy calls actually arrive.
+//
+// The fixture's trailing chunk reports 8000 thought tokens against 150 visible ones. Before the fix
+// the proxy recorded 150, so a call whose real output cost was 8150 tokens priced at under 2% of it.
+func TestGeminiThinkingTokensFoldIntoOutput(t *testing.T) {
+	meta := extractMeta(config.ProviderGemini, "/v1beta/models/gemini-2.5-pro:streamGenerateContent",
+		readFixture(t, "gemini/stream_thinking.sse"))
+	assertTokens(t, "PromptTokens", meta.PromptTokens, ptr(310))
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(8150))
+}
+
+// TestGeminiCompletionGuardsAgainstDoubleCounting is the reason geminiCompletion is not a two-term
+// sum, and the case a docs-only reading of this API would have missed.
+//
+// The reference defines totalTokenCount as prompt+thoughts+candidates, which makes candidates and
+// thoughts disjoint, and the captured response_max_tokens.json fixture confirms it arithmetically
+// (1204+96+8 = 1308). But the convention is not uniform in the field: Vertex AI excludes thinking
+// tokens from candidatesTokenCount while the Generative Language API has been observed including
+// them. On a payload where they are already folded in, a blind sum would invent tokens and
+// over-bill a reasoning-heavy call by the whole thinking share.
+//
+// total-prompt is thoughts+candidates under either convention, so it is the authority whenever the
+// provider supplied a total.
+func TestGeminiCompletionGuardsAgainstDoubleCounting(t *testing.T) {
+	// candidates(8150) already contains thoughts(8000): total-prompt says the output is 8150, not
+	// the 16150 a blind sum would report.
+	already := geminiCompletion(ptr(8150), ptr(8000), ptr(8460), ptr(310))
+	assertTokens(t, "CompletionTokens", already, ptr(8150))
+
+	// The disjoint convention: the sum agrees with total-prompt, so the sum stands.
+	disjoint := geminiCompletion(ptr(150), ptr(8000), ptr(8460), ptr(310))
+	assertTokens(t, "CompletionTokens", disjoint, ptr(8150))
+}
+
+// TestGeminiCompletionWithoutATotal pins the fallback. Some models omit totalTokenCount, and some
+// omit thoughtsTokenCount while still charging for thinking; neither absence may produce a zero.
+func TestGeminiCompletionWithoutATotal(t *testing.T) {
+	// No total to cross-check against: the sum is the best available answer.
+	assertTokens(t, "CompletionTokens", geminiCompletion(ptr(150), ptr(8000), nil, ptr(310)), ptr(8150))
+	// No thinking reported at all: unchanged from the pre-fix behaviour.
+	assertTokens(t, "CompletionTokens", geminiCompletion(ptr(150), nil, ptr(460), ptr(310)), ptr(150))
+	// Nothing reported: unknown, never 0. A blocked prompt was billed for input and produced no
+	// output, and "0 output tokens" would claim the model answered for free.
+	assertTokens(t, "CompletionTokens", geminiCompletion(nil, nil, ptr(42), ptr(42)), nil)
+	// Thinking reported with no candidates yet (an early streamed chunk, or a call cut off during
+	// thinking): the thought tokens were still billed.
+	assertTokens(t, "CompletionTokens", geminiCompletion(nil, ptr(2048), nil, nil), ptr(2048))
+}
+
+// TestGeminiStreamedCacheShareSurvivesEveryChunk: usageMetadata repeats on every chunk, so the
+// cached share is reported many times over and the fold must not lose or double it.
+func TestGeminiStreamedCacheShareSurvivesEveryChunk(t *testing.T) {
+	meta := scanSSE(config.ProviderGemini, readFixture(t, "gemini/stream_thinking.sse"))
+	// The fixture reports no cache field, so the share stays unknown rather than becoming 0.
+	assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, nil)
+	assertTokens(t, "CompletionTokens", meta.CompletionTokens, ptr(8150))
+}

--- a/infra/edge-proxy/internal/proxy/provider_payload_variations_test.go
+++ b/infra/edge-proxy/internal/proxy/provider_payload_variations_test.go
@@ -110,13 +110,18 @@ func TestGeminiMetaFromPublishedResponses(t *testing.T) {
 		wantComp   *int64
 	}{
 		{
-			// finishReason MAX_TOKENS, plus the thinking-model thoughtsTokenCount the parser does
-			// not read. candidatesTokenCount excludes thoughts, so 8 is the visible output only and
-			// the 96 thinking tokens are billed but unrecorded. Pinned here so the omission is
-			// visible rather than assumed away.
+			// finishReason MAX_TOKENS on a thinking model. CTO-376: candidatesTokenCount excludes
+			// thoughtsTokenCount, and thinking tokens are billed at the output rate, so the output
+			// is 8 visible + 96 thought = 104. This case used to pin the omission (wantComp: 8) so
+			// it would be visible rather than assumed away; the fold closes it.
+			//
+			// This fixture is also the empirical proof of the inclusion semantics the fold depends
+			// on, which is why the numbers are not round: 1204 prompt + 96 thoughts + 8 candidates
+			// is exactly the 1308 totalTokenCount the provider reported. Captured traffic, not a
+			// reading of the docs.
 			name: "max_tokens_with_thoughts", fixture: "gemini/response_max_tokens.json",
 			path:      "/v1beta/models/gemini-2.5-flash:generateContent",
-			wantModel: "gemini-2.5-flash", wantPrompt: ptr(1204), wantComp: ptr(8),
+			wantModel: "gemini-2.5-flash", wantPrompt: ptr(1204), wantComp: ptr(104),
 		},
 		{
 			// A safety-blocked prompt returns no candidates and a usageMetadata carrying only

--- a/infra/edge-proxy/internal/proxy/stream.go
+++ b/infra/edge-proxy/internal/proxy/stream.go
@@ -126,6 +126,11 @@ type streamFolder struct {
 	anthInput       *int64
 	anthCacheCreate *int64
 	anthCacheRead   *int64
+
+	// Gemini reports thinking tokens outside candidatesTokenCount, folded in geminiCompletion
+	// (CTO-376). The total rides along as that fold's cross-check against double counting.
+	gemThoughts *int64
+	gemTotal    *int64
 }
 
 func newStreamFolder(p config.Provider) *streamFolder { return &streamFolder{provider: p} }
@@ -225,11 +230,17 @@ func (f *streamFolder) feedGemini(payload []byte) {
 	if c.ModelVersion != "" {
 		f.model = c.ModelVersion
 	}
-	if c.UsageMetadata != nil {
-		setIfNotNil(&f.prompt, c.UsageMetadata.PromptTokenCount)
+	if u := c.UsageMetadata; u != nil {
+		setIfNotNil(&f.prompt, u.PromptTokenCount)
 		// The first chunks carry promptTokenCount with no candidatesTokenCount yet; an absent count
 		// must not overwrite one a later chunk supplied (nor invent a 0 for the early chunks).
-		setIfNotNil(&f.completion, c.UsageMetadata.CandidatesTokenCount)
+		setIfNotNil(&f.completion, u.CandidatesTokenCount)
+		// CTO-375/376: same last-wins rule. The cached share is fixed for the whole stream, while
+		// thoughts and the total climb with each chunk, so the trailing chunk wins and the fold in
+		// meta() runs once over the final numbers rather than per chunk.
+		setIfNotNil(&f.cached, u.CachedContentTokenCount)
+		setIfNotNil(&f.gemThoughts, u.ThoughtsTokenCount)
+		setIfNotNil(&f.gemTotal, u.TotalTokenCount)
 	}
 }
 
@@ -243,6 +254,11 @@ func (f *streamFolder) meta() responseMeta {
 	}
 	m.PromptTokens = f.prompt
 	m.CachedInputTokens = f.cached
+	if f.provider == config.ProviderGemini {
+		// CTO-376: fold the thinking tokens into the output count, with the same double-count guard
+		// the non-streamed path uses. A streamed reasoning-heavy call is the common case here.
+		m.CompletionTokens = geminiCompletion(f.completion, f.gemThoughts, f.gemTotal, f.prompt)
+	}
 	return m
 }
 

--- a/infra/edge-proxy/internal/proxy/testdata/gemini/response_cached_context.json
+++ b/infra/edge-proxy/internal/proxy/testdata/gemini/response_cached_context.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "HAND-WRITTEN from the documented usageMetadata shape (CTO-375), not captured traffic. No cachedContents handle was available to record against. The inclusion semantics it encodes (promptTokenCount already contains cachedContentTokenCount) are load-bearing and are quoted from the API reference in geminiUsageDoc; 100200 = 200 fresh + 100000 cached is consistent with that, and with the documented totalTokenCount = prompt + thoughts + candidates.",
+  "candidates": [
+    {
+      "content": { "parts": [{ "text": "Clause 14(b) covers termination for convenience." }], "role": "model" },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 100200,
+    "cachedContentTokenCount": 100000,
+    "candidatesTokenCount": 31,
+    "totalTokenCount": 100231
+  },
+  "modelVersion": "gemini-2.5-pro",
+  "responseId": "cachedCtxExampleRespId01"
+}

--- a/infra/edge-proxy/internal/proxy/testdata/gemini/stream_thinking.sse
+++ b/infra/edge-proxy/internal/proxy/testdata/gemini/stream_thinking.sse
@@ -1,0 +1,5 @@
+data: {"candidates": [{"content": {"parts": [{"text": ""}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 310,"thoughtsTokenCount": 2048,"totalTokenCount": 2358},"modelVersion": "gemini-2.5-pro"}
+
+data: {"candidates": [{"content": {"parts": [{"text": "Net margin improved"}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 310,"thoughtsTokenCount": 8000,"candidatesTokenCount": 40,"totalTokenCount": 8350},"modelVersion": "gemini-2.5-pro"}
+
+data: {"candidates": [{"content": {"parts": [{"text": " by 3 points."}],"role": "model"},"finishReason": "STOP","index": 0}],"usageMetadata": {"promptTokenCount": 310,"thoughtsTokenCount": 8000,"candidatesTokenCount": 150,"totalTokenCount": 8460},"modelVersion": "gemini-2.5-pro"}


### PR DESCRIPTION
Closes #375
Closes #376

`geminiUsageDoc` read only `promptTokenCount` and `candidatesTokenCount`, leaving two billed fields unread in opposite directions: cached context over-charged, thinking tokens under-charged.

## What I verified, and how

Both fixes hinge on whether each field is already inside the headline count, and the issues stated that from reasoning rather than evidence. That was the open question, so it came first.

**`cachedContentTokenCount` is inside `promptTokenCount`.** The API reference is explicit: it "is still the total effective prompt size meaning this includes the number of tokens in the cached content". So it is the OpenAI shape, recorded as a subset with nothing added to the total. (One Google page loosely calls the counts "separate", meaning separately reported; the field definition in the reference is unambiguous and I went with it.)

**`thoughtsTokenCount` is outside `candidatesTokenCount`, and billed.** The reference defines `totalTokenCount` as `prompt + thoughts + candidates`, and the thinking docs say "response pricing is the sum of output tokens and thinking tokens".

Better than the docs: **the repo already had captured proof.** `testdata/gemini/response_max_tokens.json` carries `promptTokenCount: 1204`, `thoughtsTokenCount: 96`, `candidatesTokenCount: 8`, `totalTokenCount: 1308`. 1204 + 96 + 8 = 1308 exactly, so on real traffic candidates excludes thoughts. No fixture needed inventing for that case.

## The one thing that is not settled, and how the code handles it

Searching turned up that the convention is **not uniform**: Vertex AI excludes thinking tokens from `candidatesTokenCount` while the Generative Language API has been observed *including* them, and some models omit `thoughtsTokenCount` entirely while still charging for thinking.

A blind `candidates + thoughts` would therefore double-count on an already-folded payload and over-bill a reasoning-heavy call by the entire thinking share. So `geminiCompletion` cross-checks the sum against `totalTokenCount - promptTokenCount`, which is `thoughts + candidates` under either convention and so is the authority whenever the provider gave us a total. Tested both ways.

This is the part a docs-only reading would have got wrong, and it is why this took a search rather than one fetch.

## Impact

| | before | after |
|---|---|---|
| 100k cached context + 200 fresh | 100200 @ full input rate | 200 standard + 100000 cached |
| 8000 thinking + 150 visible | 150 output | 8150 output |

## Fixtures

`response_cached_context.json` and `stream_thinking.sse` are **hand-written from the documented shape**, not captured, since I have no Gemini credentials or `cachedContents` handle. Each says so in the file. Their arithmetic is internally consistent with the documented `totalTokenCount` identity (310 + 8000 + 150 = 8460). The load-bearing thinking case is the pre-existing captured fixture, not one of mine.

One existing expectation changed on purpose: `max_tokens_with_thoughts` pinned `wantComp: ptr(8)` with a comment saying it existed to keep the omission visible. It now expects 104.

## Not in scope

No new price type is needed here, unlike the Anthropic `CACHE_WRITE` gap, because thinking tokens bill at the ordinary output rate. That gap stays open and stays documented.

## Verification

`cd infra/edge-proxy && go build ./... && go test ./... && gofmt -l .` all clean, `gofmt` lists nothing. `docs/anthropic-cache-tokens.md` updated so its Gemini section no longer describes these as open gaps and carries the double-count subtlety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)