### PR TITLE
feat: per-organization on/off switch for the hosted edge proxy

### DIFF
--- a/db/postgres/0033_tenant_proxy_config.sql
+++ b/db/postgres/0033_tenant_proxy_config.sql
@@ -1,0 +1,36 @@
+-- 0033_tenant_proxy_config.sql
+-- Per-organization on/off switch for the hosted edge proxy (zero-code connect).
+--
+-- WHY A SETTING AND NOT JUST A DEPLOY FLAG. The operator decides whether a proxy runs at all
+-- (deploy/demo: INGEST_DOMAIN). Each organization then decides whether its keys may be used through
+-- it. Routing production LLM traffic through a third party's server is a trust decision an org admin
+-- should make explicitly, so the default is OFF, and a key that is valid for the SDK is refused by the
+-- proxy until an admin turns the proxy on under Settings > API keys.
+--
+-- HOW THE PROXY LEARNS ABOUT A CHANGE. The proxy never queries this table. It caches key metadata
+-- from the gateway's /v1/edge/keys delta feed, which pages api_keys by a watermark. A toggle changes
+-- no api_keys row, so on its own it would never reach the feed. edge_updated_at fixes that: the
+-- toggle stamps it on the org's live keys in the same transaction, which raises their watermark, so
+-- they re-enter the feed carrying the new proxy_enabled value within one proxy refresh (45s).
+--
+-- IF NOT EXISTS throughout so replaying the migration set stays idempotent.
+
+CREATE TABLE IF NOT EXISTS tenant_proxy_config (
+    tenant_id  UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    enabled    BOOLEAN NOT NULL DEFAULT false,
+    -- The Clerk user id that last changed it, for audit. Bounded like every other free-text column.
+    updated_by TEXT CHECK (updated_by IS NULL OR length(updated_by) <= 128),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS edge_updated_at TIMESTAMPTZ;
+
+-- The feed's watermark now includes edge_updated_at, and 0030's index is over the old expression, so
+-- the planner would stop using it and every poll would be a sequential scan again. Replace it with an
+-- index over the new expression. It MUST match gateway/edge_keys.py _WATERMARK_SQL exactly.
+DROP INDEX IF EXISTS idx_api_keys_edge_watermark;
+CREATE INDEX IF NOT EXISTS idx_api_keys_edge_watermark_v2
+    ON api_keys (
+        GREATEST(created_at, COALESCE(revoked_at, created_at), COALESCE(edge_updated_at, created_at)),
+        id
+    );

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -241,6 +241,11 @@ when the client sets `stream_options: {"include_usage": true}`.
 
 - **Unknown or revoked key: `403`, never forwarded.** The proxy runs with
   `EDGE_PROXY_REQUIRE_TENANT=true`, so the hostname is not an open relay.
+- **Each organization turns it on for itself, and it starts off.** Running the proxy (this section)
+  makes it available; an org admin then enables it under Settings > API keys > Zero-code proxy. Until
+  they do, that org's keys get `403 the hosted proxy is turned off for this organization` from the
+  proxy while still working for the SDK. A change reaches running proxies within one key-feed refresh
+  (about 45s). Stored in `tenant_proxy_config` (migration 0033).
 - **The key needs `write` or `admin` scope.** Metering a call writes spans, so a `read` key is
   refused with `403 tenant key lacks write scope`, the same rule the gateway applies to
   `/v1/batches`. Settings > API keys creates `write` keys by default.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -147,6 +147,9 @@ services:
       # twice and its spend counted twice. initdb only fires on a first boot against an empty
       # volume, so an already-running stack must apply this migration by hand (`make psql`).
       - ../db/postgres/0032_ingest_batch_idempotency.sql:/docker-entrypoint-initdb.d/0032_ingest_batch_idempotency.sql:ro
+      # Per-org switch for the hosted edge proxy, plus the api_keys column that carries a toggle into
+      # the proxy's key feed.
+      - ../db/postgres/0033_tenant_proxy_config.sql:/docker-entrypoint-initdb.d/0033_tenant_proxy_config.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tally} -d ${POSTGRES_DB:-tally}"]
       interval: 5s

--- a/infra/edge-proxy/README.md
+++ b/infra/edge-proxy/README.md
@@ -124,6 +124,19 @@ is honest and bounded, not a fabricated success. A transient feed error keeps th
 resolution never fails open. `GET /v1/edge/keys` is delivered by a separate gateway PR; only the
 SHA-256 hash is ever sent over it, never a raw or reversible token.
 
+### Per-organization switch (gateway migration 0033)
+
+Each change in the feed also carries `proxy_enabled`, the organization's hosted-proxy setting from
+Settings > API keys. It is off by default, because routing an org's production LLM traffic through
+this proxy is a decision its admin makes. A valid write key whose organization has it off is refused
+with `403` under `EDGE_PROXY_REQUIRE_TENANT=true` (and forwarded untagged without it), while the same
+key keeps working for the SDK. Turning the setting on or off stamps `api_keys.edge_updated_at` on the
+org's live keys, which raises their feed watermark, so the change arrives within one refresh interval.
+
+`proxy_enabled` is a pointer on the wire: an **absent** field means a gateway that predates the
+switch, so there is no admin choice to honor and the key is allowed as before. An explicit `false` is
+always enforced. The gateway always sends the field, so this fallback only applies across versions.
+
 ## Usage extraction, including streamed responses (CTO-167 / CTO-349)
 
 With a provider protocol configured, the proxy reads the model id and the token counts off each

--- a/infra/edge-proxy/internal/edgekeys/edgekeys.go
+++ b/infra/edge-proxy/internal/edgekeys/edgekeys.go
@@ -42,6 +42,8 @@ func HashKey(token string) string {
 type entry struct {
 	tenantID string
 	scope    string
+	// proxyEnabled is the key's organization's hosted-proxy switch (gateway 0033).
+	proxyEnabled bool
 }
 
 // change is one row of the delta feed. Only the SHA-256 hash is ever sent, never a raw key.
@@ -50,6 +52,10 @@ type change struct {
 	TenantID  string `json:"tenant_id"`
 	Scope     string `json:"scope"`
 	RevokedAt string `json:"revoked_at"`
+	// ProxyEnabled is the organization's hosted-proxy switch. A pointer so ABSENT and false stay
+	// distinct: a gateway that predates the switch sends no field, and there is no admin choice to
+	// honor, so the key is allowed as before. An explicit false is an admin turning the proxy off.
+	ProxyEnabled *bool `json:"proxy_enabled"`
 }
 
 // feedResponse is the /v1/edge/keys payload: the changes since the requested cursor plus the new
@@ -112,6 +118,15 @@ func (c *Cache) Resolve(keyHash string) (tenantID string, scope string, ok bool)
 		return "", "", false
 	}
 	return e.tenantID, e.scope, true
+}
+
+// ProxyEnabled reports whether the organization behind a key has the hosted proxy turned on. A key
+// that is not in the cache reports false; callers check Resolve first. Hot path: read lock, O(1).
+func (c *Cache) ProxyEnabled(keyHash string) bool {
+	c.mu.RLock()
+	e, found := c.m[keyHash]
+	c.mu.RUnlock()
+	return found && e.proxyEnabled
 }
 
 // writeScopes mirrors the gateway's WRITE_SCOPES (gateway/auth.py): the scopes permitted to write
