### PR TITLE
docs: correct every scope-doc status line to as-built reality

### DIFF
--- a/docs/ci-cost-check-scope.md
+++ b/docs/ci-cost-check-scope.md
@@ -1,6 +1,6 @@
 # Scope: CI cost check (GitHub Action)
 
-**Status: proposal, not built.** A GitHub Action that comments on a pull request with the projected
+**Status: proposal, still NOT built, verified #342 (tracked as #344).** A GitHub Action that comments on a pull request with the projected
 cost impact of the change: "this PR raises cost per request 22 percent."
 
 The strategic case is that this reaches teams who will never install a dashboard. It lands in the

--- a/docs/cost-alerts-scope.md
+++ b/docs/cost-alerts-scope.md
@@ -1,7 +1,13 @@
 # Scope: cost alerts with Slack delivery
 
-**Status: proposal, not built.** Alert a tenant when AI spend crosses a threshold per day, week or
-month, and deliver it to Slack.
+**Status: proposal, still NOT built, verified #342.** Alert a tenant when AI spend crosses a
+threshold per day, week or month, and deliver it to Slack.
+
+Checked against the code while correcting the other scope docs: there is no alerts schema in
+`db/postgres/`, and no Slack delivery anywhere in the gateway. The `cost_cap` guardrail
+(`0006_tenant_guardrails.sql`) and the budgets in `0026_tenant_budgets.sql` are both preventive, and
+the distinction this doc draws between preventive and detective still stands. The scheduler this
+would hang off now exists (`gateway/scheduler.py`), so the main structural dependency is met.
 
 ## What exists, and what does not
 

--- a/docs/cost-per-customer-scope.md
+++ b/docs/cost-per-customer-scope.md
@@ -1,7 +1,11 @@
 # Scope: "Cost per customer" tab
 
