### PR TITLE
feat(edge-proxy): real-traffic verification harness for usage metering (CTO-350)

### DIFF
--- a/docs/real-traffic-verification.md
+++ b/docs/real-traffic-verification.md
@@ -1,0 +1,113 @@
+# Verifying the edge proxy against real provider traffic (CTO-350)
+
+The edge proxy's usage parsing (OpenAI, Anthropic, Gemini; streamed and not) has only been tested
+against fixtures built from published schemas. Issue #350 closes when a human runs real traffic
+through the proxy and checks what it recorded against each provider's own usage dashboard. This
+page is that procedure. It needs your own API keys and costs a few cents.
+
+## Why not `make chatbot-demo-realistic`
+
+The issue named it as the vehicle, but it cannot do this job:
+
+- The chatbot's `/api/demo-chat` route calls `api.openai.com` and `api.anthropic.com` directly.
+  Its traffic never passes through the edge proxy, so it verifies nothing about the proxy.
+- Its `--max-usd` cap is checked after each session, against a blended driver-side estimate
+  ($1.50 in / $8.00 out per MTok), with parallel workers. It can overrun, and the default cap is
+  $10 for about 5000 sessions.
+- It needs the full stack, Postgres, pnpm, and both the OpenAI and Anthropic keys, and it has no
+  Gemini, prompt-caching or thinking coverage.
+
+So the verification lives in a dedicated harness, `infra/edge-proxy/cmd/verify-real-traffic`.
+
+## What the harness does
+
+It starts the real proxy handler in-process (configured through `config.FromEnv`, exactly like the
+binary) and sends a fixed matrix of 14 tiny calls through it:
+
+| Provider | Calls |
+|---|---|
+| OpenAI (`gpt-4o-mini`) | non-streaming; streaming with `include_usage`; a ~9k-token prompt sent twice so the second reads the prompt cache |
+| Anthropic (`claude-haiku-4-5`) | non-streaming; streaming; a cache write (non-streaming) then a cache read (streaming) on a ~9k-token system prompt |
+| Gemini (`gemini-2.5-flash`) | non-streaming; streaming; thinking (budget 512) non-streaming and streaming; a ~9k-token prompt sent twice for implicit caching |
+
+For each call it reads the usage block the provider returned to the client (the proxy forwards
+bodies byte-for-byte, so this is the provider's own report), decodes it with a parser separate from
+the proxy's, derives what the `TraceRecord` should hold from each provider's documented semantics,
+and compares prompt, completion and cached counts field by field. Unknown is `nil` on both sides and
+`nil` against a number is a mismatch.
+
+Keys are read from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` only. A provider with no
+key is skipped and the output says so. Gemini's key is sent in the `x-goog-api-key` header, never in
+the URL.
+
+## Run it
+
+Preview the plan and the worst-case spend first. This sends nothing and needs no keys:
+
+```bash
+cd infra/edge-proxy
+go run ./cmd/verify-real-traffic --dry-run
+```
+
+Then the real run, capturing fixtures:
+
+```bash
+cd infra/edge-proxy
+export OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GEMINI_API_KEY=...
+go run ./cmd/verify-real-traffic --max-usd 0.50 --capture
+```
+
+or from `infra/`: `make verify-real-traffic ARGS=--capture`.
+
+Useful flags: `--only anthropic,gemini` to run a subset, `--openai-model gpt-5-mini` if a default
+model has been retired (the model must be in the harness price table, which mirrors
+`sdk/python/src/tally/pricing.py` and is test-checked against it).
+
+Exit codes: `0` everything matched, `1` a mismatch or provider error, `2` usage error (no keys,
+unpriced model), `3` the spend cap refused a call (incomplete run).
+
+## Cost
+
+- **Worst-case bound: $0.11** for the full matrix at the default models. The cap bounds each
+  call before sending it: prompt tokens at most the request's byte length (every tokenizer emits
+  at least one byte per token), output at most `max_tokens` plus any thinking budget, Anthropic
+  cache writes at the 1.25x premium.
+- **Expected actual spend: about 3 cents**, dominated by the Anthropic cache write.
+- `--max-usd` defaults to `$0.50`. Before every call the harness checks
+  `spent so far + this call's worst case` against the cap and refuses rather than overrun. Rates
+  are the seed catalog's, which are marked unverified there, so treat the provider dashboard as
+  the bill.
+
+## What to do with the output
+
+1. **Every row must say `MATCH`.** A `MISMATCH` names the field, both values and the delta. That is
+   the finding #350 exists to surface: open a bug against the parser in
+   `infra/edge-proxy/internal/proxy` with the row and the `raw:` line for that call.
+2. **Read `COVERAGE GAPS`.** A cache pair that did not hit, or a thinking call that reported no
+   thought tokens, did not exercise that path. Rerun (caches are timing dependent; Gemini implicit
+   caching is best-effort) until each path has been seen at least once.
+3. **Read `NOTES`.** A `gemini convention:` note records whether the live Generative Language API
+   folds thinking tokens into `candidatesTokenCount`. Paste it into #350; it settles the open
+   question in `docs/anthropic-cache-tokens.md`.
+4. **Diff against each provider's usage dashboard.** This is the part no fixture can do. The
+   `CHECK AGAINST PROVIDER DASHBOARDS` section prints the UTC time window, per-provider token totals
+   in the provider's own field names, and each call's request id:
+   - OpenAI: Usage page, filtered to the window and model. Compare input, cached input and output
+     tokens.
+   - Anthropic: Console Usage, filtered to the window and model. Compare input, cache write, cache
+     read and output tokens.
+   - Google: AI Studio usage or the Cloud console for the key's project. Compare input and output
+     tokens (Google bills thinking tokens as output).
+   Dashboards lag by minutes to hours and round, so look for agreement to within a handful of
+   tokens, not byte equality. Any larger gap is a finding even if every row matched, because it
+   means provider and proxy agree with each other but not with the bill.
+5. **Commit the captured fixtures.** `--capture` writes
+   `internal/proxy/testdata/<provider>/real_<call>.{json,sse}` with all content stripped (an
+   allowlist keeps only ids, model, finish reasons and usage), plus a `real_<call>.expected.json`
+   sidecar. Review a couple of files to confirm no prompt or completion text is present, then
+   commit them. `TestCapturedRealTrafficFixtures` turns each one into a regression test. Once the
+   Gemini `real_thinking_stream.sse` and `real_cache_read.json` captures exist, the hand-written
+   `stream_thinking.sse` and `response_cached_context.json` can be retired in favour of them.
+   Do not commit a capture whose row was a `MISMATCH` until the parser is fixed; its test fails by
+   design.
+6. **Close #350** with the table, the dashboard comparison, and the fixture commit linked.

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -2,7 +2,7 @@
 COMPOSE := docker compose
 GATEWAY := ai-tally-gateway
 
-.PHONY: help up down nuke logs ps seed demo pg-migrate ch-migrate ch-migrate-otel-engine ch-apply-retention ch-rollup-check ch-rollup-rebuild ch-priced-zero-check ch-repair-priced-zero aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop gateway-shell test prod-preflight ch psql
+.PHONY: help up down nuke logs ps seed demo pg-migrate ch-migrate ch-migrate-otel-engine ch-apply-retention ch-rollup-check ch-rollup-rebuild ch-priced-zero-check ch-repair-priced-zero aider-demo aider-demo-stop chatbot-demo chatbot-demo-realistic chatbot-demo-backfill chatbot-demo-stop verify-real-traffic gateway-shell test prod-preflight ch psql
 
 EDGE_PROXY_PID := /tmp/ai-tally-aider-edge-proxy.pid
 
@@ -241,6 +241,11 @@ chatbot-demo: ## Run the Vercel AI chatbot demo (needs OPENAI_API_KEY, ANTHROPIC
 
 chatbot-demo-realistic: ## Live realistic-volume run (~5000 sessions/~10min, REAL LLM spend capped ~$10)
 	@$(MAKE) chatbot-demo MODE=realistic
+
+verify-real-traffic: ## Check edge-proxy metering against REAL provider calls (your keys; MAX_USD cap, default 0.50; ARGS=--capture). CTO-350
+	@# A dedicated harness, not chatbot-demo-realistic: the chatbot calls providers directly and never
+	@# touches the edge proxy. See docs/real-traffic-verification.md.
+	cd edge-proxy && go run ./cmd/verify-real-traffic --max-usd $(or $(MAX_USD),0.50) $(ARGS)
 
 chatbot-demo-backfill: ## $0 backfill — POST 30 days of backdated synthetic spans to match the seed story (no LLM calls, no API keys)
 	@curl -sf http://localhost:8080/healthz >/dev/null || { \

--- a/infra/edge-proxy/cmd/verify-real-traffic/capture.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/capture.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Capture writes each real response into testdata as a fixture, with every piece of content removed
+// (CTO-350). The no-bodies-in-telemetry invariant applies to fixtures too: a committed fixture is
+// storage, and a prompt or completion in the repository is a body that reached storage.
+//
+// Stripping is an ALLOWLIST. A denylist of "content", "text", "parts" and so on would pass through the
+// next content-bearing field a provider adds, and providers adding fields without notice is the very
+// thing CTO-350 is checking for. Anything not named below is dropped.
+
+// keepScalars are identifiers and reasons, never content. stop_sequence is deliberately absent: it
+// echoes a caller-supplied string.
+var keepScalars = map[string]bool{
+	"id": true, "object": true, "created": true, "model": true, "modelVersion": true,
+	"responseId": true, "type": true, "index": true, "role": true,
+	"finish_reason": true, "finishReason": true, "stop_reason": true,
+}
+
+// descendKeys are containers that hold the scalars above (or the usage block) alongside content.
+var descendKeys = map[string]bool{
+	"choices": true, "candidates": true, "message": true, "delta": true,
+}
+
+// usageKeys are kept whole, minus any string that is not a known enum.
+var usageKeys = map[string]bool{"usage": true, "usageMetadata": true}
+
+// usageStrings are the only string values a usage block may keep.
+var usageStrings = map[string]bool{"modality": true, "service_tier": true}
+
+func strip(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := map[string]any{}
+	for k, val := range m {
+		switch {
+		case usageKeys[k]:
+			if u := stripUsage(val); u != nil {
+				out[k] = u
+			}
+		case descendKeys[k]:
+			switch t := val.(type) {
+			case map[string]any:
+				out[k] = strip(t)
+			case []any:
+				items := make([]any, 0, len(t))
+				for _, item := range t {
+					if s := strip(item); s != nil {
+						items = append(items, s)
+					}
+				}
+				out[k] = items
+			}
+		case keepScalars[k]:
+			switch val.(type) {
+			case string, json.Number, bool, nil:
+				out[k] = val
+			}
+		}
+	}
+	return out
+}
+
+func stripUsage(v any) any {
+	switch t := v.(type) {
+	case json.Number, bool:
+		return t
+	case map[string]any:
+		out := map[string]any{}
+		for k, val := range t {
+			if s, isStr := val.(string); isStr {
+				if usageStrings[k] {
+					out[k] = s
+				}
+				continue
+			}
+			if u := stripUsage(val); u != nil {
+				out[k] = u
+			}
+		}
+		return out
+	case []any:
+		items := make([]any, 0, len(t))
+		for _, item := range t {
+			if u := stripUsage(item); u != nil {
+				items = append(items, u)
+			}
+		}
+		return items
+	}
+	return nil
+}
+
+// stripJSONDoc strips a single-document response.
+func stripJSONDoc(body []byte) ([]byte, error) {
+	m := decodeObject(body)
+	if m == nil {
+		return nil, fmt.Errorf("response is not a JSON object")
+	}
+	out, err := json.MarshalIndent(strip(m), "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+// stripSSE strips an event stream and keeps only the events that carry metadata: the first event (the
+// model and id), any event with usage or a finish reason, the stream terminators, and nothing else.
+// The dozens of pure text-delta events in between hold nothing a parser test needs.
+func stripSSE(body []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	for i, ev := range splitSSE(body) {
+		if ev.Data == "[DONE]" {
+			buf.WriteString("data: [DONE]\n\n")
+			continue
+		}
+		m := decodeObject([]byte(ev.Data))
+		if m == nil {
+			continue
+		}
+		s, _ := strip(m).(map[string]any)
+		keep := i == 0 || ev.Event == "message_start" || ev.Event == "message_delta" ||
+			ev.Event == "message_stop" || carriesMetadata(s)
+		if !keep {
+			continue
+		}
+		data, err := json.Marshal(s)
+		if err != nil {
+			return nil, err
+		}
+		if ev.Event != "" {
+			fmt.Fprintf(&buf, "event: %s\n", ev.Event)
+		}
+		fmt.Fprintf(&buf, "data: %s\n\n", data)
+	}
+	if buf.Len() == 0 {
+		return nil, fmt.Errorf("stream had no metadata-bearing events")
+	}
+	return buf.Bytes(), nil
+}
+
+func carriesMetadata(m map[string]any) bool {
+	if m == nil {
+		return false
+	}
+	for k, v := range m {
+		switch {
+		case usageKeys[k] && v != nil:
+			return true
+		case (k == "finish_reason" || k == "finishReason" || k == "stop_reason") && v != nil:
+			return true
+		case descendKeys[k]:
+			switch t := v.(type) {
+			case map[string]any:
+				if carriesMetadata(t) {
+					return true
+				}
+			case []any:
+				for _, item := range t {
+					if im, ok := item.(map[string]any); ok && carriesMetadata(im) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// sidecar is written next to each captured fixture. It holds what the TraceRecord SHOULD contain,
+// derived from the provider's own usage, so internal/proxy's TestCapturedRealTrafficFixtures turns
+// every committed capture into a regression test without anyone transcribing numbers by hand.
+type sidecar struct {
+	Comment           string `json:"_comment"`
+	CapturedAt        string `json:"captured_at"`
+	Fixture           string `json:"fixture"`
+	RequestPath       string `json:"request_path"`
+	RequestID         string `json:"request_id,omitempty"`
+	Model             string `json:"model"`
+	PromptTokens      *int64 `json:"prompt_tokens"`
+	CompletionTokens  *int64 `json:"completion_tokens"`
+	CachedInputTokens *int64 `json:"cached_input_tokens"`
+}
+
+// writeCapture writes the stripped fixture and its sidecar. It returns the fixture path.
+func writeCapture(dir string, r *callResult, now time.Time) (string, error) {
+	var stripped []byte
+	var err error
+	ext := ".json"
+	if r.stream {
+		ext = ".sse"
+		stripped, err = stripSSE(r.body)
+	} else {
+		stripped, err = stripJSONDoc(r.body)
+	}
+	if err != nil {
+		return "", err
+	}
+	provDir := filepath.Join(dir, string(r.Spec.Provider))
+	if err := os.MkdirAll(provDir, 0o755); err != nil {
+		return "", err
+	}
+	base := "real_" + r.Spec.Name
+	fixture := filepath.Join(provDir, base+ext)
+	if err := os.WriteFile(fixture, stripped, 0o644); err != nil {
+		return "", err
+	}
+	path, _, _ := strings.Cut(r.Spec.Path, "?")
+	sc := sidecar{
+		Comment: "CAPTURED from real provider traffic by cmd/verify-real-traffic (CTO-350). Content " +
+			"stripped by allowlist; only ids, model, finish reasons and usage remain. The counts below " +
+			"are derived from the provider's own usage block per its documented semantics.",
+		CapturedAt:        now.UTC().Format(time.RFC3339),
+		Fixture:           base + ext,
+		RequestPath:       path,
+		RequestID:         r.RequestID,
+		Model:             r.wantModel(),
+		PromptTokens:      r.Want.Prompt,
+		CompletionTokens:  r.Want.Completion,
+		CachedInputTokens: r.Want.Cached,
+	}
+	out, err := json.MarshalIndent(sc, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(provDir, base+".expected.json"), append(out, '\n'), 0o644); err != nil {
+		return "", err
+	}
+	return fixture, nil
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/harness.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/harness.go
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/proxy"
+)
+
+// Exit codes. A mismatch outranks a refusal: a wrong number is the finding CTO-350 is looking for,
+// and a refused call only means the run was incomplete.
+const (
+	exitOK       = 0
+	exitMismatch = 1
+	exitUsage    = 2
+	exitRefused  = 3
+)
+
+var providerOrder = []config.Provider{config.ProviderOpenAI, config.ProviderAnthropic, config.ProviderGemini}
+
+var keyEnv = map[config.Provider]string{
+	config.ProviderOpenAI:    "OPENAI_API_KEY",
+	config.ProviderAnthropic: "ANTHROPIC_API_KEY",
+	config.ProviderGemini:    "GEMINI_API_KEY",
+}
+
+type options struct {
+	MaxMicro   int64
+	Capture    bool
+	CaptureDir string
+	DryRun     bool
+	Timeout    time.Duration
+	Only       map[config.Provider]bool
+	Models     map[config.Provider]string
+	Upstreams  map[config.Provider]string
+	// Keys are read from the environment only. There is deliberately no flag for them: a key on a
+	// command line lands in shell history and process listings.
+	Keys map[config.Provider]string
+}
+
+func parseFlags(args []string, getenv func(string) string, stderr io.Writer) (options, error) {
+	fs := flag.NewFlagSet("verify-real-traffic", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	maxUSD := fs.String("max-usd", "0.50", "hard spend cap in USD, enforced before every call against a worst-case bound")
+	capture := fs.Bool("capture", false, "write content-stripped usage fixtures and expectation sidecars into --capture-dir")
+	captureDir := fs.String("capture-dir", "internal/proxy/testdata", "fixture root for --capture (run from infra/edge-proxy)")
+	dryRun := fs.Bool("dry-run", false, "print the call plan and worst-case spend, send nothing")
+	only := fs.String("only", "", "comma list of providers to run (openai,anthropic,gemini); default all with a key")
+	timeout := fs.Duration("timeout", 2*time.Minute, "per-call timeout")
+	models := map[config.Provider]*string{
+		config.ProviderOpenAI:    fs.String("openai-model", "gpt-4o-mini", "OpenAI model (must be in the price table)"),
+		config.ProviderAnthropic: fs.String("anthropic-model", "claude-haiku-4-5", "Anthropic model (must be in the price table)"),
+		config.ProviderGemini:    fs.String("gemini-model", "gemini-2.5-flash", "Gemini thinking-capable model (must be in the price table)"),
+	}
+	upstreams := map[config.Provider]*string{
+		config.ProviderOpenAI:    fs.String("openai-upstream", "https://api.openai.com", "OpenAI origin (override only for testing)"),
+		config.ProviderAnthropic: fs.String("anthropic-upstream", "https://api.anthropic.com", "Anthropic origin (override only for testing)"),
+		config.ProviderGemini:    fs.String("gemini-upstream", "https://generativelanguage.googleapis.com", "Gemini origin (override only for testing)"),
+	}
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	capMicro, err := parseUSD(*maxUSD)
+	if err != nil {
+		fmt.Fprintf(stderr, "verify-real-traffic: --max-usd: %v\n", err)
+		return options{}, err
+	}
+	o := options{
+		MaxMicro: capMicro, Capture: *capture, CaptureDir: *captureDir, DryRun: *dryRun, Timeout: *timeout,
+		Models: map[config.Provider]string{}, Upstreams: map[config.Provider]string{}, Keys: map[config.Provider]string{},
+	}
+	for _, p := range providerOrder {
+		o.Models[p] = *models[p]
+		o.Upstreams[p] = strings.TrimRight(*upstreams[p], "/")
+		o.Keys[p] = strings.TrimSpace(getenv(keyEnv[p]))
+	}
+	if strings.TrimSpace(*only) != "" {
+		o.Only = map[config.Provider]bool{}
+		for _, name := range strings.Split(*only, ",") {
+			p := config.Provider(strings.TrimSpace(name))
+			if _, known := keyEnv[p]; !known {
+				err := fmt.Errorf("unknown provider %q in --only", name)
+				fmt.Fprintf(stderr, "verify-real-traffic: %v\n", err)
+				return options{}, err
+			}
+			o.Only[p] = true
+		}
+	}
+	return o, nil
+}
+
+// callResult is one executed call. body is the raw response, kept in memory only for the capture
+// step and never printed; nothing but stripped metadata ever leaves the process.
+type callResult struct {
+	Spec       callSpec
+	Status     int
+	Err        error
+	Usage      providerUsage
+	Want       counts
+	Got        counts
+	GotModel   string
+	RequestID  string
+	Mismatches []string
+	Notes      []string
+	Gap        string
+	SpentMicro int64
+
+	stream bool
+	body   []byte
+}
+
+// wantModel is the model the TraceRecord should carry: the request path's model for Gemini (the path
+// is authoritative there) and the provider-reported model otherwise.
+func (r *callResult) wantModel() string {
+	if r.Spec.Provider == config.ProviderGemini {
+		return r.Spec.Model
+	}
+	return r.Usage.Model
+}
+
+func (r *callResult) failed() bool {
+	return r.Err != nil || r.Status < 200 || r.Status > 299 || len(r.Mismatches) > 0
+}
+
+type harness struct {
+	opts   options
+	out    io.Writer
+	client *http.Client
+	now    func() time.Time
+}
+
+func newHarness(o options, out io.Writer) *harness {
+	return &harness{opts: o, out: out, client: &http.Client{Timeout: o.Timeout}, now: time.Now}
+}
+
+// chanSink hands each TraceRecord to the waiting call. Calls run one at a time, so records arrive in
+// call order and need no correlation id.
+type chanSink struct{ ch chan proxy.TraceRecord }
+
+func (s chanSink) Record(r proxy.TraceRecord) {
+	select {
+	case s.ch <- r:
+	default:
+		// Never block the proxy's request path. A dropped record shows up as "no TraceRecord" on the
+		// call, which is a failure, so nothing is hidden.
+	}
+}
+
+// startProxy runs the real proxy handler in-process, configured through config.FromEnv exactly as the
+// binary is, with path-mode routes to each provider. In-process rather than a spawned binary so the
+// harness can read TraceRecords directly instead of standing up a gateway to receive them.
+func startProxy(upstreams map[config.Provider]string, sink proxy.Sink) (string, func(), error) {
+	var routes []string
+	for _, p := range providerOrder {
+		routes = append(routes, fmt.Sprintf("/%s=%s:%s", p, upstreams[p], p))
+	}
+	env := map[string]string{
+		"EDGE_PROXY_ROUTE_MODE":     "path",
+		"EDGE_PROXY_ROUTES":         strings.Join(routes, ","),
+		"EDGE_PROXY_REQUIRE_TENANT": "false",
+	}
+	cfg, err := config.FromEnv(func(k string) string { return env[k] })
+	if err != nil {
+		return "", nil, fmt.Errorf("proxy config: %w", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	srv := &http.Server{Handler: proxy.New(cfg, proxy.WithSink(sink)), ReadHeaderTimeout: 15 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	return "http://" + ln.Addr().String(), func() { _ = srv.Close() }, nil
+}
+
+func (h *harness) run() int {
+	o := h.opts
+	enabled := map[config.Provider]bool{}
+	for _, p := range providerOrder {
+		switch {
+		case o.Only != nil && !o.Only[p]:
+			fmt.Fprintf(h.out, "SKIP %-9s not in --only\n", p)
+		case o.Keys[p] == "" && !o.DryRun:
+			fmt.Fprintf(h.out, "SKIP %-9s %s is not set\n", p, keyEnv[p])
+		default:
+			enabled[p] = true
+		}
+	}
+	specs := buildMatrix(o.Models, enabled)
+	if len(specs) == 0 {
+		fmt.Fprintln(h.out, "Nothing to verify: no provider has a key set. Export at least one of "+
+			"OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY.")
+		return exitUsage
+	}
+	for _, s := range specs {
+		if _, ok := lookupRate(s.Provider, s.Model); !ok {
+			fmt.Fprintf(h.out, "REFUSED: %s model %q has no rate in the price table, so its spend cannot be "+
+				"bounded. Pick a listed model or add the catalog row to price.go.\n", s.Provider, s.Model)
+			return exitUsage
+		}
+	}
+	if o.Capture && !o.DryRun {
+		if st, err := os.Stat(o.CaptureDir); err != nil || !st.IsDir() {
+			fmt.Fprintf(h.out, "--capture-dir %q is not a directory (run from infra/edge-proxy)\n", o.CaptureDir)
+			return exitUsage
+		}
+	}
+
+	if o.DryRun {
+		return h.plan(specs)
+	}
+
+	sink := chanSink{ch: make(chan proxy.TraceRecord, 64)}
+	base, stop, err := startProxy(o.Upstreams, sink)
+	if err != nil {
+		fmt.Fprintf(h.out, "could not start proxy: %v\n", err)
+		return exitUsage
+	}
+	defer stop()
+
+	started := h.now().UTC()
+	fmt.Fprintf(h.out, "Proxy at %s. Spend cap %s. %d calls planned.\n\n", base, formatUSD(o.MaxMicro), len(specs))
+
+	var results []*callResult
+	var spent int64
+	refused := false
+	for _, s := range specs {
+		r := lookupRateMust(s)
+		est := worstCaseMicro(s, r)
+		if spent+est > o.MaxMicro {
+			fmt.Fprintf(h.out, "REFUSED %s/%s: worst case %s would take spend to %s, over the %s cap. "+
+				"No further calls sent.\n", s.Provider, s.Name, formatUSD(est), formatUSD(spent+est), formatUSD(o.MaxMicro))
+			refused = true
+			break
+		}
+		res := h.do(base, s, sink)
+		res.SpentMicro = spentMicro(s, res.Want, r)
+		spent += res.SpentMicro
+		results = append(results, res)
+	}
+	ended := h.now().UTC()
+
+	h.report(results, started, ended, spent)
+
+	failed := false
+	for _, r := range results {
+		if r.failed() {
+			failed = true
+		}
+	}
+	if o.Capture {
+		h.capture(results)
+	}
+	switch {
+	case failed:
+		fmt.Fprintln(h.out, "\nRESULT: FAIL (a mismatch or provider error above). Exit 1.")
+		return exitMismatch
+	case refused:
+		fmt.Fprintln(h.out, "\nRESULT: INCOMPLETE (spend cap refused a call). Raise --max-usd or use --only. Exit 3.")
+		return exitRefused
+	}
+	fmt.Fprintln(h.out, "\nRESULT: every recorded count matches the provider's usage block. Now diff the totals "+
+		"above against each provider's usage dashboard.")
+	return exitOK
+}
+
+func lookupRateMust(s callSpec) rate {
+	r, _ := lookupRate(s.Provider, s.Model)
+	return r
+}
+
+func (h *harness) plan(specs []callSpec) int {
+	fmt.Fprintf(h.out, "DRY RUN: nothing is sent. Spend cap %s.\n\n", formatUSD(h.opts.MaxMicro))
+	tw := tabwriter.NewWriter(h.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "PROVIDER\tCALL\tMODE\tMODEL\tWORST CASE\tCUMULATIVE\tWITHIN CAP")
+	var total int64
+	for _, s := range specs {
+		est := worstCaseMicro(s, lookupRateMust(s))
+		total += est
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%v\n", s.Provider, s.Name, s.mode(), s.Model,
+			formatUSD(est), formatUSD(total), total <= h.opts.MaxMicro)
+	}
+	_ = tw.Flush()
+	fmt.Fprintf(h.out, "\nWorst-case total %s (prompt bounded by request bytes, output by max tokens).\n", formatUSD(total))
+	return exitOK
+}
+
+func (h *harness) do(base string, s callSpec, sink chanSink) *callResult {
+	res := &callResult{Spec: s, stream: s.Stream}
+	req, err := http.NewRequest(http.MethodPost, base+"/"+string(s.Provider)+s.Path, bytes.NewReader(s.Body))
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	setAuth(req, s.Provider, h.opts.Keys[s.Provider])
+	resp, err := h.client.Do(req)
+	if err != nil {
+		res.Err = err
+	} else {
+		// The body is read whole because the provider's usage block is in it. It stays in memory for
+		// this call and the optional stripped capture, and is never logged.
+		res.body, err = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			res.Err = err
+		}
+		res.Status = resp.StatusCode
+		res.stream = strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/event-stream") ||
+			isSSEBody(res.body)
+		if hdr := requestIDHeader(s.Provider); hdr != "" {
+			res.RequestID = resp.Header.Get(hdr)
+		}
+	}
+
+	res.Usage = parseProviderUsage(s.Provider, res.body, res.stream)
+	if res.RequestID == "" {
+		res.RequestID = res.Usage.ID
+	}
+	res.Want, res.Notes = res.Usage.expected(s.Provider)
+
+	select {
+	case rec := <-sink.ch:
+		res.Got = counts{Prompt: rec.PromptTokens, Completion: rec.CompletionTokens, Cached: rec.CachedInputTokens}
+		res.GotModel = rec.Model
+		res.Mismatches = compareCounts(res.Want, res.Got)
+		if res.Status >= 200 && res.Status <= 299 && rec.Model != res.wantModel() {
+			res.Mismatches = append(res.Mismatches, fmt.Sprintf("model provider=%q proxy=%q", res.wantModel(), rec.Model))
+		}
+	case <-time.After(10 * time.Second):
+		res.Mismatches = append(res.Mismatches, "proxy emitted no TraceRecord")
+	}
+
+	if res.Err == nil && res.Status >= 200 && res.Status <= 299 {
+		switch s.Cover {
+		case coverCacheRead:
+			if res.Want.Cached == nil || *res.Want.Cached == 0 {
+				res.Gap = "cache was not read, so the cached-token path was NOT exercised"
+			}
+		case coverThoughts:
+			if t := res.Usage.thoughts(s.Provider); t == nil || *t == 0 {
+				res.Gap = "model reported no thinking tokens, so the thoughts path was NOT exercised"
+			}
+		}
+	}
+	return res
+}
+
+func (r *callResult) resultCell() string {
+	switch {
+	case r.Err != nil:
+		return "ERROR " + transportError(r.Err)
+	case r.Status < 200 || r.Status > 299:
+		cell := fmt.Sprintf("ERROR http %d", r.Status)
+		if e := errorSummary(r.body); e != "" {
+			cell += " (" + e + ")"
+		}
+		return cell
+	case len(r.Mismatches) > 0:
+		return "MISMATCH " + strings.Join(r.Mismatches, "; ")
+	}
+	return "MATCH"
+}
+
+// transportError reports the failure class without the error string, which carries the request URL.
+func transportError(err error) string {
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return "timeout"
+	}
+	return "transport failure"
+}
+
+func (h *harness) report(results []*callResult, started, ended time.Time, spent int64) {
+	tw := tabwriter.NewWriter(h.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "PROVIDER\tCALL\tMODE\tPROVIDER prompt/compl/cached/thoughts\tPROXY prompt/compl/cached\tRESULT")
+	for _, r := range results {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s/%s/%s/%s\t%s/%s/%s\t%s\n",
+			r.Spec.Provider, r.Spec.Name, r.Spec.mode(),
+			fmtCount(r.Want.Prompt), fmtCount(r.Want.Completion), fmtCount(r.Want.Cached), fmtCount(r.Usage.thoughts(r.Spec.Provider)),
+			fmtCount(r.Got.Prompt), fmtCount(r.Got.Completion), fmtCount(r.Got.Cached),
+			r.resultCell())
+	}
+	_ = tw.Flush()
+	fmt.Fprintln(h.out, "\nProvider columns are derived from the provider's own usage block per its documented "+
+		"semantics (Anthropic prompt = input + cache writes + cache reads; Gemini completion = total - prompt).")
+
+	var gaps, notes []string
+	for _, r := range results {
+		if r.Gap != "" {
+			gaps = append(gaps, fmt.Sprintf("  %s/%s: %s", r.Spec.Provider, r.Spec.Name, r.Gap))
+		}
+		for _, n := range r.Notes {
+			notes = append(notes, fmt.Sprintf("  %s/%s: %s", r.Spec.Provider, r.Spec.Name, n))
+		}
+	}
+	if len(gaps) > 0 {
+		fmt.Fprintln(h.out, "\nCOVERAGE GAPS (not failures, but the path below was not verified; rerun, caches are timing dependent):")
+		fmt.Fprintln(h.out, strings.Join(gaps, "\n"))
+	}
+	if len(notes) > 0 {
+		fmt.Fprintln(h.out, "\nNOTES:")
+		fmt.Fprintln(h.out, strings.Join(notes, "\n"))
+	}
+
+	fmt.Fprintf(h.out, "\nCHECK AGAINST PROVIDER DASHBOARDS (window %s to %s UTC)\n",
+		started.Format(time.RFC3339), ended.Add(time.Second).Format(time.RFC3339))
+	byProvider := map[config.Provider][]*callResult{}
+	for _, r := range results {
+		byProvider[r.Spec.Provider] = append(byProvider[r.Spec.Provider], r)
+	}
+	for _, p := range providerOrder {
+		rs := byProvider[p]
+		if len(rs) == 0 {
+			continue
+		}
+		fmt.Fprintf(h.out, "\n%s (%d calls, model %s)\n", p, len(rs), rs[0].Spec.Model)
+		for _, line := range providerTotals(p, rs) {
+			fmt.Fprintln(h.out, "  "+line)
+		}
+		for _, r := range rs {
+			id := r.RequestID
+			if id == "" {
+				id = "(none returned)"
+			}
+			fmt.Fprintf(h.out, "  %-18s %-7s id=%s finish=%s\n    raw: %s\n", r.Spec.Name, r.Spec.mode(), id,
+				strings.Join(r.Usage.FinishReasons, ","), r.Usage.raw(p))
+		}
+	}
+	fmt.Fprintf(h.out, "\nCap accounting: %s of %s. This is an UPPER BOUND at seed-catalog rates with no cache "+
+		"discount, not a bill; the provider dashboard is the bill.\n", formatUSD(spent), formatUSD(h.opts.MaxMicro))
+}
+
+// providerTotals sums each raw usage field across a provider's calls, in the provider's own field
+// names. A field some call did not report is marked, rather than silently summed as if it were 0.
+func providerTotals(p config.Provider, rs []*callResult) []string {
+	type field struct {
+		name string
+		get  func(providerUsage) *int64
+	}
+	var fields []field
+	switch p {
+	case config.ProviderOpenAI:
+		fields = []field{
+			{"prompt_tokens", func(u providerUsage) *int64 { return u.PromptTokens }},
+			{"completion_tokens", func(u providerUsage) *int64 { return u.CompletionTokens }},
+			{"cached_tokens", func(u providerUsage) *int64 { return u.CachedTokens }},
+		}
+	case config.ProviderAnthropic:
+		fields = []field{
+			{"input_tokens", func(u providerUsage) *int64 { return u.InputTokens }},
+			{"cache_creation_input_tokens", func(u providerUsage) *int64 { return u.CacheCreation }},
+			{"cache_read_input_tokens", func(u providerUsage) *int64 { return u.CacheRead }},
+			{"output_tokens", func(u providerUsage) *int64 { return u.OutputTokens }},
+		}
+	case config.ProviderGemini:
+		fields = []field{
+			{"promptTokenCount", func(u providerUsage) *int64 { return u.PromptTokenCount }},
+			{"candidatesTokenCount", func(u providerUsage) *int64 { return u.CandidatesTokenCount }},
+			{"thoughtsTokenCount", func(u providerUsage) *int64 { return u.ThoughtsTokenCount }},
+			{"cachedContentTokenCount", func(u providerUsage) *int64 { return u.CachedContentTokenCount }},
+		}
+	}
+	var proxyPrompt, proxyCompletion int64
+	for _, r := range rs {
+		if r.Got.Prompt != nil {
+			proxyPrompt += *r.Got.Prompt
+		}
+		if r.Got.Completion != nil {
+			proxyCompletion += *r.Got.Completion
+		}
+	}
+	var parts []string
+	for _, f := range fields {
+		var sum int64
+		missing := 0
+		for _, r := range rs {
+			if v := f.get(r.Usage); v != nil {
+				sum += *v
+			} else {
+				missing++
+			}
+		}
+		s := fmt.Sprintf("%s=%d", f.name, sum)
+		if missing > 0 {
+			s += fmt.Sprintf(" (%d unreported)", missing)
+		}
+		parts = append(parts, s)
+	}
+	return []string{
+		"provider totals: " + strings.Join(parts, " "),
+		fmt.Sprintf("proxy totals:    prompt=%d completion=%d", proxyPrompt, proxyCompletion),
+	}
+}
+
+func (h *harness) capture(results []*callResult) {
+	fmt.Fprintf(h.out, "\nCAPTURE into %s:\n", h.opts.CaptureDir)
+	for _, r := range results {
+		if r.Err != nil || r.Status < 200 || r.Status > 299 || len(r.body) == 0 {
+			fmt.Fprintf(h.out, "  skip %s/%s: no successful response to capture\n", r.Spec.Provider, r.Spec.Name)
+			continue
+		}
+		path, err := writeCapture(h.opts.CaptureDir, r, h.now())
+		if err != nil {
+			fmt.Fprintf(h.out, "  FAILED %s/%s: %v\n", r.Spec.Provider, r.Spec.Name, err)
+			continue
+		}
+		warn := ""
+		if len(r.Mismatches) > 0 {
+			warn = "  (MISMATCH: TestCapturedRealTrafficFixtures will fail until the parser is fixed)"
+		}
+		fmt.Fprintf(h.out, "  wrote %s%s\n", path, warn)
+	}
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/harness_test.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/harness_test.go
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/proxy"
+)
+
+// These tests drive the harness end to end against a fake upstream (CTO-350). The fake speaks all
+// three providers' wire shapes, puts a sentinel string in every piece of content so a leak into the
+// report or a captured fixture is detectable, and checks each request carries its key.
+
+const sentinel = "SENTINEL-COMPLETION-TEXT"
+
+var fakeKeys = map[string]string{
+	"OPENAI_API_KEY":    "fake-openai-key",
+	"ANTHROPIC_API_KEY": "fake-anthropic-key",
+	"GEMINI_API_KEY":    "fake-gemini-key",
+}
+
+type fakeUpstream struct {
+	srv       *httptest.Server
+	requests  atomic.Int64
+	openaiN   atomic.Int64
+	anthropN  atomic.Int64
+	geminiN   atomic.Int64
+	geminiGap int64 // added to totalTokenCount to simulate an unaccounted output bucket
+}
+
+func newFakeUpstream(t *testing.T) *fakeUpstream {
+	f := &fakeUpstream{}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.serve))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func unauthorized(w http.ResponseWriter, typ string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	fmt.Fprintf(w, `{"type":"error","error":{"type":%q,"message":"bad key, prompt was %s"}}`, typ, sentinel)
+}
+
+func (f *fakeUpstream) serve(w http.ResponseWriter, r *http.Request) {
+	f.requests.Add(1)
+	body, _ := io.ReadAll(r.Body)
+	flusher, _ := w.(http.Flusher)
+	sse := func(events ...string) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, e := range events {
+			_, _ = io.WriteString(w, e+"\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}
+	switch {
+	case r.URL.Path == "/v1/chat/completions":
+		if r.Header.Get("Authorization") != "Bearer "+fakeKeys["OPENAI_API_KEY"] {
+			unauthorized(w, "invalid_api_key")
+			return
+		}
+		prompt, cached := 12, 0
+		if bytes.Contains(body, []byte(`"role":"system"`)) {
+			prompt = 2048
+			if f.openaiN.Add(1) > 1 {
+				cached = 1920
+			}
+		}
+		usage := fmt.Sprintf(`{"prompt_tokens":%d,"completion_tokens":3,"total_tokens":%d,"prompt_tokens_details":{"cached_tokens":%d},"completion_tokens_details":{"reasoning_tokens":0}}`,
+			prompt, prompt+3, cached)
+		w.Header().Set("x-request-id", "req_fake_openai")
+		const model = "gpt-4o-mini-2024-07-18"
+		if bytes.Contains(body, []byte(`"stream":true`)) {
+			sse(
+				`data: {"id":"chatcmpl-fake","object":"chat.completion.chunk","created":1,"model":"`+model+`","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"usage":null}`,
+				`data: {"id":"chatcmpl-fake","object":"chat.completion.chunk","created":1,"model":"`+model+`","choices":[{"index":0,"delta":{"content":"`+sentinel+`"},"finish_reason":null}],"usage":null}`,
+				`data: {"id":"chatcmpl-fake","object":"chat.completion.chunk","created":1,"model":"`+model+`","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}`,
+				`data: {"id":"chatcmpl-fake","object":"chat.completion.chunk","created":1,"model":"`+model+`","choices":[],"usage":`+usage+`}`,
+				`data: [DONE]`,
+			)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":"chatcmpl-fake","object":"chat.completion","created":1,"model":%q,"choices":[{"index":0,"message":{"role":"assistant","content":%q,"refusal":null},"finish_reason":"stop"}],"usage":%s}`,
+			model, sentinel, usage)
+
+	case r.URL.Path == "/v1/messages":
+		if r.Header.Get("x-api-key") != fakeKeys["ANTHROPIC_API_KEY"] {
+			unauthorized(w, "authentication_error")
+			return
+		}
+		input, create, read := 12, 0, 0
+		if bytes.Contains(body, []byte(`"cache_control"`)) {
+			input = 4
+			if f.anthropN.Add(1) > 1 {
+				read = 5000
+			} else {
+				create = 5000
+			}
+		}
+		cacheUsage := fmt.Sprintf(`"input_tokens":%d,"cache_creation_input_tokens":%d,"cache_read_input_tokens":%d`, input, create, read)
+		w.Header().Set("request-id", "req_fake_anthropic")
+		const model = "claude-haiku-4-5-20251001"
+		if bytes.Contains(body, []byte(`"stream":true`)) {
+			sse(
+				"event: message_start\ndata: "+`{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","content":[],"model":"`+model+`","stop_reason":null,"stop_sequence":null,"usage":{`+cacheUsage+`,"output_tokens":1}}}`,
+				"event: content_block_start\ndata: "+`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+				"event: content_block_delta\ndata: "+`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"`+sentinel+`"}}`,
+				"event: content_block_stop\ndata: "+`{"type":"content_block_stop","index":0}`,
+				"event: message_delta\ndata: "+`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":3}}`,
+				"event: message_stop\ndata: "+`{"type":"message_stop"}`,
+			)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":"msg_fake","type":"message","role":"assistant","model":%q,"content":[{"type":"text","text":%q}],"stop_reason":"end_turn","stop_sequence":null,"usage":{%s,"output_tokens":3}}`,
+			model, sentinel, cacheUsage)
+
+	case strings.HasPrefix(r.URL.Path, "/v1beta/models/"):
+		if r.Header.Get("x-goog-api-key") != fakeKeys["GEMINI_API_KEY"] {
+			unauthorized(w, "UNAUTHENTICATED")
+			return
+		}
+		prompt, candidates, thoughts := int64(9), int64(4), int64(0)
+		cached := ""
+		if bytes.Contains(body, []byte(`"thinkingBudget":512`)) {
+			thoughts = 300
+		}
+		if len(body) > 10_000 {
+			prompt = 9000
+			if f.geminiN.Add(1) > 1 {
+				cached = `"cachedContentTokenCount":8000,`
+			}
+		}
+		thoughtsField := ""
+		if thoughts > 0 {
+			thoughtsField = fmt.Sprintf(`"thoughtsTokenCount":%d,`, thoughts)
+		}
+		final := fmt.Sprintf(`{"promptTokenCount":%d,%s"candidatesTokenCount":%d,%s"totalTokenCount":%d}`,
+			prompt, cached, candidates, thoughtsField, prompt+candidates+thoughts+f.geminiGap)
+		if strings.Contains(r.URL.Path, ":streamGenerateContent") {
+			sse(
+				`data: {"candidates":[{"content":{"parts":[{"text":"`+sentinel+`"}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":`+fmt.Sprint(prompt)+`,"totalTokenCount":`+fmt.Sprint(prompt)+`},"modelVersion":"gemini-2.5-flash","responseId":"resp_fake_gemini"}`,
+				`data: {"candidates":[{"content":{"parts":[{"text":"`+sentinel+`"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":`+final+`,"modelVersion":"gemini-2.5-flash","responseId":"resp_fake_gemini"}`,
+			)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"candidates":[{"content":{"parts":[{"text":%q}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":%s,"modelVersion":"gemini-2.5-flash","responseId":"resp_fake_gemini"}`,
+			sentinel, final)
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (f *fakeUpstream) args(extra ...string) []string {
+	return append([]string{
+		"--openai-upstream", f.srv.URL,
+		"--anthropic-upstream", f.srv.URL,
+		"--gemini-upstream", f.srv.URL,
+		"--timeout", "10s",
+	}, extra...)
+}
+
+func envWith(keys ...string) func(string) string {
+	set := map[string]string{}
+	for _, k := range keys {
+		set[k] = fakeKeys[k]
+	}
+	return func(k string) string { return set[k] }
+}
+
+var allKeys = []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"}
+
+func runHarness(t *testing.T, getenv func(string) string, args []string) (int, string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code := run(args, getenv, &out, &errOut)
+	return code, out.String() + errOut.String()
+}
+
+func assertNoLeak(t *testing.T, where, text string) {
+	t.Helper()
+	for _, secret := range []string{sentinel, tinyPrompt, "bat and a ball", "Row 1:", "fake-openai-key", "fake-anthropic-key", "fake-gemini-key"} {
+		if strings.Contains(text, secret) {
+			t.Errorf("%s contains %q; content or a key leaked", where, secret)
+		}
+	}
+}
+
+func TestAllProvidersMatch(t *testing.T) {
+	f := newFakeUpstream(t)
+	code, out := runHarness(t, envWith(allKeys...), f.args())
+	if code != exitOK {
+		t.Fatalf("exit %d, want 0\n%s", code, out)
+	}
+	if n := strings.Count(out, "MATCH"); n != 14 {
+		t.Errorf("want 14 MATCH rows, got %d\n%s", n, out)
+	}
+	if strings.Contains(out, "MISMATCH") || strings.Contains(out, "COVERAGE GAPS") {
+		t.Errorf("unexpected mismatch or coverage gap\n%s", out)
+	}
+	if got := f.requests.Load(); got != 14 {
+		t.Errorf("upstream saw %d requests, want 14", got)
+	}
+	// The dashboard section must carry the request ids and the provider's raw field names.
+	for _, want := range []string{"req_fake_openai", "req_fake_anthropic", "resp_fake_gemini",
+		"cache_read_input_tokens=5000", "thoughtsTokenCount=600", "cachedContentTokenCount=8000"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\n%s", want, out)
+		}
+	}
+	assertNoLeak(t, "report", out)
+}
+
+func TestMissingKeySkipsProvider(t *testing.T) {
+	f := newFakeUpstream(t)
+	code, out := runHarness(t, envWith("OPENAI_API_KEY"), f.args())
+	if code != exitOK {
+		t.Fatalf("exit %d, want 0\n%s", code, out)
+	}
+	for _, want := range []string{"ANTHROPIC_API_KEY is not set", "GEMINI_API_KEY is not set"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+	if got := f.requests.Load(); got != 4 {
+		t.Errorf("upstream saw %d requests, want only the 4 OpenAI calls", got)
+	}
+}
+
+func TestNoKeysIsAUsageError(t *testing.T) {
+	f := newFakeUpstream(t)
+	code, out := runHarness(t, envWith(), f.args())
+	if code != exitUsage || f.requests.Load() != 0 {
+		t.Fatalf("exit %d with %d requests, want exit 2 and none\n%s", code, f.requests.Load(), out)
+	}
+}
+
+// TestMismatchDetected makes the provider report a total with an output bucket the proxy does not
+// account for. The proxy then records candidates+thoughts while the provider's own total says more,
+// which is precisely the shape of discrepancy a real endpoint could surprise us with.
+func TestMismatchDetected(t *testing.T) {
+	f := newFakeUpstream(t)
+	f.geminiGap = 40
+	code, out := runHarness(t, envWith("GEMINI_API_KEY"), f.args())
+	if code != exitMismatch {
+		t.Fatalf("exit %d, want 1\n%s", code, out)
+	}
+	if !strings.Contains(out, "MISMATCH completion provider=") || !strings.Contains(out, "(delta -40)") {
+		t.Errorf("mismatch row does not name the field and delta\n%s", out)
+	}
+	if !strings.Contains(out, "gemini convention:") {
+		t.Errorf("expected a convention note for the inconsistent total\n%s", out)
+	}
+}
+
+func TestProviderErrorFailsWithoutPrintingItsMessage(t *testing.T) {
+	f := newFakeUpstream(t)
+	env := func(k string) string {
+		if k == "ANTHROPIC_API_KEY" {
+			return "wrong-key"
+		}
+		return ""
+	}
+	code, out := runHarness(t, env, f.args())
+	if code != exitMismatch {
+		t.Fatalf("exit %d, want 1\n%s", code, out)
+	}
+	if !strings.Contains(out, "ERROR http 401 (authentication_error)") {
+		t.Errorf("error row missing\n%s", out)
+	}
+	assertNoLeak(t, "report", out)
+}
+
+func TestCompareCountsKeepsUnknownDistinctFromZero(t *testing.T) {
+	five, zero := int64(5), int64(0)
+	if d := compareCounts(counts{}, counts{}); len(d) != 0 {
+		t.Errorf("nil vs nil should agree, got %v", d)
+	}
+	d := compareCounts(counts{Cached: nil}, counts{Cached: &five})
+	if len(d) != 1 || d[0] != "cached provider=nil proxy=5" {
+		t.Errorf("nil vs 5: got %v", d)
+	}
+	d = compareCounts(counts{Prompt: &zero}, counts{Prompt: nil})
+	if len(d) != 1 || d[0] != "prompt provider=0 proxy=nil" {
+		t.Errorf("0 vs nil: got %v", d)
+	}
+}
+
+func TestSpendCapRefusesBeforeFirstCall(t *testing.T) {
+	f := newFakeUpstream(t)
+	code, out := runHarness(t, envWith(allKeys...), f.args("--max-usd", "0.000001"))
+	if code != exitRefused {
+		t.Fatalf("exit %d, want 3\n%s", code, out)
+	}
+	if !strings.Contains(out, "REFUSED openai/plain") {
+		t.Errorf("refusal not reported\n%s", out)
+	}
+	if got := f.requests.Load(); got != 0 {
+		t.Errorf("upstream saw %d requests; the cap must refuse BEFORE sending", got)
+	}
+}
+
+// TestSpendCapStopsMidMatrix sets a cap the two small OpenAI calls fit under and the cached-prompt
+// call does not, and checks nothing is sent from the refusal onward.
+func TestSpendCapStopsMidMatrix(t *testing.T) {
+	f := newFakeUpstream(t)
+	specs := buildMatrix(map[config.Provider]string{config.ProviderOpenAI: "gpt-4o-mini"},
+		map[config.Provider]bool{config.ProviderOpenAI: true})
+	warm := worstCaseMicro(specs[2], priceTable[config.ProviderOpenAI]["gpt-4o-mini"])
+	capUSD := strings.TrimPrefix(formatUSD(warm-1), "$")
+
+	code, out := runHarness(t, envWith("OPENAI_API_KEY"), f.args("--max-usd", capUSD))
+	if code != exitRefused {
+		t.Fatalf("exit %d, want 3\n%s", code, out)
+	}
+	if !strings.Contains(out, "REFUSED openai/cache_warm") {
+		t.Errorf("expected refusal at cache_warm\n%s", out)
+	}
+	if got := f.requests.Load(); got != 2 {
+		t.Errorf("upstream saw %d requests, want exactly the 2 calls under the cap", got)
+	}
+}
+
+func TestUnpricedModelIsRefused(t *testing.T) {
+	f := newFakeUpstream(t)
+	code, out := runHarness(t, envWith("OPENAI_API_KEY"), f.args("--openai-model", "gpt-unknown"))
+	if code != exitUsage || f.requests.Load() != 0 {
+		t.Fatalf("exit %d with %d requests, want 2 and none\n%s", code, f.requests.Load(), out)
+	}
+}
+
+// TestCaptureStripsContentAndRoundTrips captures the whole matrix, checks no content or key reached
+// disk, and replays every stripped fixture through the proxy to prove the stripping kept everything
+// the parser needs and the sidecar describes what the proxy records.
+func TestCaptureStripsContentAndRoundTrips(t *testing.T) {
+	f := newFakeUpstream(t)
+	dir := t.TempDir()
+	code, out := runHarness(t, envWith(allKeys...), f.args("--capture", "--capture-dir", dir))
+	if code != exitOK {
+		t.Fatalf("exit %d, want 0\n%s", code, out)
+	}
+
+	sidecars, _ := filepath.Glob(filepath.Join(dir, "*", "real_*.expected.json"))
+	if len(sidecars) != 14 {
+		t.Fatalf("want 14 sidecars, got %d\n%s", len(sidecars), out)
+	}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		b, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		assertNoLeak(t, path, string(b))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sc := range sidecars {
+		var want sidecar
+		b, _ := os.ReadFile(sc)
+		if err := json.Unmarshal(b, &want); err != nil {
+			t.Fatalf("%s: %v", sc, err)
+		}
+		provider := config.Provider(filepath.Base(filepath.Dir(sc)))
+		fixture, err := os.ReadFile(filepath.Join(filepath.Dir(sc), want.Fixture))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := replayThroughProxy(t, provider, want.RequestPath, fixture, strings.HasSuffix(want.Fixture, ".sse"))
+		got := counts{Prompt: rec.PromptTokens, Completion: rec.CompletionTokens, Cached: rec.CachedInputTokens}
+		if d := compareCounts(counts{Prompt: want.PromptTokens, Completion: want.CompletionTokens, Cached: want.CachedInputTokens}, got); len(d) > 0 {
+			t.Errorf("%s: replay disagrees with sidecar: %v", sc, d)
+		}
+		if rec.Model != want.Model {
+			t.Errorf("%s: replay model %q, sidecar %q", sc, rec.Model, want.Model)
+		}
+		if want.PromptTokens == nil || want.CompletionTokens == nil {
+			t.Errorf("%s: sidecar lost the usage counts", sc)
+		}
+	}
+}
+
+func replayThroughProxy(t *testing.T, p config.Provider, path string, fixture []byte, sse bool) proxy.TraceRecord {
+	t.Helper()
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if sse {
+			w.Header().Set("Content-Type", "text/event-stream")
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		_, _ = w.Write(fixture)
+	}))
+	defer up.Close()
+	sink := chanSink{ch: make(chan proxy.TraceRecord, 1)}
+	base, stop, err := startProxy(map[config.Provider]string{
+		config.ProviderOpenAI: up.URL, config.ProviderAnthropic: up.URL, config.ProviderGemini: up.URL,
+	}, sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+	resp, err := http.Post(base+"/"+string(p)+path, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	select {
+	case rec := <-sink.ch:
+		return rec
+	case <-time.After(5 * time.Second):
+		t.Fatal("no TraceRecord from replay")
+	}
+	return proxy.TraceRecord{}
+}
+
+// TestStripIsAnAllowlist feeds fields no provider sends today. An allowlist drops them; a denylist
+// would have passed each one straight into a committed fixture.
+func TestStripIsAnAllowlist(t *testing.T) {
+	doc := []byte(`{
+		"id": "x", "model": "m", "brand_new_text_field": "secret-a",
+		"choices": [{"index": 0, "finish_reason": "stop",
+			"message": {"role": "assistant", "content": "secret-b", "annotations": [{"text": "secret-c"}]}}],
+		"usage": {"prompt_tokens": 7, "novel_detail": {"label": "secret-d", "tokens": 2},
+			"promptTokensDetails": [{"modality": "TEXT", "tokenCount": 7}]},
+		"stop_sequence": "secret-e"
+	}`)
+	out, err := stripJSONDoc(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(out, []byte("secret")) {
+		t.Fatalf("content survived stripping:\n%s", out)
+	}
+	for _, keep := range []string{`"prompt_tokens": 7`, `"tokens": 2`, `"modality": "TEXT"`, `"finish_reason": "stop"`, `"model": "m"`} {
+		if !bytes.Contains(out, []byte(keep)) {
+			t.Errorf("stripped doc lost %s:\n%s", keep, out)
+		}
+	}
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/main.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/main.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Command verify-real-traffic sends a small, fixed matrix of REAL provider calls through an
+// in-process edge proxy and checks the TraceRecord token counts the proxy recorded against the usage
+// block each provider returned to the client (CTO-350).
+//
+// Why it exists: every usage parser in internal/proxy was verified only against fixtures built from
+// published schemas. A real endpoint can emit something its documentation omits, and only real
+// traffic can show that. The proxy forwards bodies byte-for-byte, so the bytes the client receives
+// carry the provider's own usage block, which is an independent reference for each call. The part of
+// CTO-350 no program can do, diffing the totals against each provider's usage dashboard, is left to
+// the human running this, and the report prints exactly what to compare.
+//
+// Keys come from OPENAI_API_KEY, ANTHROPIC_API_KEY and GEMINI_API_KEY in the environment and nowhere
+// else. A provider whose key is unset is skipped, and the run says so. Spend is capped by --max-usd,
+// enforced before each call against a worst-case bound, so the run refuses rather than overruns.
+//
+// See docs/real-traffic-verification.md for the procedure.
+package main
+
+import (
+	"io"
+	"os"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Getenv, os.Stdout, os.Stderr))
+}
+
+// run is main without the process globals, so the tests drive the whole command, flags included,
+// against a fake upstream.
+func run(args []string, getenv func(string) string, stdout, stderr io.Writer) int {
+	opts, err := parseFlags(args, getenv, stderr)
+	if err != nil {
+		return exitUsage
+	}
+	return newHarness(opts, stdout).run()
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/matrix.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/matrix.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// coverage names the code path a call exists to exercise, so the report can say plainly when a run
+// did not actually reach it (a cache miss, a model that chose not to think). A green table over a path
+// that never ran would be the fixture problem again, one level up.
+type coverage int
+
+const (
+	coverPlain coverage = iota
+	coverCacheRead
+	coverThoughts
+)
+
+// callSpec is one request in the fixed matrix.
+type callSpec struct {
+	// Name is unique within a provider and becomes the captured fixture's file name.
+	Name     string
+	Provider config.Provider
+	Stream   bool
+	Model    string
+	// Path is the upstream path (and query), without the proxy's /<provider> routing prefix.
+	Path string
+	Body []byte
+	// MaxOutput is the most output tokens the call can bill: max output plus any thinking budget.
+	MaxOutput int64
+	// CacheWrite marks a call whose prompt may bill at Anthropic's cache-write premium.
+	CacheWrite bool
+	Cover      coverage
+}
+
+func (s callSpec) mode() string {
+	if s.Stream {
+		return "stream"
+	}
+	return "json"
+}
+
+// tinyPrompt keeps the plain calls to a handful of tokens each way. The point is the usage block, not
+// the answer.
+const tinyPrompt = "Reply with the single word: ok"
+
+// thinkingPrompt is small but needs a step of reasoning, so a thinking model has a reason to spend
+// thought tokens instead of answering from the surface.
+const thinkingPrompt = "A bat and a ball cost 1.10 in total. The bat costs 1.00 more than the ball. " +
+	"How much does the ball cost? Answer in one short sentence."
+
+// prefixBytes sizes the cacheable prefix. Prompt caching only engages above a per-model minimum:
+// 1024 tokens for OpenAI and Gemini 2.5 Flash implicit caching, and 4096 for Claude Haiku 4.5, below
+// which Anthropic silently writes nothing. Numeric rows tokenize at roughly 3 bytes a token, so 28 KB
+// is about 9000 tokens: clear of every minimum with margin, and still cents under the byte-length
+// bound the spend cap uses.
+const prefixBytes = 28_000
+
+// cacheablePrefix is deterministic, because a prefix that differs by one byte never reads from cache.
+// It is synthetic filler, never captured: fixtures keep usage metadata only.
+func cacheablePrefix() string {
+	var b strings.Builder
+	b.WriteString("You are a terse assistant. The reference table below is fixed test material for a " +
+		"prompt-cache check. Do not discuss it.\n")
+	for i := 1; b.Len() < prefixBytes; i++ {
+		fmt.Fprintf(&b, "Row %d: bin %d holds %d units of part %d, reorder at %d, audited in week %d.\n",
+			i, i%97, i*7%1000, i*13%5000, i*3%400, i%52+1)
+	}
+	return b.String()
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err) // static request shapes; a failure here is a programming error
+	}
+	return b
+}
+
+// buildMatrix returns the fixed call matrix for the enabled providers, in execution order. Cache
+// pairs are adjacent so the second call lands well inside the provider's cache TTL.
+func buildMatrix(models map[config.Provider]string, enabled map[config.Provider]bool) []callSpec {
+	var out []callSpec
+	prefix := cacheablePrefix()
+
+	if enabled[config.ProviderOpenAI] {
+		m := models[config.ProviderOpenAI]
+		plain := map[string]any{
+			"model":                 m,
+			"messages":              []any{map[string]any{"role": "user", "content": tinyPrompt}},
+			"max_completion_tokens": 64,
+		}
+		stream := map[string]any{
+			"model":                 m,
+			"messages":              []any{map[string]any{"role": "user", "content": tinyPrompt}},
+			"max_completion_tokens": 64,
+			"stream":                true,
+			// Without this opt-in OpenAI puts usage on no chunk at all, and the proxy correctly records
+			// nil. The harness sets it because it is measuring the parser, not the opt-in.
+			"stream_options": map[string]any{"include_usage": true},
+		}
+		cached := map[string]any{
+			"model": m,
+			"messages": []any{
+				map[string]any{"role": "system", "content": prefix},
+				map[string]any{"role": "user", "content": tinyPrompt},
+			},
+			"max_completion_tokens": 64,
+		}
+		const path = "/v1/chat/completions"
+		out = append(out,
+			callSpec{Name: "plain", Provider: config.ProviderOpenAI, Model: m, Path: path, Body: mustJSON(plain), MaxOutput: 64},
+			callSpec{Name: "stream", Provider: config.ProviderOpenAI, Stream: true, Model: m, Path: path, Body: mustJSON(stream), MaxOutput: 64},
+			callSpec{Name: "cache_warm", Provider: config.ProviderOpenAI, Model: m, Path: path, Body: mustJSON(cached), MaxOutput: 64},
+			callSpec{Name: "cache_read", Provider: config.ProviderOpenAI, Model: m, Path: path, Body: mustJSON(cached), MaxOutput: 64, Cover: coverCacheRead},
+		)
+	}
+
+	if enabled[config.ProviderAnthropic] {
+		m := models[config.ProviderAnthropic]
+		msgs := []any{map[string]any{"role": "user", "content": tinyPrompt}}
+		plain := map[string]any{"model": m, "max_tokens": 64, "messages": msgs}
+		stream := map[string]any{"model": m, "max_tokens": 64, "messages": msgs, "stream": true}
+		system := []any{map[string]any{
+			"type": "text", "text": prefix, "cache_control": map[string]any{"type": "ephemeral"},
+		}}
+		cacheWrite := map[string]any{"model": m, "max_tokens": 64, "system": system, "messages": msgs}
+		// The read half streams on purpose: on a stream the cache buckets arrive on message_start and
+		// the output count on message_delta, which is the fold CTO-349 changed.
+		cacheRead := map[string]any{"model": m, "max_tokens": 64, "system": system, "messages": msgs, "stream": true}
+		const path = "/v1/messages"
+		out = append(out,
+			callSpec{Name: "plain", Provider: config.ProviderAnthropic, Model: m, Path: path, Body: mustJSON(plain), MaxOutput: 64},
+			callSpec{Name: "stream", Provider: config.ProviderAnthropic, Stream: true, Model: m, Path: path, Body: mustJSON(stream), MaxOutput: 64},
+			callSpec{Name: "cache_write", Provider: config.ProviderAnthropic, Model: m, Path: path, Body: mustJSON(cacheWrite), MaxOutput: 64, CacheWrite: true},
+			callSpec{Name: "cache_read_stream", Provider: config.ProviderAnthropic, Stream: true, Model: m, Path: path, Body: mustJSON(cacheRead), MaxOutput: 64, CacheWrite: true, Cover: coverCacheRead},
+		)
+	}
+
+	if enabled[config.ProviderGemini] {
+		m := models[config.ProviderGemini]
+		gen := func(maxOut, budget int) map[string]any {
+			return map[string]any{
+				"maxOutputTokens": maxOut,
+				"thinkingConfig":  map[string]any{"thinkingBudget": budget},
+			}
+		}
+		user := func(text string) []any {
+			return []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": text}}}}
+		}
+		// Thinking budget 0 on the plain calls keeps them plain; 2.5 Flash thinks by default otherwise.
+		plain := map[string]any{"contents": user(tinyPrompt), "generationConfig": gen(64, 0)}
+		thinking := map[string]any{"contents": user(thinkingPrompt), "generationConfig": gen(1024, 512)}
+		cached := map[string]any{"contents": user(prefix + "\n" + tinyPrompt), "generationConfig": gen(64, 0)}
+		gen64 := "/v1beta/models/" + m + ":generateContent"
+		stream := "/v1beta/models/" + m + ":streamGenerateContent?alt=sse"
+		out = append(out,
+			callSpec{Name: "plain", Provider: config.ProviderGemini, Model: m, Path: gen64, Body: mustJSON(plain), MaxOutput: 64},
+			callSpec{Name: "stream", Provider: config.ProviderGemini, Stream: true, Model: m, Path: stream, Body: mustJSON(plain), MaxOutput: 64},
+			// The two thinking calls replace the hand-written stream_thinking.sse once captured.
+			callSpec{Name: "thinking", Provider: config.ProviderGemini, Model: m, Path: gen64, Body: mustJSON(thinking), MaxOutput: 1024 + 512, Cover: coverThoughts},
+			callSpec{Name: "thinking_stream", Provider: config.ProviderGemini, Stream: true, Model: m, Path: stream, Body: mustJSON(thinking), MaxOutput: 1024 + 512, Cover: coverThoughts},
+			// Implicit caching is best-effort on Google's side, so a miss is reported as a coverage gap,
+			// not a failure. A hit replaces the hand-written response_cached_context.json.
+			callSpec{Name: "cache_warm", Provider: config.ProviderGemini, Model: m, Path: gen64, Body: mustJSON(cached), MaxOutput: 64},
+			callSpec{Name: "cache_read", Provider: config.ProviderGemini, Model: m, Path: gen64, Body: mustJSON(cached), MaxOutput: 64, Cover: coverCacheRead},
+		)
+	}
+	return out
+}
+
+// setAuth attaches the provider credential. Gemini's key goes in x-goog-api-key rather than ?key= so
+// the key never appears in a URL, an error string, or a captured request path.
+func setAuth(req *http.Request, p config.Provider, key string) {
+	req.Header.Set("Content-Type", "application/json")
+	switch p {
+	case config.ProviderOpenAI:
+		req.Header.Set("Authorization", "Bearer "+key)
+	case config.ProviderAnthropic:
+		req.Header.Set("x-api-key", key)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	case config.ProviderGemini:
+		req.Header.Set("x-goog-api-key", key)
+	}
+}
+
+// requestIDHeader is the response header each provider puts its request id in. Gemini has none, so
+// its body responseId stands in.
+func requestIDHeader(p config.Provider) string {
+	switch p {
+	case config.ProviderOpenAI:
+		return "x-request-id"
+	case config.ProviderAnthropic:
+		return "request-id"
+	}
+	return ""
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/price.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/price.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// rate is one model's price in integer micro-USD per million tokens. Money is never a float in this
+// codebase, and a spend cap is exactly the place a float rounding error would turn "refuse" into
+// "overrun by a hair".
+type rate struct {
+	Input       int64
+	CachedInput int64
+	Output      int64
+}
+
+// priceTable mirrors the token rows of the seed price catalog in sdk/python/src/tally/pricing.py for
+// the models this harness can be pointed at. Go cannot import the Python catalog, so the rows are
+// copied, and TestPriceTableMatchesCatalog fails the moment the two drift apart (CTO-350). A model
+// that is not listed here is refused before any call is sent: without a rate there is no way to
+// bound the spend, and an unbounded run is what the cap exists to prevent.
+var priceTable = map[config.Provider]map[string]rate{
+	config.ProviderOpenAI: {
+		"gpt-4o-mini": {Input: 150_000, CachedInput: 75_000, Output: 600_000},
+		"gpt-4o":      {Input: 2_500_000, CachedInput: 1_250_000, Output: 10_000_000},
+		"gpt-5-mini":  {Input: 250_000, CachedInput: 25_000, Output: 2_000_000},
+	},
+	config.ProviderAnthropic: {
+		"claude-haiku-4-5":  {Input: 1_000_000, CachedInput: 100_000, Output: 5_000_000},
+		"claude-sonnet-4-5": {Input: 3_000_000, CachedInput: 300_000, Output: 15_000_000},
+	},
+	config.ProviderGemini: {
+		"gemini-2.5-flash": {Input: 300_000, CachedInput: 75_000, Output: 2_500_000},
+		"gemini-2.5-pro":   {Input: 1_250_000, CachedInput: 310_000, Output: 10_000_000},
+	},
+}
+
+// catalogProvider is the provider string the Python catalog keys Gemini under. The proxy calls the
+// protocol "gemini"; the catalog and gen_ai.system call the vendor "google".
+func catalogProvider(p config.Provider) string {
+	if p == config.ProviderGemini {
+		return "google"
+	}
+	return string(p)
+}
+
+func lookupRate(p config.Provider, model string) (rate, bool) {
+	r, ok := priceTable[p][model]
+	return r, ok
+}
+
+// costMicro prices tokens at a per-million rate, rounding UP. Rounding down would let many small calls
+// each shave a fraction of a micro-dollar off the cap accounting.
+func costMicro(tokens, perMillion int64) int64 {
+	if tokens <= 0 || perMillion <= 0 {
+		return 0
+	}
+	return (tokens*perMillion + 999_999) / 1_000_000
+}
+
+// cacheWriteRate applies Anthropic's 5-minute cache-write premium (1.25x input), rounded up. The seed
+// catalog has no cache-write price type (docs/anthropic-cache-tokens.md), so the cap derives it here
+// rather than under-bounding a cache-warming call at the plain input rate.
+func cacheWriteRate(input int64) int64 {
+	return (input*5 + 3) / 4
+}
+
+// worstCaseMicro bounds what one call can cost BEFORE it is sent.
+//
+// The prompt bound is the request body's byte length. Every tokenizer these providers use emits at
+// least one byte per token, so a body of N bytes cannot bill more than N prompt tokens, and the JSON
+// framing only makes the bound looser. It overestimates a plain English prompt by roughly 4x, which
+// is the right direction for a cap. The output bound is the call's own max output tokens plus any
+// thinking budget, both of which the request sets.
+func worstCaseMicro(s callSpec, r rate) int64 {
+	in := r.Input
+	if s.CacheWrite {
+		in = cacheWriteRate(in)
+	}
+	return costMicro(int64(len(s.Body)), in) + costMicro(s.MaxOutput, r.Output)
+}
+
+// spentMicro is the cap accounting for a call that has been sent. It uses the counts the provider
+// reported, still at the uncached (and for a cache write, premium) rate, so the running total stays an
+// upper bound. Where the provider reported nothing, the pre-call bound stands in: an unknown count is
+// not a free call, and treating it as 0 would let the cap under-count.
+func spentMicro(s callSpec, want counts, r rate) int64 {
+	prompt := int64(len(s.Body))
+	if want.Prompt != nil {
+		prompt = *want.Prompt
+	}
+	completion := s.MaxOutput
+	if want.Completion != nil {
+		completion = *want.Completion
+	}
+	in := r.Input
+	if s.CacheWrite {
+		in = cacheWriteRate(in)
+	}
+	return costMicro(prompt, in) + costMicro(completion, r.Output)
+}
+
+// parseUSD turns "0.50" or "$0.50" into micro-USD without ever touching a float.
+func parseUSD(s string) (int64, error) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "$")
+	if s == "" {
+		return 0, fmt.Errorf("empty amount")
+	}
+	whole, frac, hasDot := strings.Cut(s, ".")
+	if whole == "" {
+		whole = "0"
+	}
+	if hasDot && frac == "" {
+		return 0, fmt.Errorf("invalid amount %q", s)
+	}
+	if len(frac) > 6 {
+		return 0, fmt.Errorf("amount %q has more precision than one micro-dollar", s)
+	}
+	for _, part := range []string{whole, frac} {
+		for _, c := range part {
+			if c < '0' || c > '9' {
+				return 0, fmt.Errorf("invalid amount %q", s)
+			}
+		}
+	}
+	w, err := strconv.ParseInt(whole, 10, 64)
+	if err != nil || w > 1_000_000 {
+		return 0, fmt.Errorf("invalid amount %q", s)
+	}
+	frac += strings.Repeat("0", 6-len(frac))
+	f, err := strconv.ParseInt(frac, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid amount %q", s)
+	}
+	return w*1_000_000 + f, nil
+}
+
+// formatUSD renders micro-USD for humans. Display only; nothing is computed from the string.
+func formatUSD(micro int64) string {
+	return fmt.Sprintf("$%d.%06d", micro/1_000_000, micro%1_000_000)
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/price_test.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/price_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+func TestParseUSD(t *testing.T) {
+	good := map[string]int64{
+		"0.50": 500_000, "$0.50": 500_000, "1": 1_000_000, ".25": 250_000, "0.000001": 1, "12.3": 12_300_000,
+	}
+	for in, want := range good {
+		got, err := parseUSD(in)
+		if err != nil || got != want {
+			t.Errorf("parseUSD(%q) = %d, %v; want %d", in, got, err, want)
+		}
+	}
+	for _, in := range []string{"", "-1", "0.0000001", "abc", "1.", "1e3", "0,5"} {
+		if _, err := parseUSD(in); err == nil {
+			t.Errorf("parseUSD(%q) accepted a bad amount", in)
+		}
+	}
+}
+
+func TestCostRoundsUp(t *testing.T) {
+	// 1 token at $0.15/MTok is 0.15 micro-USD; the cap must count it as 1, never 0.
+	if got := costMicro(1, 150_000); got != 1 {
+		t.Errorf("costMicro(1, 150000) = %d, want 1", got)
+	}
+	if got := costMicro(1_000_000, 150_000); got != 150_000 {
+		t.Errorf("costMicro(1M, 150000) = %d, want 150000", got)
+	}
+	if got := cacheWriteRate(1_000_000); got != 1_250_000 {
+		t.Errorf("cacheWriteRate = %d, want 1250000", got)
+	}
+}
+
+// TestPriceTableMatchesCatalog keeps the spend cap honest: it fails when a rate here drifts from the
+// seed catalog the rest of the product prices with (CTO-350). It skips only when the Python source is
+// not present, as in a build context that copied the edge proxy alone.
+func TestPriceTableMatchesCatalog(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..", "sdk", "python", "src", "tally", "pricing.py")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("catalog source not available (%v)", err)
+	}
+	row := regexp.MustCompile(`\("(openai|anthropic|google)", "([^"]+)", PriceType\.(INPUT|CACHED_INPUT|OUTPUT), "([0-9.]+)"\)`)
+	catalog := map[string]map[string]int64{}
+	for _, m := range row.FindAllStringSubmatch(string(src), -1) {
+		micro, err := parseUSD(m[4])
+		if err != nil {
+			t.Fatalf("catalog rate %q: %v", m[4], err)
+		}
+		key := m[1] + "/" + m[2]
+		if catalog[key] == nil {
+			catalog[key] = map[string]int64{}
+		}
+		catalog[key][m[3]] = micro
+	}
+	for p, models := range priceTable {
+		for model, r := range models {
+			key := catalogProvider(p) + "/" + model
+			c, ok := catalog[key]
+			if !ok {
+				t.Errorf("%s is in the harness price table but not in pricing.py", key)
+				continue
+			}
+			for typ, want := range map[string]int64{"INPUT": r.Input, "CACHED_INPUT": r.CachedInput, "OUTPUT": r.Output} {
+				if c[typ] != want {
+					t.Errorf("%s %s: harness %d micro-USD/MTok, catalog %d", key, typ, want, c[typ])
+				}
+			}
+		}
+	}
+	// The default models must be priced, or the harness refuses to run at all.
+	for p, model := range map[config.Provider]string{
+		config.ProviderOpenAI: "gpt-4o-mini", config.ProviderAnthropic: "claude-haiku-4-5", config.ProviderGemini: "gemini-2.5-flash",
+	} {
+		if _, ok := lookupRate(p, model); !ok {
+			t.Errorf("default model %s/%s has no rate", p, model)
+		}
+	}
+}

--- a/infra/edge-proxy/cmd/verify-real-traffic/usage.go
+++ b/infra/edge-proxy/cmd/verify-real-traffic/usage.go
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// providerUsage is the usage the provider reported to the client, read straight off the bytes the
+// client received.
+//
+// It is decoded here with a separate, map-based reader instead of the proxy's own extractors. That
+// separation is the point of CTO-350: a check that reused the proxy's parser could only prove the
+// parser agrees with itself, which is the same gap the schema-built fixtures left open.
+type providerUsage struct {
+	Model         string
+	ID            string
+	FinishReasons []string
+
+	// OpenAI usage.
+	PromptTokens     *int64
+	CompletionTokens *int64
+	CachedTokens     *int64
+	ReasoningTokens  *int64
+
+	// Anthropic usage.
+	InputTokens   *int64
+	OutputTokens  *int64
+	CacheCreation *int64
+	CacheRead     *int64
+
+	// Gemini usageMetadata.
+	PromptTokenCount        *int64
+	CandidatesTokenCount    *int64
+	CachedContentTokenCount *int64
+	ThoughtsTokenCount      *int64
+	TotalTokenCount         *int64
+}
+
+// counts is the triple the TraceRecord carries. nil is unknown, never 0.
+type counts struct {
+	Prompt     *int64
+	Completion *int64
+	Cached     *int64
+}
+
+type sseEvent struct {
+	Event string
+	Data  string
+}
+
+// splitSSE splits an event stream into events. Multiple data: lines in one event join with a newline,
+// as the SSE spec says.
+func splitSSE(body []byte) []sseEvent {
+	text := strings.ReplaceAll(string(body), "\r\n", "\n")
+	var out []sseEvent
+	for _, block := range strings.Split(text, "\n\n") {
+		var ev sseEvent
+		var data []string
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				ev.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				data = append(data, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if ev.Event == "" && len(data) == 0 {
+			continue
+		}
+		ev.Data = strings.Join(data, "\n")
+		out = append(out, ev)
+	}
+	return out
+}
+
+func isSSEBody(body []byte) bool {
+	b := bytes.TrimLeft(body, " \t\r\n")
+	return bytes.HasPrefix(b, []byte("data:")) || bytes.HasPrefix(b, []byte("event:"))
+}
+
+// decodeObject decodes one JSON object keeping numbers exact. nil when it is not an object.
+func decodeObject(b []byte) map[string]any {
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	var m map[string]any
+	if d.Decode(&m) != nil {
+		return nil
+	}
+	return m
+}
+
+func obj(m map[string]any, key string) map[string]any {
+	if m == nil {
+		return nil
+	}
+	v, _ := m[key].(map[string]any)
+	return v
+}
+
+func arr(m map[string]any, key string) []any {
+	if m == nil {
+		return nil
+	}
+	v, _ := m[key].([]any)
+	return v
+}
+
+func str(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, _ := m[key].(string)
+	return v
+}
+
+// num reads an integer count. An absent or non-numeric field is nil, so "not reported" survives.
+func num(m map[string]any, key string) *int64 {
+	if m == nil {
+		return nil
+	}
+	n, ok := m[key].(json.Number)
+	if !ok {
+		return nil
+	}
+	v, err := n.Int64()
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+func lastWins(dst **int64, v *int64) {
+	if v != nil {
+		*dst = v
+	}
+}
+
+func setString(dst *string, v string) {
+	if v != "" {
+		*dst = v
+	}
+}
+
+func (u *providerUsage) addFinish(reason string) {
+	if reason == "" {
+		return
+	}
+	if n := len(u.FinishReasons); n > 0 && u.FinishReasons[n-1] == reason {
+		return
+	}
+	u.FinishReasons = append(u.FinishReasons, reason)
+}
+
+// parseProviderUsage reads the provider's usage from a response body, event by event for a stream.
+// Counts are last-wins across events because every provider reports cumulative totals on its later
+// events, never increments.
+func parseProviderUsage(p config.Provider, body []byte, stream bool) providerUsage {
+	var u providerUsage
+	if stream || isSSEBody(body) {
+		for _, ev := range splitSSE(body) {
+			if ev.Data == "" || ev.Data == "[DONE]" {
+				continue
+			}
+			if m := decodeObject([]byte(ev.Data)); m != nil {
+				u.absorb(p, m)
+			}
+		}
+		return u
+	}
+	if m := decodeObject(body); m != nil {
+		u.absorb(p, m)
+	}
+	return u
+}
+
+func (u *providerUsage) absorb(p config.Provider, m map[string]any) {
+	switch p {
+	case config.ProviderOpenAI:
+		setString(&u.Model, str(m, "model"))
+		setString(&u.ID, str(m, "id"))
+		for _, c := range arr(m, "choices") {
+			if cm, ok := c.(map[string]any); ok {
+				u.addFinish(str(cm, "finish_reason"))
+			}
+		}
+		if us := obj(m, "usage"); us != nil {
+			lastWins(&u.PromptTokens, num(us, "prompt_tokens"))
+			lastWins(&u.CompletionTokens, num(us, "completion_tokens"))
+			lastWins(&u.CachedTokens, num(obj(us, "prompt_tokens_details"), "cached_tokens"))
+			lastWins(&u.ReasoningTokens, num(obj(us, "completion_tokens_details"), "reasoning_tokens"))
+		}
+	case config.ProviderAnthropic:
+		// A non-streamed body is the message itself; message_start wraps it in "message".
+		msg := m
+		if inner := obj(m, "message"); inner != nil {
+			msg = inner
+		}
+		setString(&u.Model, str(msg, "model"))
+		if str(msg, "type") == "message" {
+			setString(&u.ID, str(msg, "id"))
+		}
+		u.addFinish(str(msg, "stop_reason"))
+		u.addFinish(str(obj(m, "delta"), "stop_reason"))
+		for _, us := range []map[string]any{obj(msg, "usage"), obj(m, "usage")} {
+			if us == nil {
+				continue
+			}
+			lastWins(&u.InputTokens, num(us, "input_tokens"))
+			lastWins(&u.OutputTokens, num(us, "output_tokens"))
+			lastWins(&u.CacheCreation, num(us, "cache_creation_input_tokens"))
+			lastWins(&u.CacheRead, num(us, "cache_read_input_tokens"))
+		}
+	case config.ProviderGemini:
+		setString(&u.Model, str(m, "modelVersion"))
+		setString(&u.ID, str(m, "responseId"))
+		for _, c := range arr(m, "candidates") {
+			if cm, ok := c.(map[string]any); ok {
+				u.addFinish(str(cm, "finishReason"))
+			}
+		}
+		if us := obj(m, "usageMetadata"); us != nil {
+			lastWins(&u.PromptTokenCount, num(us, "promptTokenCount"))
+			lastWins(&u.CandidatesTokenCount, num(us, "candidatesTokenCount"))
+			lastWins(&u.CachedContentTokenCount, num(us, "cachedContentTokenCount"))
+			lastWins(&u.ThoughtsTokenCount, num(us, "thoughtsTokenCount"))
+			lastWins(&u.TotalTokenCount, num(us, "totalTokenCount"))
+		}
+	}
+}
+
+func sumPresent(vals ...*int64) *int64 {
+	var total int64
+	seen := false
+	for _, v := range vals {
+		if v != nil {
+			total += *v
+			seen = true
+		}
+	}
+	if !seen {
+		return nil
+	}
+	return &total
+}
+
+// expected derives what the TraceRecord should hold from the provider's own usage, following each
+// provider's DOCUMENTED semantics (docs/anthropic-cache-tokens.md), not the proxy's code:
+//
+//   - OpenAI: prompt_tokens already includes the cached share.
+//   - Anthropic: input_tokens excludes both cache buckets, so the prompt is the sum of all three and
+//     the cached share is the cache-read bucket.
+//   - Gemini: promptTokenCount includes the cached share, and totalTokenCount - promptTokenCount is
+//     thoughts + candidates under either reporting convention, so it is the billable output when a
+//     total was reported.
+//
+// The notes flag anything worth a human's eye that is not itself a mismatch, such as which Gemini
+// reporting convention the live endpoint actually used.
+func (u providerUsage) expected(p config.Provider) (counts, []string) {
+	var notes []string
+	switch p {
+	case config.ProviderOpenAI:
+		return counts{Prompt: u.PromptTokens, Completion: u.CompletionTokens, Cached: u.CachedTokens}, nil
+	case config.ProviderAnthropic:
+		return counts{
+			Prompt:     sumPresent(u.InputTokens, u.CacheCreation, u.CacheRead),
+			Completion: u.OutputTokens,
+			Cached:     u.CacheRead,
+		}, nil
+	case config.ProviderGemini:
+		c := counts{Prompt: u.PromptTokenCount, Cached: u.CachedContentTokenCount}
+		summed := sumPresent(u.CandidatesTokenCount, u.ThoughtsTokenCount)
+		if u.TotalTokenCount != nil && u.PromptTokenCount != nil {
+			billable := *u.TotalTokenCount - *u.PromptTokenCount
+			c.Completion = &billable
+			if summed != nil && *summed != billable {
+				notes = append(notes, fmt.Sprintf(
+					"gemini convention: candidates+thoughts=%d but total-prompt=%d", *summed, billable))
+			}
+		} else {
+			c.Completion = summed
+		}
+		return c, notes
+	}
+	return counts{}, nil
+}
+
+// thoughts is the reasoning-token figure for the report column: Gemini thoughtsTokenCount, or OpenAI
+// reasoning_tokens (already inside completion_tokens). Anthropic reports none separately.
+func (u providerUsage) thoughts(p config.Provider) *int64 {
+	switch p {
+	case config.ProviderOpenAI:
+		return u.ReasoningTokens
+	case config.ProviderGemini:
+		return u.ThoughtsTokenCount
+	}
+	return nil
+}
+
+// raw renders the provider's own field names and values, which is what a human reads off a provider
+// dashboard or log line.
+func (u providerUsage) raw(p config.Provider) string {
+	f := func(name string, v *int64) string { return name + "=" + fmtCount(v) }
+	switch p {
+	case config.ProviderOpenAI:
+		return strings.Join([]string{f("prompt_tokens", u.PromptTokens), f("completion_tokens", u.CompletionTokens),
+			f("cached_tokens", u.CachedTokens), f("reasoning_tokens", u.ReasoningTokens)}, " ")
+	case config.ProviderAnthropic:
+		return strings.Join([]string{f("input_tokens", u.InputTokens), f("cache_creation_input_tokens", u.CacheCreation),
+			f("cache_read_input_tokens", u.CacheRead), f("output_tokens", u.OutputTokens)}, " ")
+	case config.ProviderGemini:
+		return strings.Join([]string{f("promptTokenCount", u.PromptTokenCount), f("candidatesTokenCount", u.CandidatesTokenCount),
+			f("thoughtsTokenCount", u.ThoughtsTokenCount), f("cachedContentTokenCount", u.CachedContentTokenCount),
+			f("totalTokenCount", u.TotalTokenCount)}, " ")
+	}
+	return ""
+}
+
+// errorSummary names a provider error by its type or code only. The message field is dropped: some
+// providers echo request content into it, and the report must not print a prompt.
+func errorSummary(body []byte) string {
+	m := decodeObject(body)
+	e := obj(m, "error")
+	if e == nil {
+		return ""
+	}
+	var parts []string
+	for _, k := range []string{"type", "code", "status"} {
+		if v := str(e, k); v != "" {
+			parts = append(parts, v)
+		}
+	}
+	if n := num(e, "code"); n != nil {
+		parts = append(parts, fmt.Sprint(*n))
+	}
+	return strings.Join(parts, "/")
+}
+
+func fmtCount(v *int64) string {
+	if v == nil {
+		return "nil"
+	}
+	return fmt.Sprint(*v)
+}
+
+// diffCounts compares one field. Both nil is agreement (both say unknown); one nil is a mismatch,
+// because the invariant is that unknown stays unknown and known stays known.
+func diffCounts(field string, want, got *int64) string {
+	switch {
+	case want == nil && got == nil:
+		return ""
+	case want == nil || got == nil:
+		return fmt.Sprintf("%s provider=%s proxy=%s", field, fmtCount(want), fmtCount(got))
+	case *want != *got:
+		return fmt.Sprintf("%s provider=%d proxy=%d (delta %+d)", field, *want, *got, *got-*want)
+	}
+	return ""
+}
+
+func compareCounts(want, got counts) []string {
+	var out []string
+	for _, d := range []string{
+		diffCounts("prompt", want.Prompt, got.Prompt),
+		diffCounts("completion", want.Completion, got.Completion),
+		diffCounts("cached", want.Cached, got.Cached),
+	} {
+		if d != "" {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/infra/edge-proxy/internal/proxy/real_fixtures_test.go
+++ b/infra/edge-proxy/internal/proxy/real_fixtures_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+package proxy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
+)
+
+// TestCapturedRealTrafficFixtures turns every fixture captured from real provider traffic into a
+// regression test (CTO-350).
+//
+// cmd/verify-real-traffic --capture writes testdata/<provider>/real_<call>.{json,sse} with content
+// stripped, plus a real_<call>.expected.json sidecar holding the counts derived from the provider's
+// own usage block. Unlike the fixtures transcribed from published schemas, these record what a live
+// endpoint actually sent, so a parser change that breaks on a real payload fails here rather than in
+// a variance report. It skips until a human has run the capture and committed the output.
+func TestCapturedRealTrafficFixtures(t *testing.T) {
+	sidecars, err := filepath.Glob(filepath.Join("testdata", "*", "real_*.expected.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sidecars) == 0 {
+		t.Skip("no captured real-traffic fixtures yet; see docs/real-traffic-verification.md (CTO-350)")
+	}
+	for _, sc := range sidecars {
+		t.Run(filepath.ToSlash(sc), func(t *testing.T) {
+			raw, err := os.ReadFile(sc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var want struct {
+				Fixture           string `json:"fixture"`
+				RequestPath       string `json:"request_path"`
+				Model             string `json:"model"`
+				PromptTokens      *int64 `json:"prompt_tokens"`
+				CompletionTokens  *int64 `json:"completion_tokens"`
+				CachedInputTokens *int64 `json:"cached_input_tokens"`
+			}
+			if err := json.Unmarshal(raw, &want); err != nil {
+				t.Fatalf("sidecar: %v", err)
+			}
+			body, err := os.ReadFile(filepath.Join(filepath.Dir(sc), want.Fixture))
+			if err != nil {
+				t.Fatalf("fixture named by sidecar: %v", err)
+			}
+			provider := config.Provider(filepath.Base(filepath.Dir(sc)))
+			meta := extractMeta(provider, want.RequestPath, body)
+			assertTokens(t, "PromptTokens", meta.PromptTokens, want.PromptTokens)
+			assertTokens(t, "CompletionTokens", meta.CompletionTokens, want.CompletionTokens)
+			assertTokens(t, "CachedInputTokens", meta.CachedInputTokens, want.CachedInputTokens)
+			if meta.Model != want.Model {
+				t.Errorf("Model = %q, want %q", meta.Model, want.Model)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #350. This PR does **not** close it: the issue closes after a human runs this with real keys and checks the output against the provider dashboards.

## What

`infra/edge-proxy/cmd/verify-real-traffic` starts the real proxy handler in-process (configured through `config.FromEnv`, path-mode routes) and sends a fixed matrix of 14 tiny calls:

| Provider | Calls |
|---|---|
| OpenAI `gpt-4o-mini` | json, stream (`include_usage`), cached prompt pair |
| Anthropic `claude-haiku-4-5` | json, stream, cache write (json), cache read (stream) |
| Gemini `gemini-2.5-flash` | json, stream, thinking json + stream, implicit cache pair |

For each call it decodes the usage block the provider returned to the client with its own map-based parser, not the proxy's. It derives the expected `TraceRecord` counts from each provider's documented semantics and compares prompt, completion, cached and model. `nil` against a number counts as a mismatch. Output:
- a per-call table: provider-reported prompt/completion/cached/thoughts, proxy-recorded counts, `MATCH` or `MISMATCH` with the delta
- coverage gaps, e.g. a cache that did not hit or a model that did not think
- Gemini reporting-convention notes
- a dashboard section: UTC window, per-provider totals in the provider's own field names, and request ids

It exits non-zero on any mismatch or provider error.

- **Keys:** read only from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`. There is no flag for them. A provider with no key is skipped, and the output says so.
- **Spend cap:** `--max-usd`, default `0.50`, in integer micro-USD. Before every call it checks spend so far plus a worst-case bound for that call, and refuses rather than overrun. The bound uses:
  - prompt tokens no more than the request's byte count
  - output no more than max tokens plus the thinking budget
  - the Anthropic cache-write premium

  Models without a rate are refused. The rates mirror `pricing.py`, and a test fails if they drift. `--dry-run` shows a **worst case of $0.107** for the whole matrix; I expect actual spend to be a few cents.
- **`--capture`:** writes `internal/proxy/testdata/<provider>/real_<call>.{json,sse}` stripped by an **allowlist**, keeping only ids, model, finish reasons and usage. It also writes an `.expected.json` sidecar. The new `TestCapturedRealTrafficFixtures` turns committed captures into regression tests; it skips until some exist. The captures are meant to replace the hand-written Gemini `stream_thinking.sse` and `response_cached_context.json`.
- `make verify-real-traffic` target and `docs/real-traffic-verification.md` (exact command, cost, what to do with the output).

## Why not `make chatbot-demo-realistic`

It cannot verify the proxy. `examples/vercel-chatbot/app/app/api/demo-chat/route.ts` fetches `api.openai.com` and `api.anthropic.com` directly, so none of its traffic passes through the edge proxy. It also has other problems:
- Its `--max-usd` check runs after each session, against a blended estimate, with parallel workers, so it can overrun. The default cap is $10.
- It needs the full stack, pnpm and both keys.
- It has no Gemini, caching or thinking coverage.

## Tests (fake upstream, no keys)

Match across all 14 calls; skipped providers; no keys; mismatch detection (Gemini total with an unaccounted bucket, reported with its delta); provider 401 reported without echoing its message; nil vs 0; cap refusing before the first call and partway through the matrix; unpriced model refused; capture writes no content or keys and every fixture replays through the proxy to its sidecar; strip is an allowlist; USD parsing and round-up; price table matches the catalog.

`cd infra/edge-proxy && go build ./... && go test ./... && gofmt -l .` is green, and the harness package also passes under `-race`.

## For the human run

```bash
cd infra/edge-proxy
export OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GEMINI_API_KEY=...
go run ./cmd/verify-real-traffic --max-usd 0.50 --capture
```

Then follow `docs/real-traffic-verification.md`: every row should say MATCH, rerun any coverage gaps, diff the totals against each provider's dashboard, commit the captured fixtures, and close #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