@@ -213,7 +228,9 @@ func (c *Cache) Refresh(ctx context.Context) error {
 			delete(c.m, ch.KeyHash)
 			continue
 		}
-		c.m[ch.KeyHash] = entry{tenantID: ch.TenantID, scope: ch.Scope}
+		// Absent field: a gateway without the per-org switch, so nothing to enforce (see change).
+		enabled := ch.ProxyEnabled == nil || *ch.ProxyEnabled
+		c.m[ch.KeyHash] = entry{tenantID: ch.TenantID, scope: ch.Scope, proxyEnabled: enabled}
 	}
 	if fr.Cursor != "" {
 		c.cursor = fr.Cursor

--- a/infra/edge-proxy/internal/edgekeys/edgekeys_test.go
+++ b/infra/edge-proxy/internal/edgekeys/edgekeys_test.go
@@ -261,3 +261,58 @@ func TestRunRefreshesUntilContextCancelled(t *testing.T) {
 		t.Fatal("Run did not return after cancel")
 	}
 }
+
+// TestProxySwitchFromFeed covers the per-organization hosted-proxy switch (gateway 0033). An ABSENT
+// field is a gateway that predates the switch, so there is no admin choice to honor and the key is
+// allowed; an explicit false is an admin turning the proxy off and must be honored; and a later
+// change flipping it back on is applied in place, which is how a toggle reaches a running proxy.
+func TestProxySwitchFromFeed(t *testing.T) {
+	on, off := true, false
+	legacy := hashOf("tally_sk_live_legacy")
+	optedOut := hashOf("tally_sk_live_off")
+	optedIn := hashOf("tally_sk_live_on")
+	feed := &fakeFeed{responses: map[string]feedResponse{
+		"": {
+			Changes: []change{
+				{KeyHash: legacy, TenantID: "uuid-l", Scope: "write"},
+				{KeyHash: optedOut, TenantID: "uuid-o", Scope: "write", ProxyEnabled: &off},
+				{KeyHash: optedIn, TenantID: "uuid-i", Scope: "write", ProxyEnabled: &on},
+			},
+			Cursor: "c1",
+		},
+		"c1": {
+			Changes: []change{{KeyHash: optedOut, TenantID: "uuid-o", Scope: "write", ProxyEnabled: &on}},
+			Cursor:  "c2",
+		},
+	}}
+	srv := httptest.NewServer(feed)
+	defer srv.Close()
+
+	c := New(Options{URL: srv.URL, ServiceToken: "t", Interval: time.Minute})
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if !c.ProxyEnabled(legacy) {
+		t.Error("a change with no proxy_enabled field must allow the key (gateway without the switch)")
+	}
+	if c.ProxyEnabled(optedOut) {
+		t.Error("proxy_enabled=false must be honored")
+	}
+	// Turned off is not revoked: the key is still valid, for the SDK path, and still resolves.
+	if _, _, ok := c.Resolve(optedOut); !ok {
+		t.Error("a key whose org turned the proxy off must still resolve")
+	}
+	if !c.ProxyEnabled(optedIn) {
+		t.Error("proxy_enabled=true must allow the key")
+	}
+	if c.ProxyEnabled(hashOf("tally_sk_live_unknown")) {
+		t.Error("an unknown key must never report the proxy as enabled")
+	}
+
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+	if !c.ProxyEnabled(optedOut) {
+		t.Error("a later change turning the proxy on must be applied to the cached key")
+	}
+}

--- a/infra/edge-proxy/internal/proxy/proxy.go
+++ b/infra/edge-proxy/internal/proxy/proxy.go
@@ -42,6 +42,13 @@ type TenantResolver interface {
 	Resolve(keyHash string) (tenantID string, scope string, ok bool)
 }
 
+// OrgSwitchResolver is implemented by resolvers that also carry each organization's hosted-proxy
+// switch (edgekeys.Cache does). It is a separate, optional interface so resolvers that predate the
+// switch keep compiling and keep their behavior: without it, nothing is enforced.
+type OrgSwitchResolver interface {
+	ProxyEnabled(keyHash string) bool
+}
+
 // Proxy is an http.Handler that forwards to a configured upstream and emits telemetry copies.
 type Proxy struct {
 	cfg      config.Config
@@ -224,7 +231,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// unknown or revoked key when RequireTenant is set, never forwarding an unauthenticated call.
 	var tenantID string
 	if p.resolver != nil && tenant != "" {
-		id, scope, found := p.resolver.Resolve(edgekeys.HashKey(tenant))
+		keyHash := edgekeys.HashKey(tenant)
+		id, scope, found := p.resolver.Resolve(keyHash)
+		orgSwitch, hasSwitch := p.resolver.(OrgSwitchResolver)
 		switch {
 		case !found:
 			if p.cfg.RequireTenant {
@@ -238,6 +247,14 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// TenantId (an honest blank, never a fabricated tag for a key that may not be attributed).
 			if p.cfg.RequireTenant {
 				http.Error(w, `{"error":"tenant key lacks write scope"}`+"\n", http.StatusForbidden)
+				return
+			}
+		case hasSwitch && !orgSwitch.ProxyEnabled(keyHash):
+			// A valid key whose organization has the hosted proxy turned OFF (gateway 0033, Settings >
+			// API keys). The same key still works for the SDK. Fail closed only under RequireTenant, as
+			// for scope; in open mode forward untagged rather than attribute traffic the org opted out of.
+			if p.cfg.RequireTenant {
+				http.Error(w, `{"error":"the hosted proxy is turned off for this organization; an admin can turn it on under Settings > API keys"}`+"\n", http.StatusForbidden)
 				return
 			}
 		default:

--- a/infra/edge-proxy/internal/proxy/tenant_resolve_test.go
+++ b/infra/edge-proxy/internal/proxy/tenant_resolve_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jain-aanchal/ai-tally/infra/edge-proxy/internal/config"
@@ -194,5 +196,97 @@ func TestByteForByteUnderRouting(t *testing.T) {
 	echoed, _ := io.ReadAll(resp.Body)
 	if !bytes.Equal(echoed, payload) {
 		t.Errorf("echoed %d bytes, want %d exact byte-for-byte", len(echoed), len(payload))
+	}
+}
+
+// switchResolver resolves one write-scope key and reports a fixed hosted-proxy switch for its
+// organization, exercising the optional OrgSwitchResolver path (gateway 0033).
+type switchResolver struct {
+	keyHash string
+	tenant  string
+	enabled bool
+}
+
+func (s switchResolver) Resolve(keyHash string) (string, string, bool) {
+	if keyHash == s.keyHash {
+		return s.tenant, "write", true
+	}
+	return "", "", false
+}
+
+func (s switchResolver) ProxyEnabled(keyHash string) bool { return keyHash == s.keyHash && s.enabled }
+
+// TestOrgSwitchOffFailsClosed: a valid write key whose organization has the hosted proxy turned OFF
+// is refused with 403 and never forwarded. This is the whole point of the setting: an admin's "off"
+// holds even though the key itself is valid.
+func TestOrgSwitchOffFailsClosed(t *testing.T) {
+	var forwarded atomic.Bool
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded.Store(true)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+	resolver := switchResolver{keyHash: edgekeys.HashKey("tally_sk_live_optedout"), tenant: "uuid-acme", enabled: false}
+	front, _ := resolverProxy(t, true, resolver, upstream)
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_optedout")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 when the org has the proxy turned off", resp.StatusCode)
+	}
+	// The error has to say what to do, or a customer reads a valid key being refused as a bug.
+	if !strings.Contains(string(body), "turned off for this organization") {
+		t.Errorf("body = %q, want it to say the proxy is turned off for the organization", body)
+	}
+	if forwarded.Load() {
+		t.Error("a key whose org turned the proxy off must not be forwarded upstream")
+	}
+}
+
+// TestOrgSwitchOnForwardsAndAttributes: the same key with the switch on forwards and is attributed.
+func TestOrgSwitchOnForwardsAndAttributes(t *testing.T) {
+	resolver := switchResolver{keyHash: edgekeys.HashKey("tally_sk_live_optedin"), tenant: "uuid-acme", enabled: true}
+	front, sink := resolverProxy(t, true, resolver, echoUpstream())
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_optedin")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 when the org has the proxy turned on", resp.StatusCode)
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last(); got.TenantId != "uuid-acme" {
+		t.Errorf("TenantId = %q, want uuid-acme", got.TenantId)
+	}
+}
+
+// TestOrgSwitchOffOpenModeForwardsUntagged: without RequireTenant the call still forwards, as for a
+// read-only key, but carries no TenantId: traffic an organization opted out of is never attributed.
+func TestOrgSwitchOffOpenModeForwardsUntagged(t *testing.T) {
+	resolver := switchResolver{keyHash: edgekeys.HashKey("tally_sk_live_optedout"), tenant: "uuid-acme", enabled: false}
+	front, sink := resolverProxy(t, false, resolver, echoUpstream())
+
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", nil)
+	req.Header.Set("X-Tenant-Key", "tally_sk_live_optedout")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (open when tenant not required)", resp.StatusCode)
+	}
+	sink.waitFor(t, 1)
+	if got := sink.last(); got.TenantId != "" {
+		t.Errorf("TenantId = %q, want empty for a key whose org turned the proxy off", got.TenantId)
 	}
 }

