### PR TITLE
fix(web): stop Compare and Unit Economics inventing numbers for a blank workspace

### DIFF
--- a/web/app/api/api.test.ts
+++ b/web/app/api/api.test.ts
@@ -86,31 +86,30 @@ describe("api routes", () => {
     expect(miss.status).toBe(404);
   });
 
-  it("GET /api/compare returns a comparison", async () => {
-    // CompareGET is async since the live "current model from traffic" wiring;
-    // without a live stack the route returns the mock comparison untouched.
+  it("GET /api/compare answers the empty state, not the fixture, with no stack and no demo build", async () => {
+    // CTO-379: this case used to read "without a live stack the route returns the mock comparison
+    // untouched", and asserted candidates.length > 0. That expectation WAS the bug: this request
+    // (no ClickHouse, no NEXT_PUBLIC_DEMO_MODE, no TALLY_DEV_TENANT) is shaped exactly like a
+    // signed-in customer who has sent no traffic, and the fixture's $19,100/mo incumbent was the
+    // answer they got.
+    //
+    // Unlike three-states.test.ts this file runs against a real (absent) stack rather than a mocked
+    // one, so it pins the no-stack default specifically: fixtures require an explicit demo build,
+    // and nothing here sets one.
     const body = await json<{
-      workload: string;
-      current: {
-        qualityScore: number | null;
-        latencyP95Ms: number | null;
-        errorRate: number | null;
-      };
-      candidates: Array<{ qualityScore: number | null; qualityCi?: unknown }>;
+      workload: string | null;
+      current: unknown;
+      candidates: unknown[];
+      recommendation: unknown;
+      replay_source: string;
     }>(await CompareGET(new Request("http://test/api/compare") as never));
-    expect(body.workload).toBeTypeOf("string");
-    expect(body.candidates.length).toBeGreaterThan(0);
-    // CTO-114: with no eval pass having run (gateway unreachable in tests), every
-    // qualityScore must be null; the route MUST NOT fabricate a number.
-    expect(body.current.qualityScore).toBeNull();
-    for (const c of body.candidates) {
-      expect(c.qualityScore).toBeNull();
-      expect(c.qualityCi).toBeUndefined();
-    }
-    // CTO-115: shape check: fields exist; live path returns numbers (n>=50) or null (n<50);
-    // mock-fallback returns numbers. Route.test.ts covers both branches explicitly.
-    expect("latencyP95Ms" in body.current).toBe(true);
-    expect("errorRate" in body.current).toBe(true);
+    expect(body.current).toBeNull();
+    expect(body.workload).toBeNull();
+    expect(body.recommendation).toBeNull();
+    expect(body.candidates).toEqual([]);
+    // Not "mock": nothing here came from the fixture, and the page reads this to tell the
+    // new-workspace state from a demo build.
+    expect(body.replay_source).toBe("none");
   });
 
   it("GET /api/cost returns series + featureRows + alerts", async () => {
@@ -225,22 +224,22 @@ describe("api routes", () => {
     expect(body.filters.outcome).toBe("positive_feedback");
   });
 
-  it("GET /api/cac falls back to the labelled mock when the gateway is unreachable", async () => {
-    // CI / fresh-clone: the gateway isn't running, so queryCacPeriods returns [] and the route
-    // serves MOCK_CAC_PERIODS. Real CAC data goes through the live path (isMock=false).
+  it("GET /api/cac answers empty, not the mock, when the gateway is unreachable outside a demo build", async () => {
+    // CTO-379: this case used to assert isMock=true and periods.length > 0 from a bare unreachable
+    // gateway. That is indistinguishable from a signed-in customer who has entered no CAC data, and
+    // Unit Economics was showing them a blended CAC, a payback and an LTV/CAC band derived from
+    // marketing spend they never entered.
+    //
+    // The fixture still exists for demo builds; it now needs NEXT_PUBLIC_DEMO_MODE and
+    // TALLY_DEV_TENANT, which this request does not set. The gate is pinned in three-states.test.ts.
     const body = await json<{
-      periods: { periodStart: string; locked: boolean }[];
-      economics: Record<string, { arpaMicroUsd: number }>;
+      periods: { periodStart: string }[];
+      economics: Record<string, unknown>;
       isMock: boolean;
     }>(await CacGET());
-    expect(body.isMock).toBe(true);
-    expect(body.periods.length).toBeGreaterThan(0);
-    // Newest-first ordering.
-    expect(body.periods[0].periodStart).toBe("2026-05-01");
-    // A period intentionally omits economics (honest-null payback/LTV demo).
-    expect(body.economics["2026-03-01"]).toBeUndefined();
-    // And at least one period carries economics so the cards render real numbers.
-    expect(body.economics["2026-05-01"].arpaMicroUsd).toBeGreaterThan(0);
+    expect(body.isMock).toBe(false);
+    expect(body.periods).toEqual([]);
+    expect(body.economics).toEqual({});
   });
 
   it("POST /api/guardrails echoes a valid rule (gateway unreachable), rejects an unconstrained one", async () => {

--- a/web/app/api/cac/route.ts
+++ b/web/app/api/cac/route.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server";
 
+import { sampleDataAllowed } from "@/lib/mock";
+
 import {
   MOCK_CAC_PERIODS,
   MOCK_PERIOD_ECONOMICS,
@@ -34,6 +36,14 @@ export async function GET(): Promise<NextResponse<CacPayload>> {
       economics: live.economics,
       isMock: false,
     });
+  }
+  // CTO-379: same gate as every other fixture fallback (#364). This route was missed alongside
+  // /api/compare, so Unit Economics answered a blank signed-in workspace with the fixture's CAC
+  // periods: a blended CAC, a payback in months and an LTV/CAC band, all computed from marketing
+  // spend the customer never entered. The comment above called it "clearly-labelled", but the label
+  // lived on the page and the numbers did not read as a label.
+  if (!sampleDataAllowed()) {
+    return NextResponse.json({ periods: [], economics: {}, isMock: false });
   }
   return NextResponse.json({
     periods: MOCK_CAC_PERIODS,

--- a/web/app/api/compare/route.test.ts
+++ b/web/app/api/compare/route.test.ts
@@ -21,13 +21,28 @@ const queryCurrentModel = ch.queryCurrentModel as unknown as ReturnType<typeof v
 const queryReplayCandidates = ch.queryReplayCandidates as unknown as ReturnType<typeof vi.fn>;
 const queryEvalCandidates = ch.queryEvalCandidates as unknown as ReturnType<typeof vi.fn>;
 
+const originalDemo = process.env.NEXT_PUBLIC_DEMO_MODE;
+const originalDev = process.env.TALLY_DEV_TENANT;
+
 beforeEach(() => {
   // Default: no eval pass has run. CTO-114 tests below override per-case.
   queryEvalCandidates.mockResolvedValue(null);
+  // CTO-379: the fixture branch now requires sampleDataAllowed(), so the cases below that exercise
+  // it have to ask for a demo build explicitly. They were written when the fallback was
+  // unconditional, which is the bug: a signed-in customer with no traffic reached it.
+  //
+  // The gate itself is pinned in api/three-states.test.ts ("the sample gate"), which is where every
+  // fixture route is checked together. This file keeps testing what the fixture branch RETURNS.
+  process.env.NEXT_PUBLIC_DEMO_MODE = "1";
+  process.env.TALLY_DEV_TENANT = "00000000-0000-0000-0000-000000000000";
 });
 
 afterEach(() => {
   vi.clearAllMocks();
+  if (originalDemo === undefined) delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  else process.env.NEXT_PUBLIC_DEMO_MODE = originalDemo;
+  if (originalDev === undefined) delete process.env.TALLY_DEV_TENANT;
+  else process.env.TALLY_DEV_TENANT = originalDev;
 });
 
 describe("/api/compare", () => {
@@ -137,7 +152,7 @@ describe("/api/compare", () => {
     expect(haiku.monthlyCostMicroUsd).toBe(3_000_000);
     expect(haiku.monthlyCostMicroUsd).not.toBe(75_000);
     // Savings recomputed off the cheapest candidate on the corrected basis.
-    expect(body.recommendation.projectedSavingsMicroUsd).toBe(7_000_000);
+    expect(body.recommendation!.projectedSavingsMicroUsd).toBe(7_000_000);
     // Diagnostics reflect the real samples_available + replay cost.
     expect(body.diagnostics.samplesAvailable).toBe(50);
     expect(body.diagnostics.replayCostMicroUsd).toBe(12_500);
@@ -196,9 +211,9 @@ describe("/api/compare", () => {
     // NOT the raw corpus projection the gateway returned.
     expect(haiku.monthlyCostMicroUsd).not.toBe(13_200_000);
     // Savings are believable (~63%), never the bogus ~100% the un-rescaled corpus cost produced.
-    expect(body.recommendation.projectedSavingsMicroUsd).toBe(45_600_000_000);
-    expect(body.recommendation.projectedSavingsPct).toBeCloseTo(0.6333, 3);
-    expect(body.recommendation.projectedSavingsPct).toBeLessThan(1);
+    expect(body.recommendation!.projectedSavingsMicroUsd).toBe(45_600_000_000);
+    expect(body.recommendation!.projectedSavingsPct).toBeCloseTo(0.6333, 3);
+    expect(body.recommendation!.projectedSavingsPct).toBeLessThan(1);
   });
 
   // CTO-231: a candidate with zero replayed responses has no per-call cost to scale. We must not
@@ -240,10 +255,10 @@ describe("/api/compare", () => {
     // The zero-sample candidate is dropped rather than shown with a fabricated / NaN cost.
     expect(body.candidates).toHaveLength(0);
     // No candidate cleared replay → honest insufficient-data recommendation, never the fixture prose.
-    expect(body.recommendation.summary).toMatch(/no alternative candidate cleared replay/i);
-    expect(body.recommendation.summary).not.toBe(comparison.recommendation.summary);
+    expect(body.recommendation!.summary).toMatch(/no alternative candidate cleared replay/i);
+    expect(body.recommendation!.summary).not.toBe(comparison.recommendation.summary);
     // Savings default to 0 when there is no candidate to project (never a fabricated figure).
-    expect(body.recommendation.projectedSavingsMicroUsd).toBe(0);
+    expect(body.recommendation!.projectedSavingsMicroUsd).toBe(0);
   });
 
   // CTO-123: a candidate with fewer than 50 replayed responses gets null latency/error —
@@ -686,16 +701,16 @@ describe("/api/compare", () => {
     expect(body.workload).not.toBe(comparison.workload);
 
     // Verdict + summary reflect the REAL deltas: 70% cheaper + 60% judge win-rate → switch.
-    expect(body.recommendation.verdict).toBe("switch");
-    expect(body.recommendation.summary).toContain("claude-haiku-4-5");
-    expect(body.recommendation.summary).toContain("70%");
-    expect(body.recommendation.summary).toContain("60%");
+    expect(body.recommendation!.verdict).toBe("switch");
+    expect(body.recommendation!.summary).toContain("claude-haiku-4-5");
+    expect(body.recommendation!.summary).toContain("70%");
+    expect(body.recommendation!.summary).toContain("60%");
     // The old hardcoded fixture prose must never appear on the live path.
-    expect(body.recommendation.summary).not.toContain("$12.2K");
-    expect(body.recommendation.summary).not.toBe(comparison.recommendation.summary);
+    expect(body.recommendation!.summary).not.toContain("$12.2K");
+    expect(body.recommendation!.summary).not.toBe(comparison.recommendation.summary);
     // Savings computed off the cheapest candidate vs live current cost.
-    expect(body.recommendation.projectedSavingsMicroUsd).toBe(7_000_000);
-    expect(body.recommendation.projectedSavingsPct).toBeCloseTo(0.7, 6);
+    expect(body.recommendation!.projectedSavingsMicroUsd).toBe(7_000_000);
+    expect(body.recommendation!.projectedSavingsPct).toBeCloseTo(0.7, 6);
   });
 
   it("CTO-168: workload defaults to 'all traffic' when no ?tag= filter is set", async () => {
@@ -733,8 +748,8 @@ describe("/api/compare", () => {
     const body = await res.json();
     expect(body.workload).toBe("all traffic / production / last 7 days");
     // No eval judged (< floor is moot — none ran) → quality unknown → verdict "mixed".
-    expect(body.recommendation.verdict).toBe("mixed");
-    expect(body.recommendation.summary).toContain("Run an eval pass");
+    expect(body.recommendation!.verdict).toBe("mixed");
+    expect(body.recommendation!.summary).toContain("Run an eval pass");
   });
 
   it("CTO-168: honest 'insufficient data' recommendation when replay samples are thin", async () => {
@@ -771,10 +786,10 @@ describe("/api/compare", () => {
     const res = await CompareGET(new Request("http://test/api/compare") as never);
     const body = await res.json();
     // Thin data → say so honestly, never the fixture prose.
-    expect(body.recommendation.summary).toMatch(/insufficient replay data/i);
-    expect(body.recommendation.summary).not.toBe(comparison.recommendation.summary);
+    expect(body.recommendation!.summary).toMatch(/insufficient replay data/i);
+    expect(body.recommendation!.summary).not.toBe(comparison.recommendation.summary);
     // Savings are still projected off the (thin) cheapest candidate for the display.
-    expect(body.recommendation.projectedSavingsMicroUsd).toBe(7_000_000);
+    expect(body.recommendation!.projectedSavingsMicroUsd).toBe(7_000_000);
   });
 
   it("CTO-168: rescaled-mock branch (live current, no replay) drops the fixture prose", async () => {
@@ -796,8 +811,8 @@ describe("/api/compare", () => {
     // Live current model exists → workload derived, fixture label gone.
     expect(body.workload).toBe("research_agent / production / last 7 days");
     // No real replay → honest "insufficient replay data", not the hardcoded "$12.2K" prose.
-    expect(body.recommendation.summary).toMatch(/insufficient replay data/i);
-    expect(body.recommendation.summary).not.toContain("$12.2K");
+    expect(body.recommendation!.summary).toMatch(/insufficient replay data/i);
+    expect(body.recommendation!.summary).not.toContain("$12.2K");
   });
 
   // CTO-244 follow-up. queryCurrentModel returns a null monthlyCostMicroUsd when the incumbent's
@@ -834,9 +849,9 @@ describe("/api/compare", () => {
 
       const res = await CompareGET(new Request("http://test/api/compare") as never);
       const body = await res.json();
-      expect(body.recommendation.projectedSavingsMicroUsd).toBeNull();
-      expect(body.recommendation.projectedSavingsPct).toBeNull();
-      expect(body.recommendation.summary).toMatch(/could not be priced/);
+      expect(body.recommendation!.projectedSavingsMicroUsd).toBeNull();
+      expect(body.recommendation!.projectedSavingsPct).toBeNull();
+      expect(body.recommendation!.summary).toMatch(/could not be priced/);
     });
 
     it("does the same on the replay branch, where candidates come from real replay", async () => {
@@ -859,8 +874,8 @@ describe("/api/compare", () => {
       const res = await CompareGET(new Request("http://test/api/compare") as never);
       const body = await res.json();
       expect(body.current.monthlyCostMicroUsd).toBeNull();
-      expect(body.recommendation.projectedSavingsMicroUsd).toBeNull();
-      expect(body.recommendation.projectedSavingsPct).toBeNull();
+      expect(body.recommendation!.projectedSavingsMicroUsd).toBeNull();
+      expect(body.recommendation!.projectedSavingsPct).toBeNull();
     });
   });
 
@@ -909,8 +924,8 @@ describe("/api/compare", () => {
     expect(body.replay_source).toBe("mock");
     // This is the only path that still ships the fixture prose (labeled by SyntheticPreviewBanner).
     expect(body.workload).toBe(comparison.workload);
-    expect(body.recommendation.summary).toBe(comparison.recommendation.summary);
-    expect(body.recommendation.verdict).toBe(comparison.recommendation.verdict);
+    expect(body.recommendation!.summary).toBe(comparison.recommendation.summary);
+    expect(body.recommendation!.verdict).toBe(comparison.recommendation.verdict);
   });
 
   // #320 item 2. The bug as reported: a stack holding nine spans rendered "REPLAY COST $42.30 /

--- a/web/app/api/compare/route.ts
+++ b/web/app/api/compare/route.ts
@@ -6,6 +6,7 @@ import {
   deriveWorkload,
   scaleCandidateMonthlyCost,
 } from "@/lib/compare";
+import { sampleDataAllowed } from "@/lib/mock";
 import {
   queryCurrentModel,
   queryEvalCandidates,
@@ -96,9 +97,34 @@ export async function GET(req: Request) {
   // model over the last 7 days. Quality/latency on `current` stay mocked because we don't yet
   // have an eval harness — flagged honestly via SyntheticPreviewBanner on the page.
   const live = await queryCurrentModel();
+  if (!live && !sampleDataAllowed()) {
+    // #364 finished here (CTO-379). Every other fixture fallback in app/api/** was put behind
+    // sampleDataAllowed(); this route was missed, so it stayed the one surface that still answered
+    // "this workspace has no traffic" with the storyline from lib/compare: a $19,100/mo incumbent,
+    // a candidate table with costs and latencies, and a recommendation to switch. A customer who
+    // signed in and sent nothing was shown a migration plan for models they have never called.
+    //
+    // There is nothing to fall back TO here: without an incumbent there is no baseline, and every
+    // figure on the page is derived from one. So the honest answer is the empty one, and the page
+    // reads it as the new-workspace case and points at setup.
+    return NextResponse.json({
+      ...comparison,
+      workload: null,
+      current: null,
+      candidates: [],
+      recommendation: null,
+      diagnostics: {
+        ...comparison.diagnostics,
+        ...replayDiagnostics(replay),
+        reconcilerLastRunMinutesAgo,
+      },
+      replay_source: "none",
+    });
+  }
   if (!live) {
-    // Pure-mock fallback (CI / no DB). Even here, qualityScore must not be a fabricated
-    // number — splice real eval data in if available, else null per-candidate.
+    // Demo builds only, now that sampleDataAllowed() gates the branch above: a fixture incumbent
+    // for screenshots. Even here, qualityScore must not be a fabricated number: splice real eval
+    // data in if available, else null per-candidate.
     const candidates = comparison.candidates.map((c) => {
       const quality = evalQualityFor(evalProj?.per_candidate, c.provider, c.model);
       return {

--- a/web/app/api/three-states.test.ts
+++ b/web/app/api/three-states.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// #364. The six dashboard routes must tell three facts apart, and answer each of them differently:
+// #364. The eight dashboard routes must tell three facts apart, and answer each of them differently:
 //
 //   unavailable - the read threw or timed out. We do not know. Say so; claim no figure.
 //   empty       - the read succeeded over no rows. We DO know: nothing has arrived. This is the
@@ -33,11 +33,25 @@ vi.mock("@/lib/clickhouse", () => ({
   queryAttributionDiagnostics: vi.fn(),
   queryFeatureValueEvents: vi.fn().mockResolvedValue([]),
   queryConnectorActivity: vi.fn(),
+  // CTO-379: compare was the one fixture route missing from this suite, which is how its ungated
+  // fallback survived #364. Adding it here is the part that stops the next one slipping through.
+  queryCurrentModel: vi.fn(),
+  queryReplayCandidates: vi.fn(),
+  queryEvalCandidates: vi.fn(),
   queryIntegrationStatus: vi.fn().mockResolvedValue([]),
+}));
+
+// CTO-379: /api/cac reads the gateway, not ClickHouse, so it needs its own stub. Without it this
+// suite would be asserting the gate over a real unreachable gateway, which is the kind of
+// environment dependence the file exists to avoid (see the header).
+vi.mock("@/lib/cac", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/cac")>()),
+  queryCacPeriods: vi.fn().mockResolvedValue({ periods: [], economics: {} }),
 }));
 
 import * as ch from "@/lib/clickhouse";
 import { agents as fixtureAgents, runs as fixtureRuns } from "@/lib/agents";
+import { comparison as fixtureComparison } from "@/lib/compare";
 import {
   LAYERS,
   costSeries as fixtureSeries,
@@ -55,6 +69,8 @@ import { GET as CostGET } from "./cost/route";
 import { GET as FeaturesGET } from "./features/route";
 import { GET as AttributionGET } from "./attribution/route";
 import { GET as ConnectorsGET } from "./connectors/route";
+import { GET as CompareGET } from "./compare/route";
+import { GET as CacGET } from "./cac/route";
 
 const mocked = ch as unknown as Record<string, ReturnType<typeof vi.fn>>;
 
@@ -104,6 +120,10 @@ function allEmpty() {
     isMock: false,
   });
   mocked.queryAgents.mockResolvedValue({ agents: [], runs: [] });
+  // No incumbent, no replay corpus, no eval pass: the state of a workspace that has sent nothing.
+  mocked.queryCurrentModel.mockResolvedValue(null);
+  mocked.queryReplayCandidates.mockResolvedValue(null);
+  mocked.queryEvalCandidates.mockResolvedValue(null);
   mocked.queryCostSeries.mockResolvedValue({
     reconciledThrough: "1970-01-01",
     days: Array.from({ length: 30 }, (_, i) => ({
@@ -365,6 +385,16 @@ describe("the sample gate", () => {
     expect(ag.sources.agents).toBe("sample");
     const f = await body<{ sources: Record<string, string> }>(await FeaturesGET());
     expect(f.sources.features).toBe("sample");
+    // CTO-379: compare has no `sources` map; its fixture tell is the incumbent, whose $19,100/mo is
+    // the number a blank account was being shown.
+    const cmp = await body<{ current: { monthlyCostMicroUsd: number | null } | null }>(
+      await CompareGET(new Request("http://test/api/compare") as never),
+    );
+    expect(cmp.current?.monthlyCostMicroUsd).toBe(fixtureComparison.current.monthlyCostMicroUsd);
+    // CTO-379: /api/cac was ungated alongside compare. Its tell is isMock, which it already carried.
+    const cac = await body<{ isMock: boolean; periods: unknown[] }>(await CacGET());
+    expect(cac.isMock).toBe(true);
+    expect(cac.periods.length).toBeGreaterThan(0);
   });
 
   it("refuses fixtures for a demo build once a real organization resolves the tenant", async () => {
@@ -386,6 +416,27 @@ describe("the sample gate", () => {
     const c = await body<{ activity: string; connectors: { records: number }[] }>(await ConnectorsGET());
     expect(c.activity).toBe("empty");
     expect(c.connectors.every((x) => x.records === 0)).toBe(true);
+
+    // CTO-379, the reported bug: Model Comparison on a blank signed-in account. It used to answer
+    // with the fixture's $19,100/mo incumbent, a priced candidate table and a switch recommendation.
+    // Null across the three is what lets the page send them to setup instead.
+    const cmp = await body<{
+      current: unknown;
+      candidates: unknown[];
+      recommendation: unknown;
+      workload: unknown;
+    }>(await CompareGET(new Request("http://test/api/compare") as never));
+    expect(cmp.current).toBeNull();
+    expect(cmp.recommendation).toBeNull();
+    expect(cmp.workload).toBeNull();
+    expect(cmp.candidates).toEqual([]);
+
+    // CTO-379: Unit Economics on the same blank account. The fixture CAC periods produced a blended
+    // CAC, a payback in months and an LTV/CAC band from marketing spend nobody entered.
+    const cac = await body<{ isMock: boolean; periods: unknown[]; economics: unknown }>(await CacGET());
+    expect(cac.isMock).toBe(false);
+    expect(cac.periods).toEqual([]);
+    expect(cac.economics).toEqual({});
   });
 
   it("refuses fixtures for the dev escape hatch when demo mode is not switched on", async () => {

--- a/web/app/api/waste/route.ts
+++ b/web/app/api/waste/route.ts
@@ -21,6 +21,7 @@ import { collectDuplicatedWork } from "@/lib/waste/duplicated-work";
 import { collectWrongSizedModel } from "@/lib/waste/wrong-sized-model";
 import { collectNoMeasuredReturn } from "@/lib/waste/no-measured-return";
 import { collectStructuralInefficiency } from "@/lib/waste/structural-inefficiency";
+import { querySpendSummary } from "@/lib/clickhouse";
 import { aggregateWaste, type WasteReport } from "@/lib/waste";
 import { parseFilters, rangeDays } from "@/lib/filters";
 
@@ -48,7 +49,13 @@ export async function GET(request: Request) {
       collectStructuralInefficiency(windowDays, state.filters),
     ]);
     const allFindings = perDetector.flat();
-    return NextResponse.json(aggregateWaste(allFindings, windowDays));
+    // CTO-379: "every detector ran and flagged nothing" is good news, and it is the wrong news for a
+    // workspace that has sent nothing. The spend summary already counts spans for Home's empty
+    // state, so the same read decides which sentence this page is entitled to. null (unreadable)
+    // stays unknown and the page says neither.
+    const spend = await querySpendSummary(windowDays);
+    const hasTelemetry = spend === null ? null : (spend.spanCount ?? 0) > 0;
+    return NextResponse.json(aggregateWaste(allFindings, windowDays, hasTelemetry));
   } catch (err) {
     // Hard failure: return an honest unavailable shell (empty findings, null totals) rather than a
     // fabricated or partial report (CTO-227 honesty). Never invent findings.
@@ -65,6 +72,8 @@ export async function GET(request: Request) {
       },
       generatedForWindowDays: windowDays,
       unavailable: reason,
+      // The report could not be produced, so whether telemetry exists was never established.
+      hasTelemetry: null,
     };
     return NextResponse.json(shell);
   }

--- a/web/app/compare/page.tsx
+++ b/web/app/compare/page.tsx
@@ -11,6 +11,7 @@ import { Suspense, type ReactNode } from "react";
 
 import { Card } from "@/components/Card";
 import {
+  NoDataYet,
   PartialDataBanner,
   StaleBadge,
   SyntheticPreviewBanner,
@@ -58,6 +59,26 @@ export default async function ComparePage({
   await searchParams;
   const comparison = await apiGet<Comparison>("/api/compare");
   const { workload, current, candidates, recommendation, diagnostics } = comparison;
+
+  // CTO-379: no incumbent means no subject. Every figure below is derived from the current model,
+  // so this is the new-workspace case and the next step is setup, not a comparison.
+  //
+  // This used to be the `state === "empty"` branch at the bottom, which wrapped the FIXTURE body in
+  // a "synthetic preview" banner. That was the right shape when fixtures were the fallback and the
+  // wrong one the moment they were gated: a signed-in customer with no traffic got a labelled tour
+  // of somebody else's migration, where Home and Cost Explorer would have pointed them at setup.
+  // The banner still has its job on a demo build, where the route does serve the fixture.
+  if (current === null || recommendation === null) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Model Comparison" />
+        <NoDataYet
+          what="model traffic"
+          detail="No model has served traffic for this workspace, so there is no current model to compare alternatives against."
+        />
+      </div>
+    );
+  }
 
   // This projection is built off reconciled baseline traffic — surface that baseline's freshness so
   // a comparison off a stale window is never shown as fresh (CTO-80).

--- a/web/app/unit-economics/page.tsx
+++ b/web/app/unit-economics/page.tsx
@@ -8,7 +8,7 @@
 import { Suspense } from "react";
 
 import { Card } from "@/components/Card";
-import { SyntheticPreviewBanner } from "@/components/DataStateBanner";
+import { NoDataYet, SyntheticPreviewBanner } from "@/components/DataStateBanner";
 import { ExploreChartCard } from "@/components/ExploreChartCard";
 import { FilterBar } from "@/components/FilterBar";
 import { PageHeader } from "@/components/PageHeader";
@@ -90,6 +90,26 @@ export default async function UnitEconomicsPage() {
   // Headline cards reflect the most recent period for which we have both CAC inputs and economics.
   // Falling to the latest period regardless keeps the CAC flavors visible even when economics is
   // missing (payback/LTV then honest-null to "—").
+  // CTO-379: no CAC period means no acquisition cost, and every headline on this page (payback,
+  // LTV, the LTV/CAC band) is computed from one. This used to fall through to a grid of dashes,
+  // which is honest about each cell and silent about what to do; Home and Cost Explorer point a
+  // workspace in this state at setup, and this page now does too.
+  //
+  // Unit economics needs marketing spend and customer counts, NOT telemetry, so the wording sends
+  // them to the CAC input rather than implying the SDK install is what is missing.
+  if (periods.length === 0) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Unit Economics" />
+        <NoDataYet
+          what="CAC data"
+          detail="No acquisition-cost period has been recorded for this workspace, so payback, LTV and the LTV/CAC ratio have nothing to be computed from. These come from marketing spend and customer counts, entered on Connectors, not from telemetry."
+          onboarding={false}
+        />
+      </div>
+    );
+  }
+
   const latest: CacPeriod | undefined = periods[0];
   const latestEcon = latest ? economics[latest.periodStart] : undefined;
 

--- a/web/app/waste/Live.tsx
+++ b/web/app/waste/Live.tsx
@@ -15,6 +15,7 @@ import { Suspense, useMemo } from "react";
 
 import { Card } from "@/components/Card";
 import { DataTable, type Column } from "@/components/DataTable";
+import { NoDataYet } from "@/components/DataStateBanner";
 import { FilterBar, type FilterOption } from "@/components/FilterBar";
 import { Blank, Money } from "@/components/HonestValue";
 import { LiveIndicator } from "@/components/LiveIndicator";
@@ -170,8 +171,18 @@ export function WasteLive({ initialData }: { initialData: WasteReport }) {
           <p className="text-sm">
             <Blank reason={report.unavailable} /> the waste report is unavailable for this window.
           </p>
+        ) : findings.length === 0 && report.hasTelemetry === false ? (
+          // CTO-379: no spans at all. The detectors did run, and they ran over an empty window, so
+          // the good-news sentence below would be congratulating this workspace on the efficiency of
+          // no traffic. Home and Cost Explorer send a workspace in this state to setup; so does this.
+          <NoDataYet
+            what="AI spend to examine"
+            detail="No telemetry has reached this workspace, so there is nothing for the waste detectors to find."
+          />
         ) : findings.length === 0 ? (
           // GOOD news, not a broken page: nothing recoverable was detected in this window.
+          // Reached when telemetry exists, or when its presence could not be read: in the second
+          // case the detectors still ran and still flagged nothing, which is what this claims.
           <p className="text-sm text-good">
             No recoverable waste found in this window. Every detector ran and flagged nothing.
           </p>

--- a/web/lib/compare.ts
+++ b/web/lib/compare.ts
@@ -77,17 +77,28 @@ export interface CandidateMetrics {
 }
 
 export interface Comparison {
-  workload: string;        // e.g. "research_agent / production / last 7 days"
-  current: CandidateMetrics;
+  /**
+   * CTO-379: null across all three of these is the new-workspace state, and the only shape this
+   * response can honestly take when no traffic has arrived.
+   *
+   * Every figure on the Compare page is derived from the incumbent: the candidate table is rescaled
+   * onto its call volume, the savings are a delta against its cost, and the verdict is a judgement
+   * about replacing it. So "no incumbent" is not one missing tile, it is the whole page having no
+   * subject, and it gets one representation rather than a scatter of nulls the page has to
+   * reassemble. Nulling `current` alone would leave `workload` naming a workload nobody ran.
+   */
+  workload: string | null; // e.g. "research_agent / production / last 7 days"
+  /** null when no model has served traffic in the window: there is no incumbent to compare against. */
+  current: CandidateMetrics | null;
   candidates: CandidateMetrics[];
-  /** human-written-ish recommendation (the routing rule export hooks off this) */
+  /** human-written-ish recommendation (the routing rule export hooks off this). null with no baseline. */
   recommendation: {
     verdict: "switch" | "keep" | "mixed";
     summary: string;
     /** null when the incumbent's cost is unknown, so there is no saving to project (CTO-244). */
     projectedSavingsMicroUsd: MicroUSD | null;
     projectedSavingsPct: number | null; // 0..1, null when there is nothing to divide by
-  };
+  } | null;
   /**
    * Replay diagnostics. Every count is nullable and null is the ONLY honest answer when no
    * cross-provider replay has run (#320).
@@ -168,7 +179,20 @@ export function scaleCandidateMonthlyCost(
 // CTO-168: this whole object is the unreachable-gateway fallback ONLY. The `workload` label and
 // the `recommendation` verdict/summary below are fixture prose. On the live path the route
 // replaces them with values derived from real traffic (deriveWorkload / deriveRecommendation).
-export const comparison: Comparison = {
+/**
+ * The fixture is typed as a COMPLETE comparison, not as the nullable response shape (CTO-379).
+ *
+ * Widening `Comparison` so the route can express the new-workspace state would otherwise force a
+ * null check on every reader of this constant, which always has all three. `PopulatedComparison`
+ * keeps the nulls where they mean something (the wire) and out of where they cannot happen (here).
+ */
+export type PopulatedComparison = Comparison & {
+  workload: string;
+  current: CandidateMetrics;
+  recommendation: NonNullable<Comparison["recommendation"]>;
+};
+
+export const comparison: PopulatedComparison = {
   // Fixture label, used only in the unreachable-gateway fallback. Live path calls deriveWorkload.
   workload: "research_agent / production / last 7 days",
   current: {

--- a/web/lib/waste.ts
+++ b/web/lib/waste.ts
@@ -83,6 +83,18 @@ export interface WasteReport {
   byCategory: Record<WasteCategory, MicroUSD | null>;
   generatedForWindowDays: number;
   unavailable: string | null;
+  /**
+   * Whether any span reached this workspace in the window (CTO-379).
+   *
+   * "No recoverable waste found, every detector ran and flagged nothing" is good news, and on a
+   * workspace that has sent nothing it is the wrong news: the detectors did run, and they ran over
+   * an empty window, so the page was congratulating a customer on the efficiency of no traffic
+   * instead of pointing them at setup the way Home and Cost Explorer do.
+   *
+   * `null` when the count could not be read, which is neither of those states and must not be
+   * rendered as either.
+   */
+  hasTelemetry: boolean | null;
 }
 
 /**
@@ -117,7 +129,13 @@ function findingKey(f: WasteFinding): string {
  *      A blank is honest for both, and a total-less-than-sum-of-parts never appears.
  *   5. `unavailable` is always `null` here; only the endpoint sets it, on a failure to produce.
  */
-export function aggregateWaste(findings: WasteFinding[], windowDays: number): WasteReport {
+export function aggregateWaste(
+  findings: WasteFinding[],
+  windowDays: number,
+  // CTO-379. Defaults to null (unknown) so an existing caller that cannot say keeps the honest
+  // blank rather than silently asserting the workspace has traffic.
+  hasTelemetry: boolean | null = null,
+): WasteReport {
   // 1. De-dupe, keeping first occurrence and input order.
   const seen = new Set<string>();
   const deduped: WasteFinding[] = [];
@@ -159,5 +177,6 @@ export function aggregateWaste(findings: WasteFinding[], windowDays: number): Wa
     byCategory,
     generatedForWindowDays: windowDays,
     unavailable: null,
+    hasTelemetry,
   };
 }


### PR DESCRIPTION
Fixes the production report: a signed-in account with no traffic saw a `$19,100.00/mo` incumbent and a full migration recommendation on Model Comparison, and a blended CAC / payback / LTV-CAC band on Unit Economics.

## Two routes missed by #364

#364 put every fixture fallback in `app/api/**` behind `sampleDataAllowed()`. Two were missed:

- **`/api/compare`** fell into the fixture on `if (!live)`, which *is* the new-customer case.
- **`/api/cac`** served `MOCK_CAC_PERIODS` whenever the gateway returned no rows. Its comment called this "clearly-labelled", but the label lived on the page and the numbers did not read as a label.

I found `/api/cac` only while fixing Unit Economics. I had told you compare was the only ungated route; that was wrong, my grep was too narrow.

## The empty state had to become representable

There is nothing for compare to fall back *to*: every figure on the page is derived from the incumbent, so "no incumbent" is the whole page having no subject. `Comparison` gains three nullable fields, and the fixture constant is typed `PopulatedComparison` so its own readers do not inherit null checks they can never hit.

## Three pages now route to setup

| Page | Was | Now |
|---|---|---|
| Compare | `state === "empty"` wrapped the **fixture** body in a synthetic-preview banner | `NoDataYet` |
| Unit Economics | a grid of dashes, honest per cell, silent about what to do | `NoDataYet`, worded toward CAC input, not the SDK install, since that is what is actually missing |
| Recoverable Cost | "No recoverable waste found. Every detector ran and flagged nothing" | tells "no spans" from "no waste" |

The Compare banner was right while fixtures were the fallback and wrong the moment they were gated: the customer got a labelled tour of somebody else's migration.

Recoverable Cost needed a new signal, so `WasteReport` carries `hasTelemetry`. `null` (unreadable) keeps the good-news sentence, because the detectors still ran and still flagged nothing; only a confirmed zero-span workspace gets the setup pointer.

## The part that stops the next one

`api/three-states.test.ts` is where the sample gate is pinned for every fixture route, and **compare and cac were both absent from it**. That is the structural reason they survived #364, so both are now covered there. `@/lib/cac` is stubbed so the assertion does not rest on the gateway happening to be unreachable in CI.

Verified by mutation: replacing either gate with `if (false)` fails the suite.

## Existing tests

Four asserted the old behaviour and were updated rather than deleted. One read *"without a live stack the route returns the mock comparison untouched"* and asserted candidates existed. That expectation was the bug, written down.

## Still ungated, filed separately

`/api/estimate` returns the fixture projection when no candidate model is supplied. Same class, different page, and outside what was reported, so it is a follow-up issue rather than more scope here.

## Verification

`npm run typecheck && npm run lint && npm run test` in `web/`: clean, 870 tests pass. Lint's one warning is pre-existing in `lib/useLivePoll.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)