-**Status: proposal, not built.** This is a scoping doc for a new dashboard tab that answers "what
+**Status: SHIPPED (#342).** This is the scoping doc for the dashboard tab that answers "what
 does each of our customers cost us in AI spend, and are they profitable?"
+
+The tab is built and live at `web/app/cost-per-customer/`, with per-account drill-down
+(`[account]/`), identity resolution and its own onboarding panel. Read below for the reasoning, not
+as a plan.
 
 The short version: the reporting and UI are the easy half. The hard half is that ai-tally has no
 concept of a customer today, and roughly half of a tenant's bill cannot be attributed to one

--- a/docs/enforcing-guardrails-scope.md
+++ b/docs/enforcing-guardrails-scope.md
@@ -1,7 +1,10 @@
 # Scope: guardrails that stop things
 
-**Status: proposal, not built.** A budget ceiling per feature and per tenant that can downgrade the
+**Status: SHIPPED (#342).** A budget ceiling per feature and per tenant that can downgrade the
 model or refuse the call.
+
+The control plane is `infra/gateway/src/gateway/tenant_budgets.py` over `0026_tenant_budgets.sql`,
+with the SDK-side engine enforcing in-flight and the dashboard at `web/app/guardrails/`.
 
 ## One correction: refusal already works
 

--- a/docs/hosted-version-scope.md
+++ b/docs/hosted-version-scope.md
@@ -1,7 +1,21 @@
 # Scope: hosted ai-tally
 
-**Status: proposal, not built.** A managed multi-tenant service, so evaluating ai-tally does not
-require standing up ClickHouse, Postgres, Redpanda and MinIO first.
+**Status: proposal. NOT built, but both of its stated blockers are gone (#342).** A managed
+multi-tenant service, so evaluating ai-tally does not require standing up ClickHouse, Postgres,
+Redpanda and MinIO first.
+
+This is the doc most worth re-reading, because it argues from two obstacles that Initiative 1 has
+since cleared:
+
+- "the dashboard has no authentication at all" is false. Clerk protects every route through
+  `web/middleware.ts`.
+- "the tenant is a deploy-time environment variable" is false. `web/lib/getTenant.ts` resolves the
+  tenant from the authenticated Clerk organization and throws rather than falling back; the
+  `TALLY_DEV_TENANT` escape hatch is for keyless local dev and CI, and a production build refuses to
+  boot on it (`instrumentation.ts`).
+
+So the feature is still unbuilt, but the case below for it being far off no longer holds. See
+`docs/initiatives/01-organizations-users-access.md` §13 for the as-built status map.
 
 ## One correction to the premise
 

--- a/docs/scheduler-scope.md
+++ b/docs/scheduler-scope.md
@@ -1,6 +1,8 @@
 # Scope: the scheduler
 
-**Status: proposal.** Periodic per-tenant job execution. Nothing in this repo schedules anything, and five features are blocked on that.
+**Status: SHIPPED (#342).** Periodic per-tenant job execution.
+
+The opening claim below ("nothing in this repo schedules anything, and five features are blocked on that") is no longer true: `infra/gateway/src/gateway/scheduler.py` is built and runs per-tenant jobs on a cadence. It follows the design argued here, calling the existing `record_run` paths rather than inventing a second source of truth for "did it run".
 
 ## The problem, measured
 

--- a/docs/self-hosted-scope.md
+++ b/docs/self-hosted-scope.md
@@ -1,7 +1,19 @@
 # Scope: self-hosting ai-tally and linking it from your website
 
-**Status: proposal.** One organization (ours) runs one ai-tally instance on its own cloud account,
-for its own AI spend, and links to it from its own marketing site.
+**Status: SHIPPED, on a different substrate than this doc recommends (#342).** One organization
+(ours) runs one ai-tally instance on its own cloud account, for its own AI spend, and links to it
+from its own marketing site.
+
+This is live at `https://app.ai-tally.com`, and the deployment is real: a single VM (DigitalOcean,
+not the AWS path this doc and `docs/aws-bundle-scope.md` argue for), the compose stack from
+`deploy/demo/` in `AUTH_MODE=clerk`, Caddy terminating Let's Encrypt TLS, and a Clerk production
+instance on `accounts.ai-tally.com`. The single-VM route was chosen over ECS Fargate for operational
+weight, not because the argument below is wrong.
+
+So read the reasoning here as sound and the AWS-specific mechanics as the road not taken. The
+recommendation this doc makes and that DID hold is the sequencing: a private Clerk-gated instance
+first, a public demo later and separately, because a public demo needs an anonymous read-only mode
+that still does not exist. See #333 for the epic, which needs the same correction.
 
 ## What this is and is not
 

--- a/docs/spend-forecasting-scope.md
+++ b/docs/spend-forecasting-scope.md
@@ -1,6 +1,10 @@
 # Scope: spend forecasting and burn-down
 
-**Status: proposal, not built.** Projected month-end spend against a budget, with a burn-down chart.
+**Status: SHIPPED (#342).** Projected month-end spend against a budget, with a burn-down chart.
+
+Built across `web/lib/forecast.ts`, `web/lib/budgetVsActual.ts` and `web/lib/burndown.ts`, surfaced
+by `BudgetVsActualCard` and `BurndownCard` on `/cost`, with budgets managed at
+`/settings/budgets` and served by `web/app/api/cost/budget/route.ts`.
 
 ## What exists
 

--- a/docs/waste-detection-scope.md
+++ b/docs/waste-detection-scope.md
@@ -1,7 +1,14 @@
 # Scope: waste detection
 
-**Status: proposal, not built.** Find the spend that produced nothing: the gap between "here is your
+**Status: SHIPPED (#342).** Find the spend that produced nothing: the gap between "here is your
 bill" and "here is the $3k a month you are burning for no reason".
+
+All five detectors are built and running behind `/waste`: `paid-for-nothing`, `duplicated-work`,
+`wrong-sized-model`, `no-measured-return` and `structural-inefficiency`, each in `web/lib/waste/`
+with its own tests, aggregated by the pure `aggregateWaste` in `web/lib/waste.ts` and served by
+`web/app/api/waste/route.ts`. Read the sections below as the reasoning behind what shipped, not as
+work waiting to be done. The retry-attribution gap noted in the table further down is still real:
+the SDK has no retry attribute, so that class of waste remains undetectable.
 
 This is the most demo-able idea in the product. It is also the one most able to damage trust,
 because every number it prints is a claim about money you could have saved, and that claim is a


### PR DESCRIPTION
Closes #342

Nine of ten scope docs opened with "Status: proposal, not built." These are what anyone planning work reads first, so a stale "not built" invites rebuilding something that exists, and a stale blocker list hides work that has become possible.

## The ticket was wrong on one row

I checked each claim against the code rather than taking the issue's table on trust, and **#342 listed `cost-alerts` as built. It is not.** There is no alerts schema in `db/postgres/`, and no Slack delivery anywhere in the gateway — the only `slack` match in the whole repo is the word in a comment about transfer slack. Propagating that into the doc would have introduced exactly the error this ticket exists to remove.

Its status line now says so explicitly, and records that the scheduler it would hang off does now exist, so the main structural dependency is met.

## Corrected

| Doc | Now |
|---|---|
| `waste-detection` | shipped, 5 detectors behind `/waste` |
| `cost-per-customer` | shipped, with per-account drill-down |
| `scheduler` | shipped, `gateway/scheduler.py` |
| `spend-forecasting` | shipped, burn-down + budget-vs-actual on `/cost` |
| `enforcing-guardrails` | shipped, `tenant_budgets.py` + `/guardrails` |
| `cost-alerts` | **still not built**, verified |
| `ci-cost-check` | still not built, verified (#344) |

Each shipped line names the files that implement it, so the next reader verifies in one step instead of re-auditing.

## Two needed more than a status flip

**`hosted-version-scope.md`** argues from two obstacles Initiative 1 cleared: "the dashboard has no authentication at all" and "the tenant is a deploy-time environment variable". Both false now. The feature is still unbuilt, but the case for it being far off no longer holds, and that is the sentence a reader actually needs.

**`self-hosted-scope.md`** is shipped **on a substrate it does not describe**. `app.ai-tally.com` runs on a single DigitalOcean VM via `deploy/demo` in `AUTH_MODE=clerk`, not the ECS Fargate path this doc and `aws-bundle-scope.md` argue for. I marked the AWS mechanics as the road not taken rather than deleting the reasoning, which is sound. The sequencing it recommended did hold: private instance first, public demo later and separately, because anonymous read-only mode still does not exist.

That same divergence is why #333 needs rewriting, which is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)