--- a/infra/gateway/src/gateway/app.py
+++ b/infra/gateway/src/gateway/app.py
@@ -168,6 +168,7 @@ from gateway.tenant_guardrails import (
     TenantGuardrailStore,
 )
 from gateway.tenant_integrations import TenantIntegrationStore
+from gateway.tenant_proxy import TenantProxyStore
 from gateway.tenant_replay import TenantReplayStore
 from gateway.revenue_upload import (
     UPLOAD_SOURCE,
@@ -344,6 +345,7 @@ async def lifespan(app: FastAPI):
     # a deployment shim. Replay runs accumulate in-memory until ClickHouse writeback lands
     # (sink wired to a list for v1; the projection API reads from it directly).
     app.state.tenant_replay = TenantReplayStore(settings)
+    app.state.tenant_proxy = TenantProxyStore(settings)
     app.state.replay_blob_store = _build_replay_blob_store(settings)
     app.state.replay_sample_index = []  # list[ReplaySampleRow]
     # Hydrate the in-memory replay index from ClickHouse so /v1/replay + /v1/eval serve a captured
@@ -3090,6 +3092,50 @@ def _response_dict(resp: BatchResponse, *, replayed: bool = False) -> dict[str, 
 # --------------------------------------------------------------------------------------------
 # Replay infrastructure (CTO-113): sampling config, capture, projection.
 # --------------------------------------------------------------------------------------------
+
+
+@app.get("/v1/tenant/proxy/config")
+def get_tenant_proxy_config(
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Read whether the hosted edge proxy is on for the caller's organization (0033).
+
+    ``enabled=false`` for a tenant that has never changed it: the proxy is opt-in.
+    """
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    cfg = app.state.tenant_proxy.get(tenant_id)
+    return JSONResponse({"tenant_id": tenant_id, "config": cfg.as_dict()})
+
+
+@app.post("/v1/tenant/proxy/config")
+async def set_tenant_proxy_config(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_tenant_id: str | None = Header(default=None),
+    x_clerk_user_id: str | None = Header(default=None),
+) -> JSONResponse:
+    """Turn the hosted edge proxy on or off for the caller's organization. Body: ``{enabled: bool}``.
+
+    The web server has already checked the caller is an org admin, as for key management. The change
+    reaches running proxies through the edge-key feed within one refresh interval.
+    """
+    _require_service_token(authorization)
+    tenant_id = _service_token_tenant(x_tenant_id)
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=422, detail=f"invalid JSON: {exc}") from exc
+    if not isinstance(body, dict) or "enabled" not in body:
+        raise HTTPException(status_code=422, detail="body must be a JSON object with a boolean 'enabled'")
+    try:
+        cfg = app.state.tenant_proxy.set_enabled(
+            tenant_id, body["enabled"], updated_by=x_clerk_user_id
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return JSONResponse({"tenant_id": tenant_id, "config": cfg.as_dict()})
 
 
 @app.get("/v1/tenant/replay/config")

--- a/infra/gateway/src/gateway/edge_keys.py
+++ b/infra/gateway/src/gateway/edge_keys.py
@@ -39,9 +39,14 @@ from datetime import datetime, timedelta, timezone
 
 import psycopg
 
-#: The row's change watermark: the later of creation and revocation. A live key sits at its
-#: ``created_at``; a revoked key rises to its ``revoked_at`` so the revoke re-enters the feed.
-_WATERMARK_SQL = "GREATEST(created_at, COALESCE(revoked_at, created_at))"
+#: The row's change watermark: the latest of creation, revocation and an edge-visible settings
+#: change. A live key sits at its ``created_at``; a revoked key rises to its ``revoked_at`` so the
+#: revoke re-enters the feed; and turning the org's hosted proxy on or off stamps ``edge_updated_at``
+#: on its live keys, so they re-enter carrying the new ``proxy_enabled``. MUST match the expression in
+#: ``idx_api_keys_edge_watermark_v2`` (0033) or every poll becomes a sequential scan.
+_WATERMARK_SQL = (
+    "GREATEST(k.created_at, COALESCE(k.revoked_at, k.created_at), COALESCE(k.edge_updated_at, k.created_at))"
+)
 
 #: Max changes returned per call. The proxy pages with the returned cursor until a short page. Large
 #: enough that a cold start is a handful of round-trips, bounded so one call is never unbounded.
@@ -60,6 +65,10 @@ class KeyChange:
     tenant_id: str
     scope: str
     revoked_at: datetime | None
+    #: Whether the key's organization has the hosted proxy turned on (0033). Defaults to False, the
+    #: same default as a tenant with no ``tenant_proxy_config`` row, so a change built without it
+    #: refuses the proxy rather than silently allowing it.
+    proxy_enabled: bool = False
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -68,6 +77,9 @@ class KeyChange:
             "scope": self.scope,
             # null means live; a timestamp means revoked. The proxy drops any row with a timestamp.
             "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+            # Always sent. The proxy treats an ABSENT field as "this gateway has no per-org switch" and
+            # allows the key, so omitting it here would quietly bypass an admin's "off".
+            "proxy_enabled": self.proxy_enabled,
         }
 
 
@@ -117,11 +129,13 @@ class EdgeKeyStore:
         with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
             cur.execute(
                 f"""
-                SELECT key_hash, tenant_id, scope, revoked_at, {_WATERMARK_SQL} AS wm, id
-                FROM api_keys
-                WHERE ({_WATERMARK_SQL}, id) > (%s, %s)
+                SELECT k.key_hash, k.tenant_id, k.scope, k.revoked_at, {_WATERMARK_SQL} AS wm, k.id,
+                       COALESCE(c.enabled, false) AS proxy_enabled
+                FROM api_keys k
+                LEFT JOIN tenant_proxy_config c ON c.tenant_id = k.tenant_id
+                WHERE ({_WATERMARK_SQL}, k.id) > (%s, %s)
                   AND {_WATERMARK_SQL} <= now() - make_interval(secs => %s)
-                ORDER BY wm, id
+                ORDER BY wm, k.id
                 LIMIT %s
                 """,
                 (after_wm, after_id, self._safe_lag_seconds, self._limit),
@@ -136,6 +150,7 @@ class EdgeKeyStore:
                 tenant_id=str(row[1]),
                 scope=str(row[2]),
                 revoked_at=row[3],
+                proxy_enabled=bool(row[6]),
             )
             for row in rows
         ]

--- a/infra/gateway/src/gateway/tenant_proxy.py
+++ b/infra/gateway/src/gateway/tenant_proxy.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-organization on/off switch for the hosted edge proxy (zero-code connect).
+
+Off by default. Routing production LLM calls through ai-tally's server is a trust decision, so an org
+admin turns it on explicitly and a key that works for the SDK is refused by the proxy until they do.
+See ``db/postgres/0033_tenant_proxy_config.sql`` for the schema and why the switch rides the edge-key
+feed rather than being a separate channel.
+
+A tenant with no row reads as ``enabled=False``: the gateway never provisions a row at signup, and the
+row appears only when an admin first changes the setting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg
+from gateway.config import Settings
+from gateway.tenant_lookup import resolve_tenant_uuid
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyConfig:
+    enabled: bool
+    #: When it last changed. None for a tenant that has never touched the setting.
+    updated_at: datetime | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "enabled": self.enabled,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+DEFAULT_CONFIG = ProxyConfig(enabled=False, updated_at=None)
+
+
+class TenantProxyStore:
+    """Postgres surface over ``tenant_proxy_config``."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._dsn = settings.postgres_dsn
+
+    def get(self, tenant_id: str) -> ProxyConfig:
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                "SELECT enabled, updated_at FROM tenant_proxy_config WHERE tenant_id = %s",
+                (resolved,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return DEFAULT_CONFIG
+        return ProxyConfig(enabled=bool(row[0]), updated_at=row[1])
+
+    def set_enabled(self, tenant_id: str, enabled: object, *, updated_by: str | None = None) -> ProxyConfig:
+        """Turn the proxy on or off for a tenant, and push the change into the edge-key feed.
+
+        ``enabled`` must be a real boolean. A string "false" is truthy in Python, and coercing it would
+        switch a tenant's proxy ON when the caller meant off, so anything else is refused.
+
+        The config write and the ``api_keys.edge_updated_at`` stamp commit in ONE transaction. If they
+        were separate, a proxy poll between them could cache the old value against a watermark that
+        has already moved past it, and the change would never arrive.
+        """
+        if not isinstance(enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        if updated_by is not None and len(updated_by) > 128:
+            updated_by = None  # audit only; never fail the toggle over an oversized id
+        with psycopg.connect(self._dsn) as conn, conn.cursor() as cur:
+            resolved = resolve_tenant_uuid(cur, tenant_id)
+            cur.execute(
+                """
+                INSERT INTO tenant_proxy_config (tenant_id, enabled, updated_by, updated_at)
+                VALUES (%s, %s, %s, now())
+                ON CONFLICT (tenant_id) DO UPDATE
+                  SET enabled    = EXCLUDED.enabled,
+                      updated_by = EXCLUDED.updated_by,
+                      updated_at = now()
+                RETURNING enabled, updated_at
+                """,
+                (resolved, enabled, updated_by),
+            )
+            row = cur.fetchone()
+            # Revoked keys are already gone from every proxy cache; re-emitting them would be noise.
+            cur.execute(
+                "UPDATE api_keys SET edge_updated_at = now() WHERE tenant_id = %s AND revoked_at IS NULL",
+                (resolved,),
+            )
+            conn.commit()
+        return ProxyConfig(enabled=bool(row[0]), updated_at=row[1])

--- a/infra/gateway/tests/test_app_hmac_and_edge_keys.py
+++ b/infra/gateway/tests/test_app_hmac_and_edge_keys.py
@@ -264,7 +264,9 @@ def test_edge_keys_payload_is_metadata_only() -> None:
     with _client(auth_on=True, edge=edge) as (c, _h, _e):
         r = c.get("/v1/edge/keys", headers={"Authorization": f"Bearer {SERVICE_TOKEN}"})
         change = r.json()["changes"][0]
-        # Exactly the metadata contract, and no token/token_prefix/secret leaks in.
-        assert set(change.keys()) == {"key_hash", "tenant_id", "scope", "revoked_at"}
+        # Exactly the metadata contract, and no token/token_prefix/secret leaks in. proxy_enabled (0033)
+        # is the org's hosted-proxy switch: a boolean about the organization, not about the key's
+        # secret, so it belongs in the contract and must always be present (see KeyChange.as_dict).
+        assert set(change.keys()) == {"key_hash", "tenant_id", "scope", "revoked_at", "proxy_enabled"}
         assert change["key_hash"] == "hash123"
         assert "token" not in change

--- a/infra/gateway/tests/test_edge_keys_store.py
+++ b/infra/gateway/tests/test_edge_keys_store.py
@@ -39,9 +39,17 @@ class Row:
     revoked_at: dt.datetime | None
     row_id: str
     visible_at: dt.datetime  # models commit time: the row is invisible to reads before this
+    # 0033: a hosted-proxy toggle stamps this on the org's live keys, and the LEFT JOIN to
+    # tenant_proxy_config supplies proxy_enabled (false for an org with no row).
+    edge_updated_at: dt.datetime | None = None
+    proxy_enabled: bool = False
 
     def watermark(self) -> dt.datetime:
-        return max(self.created_at, self.revoked_at or self.created_at)
+        return max(
+            self.created_at,
+            self.revoked_at or self.created_at,
+            self.edge_updated_at or self.created_at,
+        )
 
 
 class FakeCursor:
@@ -62,7 +70,7 @@ class FakeCursor:
         ]
         matched.sort(key=lambda r: (r.watermark(), r.row_id))
         self._result = [
-            (r.key_hash, r.tenant_id, r.scope, r.revoked_at, r.watermark(), r.row_id)
+            (r.key_hash, r.tenant_id, r.scope, r.revoked_at, r.watermark(), r.row_id, r.proxy_enabled)
             for r in matched[:limit]
         ]
 
@@ -170,3 +178,56 @@ def test_revocation_propagates_once_outside_the_lag_window(monkeypatch) -> None:
     changes, _ = store.changes_since(cursor)
     assert len(changes) == 1
     assert changes[0].revoked_at == _ts(40)
+
+
+def test_proxy_enabled_is_carried_on_every_change(monkeypatch) -> None:
+    """0033: the feed carries each key's org hosted-proxy switch, off for an org that never set it."""
+    table = FakeTable()
+    table.rows = [
+        Row("hashOff", "tenantOff", "write", _ts(10), None, "keyOff", visible_at=_ts(10)),
+        Row("hashOn", "tenantOn", "write", _ts(11), None, "keyOn", visible_at=_ts(11), proxy_enabled=True),
+    ]
+    store = _store(monkeypatch, table, lag_seconds=5.0)
+    table.now = _ts(100)
+    changes, _ = store.changes_since(None)
+    by_hash = {c.key_hash: c for c in changes}
+    assert by_hash["hashOff"].proxy_enabled is False
+    assert by_hash["hashOn"].proxy_enabled is True
+    # Always present on the wire. The proxy reads an ABSENT field as "no switch exists" and allows the
+    # key, so dropping it from the payload would silently bypass an admin's "off".
+    assert by_hash["hashOff"].as_dict()["proxy_enabled"] is False
+
+
+def test_toggle_re_emits_keys_already_past_the_cursor(monkeypatch) -> None:
+    """A toggle changes no key row, so without edge_updated_at a running proxy would never learn of it.
+
+    The key is delivered once (proxy off), the cursor moves past it, then an admin turns the proxy on.
+    The toggle stamps edge_updated_at, which raises the watermark above the cursor, so the next poll
+    outside the lag window re-emits the key carrying proxy_enabled=True.
+    """
+    table = FakeTable()
+    key = Row("hashK", "tenantK", "write", _ts(10), None, "keyK", visible_at=_ts(10))
+    table.rows = [key]
+    store = _store(monkeypatch, table, lag_seconds=5.0)
+
+    table.now = _ts(100)
+    changes, cursor = store.changes_since(None)
+    assert [(c.key_hash, c.proxy_enabled) for c in changes] == [("hashK", False)]
+
+    # Steady state: nothing changed, nothing re-sent.
+    table.now = _ts(150)
+    changes, cursor = store.changes_since(cursor)
+    assert changes == []
+
+    # The admin turns the proxy on at t=200 (same transaction as the config write).
+    key.edge_updated_at = _ts(200)
+    key.proxy_enabled = True
+
+    # Inside the lag window the change is held back, exactly like a fresh key.
+    table.now = _ts(202)
+    changes, cursor = store.changes_since(cursor)
+    assert changes == []
+
+    table.now = _ts(210)
+    changes, cursor = store.changes_since(cursor)
+    assert [(c.key_hash, c.proxy_enabled) for c in changes] == [("hashK", True)]

--- a/infra/gateway/tests/test_tenant_proxy.py
+++ b/infra/gateway/tests/test_tenant_proxy.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The per-organization hosted-proxy switch (0033): the store, the control-plane routes, and the
+invariant that ties the feed's watermark SQL to the index that serves it."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway import edge_keys, tenant_proxy
+from gateway.app import app
+from gateway.tenant_proxy import DEFAULT_CONFIG, ProxyConfig, TenantProxyStore
+
+T = "t-acme"
+NOW = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+
+
+# --- store ----------------------------------------------------------------------------------------
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.row: tuple | None = None
+        self.statements: list[tuple[str, tuple]] = []
+        self.commits = 0
+        self.connects = 0
+
+
+class FakeCursor:
+    def __init__(self, db: FakeDB) -> None:
+        self._db = db
+        self._one: tuple | None = None
+
+    def execute(self, sql: str, params: tuple) -> None:
+        flat = " ".join(sql.split())
+        self._db.statements.append((flat, params))
+        if flat.startswith("SELECT enabled"):
+            self._one = self._db.row
+        elif flat.startswith("INSERT INTO tenant_proxy_config"):
+            self._db.row = (params[1], NOW)
+            self._one = self._db.row
+        else:
+            self._one = None
+
+    def fetchone(self) -> tuple | None:
+        return self._one
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConn:
+    def __init__(self, db: FakeDB) -> None:
+        self._db = db
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self._db)
+
+    def commit(self) -> None:
+        self._db.commits += 1
+
+    def __enter__(self) -> "FakeConn":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+@pytest.fixture
+def db(monkeypatch) -> FakeDB:
+    fake = FakeDB()
+
+    def _connect(_dsn: str) -> FakeConn:
+        fake.connects += 1
+        return FakeConn(fake)
+
+    monkeypatch.setattr(tenant_proxy.psycopg, "connect", _connect)
+    monkeypatch.setattr(tenant_proxy, "resolve_tenant_uuid", lambda _cur, tenant: tenant)
+    return fake
+
+
+def _store() -> TenantProxyStore:
+    return TenantProxyStore(SimpleNamespace(postgres_dsn="postgresql://ignored"))
+
+
+def test_a_tenant_that_never_set_it_is_off(db: FakeDB) -> None:
+    assert _store().get(T) == DEFAULT_CONFIG
+    assert DEFAULT_CONFIG.enabled is False
+
+
+def test_toggle_writes_config_and_re_emits_keys_in_one_transaction(db: FakeDB) -> None:
+    cfg = _store().set_enabled(T, True, updated_by="user_123")
+    assert cfg == ProxyConfig(enabled=True, updated_at=NOW)
+    kinds = [stmt.split(" ")[0] for stmt, _ in db.statements]
+    assert kinds == ["INSERT", "UPDATE"]
+    update_sql, update_params = db.statements[1]
+    # The stamp is what carries the change into a running proxy's key cache; only live keys need it.
+    assert "SET edge_updated_at = now()" in update_sql
+    assert "revoked_at IS NULL" in update_sql
+    assert update_params == (T,)
+    # ONE commit covering both. Split commits let a proxy poll land between them and cache the old
+    # value against a watermark that has already moved past it.
+    assert db.commits == 1
+    assert db.connects == 1
+
+
+@pytest.mark.parametrize("value", ["false", "true", 0, 1, None, "off"])
+def test_non_boolean_is_refused_before_touching_the_database(db: FakeDB, value: object) -> None:
+    # "false" is truthy in Python. Coercing it would switch a tenant's proxy ON when the caller meant off.
+    with pytest.raises(ValueError):
+        _store().set_enabled(T, value)
+    assert db.connects == 0
+
+
+def test_oversized_audit_id_does_not_block_the_toggle(db: FakeDB) -> None:
+    _store().set_enabled(T, False, updated_by="u" * 500)
+    _insert_sql, insert_params = db.statements[0]
+    assert insert_params == (T, False, None)
+
+
+# --- routes ---------------------------------------------------------------------------------------
+
+
+class FakeProxyStore:
+    """In-memory TenantProxyStore with the same boolean contract."""
+
+    def __init__(self) -> None:
+        self.cfg: dict[str, ProxyConfig] = {}
+        self.updated_by: str | None = None
+
+    def get(self, tenant_id: str) -> ProxyConfig:
+        return self.cfg.get(tenant_id, DEFAULT_CONFIG)
+
+    def set_enabled(self, tenant_id: str, enabled: object, *, updated_by: str | None = None) -> ProxyConfig:
+        if not isinstance(enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        self.updated_by = updated_by
+        self.cfg[tenant_id] = ProxyConfig(enabled=enabled, updated_at=NOW)
+        return self.cfg[tenant_id]
+
+
+@pytest.fixture
+def client() -> Iterator[tuple[TestClient, FakeProxyStore]]:
+    with TestClient(app) as c:
+        store = FakeProxyStore()
+        app.state.tenant_proxy = store
+        yield c, store
+
+
+def test_get_defaults_off(client) -> None:
+    c, _ = client
+    r = c.get("/v1/tenant/proxy/config", headers={"X-Tenant-Id": T})
+    assert r.status_code == 200
+    assert r.json()["config"] == {"enabled": False, "updated_at": None}
+
+
+def test_post_round_trip_records_who_changed_it(client) -> None:
+    c, store = client
+    r = c.post(
+        "/v1/tenant/proxy/config",
+        headers={"X-Tenant-Id": T, "X-Clerk-User-Id": "user_123"},
+        json={"enabled": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["config"]["enabled"] is True
+    assert store.updated_by == "user_123"
+    assert c.get("/v1/tenant/proxy/config", headers={"X-Tenant-Id": T}).json()["config"]["enabled"] is True
+
+
+@pytest.mark.parametrize("body", [{"enabled": "false"}, {"enabled": 1}, {}, ["enabled"]])
+def test_post_refuses_anything_but_a_boolean(client, body: object) -> None:
+    c, store = client
+    r = c.post("/v1/tenant/proxy/config", headers={"X-Tenant-Id": T}, json=body)
+    assert r.status_code == 422
+    assert store.get(T).enabled is False
+
+
+# --- the watermark and its index must agree -------------------------------------------------------
+
+
+def test_feed_watermark_matches_the_0033_index_expression() -> None:
+    """If these drift, Postgres stops using the index and every proxy poll scans api_keys.
+
+    0030 said the same thing in a comment. A comment did not stop 0033 needing a new index, so this
+    time it is a test.
+    """
+    migration = (Path(__file__).resolve().parents[3] / "db" / "postgres" / "0033_tenant_proxy_config.sql").read_text()
+    match = re.search(r"ON api_keys \(\s*(GREATEST\(.*?\)),\s*id\s*\)", migration, re.S)
+    assert match, "could not find the watermark index expression in 0033"
+    normalize = lambda sql: re.sub(r"\s+", "", sql)  # noqa: E731
+    assert normalize(edge_keys._WATERMARK_SQL.replace("k.", "")) == normalize(match.group(1))

--- a/web/app/api/settings/proxy/route.test.ts
+++ b/web/app/api/settings/proxy/route.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// The hosted-proxy switch's server seam (0033). As with /api/keys, the gateway sees only the service
+// token and a resolved tenant, so the admin check lives here and these tests pin it: a member cannot
+// change whether the organization's production LLM traffic is accepted, and a refused or malformed
+// request never reaches the gateway.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+vi.mock("@clerk/nextjs/server", () => ({ auth: authMock }));
+
+const TENANT_UUID = "3f8c1c2a-0b7e-4d3a-9a1b-77c0d5e2f011";
+const ORG_ID = "org_test";
+
+const originalDevTenant = process.env.TALLY_DEV_TENANT;
+const originalToken = process.env.GATEWAY_SERVICE_TOKEN;
+
+let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+/** What the gateway's GET answers with, so the unreadable case can be exercised. */
+let configStatus: number;
+
+function json(body: unknown, status = 200): Promise<Response> {
+  return Promise.resolve(new Response(JSON.stringify(body), { status }));
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.TALLY_DEV_TENANT;
+  process.env.GATEWAY_SERVICE_TOKEN = "svc-token";
+  fetchCalls = [];
+  configStatus = 200;
+  vi.stubGlobal("fetch", (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    fetchCalls.push({ url, init });
+    if (url.includes("/v1/tenant/by-clerk-org/")) {
+      return json({ tenant_id: TENANT_UUID, plan: "free" });
+    }
+    if (url.endsWith("/v1/tenant/proxy/config") && init?.method === "POST") {
+      const sent = JSON.parse(String(init.body)) as { enabled: boolean };
+      return json({ tenant_id: TENANT_UUID, config: { enabled: sent.enabled, updated_at: null } });
+    }
+    if (url.endsWith("/v1/tenant/proxy/config")) {
+      return configStatus === 200
+        ? json({ tenant_id: TENANT_UUID, config: { enabled: false, updated_at: null } })
+        : json({ detail: "boom" }, configStatus);
+    }
+    return json({}, 404);
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  authMock.mockReset();
+  if (originalDevTenant === undefined) delete process.env.TALLY_DEV_TENANT;
+  else process.env.TALLY_DEV_TENANT = originalDevTenant;
+  if (originalToken === undefined) delete process.env.GATEWAY_SERVICE_TOKEN;
+  else process.env.GATEWAY_SERVICE_TOKEN = originalToken;
+});
+
+function setRequest(body: unknown): Request {
+  return new Request("http://localhost/api/settings/proxy", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const gatewayWrites = () =>
+  fetchCalls.filter((c) => c.url.endsWith("/v1/tenant/proxy/config") && c.init?.method === "POST");
+
+describe("POST /api/settings/proxy", () => {
+  it("refuses a member with 403 and never writes to the gateway", async () => {
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:member", userId: "user_1" });
+    const { POST } = await import("./route");
+
+    const res = await POST(setRequest({ enabled: true }));
+
+    expect(res.status).toBe(403);
+    expect(gatewayWrites()).toHaveLength(0);
+  });
+
+  it("lets an admin turn it on, forwarding the service token, tenant and who did it", async () => {
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:admin", userId: "user_1" });
+    const { POST } = await import("./route");
+
+    const res = await POST(setRequest({ enabled: true }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ enabled: true });
+    const [write] = gatewayWrites();
+    const headers = write.init?.headers as Record<string, string>;
+    expect(headers["x-tenant-id"]).toBe(TENANT_UUID);
+    expect(headers.authorization).toBe("Bearer svc-token");
+    expect(headers["x-clerk-user-id"]).toBe("user_1");
+    expect(JSON.parse(String(write.init?.body))).toEqual({ enabled: true });
+  });
+
+  it.each([["false"], [1], [null]])(
+    "refuses a non-boolean enabled (%j) with 400 before it reaches the gateway",
+    async (value) => {
+      // "false" as a string is truthy almost everywhere. Coercing it would turn the proxy ON.
+      authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:admin", userId: "user_1" });
+      const { POST } = await import("./route");
+
+      const res = await POST(setRequest({ enabled: value }));
+
+      expect(res.status).toBe(400);
+      expect(gatewayWrites()).toHaveLength(0);
+    },
+  );
+});
+
+describe("GET /api/settings/proxy", () => {
+  it("is readable by a member", async () => {
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:member", userId: "user_1" });
+    const { GET } = await import("./route");
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ enabled: false });
+  });
+
+  it("reports an unreadable setting as null, never as off", async () => {
+    // "Off" when the gateway could not answer would tell an admin their proxy is disabled while it may
+    // be accepting traffic.
+    configStatus = 500;
+    authMock.mockResolvedValue({ orgId: ORG_ID, orgRole: "org:admin", userId: "user_1" });
+    const { GET } = await import("./route");
+
+    const res = await GET();
+
+    expect(await res.json()).toEqual({ enabled: null });
+  });
+});

--- a/web/app/api/settings/proxy/route.ts
+++ b/web/app/api/settings/proxy/route.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Server-side seam for the hosted-proxy switch. Like /api/keys, the browser never holds the gateway
+// service token, and this handler is where the admin role is enforced: the gateway sees only the
+// service token and the resolved tenant, so it cannot tell an admin from a member.
+import { NextResponse } from "next/server";
+
+import { canManage, controlPlaneHeaders, currentUserId, getTenant } from "@/lib/getTenant";
+import { queryProxyEnabled } from "@/lib/proxySetting";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+/** Any member may read it; the Connect snippets need to know whether they will work. */
+export async function GET(): Promise<NextResponse> {
+  const tenant = await getTenant();
+  return NextResponse.json({ enabled: await queryProxyEnabled(tenant.tenantId) });
+}
+
+/** Admins only. Body: `{ enabled: boolean }`. */
+export async function POST(req: Request): Promise<NextResponse> {
+  const tenant = await getTenant();
+  if (!canManage(tenant)) {
+    return NextResponse.json(
+      { error: "admin role required to change the hosted proxy setting" },
+      { status: 403 },
+    );
+  }
+  const input = (await req.json().catch(() => null)) as { enabled?: unknown } | null;
+  // Checked here as well as at the gateway so a malformed request never leaves the server.
+  if (!input || typeof input.enabled !== "boolean") {
+    return NextResponse.json({ error: "enabled must be a boolean" }, { status: 400 });
+  }
+  const userId = await currentUserId();
+  const res = await fetch(`${GATEWAY_URL}/v1/tenant/proxy/config`, {
+    method: "POST",
+    headers: controlPlaneHeaders(tenant.tenantId, {
+      "content-type": "application/json",
+      ...(userId ? { "x-clerk-user-id": userId } : {}),
+    }),
+    body: JSON.stringify({ enabled: input.enabled }),
+    cache: "no-store",
+  });
+  const body = (await res.json().catch(() => ({}))) as {
+    config?: { enabled?: boolean };
+    detail?: unknown;
+  };
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `could not save the setting (gateway HTTP ${res.status})` },
+      { status: res.status },
+    );
+  }
+  return NextResponse.json({ enabled: body.config?.enabled ?? input.enabled });
+}

--- a/web/app/settings/keys/ConnectPanel.tsx
+++ b/web/app/settings/keys/ConnectPanel.tsx
@@ -104,7 +104,18 @@ function FirstEventBadge() {
   );
 }
 
-export function ConnectPanel({ token }: { token: string }) {
+export function ConnectPanel({
+  token,
+  proxyEnabled = null,
+}: {
+  token: string;
+  /**
+   * The organization's hosted-proxy switch (0033). false shows a warning on the proxy tab, because
+   * those snippets are refused with 403 until an admin turns it on. null (unknown) shows nothing
+   * rather than guessing either way.
+   */
+  proxyEnabled?: boolean | null;
+}) {
   const [path, setPath] = useState<ConnectPath>("proxy");
   const snippets = connectSnippets(token);
   const [active, setActive] = useState(0);
@@ -147,6 +158,12 @@ export function ConnectPanel({ token }: { token: string }) {
               {s.label}
             </button>
           ))}
+        </div>
+      )}
+      {path === "proxy" && proxyEnabled === false && (
+        <div className="rounded-md border border-warn/40 bg-warn/10 px-3 py-2 text-xs text-warn">
+          The zero-code proxy is off for this organization, so these snippets are refused with a 403
+          until an admin turns it on above. The SDK path works either way.
         </div>
       )}
       <CodeBlock snippet={shown} />

--- a/web/app/settings/keys/KeyManager.tsx
+++ b/web/app/settings/keys/KeyManager.tsx
@@ -33,7 +33,14 @@ function orDash(v: string | null): string {
   return v && v.trim() ? v : "—";
 }
 
-export function KeyManager({ canManage }: { canManage: boolean }) {
+export function KeyManager({
+  canManage,
+  proxyEnabled = null,
+}: {
+  canManage: boolean;
+  /** Passed through to the Connect snippets so the proxy tab can say when it will be refused. */
+  proxyEnabled?: boolean | null;
+}) {
   const [keys, setKeys] = useState<KeyMeta[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -184,7 +191,7 @@ export function KeyManager({ canManage }: { canManage: boolean }) {
           {/* One-step connect (Initiative 2, §9): snippets with the real key inlined into this
               one-time view, plus the live first-event indicator. The key is never stored to render
               this later; it lives only in `minted` until dismissed. */}
-          <ConnectPanel token={minted.token} />
+          <ConnectPanel token={minted.token} proxyEnabled={proxyEnabled} />
         </div>
       )}
 

--- a/web/app/settings/keys/ProxySwitch.tsx
+++ b/web/app/settings/keys/ProxySwitch.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// The organization's hosted-proxy switch (zero-code connect). Off by default.
+//
+// Deliberately NOT optimistic, unlike the connector toggle. This controls whether production LLM
+// traffic is accepted, so the control shows a new state only after the gateway has stored it.
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { Blank } from "@/components/HonestValue";
+
+export function ProxySwitch({
+  initialEnabled,
+  canManage,
+}: {
+  /** null when the setting could not be read: shown as unknown, never as "Off". */
+  initialEnabled: boolean | null;
+  canManage: boolean;
+}) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [status, setStatus] = useState<{ tone: "ok" | "err"; text: string } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function change(next: boolean) {
+    setStatus(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/settings/proxy", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: next }),
+        });
+        const body = (await res.json().catch(() => ({}))) as { enabled?: boolean; error?: string };
+        if (!res.ok || typeof body.enabled !== "boolean") {
+          setStatus({ tone: "err", text: body.error ?? `Could not save (HTTP ${res.status}).` });
+          return;
+        }
+        setEnabled(body.enabled);
+        setStatus({
+          tone: "ok",
+          // Honest about propagation: running proxies learn of it on their next key-feed refresh.
+          text: body.enabled
+            ? "On. Proxies start accepting this organization's keys within about a minute."
+            : "Off. Proxies refuse this organization's keys within about a minute. The SDK is unaffected.",
+        });
+      } catch (e) {
+        setStatus({ tone: "err", text: (e as Error).message });
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-edge bg-panel p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="max-w-prose">
+          <div className="text-sm font-semibold text-fg">Zero-code proxy</div>
+          <p className="mt-1 text-xs text-muted">
+            Lets this organization&apos;s keys meter LLM calls by changing a base URL instead of
+            installing the SDK. Calls pass through ai-tally&apos;s proxy on the way to the provider;
+            prompts and responses are forwarded, never stored. While off, the proxy refuses these
+            keys and the SDK keeps working.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {enabled === null ? (
+            <span className="text-sm text-muted">
+              <Blank reason="the setting could not be read from the gateway, so whether the proxy is on is unknown" />
+            </span>
+          ) : (
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${
+                enabled ? "border-good/40 bg-good/10 text-good" : "border-edge bg-ink/40 text-muted"
+              }`}
+            >
+              <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${enabled ? "bg-good" : "bg-muted"}`} />
+              {enabled ? "On" : "Off"}
+            </span>
+          )}
+          {canManage && enabled !== null && (
+            <button
+              type="button"
+              disabled={pending}
+              onClick={() => change(!enabled)}
+              className="rounded border border-edge px-2.5 py-1 text-xs font-medium text-fg disabled:opacity-50"
+            >
+              {pending ? "Saving…" : enabled ? "Turn off" : "Turn on"}
+            </button>
+          )}
+        </div>
+      </div>
+      {!canManage && (
+        <p className="text-xs text-muted">Only an organization admin can change this.</p>
+      )}
+      {status && (
+        <p className={`text-xs ${status.tone === "ok" ? "text-good" : "text-warn"}`}>{status.text}</p>
+      )}
+    </div>
+  );
+}

--- a/web/app/settings/keys/page.tsx
+++ b/web/app/settings/keys/page.tsx
@@ -3,10 +3,13 @@
 // and the caller's role, then hands the client manager whether this user may mint/rotate/revoke.
 // Members see the list read-only; admins get the write controls (§9).
 import { canManage, getTenant } from "@/lib/getTenant";
+import { queryProxyEnabled } from "@/lib/proxySetting";
 import { KeyManager } from "./KeyManager";
+import { ProxySwitch } from "./ProxySwitch";
 
 export default async function KeysPage() {
   const tenant = await getTenant();
+  const proxyEnabled = await queryProxyEnabled(tenant.tenantId);
   return (
     <div className="space-y-4">
       <div>
@@ -16,7 +19,8 @@ export default async function KeysPage() {
           once at creation and never again.
         </p>
       </div>
-      <KeyManager canManage={canManage(tenant)} />
+      <ProxySwitch initialEnabled={proxyEnabled} canManage={canManage(tenant)} />
+      <KeyManager canManage={canManage(tenant)} proxyEnabled={proxyEnabled} />
     </div>
   );
 }

--- a/web/lib/proxySetting.ts
+++ b/web/lib/proxySetting.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// The per-organization switch for the hosted edge proxy (zero-code connect). Server-only.
+//
+// Off by default: routing production LLM calls through ai-tally's server is a trust decision an org
+// admin makes explicitly. The gateway owns the setting (tenant_proxy_config, 0033) and carries it to
+// running proxies through the edge-key feed, so the dashboard never talks to a proxy directly.
+import { controlPlaneHeaders } from "./getTenant";
+
+const GATEWAY_URL = process.env.TALLY_GATEWAY_URL ?? "http://localhost:8080";
+
+interface ProxyConfigResponse {
+  tenant_id: string;
+  config: { enabled: boolean; updated_at: string | null };
+}
+
+/**
+ * Whether the hosted proxy is on for this tenant, or null when the gateway could not say.
+ *
+ * Null is not false. Rendering an unreadable setting as "Off" would tell an admin their proxy is
+ * disabled when it may be serving traffic, which is the one wrong answer this switch must never give.
+ */
+export async function queryProxyEnabled(tenantId: string): Promise<boolean | null> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/tenant/proxy/config`, {
+      headers: controlPlaneHeaders(tenantId),
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as ProxyConfigResponse;
+    return typeof body.config?.enabled === "boolean" ? body.config.enabled : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
**Stacked on #384.** Merge #384 first; this PR's base will then retarget to `main`.

Two levels of "optional" for zero-code connect:

| Level | Who decides | Where | Default |
|---|---|---|---|
| Does a proxy run at all | operator | `INGEST_DOMAIN` in `.env` (#384) | off |
| May this org's keys use it | org admin | Settings > API keys > Zero-code proxy (this PR) | **off** |

Routing an org's production LLM calls through our server is a trust decision its admin should make explicitly. While off, the proxy refuses that org's keys with `403 the hosted proxy is turned off for this organization`, and **the same keys keep working for the SDK**.

## How a toggle reaches a running proxy

The proxy never reads the setting. It caches key metadata from the gateway's `/v1/edge/keys` delta feed, which pages `api_keys` by a watermark, and **a toggle changes no `api_keys` row**, so on its own it would never arrive.

Migration 0033 adds `api_keys.edge_updated_at`. The toggle stamps it on the org's live keys **in the same transaction** as the config write, the feed's watermark includes it, and those keys re-enter the feed carrying `proxy_enabled` within one refresh (~45s). 0030's index covered the old watermark expression, so 0033 replaces it, and `test_feed_watermark_matches_the_0033_index_expression` pins the two together.

## By layer

- **db:** `tenant_proxy_config` (`enabled` default false, bounded `updated_by` for audit), plus the column and the new index.
- **gateway:** `TenantProxyStore`, `GET/POST /v1/tenant/proxy/config` behind the service token, and `proxy_enabled` on every feed change.
  - The store refuses any non-boolean: `"false"` is truthy, and coercing it would switch a proxy **on**.
  - The field is always sent, since the proxy reads an absent field as "no switch exists".
- **edge proxy:** `proxy_enabled` is a pointer on the wire.
  - **Absent** (a gateway that predates the switch) allows as before; an explicit `false` is always enforced.
  - Enforced through an optional `OrgSwitchResolver` interface, so existing resolvers compile unchanged.
  - Under `RequireTenant` the response is a 403 that names the fix. Without it the call is forwarded untagged, the same shape as the scope gate.
- **web:**
  - `/api/settings/proxy` enforces the admin role, since the gateway can't tell an admin from a member.
  - The switch on the keys page is **not optimistic**: it shows a new state only after the gateway stored it, and an unreadable setting shows as unknown, never "Off".
  - The Connect snippets' proxy tab warns while the switch is off.

## Verification

| Check | Result |
|---|---|
| gateway `pytest` + `ruff` | 1076 passed, clean |
| web `typecheck` / `lint` / `test` | clean / pre-existing warning only / 886 passed |
| edge proxy `build` / `test` / `gofmt` | all pass, gofmt silent |
| Mutation: disable proxy enforcement | both "switch off" tests fail |
| Real Postgres 16, all compose-mounted migrations | see below |

On real Postgres:
1. 0033 applies cleanly, and the old index is replaced by `idx_api_keys_edge_watermark_v2`.
2. `EXPLAIN` shows a Bitmap Index Scan on the new index for the feed's watermark condition.
3. Cold start: both keys come through with `proxy_enabled=false`.
4. A steady-state cursor returns nothing.
5. Toggle on: only the live key gets `edge_updated_at`, and it's re-emitted past the cursor with `true`. The revoked key stays out.
6. Toggle off: the live key is re-emitted with `false`.
7. `updated_by` over 128 characters violates its CHECK.
8. Deleting the tenant cascades the setting.

Not verified: the full stack on the droplet, which lands with #384.

## Rollout note

Everyone starts **off**, including your own org. After deploying, turn it on under Settings > API keys before pointing anything at `ingest.ai-tally.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)